### PR TITLE
fix: resolve 13 Windows test failures (#99) 

### DIFF
--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -20,6 +20,25 @@
 
 ModuleRegistry* global_module_registry = NULL;
 
+// Source file directory for resolving lib/ imports relative to the source file.
+static char g_source_dir[2048] = "";
+
+void module_set_source_dir(const char* source_path) {
+    if (!source_path) { g_source_dir[0] = '\0'; return; }
+    strncpy(g_source_dir, source_path, sizeof(g_source_dir) - 1);
+    g_source_dir[sizeof(g_source_dir) - 1] = '\0';
+    // Strip filename to get directory
+    char* last_sep = NULL;
+    for (char* p = g_source_dir; *p; p++) {
+        if (*p == '/' || *p == '\\') last_sep = p;
+    }
+    if (last_sep) {
+        *(last_sep + 1) = '\0';  // keep trailing slash
+    } else {
+        g_source_dir[0] = '\0';  // no directory component
+    }
+}
+
 // Module management
 void module_registry_init() {
     if (!global_module_registry) {
@@ -449,7 +468,7 @@ char* module_resolve_stdlib_path(const char* module_name) {
 // Resolve a local module path (e.g., "mypackage.utils") to a file path.
 char* module_resolve_local_path(const char* module_path) {
     char converted[512];
-    char path[2048];
+    char path[4096];
 
     // Convert dots to slashes
     strncpy(converted, module_path, sizeof(converted) - 1);
@@ -458,7 +477,7 @@ char* module_resolve_local_path(const char* module_path) {
         if (*p == '.') *p = '/';
     }
 
-    // Try 1: lib/module_path/module.ae
+    // Try 1: lib/module_path/module.ae (CWD-relative)
     snprintf(path, sizeof(path), "lib/%s/module.ae", converted);
     if (access(path, F_OK) == 0) return strdup(path);
 
@@ -481,6 +500,22 @@ char* module_resolve_local_path(const char* module_path) {
     // Try 6: module_path.ae (single file in root)
     snprintf(path, sizeof(path), "%s.ae", converted);
     if (access(path, F_OK) == 0) return strdup(path);
+
+    // Try 6b: Search relative to source file directory (e.g. tests/integration/pure_module/lib/)
+    if (g_source_dir[0]) {
+        snprintf(path, sizeof(path), "%slib/%s/module.ae", g_source_dir, converted);
+        if (access(path, F_OK) == 0) return strdup(path);
+        snprintf(path, sizeof(path), "%slib/%s.ae", g_source_dir, converted);
+        if (access(path, F_OK) == 0) return strdup(path);
+        snprintf(path, sizeof(path), "%ssrc/%s/module.ae", g_source_dir, converted);
+        if (access(path, F_OK) == 0) return strdup(path);
+        snprintf(path, sizeof(path), "%ssrc/%s.ae", g_source_dir, converted);
+        if (access(path, F_OK) == 0) return strdup(path);
+        snprintf(path, sizeof(path), "%s%s/module.ae", g_source_dir, converted);
+        if (access(path, F_OK) == 0) return strdup(path);
+        snprintf(path, sizeof(path), "%s%s.ae", g_source_dir, converted);
+        if (access(path, F_OK) == 0) return strdup(path);
+    }
 
     // Try 7-9: Search installed packages at ~/.aether/packages/
     // import mylib.utils → search ~/.aether/packages/*/mylib/src/utils/module.ae

--- a/compiler/aether_module.h
+++ b/compiler/aether_module.h
@@ -79,6 +79,9 @@ void package_manifest_free(PackageManifest* manifest);
 // Module orchestration — call between parsing and type checking
 #define MAX_MODULE_TOKENS 2000
 
+// Set the source file directory so module resolution can search lib/ relative to it.
+void module_set_source_dir(const char* source_path);
+
 // Orchestrate all module loading: scan imports, resolve, parse, cache, detect cycles.
 // Returns 1 on success, 0 on circular dependency error.
 int module_orchestrate(ASTNode* program);

--- a/compiler/aetherc.c
+++ b/compiler/aetherc.c
@@ -199,6 +199,7 @@ int compile_source(const char* input_path, const char* output_path) {
 
     // Step 2.5: Module Orchestration
     if (verbose_mode) printf("[Phase 2.5/5] Module resolution...\n");
+    module_set_source_dir(input_path);
     if (!module_orchestrate(program)) {
         report_compilation_failure();
         free_ast_node(program);

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -138,13 +138,11 @@ char* path_join(const char* path1, const char* path2) {
     size_t len1 = strlen(path1);
     size_t len2 = strlen(path2);
 
-    #ifdef _WIN32
-    char sep = '\\';
-    #else
+    // Always use '/' — it works on all platforms (Windows C stdlib accepts '/')
+    // and keeps paths consistent with Aether's module system.
     char sep = '/';
-    #endif
 
-    int needs_sep = (len1 > 0 && path1[len1-1] != sep && path1[len1-1] != '/');
+    int needs_sep = (len1 > 0 && path1[len1-1] != '/' && path1[len1-1] != '\\');
     size_t total = len1 + len2 + (needs_sep ? 1 : 0);
 
     char* result = (char*)malloc(total + 1);
@@ -218,17 +216,17 @@ char* path_extension(const char* path) {
 int path_is_absolute(const char* path) {
     if (!path || path[0] == '\0') return 0;
 
+    // Unix-style absolute: /path (works on all platforms)
+    if (path[0] == '/') return 1;
+
     #ifdef _WIN32
-    // Windows: C:\ or \\server\share
+    // Windows: C:\ or C:/ or \\server\share
     if ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) {
         if (path[1] && path[1] == ':' && path[2] && (path[2] == '\\' || path[2] == '/')) {
             return 1;
         }
     }
     if (path[0] == '\\' && path[1] && path[1] == '\\') return 1;
-    #else
-    // Unix: /path
-    if (path[0] == '/') return 1;
     #endif
 
     return 0;

--- a/tests/regression/test_file_io_char_return.ae
+++ b/tests/regression/test_file_io_char_return.ae
@@ -7,7 +7,15 @@ import std.io
 import std.fs
 
 main() {
-    test_file = "/tmp/_aether_test_file_io_char.txt"
+    // Use platform temp dir: TEMP (Windows) or TMPDIR (Unix), fallback /tmp
+    tmp = io.getenv("TEMP")
+    if tmp == 0 {
+        tmp = io.getenv("TMPDIR")
+    }
+    if tmp == 0 {
+        tmp = "/tmp"
+    }
+    test_file = "${tmp}/_aether_test_file_io_char.txt"
 
     // Test 1: Write and read back
     io.write_file(test_file, "hello aether")

--- a/tests/regression/test_fs_return_values.ae
+++ b/tests/regression/test_fs_return_values.ae
@@ -5,13 +5,23 @@
 
 import std.file
 import std.dir
+import std.io
 
 main() {
     println("=== FS Return Value Tests ===")
 
+    // Use platform temp dir
+    tmp = io.getenv("TEMP")
+    if tmp == 0 {
+        tmp = io.getenv("TMPDIR")
+    }
+    if tmp == 0 {
+        tmp = "/tmp"
+    }
+
     // Test 1: file.delete on non-existent file returns 0
     println("\nTest 1: file.delete non-existent returns 0")
-    r = file.delete("/tmp/aether_fs_test_nonexistent_xyz")
+    r = file.delete("${tmp}/aether_fs_test_nonexistent_xyz")
     if r == 0 {
         println("  PASS")
     } else {
@@ -21,7 +31,7 @@ main() {
 
     // Test 2: file.write returns 1 on success
     println("\nTest 2: file.write returns 1 on success")
-    f = file.open("/tmp/aether_fs_write_test.txt", "w")
+    f = file.open("${tmp}/aether_fs_write_test.txt", "w")
     wr = file.write(f, "test data", 9)
     if wr == 1 {
         println("  PASS")
@@ -42,7 +52,7 @@ main() {
 
     // Test 4: file.delete on existing file returns 1
     println("\nTest 4: file.delete existing file returns 1")
-    dr = file.delete("/tmp/aether_fs_write_test.txt")
+    dr = file.delete("${tmp}/aether_fs_write_test.txt")
     if dr == 1 {
         println("  PASS")
     } else {
@@ -52,7 +62,7 @@ main() {
 
     // Test 5: file.delete same file again returns 0 (already deleted)
     println("\nTest 5: file.delete already-deleted file returns 0")
-    dr2 = file.delete("/tmp/aether_fs_write_test.txt")
+    dr2 = file.delete("${tmp}/aether_fs_write_test.txt")
     if dr2 == 0 {
         println("  PASS")
     } else {
@@ -62,7 +72,7 @@ main() {
 
     // Test 6: dir.exists on non-existent directory returns 0
     println("\nTest 6: dir.exists non-existent returns 0")
-    de = dir.exists("/tmp/aether_fs_test_nonexistent_dir_xyz")
+    de = dir.exists("${tmp}/aether_fs_test_nonexistent_dir_xyz")
     if de == 0 {
         println("  PASS")
     } else {
@@ -72,7 +82,7 @@ main() {
 
     // Test 7: dir.create returns 1 on success
     println("\nTest 7: dir.create returns 1 on success")
-    dc = dir.create("/tmp/aether_fs_test_dir")
+    dc = dir.create("${tmp}/aether_fs_test_dir")
     if dc == 1 {
         println("  PASS")
     } else {
@@ -82,7 +92,7 @@ main() {
 
     // Test 8: dir.exists on existing directory returns 1
     println("\nTest 8: dir.exists on existing directory returns 1")
-    de2 = dir.exists("/tmp/aether_fs_test_dir")
+    de2 = dir.exists("${tmp}/aether_fs_test_dir")
     if de2 == 1 {
         println("  PASS")
     } else {
@@ -92,7 +102,7 @@ main() {
 
     // Test 9: dir.create on already-existing directory returns 0
     println("\nTest 9: dir.create duplicate returns 0")
-    dc2 = dir.create("/tmp/aether_fs_test_dir")
+    dc2 = dir.create("${tmp}/aether_fs_test_dir")
     if dc2 == 0 {
         println("  PASS")
     } else {
@@ -102,7 +112,7 @@ main() {
 
     // Test 10: dir.delete on existing directory returns 1
     println("\nTest 10: dir.delete existing returns 1")
-    dd = dir.delete("/tmp/aether_fs_test_dir")
+    dd = dir.delete("${tmp}/aether_fs_test_dir")
     if dd == 1 {
         println("  PASS")
     } else {
@@ -112,7 +122,7 @@ main() {
 
     // Test 11: dir.delete on non-existent directory returns 0
     println("\nTest 11: dir.delete non-existent returns 0")
-    dd2 = dir.delete("/tmp/aether_fs_test_nonexistent_dir_xyz")
+    dd2 = dir.delete("${tmp}/aether_fs_test_nonexistent_dir_xyz")
     if dd2 == 0 {
         println("  PASS")
     } else {
@@ -122,7 +132,7 @@ main() {
 
     // Test 12: dir.delete same directory again returns 0
     println("\nTest 12: dir.delete already-deleted returns 0")
-    dd3 = dir.delete("/tmp/aether_fs_test_dir")
+    dd3 = dir.delete("${tmp}/aether_fs_test_dir")
     if dd3 == 0 {
         println("  PASS")
     } else {
@@ -132,7 +142,7 @@ main() {
 
     // Test 13: dir.exists confirms deletion
     println("\nTest 13: dir.exists after delete returns 0")
-    de3 = dir.exists("/tmp/aether_fs_test_dir")
+    de3 = dir.exists("${tmp}/aether_fs_test_dir")
     if de3 == 0 {
         println("  PASS")
     } else {
@@ -152,15 +162,15 @@ main() {
 
     // Test 15: file.exists on file vs directory
     println("\nTest 15: file.exists on directory returns 0")
-    dir.create("/tmp/aether_fs_test_dir2")
-    fe = file.exists("/tmp/aether_fs_test_dir2")
+    dir.create("${tmp}/aether_fs_test_dir2")
+    fe = file.exists("${tmp}/aether_fs_test_dir2")
     if fe == 0 {
         println("  PASS: file.exists correctly rejects directory")
     } else {
         println("  FAIL: file.exists should return 0 for directories")
         exit(1)
     }
-    dir.delete("/tmp/aether_fs_test_dir2")
+    dir.delete("${tmp}/aether_fs_test_dir2")
 
     println("\n=== All FS Return Value Tests Passed ===")
 }

--- a/tests/regression/test_io_edge_cases.ae
+++ b/tests/regression/test_io_edge_cases.ae
@@ -6,9 +6,18 @@ import std.io
 main() {
     print("=== IO Edge Case Tests ===\n\n")
 
+    // Use platform temp dir
+    tmp = io.getenv("TEMP")
+    if tmp == 0 {
+        tmp = io.getenv("TMPDIR")
+    }
+    if tmp == 0 {
+        tmp = "/tmp"
+    }
+
     // Test 1: read non-existent file returns NULL
     print("Test 1: read non-existent file\n")
-    content = io.read_file("/tmp/aether_nonexistent_xyz_987")
+    content = io.read_file("${tmp}/aether_nonexistent_xyz_987")
     if content == 0 {
         print("  PASS: read_file returns NULL for missing file\n")
     } else {
@@ -18,7 +27,7 @@ main() {
 
     // Test 2: write + read round-trip
     print("\nTest 2: write + read round-trip\n")
-    test_path = "/tmp/aether_io_test.txt"
+    test_path = "${tmp}/aether_io_test.txt"
     ok = io.write_file(test_path, "hello io")
     if ok == 1 {
         content2 = io.read_file(test_path)
@@ -74,7 +83,7 @@ main() {
 
     // Test 6: delete non-existent file
     print("\nTest 6: delete non-existent file\n")
-    r = io.delete_file("/tmp/aether_nonexistent_xyz_987")
+    r = io.delete_file("${tmp}/aether_nonexistent_xyz_987")
     if r == 0 {
         print("  PASS: delete non-existent returns 0\n")
     } else {
@@ -84,7 +93,7 @@ main() {
 
     // Test 7: write empty content
     print("\nTest 7: write empty content\n")
-    test_path2 = "/tmp/aether_io_empty_test.txt"
+    test_path2 = "${tmp}/aether_io_empty_test.txt"
     ok3 = io.write_file(test_path2, "")
     if ok3 == 1 {
         content4 = io.read_file(test_path2)
@@ -122,7 +131,7 @@ main() {
 
     // Test 10: file_info
     print("\nTest 10: file_info on non-existent\n")
-    info = io.file_info("/tmp/aether_nonexistent_xyz_987")
+    info = io.file_info("${tmp}/aether_nonexistent_xyz_987")
     if info == 0 {
         print("  PASS: file_info returns NULL for missing file\n")
     } else {

--- a/tests/regression/test_stdlib_edge_cases.ae
+++ b/tests/regression/test_stdlib_edge_cases.ae
@@ -6,9 +6,19 @@ import std.fs
 import std.file
 import std.path
 import std.json
+import std.io
 
 main() {
     print("=== Stdlib Edge Case Tests ===\n\n")
+
+    // Use platform temp dir
+    tmp = io.getenv("TEMP")
+    if tmp == 0 {
+        tmp = io.getenv("TMPDIR")
+    }
+    if tmp == 0 {
+        tmp = "/tmp"
+    }
 
     // === PATH MODULE: return types should be string, not ptr ===
     print("Test 1: path.join returns usable string\n")
@@ -94,7 +104,7 @@ main() {
 
     // === FILE SIZE ===
     print("\nTest 8: file.size on non-existent file\n")
-    sz = file.size("/tmp/nonexistent_aether_test_file_xyz")
+    sz = file.size("${tmp}/nonexistent_aether_test_file_xyz")
     if sz == 0 {
         print("  PASS: file.size returns 0 for missing file\n")
     } else {
@@ -104,7 +114,7 @@ main() {
 
     // === FILE EXISTS ===
     print("\nTest 9: file.exists on non-existent file\n")
-    ex = file.exists("/tmp/nonexistent_aether_test_file_xyz")
+    ex = file.exists("${tmp}/nonexistent_aether_test_file_xyz")
     if ex == 0 {
         print("  PASS: file.exists returns 0 for missing file\n")
     } else {
@@ -238,7 +248,7 @@ main() {
 
     // === FILE WRITE / READ ROUND-TRIP ===
     print("\nTest 21: file write + read round-trip\n")
-    test_path = "/tmp/aether_edge_test.txt"
+    test_path = "${tmp}/aether_edge_test.txt"
     f = file.open(test_path, "w")
     file.write(f, "edge case test", 14)
     file.close(f)


### PR DESCRIPTION
### Summary

- **Module resolution**: `aetherc` now searches `lib/` and `src/` relative to the source file's directory, not just CWD — fixes integration tests that use local `lib/` directories
- **Cross-platform paths in stdlib**: `path_join()` uses `/` on all platforms; `path_is_absolute()` recognizes `/` on Windows
- **Cross-platform temp paths in tests**: regression tests use `io.getenv("TEMP")` / `io.getenv("TMPDIR")` with `/tmp` fallback instead of hardcoded `/tmp/`

### Root causes

| Failure group | Tests | Root cause |
|---|---|---|
| Compile errors (5) | `export_visibility`, `pure_module`, `pure_module_mixed`, `pure_module_noexport` | `module_resolve_local_path()` only searched CWD, not the source file's directory |
| Runtime failures (4) | `test_file_io_char_return`, `test_fs_return_values`, `test_io_edge_cases`, `test_stdlib_edge_cases` | Hardcoded `/tmp/` paths + `path_join` using `\` on Windows |

### Files changed

- `compiler/aether_module.c` — added `module_set_source_dir()` + source-relative `lib/`/`src/` search
- `compiler/aether_module.h` — new function declaration
- `compiler/aetherc.c` — call `module_set_source_dir(input_path)` before orchestration
- `std/fs/aether_fs.c` — `path_join` uses `/` universally; `path_is_absolute` recognizes `/` on Windows
- 4 test files — cross-platform temp dir via `TEMP`/`TMPDIR` env vars

### Test plan

- [x] All 13 previously-failing tests now pass on Windows (MinGW64)
- [x] `make ci` passes: 166 C tests, 129 .ae tests, 62 examples, install smoke test
- [x] No behavior change on Linux/macOS (source-dir search is additive, `/` separator already used)

Closes #99
