### PR TITLE
Add callback keyword — third trailing-block mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 the release pipeline automatically replaces `[current]` with the next version
 number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`callback` keyword for trailing blocks**: Third trailing-block mode — `func(args) callback { body }` creates a real closure (hoisted, captures variables from scope) rather than an inline DSL block. The block runs later when invoked, not at construction time. Also supports explicit params (`callback |x: int| { ... }`) and arrow bodies (`callback |x| -> x * 2`).
+
 ## [0.47.0]
 
 ### Added

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -333,6 +333,7 @@ Token* read_identifier() {
     else if (strcmp(buffer, "const") == 0) token = create_token(TOKEN_CONST, buffer, current_line, current_column);
     else if (strcmp(buffer, "in") == 0) token = create_token(TOKEN_IN, buffer, current_line, current_column);
     else if (strcmp(buffer, "after") == 0) token = create_token(TOKEN_AFTER, buffer, current_line, current_column);
+    else if (strcmp(buffer, "callback") == 0) token = create_token(TOKEN_CALLBACK, buffer, current_line, current_column);
     else if (strcmp(buffer, "ptr") == 0) token = create_token(TOKEN_PTR, buffer, current_line, current_column);
     else if (strcmp(buffer, "int") == 0) token = create_token(TOKEN_INT, buffer, current_line, current_column);
     else if (strcmp(buffer, "long") == 0) token = create_token(TOKEN_INT64, buffer, current_line, current_column);
@@ -708,6 +709,7 @@ const char* token_type_to_string(AeTokenType type) {
         case TOKEN_LSHIFT_ASSIGN: return "LSHIFT_ASSIGN";
         case TOKEN_RSHIFT_ASSIGN: return "RSHIFT_ASSIGN";
         case TOKEN_NULL: return "NULL";
+        case TOKEN_CALLBACK: return "CALLBACK";
         case TOKEN_IN: return "IN";
         case TOKEN_DOTDOT: return "DOTDOT";
         case TOKEN_CONST: return "CONST";

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -838,9 +838,31 @@ static ASTNode* parse_postfix_expression(Parser* parser) {
             
             // Check for trailing closure/block after function call
             // func(args) { body }  or  func(args) |x| { body }
+            // func(args) callback { body }  or  func(args) callback |x| { body }
             {
                 Token* next_tok = peek_token(parser);
-                if (next_tok && (next_tok->type == TOKEN_PIPE || next_tok->type == TOKEN_OR)) {
+                if (next_tok && next_tok->type == TOKEN_CALLBACK) {
+                    // Callback trailing block: always a real closure (hoisted, captures vars)
+                    // func(args) callback { body }  — zero-param closure
+                    // func(args) callback |x| { body }  — parameterized closure
+                    advance_token(parser); // consume 'callback'
+                    Token* after_cb = peek_token(parser);
+                    if (after_cb && (after_cb->type == TOKEN_PIPE || after_cb->type == TOKEN_OR)) {
+                        // callback |params| { body }
+                        ASTNode* trailing = parse_closure_expression(parser);
+                        if (trailing) {
+                            add_child(func_call, trailing);
+                        }
+                    } else if (after_cb && after_cb->type == TOKEN_LEFT_BRACE) {
+                        // callback { body } — zero-param closure (NOT a DSL block)
+                        ASTNode* trailing = create_ast_node(AST_CLOSURE, NULL,
+                                                             after_cb->line, after_cb->column);
+                        trailing->node_type = create_type(TYPE_FUNCTION);
+                        ASTNode* body = parse_block(parser);
+                        add_child(trailing, body);
+                        add_child(func_call, trailing);
+                    }
+                } else if (next_tok && (next_tok->type == TOKEN_PIPE || next_tok->type == TOKEN_OR)) {
                     // Trailing closure with params: func(args) |x| { ... }
                     // These are real closures (not DSL blocks) — they get hoisted
                     ASTNode* trailing = parse_closure_expression(parser);

--- a/compiler/parser/tokens.h
+++ b/compiler/parser/tokens.h
@@ -43,6 +43,7 @@ typedef enum {
     TOKEN_CONST,            // 'const' keyword for top-level constants
     TOKEN_IN,               // 'in' keyword for range-based for loops
     TOKEN_AFTER,            // 'after' keyword for receive timeouts
+    TOKEN_CALLBACK,         // 'callback' keyword for callback trailing blocks
 
     // Types
     TOKEN_INT,

--- a/docs/closures-and-builder-dsl.md
+++ b/docs/closures-and-builder-dsl.md
@@ -112,6 +112,38 @@ call(save_handler)    // prints "saved!"
 
 This mirrors Groovy's `actionPerformed: { ... }` pattern.
 
+### Callback blocks
+
+The `callback` keyword before a trailing block creates a real closure (hoisted,
+with variable capture) without requiring explicit parameters. This is the third
+trailing-block mode:
+
+| Mode | Syntax | Semantics |
+|------|--------|-----------|
+| Immediate | `func() { block }` | Runs inline as DSL structure |
+| Closure | `func() \|x\| { block }` | Real closure with explicit params |
+| Callback | `func() callback { block }` | Real closure, captures from scope |
+
+```aether
+counter = ref(0)
+
+btn("increment") callback { ref_set(counter, ref_get(counter) + 1) }
+btn("decrement") callback { ref_set(counter, ref_get(counter) - 1) }
+```
+
+The callbacks capture `counter` from the enclosing scope. No need to thread it
+through as an explicit parameter. At the call site, `call(handler)` is enough.
+
+Callback blocks also support explicit params and arrow bodies:
+
+```aether
+// With params — invoked as call(adder, 3, 4)
+store(action) callback |a: int, b: int| { return a + b }
+
+// Arrow body — shorthand for single-expression callbacks
+store(action) callback |x: int| -> x * 2
+```
+
 ## Higher-Order Functions
 
 Closures enable functional patterns with standard library collections:

--- a/examples/calculator-tui.ae
+++ b/examples/calculator-tui.ae
@@ -77,37 +77,39 @@ main() {
     }
 
     // ---- THE DSL: button layout with callbacks right here ----
+    // callback { } creates a real closure that captures from scope
+    // — no need to thread num/prev/op as explicit params
     g = grid() {
-        btn("7") |n: ptr, p: ptr, o: ptr| { call(digit, n, 7) }
-        btn("8") |n: ptr, p: ptr, o: ptr| { call(digit, n, 8) }
-        btn("9") |n: ptr, p: ptr, o: ptr| { call(digit, n, 9) }
-        btn("+") |n: ptr, p: ptr, o: ptr| { call(set_op, n, p, o, PLUS) }
+        btn("7") callback { call(digit, num, 7) }
+        btn("8") callback { call(digit, num, 8) }
+        btn("9") callback { call(digit, num, 9) }
+        btn("+") callback { call(set_op, num, prev, op, PLUS) }
 
-        btn("4") |n: ptr, p: ptr, o: ptr| { call(digit, n, 4) }
-        btn("5") |n: ptr, p: ptr, o: ptr| { call(digit, n, 5) }
-        btn("6") |n: ptr, p: ptr, o: ptr| { call(digit, n, 6) }
-        btn("-") |n: ptr, p: ptr, o: ptr| { call(set_op, n, p, o, MINUS) }
+        btn("4") callback { call(digit, num, 4) }
+        btn("5") callback { call(digit, num, 5) }
+        btn("6") callback { call(digit, num, 6) }
+        btn("-") callback { call(set_op, num, prev, op, MINUS) }
 
-        btn("1") |n: ptr, p: ptr, o: ptr| { call(digit, n, 1) }
-        btn("2") |n: ptr, p: ptr, o: ptr| { call(digit, n, 2) }
-        btn("3") |n: ptr, p: ptr, o: ptr| { call(digit, n, 3) }
-        btn("*") |n: ptr, p: ptr, o: ptr| { call(set_op, n, p, o, STAR) }
+        btn("1") callback { call(digit, num, 1) }
+        btn("2") callback { call(digit, num, 2) }
+        btn("3") callback { call(digit, num, 3) }
+        btn("*") callback { call(set_op, num, prev, op, STAR) }
 
-        btn("0") |n: ptr, p: ptr, o: ptr| { call(digit, n, 0) }
-        btn(".") |n: ptr, p: ptr, o: ptr| { }
-        btn("=") |n: ptr, p: ptr, o: ptr| {
-            v = ref_get(n)
-            pv = ref_get(p)
-            ov = ref_get(o)
+        btn("0") callback { call(digit, num, 0) }
+        btn(".") callback { }
+        btn("=") callback {
+            v = ref_get(num)
+            pv = ref_get(prev)
+            ov = ref_get(op)
             if ov == PLUS  { v = pv + v }
             if ov == MINUS { v = pv - v }
             if ov == STAR  { v = pv * v }
             if ov == SLASH && v != 0 { v = pv / v }
-            ref_set(n, v)
-            ref_set(p, 0)
-            ref_set(o, 0)
+            ref_set(num, v)
+            ref_set(prev, 0)
+            ref_set(op, 0)
         }
-        btn("/") |n: ptr, p: ptr, o: ptr| { call(set_op, n, p, o, SLASH) }
+        btn("/") callback { call(set_op, num, prev, op, SLASH) }
     }
     defer list.free(g)
 
@@ -134,7 +136,7 @@ main() {
         if key == SPACE || key == ENTER {
             boxed = list.get(list.get(g, 1), cur)
             handler = unbox_closure(boxed)
-            call(handler, num, prev, op)
+            call(handler)
         }
 
         // Also support direct key input (digits/operators)

--- a/tests/syntax/test_callback_edges.ae
+++ b/tests/syntax/test_callback_edges.ae
@@ -1,0 +1,84 @@
+// Test: callback keyword — edge cases
+// Covers: params, empty body, string capture, loops, nesting, arrow body, defer
+
+import std.list
+
+// Helper: store a callback, return it
+store_fn(action: fn) { return action }
+
+// Builder that takes a callback
+on_event(_ctx: ptr, handler: fn) {
+    list.add(_ctx, box_closure(handler))
+}
+
+make_list() { return list.new() }
+
+main() {
+    // --- 1. callback with explicit params ---
+    adder = store_fn() callback |a: int, b: int| {
+        return a + b
+    }
+    println(call(adder, 3, 4))
+
+    // --- 2. callback with arrow body ---
+    doubler = store_fn() callback |x: int| -> x * 2
+    println(call(doubler, 6))
+
+    // --- 3. empty callback body ---
+    noop = store_fn() callback { }
+    call(noop)
+    println("noop ok")
+
+    // --- 4. callback capturing a string ---
+    greeting = "hello"
+    greeter = store_fn() callback {
+        println(greeting)
+    }
+    call(greeter)
+
+    // --- 5. multiple callbacks sharing one captured variable ---
+    val = ref(100)
+    defer ref_free(val)
+    inc = store_fn() callback { ref_set(val, ref_get(val) + 1) }
+    dec = store_fn() callback { ref_set(val, ref_get(val) - 1) }
+    call(inc)
+    call(inc)
+    call(dec)
+    println(ref_get(val))
+
+    // --- 6. callbacks created inside a loop ---
+    fns = list.new()
+    defer list.free(fns)
+    for (i = 1; i <= 3; i++) {
+        captured = i  // snapshot
+        list.add(fns, box_closure(store_fn() callback |x: int| -> x + captured))
+    }
+    f0 = unbox_closure(list.get(fns, 0))
+    f1 = unbox_closure(list.get(fns, 1))
+    f2 = unbox_closure(list.get(fns, 2))
+    println(call(f0, 10))
+    println(call(f1, 10))
+    println(call(f2, 10))
+
+    // --- 7. callback nested inside a DSL trailing block ---
+    events = make_list() {
+        on_event() callback { println("event A") }
+        on_event() callback { println("event B") }
+    }
+    defer list.free(events)
+    ea = unbox_closure(list.get(events, 0))
+    eb = unbox_closure(list.get(events, 1))
+    call(ea)
+    call(eb)
+
+    // --- 8. callback mutating captured state ---
+    counter = ref(0)
+    defer ref_free(counter)
+    with_cleanup = store_fn() callback {
+        ref_set(counter, 42)
+    }
+    call(with_cleanup)
+    println(ref_get(counter))
+
+    println("edges ok")
+}

--- a/tests/syntax/test_callback_keyword.ae
+++ b/tests/syntax/test_callback_keyword.ae
@@ -1,0 +1,54 @@
+// Test: callback keyword for trailing closure blocks
+// callback { } creates a real closure (hoisted, captures) — not a DSL block.
+// This is the third trailing-block mode: block-now, function-later.
+
+import std.list
+
+// A builder func that accepts a callback (fn parameter)
+register(_ctx: ptr, name: string, handler: fn) {
+    list.add(list.get(_ctx, 0), name)
+    list.add(list.get(_ctx, 1), box_closure(handler))
+}
+
+make_registry() {
+    r = list.new()
+    list.add(r, list.new())  // names
+    list.add(r, list.new())  // handlers
+    return r
+}
+
+main() {
+    counter = ref(0)
+    defer ref_free(counter)
+
+    // Build registry — callback blocks capture `counter` from scope
+    reg = make_registry() {
+        register("inc") callback { ref_set(counter, ref_get(counter) + 1) }
+        register("dec") callback { ref_set(counter, ref_get(counter) - 1) }
+        register("add10") callback { ref_set(counter, ref_get(counter) + 10) }
+    }
+    defer list.free(reg)
+
+    // Nothing has fired yet
+    println(ref_get(counter))
+
+    // Invoke callbacks — they captured `counter` at registration time
+    handlers = list.get(reg, 1)
+    h0 = unbox_closure(list.get(handlers, 0))
+    call(h0)
+    println(ref_get(counter))
+
+    call(h0)
+    call(h0)
+    println(ref_get(counter))
+
+    h1 = unbox_closure(list.get(handlers, 1))
+    call(h1)
+    println(ref_get(counter))
+
+    h2 = unbox_closure(list.get(handlers, 2))
+    call(h2)
+    println(ref_get(counter))
+
+    println("callback ok")
+}


### PR DESCRIPTION
callback { } creates a real closure (hoisted, captures variables) rather than an inline DSL block. This enables cleaner event handler syntax where the block runs later, not at construction time.

Updated calculator-tui.ae to use callback syntax for button handlers. Added edge case tests covering params, arrow bodies, string capture, loop capture, nesting inside DSL blocks, and shared mutable state.