### PR TITLE
Fix variable scoping across while blocks and parameter reassignment in loops

### DIFF
--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -309,6 +309,18 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
     indent(gen);
     clear_declared_vars(gen);  // Reset for each function
     clear_heap_string_vars(gen);
+
+    // Mark function parameters as declared so they aren't re-declared
+    // (e.g., by hoist_loop_vars when a parameter is reassigned in a loop)
+    for (int i = 0; i < func->child_count; i++) {
+        ASTNode* child = func->children[i];
+        if (!child) continue;
+        if ((child->type == AST_PATTERN_VARIABLE || child->type == AST_VARIABLE_DECLARATION)
+            && child->value) {
+            mark_var_declared(gen, child->value);
+        }
+    }
+
     // Reset defer state for new function and enter function scope
     gen->defer_count = 0;
     gen->scope_depth = 0;

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -410,6 +410,39 @@ static int is_heap_string_expr(ASTNode* expr) {
     return 0;
 }
 
+// Pre-declare variables from a while/for loop body so they're visible
+// at function scope in the generated C. Without this, variables first
+// assigned inside a while block are C-block-scoped and invisible to
+// subsequent while blocks in the same function.
+static void hoist_loop_vars(CodeGenerator* gen, ASTNode* body) {
+    if (!body) return;
+    for (int i = 0; i < body->child_count; i++) {
+        ASTNode* child = body->children[i];
+        if (!child) continue;
+        if (child->type == AST_VARIABLE_DECLARATION && child->value) {
+            if (!is_var_declared(gen, child->value)) {
+                mark_var_declared(gen, child->value);
+                // Determine type
+                Type* var_type = child->node_type;
+                if ((!var_type || var_type->kind == TYPE_VOID || var_type->kind == TYPE_UNKNOWN)
+                    && child->child_count > 0 && child->children[0] && child->children[0]->node_type) {
+                    var_type = child->children[0]->node_type;
+                }
+                const char* c_type = get_c_type(var_type);
+                print_indent(gen);
+                fprintf(gen->output, "%s %s;\n", c_type, child->value);
+            }
+        }
+        // Recurse into nested blocks (e.g., if inside while)
+        if (child->type == AST_IF_STATEMENT || child->type == AST_WHILE_LOOP ||
+            child->type == AST_FOR_LOOP) {
+            for (int j = 0; j < child->child_count; j++) {
+                hoist_loop_vars(gen, child->children[j]);
+            }
+        }
+    }
+}
+
 void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
     if (!stmt) return;
 
@@ -977,6 +1010,12 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             if (has_sends && gen->current_actor == NULL) {
                 print_line(gen, "scheduler_send_batch_start();");
                 gen->in_main_loop = 1;
+            }
+
+            // Hoist variable declarations from loop body to function scope
+            // so they're visible to subsequent while blocks
+            if (stmt->child_count > 1) {
+                hoist_loop_vars(gen, stmt->children[1]);
             }
 
             fprintf(gen->output, "while (");

--- a/tests/regression/test_string_replace_in_function.ae
+++ b/tests/regression/test_string_replace_in_function.ae
@@ -1,0 +1,41 @@
+// Regression test: reassigning a function parameter in a loop causes OOM
+//
+// This test SHOULD pass but will OOM-kill the process (signal 9) due to
+// a bug where reassigning a function parameter doesn't update the loop
+// condition's view of the variable. The loop runs forever.
+//
+// If this test completes and prints PASS, the bug is fixed.
+// If it gets killed (signal 9/11), the bug is confirmed.
+
+extern string_concat(a: string, b: string) -> string
+extern string_length(s: string) -> int
+extern string_contains(s: string, sub: string) -> int
+extern string_index_of(s: string, sub: string) -> int
+extern string_substring(s: string, start: int, end: int) -> string
+
+// This function reassigns parameter `s` in the loop — triggers the bug
+_replace_all(s: string, from: string, to: string) {
+    result = ""
+    from_len = string_length(from)
+    while string_contains(s, from) == 1 {
+        idx = string_index_of(s, from)
+        prefix = string_substring(s, 0, idx)
+        result = string_concat(result, prefix)
+        result = string_concat(result, to)
+        s = string_substring(s, idx + from_len, string_length(s))
+    }
+    result = string_concat(result, s)
+    return result
+}
+
+main() {
+    println("=== Parameter reassignment in loop ===")
+    // This call will OOM if the bug is present
+    result = _replace_all("a/b/c", "/", "_")
+    if result == "a_b_c" {
+        println("PASS: parameter reassignment works")
+    } else {
+        println("FAIL: got ${result}")
+    }
+    println("=== ALL DONE ===")
+}

--- a/tests/regression/test_variable_scope_across_loops.ae
+++ b/tests/regression/test_variable_scope_across_loops.ae
@@ -1,0 +1,64 @@
+// Regression test: variables declared inside a while block are not visible
+// in subsequent while blocks within the same function.
+//
+// When this code is in a function (not main), it FAILS to compile with:
+//   error: 'item' undeclared (first use in this function)
+//
+// Workaround: pre-declare variables before the first while loop.
+
+extern string_concat(a: string, b: string) -> string
+extern string_length(s: string) -> int
+
+process_two_lists(a: string, b: string) {
+    result = ""
+
+    // First "loop" — declares `item`
+    item = "first"
+    result = string_concat(result, a)
+    result = string_concat(result, " ")
+
+    // Reset and reuse — in a function this can fail if `item` scope is limited
+    item = "second"
+    result = string_concat(result, b)
+
+    return result
+}
+
+// The actual failing case: two while loops in a function
+concat_lists(items1: string, items2: string) {
+    result = ""
+    count = 2
+
+    // First loop
+    i = 0
+    while i < 1 {
+        part = items1
+        result = string_concat(result, part)
+        result = string_concat(result, " ")
+        i = i + 1
+    }
+
+    // Second loop — `part` was declared in first loop
+    // BUG: in a function, `part` is undeclared here
+    i = 0
+    while i < 1 {
+        part = items2
+        result = string_concat(result, part)
+        i = i + 1
+    }
+
+    return result
+}
+
+main() {
+    println("=== Variable scope across loops ===")
+
+    result = concat_lists("hello", "world")
+    if result == "hello world" {
+        println("PASS: variable visible across while blocks in function")
+    } else {
+        println("FAIL: got: ${result}")
+    }
+
+    println("=== ALL DONE ===")
+}


### PR DESCRIPTION
Two related codegen bugs where variables inside while loop bodies were incorrectly scoped in the generated C:

1. Variables declared in one while block were invisible to subsequent while blocks in the same function, because the C declaration was inside the while() { } braces (C block scope). Fix: hoist_loop_vars() pre-scans while bodies and emits forward declarations before the while keyword.

2. Function parameters weren't tracked in declared_vars, so hoist_loop_vars could try to redeclare them, causing "redeclared as different kind of symbol" errors. Fix: mark all function parameters as declared after clear_declared_vars().

The parameter fix also resolves OOM/segfault when reassigning a function parameter inside a while loop — the reassignment was treated as a new declaration instead of an assignment to the existing variable.