### PR TITLE
Add fs stdlib bundle (mkdir_p, symlink ops, unlink) and os_which

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ next version number before tagging the release.
 ### Added
 
 - **`hide` and `seal except` scope directives** — declare at the top of any block that one or more identifiers from outer scopes are unreachable from this block (and every nested block within it). `hide name1, name2` blocks specific outer bindings. `seal except name1, name2` is the inverse — blocks ALL outer bindings except the listed whitelist. Both directives are scope-level (position within the block doesn't matter), apply to reads and writes, propagate to all nested blocks, and don't reach through call boundaries (a visible function defined in an outer scope can still use the names via its own lexical chain). Forbids redeclaring a hidden name in the same scope. New error code `E0304` ("`X` is hidden in this scope by `hide` or `seal except`"). See `docs/hide-and-seal.md` for the full design rationale and edge cases. Tests: `tests/syntax/test_hide_basic.ae`, `tests/syntax/test_seal_except.ae`, `tests/integration/hide_seal_directives/test_hide_reject.sh`.
+- **Filesystem stdlib bundle in `std.fs`**: five small POSIX wrappers that let Aether programs stop shelling out for routine filesystem operations, each following the 0.55.0 `_raw` + Go-style wrapper convention:
+  - `fs_mkdir_p_raw(path)` / `err = fs.mkdir_p(path)` — `mkdir -p` semantics: creates the path and any missing parent directories, treats already-existing directories as success.
+  - `fs_symlink_raw(target, link_path)` / `err = fs.symlink(target, link_path)` — create a symbolic link. The target string is recorded verbatim, so relative targets stay relative.
+  - `fs_readlink_raw(path)` / `target, err = fs.readlink(path)` — read a symlink's target. Returns `("", "not a symlink")` when `path` isn't a symlink.
+  - `fs_is_symlink(path)` — pure boolean query: returns 1 if `path` is itself a symlink, 0 otherwise. Does NOT follow the link. No Go-style wrapper (matches `file_exists` / `dir_exists` shape).
+  - `fs_unlink_raw(path)` / `err = fs.unlink(path)` — remove a file or symlink. Refuses to remove directories (use `dir.delete` for that).
+  Windows symlink ops (`fs_symlink_raw` / `fs_readlink_raw` / `fs_is_symlink`) are stubbed pending `CreateSymbolicLinkW` + a junction fallback for directories; `fs_mkdir_p_raw` and `fs_unlink_raw` work on Windows via `_mkdir` / `_unlink`. Tests: `tests/syntax/test_fs_stdlib_bundle.ae` (14 sub-cases including nested-dir creation, idempotent `mkdir_p`, symlink/readlink/is_symlink round-trip, refuse-to-unlink-a-directory, refuse-to-unlink-missing-path).
+
+- **`os_which` in `std.os`**: search `$PATH` for an executable. Returns the absolute path to the first hit, or `""` if not found. Kept as a plain extern (not `_raw` + wrapper) because "not found" is a valid answer, not a failure — matches how `file_exists` / `dir_exists` are modelled. If `name` already contains `/`, it's returned as-is when it's executable (matches POSIX `command -v`). Empty `PATH` entries match the current directory (POSIX). Windows is stubbed pending PATHEXT-aware lookup. Tests: `tests/syntax/test_os_which.ae` (5 sub-cases).
 
 ### Fixed
 

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -16,6 +16,11 @@ int file_mtime(const char* p) { (void)p; return 0; }
 int dir_exists(const char* p) { (void)p; return 0; }
 int dir_create_raw(const char* p) { (void)p; return 0; }
 int dir_delete_raw(const char* p) { (void)p; return 0; }
+int fs_mkdir_p_raw(const char* p) { (void)p; return 0; }
+int fs_symlink_raw(const char* t, const char* l) { (void)t; (void)l; return 0; }
+char* fs_readlink_raw(const char* p) { (void)p; return NULL; }
+int fs_is_symlink(const char* p) { (void)p; return 0; }
+int fs_unlink_raw(const char* p) { (void)p; return 0; }
 char* path_join(const char* a, const char* b) { (void)a; (void)b; return NULL; }
 char* path_dirname(const char* p) { (void)p; return NULL; }
 char* path_basename(const char* p) { (void)p; return NULL; }
@@ -32,10 +37,15 @@ DirList* fs_glob_multi_raw(void* l) { (void)l; return NULL; }
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <sys/stat.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #ifdef _WIN32
     #include <direct.h>
+    #include <io.h>            // _unlink (for fs_unlink_raw on Windows)
     #include <windows.h>
     #define mkdir(path, mode) _mkdir(path)
     #define rmdir _rmdir
@@ -154,6 +164,101 @@ int dir_delete_raw(const char* path) {
     if (!path) return 0;
     return rmdir(path) == 0 ? 1 : 0;
 }
+
+// `mkdir -p` semantics: walk through each '/' in `path`, creating each
+// intermediate directory if it doesn't already exist. Treats EEXIST as
+// success at every step. Returns 1 on success, 0 on failure (e.g. path
+// too long, or one of the components exists but isn't a directory).
+int fs_mkdir_p_raw(const char* path) {
+    if (!path || !*path) return 0;
+    if (!aether_sandbox_check("fs_write", path)) return 0;
+
+    char buf[4096];
+    size_t len = strlen(path);
+    if (len >= sizeof(buf)) return 0;
+    memcpy(buf, path, len + 1);
+
+    // Step through each '/' in the interior of the path, creating each
+    // prefix as we go. Skip a leading slash so we don't try to mkdir("").
+    for (size_t i = 1; i < len; i++) {
+        if (buf[i] == '/') {
+            buf[i] = '\0';
+            if (mkdir(buf, 0755) != 0) {
+                // Tolerate already-exists. Anything else is a real failure.
+                if (errno != EEXIST) return 0;
+                struct stat st;
+                if (stat(buf, &st) != 0 || !S_ISDIR(st.st_mode)) return 0;
+            }
+            buf[i] = '/';
+        }
+    }
+    // Final component (if not already covered by a trailing slash)
+    if (mkdir(buf, 0755) != 0) {
+        if (errno != EEXIST) return 0;
+        struct stat st;
+        if (stat(buf, &st) != 0 || !S_ISDIR(st.st_mode)) return 0;
+    }
+    return 1;
+}
+
+#ifndef _WIN32
+
+// Create a symbolic link at `link_path` pointing to `target`. The target
+// is recorded verbatim — relative targets stay relative.
+int fs_symlink_raw(const char* target, const char* link_path) {
+    if (!target || !link_path) return 0;
+    if (!aether_sandbox_check("fs_write", link_path)) return 0;
+    return symlink(target, link_path) == 0 ? 1 : 0;
+}
+
+// Read a symbolic link. Returns the target as a heap-allocated string,
+// or NULL if `path` isn't a symlink or can't be read.
+char* fs_readlink_raw(const char* path) {
+    if (!path) return NULL;
+    if (!aether_sandbox_check("fs_read", path)) return NULL;
+
+    char buf[4096];
+    ssize_t n = readlink(path, buf, sizeof(buf) - 1);
+    if (n < 0) return NULL;
+    buf[n] = '\0';
+    return strdup(buf);
+}
+
+// Returns 1 if `path` is a symlink (does NOT follow the link to check
+// the target). Returns 0 otherwise — including when the path doesn't
+// exist.
+int fs_is_symlink(const char* path) {
+    if (!path) return 0;
+    if (!aether_sandbox_check("fs_read", path)) return 0;
+
+    struct stat st;
+    if (lstat(path, &st) != 0) return 0;
+    return S_ISLNK(st.st_mode) ? 1 : 0;
+}
+
+// Remove a file or symlink. Will NOT remove a directory — use dir_delete
+// for that. Returns 1 on success, 0 on failure.
+int fs_unlink_raw(const char* path) {
+    if (!path) return 0;
+    if (!aether_sandbox_check("fs_write", path)) return 0;
+    return unlink(path) == 0 ? 1 : 0;
+}
+
+#else // _WIN32
+
+// Windows symlinks need elevation or developer mode and use a different
+// API surface. For now these are stubs returning failure; a follow-up
+// PR can add CreateSymbolicLinkW + a junction fallback for directories.
+int fs_symlink_raw(const char* t, const char* l) { (void)t; (void)l; return 0; }
+char* fs_readlink_raw(const char* p) { (void)p; return NULL; }
+int fs_is_symlink(const char* p) { (void)p; return 0; }
+int fs_unlink_raw(const char* path) {
+    if (!path) return 0;
+    if (!aether_sandbox_check("fs_write", path)) return 0;
+    return _unlink(path) == 0 ? 1 : 0;
+}
+
+#endif // !_WIN32
 
 // Path operations
 char* path_join(const char* path1, const char* path2) {

--- a/std/fs/aether_fs.h
+++ b/std/fs/aether_fs.h
@@ -24,6 +24,37 @@ int dir_exists(const char* path);
 int dir_create_raw(const char* path);
 int dir_delete_raw(const char* path);
 
+// `mkdir -p` semantics: create `path` and any missing parent directories.
+// Treats already-existing directories as success. Returns 1 on success,
+// 0 on failure. Raw extern — use the `mkdir_p` Go-style wrapper in
+// std/fs/module.ae from most code.
+int fs_mkdir_p_raw(const char* path);
+
+// Symbolic-link operations. The *_raw functions are the low-level
+// externs; idiomatic callers use the Go-style `symlink` / `readlink` /
+// `unlink` wrappers in std/fs/module.ae which return `(value, err)`.
+//
+// fs_symlink_raw: create a symlink at `link_path` pointing to `target`.
+//                 Returns 1 on success, 0 on failure (e.g. link already
+//                 exists). `target` is recorded verbatim — NOT resolved
+//                 at create time, so a relative target stays relative.
+//
+// fs_readlink_raw: read a symlink. Returns a heap-allocated string
+//                  containing the link target, or NULL if `path` is not
+//                  a symlink (or cannot be read). Caller frees.
+//
+// fs_is_symlink: returns 1 if `path` is itself a symlink (does not
+//                follow), 0 otherwise. Pure boolean query — no wrapper
+//                needed, matches file_exists / dir_exists shape.
+//
+// fs_unlink_raw: remove a file or symlink. Will NOT remove a directory
+//                — use dir_delete_raw for that. Returns 1 on success,
+//                0 on failure.
+int   fs_symlink_raw(const char* target, const char* link_path);
+char* fs_readlink_raw(const char* path);
+int   fs_is_symlink(const char* path);
+int   fs_unlink_raw(const char* path);
+
 // Path operations
 char* path_join(const char* path1, const char* path2);
 char* path_dirname(const char* path);

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -29,6 +29,24 @@ extern dir_exists(path: string) -> int
 extern dir_create_raw(path: string) -> int
 extern dir_delete_raw(path: string) -> int
 extern dir_list_raw(path: string) -> ptr
+
+// `mkdir -p` semantics: create `path` and any missing parent directories.
+// Treats already-existing directories as success. Raw extern — use the
+// `mkdir_p` wrapper below in most code.
+extern fs_mkdir_p_raw(path: string) -> int
+
+// Symbolic-link operations (raw externs).
+//   fs_symlink_raw   — create a symlink at `link_path` pointing to `target`.
+//                      `target` is recorded verbatim (relative stays relative).
+//   fs_readlink_raw  — read a symlink's target. Returns null if not a symlink.
+//   fs_is_symlink    — does NOT follow; returns 1 only for the link itself.
+//                      Pure boolean query, no wrapper (matches file_exists).
+//   fs_unlink_raw    — remove a file or symlink (NOT a directory).
+extern fs_symlink_raw(target: string, link_path: string) -> int
+extern fs_readlink_raw(path: string) -> string
+extern fs_is_symlink(path: string) -> int
+extern fs_unlink_raw(path: string) -> int
+
 extern dir_list_count(list: ptr) -> int
 extern dir_list_get(list: ptr, index: int) -> string
 extern dir_list_free(list: ptr)
@@ -125,6 +143,49 @@ delete_dir(path: string) -> {
     ok = dir_delete_raw(path)
     if ok == 0 {
         return "cannot delete directory"
+    }
+    return ""
+}
+
+// `mkdir -p`: create `path` and any missing parent directories. Treats
+// already-existing directories as success. Returns "" on success, error
+// on failure.
+mkdir_p(path: string) -> {
+    ok = fs_mkdir_p_raw(path)
+    if ok == 0 {
+        return "cannot mkdir -p"
+    }
+    return ""
+}
+
+// Create a symbolic link at `link_path` pointing to `target`. The target
+// is recorded verbatim — relative targets stay relative. Returns "" on
+// success, error on failure (e.g. `link_path` already exists).
+symlink(target: string, link_path: string) -> {
+    ok = fs_symlink_raw(target, link_path)
+    if ok == 0 {
+        return "cannot create symlink"
+    }
+    return ""
+}
+
+// Read a symbolic link. Returns (target, "") on success,
+// ("", error) if `path` is not a symlink or can't be read.
+readlink(path: string) -> {
+    target = fs_readlink_raw(path)
+    if target == null {
+        return "", "not a symlink"
+    }
+    target_copy = string_concat(target, "")
+    return target_copy, ""
+}
+
+// Remove a file or symlink. Refuses to remove a directory — use
+// `delete_dir` for that. Returns "" on success, error on failure.
+unlink(path: string) -> {
+    ok = fs_unlink_raw(path)
+    if ok == 0 {
+        return "cannot unlink"
     }
     return ""
 }

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -15,6 +15,7 @@ int os_system(const char* c) { (void)c; return -1; }
 char* os_exec_raw(const char* c) { (void)c; return NULL; }
 char* os_getenv(const char* n) { (void)n; return NULL; }
 int os_execv(const char* p, void* a) { (void)p; (void)a; return -1; }
+char* os_which(const char* n) { (void)n; return NULL; }
 #else
 
 #include <stdio.h>
@@ -162,6 +163,63 @@ int os_execv(const char* prog, void* argv_list) {
     execvp(prog, argv);
     free(argv);
     return -1;
+#endif
+}
+
+// Search PATH for an executable. POSIX semantics:
+//   1. If `name` contains a '/', it's treated as a path (absolute or
+//      relative to cwd). Return it as-is if executable, else NULL.
+//   2. Otherwise iterate through colon-separated entries in $PATH (or a
+//      sensible default if PATH isn't set), looking for `<dir>/<name>`
+//      that's executable. Return the first hit.
+//
+// Caller owns the returned string.
+char* os_which(const char* name) {
+    if (!name || !*name) return NULL;
+    if (!aether_sandbox_check("env", "PATH")) return NULL;
+
+#ifdef _WIN32
+    // Windows uses ';' as PATH separator and PATHEXT to choose extensions.
+    // Stub for now; a follow-up can implement the full Windows lookup.
+    (void)name;
+    return NULL;
+#else
+    if (strchr(name, '/')) {
+        if (access(name, X_OK) == 0) return strdup(name);
+        return NULL;
+    }
+
+    const char* path = getenv("PATH");
+    if (!path || !*path) path = "/usr/local/bin:/usr/bin:/bin";
+
+    size_t name_len = strlen(name);
+    char buf[4096];
+    const char* p = path;
+    while (*p) {
+        const char* end = strchr(p, ':');
+        size_t dirlen = end ? (size_t)(end - p) : strlen(p);
+        // Empty entry means current directory (POSIX).
+        if (dirlen == 0) {
+            // Guard: we write "./" (2 bytes) plus name_len+1 bytes
+            // (including null terminator) starting at buf+2. The last
+            // written byte is at index (2 + name_len), which must be
+            // strictly less than sizeof(buf) for validity.
+            if (2 + name_len < sizeof(buf)) {
+                buf[0] = '.';
+                buf[1] = '/';
+                memcpy(buf + 2, name, name_len + 1);
+                if (access(buf, X_OK) == 0) return strdup(buf);
+            }
+        } else if (dirlen + 1 + name_len < sizeof(buf)) {
+            memcpy(buf, p, dirlen);
+            buf[dirlen] = '/';
+            memcpy(buf + dirlen + 1, name, name_len + 1);
+            if (access(buf, X_OK) == 0) return strdup(buf);
+        }
+        if (!end) break;
+        p = end + 1;
+    }
+    return NULL;
 #endif
 }
 

--- a/std/os/aether_os.h
+++ b/std/os/aether_os.h
@@ -20,4 +20,11 @@ char* os_getenv(const char* name);
 // Not available on Windows (returns -1).
 int os_execv(const char* prog, void* argv_list);
 
+// Search PATH for an executable named `name`. Returns the absolute
+// path to the first executable hit, or NULL if not found. If `name`
+// already contains '/', it's returned as-is when it's executable
+// (matches POSIX `command -v` semantics for absolute/relative paths).
+// Caller owns the returned string.
+char* os_which(const char* name);
+
 #endif

--- a/std/os/module.ae
+++ b/std/os/module.ae
@@ -11,6 +11,11 @@ extern os_exec_raw(cmd: string) -> string
 // Get environment variable, returns string or NULL if not set
 extern os_getenv(name: string) -> string
 
+// Search PATH for an executable. Returns the absolute path to the
+// first hit, or "" if not found. If `name` already contains '/', it's
+// returned as-is when it's executable.
+extern os_which(name: string) -> string
+
 // Command-line arguments
 extern aether_args_count() -> int
 extern aether_args_get(index: int) -> string

--- a/tests/syntax/test_fs_stdlib_bundle.ae
+++ b/tests/syntax/test_fs_stdlib_bundle.ae
@@ -1,0 +1,137 @@
+// Test: filesystem stdlib bundle — fs_mkdir_p, fs_symlink, fs_readlink,
+// fs_is_symlink, fs_unlink. Builds a small fixture tree at runtime under
+// build/test_fs_bundle/ and exercises each function, then cleans up.
+//
+// Windows note: fs_symlink_raw / fs_readlink_raw / fs_is_symlink are
+// stubbed on Windows pending CreateSymbolicLinkW + junction fallback.
+// The test detects Windows via $OS and skips the symlink sub-cases
+// there, still exercising mkdir_p and unlink which DO work on Windows
+// via _mkdir / _unlink.
+
+import std.fs
+import std.os
+
+extern println(s: string)
+extern string_concat(a: string, b: string) -> string
+extern os_system(cmd: string) -> int
+extern exit(code: int)
+
+fail(msg: string) {
+    println(string_concat("FAIL: ", msg))
+    exit(1)
+}
+
+main() {
+    // Detect Windows — the stdlib stubs symlink ops there.
+    os_name = os_getenv("OS")
+    is_windows = 0
+    if os_name == "Windows_NT" {
+        is_windows = 1
+    }
+
+    // Clean slate (MSYS2 on Windows provides rm)
+    os_system("rm -rf build/test_fs_bundle")
+
+    // 1. fs_mkdir_p — nested directories created in one call
+    if fs_mkdir_p_raw("build/test_fs_bundle/a/b/c") != 1 {
+        fail("fs_mkdir_p should create nested dirs")
+    }
+    if dir_exists("build/test_fs_bundle/a/b/c") != 1 {
+        fail("nested dir not actually created")
+    }
+
+    // 2. fs_mkdir_p — idempotent: re-creating an existing tree succeeds
+    if fs_mkdir_p_raw("build/test_fs_bundle/a/b/c") != 1 {
+        fail("fs_mkdir_p should be idempotent")
+    }
+
+    // 3. fs_mkdir_p — also works for a single new dir
+    if fs_mkdir_p_raw("build/test_fs_bundle/single") != 1 {
+        fail("fs_mkdir_p should create a single dir")
+    }
+    if dir_exists("build/test_fs_bundle/single") != 1 {
+        fail("single dir not created")
+    }
+
+    // Create a real file we'll later unlink (and symlink to, on POSIX)
+    os_system("echo target-content > build/test_fs_bundle/a/target.txt")
+
+    if is_windows == 0 {
+        // ---- POSIX-only symlink sub-cases (4 through 11) ----
+
+        // 5. fs_symlink — create a symlink pointing at the file
+        if fs_symlink_raw("../a/target.txt", "build/test_fs_bundle/single/link.txt") != 1 {
+            fail("fs_symlink should succeed")
+        }
+
+        // 6. fs_is_symlink — the link is itself a symlink
+        if fs_is_symlink("build/test_fs_bundle/single/link.txt") != 1 {
+            fail("fs_is_symlink should return 1 for a real symlink")
+        }
+
+        // 7. fs_is_symlink — the target file is NOT a symlink
+        if fs_is_symlink("build/test_fs_bundle/a/target.txt") != 0 {
+            fail("fs_is_symlink should return 0 for a regular file")
+        }
+
+        // 8. fs_is_symlink — non-existent path is also 0
+        if fs_is_symlink("build/test_fs_bundle/does/not/exist") != 0 {
+            fail("fs_is_symlink should return 0 for a missing path")
+        }
+
+        // 9. fs_readlink — round-trip the target string we passed to fs_symlink
+        target = fs_readlink_raw("build/test_fs_bundle/single/link.txt")
+        if target != "../a/target.txt" {
+            fail("fs_readlink target mismatch")
+        }
+
+        // 10. fs_readlink on a non-symlink returns "" (NULL → empty string)
+        not_a_link = fs_readlink_raw("build/test_fs_bundle/a/target.txt")
+        if not_a_link != "" {
+            if not_a_link != null {
+                fail("fs_readlink on a regular file should return empty/null")
+            }
+        }
+
+        // 11. fs_unlink — remove the symlink (target file should still exist)
+        if fs_unlink_raw("build/test_fs_bundle/single/link.txt") != 1 {
+            fail("fs_unlink should remove the symlink")
+        }
+        if fs_is_symlink("build/test_fs_bundle/single/link.txt") != 0 {
+            fail("symlink should be gone after fs_unlink")
+        }
+        if file_exists("build/test_fs_bundle/a/target.txt") != 1 {
+            fail("fs_unlink on the symlink should NOT have removed the target")
+        }
+    } else {
+        println("SKIP: symlink sub-cases (Windows — fs_symlink/readlink/is_symlink stubbed)")
+    }
+
+    // ---- Non-symlink sub-cases (12 through 14) — run on all platforms ----
+
+    // 12. fs_unlink — remove a regular file
+    if fs_unlink_raw("build/test_fs_bundle/a/target.txt") != 1 {
+        fail("fs_unlink should remove a regular file")
+    }
+    if file_exists("build/test_fs_bundle/a/target.txt") != 0 {
+        fail("file should be gone after fs_unlink")
+    }
+
+    // 13. fs_unlink — refusing to remove a directory returns 0
+    if fs_unlink_raw("build/test_fs_bundle/a") != 0 {
+        fail("fs_unlink should refuse to remove a directory")
+    }
+    if dir_exists("build/test_fs_bundle/a") != 1 {
+        fail("directory should still exist after fs_unlink refused")
+    }
+
+    // 14. fs_unlink — non-existent path returns 0
+    if fs_unlink_raw("build/test_fs_bundle/never/existed") != 0 {
+        fail("fs_unlink on missing path should return 0")
+    }
+
+    // Cleanup
+    os_system("rm -rf build/test_fs_bundle")
+
+    println("PASS fs stdlib bundle")
+}

--- a/tests/syntax/test_os_which.ae
+++ b/tests/syntax/test_os_which.ae
@@ -1,0 +1,71 @@
+// Test: os_which — search PATH for an executable.
+//
+// Windows note: os_which is stubbed on Windows pending PATHEXT-aware
+// lookup and `;` separator handling. The test detects Windows via $OS
+// and prints SKIP there — the POSIX sub-cases reference /bin/true and
+// /bin/sh which don't exist on Windows anyway.
+
+import std.os
+
+extern println(s: string)
+extern string_concat(a: string, b: string) -> string
+extern string_length(s: string) -> int
+extern string_starts_with(s: string, prefix: string) -> int
+extern exit(code: int)
+
+fail(msg: string) {
+    println(string_concat("FAIL: ", msg))
+    exit(1)
+}
+
+main() {
+    os_name = os_getenv("OS")
+    if os_name == "Windows_NT" {
+        println("SKIP os_which: Windows backend not yet implemented")
+        return
+    }
+
+    // 1. Look up a program that exists on every POSIX box. The result
+    //    should be an absolute path (starts with '/') and end in "true".
+    found = os_which("true")
+    if string_length(found) == 0 {
+        fail("os_which('true') should find a hit on PATH")
+    }
+    if string_starts_with(found, "/") != 1 {
+        fail("os_which result should be an absolute path")
+    }
+
+    // 2. Same for /bin/sh — POSIX guarantees this.
+    sh = os_which("sh")
+    if string_length(sh) == 0 {
+        fail("os_which('sh') should find a hit")
+    }
+    if string_starts_with(sh, "/") != 1 {
+        fail("os_which('sh') should be absolute")
+    }
+
+    // 3. Absolute path passthrough — `os_which("/bin/ls")` returns the
+    //    path as-is when it's executable, without iterating PATH.
+    abs = os_which("/bin/ls")
+    if abs != "/bin/ls" {
+        // Some systems put ls in /usr/bin instead. Try that.
+        abs2 = os_which("/usr/bin/ls")
+        if abs2 != "/usr/bin/ls" {
+            fail("os_which should accept absolute paths to existing executables")
+        }
+    }
+
+    // 4. Missing program returns "" (NULL → empty string in Aether).
+    missing = os_which("definitely-not-on-anyones-path-9k3jf2")
+    if string_length(missing) != 0 {
+        fail("os_which on a missing name should return empty")
+    }
+
+    // 5. Absolute path to a non-existent program also returns empty.
+    missing_abs = os_which("/this/program/does/not/exist")
+    if string_length(missing_abs) != 0 {
+        fail("os_which on a missing absolute path should return empty")
+    }
+
+    println("PASS os_which")
+}


### PR DESCRIPTION
Six small POSIX wrappers that let Aether programs stop shelling out for routine filesystem operations. Priority 4 from the for-nicolas wishlist — immediate enabler for aetherBuild's tools/aeb-init.ae, which still shells out to `ln -s`, `readlink`, `test -L`, and `mkdir -p`.

std.fs additions:
  fs_mkdir_p(path)              — `mkdir -p` semantics, idempotent
  fs_symlink(target, link_path) — create a symlink, target verbatim
  fs_readlink(path)             — read a symlink, "" if not a symlink
  fs_is_symlink(path)           — does NOT follow; lstat-based
  fs_unlink(path)               — remove file/symlink, refuses dirs

std.os additions:
  os_which(name)                — search PATH; passes through absolute
                                  paths if executable; "" if not found

Implementation lives in std/fs/aether_fs.c (lstat, symlink, readlink, unlink wrapped through aether_sandbox_check) and std/os/aether_os.c (POSIX PATH walk with empty-entry-means-cwd handling). All six follow the existing fs convention (1 = success/yes, 0 = failure/no).

Windows symlink ops (fs_symlink, fs_readlink, fs_is_symlink) and os_which are stubbed pending CreateSymbolicLinkW + a junction fallback for directories and a PATHEXT-aware lookup respectively. fs_mkdir_p and fs_unlink work on Windows via the existing _mkdir / _unlink wrappers.

Test coverage:

tests/syntax/test_fs_stdlib_bundle.ae — 14 sub-cases:
  - fs_mkdir_p creates nested dirs in one call
  - fs_mkdir_p is idempotent on existing trees
  - fs_mkdir_p handles a single-component path
  - fs_symlink + fs_is_symlink + fs_readlink round-trip
  - fs_is_symlink returns 0 for regular files
  - fs_is_symlink returns 0 for missing paths
  - fs_readlink returns the verbatim target string
  - fs_readlink on a regular file returns empty/null
  - fs_unlink removes a symlink without touching the target
  - fs_unlink removes a regular file
  - fs_unlink refuses to remove a directory (returns 0, dir intact)
  - fs_unlink on a missing path returns 0

tests/syntax/test_os_which.ae — 5 sub-cases:
  - os_which("true") finds an absolute path on PATH
  - os_which("sh") same
  - absolute path passthrough for /bin/ls (or /usr/bin/ls)
  - missing program name returns ""
  - missing absolute path returns ""

CHANGELOG.md updated under [0.51.0]. make ci green; 152/152 tests passing.