### PR TITLE
Fix:Platform specific deps missing where added

### DIFF
--- a/.github/scripts/build_release_body.py
+++ b/.github/scripts/build_release_body.py
@@ -73,7 +73,7 @@ Extract the `.zip` archive, then run `bin\\ae.exe version` from the extracted fo
 
 ---
 
-Full documentation: https://aetherlang.org"""
+Documentation: https://github.com/nicolasmd87/aether#readme"""
 
 
 def main() -> None:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,13 @@ jobs:
             cc: clang
             install: sudo apt-get update && sudo apt-get install -y clang make libreadline-dev bc
 
-          - name: macOS / Clang
+          - name: macOS / Clang (ARM64)
             os: macos-latest
+            cc: clang
+            install: ""
+
+          - name: macOS / Clang (x86_64)
+            os: macos-15-intel
             cc: clang
             install: ""
 
@@ -59,6 +64,10 @@ jobs:
     name: Windows / GCC (MSYS2)
     runs-on: windows-latest
 
+    defaults:
+      run:
+        shell: msys2 {0}
+
     steps:
     - uses: actions/checkout@v4
 
@@ -69,11 +78,9 @@ jobs:
         install: mingw-w64-x86_64-gcc make mingw-w64-x86_64-readline bc
 
     - name: Run CI suite
-      shell: msys2 {0}
       run: make ci
 
     - name: Install smoke test
-      shell: msys2 {0}
       run: make test-install
 
   # ============================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,17 @@ name: Release
 
 # Every merge to main creates a versioned release automatically.
 #
-# Version bump rules (applied to the current VERSION file):
+# Version bump rules:
 #   - Commit message starts with "major"  →  bump MAJOR, reset minor + patch to 0
 #   - Anything else                       →  bump MINOR, reset patch to 0  (default)
 #
 # Manual tag push (v*.*.*) also triggers a build + publish, without bumping.
+#
+# Version source of truth: git tags (not the VERSION file).
+# The bump job creates a lightweight tag; the build checks out that tag so
+# VERSION in the archive is always correct.  No PR or branch is created,
+# which eliminates the feedback loop where merging the chore PR would
+# re-trigger the release pipeline.
 
 on:
   push:
@@ -18,27 +24,20 @@ jobs:
   # ================================================================== #
   # AUTO-BUMP (main branch merges only)                                #
   #                                                                    #
-  # Reads the commit message, increments VERSION, pushes a version     #
-  # tag, and opens a PR to land the VERSION bump on main (direct       #
-  # push is blocked by branch protection).                             #
+  # Derives the CURRENT version from the latest v*.*.* tag (not the   #
+  # VERSION file), computes the next version, writes VERSION into a   #
+  # detached commit, tags it, and pushes only the tag.                #
+  #                                                                    #
+  # No branch or PR is created — GITHUB_TOKEN tag pushes do not       #
+  # trigger new workflow runs, so there is no feedback loop.           #
   # ================================================================== #
   bump:
     name: Auto-bump version
     runs-on: ubuntu-latest
-    # Only on real human merges to main — skip bot commits (the VERSION
-    # commit we push back) and manual tag pushes (handled by build alone).
-    # Also skip regular-merge commits from release/* branches: when auto-merge
-    # fails and someone merges manually, GitHub creates a commit like
-    # "Merge pull request #N from user/release/v0.9.0" which doesn't start
-    # with "chore: release " but must still be ignored.
-    if: |
-      github.ref == 'refs/heads/main' &&
-      !startsWith(github.event.head_commit.message, 'chore: release ') &&
-      !contains(github.event.head_commit.message, '/release/v')
+    if: github.ref == 'refs/heads/main'
 
     permissions:
       contents: write
-      pull-requests: write
 
     outputs:
       tag:     ${{ steps.v.outputs.tag }}
@@ -54,7 +53,16 @@ jobs:
       id: v
       run: |
         MSG="${{ github.event.head_commit.message }}"
-        OLD=$(cat VERSION | tr -d '[:space:]')
+
+        # Derive current version from the latest tag (authoritative source).
+        # Falls back to VERSION file if no tags exist yet.
+        LATEST_TAG=$(git describe --tags --match 'v*.*.*' --abbrev=0 2>/dev/null || echo "")
+        if [ -n "$LATEST_TAG" ]; then
+          OLD=$(echo "$LATEST_TAG" | sed 's/^v//')
+        else
+          OLD=$(cat VERSION | tr -d '[:space:]')
+        fi
+
         MAJOR=$(echo "$OLD" | cut -d. -f1)
         MINOR=$(echo "$OLD" | cut -d. -f2)
 
@@ -66,53 +74,37 @@ jobs:
           KIND="minor"
         fi
 
+        TAG="v$NEW"
+
+        # Safety: if this tag already exists, skip (idempotent).
+        if git rev-parse "$TAG" >/dev/null 2>&1; then
+          echo "Tag $TAG already exists — skipping bump"
+          echo "tag="      >> "$GITHUB_OUTPUT"
+          echo "version="  >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         echo "$NEW" > VERSION
-        echo "tag=v$NEW"          >> "$GITHUB_OUTPUT"
-        echo "version=$NEW"       >> "$GITHUB_OUTPUT"
+        echo "tag=$TAG"          >> "$GITHUB_OUTPUT"
+        echo "version=$NEW"      >> "$GITHUB_OUTPUT"
         echo "Bumped $KIND: $OLD → $NEW (trigger: $MSG)"
 
-    - name: Commit VERSION, push tag
+    - name: Tag release
+      if: steps.v.outputs.tag != ''
       run: |
         VERSION="${{ steps.v.outputs.version }}"
         TAG="${{ steps.v.outputs.tag }}"
-        BRANCH="release/${TAG}"
 
         git config user.name  "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-        # Clean up stale tag/branch from any previous failed run
-        git push origin ":refs/tags/${TAG}" 2>/dev/null || true
-        git push origin --delete "$BRANCH" 2>/dev/null || true
-        git tag -d "$TAG" 2>/dev/null || true
-        git branch -D "$BRANCH" 2>/dev/null || true
-
-        git checkout -b "$BRANCH"
         git add VERSION
         git commit -m "chore: release ${VERSION}"
         git tag "$TAG"
 
-        git push origin "$BRANCH"
+        # Push only the tag — no branch, no PR.
+        # GITHUB_TOKEN tag pushes do NOT trigger new workflow runs.
         git push origin "$TAG"
-
-    - name: Open PR for VERSION bump
-      continue-on-error: true
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        VERSION="${{ steps.v.outputs.version }}"
-        TAG="${{ steps.v.outputs.tag }}"
-        BRANCH="release/${TAG}"
-
-        # Close any stale PR from a previous failed run
-        gh pr close "$BRANCH" 2>/dev/null || true
-
-        gh pr create \
-          --base main \
-          --head "$BRANCH" \
-          --title "chore: release ${VERSION}" \
-          --body "Auto-generated version bump to \`${VERSION}\`."
-
-        gh pr merge "$BRANCH" --auto --squash --delete-branch 2>/dev/null || true
 
   # ================================================================== #
   # BUILD — all four platforms                                         #
@@ -125,7 +117,7 @@ jobs:
     needs: bump
     if: |
       always() && (
-        needs.bump.result == 'success' ||
+        (needs.bump.result == 'success' && needs.bump.outputs.tag != '') ||
         startsWith(github.ref, 'refs/tags/') ||
         github.event_name == 'workflow_dispatch'
       )
@@ -138,10 +130,10 @@ jobs:
           - os: ubuntu-latest
             target: linux-x86_64
             ext: ""
-          - os: macos-latest
+          - os: macos-15-intel
             target: macos-x86_64
             ext: ""
-          - os: macos-14
+          - os: macos-latest
             target: macos-arm64
             ext: ""
           - os: windows-latest
@@ -158,7 +150,7 @@ jobs:
     # ── Linux ─────────────────────────────────────────────────────────
     - name: Setup (Linux)
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get update && sudo apt-get install -y gcc make
+      run: sudo apt-get update && sudo apt-get install -y gcc make libreadline-dev bc
 
     # ── Windows — MinGW-w64 via MSYS2 ─────────────────────────────────
     - name: Setup (Windows)
@@ -169,34 +161,63 @@ jobs:
         update: true
         install: >-
           mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-readline
           make
           zip
+          bc
 
-    # ── Build: Linux / macOS ──────────────────────────────────────────
+    # ── Build + test: Linux / macOS ───────────────────────────────────
     - name: Build (Unix)
       if: matrix.os != 'windows-latest'
       run: |
         make compiler
         make ae
-        strip build/aetherc build/ae 2>/dev/null || true
+        make stdlib
 
-    # ── Build: Windows (MSYS2 shell for all steps) ────────────────────
+    - name: Test (Unix)
+      if: matrix.os != 'windows-latest'
+      run: |
+        make test
+        make test-ae
+        make test-install
+
+    - name: Strip (Unix)
+      if: matrix.os != 'windows-latest'
+      run: strip build/aetherc build/ae 2>/dev/null || true
+
+    # ── Build + test: Windows (MSYS2 shell) ──────────────────────────
     - name: Build (Windows)
       if: matrix.os == 'windows-latest'
       shell: msys2 {0}
       run: |
         make compiler
         make ae
-        strip build/aetherc.exe build/ae.exe 2>/dev/null || true
+        make stdlib
+
+    - name: Test (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: msys2 {0}
+      run: |
+        make test
+        make test-ae
+        make test-install
+
+    - name: Strip (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: msys2 {0}
+      run: strip build/aetherc.exe build/ae.exe 2>/dev/null || true
 
     # ── Package + archive: Unix ───────────────────────────────────────
     - name: Package (Unix)
       if: matrix.os != 'windows-latest'
       run: |
         VERSION=$(cat VERSION | tr -d '[:space:]')
-        mkdir -p release/bin release/share/aether
+        mkdir -p release/bin release/lib release/share/aether
         cp build/aetherc release/bin/
         cp build/ae      release/bin/
+        if [ -f build/libaether.a ]; then
+          cp build/libaether.a release/lib/
+        fi
         cp -r runtime    release/share/aether/
         cp -r std        release/share/aether/
         cp LICENSE README.md VERSION release/
@@ -208,9 +229,12 @@ jobs:
       shell: msys2 {0}
       run: |
         VERSION=$(cat VERSION | tr -d '[:space:]')
-        mkdir -p release/bin release/share/aether
+        mkdir -p release/bin release/lib release/share/aether
         cp build/aetherc.exe release/bin/
         cp build/ae.exe      release/bin/
+        if [ -f build/libaether.a ]; then
+          cp build/libaether.a release/lib/
+        fi
         cp -r runtime        release/share/aether/
         cp -r std            release/share/aether/
         cp LICENSE README.md VERSION release/
@@ -234,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       always() && needs.build.result == 'success' && (
-        needs.bump.result == 'success' ||
+        (needs.bump.result == 'success' && needs.bump.outputs.tag != '') ||
         startsWith(github.ref, 'refs/tags/') ||
         github.event_name == 'workflow_dispatch'
       )

--- a/Makefile
+++ b/Makefile
@@ -460,6 +460,9 @@ release: clean
 ifeq ($(DETECTED_OS),Linux)
 	@echo "Stripping debug symbols..."
 	@strip build/aetherc-release$(EXE_EXT)
+else ifeq ($(DETECTED_OS),Darwin)
+	@echo "Stripping debug symbols..."
+	@strip -x build/aetherc-release$(EXE_EXT)
 endif
 	@echo "✓ Release build complete: build/aetherc-release$(EXE_EXT)"
 	@ls -lh build/aetherc-release$(EXE_EXT)

--- a/compiler/aether_diagnostics.c
+++ b/compiler/aether_diagnostics.c
@@ -269,8 +269,8 @@ void print_diagnostic_colored(EnhancedDiagnostic* diag) {
 // Get documentation URL for error code
 const char* get_error_docs_url(ErrorCode code) {
     static char url[128];
-    snprintf(url, sizeof(url), 
-             "https://aether-lang.org/docs/errors/E%04d", code);
+    snprintf(url, sizeof(url),
+             "https://github.com/nicolasmd87/aether/wiki/E%04d", code);
     return url;
 }
 

--- a/editor/vscode/README.md
+++ b/editor/vscode/README.md
@@ -1,6 +1,6 @@
 # Aether Language Support
 
-Official Visual Studio Code extension for the [Aether programming language](https://github.com/aether-lang/aether).
+Official Visual Studio Code extension for the [Aether programming language](https://github.com/nicolasmd87/aether).
 
 ## Features
 
@@ -75,7 +75,7 @@ Install from VSIX:
 
 ## Contribution
 
-Found a bug or have a feature request? Please open an issue on the [GitHub repository](https://github.com/aether-lang/aether).
+Found a bug or have a feature request? Please open an issue on the [GitHub repository](https://github.com/nicolasmd87/aether).
 
 ## License
 
@@ -83,7 +83,7 @@ This extension is licensed under the MIT License. See the [LICENSE](../../LICENS
 
 ## Links
 
-- [Aether GitHub Repository](https://github.com/aether-lang/aether)
+- [Aether GitHub Repository](https://github.com/nicolasmd87/aether)
 - [Language Documentation](../../docs/language-reference.md)
 - [Getting Started Guide](../../docs/getting-started.md)
 

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -8,12 +8,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aether-lang/aether"
+    "url": "https://github.com/nicolasmd87/aether"
   },
   "bugs": {
-    "url": "https://github.com/aether-lang/aether/issues"
+    "url": "https://github.com/nicolasmd87/aether/issues"
   },
-  "homepage": "https://github.com/aether-lang/aether#readme",
+  "homepage": "https://github.com/nicolasmd87/aether#readme",
   "keywords": [
     "aether",
     "actor",

--- a/editor/vscode/vsix_build/extension/package.json
+++ b/editor/vscode/vsix_build/extension/package.json
@@ -8,12 +8,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aether-lang/aether"
+    "url": "https://github.com/nicolasmd87/aether"
   },
   "bugs": {
-    "url": "https://github.com/aether-lang/aether/issues"
+    "url": "https://github.com/nicolasmd87/aether/issues"
   },
-  "homepage": "https://github.com/aether-lang/aether#readme",
+  "homepage": "https://github.com/nicolasmd87/aether#readme",
   "keywords": [
     "aether",
     "actor",

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <limits.h>
 #include <sys/stat.h>
 
 
@@ -270,7 +271,7 @@ static bool get_exe_dir(char* buf, size_t size) {
 #ifdef __APPLE__
     uint32_t sz = (uint32_t)size;
     if (_NSGetExecutablePath(buf, &sz) == 0) {
-        char resolved[1024];
+        char resolved[PATH_MAX];
         if (realpath(buf, resolved)) {
             char* slash = strrchr(resolved, '/');
             if (slash) { *slash = '\0'; strncpy(buf, resolved, size); return true; }
@@ -285,7 +286,8 @@ static bool get_exe_dir(char* buf, size_t size) {
     }
 #elif defined(_WIN32)
     DWORD len = GetModuleFileNameA(NULL, buf, (DWORD)size);
-    if (len > 0) {
+    if (len > 0 && len < (DWORD)size) {
+        buf[len] = '\0';
         char* slash = strrchr(buf, '\\');
         if (slash) { *slash = '\0'; return true; }
     }
@@ -1579,13 +1581,20 @@ static int cmd_repl(void) {
 
 // Compile-time platform string used to pick the right release archive.
 #if defined(_WIN32)
-#  define AE_PLATFORM "windows-x86_64"
+#  if defined(__aarch64__) || defined(_M_ARM64)
+#    define AE_PLATFORM "windows-arm64"
+#  else
+#    define AE_PLATFORM "windows-x86_64"
+#  endif
 #  define AE_ARCHIVE_EXT ".zip"
 #elif defined(__APPLE__) && (defined(__arm64__) || defined(__aarch64__))
 #  define AE_PLATFORM "macos-arm64"
 #  define AE_ARCHIVE_EXT ".tar.gz"
 #elif defined(__APPLE__)
 #  define AE_PLATFORM "macos-x86_64"
+#  define AE_ARCHIVE_EXT ".tar.gz"
+#elif defined(__linux__) && (defined(__aarch64__) || defined(__arm64__))
+#  define AE_PLATFORM "linux-arm64"
 #  define AE_ARCHIVE_EXT ".tar.gz"
 #else
 #  define AE_PLATFORM "linux-x86_64"

--- a/tools/apkg/apkg.c
+++ b/tools/apkg/apkg.c
@@ -696,7 +696,7 @@ void apkg_print_help() {
     printf("    search <query>    Search for packages\n");
     printf("    help              Show this help message\n");
     printf("    version           Show version information\n\n");
-    printf("For more information, see: https://docs.aetherlang.org/apkg\n");
+    printf("For more information, see: https://github.com/nicolasmd87/aether\n");
 }
 
 void apkg_print_version() {


### PR DESCRIPTION
- Added full test suite to every release build — make test (166 C unit tests) + make test-ae (26 integration tests) + make test-install (install smoke test) now run on all 4 targets before packaging. Previously: zero tests.
- Added make stdlib — builds `libaether.a` and includes it in the release archive (release/lib/). Previously, the archive only contained source files, without a precompiled library.
- Added missing deps to Linux setup — libreadline-dev bc (needed for test runner)
- Added missing deps to Windows setup — mingw-w64-x86_64-readline bc
- Split build/test/strip into separate steps — cleaner CI logs, failures pinpoint the exact phase