### PR TITLE
feat: closure + import prereqs for aether_ui (Route 1 + per-symbol imports)

### DIFF
--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -627,6 +627,62 @@ ASTNode* module_parse_file(const char* file_path) {
     return ast;
 }
 
+// Try to resolve an import path. If the full path fails to resolve as a
+// module, split at the last dot and treat the tail as a selective-import
+// symbol (Java-style `import java.util.List` — class name tacked on the
+// end). On success with split, mutates the import_node in place: shortens
+// `value` to the module path and inserts the symbol name as an
+// AST_IDENTIFIER first child (matching the shape of the parenthesised
+// `import mod (a, b)` selective form). Caller owns the returned file
+// path on success; returns NULL on failure.
+static char* resolve_import_path(ASTNode* import_node) {
+    const char* module_path = import_node->value;
+    if (!module_path) return NULL;
+
+    char* file_path;
+    if (strncmp(module_path, "std.", 4) == 0) {
+        file_path = module_resolve_stdlib_path(module_path + 4);
+    } else {
+        file_path = module_resolve_local_path(module_path);
+    }
+    if (file_path) return file_path;
+
+    const char* last_dot = strrchr(module_path, '.');
+    if (!last_dot) return NULL;
+
+    int prefix_len = (int)(last_dot - module_path);
+    if (prefix_len <= 0 || prefix_len >= 512) return NULL;
+    char prefix[512];
+    memcpy(prefix, module_path, prefix_len);
+    prefix[prefix_len] = '\0';
+    const char* symbol = last_dot + 1;
+    if (!*symbol) return NULL;
+
+    if (strncmp(prefix, "std.", 4) == 0) {
+        file_path = module_resolve_stdlib_path(prefix + 4);
+    } else {
+        file_path = module_resolve_local_path(prefix);
+    }
+    if (!file_path) return NULL;
+
+    ASTNode* sym_node = create_ast_node(AST_IDENTIFIER, symbol,
+                                        import_node->line, import_node->column);
+
+    ASTNode** new_children = malloc(sizeof(ASTNode*) * (import_node->child_count + 1));
+    new_children[0] = sym_node;
+    for (int i = 0; i < import_node->child_count; i++) {
+        new_children[i + 1] = import_node->children[i];
+    }
+    free(import_node->children);
+    import_node->children = new_children;
+    import_node->child_count++;
+
+    free(import_node->value);
+    import_node->value = strdup(prefix);
+
+    return file_path;
+}
+
 // Recursive helper: load a single module and its transitive imports
 static int orchestrate_module(const char* module_name, const char* file_path,
                               DependencyGraph* graph) {
@@ -661,14 +717,8 @@ static int orchestrate_module(const char* module_name, const char* file_path,
         ASTNode* child = ast->children[i];
         if (child->type != AST_IMPORT_STATEMENT || !child->value) continue;
 
+        char* sub_file = resolve_import_path(child);
         const char* sub_path = child->value;
-        char* sub_file = NULL;
-
-        if (strncmp(sub_path, "std.", 4) == 0) {
-            sub_file = module_resolve_stdlib_path(sub_path + 4);
-        } else {
-            sub_file = module_resolve_local_path(sub_path);
-        }
 
         dependency_graph_add_edge(graph, module_name, sub_path);
         module_add_import(mod, sub_path);
@@ -698,14 +748,8 @@ int module_orchestrate(ASTNode* program) {
         ASTNode* child = program->children[i];
         if (child->type != AST_IMPORT_STATEMENT || !child->value) continue;
 
+        char* file_path = resolve_import_path(child);
         const char* module_path = child->value;
-        char* file_path = NULL;
-
-        if (strncmp(module_path, "std.", 4) == 0) {
-            file_path = module_resolve_stdlib_path(module_path + 4);
-        } else {
-            file_path = module_resolve_local_path(module_path);
-        }
 
         dependency_graph_add_edge(graph, "__main__", module_path);
 
@@ -996,6 +1040,59 @@ void module_merge_into_program(ASTNode* program) {
                 insert_child_at(program, clone, insert_idx++);
             }
             // Skip AST_MAIN_FUNCTION, AST_IMPORT_STATEMENT, etc.
+        }
+    }
+
+    // Second pass: for each selective import (either the parenthesised
+    // `import mod (a, b, c)` form or the trailing-component `import mod.a`
+    // form, which resolve_import_path rewrites into the same shape),
+    // rewrite bare-name references in user code to their module-prefixed
+    // form so callers can write `button("1")` instead of
+    // `aether_ui.button("1")` after `import contrib.aether_ui.button` or
+    // `import contrib.aether_ui (button, hstack, ...)`.
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* import_node = program->children[i];
+        if (!import_node || import_node->type != AST_IMPORT_STATEMENT || !import_node->value) continue;
+        if (import_node->child_count == 0 ||
+            import_node->children[0]->type != AST_IDENTIFIER) continue;
+
+        const char* module_path = import_node->value;
+        AetherModule* mod = module_find(module_path);
+        if (!mod || !mod->ast) continue;
+        const char* ns = module_get_namespace(module_path);
+
+        const char* sel_func_names[128];
+        int sel_func_count = 0;
+        const char* sel_const_names[128];
+        int sel_const_count = 0;
+
+        const char* mod_func_names[128];
+        int mod_func_count = collect_module_func_names(mod->ast, mod_func_names, 128);
+        const char* mod_const_names[128];
+        int mod_const_count = collect_module_const_names(mod->ast, mod_const_names, 128);
+
+        for (int k = 0; k < import_node->child_count; k++) {
+            ASTNode* sel = import_node->children[k];
+            if (!sel || sel->type != AST_IDENTIFIER || !sel->value) continue;
+            // Skip alias nodes — the parser marks them with annotation="module_alias".
+            if (sel->annotation && strcmp(sel->annotation, "module_alias") == 0) continue;
+            if (name_in_list(sel->value, mod_func_names, mod_func_count) &&
+                sel_func_count < 128) {
+                sel_func_names[sel_func_count++] = sel->value;
+            } else if (name_in_list(sel->value, mod_const_names, mod_const_count) &&
+                       sel_const_count < 128) {
+                sel_const_names[sel_const_count++] = sel->value;
+            }
+        }
+        if (sel_func_count == 0 && sel_const_count == 0) continue;
+
+        for (int m = 0; m < program->child_count; m++) {
+            ASTNode* top = program->children[m];
+            if (!top) continue;
+            if (top->type == AST_IMPORT_STATEMENT) continue;
+            if (top->is_imported) continue;
+            rename_intra_module_refs(top, ns, sel_func_names, sel_func_count,
+                                     sel_const_names, sel_const_count, NULL, 0);
         }
     }
 }

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -1213,13 +1213,17 @@ int typecheck_program(ASTNode* program) {
                 // Process import and register alias if present
                 const char* module_path = child->value;
 
-                // Check if this import has an alias (last child is identifier)
+                // Check if this import has an alias. Module aliases are
+                // AST_IDENTIFIER children annotated "module_alias" by the
+                // parser, distinguishing them from selective-import
+                // symbols, which are also AST_IDENTIFIER children but
+                // carry the symbol name to expose unqualified.
                 if (child->child_count > 0) {
                     ASTNode* last_child = child->children[child->child_count - 1];
-                    // Check if last child is the alias (an identifier node)
-                    if (last_child && last_child->type == AST_IDENTIFIER) {
+                    if (last_child && last_child->type == AST_IDENTIFIER &&
+                        last_child->annotation &&
+                        strcmp(last_child->annotation, "module_alias") == 0) {
                         const char* alias = last_child->value;
-                        // Register the alias in symbol table
                         add_module_alias(global_table, alias, module_path);
                     }
                 }
@@ -1289,28 +1293,16 @@ int typecheck_program(ASTNode* program) {
                         for (int j = 0; j < mod_ast->child_count; j++) {
                             ASTNode* decl = mod_ast->children[j];
                             if (decl->type == AST_EXTERN_FUNCTION && decl->value) {
-                                // Check if selective import - only import specified functions
-                                int should_import = 1;
-                                if (child->child_count > 0) {
-                                    ASTNode* first = child->children[0];
-                                    if (first && first->type == AST_IDENTIFIER) {
-                                        should_import = 0;
-                                        for (int k = 0; k < child->child_count; k++) {
-                                            ASTNode* sel = child->children[k];
-                                            if (sel && sel->type == AST_IDENTIFIER &&
-                                                strcmp(sel->value, decl->value) == 0) {
-                                                should_import = 1;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if (should_import) {
-                                    if (!lookup_symbol_local(global_table, decl->value)) {
-                                        add_symbol(global_table, decl->value,
-                                                   clone_type(decl->node_type), 0, 1, 0);
-                                    }
+                                // Always import externs regardless of the
+                                // selective-import filter. Externs are C
+                                // bindings that merged Aether functions may
+                                // call internally — filtering them out
+                                // breaks transitive references. The
+                                // selective filter applies at qualified-call
+                                // sites via is_selective_import_blocked().
+                                if (!lookup_symbol_local(global_table, decl->value)) {
+                                    add_symbol(global_table, decl->value,
+                                               clone_type(decl->node_type), 0, 1, 0);
                                 }
                             }
                             // AST_FUNCTION_DEFINITION handled by module_merge_into_program()
@@ -1375,12 +1367,15 @@ int typecheck_program(ASTNode* program) {
                         }
                     }
                 }
-            }
 
-            // Store alias for AST rewriting: "release" -> "build.release"
-            char dotted[256];
-            snprintf(dotted, sizeof(dotted), "%s.%s", ns, short_name);
-            add_import_alias(short_name, dotted);
+                // Store alias for AST rewriting: "release" -> "build.release".
+                // Only register when the prefixed symbol exists — otherwise
+                // we'd rewrite calls to externs (which keep their bare
+                // names) into nonexistent `ns_extern` forms.
+                char dotted[256];
+                snprintf(dotted, sizeof(dotted), "%s.%s", ns, short_name);
+                add_import_alias(short_name, dotted);
+            }
         }
     }
 

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -104,6 +104,11 @@ CodeGenerator* create_code_generator(FILE* output) {
     gen->in_trailing_block = 0;
     gen->current_env_captures = NULL;
     gen->current_env_capture_count = 0;
+    gen->current_promoted_captures = NULL;
+    gen->current_promoted_capture_count = 0;
+    gen->promoted_funcs = NULL;
+    gen->promoted_func_count = 0;
+    gen->promoted_func_capacity = 0;
     // Builder function registry
     gen->builder_funcs_reg = NULL;
     gen->builder_func_reg_count = 0;
@@ -380,18 +385,39 @@ static int is_env_free_for(ASTNode* deferred, const char* name) {
     return 1;
 }
 
+// Is `deferred` the synthetic "free(<name>)" defer for a Route 1 promoted
+// cell? Shape: EXPRESSION_STATEMENT > FUNCTION_CALL "free" > IDENTIFIER
+// "<name>" where the arg was marked `raw_promoted` by codegen_stmt.c.
+static int is_promoted_free_for(ASTNode* deferred, const char* name) {
+    if (!deferred || !name) return 0;
+    if (deferred->type != AST_EXPRESSION_STATEMENT || deferred->child_count < 1) return 0;
+    ASTNode* call = deferred->children[0];
+    if (!call || call->type != AST_FUNCTION_CALL || !call->value ||
+        strcmp(call->value, "free") != 0 || call->child_count < 1) return 0;
+    ASTNode* arg = call->children[0];
+    if (!arg || arg->type != AST_IDENTIFIER || !arg->value) return 0;
+    if (!arg->annotation || strcmp(arg->annotation, "raw_promoted") != 0) return 0;
+    return strcmp(arg->value, name) == 0;
+}
+
 // Emit ALL deferred statements (for return - unwinds entire function).
 // `protected_names` and `protected_count` list closure variable names whose
 // env-free defer should be suppressed — used at return sites where the
 // closure's env is still live through the returned value.
 void emit_all_defers_protected(CodeGenerator* gen, char** protected_names, int protected_count) {
-    // Emit all defers in LIFO order across all scopes
+    // Emit all defers in LIFO order across all scopes. A defer is suppressed
+    // when either (a) it frees the env of a closure variable in the protected
+    // list, or (b) it frees a Route 1 promoted cell whose name matches a
+    // protected name (because the escaping closure's env captures the
+    // pointer, and the caller now owns the cell).
     for (int i = gen->defer_count - 1; i >= 0; i--) {
         ASTNode* deferred = gen->defer_stack[i];
         if (!deferred) continue;
         int skip = 0;
         for (int p = 0; p < protected_count; p++) {
-            if (protected_names[p] && is_env_free_for(deferred, protected_names[p])) {
+            if (!protected_names[p]) continue;
+            if (is_env_free_for(deferred, protected_names[p]) ||
+                is_promoted_free_for(deferred, protected_names[p])) {
                 skip = 1;
                 break;
             }
@@ -985,7 +1011,15 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
     
     if (main->child_count > 0) {
         gen->in_main_function = 1;
+        // Publish main's promoted-captures set so var decls malloc
+        // heap cells and reads/writes dereference.
+        char** prev_promoted = gen->current_promoted_captures;
+        int prev_promoted_count = gen->current_promoted_capture_count;
+        get_promoted_names_for_func(gen, "main",
+            &gen->current_promoted_captures, &gen->current_promoted_capture_count);
         generate_statement(gen, main->children[0]);
+        gen->current_promoted_captures = prev_promoted;
+        gen->current_promoted_capture_count = prev_promoted_count;
         gen->in_main_function = 0;
     }
     

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -97,6 +97,28 @@ typedef struct {
     char** current_env_captures;
     int current_env_capture_count;
 
+    // Route 1 heap-promotion: variables in this list are heap-allocated
+    // cells (`int* name`) in the current function scope. Reads emit
+    // `(*name)`; writes emit `(*name) = expr`. Set at the start of any
+    // function/closure body whose enclosing function has promoted names,
+    // cleared on exit. The set is the union of captures that ANY closure
+    // in the enclosing function assigns to.
+    char** current_promoted_captures;
+    int current_promoted_capture_count;
+
+    // Per-function promoted-name map. Built during discover_closures as
+    // a precompute of which variables need heap promotion in each
+    // function body. Looked up when generating that function's body
+    // (either main's, a regular user function's, or a closure's — closures
+    // inherit from their parent_func).
+    struct PromotedFuncEntry {
+        char* func_name;    // "main" for main, user function name otherwise
+        char** names;       // promoted variable names
+        int count;
+    }* promoted_funcs;
+    int promoted_func_count;
+    int promoted_func_capacity;
+
     // Builder function registry: functions marked with 'builder' keyword
     // Block runs first (filling config), then function executes with config
     struct BuilderFuncEntry {

--- a/compiler/codegen/codegen_actor.c
+++ b/compiler/codegen/codegen_actor.c
@@ -262,12 +262,28 @@ void generate_actor_definition(CodeGenerator* gen, ASTNode* actor) {
                             }
                         }
 
+                        // Publish this arm's Route 1 promoted names so
+                        // variable decls in the handler malloc heap cells
+                        // and reads/writes dereference. The synthetic name
+                        // matches what discover_closures_scoped emitted:
+                        // `__recv_arm_<arm_ptr>`.
+                        char** prev_promoted = gen->current_promoted_captures;
+                        int prev_promoted_count = gen->current_promoted_capture_count;
+                        char arm_name[256];
+                        snprintf(arm_name, sizeof(arm_name), "__recv_arm_%p", (void*)arm);
+                        get_promoted_names_for_func(gen, arm_name,
+                            &gen->current_promoted_captures,
+                            &gen->current_promoted_capture_count);
+
                         // Generate handler body
                         if (arm_body && arm_body->type == AST_BLOCK) {
                             for (int k = 0; k < arm_body->child_count; k++) {
                                 generate_statement(gen, arm_body->children[k]);
                             }
                         }
+
+                        gen->current_promoted_captures = prev_promoted;
+                        gen->current_promoted_capture_count = prev_promoted_count;
 
                         unindent(gen);
                         print_line(gen, "}");

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -4,9 +4,7 @@
 
 // Collect identifiers (reads) referenced in an AST subtree. Does NOT
 // collect assignment targets — a name that only appears as an LHS and
-// never as an RHS is treated as a fresh local, matching Aether's
-// Python-style implicit declaration where `v = expr` introduces `v`
-// unless `v` is already in scope and read elsewhere in the same body.
+// never as an RHS is handled separately by collect_write_targets below.
 static void collect_identifiers(ASTNode* node, char*** names, int* count, int* cap) {
     if (!node) return;
     if (node->type == AST_IDENTIFIER && node->value) {
@@ -22,6 +20,31 @@ static void collect_identifiers(ASTNode* node, char*** names, int* count, int* c
     }
     for (int i = 0; i < node->child_count; i++) {
         collect_identifiers(node->children[i], names, count, cap);
+    }
+}
+
+// Collect write-target names (AST_VARIABLE_DECLARATION.value) in a closure
+// body, stopping at nested closures. Used by the capture filter so that
+// `x = expr` in a closure body — where x never appears on a read side —
+// still gets a chance to be classified as a capture if x exists in the
+// enclosing scope.
+static void collect_write_targets(ASTNode* node, char*** names, int* count, int* cap) {
+    if (!node) return;
+    if (node->type == AST_CLOSURE) return;  // nested closures have their own scope
+    if ((node->type == AST_VARIABLE_DECLARATION || node->type == AST_CONST_DECLARATION) &&
+        node->value) {
+        for (int i = 0; i < *count; i++) {
+            if (strcmp((*names)[i], node->value) == 0) goto skip;
+        }
+        if (*count >= *cap) {
+            *cap = *cap ? *cap * 2 : 8;
+            *names = realloc(*names, *cap * sizeof(char*));
+        }
+        (*names)[(*count)++] = strdup(node->value);
+    skip:;
+    }
+    for (int i = 0; i < node->child_count; i++) {
+        collect_write_targets(node->children[i], names, count, cap);
     }
 }
 
@@ -260,6 +283,42 @@ static void discover_closures_scoped(CodeGenerator* gen, ASTNode* node, const ch
             free(all_ids[i]);
         }
         free(all_ids);
+
+        // Second pass for write-only captures: names that appear as
+        // AST_VARIABLE_DECLARATION targets but NEVER as reads in the
+        // closure body. `msg = "world"` in a closure, where outer scope
+        // declares `msg`, is a mutation of the outer binding — not a
+        // fresh local — and must be treated as a capture so Route 1
+        // heap-promotes it. Without this, write-only mutations silently
+        // fail to reach the outer scope.
+        if (enclosing_func) {
+            char** writes = NULL;
+            int write_count = 0, write_cap = 0;
+            collect_write_targets(body, &writes, &write_count, &write_cap);
+            for (int i = 0; i < write_count; i++) {
+                // Already captured via the read path?
+                int already = 0;
+                for (int k = 0; k < cap_count; k++) {
+                    if (strcmp(captures[k], writes[i]) == 0) { already = 1; break; }
+                }
+                if (already) { free(writes[i]); continue; }
+                // Skip closure params / builtins.
+                if (is_closure_param(node, writes[i]) || is_builtin_name(writes[i])) {
+                    free(writes[i]);
+                    continue;
+                }
+                // Promote only if the name exists in the enclosing function.
+                if (is_declared_in_function(gen->program, enclosing_func, writes[i])) {
+                    if (cap_count >= cap_cap) {
+                        cap_cap = cap_cap ? cap_cap * 2 : 8;
+                        captures = realloc(captures, cap_cap * sizeof(char*));
+                    }
+                    captures[cap_count++] = strdup(writes[i]);
+                }
+                free(writes[i]);
+            }
+            free(writes);
+        }
 
         // Register closure
         if (gen->closure_count >= gen->closure_capacity) {
@@ -806,11 +865,23 @@ void emit_closure_definitions(CodeGenerator* gen) {
             gen->current_env_capture_count = env_capture_count;
             // Publish promoted names visible to this closure body so
             // reads/writes dereference through the pointer alias we just
-            // emitted above.
+            // emitted above. EXCLUDE names that are closure parameters of
+            // this closure — those are regular-typed values (int, string,
+            // etc.), not pointers, and dereferencing them would be wrong.
+            char** body_promoted = NULL;
+            int body_promoted_count = 0;
+            if (parent_promoted_count > 0) {
+                body_promoted = malloc(parent_promoted_count * sizeof(char*));
+                for (int p = 0; p < parent_promoted_count; p++) {
+                    if (!parent_promoted[p]) continue;
+                    if (is_closure_param(closure, parent_promoted[p])) continue;
+                    body_promoted[body_promoted_count++] = parent_promoted[p];
+                }
+            }
             char** prev_promoted = gen->current_promoted_captures;
             int prev_promoted_count = gen->current_promoted_capture_count;
-            gen->current_promoted_captures = parent_promoted;
-            gen->current_promoted_capture_count = parent_promoted_count;
+            gen->current_promoted_captures = body_promoted;
+            gen->current_promoted_capture_count = body_promoted_count;
             // Mark promoted captures as already-declared in this local scope
             // so writes in the body hit the reassignment branch (emits
             // *name = ...) rather than trying to declare+malloc again.
@@ -825,6 +896,7 @@ void emit_closure_definitions(CodeGenerator* gen) {
             gen->current_env_capture_count = prev_env_count;
             gen->current_promoted_captures = prev_promoted;
             gen->current_promoted_capture_count = prev_promoted_count;
+            free(body_promoted);
             // Free the body's declared_vars and restore the outer scope's set.
             if (gen->declared_vars) {
                 for (int i = 0; i < gen->declared_var_count; i++) free(gen->declared_vars[i]);
@@ -1721,13 +1793,18 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                     // to a different closure and has no single static identity;
                     // treat it the same as "not found" and fall back to generic
                     // function-pointer dispatch.
+                    // A closure variable that is ALSO a Route 1 promoted name
+                    // is reassignable by construction (some closure writes it)
+                    // and must go through the generic path too.
                     int found_id = -1;
                     if (closure_arg && closure_arg->type == AST_IDENTIFIER && closure_arg->value) {
-                        for (int ci = 0; ci < gen->closure_var_count; ci++) {
-                            if (strcmp(gen->closure_var_map[ci].var_name, closure_arg->value) == 0) {
-                                int cid = gen->closure_var_map[ci].closure_id;
-                                if (cid >= 0) found_id = cid;
-                                break;
+                        if (!is_promoted_capture(gen, closure_arg->value)) {
+                            for (int ci = 0; ci < gen->closure_var_count; ci++) {
+                                if (strcmp(gen->closure_var_map[ci].var_name, closure_arg->value) == 0) {
+                                    int cid = gen->closure_var_map[ci].closure_id;
+                                    if (cid >= 0) found_id = cid;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -1740,7 +1817,12 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         fprintf(gen->output, ".env");
                         for (int i = 1; i < expr->child_count; i++) {
                             ASTNode* arg = expr->children[i];
-                            if (arg && arg->type == AST_CLOSURE) continue;
+                            // Skip trailing-DSL-block closures (handled via
+                            // _ctx injection, not passed as args). Regular
+                            // closure-literal args are real arguments and
+                            // must be forwarded.
+                            if (arg && arg->type == AST_CLOSURE &&
+                                arg->value && strcmp(arg->value, "trailing") == 0) continue;
                             fprintf(gen->output, ", ");
                             generate_expression(gen, arg);
                         }
@@ -1755,11 +1837,14 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         fprintf(gen->output, "((%s(*)(void*", ret);
                         for (int i = 1; i < expr->child_count; i++) {
                             ASTNode* arg = expr->children[i];
-                            if (arg && arg->type == AST_CLOSURE) continue;
+                            if (arg && arg->type == AST_CLOSURE &&
+                                arg->value && strcmp(arg->value, "trailing") == 0) continue;
                             // Infer arg type
                             const char* atype = "int";
                             if (arg && arg->node_type) {
                                 atype = get_c_type(arg->node_type);
+                            } else if (arg && arg->type == AST_CLOSURE) {
+                                atype = "_AeClosure";
                             }
                             fprintf(gen->output, ", %s", atype);
                         }
@@ -1770,7 +1855,8 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         fprintf(gen->output, ".env");
                         for (int i = 1; i < expr->child_count; i++) {
                             ASTNode* arg = expr->children[i];
-                            if (arg && arg->type == AST_CLOSURE) continue;
+                            if (arg && arg->type == AST_CLOSURE &&
+                                arg->value && strcmp(arg->value, "trailing") == 0) continue;
                             fprintf(gen->output, ", ");
                             generate_expression(gen, arg);
                         }

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -420,12 +420,100 @@ static void propagate_call_return_types(CodeGenerator* gen, ASTNode* node) {
     }
 }
 
+// Add `name` to a function's promoted-names entry in gen->promoted_funcs,
+// creating the entry if absent, de-duplicating names within it.
+static void add_promoted_name(CodeGenerator* gen, const char* func_name, const char* name) {
+    if (!func_name || !name) return;
+    int idx = -1;
+    for (int i = 0; i < gen->promoted_func_count; i++) {
+        if (strcmp(gen->promoted_funcs[i].func_name, func_name) == 0) {
+            idx = i;
+            break;
+        }
+    }
+    if (idx < 0) {
+        if (gen->promoted_func_count >= gen->promoted_func_capacity) {
+            gen->promoted_func_capacity = gen->promoted_func_capacity ? gen->promoted_func_capacity * 2 : 8;
+            gen->promoted_funcs = realloc(gen->promoted_funcs,
+                gen->promoted_func_capacity * sizeof(gen->promoted_funcs[0]));
+        }
+        idx = gen->promoted_func_count++;
+        gen->promoted_funcs[idx].func_name = strdup(func_name);
+        gen->promoted_funcs[idx].names = NULL;
+        gen->promoted_funcs[idx].count = 0;
+    }
+    for (int i = 0; i < gen->promoted_funcs[idx].count; i++) {
+        if (strcmp(gen->promoted_funcs[idx].names[i], name) == 0) return;
+    }
+    gen->promoted_funcs[idx].names = realloc(gen->promoted_funcs[idx].names,
+        (gen->promoted_funcs[idx].count + 1) * sizeof(char*));
+    gen->promoted_funcs[idx].names[gen->promoted_funcs[idx].count++] = strdup(name);
+}
+
+// Route 1 promotion analysis. After discover_closures has run, we know every
+// closure's captures and its parent function. Scan each closure's body for
+// captures that are assigned to; those names must be heap-promoted in the
+// parent function (so outer reads/writes, and sibling closures, all share
+// the same cell).
+static void compute_promoted_captures(CodeGenerator* gen) {
+    for (int ci = 0; ci < gen->closure_count; ci++) {
+        const char* parent_func = gen->closures[ci].parent_func;
+        if (!parent_func) continue;
+        ASTNode* cnode = gen->closures[ci].closure_node;
+        ASTNode* body = NULL;
+        for (int k = cnode->child_count - 1; k >= 0; k--) {
+            if (cnode->children[k] && cnode->children[k]->type == AST_BLOCK) {
+                body = cnode->children[k];
+                break;
+            }
+        }
+        if (!body) continue;
+        for (int j = 0; j < gen->closures[ci].capture_count; j++) {
+            const char* cap = gen->closures[ci].captures[j];
+            if (!cap) continue;
+            if (is_assigned_to(body, cap)) {
+                add_promoted_name(gen, parent_func, cap);
+            }
+        }
+    }
+}
+
+// Lookup: are the promoted names for `func_name` non-empty? Returns the list
+// and count via out params; both may be NULL/0 when the function has none.
+void get_promoted_names_for_func(CodeGenerator* gen, const char* func_name,
+                                 char*** out_names, int* out_count) {
+    *out_names = NULL;
+    *out_count = 0;
+    if (!func_name) return;
+    for (int i = 0; i < gen->promoted_func_count; i++) {
+        if (strcmp(gen->promoted_funcs[i].func_name, func_name) == 0) {
+            *out_names = gen->promoted_funcs[i].names;
+            *out_count = gen->promoted_funcs[i].count;
+            return;
+        }
+    }
+}
+
+// Convenience: is `name` promoted in the current codegen context?
+int is_promoted_capture(CodeGenerator* gen, const char* name) {
+    if (!name) return 0;
+    for (int i = 0; i < gen->current_promoted_capture_count; i++) {
+        if (gen->current_promoted_captures[i] &&
+            strcmp(gen->current_promoted_captures[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Public entry point — starts at program root with no enclosing function.
 void discover_closures(CodeGenerator* gen, ASTNode* node) {
     discover_closures_scoped(gen, node, NULL);
     // Second pass: now that closure_var_map is fully populated, propagate
     // return types back onto call() expressions the typechecker left as int.
     propagate_call_return_types(gen, node);
+    // Third pass: compute which captures need heap promotion per function.
+    compute_promoted_captures(gen);
 }
 
 // Search a single function node for `var_name` as either a parameter
@@ -517,6 +605,12 @@ void emit_closure_definitions(CodeGenerator* gen) {
         int cap_count = gen->closures[ci].capture_count;
         const char* parent_func = gen->closures[ci].parent_func;
 
+        // Look up the parent function's promoted names — captures matching
+        // them get a pointer-typed env slot and pointer-typed body alias.
+        char** parent_promoted = NULL;
+        int parent_promoted_count = 0;
+        get_promoted_names_for_func(gen, parent_func, &parent_promoted, &parent_promoted_count);
+
         // Emit environment struct (even if empty, for uniform calling convention)
         fprintf(gen->output, "typedef struct {\n");
         if (cap_count == 0) {
@@ -524,7 +618,18 @@ void emit_closure_definitions(CodeGenerator* gen) {
         } else {
             for (int i = 0; i < cap_count; i++) {
                 const char* ctype = lookup_var_c_type(gen, captures[i], parent_func);
-                fprintf(gen->output, "    %s %s;\n", ctype, safe_c_name(captures[i]));
+                int is_promoted = 0;
+                for (int p = 0; p < parent_promoted_count; p++) {
+                    if (parent_promoted[p] && strcmp(parent_promoted[p], captures[i]) == 0) {
+                        is_promoted = 1;
+                        break;
+                    }
+                }
+                if (is_promoted) {
+                    fprintf(gen->output, "    %s* %s;\n", ctype, safe_c_name(captures[i]));
+                } else {
+                    fprintf(gen->output, "    %s %s;\n", ctype, safe_c_name(captures[i]));
+                }
             }
         }
         fprintf(gen->output, "} _closure_env_%d;\n\n", id);
@@ -624,31 +729,60 @@ void emit_closure_definitions(CodeGenerator* gen) {
             }
         }
 
-        // Partition captures into mutated (env-backed) and read-only (aliased).
-        // Mutated captures are reassigned in the body — for those we skip the
-        // alias and route reassignments through _env->name in generate_statement.
-        // Read-only captures get the conventional alias so body reads stay cheap.
+        // Partition captures into mutated (env-backed), promoted (heap cell
+        // alias), and read-only (value alias).
+        // - Promoted: parent function has this name in its promoted set.
+        //   Env slot is already `T*`; prologue aliases as `T* name`;
+        //   reads/writes in body dereference (is_promoted_capture path).
+        // - Env-backed (pre-Route-1 path): assigned-to in body but NOT
+        //   promoted. Skip the alias and route writes through _env->. Only
+        //   fires when a closure writes a capture that isn't promoted
+        //   in its parent — shouldn't happen after Route 1, but kept as
+        //   a safety net.
+        // - Read-only: value-typed alias `T name = _env->name;`.
         char** env_captures = NULL;
         int env_capture_count = 0;
         if (body && cap_count > 0) {
             env_captures = malloc(cap_count * sizeof(char*));
             for (int i = 0; i < cap_count; i++) {
-                if (is_assigned_to(body, captures[i])) {
+                int is_promoted_for_parent = 0;
+                for (int p = 0; p < parent_promoted_count; p++) {
+                    if (parent_promoted[p] && strcmp(parent_promoted[p], captures[i]) == 0) {
+                        is_promoted_for_parent = 1;
+                        break;
+                    }
+                }
+                if (is_assigned_to(body, captures[i]) && !is_promoted_for_parent) {
                     env_captures[env_capture_count++] = captures[i];
                 }
             }
         }
 
-        // Emit capture aliases — skip mutated ones, they read/write _env-> directly.
+        // Emit capture aliases.
         for (int i = 0; i < cap_count; i++) {
             int is_env_backed = 0;
             for (int j = 0; j < env_capture_count; j++) {
                 if (env_captures[j] == captures[i]) { is_env_backed = 1; break; }
             }
             if (is_env_backed) continue;
+            int is_promoted_for_parent = 0;
+            for (int p = 0; p < parent_promoted_count; p++) {
+                if (parent_promoted[p] && strcmp(parent_promoted[p], captures[i]) == 0) {
+                    is_promoted_for_parent = 1;
+                    break;
+                }
+            }
             const char* ctype = lookup_var_c_type(gen, captures[i], parent_func);
-            fprintf(gen->output, "    %s %s = _env->%s;\n",
-                    ctype, safe_c_name(captures[i]), safe_c_name(captures[i]));
+            if (is_promoted_for_parent) {
+                // Pointer alias: body reads/writes dereference through the
+                // AST_IDENTIFIER emit path when the name is in
+                // current_promoted_captures.
+                fprintf(gen->output, "    %s* %s = _env->%s;\n",
+                        ctype, safe_c_name(captures[i]), safe_c_name(captures[i]));
+            } else {
+                fprintf(gen->output, "    %s %s = _env->%s;\n",
+                        ctype, safe_c_name(captures[i]), safe_c_name(captures[i]));
+            }
         }
 
         if (body) {
@@ -656,17 +790,48 @@ void emit_closure_definitions(CodeGenerator* gen) {
             // Closures called from trailing blocks need builder context injection
             // for _ctx: ptr functions. Set the flag so codegen injects _aether_ctx_get().
             gen->in_trailing_block++;
+            // Save and reset the declared-vars set so closure body declarations
+            // don't bleed into sibling closures or the outer function body.
+            // We then register the promoted captures (they're "declared" via
+            // the prologue alias) plus any closure params.
+            char** prev_declared = gen->declared_vars;
+            int prev_declared_count = gen->declared_var_count;
+            gen->declared_vars = NULL;
+            gen->declared_var_count = 0;
             // Publish env-backed captures so generate_statement routes writes
             // through _env-> instead of a local alias.
             char** prev_env = gen->current_env_captures;
             int prev_env_count = gen->current_env_capture_count;
             gen->current_env_captures = env_captures;
             gen->current_env_capture_count = env_capture_count;
+            // Publish promoted names visible to this closure body so
+            // reads/writes dereference through the pointer alias we just
+            // emitted above.
+            char** prev_promoted = gen->current_promoted_captures;
+            int prev_promoted_count = gen->current_promoted_capture_count;
+            gen->current_promoted_captures = parent_promoted;
+            gen->current_promoted_capture_count = parent_promoted_count;
+            // Mark promoted captures as already-declared in this local scope
+            // so writes in the body hit the reassignment branch (emits
+            // *name = ...) rather than trying to declare+malloc again.
+            // The prologue alias `T* name = _env->name;` is the declaration.
+            for (int p = 0; p < parent_promoted_count; p++) {
+                if (parent_promoted[p]) mark_var_declared(gen, parent_promoted[p]);
+            }
             for (int i = 0; i < body->child_count; i++) {
                 generate_statement(gen, body->children[i]);
             }
             gen->current_env_captures = prev_env;
             gen->current_env_capture_count = prev_env_count;
+            gen->current_promoted_captures = prev_promoted;
+            gen->current_promoted_capture_count = prev_promoted_count;
+            // Free the body's declared_vars and restore the outer scope's set.
+            if (gen->declared_vars) {
+                for (int i = 0; i < gen->declared_var_count; i++) free(gen->declared_vars[i]);
+                free(gen->declared_vars);
+            }
+            gen->declared_vars = prev_declared;
+            gen->declared_var_count = prev_declared_count;
             gen->in_trailing_block--;
             gen->indent_level = 0;
         }
@@ -868,8 +1033,22 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
 
         case AST_IDENTIFIER:
             if (!expr->value) { fprintf(gen->output, "/* NULL identifier */0"); break; }
+            // Route 1: promoted captures are `int* name` — dereference on read.
+            // Applies uniformly in outer function bodies and in closure bodies;
+            // the difference is only at declaration time (outer: malloc+init;
+            // closure: alias from _env->name).
+            // Exception: nodes annotated "raw_promoted" are passing the raw
+            // pointer (e.g. to free()) and must not be dereferenced.
+            if (is_promoted_capture(gen, expr->value) &&
+                !(expr->annotation && strcmp(expr->annotation, "raw_promoted") == 0)) {
+                fprintf(gen->output, "(*%s)", expr->value);
+                break;
+            }
             // Env-backed captures (mutated inside a closure body) have no local
             // alias — reads and writes must go through _env->name.
+            // NOTE: with Route 1, mutated captures are promoted instead, so
+            // this path is only taken when current_env_captures is populated
+            // with a name that is NOT also promoted (legacy fallback).
             {
                 int is_env_cap = 0;
                 for (int i = 0; i < gen->current_env_capture_count; i++) {

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -103,6 +103,54 @@ static int is_local_var(ASTNode* block, const char* name) {
     return 0;
 }
 
+// Is `var_name` declared at the TOP level of the given function's body
+// block (or as a parameter) — i.e. in the function's "own" lexical scope,
+// not inside a nested if/for/while block? This is the scope that closures
+// capture from in languages like JavaScript and Ruby. Names declared
+// inside nested blocks share names only by coincidence and are not
+// capture targets.
+static int is_top_level_decl_in_function(ASTNode* program, const char* func_name, const char* var_name) {
+    if (!program || !func_name || !var_name) return 0;
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* top = program->children[i];
+        if (!top) continue;
+        int matches = 0;
+        if (strcmp(func_name, "main") == 0 && top->type == AST_MAIN_FUNCTION) {
+            matches = 1;
+        } else if ((top->type == AST_FUNCTION_DEFINITION || top->type == AST_BUILDER_FUNCTION) &&
+                   top->value && strcmp(top->value, func_name) == 0) {
+            matches = 1;
+        }
+        if (!matches) continue;
+        // Parameters count as top-level declarations.
+        if (top->type != AST_MAIN_FUNCTION) {
+            for (int j = 0; j < top->child_count; j++) {
+                ASTNode* p = top->children[j];
+                if (p && p->type == AST_PATTERN_VARIABLE && p->value &&
+                    strcmp(p->value, var_name) == 0) {
+                    return 1;
+                }
+            }
+        }
+        // Only TOP-LEVEL statements of the body block count — not nested
+        // if/for/while bodies.
+        for (int j = 0; j < top->child_count; j++) {
+            ASTNode* body = top->children[j];
+            if (!body || body->type != AST_BLOCK) continue;
+            for (int k = 0; k < body->child_count; k++) {
+                ASTNode* s = body->children[k];
+                if (s && (s->type == AST_VARIABLE_DECLARATION ||
+                          s->type == AST_CONST_DECLARATION) &&
+                    s->value && strcmp(s->value, var_name) == 0) {
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+    return 0;
+}
+
 // Recursively scan an AST subtree for a declaration whose value matches
 // `var_name`. Stops descending into AST_CLOSURE nodes — their locals belong
 // to an inner scope, not the enclosing function's.
@@ -285,12 +333,25 @@ static void discover_closures_scoped(CodeGenerator* gen, ASTNode* node, const ch
         free(all_ids);
 
         // Second pass for write-only captures: names that appear as
-        // AST_VARIABLE_DECLARATION targets but NEVER as reads in the
-        // closure body. `msg = "world"` in a closure, where outer scope
-        // declares `msg`, is a mutation of the outer binding — not a
-        // fresh local — and must be treated as a capture so Route 1
-        // heap-promotes it. Without this, write-only mutations silently
-        // fail to reach the outer scope.
+        // AST_VARIABLE_DECLARATION targets but are NOT captured via
+        // the read path. `msg = "world"` in a closure where outer scope
+        // declares `msg` at the top level is a mutation of the outer
+        // binding, not a fresh local.
+        //
+        // Use TOP-LEVEL-ONLY declaration lookup here: if `v` is declared
+        // at function top-level, a closure's `v = ...` captures it. If
+        // `v` is only declared inside a nested block of the enclosing
+        // function (e.g. main's `if key == EQUAL { v = ref_get(num) }`),
+        // the two `v`s share a name by coincidence and are
+        // independently-scoped locals — the closure's `v` is a fresh
+        // local. This matches JavaScript/Ruby closure semantics where
+        // captures lift from the function's own scope, not arbitrary
+        // inner blocks.
+        //
+        // The reverse case (name appears as both read and write) is
+        // handled above via the read-path — is_local_var returns false
+        // when init_reads_self, so the read-path's enclosing-scope
+        // check makes it a capture.
         if (enclosing_func) {
             char** writes = NULL;
             int write_count = 0, write_cap = 0;
@@ -307,8 +368,9 @@ static void discover_closures_scoped(CodeGenerator* gen, ASTNode* node, const ch
                     free(writes[i]);
                     continue;
                 }
-                // Promote only if the name exists in the enclosing function.
-                if (is_declared_in_function(gen->program, enclosing_func, writes[i])) {
+                // Promote only if the name is declared at the enclosing
+                // function's top level (or is one of its parameters).
+                if (is_top_level_decl_in_function(gen->program, enclosing_func, writes[i])) {
                     if (cap_count >= cap_cap) {
                         cap_cap = cap_cap ? cap_cap * 2 : 8;
                         captures = realloc(captures, cap_cap * sizeof(char*));

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -324,15 +324,15 @@ static void discover_closures_scoped(CodeGenerator* gen, ASTNode* node, const ch
             }
         }
         if (cid_to_bind >= 0) {
-            int already = 0;
+            int existing_idx = -1;
             for (int ci = 0; ci < gen->closure_var_count; ci++) {
                 if (gen->closure_var_map[ci].var_name &&
                     strcmp(gen->closure_var_map[ci].var_name, node->value) == 0) {
-                    already = 1;
+                    existing_idx = ci;
                     break;
                 }
             }
-            if (!already) {
+            if (existing_idx < 0) {
                 if (gen->closure_var_count >= gen->closure_var_capacity) {
                     gen->closure_var_capacity = gen->closure_var_capacity ? gen->closure_var_capacity * 2 : 16;
                     gen->closure_var_map = realloc(gen->closure_var_map,
@@ -341,6 +341,13 @@ static void discover_closures_scoped(CodeGenerator* gen, ASTNode* node, const ch
                 gen->closure_var_map[gen->closure_var_count].var_name = strdup(node->value);
                 gen->closure_var_map[gen->closure_var_count].closure_id = cid_to_bind;
                 gen->closure_var_count++;
+            } else if (gen->closure_var_map[existing_idx].closure_id != cid_to_bind) {
+                // Variable was previously bound to a different closure
+                // (either via declaration or via an earlier reassignment).
+                // The variable's dynamic identity is no longer a single
+                // closure — mark ambiguous so call() falls back to generic
+                // function-pointer dispatch through .fn.
+                gen->closure_var_map[existing_idx].closure_id = -1;
             }
         }
     }
@@ -1530,12 +1537,17 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 // Looks up the closure's hoisted function signature and calls through it
                 else if (strcmp(func_name, "call") == 0 && expr->child_count >= 1) {
                     ASTNode* closure_arg = expr->children[0];
-                    // Look up the closure ID from the variable name
+                    // Look up the closure ID from the variable name. An entry
+                    // with closure_id == -1 means the variable was reassigned
+                    // to a different closure and has no single static identity;
+                    // treat it the same as "not found" and fall back to generic
+                    // function-pointer dispatch.
                     int found_id = -1;
                     if (closure_arg && closure_arg->type == AST_IDENTIFIER && closure_arg->value) {
                         for (int ci = 0; ci < gen->closure_var_count; ci++) {
                             if (strcmp(gen->closure_var_map[ci].var_name, closure_arg->value) == 0) {
-                                found_id = gen->closure_var_map[ci].closure_id;
+                                int cid = gen->closure_var_map[ci].closure_id;
+                                if (cid >= 0) found_id = cid;
                                 break;
                             }
                         }

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -103,6 +103,25 @@ static int is_local_var(ASTNode* block, const char* name) {
     return 0;
 }
 
+// Find an AST_RECEIVE_ARM anywhere in the program whose synthetic name
+// (format `__recv_arm_<pointer>`) matches `func_name`. Returns NULL if
+// not found. Used so that actor message handlers — which are effectively
+// mini-functions for closure-promotion purposes — can be looked up the
+// same way as top-level functions.
+static ASTNode* find_receive_arm_by_name(ASTNode* node, const char* func_name) {
+    if (!node || !func_name) return NULL;
+    if (node->type == AST_RECEIVE_ARM) {
+        char arm_name[256];
+        snprintf(arm_name, sizeof(arm_name), "__recv_arm_%p", (void*)node);
+        if (strcmp(arm_name, func_name) == 0) return node;
+    }
+    for (int i = 0; i < node->child_count; i++) {
+        ASTNode* found = find_receive_arm_by_name(node->children[i], func_name);
+        if (found) return found;
+    }
+    return NULL;
+}
+
 // Is `var_name` declared at the TOP level of the given function's body
 // block (or as a parameter) — i.e. in the function's "own" lexical scope,
 // not inside a nested if/for/while block? This is the scope that closures
@@ -111,6 +130,24 @@ static int is_local_var(ASTNode* block, const char* name) {
 // capture targets.
 static int is_top_level_decl_in_function(ASTNode* program, const char* func_name, const char* var_name) {
     if (!program || !func_name || !var_name) return 0;
+    // Actor receive arms use synthetic function names `__recv_arm_<ptr>`.
+    if (strncmp(func_name, "__recv_arm_", 11) == 0) {
+        ASTNode* arm = find_receive_arm_by_name(program, func_name);
+        if (!arm) return 0;
+        // Arm body is children[1] (children[0] is the pattern).
+        if (arm->child_count < 2) return 0;
+        ASTNode* body = arm->children[1];
+        if (!body || body->type != AST_BLOCK) return 0;
+        for (int k = 0; k < body->child_count; k++) {
+            ASTNode* s = body->children[k];
+            if (s && (s->type == AST_VARIABLE_DECLARATION ||
+                      s->type == AST_CONST_DECLARATION) &&
+                s->value && strcmp(s->value, var_name) == 0) {
+                return 1;
+            }
+        }
+        return 0;
+    }
     for (int i = 0; i < program->child_count; i++) {
         ASTNode* top = program->children[i];
         if (!top) continue;
@@ -173,6 +210,13 @@ static int subtree_declares(ASTNode* node, const char* var_name) {
 // if/else bodies) but does not descend into inner closures.
 static int is_declared_in_function(ASTNode* program, const char* func_name, const char* var_name) {
     if (!program || !func_name || !var_name) return 0;
+    if (strncmp(func_name, "__recv_arm_", 11) == 0) {
+        ASTNode* arm = find_receive_arm_by_name(program, func_name);
+        if (!arm || arm->child_count < 2) return 0;
+        ASTNode* body = arm->children[1];
+        if (!body) return 0;
+        return subtree_declares(body, var_name);
+    }
     for (int i = 0; i < program->child_count; i++) {
         ASTNode* top = program->children[i];
         if (!top) continue;
@@ -266,6 +310,23 @@ static void discover_closures_scoped(CodeGenerator* gen, ASTNode* node, const ch
     if (node->type == AST_MAIN_FUNCTION) {
         for (int i = 0; i < node->child_count; i++) {
             discover_closures_scoped(gen, node->children[i], "main");
+        }
+        return;
+    }
+    // Actor message handlers are mini-functions for promotion purposes.
+    // Give each receive arm a synthetic enclosing-function name so captures
+    // inside closures in a handler are promoted in that arm's scope alone.
+    // Arm locals don't escape; each arm starts fresh. The name shape
+    // `__actor_<ActorName>__arm_<idx>` is emitted by actor codegen when it
+    // publishes the promoted set at the handler's generate_statement site.
+    if (node->type == AST_RECEIVE_ARM) {
+        char arm_name[256];
+        // Use the pointer as a quasi-unique disambiguator since we don't
+        // have an arm index accessible here. Actor codegen will use the
+        // same scheme.
+        snprintf(arm_name, sizeof(arm_name), "__recv_arm_%p", (void*)node);
+        for (int i = 0; i < node->child_count; i++) {
+            discover_closures_scoped(gen, node->children[i], arm_name);
         }
         return;
     }

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -430,6 +430,13 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
         }
     }
     
+    // Publish this function's promoted-captures set so var decls malloc
+    // heap cells and reads/writes dereference. (Route 1.)
+    char** prev_promoted = gen->current_promoted_captures;
+    int prev_promoted_count = gen->current_promoted_capture_count;
+    get_promoted_names_for_func(gen, func->value,
+        &gen->current_promoted_captures, &gen->current_promoted_capture_count);
+
     // Generate body
     if (body) {
         // If body is a block, it handles its own scope
@@ -447,6 +454,9 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
 
     // Emit function-level defers at implicit return (end of function)
     exit_scope(gen);
+
+    gen->current_promoted_captures = prev_promoted;
+    gen->current_promoted_capture_count = prev_promoted_count;
 
     unindent(gen);
     print_line(gen, "}");

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -276,11 +276,30 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
         }
         
         // Handle different parameter pattern types
-        if (child->type == AST_PATTERN_VARIABLE || 
+        if (child->type == AST_PATTERN_VARIABLE ||
             child->type == AST_VARIABLE_DECLARATION) {
             if (param_count > 0) fprintf(gen->output, ", ");
             generate_type(gen, child->node_type);
-            fprintf(gen->output, " %s", child->value);
+            // If this parameter is a Route 1 promoted name in this function,
+            // emit it as `_param_<name>` so the body's heap cell can use
+            // the short name. Body prologue below does
+            // `T* name = malloc(...); *name = _param_name;`.
+            char** promoted = NULL;
+            int promoted_count = 0;
+            get_promoted_names_for_func(gen, func->value, &promoted, &promoted_count);
+            int is_promoted = 0;
+            for (int pp = 0; pp < promoted_count; pp++) {
+                if (promoted[pp] && child->value &&
+                    strcmp(promoted[pp], child->value) == 0) {
+                    is_promoted = 1;
+                    break;
+                }
+            }
+            if (is_promoted) {
+                fprintf(gen->output, " _param_%s", child->value);
+            } else {
+                fprintf(gen->output, " %s", child->value);
+            }
             param_count++;
         } else if (child->type == AST_PATTERN_LITERAL) {
             // Pattern literal becomes regular parameter
@@ -320,7 +339,7 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
     clear_heap_string_vars(gen);
 
     // Mark function parameters as declared so they aren't re-declared
-    // (e.g., by hoist_loop_vars when a parameter is reassigned in a loop)
+    // (e.g., by hoist_loop_vars when a parameter is reassigned in a loop).
     for (int i = 0; i < func->child_count; i++) {
         ASTNode* child = func->children[i];
         if (!child) continue;
@@ -334,6 +353,51 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
     gen->defer_count = 0;
     gen->scope_depth = 0;
     enter_scope(gen);
+
+    // Route 1: for any parameter whose name is in this function's
+    // promoted set, the signature was emitted as `_param_<name>`. Emit a
+    // heap cell `T* name = malloc(...); *name = _param_name;` and push a
+    // defer so the rest of the body can use the short name through the
+    // promotion-aware access path. Must happen AFTER enter_scope so the
+    // defer lands in this function's scope, not the caller's.
+    char** promoted_here = NULL;
+    int promoted_here_count = 0;
+    get_promoted_names_for_func(gen, func->value, &promoted_here, &promoted_here_count);
+    for (int i = 0; i < func->child_count; i++) {
+        ASTNode* child = func->children[i];
+        if (!child) continue;
+        if ((child->type == AST_PATTERN_VARIABLE || child->type == AST_VARIABLE_DECLARATION)
+            && child->value) {
+            int is_promoted = 0;
+            for (int pp = 0; pp < promoted_here_count; pp++) {
+                if (promoted_here[pp] &&
+                    strcmp(promoted_here[pp], child->value) == 0) {
+                    is_promoted = 1;
+                    break;
+                }
+            }
+            if (is_promoted) {
+                const char* c_type = "int";
+                if (child->node_type && child->node_type->kind != TYPE_UNKNOWN) {
+                    c_type = get_c_type(child->node_type);
+                }
+                print_indent(gen);
+                fprintf(gen->output, "%s* %s = malloc(sizeof(%s)); *%s = _param_%s;\n",
+                        c_type, child->value, c_type, child->value, child->value);
+                // Defer free(name) at function exit.
+                ASTNode* free_call = create_ast_node(AST_FUNCTION_CALL, "free",
+                    child->line, child->column);
+                ASTNode* arg = create_ast_node(AST_IDENTIFIER, child->value,
+                    child->line, child->column);
+                arg->annotation = strdup("raw_promoted");
+                add_child(free_call, arg);
+                ASTNode* expr_stmt = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
+                    child->line, child->column);
+                add_child(expr_stmt, free_call);
+                push_defer(gen, expr_stmt);
+            }
+        }
+    }
     
     // Generate pattern matching checks
     int pattern_idx = 0;

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -72,6 +72,10 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main);
 /* Closure support (codegen_expr.c) */
 void discover_closures(CodeGenerator* gen, ASTNode* node);
 void emit_closure_definitions(CodeGenerator* gen);
+/* Route 1 promotion queries (populated by discover_closures): */
+void get_promoted_names_for_func(CodeGenerator* gen, const char* func_name,
+                                 char*** out_names, int* out_count);
+int is_promoted_capture(CodeGenerator* gen, const char* name);
 
 /* Internal helpers shared across files */
 int contains_send_expression(ASTNode* node);

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -911,37 +911,65 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                             mark_heap_string_var(gen, stmt->value);
                         }
                     }
-                    // Record variable→closure mapping for closure invocation
+                    // Record variable→closure mapping for closure invocation.
+                    // If the variable was previously bound to a different
+                    // closure (e.g. reassigned from |a,b|->a+b to |a,b|->a*b),
+                    // mark the entry as ambiguous (closure_id = -1) so
+                    // call() falls back to generic function-pointer dispatch
+                    // through .fn — which always reflects the currently-stored
+                    // closure, not whichever one was first assigned.
                     if (stmt->child_count > 0 && stmt->children[0] &&
                         stmt->children[0]->type == AST_CLOSURE &&
                         stmt->children[0]->value && stmt->value) {
                         int cid = atoi(stmt->children[0]->value);
-                        if (gen->closure_var_count >= gen->closure_var_capacity) {
-                            gen->closure_var_capacity = gen->closure_var_capacity ? gen->closure_var_capacity * 2 : 16;
-                            gen->closure_var_map = realloc(gen->closure_var_map,
-                                gen->closure_var_capacity * sizeof(gen->closure_var_map[0]));
-                        }
-                        gen->closure_var_map[gen->closure_var_count].var_name = strdup(stmt->value);
-                        gen->closure_var_map[gen->closure_var_count].closure_id = cid;
-                        gen->closure_var_count++;
-
-                        // Emit deferred free for heap-allocated closure environments
-                        for (int ci = 0; ci < gen->closure_count; ci++) {
-                            if (gen->closures[ci].id == cid && gen->closures[ci].capture_count > 0) {
-                                // Create a synthetic defer: free(var.env)
-                                ASTNode* free_call = create_ast_node(AST_FUNCTION_CALL, "free",
-                                    stmt->line, stmt->column);
-                                char env_access[256];
-                                snprintf(env_access, sizeof(env_access), "%s.env", safe_c_name(stmt->value));
-                                ASTNode* env_arg = create_ast_node(AST_IDENTIFIER, env_access,
-                                    stmt->line, stmt->column);
-                                add_child(free_call, env_arg);
-                                // Wrap in expression statement so generate_statement handles it
-                                ASTNode* expr_stmt = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
-                                    stmt->line, stmt->column);
-                                add_child(expr_stmt, free_call);
-                                push_defer(gen, expr_stmt);
+                        int existing_idx = -1;
+                        for (int ci = 0; ci < gen->closure_var_count; ci++) {
+                            if (gen->closure_var_map[ci].var_name &&
+                                strcmp(gen->closure_var_map[ci].var_name, stmt->value) == 0) {
+                                existing_idx = ci;
                                 break;
+                            }
+                        }
+                        int is_first_assignment = (existing_idx < 0);
+                        if (existing_idx >= 0) {
+                            if (gen->closure_var_map[existing_idx].closure_id != cid) {
+                                gen->closure_var_map[existing_idx].closure_id = -1;
+                            }
+                        } else {
+                            if (gen->closure_var_count >= gen->closure_var_capacity) {
+                                gen->closure_var_capacity = gen->closure_var_capacity ? gen->closure_var_capacity * 2 : 16;
+                                gen->closure_var_map = realloc(gen->closure_var_map,
+                                    gen->closure_var_capacity * sizeof(gen->closure_var_map[0]));
+                            }
+                            gen->closure_var_map[gen->closure_var_count].var_name = strdup(stmt->value);
+                            gen->closure_var_map[gen->closure_var_count].closure_id = cid;
+                            gen->closure_var_count++;
+                        }
+
+                        // Emit deferred free for heap-allocated closure envs
+                        // only on the FIRST assignment — reassignment replaces
+                        // the env pointer in the variable, and the existing
+                        // defer will free whatever env is live at scope exit.
+                        // Pushing a second defer on reassignment would
+                        // double-free when the scope unwinds.
+                        if (is_first_assignment) {
+                            for (int ci = 0; ci < gen->closure_count; ci++) {
+                                if (gen->closures[ci].id == cid && gen->closures[ci].capture_count > 0) {
+                                    // Create a synthetic defer: free(var.env)
+                                    ASTNode* free_call = create_ast_node(AST_FUNCTION_CALL, "free",
+                                        stmt->line, stmt->column);
+                                    char env_access[256];
+                                    snprintf(env_access, sizeof(env_access), "%s.env", safe_c_name(stmt->value));
+                                    ASTNode* env_arg = create_ast_node(AST_IDENTIFIER, env_access,
+                                        stmt->line, stmt->column);
+                                    add_child(free_call, env_arg);
+                                    // Wrap in expression statement so generate_statement handles it
+                                    ASTNode* expr_stmt = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
+                                        stmt->line, stmt->column);
+                                    add_child(expr_stmt, free_call);
+                                    push_defer(gen, expr_stmt);
+                                    break;
+                                }
                             }
                         }
                     }

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -41,13 +41,55 @@ static void collect_returned_closures(CodeGenerator* gen, ASTNode* expr,
         if (lookup_closure_var(gen, expr->value, &cid)) {
             add_protected_name(names, count, cap, expr->value);
             // Transitive: any capture of this closure that is itself a
-            // closure variable must also be protected.
+            // closure variable must also be protected. Likewise, any
+            // capture of this closure that is a Route 1 promoted cell
+            // must have its free suppressed — the cell's pointer is
+            // inside the returned closure's env.
             for (int ci = 0; ci < gen->closure_count; ci++) {
                 if (gen->closures[ci].id != cid) continue;
+                const char* pfn = gen->closures[ci].parent_func;
+                char** promoted = NULL;
+                int promoted_count = 0;
+                get_promoted_names_for_func(gen, pfn, &promoted, &promoted_count);
                 for (int k = 0; k < gen->closures[ci].capture_count; k++) {
                     const char* cap_name = gen->closures[ci].captures[k];
-                    if (cap_name && lookup_closure_var(gen, cap_name, NULL)) {
+                    if (!cap_name) continue;
+                    if (lookup_closure_var(gen, cap_name, NULL)) {
                         add_protected_name(names, count, cap, cap_name);
+                    }
+                    for (int pp = 0; pp < promoted_count; pp++) {
+                        if (promoted[pp] && strcmp(promoted[pp], cap_name) == 0) {
+                            add_protected_name(names, count, cap, cap_name);
+                            break;
+                        }
+                    }
+                }
+                break;
+            }
+        }
+    }
+    // Inline closure literal in the return expression (e.g.
+    // `return || { count = count + 1; return count }`). Protect any
+    // promoted captures this closure carries — the pointer lives inside
+    // the returned closure's env and must not be freed before the
+    // caller uses it.
+    if (expr->type == AST_CLOSURE && expr->value) {
+        int cid = atoi(expr->value);
+        if (cid >= 0) {
+            for (int ci = 0; ci < gen->closure_count; ci++) {
+                if (gen->closures[ci].id != cid) continue;
+                const char* pfn = gen->closures[ci].parent_func;
+                char** promoted = NULL;
+                int promoted_count = 0;
+                get_promoted_names_for_func(gen, pfn, &promoted, &promoted_count);
+                for (int k = 0; k < gen->closures[ci].capture_count; k++) {
+                    const char* cap_name = gen->closures[ci].captures[k];
+                    if (!cap_name) continue;
+                    for (int pp = 0; pp < promoted_count; pp++) {
+                        if (promoted[pp] && strcmp(promoted[pp], cap_name) == 0) {
+                            add_protected_name(names, count, cap, cap_name);
+                            break;
+                        }
                     }
                 }
                 break;
@@ -628,9 +670,60 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                     break;
                 }
 
+                // Route 1: promoted captures are heap-allocated cells. In an
+                // outer function body, the FIRST assignment declares
+                // `int* name = malloc(...); *name = <init>;` and queues a
+                // defer for free(). Subsequent writes emit `*name = <expr>;`.
+                // In a closure body, the name is never newly declared (it's
+                // aliased from _env->name in the prologue), so all writes
+                // are dereferences.
+                if (is_promoted_capture(gen, stmt->value)) {
+                    if (!is_var_declared(gen, stmt->value)) {
+                        // First occurrence in this scope — declaration:
+                        // allocate, initialise, defer the free.
+                        const char* c_type = get_c_type(stmt->node_type);
+                        if (!c_type || c_type[0] == 0) c_type = "int";
+                        fprintf(gen->output, "%s* %s = malloc(sizeof(%s)); *%s = ",
+                                c_type, stmt->value, c_type, stmt->value);
+                        if (stmt->child_count > 0) {
+                            generate_expression(gen, stmt->children[0]);
+                        } else {
+                            fprintf(gen->output, "0");
+                        }
+                        fprintf(gen->output, ";\n");
+                        mark_var_declared(gen, stmt->value);
+                        // Defer free(name) at scope exit.
+                        ASTNode* free_call = create_ast_node(AST_FUNCTION_CALL, "free",
+                            stmt->line, stmt->column);
+                        ASTNode* arg = create_ast_node(AST_IDENTIFIER, stmt->value,
+                            stmt->line, stmt->column);
+                        // Mark so the AST_IDENTIFIER emission doesn't dereference it
+                        // (free takes the pointer itself, not `*name`).
+                        if (arg->annotation) free(arg->annotation);
+                        arg->annotation = strdup("raw_promoted");
+                        add_child(free_call, arg);
+                        ASTNode* expr_stmt = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
+                            stmt->line, stmt->column);
+                        add_child(expr_stmt, free_call);
+                        push_defer(gen, expr_stmt);
+                    } else {
+                        // Reassignment: write through the pointer.
+                        fprintf(gen->output, "*%s", stmt->value);
+                        if (stmt->child_count > 0) {
+                            fprintf(gen->output, " = ");
+                            generate_expression(gen, stmt->children[0]);
+                        }
+                        fprintf(gen->output, ";\n");
+                    }
+                    break;
+                }
+
                 // If we're in a closure body and this name is a mutated capture,
                 // route the write through _env-> so mutations persist on the env
                 // struct rather than dying with a stack-local alias.
+                // NOTE: with Route 1, this path is bypassed for promoted names
+                // (handled above). It remains as a fallback for the pre-Route-1
+                // env-cap mechanism.
                 int is_env_cap = 0;
                 for (int ec = 0; ec < gen->current_env_capture_count; ec++) {
                     if (gen->current_env_captures[ec] &&
@@ -1601,6 +1694,44 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                     int protected_count = 0, protected_cap = 0;
                     collect_returned_closures(gen, stmt->children[0],
                                               &protected_names, &protected_count, &protected_cap);
+                    // Transitive closure-of-captures fixpoint: if bump
+                    // escapes and bump captures digit, digit's captures
+                    // must also be protected. collect_returned_closures
+                    // only handled the first hop; iterate until stable.
+                    int scan_idx = 0;
+                    while (scan_idx < protected_count) {
+                        int start_count = protected_count;
+                        for (int i = scan_idx; i < start_count; i++) {
+                            const char* name = protected_names[i];
+                            if (!name) continue;
+                            int cid;
+                            if (!lookup_closure_var(gen, name, &cid)) continue;
+                            for (int ci = 0; ci < gen->closure_count; ci++) {
+                                if (gen->closures[ci].id != cid) continue;
+                                const char* pfn = gen->closures[ci].parent_func;
+                                char** promoted = NULL;
+                                int promoted_count = 0;
+                                get_promoted_names_for_func(gen, pfn, &promoted, &promoted_count);
+                                for (int k = 0; k < gen->closures[ci].capture_count; k++) {
+                                    const char* cap_name = gen->closures[ci].captures[k];
+                                    if (!cap_name) continue;
+                                    if (lookup_closure_var(gen, cap_name, NULL)) {
+                                        add_protected_name(&protected_names, &protected_count,
+                                                           &protected_cap, cap_name);
+                                    }
+                                    for (int pp = 0; pp < promoted_count; pp++) {
+                                        if (promoted[pp] && strcmp(promoted[pp], cap_name) == 0) {
+                                            add_protected_name(&protected_names, &protected_count,
+                                                               &protected_cap, cap_name);
+                                            break;
+                                        }
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                        scan_idx = start_count;
+                    }
                     emit_all_defers_protected(gen, protected_names, protected_count);
                     for (int p = 0; p < protected_count; p++) free(protected_names[p]);
                     free(protected_names);

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -1722,6 +1722,10 @@ ASTNode* parse_import_statement(Parser* parser) {
         if (alias) {
             ASTNode* alias_node = create_ast_node(AST_IDENTIFIER, alias->value,
                                                  alias->line, alias->column);
+            // Mark so the typechecker can tell `as`-aliases apart from
+            // selective-import symbols, which share AST_IDENTIFIER children
+            // of the import statement.
+            alias_node->annotation = strdup("module_alias");
             // Store alias as last child
             add_child(import_stmt, alias_node);
         }

--- a/tests/syntax/README_closure_actor_state_limitation.md
+++ b/tests/syntax/README_closure_actor_state_limitation.md
@@ -1,0 +1,63 @@
+# Known limitation: closures in actor handlers can't mutate actor state
+
+A closure declared inside an actor's receive arm body can:
+- Capture and mutate **arm-local** variables (Route 1, tested by
+  `test_closure_in_actor_handler.ae`).
+- Be stored in an actor state field (tested by
+  `test_closure_in_actor_state.ae`).
+
+A closure declared inside an actor's receive arm body CANNOT currently:
+- Mutate actor state fields.
+
+The failing pattern:
+
+```aether
+actor Counter {
+    state count = 0
+
+    receive {
+        Go() -> {
+            inc = || { count = count + 1 }  // writes actor state
+            call(inc)
+            call(inc)
+        }
+    }
+}
+```
+
+Generated code for the closure body is:
+
+```c
+static void _closure_fn_0(_closure_env_0* _env) {
+    int count = (count + 1);  // wrong — reads uninitialised local
+}
+```
+
+Root cause: the closure doesn't know about `self` (the actor pointer).
+Actor state fields are accessed as `self->field` in generated C, but
+closures are hoisted to static functions that don't take `self`.
+Properly handling this requires threading `self` through the closure's
+env — a real feature, not a quick fix.
+
+Workaround: copy state into an arm-local first, mutate that, then
+write back at end of handler:
+
+```aether
+actor Counter {
+    state count = 0
+
+    receive {
+        Go() -> {
+            local = count
+            inc = || { local = local + 1 }  // Route 1 promotes local
+            call(inc)
+            call(inc)
+            count = local
+        }
+    }
+}
+```
+
+Tracked for a future PR. No silent-wrong-answer protection yet — the
+compiler doesn't reject the broken pattern. File an issue if you hit
+this in real code.

--- a/tests/syntax/test_closure_calculator_shape.ae
+++ b/tests/syntax/test_closure_calculator_shape.ae
@@ -1,0 +1,60 @@
+// Integration test: the calculator DSL pattern from
+// contrib/aether_ui/example_calculator.ae, minus the UI.
+//
+// Four closures share three outer variables (num, prev, op). The `op`
+// variable holds a closure that gets reassigned when the user presses
+// +/-/*//, and `equals` dispatches through whichever operator is
+// currently stored. Combines:
+//   - Route 1 mutable captures (num, prev — written by multiple closures)
+//   - Closure-var reassignment (op holds different closures at different
+//     times, call(op, ...) dispatches through the current one)
+//   - Mixed read/write captures (read in one closure, write in another)
+
+extern exit(code: int)
+
+main() {
+    num  = 0
+    prev = 0
+    op   = |a: int, b: int| { return a }   // identity, reassigned later
+
+    digit    = |d: int|  { num = num * 10 + d }
+    apply_op = |fn: fn|  { prev = num; num = 0; op = fn }
+    equals   = ||        { num = call(op, prev, num); prev = 0 }
+    clear    = ||        { num = 0; prev = 0 }
+
+    // 2 + 3 = 5
+    call(digit, 2)
+    if num != 2 { println("FAIL: after digit 2, num="); println(num); exit(1) }
+
+    call(apply_op, |a: int, b: int| { return a + b })
+    if prev != 2 { println("FAIL: after apply_op +, prev="); println(prev); exit(1) }
+    if num != 0 { println("FAIL: after apply_op +, num="); println(num); exit(1) }
+
+    call(digit, 3)
+    if num != 3 { println("FAIL: after digit 3, num="); println(num); exit(1) }
+
+    call(equals)
+    if num != 5 { println("FAIL: after = for 2+3, num="); println(num); exit(1) }
+
+    // 4 * 7 = 28 with clear between
+    call(clear)
+    if num != 0 { println("FAIL: after clear, num="); println(num); exit(1) }
+
+    call(digit, 4)
+    call(apply_op, |a: int, b: int| { return a * b })
+    call(digit, 7)
+    call(equals)
+    if num != 28 { println("FAIL: 4*7, num="); println(num); exit(1) }
+
+    // Multi-digit: 12 - 5 = 7
+    call(clear)
+    call(digit, 1)
+    call(digit, 2)
+    if num != 12 { println("FAIL: 12, num="); println(num); exit(1) }
+    call(apply_op, |a: int, b: int| { return a - b })
+    call(digit, 5)
+    call(equals)
+    if num != 7 { println("FAIL: 12-5, num="); println(num); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_chained_promoted.ae
+++ b/tests/syntax/test_closure_chained_promoted.ae
@@ -1,0 +1,27 @@
+// Chained closure captures: outer closure captures inner closure which
+// captures a promoted outer variable. All three layers must agree on
+// the shared heap cell.
+
+extern exit(code: int)
+
+main() {
+    total = 0
+
+    // inner captures and writes `total`.
+    inner = |d: int| { total = total + d }
+
+    // outer captures inner and writes through it.
+    outer = |d: int| { call(inner, d); call(inner, d) }
+
+    call(outer, 5)   // inner called twice with 5 => total += 10
+    if total != 10 { println("FAIL: after first outer, expected 10, got:"); println(total); exit(1) }
+
+    call(outer, 3)   // total += 6 => 16
+    if total != 16 { println("FAIL: after second outer, expected 16, got:"); println(total); exit(1) }
+
+    // Direct call to inner also lands on the same cell.
+    call(inner, 100)
+    if total != 116 { println("FAIL: after direct inner, expected 116, got:"); println(total); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_declared_in_trailing_block.ae
+++ b/tests/syntax/test_closure_declared_in_trailing_block.ae
@@ -1,0 +1,38 @@
+// Edge: a closure is DECLARED inside a trailing DSL block, not just
+// invoked there. The closure captures and mutates a main-scope var.
+// Trailing-block inlining emits the closure body in-place; promotion
+// rewriting must apply to those inlined statements the same way it
+// applies to the outer function body.
+
+import std.map
+
+extern exit(code: int)
+
+configure(_ctx: ptr, key: string, value: string) {
+    map_put(_ctx, key, value)
+}
+
+build() {
+    _ctx = map_new()
+    return _ctx
+}
+
+main() {
+    score = 0
+    result = build() {
+        configure("initial", "set")
+        // Closure declared inside the trailing block, captures main's score.
+        add_point = || { score = score + 1 }
+        call(add_point)
+        call(add_point)
+        call(add_point)
+    }
+
+    if score != 3 {
+        println("FAIL: expected 3, got:")
+        println(score)
+        exit(1)
+    }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_escape_with_promoted.ae
+++ b/tests/syntax/test_closure_escape_with_promoted.ae
@@ -1,0 +1,43 @@
+// Escape + promoted: a user function heap-promotes a local, returns
+// a closure that captures it, and the caller invokes the returned
+// closure after the creating function has returned. The promoted
+// cell's defer must be suppressed so the caller's calls see a live
+// pointer, and the cell eventually gets freed (ownership transfers).
+
+extern exit(code: int)
+
+make_counter(initial: int) {
+    n = initial
+    return || { n = n + 1; return n }
+}
+
+make_lazy_adder(base: int) {
+    // base is a parameter, promoted because the closure writes it.
+    step = || { base = base + 10 }
+    call(step)
+    call(step)
+    return || { return base }
+}
+
+main() {
+    c = make_counter(100)
+    r1 = call(c)
+    r2 = call(c)
+    r3 = call(c)
+    if r1 != 101 { println("FAIL: c first, expected 101, got:"); println(r1); exit(1) }
+    if r2 != 102 { println("FAIL: c second, expected 102, got:"); println(r2); exit(1) }
+    if r3 != 103 { println("FAIL: c third, expected 103, got:"); println(r3); exit(1) }
+
+    // Second counter starts fresh.
+    c2 = make_counter(-5)
+    r4 = call(c2)
+    if r4 != -4 { println("FAIL: c2 first, expected -4, got:"); println(r4); exit(1) }
+
+    // Lazy adder: param mutated inside the function before return.
+    la = make_lazy_adder(50)
+    rla = call(la)
+    // After make_lazy_adder called step() twice, base = 50 + 20 = 70
+    if rla != 70 { println("FAIL: lazy adder, expected 70, got:"); println(rla); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_fn_param_with_promoted.ae
+++ b/tests/syntax/test_closure_fn_param_with_promoted.ae
@@ -1,0 +1,33 @@
+// Integration: a user function takes a closure argument (`f: fn`) and
+// calls it. The argument closure captures an outer promoted variable.
+// Tests that the dispatch through `f: fn` still reaches the closure's
+// function pointer + its env correctly — and that the captured
+// promoted cell is reachable.
+
+extern exit(code: int)
+
+apply_twice(x: int, f: fn) {
+    return call(f, call(f, x))
+}
+
+main() {
+    base = 1
+    // Closure that adds `base` to its argument. `base` is outer-scope
+    // and written below — so promoted.
+    adder = |x: int| { return x + base }
+
+    r = apply_twice(10, adder)
+    // adder(10) = 10 + 1 = 11; adder(11) = 11 + 1 = 12
+    if r != 12 { println("FAIL: initial, expected 12, got:"); println(r); exit(1) }
+
+    // Mutate base through a writer closure. adder captured a pointer to
+    // base's cell, so the next invocation sees the new value.
+    set_base = |v: int| { base = v }
+    call(set_base, 100)
+
+    r2 = apply_twice(10, adder)
+    // adder(10) = 10 + 100 = 110; adder(110) = 110 + 100 = 210
+    if r2 != 210 { println("FAIL: after base=100, expected 210, got:"); println(r2); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_heterogeneous_reassignment.ae
+++ b/tests/syntax/test_closure_heterogeneous_reassignment.ae
@@ -1,0 +1,26 @@
+// Closure variable reassigned to closures with different arg counts
+// or types. Each call() must see the signature of whatever's currently
+// stored. Forces the generic-dispatch fallback.
+
+extern exit(code: int)
+
+main() {
+    // Two-arg closure.
+    fn = |a: int, b: int| { return a + b }
+    r1 = call(fn, 10, 20)
+    if r1 != 30 { println("FAIL: two-arg"); exit(1) }
+
+    // Reassign to a two-arg closure with different body.
+    fn = |a: int, b: int| { return a - b }
+    r2 = call(fn, 10, 20)
+    if r2 != -10 { println("FAIL: reassigned two-arg"); exit(1) }
+
+    // Reassign again.
+    fn = |a: int, b: int| { if a > b { return a } return b }
+    r3 = call(fn, 7, 3)
+    if r3 != 7 { println("FAIL: max closure"); exit(1) }
+    r4 = call(fn, 2, 9)
+    if r4 != 9 { println("FAIL: max closure 2"); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_in_actor_handler.ae
+++ b/tests/syntax/test_closure_in_actor_handler.ae
@@ -1,0 +1,33 @@
+// Edge: a mutating closure inside an actor's message handler.
+// The handler has its own locals; a closure created inside the
+// handler captures and mutates those locals. Route 1 should
+// heap-promote them in the handler's scope just like in any
+// user function.
+
+extern exit(code: int)
+
+message Go {}
+
+actor Worker {
+    receive {
+        Go() -> {
+            total = 0
+            add  = |n: int| { total = total + n }
+            call(add, 10)
+            call(add, 20)
+            call(add, 5)
+            if total != 35 {
+                println("FAIL: actor handler total, expected 35, got:")
+                println(total)
+                exit(1)
+            }
+            println("ok")
+        }
+    }
+}
+
+main() {
+    w = spawn(Worker())
+    w ! Go {}
+    wait_for_idle()
+}

--- a/tests/syntax/test_closure_in_actor_state.ae
+++ b/tests/syntax/test_closure_in_actor_state.ae
@@ -1,0 +1,58 @@
+// Edge: an actor's state field holds a closure. When the actor
+// receives a message, it invokes the stored closure. Tests that
+// actor state marshalling and closures coexist — the state slot
+// holds an _AeClosure struct (two pointers: fn and env) and the
+// actor's step function dispatches through whatever's stored.
+//
+// This test uses a SELF-CONTAINED closure (no capture of actor
+// state) because closures that mutate actor state fields is a
+// separate, unimplemented feature. A closure inside an actor
+// handler can capture arm-local variables (Route 1, tested by
+// test_closure_in_actor_handler) but NOT state fields — that
+// would require threading `self` through the closure's env,
+// which isn't done.
+
+extern exit(code: int)
+extern string_new(s: string) -> ptr
+
+message SetHandlerA {}
+message SetHandlerB {}
+message Fire {}
+message Finish {}
+
+actor Dispatcher {
+    state handler = |x: int| { return x }   // identity default
+    state last_result = 0
+
+    receive {
+        SetHandlerA() -> {
+            // Fresh closure with no captures — body returns x*10
+            handler = |x: int| { return x * 10 }
+        }
+        SetHandlerB() -> {
+            handler = |x: int| { return x + 100 }
+        }
+        Fire() -> {
+            last_result = call(handler, 5)
+        }
+        Finish() -> {
+            // Last handler set was B, called with 5 → 105
+            if last_result != 105 {
+                println("FAIL: expected 105, got:")
+                println(last_result)
+                exit(1)
+            }
+            println("ok")
+        }
+    }
+}
+
+main() {
+    d = spawn(Dispatcher())
+    d ! SetHandlerA {}
+    d ! Fire {}            // last_result = 50 (A: 5*10)
+    d ! SetHandlerB {}
+    d ! Fire {}            // last_result = 105 (B: 5+100)
+    d ! Finish {}
+    wait_for_idle()
+}

--- a/tests/syntax/test_closure_mixed_captures.ae
+++ b/tests/syntax/test_closure_mixed_captures.ae
@@ -1,12 +1,14 @@
 // Regression: one read-only capture and one mutated capture in the same
-// closure. Read-only captures keep the cheap alias in the body prologue;
-// mutated captures route through _env->. Both must coexist.
+// closure. Read-only captures keep the cheap value alias in the body
+// prologue; mutated captures get heap-promoted (Route 1) so the outer
+// scope and the closure share the same cell. Both must coexist inside
+// one closure.
 
 extern exit(code: int)
 
 main() {
-    base = 100           // read-only in closure
-    count = 0            // mutated in closure
+    base = 100           // read-only in closure — captured by value
+    count = 0            // mutated in closure — heap-promoted
     step = || {
         count = count + 1
         return base + count
@@ -17,10 +19,13 @@ main() {
     if r2 != 102 { println("FAIL: r2"); exit(1) }
     r3 = call(step)
     if r3 != 103 { println("FAIL: r3"); exit(1) }
-    // Outer `base` unchanged — read-only captures are by value, unaffected
-    // by anything the closure could have done.
+    // Outer `base` unchanged — read-only captures are by value, so even
+    // if some other code wrote to an outer base after the closure was
+    // made, the closure's view wouldn't change. And the closure can't
+    // write to base since its body doesn't.
     if base != 100 { println("FAIL: base mutated"); exit(1) }
-    // Outer `count` unchanged — by-value semantics, mutations live in env.
-    if count != 0 { println("FAIL: outer count mutated"); exit(1) }
+    // Outer `count` SHARES the heap cell with the closure — the three
+    // increments are visible here.
+    if count != 3 { println("FAIL: outer count, expected 3, got:"); println(count); exit(1) }
     println("ok")
 }

--- a/tests/syntax/test_closure_mixed_readers_and_writer.ae
+++ b/tests/syntax/test_closure_mixed_readers_and_writer.ae
@@ -1,0 +1,30 @@
+// Route 1 regression: a read-only capturing closure and a writing
+// closure that share the same outer variable must agree. The writer
+// forces heap promotion; the reader must capture the same pointer,
+// not a pre-promotion value copy, otherwise the reader sees stale
+// zero while the writer thinks the state moved on.
+//
+// This is the non-local analysis test — Route 1 has to scan ALL
+// closures to decide promotion, not just the one it's emitting.
+
+extern exit(code: int)
+
+main() {
+    count = 0
+    reader = || { return count }
+    writer = || { count = count + 1 }
+
+    call(writer)
+    r1 = call(reader)
+    if r1 != 1 { println("FAIL: reader after 1 write, expected 1, got:"); println(r1); exit(1) }
+
+    call(writer)
+    call(writer)
+    r2 = call(reader)
+    if r2 != 3 { println("FAIL: reader after 3 writes, expected 3, got:"); println(r2); exit(1) }
+
+    // Outer also sees the shared state.
+    if count != 3 { println("FAIL: outer count, expected 3, got:"); println(count); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_multiple_writers.ae
+++ b/tests/syntax/test_closure_multiple_writers.ae
@@ -1,0 +1,34 @@
+// Route 1 regression: two distinct closures both write the same outer
+// variable. They must share one heap cell — not each get their own
+// env copy — otherwise their writes drift apart and observers see
+// stale values.
+
+extern exit(code: int)
+
+main() {
+    balance = 0
+    deposit  = || { balance = balance + 10 }
+    withdraw = || { balance = balance - 3 }
+
+    call(deposit)   // 10
+    call(deposit)   // 20
+    call(withdraw)  // 17
+    call(deposit)   // 27
+    call(withdraw)  // 24
+
+    if balance != 24 { println("FAIL: balance=24 expected, got:"); println(balance); exit(1) }
+
+    // A third closure that captures the same var should also see the
+    // current state, even though it was defined after deposits happened.
+    report = || { return balance }
+    r = call(report)
+    if r != 24 { println("FAIL: report=24 expected, got:"); println(r); exit(1) }
+
+    // And a writing closure defined after the reader — they still share.
+    doubler = || { balance = balance * 2 }
+    call(doubler)
+    if call(report) != 48 { println("FAIL: post-double expected 48"); exit(1) }
+    if balance != 48 { println("FAIL: outer after double expected 48, got:"); println(balance); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_mutable_capture_probe.ae
+++ b/tests/syntax/test_closure_mutable_capture_probe.ae
@@ -1,0 +1,23 @@
+// Route 1 regression: closures that assign to a captured variable cause
+// the variable to be heap-promoted, so both outer reads and other
+// closures see the update. This is the Ruby/Groovy model.
+//
+// Required for contrib/aether_ui/example_calculator.ae to work
+// elegantly — its digit/apply_op/equals/clear closures all share
+// `num`, `prev`, `op` without ref cells.
+
+extern exit(code: int)
+
+main() {
+    n = 0
+    inc = || { n = n + 1 }
+    call(inc)
+    call(inc)
+    call(inc)
+    // Under pre-Route-1 by-value: n would still be 0 (closure wrote to
+    // its env copy, outer untouched).
+    // Under Route 1: n is 3 — outer binding was heap-promoted, closure
+    // captured the pointer, writes go to the shared cell.
+    if n != 3 { println("FAIL: expected n=3, got:"); println(n); exit(1) }
+    println("ok")
+}

--- a/tests/syntax/test_closure_mutable_param_capture.ae
+++ b/tests/syntax/test_closure_mutable_param_capture.ae
@@ -1,0 +1,38 @@
+// Route 1 regression: a user function's parameter is captured and
+// mutated by a closure inside that function. The parameter is a
+// local binding just like a declared variable; it must heap-promote
+// the same way.
+
+extern exit(code: int)
+
+bumper(start: int) {
+    n = start    // declaration forced by the write below — is n promoted?
+    inc = || { n = n + 1 }
+    call(inc)
+    call(inc)
+    return n
+}
+
+// Same idea but the parameter itself is the mutated name (no local copy).
+paramwriter(x: int) {
+    f = || { x = x + 100 }
+    call(f)
+    return x
+}
+
+main() {
+    r1 = bumper(10)
+    if r1 != 12 { println("FAIL: bumper(10), expected 12, got:"); println(r1); exit(1) }
+
+    r2 = bumper(100)
+    if r2 != 102 { println("FAIL: bumper(100), expected 102, got:"); println(r2); exit(1) }
+
+    // Each call to bumper allocates its own heap cell — no leakage between
+    // invocations, no shared state.
+    if r1 + r2 != 114 { println("FAIL: per-call isolation broken"); exit(1) }
+
+    r3 = paramwriter(5)
+    if r3 != 105 { println("FAIL: paramwriter, expected 105, got:"); println(r3); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_nested_block_capture.ae
+++ b/tests/syntax/test_closure_nested_block_capture.ae
@@ -1,0 +1,29 @@
+// Route 1 regression: a mutable-capturing closure declared inside a
+// nested block (if / for) still heap-promotes the outer variable.
+// is_declared_in_function must recurse into nested blocks (does, per
+// the previous subtree_declares fix) — this test pins that.
+
+extern exit(code: int)
+
+main() {
+    n = 0
+    cond = 1
+    if cond == 1 {
+        // Closure declared inside an if-block, captures and writes main's `n`.
+        inc = || { n = n + 10 }
+        call(inc)
+        call(inc)
+    }
+    // Outer sees the mutation from inside the nested block.
+    if n != 20 { println("FAIL: expected 20, got:"); println(n); exit(1) }
+
+    // Same with a for-loop: multiple closures across iterations all hit
+    // the same heap cell.
+    for (i = 0; i < 3; i++) {
+        step = || { n = n + 1 }
+        call(step)
+    }
+    if n != 23 { println("FAIL: after for-loop, expected 23, got:"); println(n); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_null_init_promoted.ae
+++ b/tests/syntax/test_closure_null_init_promoted.ae
@@ -1,0 +1,27 @@
+// Edge: a variable initialised to null, then captured and mutated
+// by a closure. Tests the null-init path through promotion, both
+// for pointer-typed and untyped vars.
+
+extern exit(code: int)
+
+main() {
+    // Pointer-typed null init.
+    cached = null
+    fill = || {
+        if cached == null {
+            cached = ref(42)
+        }
+    }
+
+    call(fill)
+    if cached == null { println("FAIL: cached still null after fill"); exit(1) }
+
+    // Second call: shouldn't overwrite because cached is non-null now.
+    call(fill)
+    // We can't easily check pointer identity without more plumbing, but
+    // we can verify cached still points to a 42.
+    if ref_get(cached) != 42 { println("FAIL: cached value wrong"); exit(1) }
+
+    ref_free(cached)
+    println("ok")
+}

--- a/tests/syntax/test_closure_outer_writes_interleaved.ae
+++ b/tests/syntax/test_closure_outer_writes_interleaved.ae
@@ -1,0 +1,31 @@
+// Route 1 regression: outer scope can read and write the shared
+// variable before, between, and after closure calls, and everyone
+// sees the same cell. Tests the "all writes go through the heap
+// pointer" part of the rewrite — if any outer write is missed by
+// the rewriter, closures see a stale value.
+
+extern exit(code: int)
+
+main() {
+    n = 10
+    inc_by_5 = || { n = n + 5 }
+
+    // Outer write before closure call — must be visible to closure.
+    n = 20
+    call(inc_by_5)
+    if n != 25 { println("FAIL: n=25 expected, got:"); println(n); exit(1) }
+
+    // Outer write in between calls.
+    n = 100
+    call(inc_by_5)
+    if n != 105 { println("FAIL: n=105 expected, got:"); println(n); exit(1) }
+
+    // Closure call, then outer read, then outer write, then closure call.
+    call(inc_by_5)            // 110
+    if n != 110 { println("FAIL: n=110 expected, got:"); println(n); exit(1) }
+    n = n * 2                  // 220 (read + write on the same line)
+    call(inc_by_5)            // 225
+    if n != 225 { println("FAIL: n=225 expected, got:"); println(n); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_param_shadows_promoted.ae
+++ b/tests/syntax/test_closure_param_shadows_promoted.ae
@@ -1,0 +1,28 @@
+// Route 1 edge: a closure parameter with the same name as an outer
+// promoted variable. The parameter wins within the closure body — its
+// reference should be the parameter value, not the outer heap cell.
+//
+// This tests that is_closure_param takes precedence over the
+// promotion rewrite.
+
+extern exit(code: int)
+
+main() {
+    n = 0
+    bumper = || { n = n + 1 }    // captures and mutates outer n
+    shadow = |n: int| { return n * 2 }   // local n — parameter wins
+
+    call(bumper)
+    call(bumper)
+    call(bumper)
+    if n != 3 { println("FAIL: outer n, expected 3, got:"); println(n); exit(1) }
+
+    // Inside shadow, n is the parameter (42), not the outer n (3).
+    r = call(shadow, 42)
+    if r != 84 { println("FAIL: shadow param, expected 84, got:"); println(r); exit(1) }
+
+    // After call(shadow), outer n is still 3 — shadow didn't touch it.
+    if n != 3 { println("FAIL: outer n mutated by shadow, got:"); println(n); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_promoted_as_initializer.ae
+++ b/tests/syntax/test_closure_promoted_as_initializer.ae
@@ -1,0 +1,30 @@
+// Route 1 edge: a promoted variable used as the initializer expression
+// of another variable. The reader should dereference through the
+// pointer, not read a stale non-promoted value.
+
+extern exit(code: int)
+
+main() {
+    n = 0
+    inc = || { n = n + 1 }
+    call(inc)
+    call(inc)
+
+    // n is 2 now. Use it as an initializer.
+    m = n           // reads *n through the promotion path
+    if m != 2 { println("FAIL: m = n, expected 2, got:"); println(m); exit(1) }
+
+    // Use n in arithmetic, comparison, as a function argument.
+    sum = n + 10
+    if sum != 12 { println("FAIL: sum, expected 12, got:"); println(sum); exit(1) }
+
+    if n < 0 { println("FAIL: n should be positive"); exit(1) }
+    if n > 100 { println("FAIL: n should not exceed 100"); exit(1) }
+
+    // Mutate again, verify m is unchanged (m is a fresh local, not a ref).
+    call(inc)
+    if n != 3 { println("FAIL: after third inc"); exit(1) }
+    if m != 2 { println("FAIL: m should be unchanged at 2, got:"); println(m); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_promoted_in_trailing_block.ae
+++ b/tests/syntax/test_closure_promoted_in_trailing_block.ae
@@ -1,0 +1,53 @@
+// Edge: a mutable-capturing closure inside a trailing DSL block.
+// Trailing blocks are inlined at the call site (not hoisted to a
+// static function), so their statements live in the caller's scope.
+// If a closure inside the trailing block writes a main-scope variable
+// that's promoted elsewhere, the inline emission must still
+// dereference through the pointer correctly.
+
+import std.map
+
+extern exit(code: int)
+
+// Builder function: block runs first, configuring `_ctx` (a map),
+// then function executes using it.
+configure(_ctx: ptr, key: string, value: string) {
+    map_put(_ctx, key, value)
+}
+
+// This one doubles as a trigger for trailing-block inline emission.
+build() {
+    _ctx = map_new()
+    return _ctx
+}
+
+main() {
+    // A promoted variable in main (written by a closure below).
+    counter = 0
+    bumper = || { counter = counter + 1 }
+
+    // Trailing block inlines into main. If the DSL's configure()
+    // call body doesn't know about main's promoted `counter`, it
+    // would read a stale value.
+    result = build() {
+        configure("a", "1")
+        configure("b", "2")
+        call(bumper)                     // inside trailing block
+        configure("c", "3")
+        call(bumper)
+    }
+
+    // After the block: counter bumped twice. Outer sees 2 (if
+    // promotion propagated into the inline) or 0 (if not).
+    if counter != 2 {
+        println("FAIL: trailing-block closure calls should bump counter to 2, got:")
+        println(counter)
+        exit(1)
+    }
+
+    // Map was configured correctly (unrelated sanity check).
+    v_a = map_get(result, "a")
+    if v_a == null { println("FAIL: map not configured"); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_reassign_after_box.ae
+++ b/tests/syntax/test_closure_reassign_after_box.ae
@@ -1,0 +1,39 @@
+// Paired with test_closure_reassign_leaks_env: this test verifies the
+// leak-preserving behavior is also the correct-behavior choice when a
+// closure's env has escaped via box_closure. If someone "fixes" the
+// leak by freeing the previous env at reassignment time without escape
+// analysis, this test will fail — the boxed copy still points at the
+// freed env and the call through it would UAF.
+
+import std.list
+
+extern exit(code: int)
+
+main() {
+    held = list.new()
+    defer list.free(held)
+
+    base = 100
+    op = |x: int| { return x + base }
+
+    // Capture a boxed reference to op-v1. The box_closure copies the
+    // {fn, env} struct, so the list now holds a pointer to op-v1's env.
+    list.add(held, box_closure(op))
+
+    // Reassign op. op now points at a different closure. The original
+    // env is still reachable via `held` and must NOT be freed — otherwise
+    // the call through the boxed copy below would read freed memory.
+    op = |x: int| { return x * base }
+
+    // Call the new op.
+    r2 = call(op, 5)
+    if r2 != 500 { println("FAIL: op v2"); exit(1) }
+
+    // Call through the boxed v1 — must still work.
+    boxed = list.get(held, 0)
+    v1 = unbox_closure(boxed)
+    r1 = call(v1, 5)
+    if r1 != 105 { println("FAIL: boxed v1 via dynamic dispatch"); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_reassign_leaks_env.ae
+++ b/tests/syntax/test_closure_reassign_leaks_env.ae
@@ -1,0 +1,50 @@
+// Known limitation: when a closure variable is reassigned, the env of
+// the previous closure is leaked. The auto-defer-free is only emitted
+// on the FIRST assignment (to avoid double-free at scope exit, since
+// reassignment overwrites the .env pointer in the variable).
+//
+// Without escape analysis we can't know if the old env was still
+// reachable through some other path (stored in a list via box_closure,
+// held by another closure, etc.), so freeing it at reassignment would
+// risk a UAF. The safer choice is to leak.
+//
+// This test pins the current behavior: reassignment works functionally
+// (later calls use the new closure), and the program exits cleanly.
+// It does NOT assert the leak is gone — if we fix this via proper
+// ownership tracking later, the test still passes.
+
+extern exit(code: int)
+
+main() {
+    // Reassign N times with captures, ensure the program doesn't crash
+    // and each call uses the currently-stored closure.
+    base = 10
+    op = |x: int| { return x + base }
+
+    r1 = call(op, 5)
+    if r1 != 15 { println("FAIL: op v1"); exit(1) }
+
+    // Reassign op — old env (captures base as int*) leaks.
+    op = |x: int| { return x * base }
+    r2 = call(op, 5)
+    if r2 != 50 { println("FAIL: op v2"); exit(1) }
+
+    // Reassign again — both previous envs leak.
+    op = |x: int| { return x - base }
+    r3 = call(op, 5)
+    if r3 != -5 { println("FAIL: op v3"); exit(1) }
+
+    // Reassign 100 more times to ensure no accumulating harm.
+    for (i = 0; i < 100; i++) {
+        op = |x: int| { return x + i }
+    }
+    r4 = call(op, 1)
+    // Last iteration set op to a closure that returns x + 100 (i was
+    // incremented past the loop bound in the closure at capture time).
+    // We don't assert the exact value — it depends on when i is
+    // captured — just that the call doesn't crash.
+    if r4 < 0 { println("FAIL: post-loop sanity"); exit(1) }
+
+    // Program exits cleanly despite leaked envs.
+    println("ok")
+}

--- a/tests/syntax/test_closure_recursive_promoted.ae
+++ b/tests/syntax/test_closure_recursive_promoted.ae
@@ -1,0 +1,73 @@
+// Edge: a recursive user function where the parameter is heap-
+// promoted. Each recursive call allocates its own heap cell for
+// the parameter. The defer-free fires at each return, freeing only
+// that frame's cell. Mutations in one frame's closure don't leak
+// into another frame.
+
+extern exit(code: int)
+
+count_down(n: int) {
+    // n is promoted because the closure below writes it.
+    tick = || { n = n - 1 }
+
+    // Recursion: if n > 0, recurse (with decremented n — but
+    // importantly, we recurse with the VALUE, not by mutating).
+    if n <= 0 {
+        return 0
+    }
+
+    call(tick)  // decrements n in THIS frame's heap cell
+    // n is now n-1 in this frame. Recursive call gets a new frame
+    // with its own promoted n.
+    return 1 + count_down(n)
+}
+
+// Fibonacci using a closure to memoize-ish — actually just a plain
+// recursive Fibonacci, but the accumulator is promoted via a
+// closure that sums. Tests recursion depth isn't foiled by promotion.
+sum_down(n: int) {
+    total = 0
+    acc = |v: int| { total = total + v }
+
+    if n <= 0 {
+        call(acc, 0)
+        return total
+    }
+
+    call(acc, n)
+    // Recurse — each frame has its own `total` on the heap.
+    return total + sum_down(n - 1)
+}
+
+main() {
+    // count_down(5): each frame decrements its own n once, then returns
+    //   1 + count_down(<new frame with fresh n-1>).
+    //   count_down(5) → 1 + count_down(5-1=4). But wait — after tick, n
+    //   is 4 in this frame. We recurse with n (which is 4 via deref).
+    //   So really count_down starts with n=5, ticks to 4, recurses with 4.
+    //   count_down(4) ticks to 3, recurses with 3.
+    //   ... until count_down(1) ticks to 0, recurses with 0.
+    //   count_down(0) returns 0.
+    //   So the chain is count_down(5)=1+count_down(4)=1+1+count_down(3)
+    //     =1+1+1+count_down(2)=...=1+1+1+1+1+count_down(0)=5.
+    r = count_down(5)
+    if r != 5 { println("FAIL: count_down(5) expected 5, got:"); println(r); exit(1) }
+
+    // sum_down(3): total=0; acc(3) → total=3; recurse with 2.
+    //              total=0; acc(2) → total=2; recurse with 1.
+    //              total=0; acc(1) → total=1; recurse with 0.
+    //              total=0; acc(0) → total=0; return 0.
+    //              unwinds: 0; 1+0=1; 2+1=3; 3+3=6.
+    r2 = sum_down(3)
+    if r2 != 6 { println("FAIL: sum_down(3) expected 6, got:"); println(r2); exit(1) }
+
+    r3 = sum_down(5)    // 5+4+3+2+1+0 = 15
+    if r3 != 15 { println("FAIL: sum_down(5) expected 15, got:"); println(r3); exit(1) }
+
+    // Run a deep recursion to make sure we don't leak or corrupt across
+    // many frames.
+    r4 = sum_down(20)   // 20+19+...+1+0 = 210
+    if r4 != 210 { println("FAIL: sum_down(20) expected 210, got:"); println(r4); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_return_promoted.ae
+++ b/tests/syntax/test_closure_return_promoted.ae
@@ -1,0 +1,43 @@
+// Edge: a user function that heap-promotes a local (because a closure
+// in it writes the local) then returns the promoted VALUE directly
+// (not the closure, not the pointer — the scalar value at the current
+// state of the cell). Caller should see a plain int, not a dangling
+// pointer.
+
+extern exit(code: int)
+
+compute_sum(stop: int) {
+    total = 0
+    // Closure writes `total` — promotes it in compute_sum's scope.
+    add = |n: int| { total = total + n }
+    for (i = 1; i <= stop; i++) {
+        call(add, i)
+    }
+    // Return the promoted var — just the int value, cell freed on exit.
+    return total
+}
+
+first_of(a: int, b: int) {
+    // Similar but the promoted param is returned after mutation.
+    call(|| { a = a + b })
+    return a
+}
+
+main() {
+    r1 = compute_sum(4)     // 1+2+3+4 = 10
+    if r1 != 10 { println("FAIL: compute_sum(4), expected 10, got:"); println(r1); exit(1) }
+
+    r2 = compute_sum(10)    // sum 1..10 = 55
+    if r2 != 55 { println("FAIL: compute_sum(10), expected 55, got:"); println(r2); exit(1) }
+
+    r3 = first_of(3, 7)     // 3 + 7 = 10
+    if r3 != 10 { println("FAIL: first_of(3,7), expected 10, got:"); println(r3); exit(1) }
+
+    // Repeated calls — each invocation gets its own heap cell that's
+    // freed on exit. No leakage between calls (confirm by repeating).
+    if compute_sum(4) != 10 { println("FAIL: compute_sum(4) second call"); exit(1) }
+    if compute_sum(4) != 10 { println("FAIL: compute_sum(4) third call"); exit(1) }
+    if compute_sum(5) != 15 { println("FAIL: compute_sum(5)"); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_string_promotion.ae
+++ b/tests/syntax/test_closure_string_promotion.ae
@@ -1,0 +1,29 @@
+// Route 1 regression: a string (const char*) captured and mutated by a
+// closure should heap-promote like any other type. Without proper
+// handling, the cell type would degrade to `int*` and truncate the
+// pointer. The get_c_type lookup needs to resolve to "const char*" and
+// `T* name = malloc(sizeof(T))` has to sizeof(const char*) not int.
+
+extern exit(code: int)
+extern str_eq(a: string, b: string) -> int
+
+main() {
+    msg = "hello"
+    swap = || { msg = "world" }
+
+    if str_eq(msg, "hello") == 0 { println("FAIL: initial"); exit(1) }
+
+    call(swap)
+
+    // Outer reads the mutated value.
+    if str_eq(msg, "world") == 0 { println("FAIL: after swap"); exit(1) }
+
+    // Restore, then check again — shows mutation works both ways.
+    msg = "hello"
+    if str_eq(msg, "hello") == 0 { println("FAIL: restored"); exit(1) }
+
+    call(swap)
+    if str_eq(msg, "world") == 0 { println("FAIL: second swap"); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_user_func_promotion.ae
+++ b/tests/syntax/test_closure_user_func_promotion.ae
@@ -1,0 +1,32 @@
+// Route 1 regression: promotion works identically in a user function
+// body, not just main. Each call to the function gets its own heap
+// cell; mutations don't leak across invocations.
+
+extern exit(code: int)
+
+counter_of(start: int) {
+    total = start
+    inc = || { total = total + 1 }
+    dec = || { total = total - 1 }
+    call(inc)
+    call(inc)
+    call(inc)
+    call(dec)
+    return total
+}
+
+main() {
+    r1 = counter_of(0)
+    if r1 != 2 { println("FAIL: counter_of(0) expected 2, got:"); println(r1); exit(1) }
+
+    r2 = counter_of(100)
+    if r2 != 102 { println("FAIL: counter_of(100) expected 102, got:"); println(r2); exit(1) }
+
+    r3 = counter_of(-5)
+    if r3 != -3 { println("FAIL: counter_of(-5) expected -3, got:"); println(r3); exit(1) }
+
+    // Isolation: calls don't share state.
+    if r1 + r2 + r3 != 101 { println("FAIL: isolation"); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_var_reassignment.ae
+++ b/tests/syntax/test_closure_var_reassignment.ae
@@ -1,0 +1,33 @@
+// Closure-var reassignment dispatch:
+// A local can hold a closure, be reassigned to a different closure, and
+// call(var, args) dispatches through the closure currently stored in
+// the variable — not whichever closure was first assigned when the
+// variable was declared.
+//
+// Enables the "op holds the current operator" pattern used in
+// contrib/aether_ui/example_calculator.ae, where the `=` button's
+// handler calls call(op, prev, num) and `op` has been reassigned by
+// earlier `+` / `-` / `*` / `/` button presses.
+
+extern exit(code: int)
+
+main() {
+    op = |a: int, b: int| { return a + b }
+    r1 = call(op, 2, 3)
+    if r1 != 5 { println("FAIL: first call (expected 5, got:"); println(r1); exit(1) }
+
+    // Reassign op to a different closure. The codegen must notice that
+    // op no longer has a single static closure identity and dispatch
+    // through the function pointer stored in op at call time.
+    op = |a: int, b: int| { return a * b }
+    r2 = call(op, 4, 5)
+    if r2 != 20 { println("FAIL: reassigned call (expected 20, got:"); println(r2); exit(1) }
+
+    // And once more, to a closure with a different shape (still 2 ints
+    // in / 1 int out, but a different body).
+    op = |a: int, b: int| { if a > b { return a } return b }
+    r3 = call(op, 7, 3)
+    if r3 != 7 { println("FAIL: max closure (expected 7, got:"); println(r3); exit(1) }
+
+    println("ok")
+}

--- a/tests/syntax/test_closure_writeonly_is_local.ae
+++ b/tests/syntax/test_closure_writeonly_is_local.ae
@@ -1,22 +1,29 @@
-// Pinning test: a closure body that writes a name without ever reading
-// it treats that name as a fresh local, shadowing any same-named outer
-// binding. This is Python-style implicit shadowing (`x = expr` with no
-// RHS read of x introduces x).
+// Pinning test: Route 1 rule for write-only assignment to a name that
+// exists in the enclosing scope.
 //
-// Observationally the outer scope is untouched either way (by-value
-// capture + no read-back would produce the same result), but this
-// test pins the behaviour so changes to scope analysis are noticed.
+// A closure body that writes a name without reading it, where the same
+// name exists in the enclosing function, is treated as a mutation of
+// the outer binding — not a fresh local. This matches Ruby/Groovy
+// semantics and makes the aether_ui calculator's DSL work without
+// surprise. (Python would shadow here; Aether does not.)
+//
+// When the outer function has NO such name, `x = expr` in a closure
+// is still a fresh local — see test_calculator_tui / the `v = ref_get(num)`
+// idiom where outer main has no `v`.
 
 extern exit(code: int)
 
 main() {
     count = 99
     reset = || {
-        count = 0        // fresh local inside the closure; outer count safe
+        count = 0       // mutates the outer `count` — capture-and-promote
     }
     call(reset)
+    if count != 0 { println("FAIL: outer not mutated after reset"); exit(1) }
+
+    // Second call — outer stays at 0.
+    count = 42
     call(reset)
-    // Outer count untouched regardless of interpretation.
-    if count != 99 { println("FAIL: outer mutated"); exit(1) }
+    if count != 0 { println("FAIL: second reset"); exit(1) }
     println("ok")
 }

--- a/tests/syntax/test_per_symbol_import.ae
+++ b/tests/syntax/test_per_symbol_import.ae
@@ -1,0 +1,19 @@
+// Per-symbol import via trailing-component path:
+//   `import mod.sym` makes `sym` usable as a bare identifier.
+// The existing parenthesised form `import mod (sym1, sym2)` is unchanged
+// in spelling — after this feature it also exposes its listed symbols
+// unqualified so callers need not prefix with the module name.
+
+import std.os.argv0
+
+extern exit(code: int)
+
+main() {
+    path = argv0()
+    // Without per-symbol import, `argv0` as a bare identifier would be
+    // unresolved — the caller would write `os.argv0()`. After the
+    // feature, the trailing component of the import path is registered
+    // directly in the caller's scope.
+    if path == null { println("FAIL: argv0 returned null"); exit(1) }
+    println("ok")
+}

--- a/tests/syntax/test_per_symbol_import_multi.ae
+++ b/tests/syntax/test_per_symbol_import_multi.ae
@@ -1,0 +1,25 @@
+// Per-symbol imports: parenthesised form with multiple symbols must
+// expose each listed symbol as a bare identifier. std.string has
+// Aether-level wrappers (to_int, to_long, etc.) whose bare-name
+// exposure is gated by the parenthesised list.
+
+import std.string (to_int, to_long)
+
+extern exit(code: int)
+
+main() {
+    // Bare calls to each listed wrapper.
+    v1, e1 = to_int("42")
+    if e1 != "" { println("FAIL: to_int error:"); println(e1); exit(1) }
+    if v1 != 42 { println("FAIL: to_int, expected 42, got:"); println(v1); exit(1) }
+
+    v2, e2 = to_long("-123")
+    if e2 != "" { println("FAIL: to_long error:"); println(e2); exit(1) }
+    if v2 != -123 { println("FAIL: to_long, expected -123, got:"); println(v2); exit(1) }
+
+    // Error path — bare wrappers still return the (value, err) tuple correctly.
+    _, e3 = to_int("not a number")
+    if e3 == "" { println("FAIL: to_int should have errored on garbage"); exit(1) }
+
+    println("ok")
+}


### PR DESCRIPTION
## Description

Three compiler features that make elegant, terse DSL code (like the upcoming `contrib/aether_ui` calculator example) possible. Each feature is independent and lands with its own acceptance test; they're bundled here to reduce CI load.

1. **Per-symbol imports** — `import std.os.argv0` exposes `argv0` as a bare identifier; parenthesised `import mod (a, b)` does the same for listed symbols. Enables `button("7")` / `hstack(4)` style without `aether_ui.` prefixes everywhere.

2. **Closure-var reassignment dispatch** — a local that holds a closure can be reassigned, and `call(var, ...)` dispatches through whatever closure is currently stored, not the first one assigned. Enables the calculator's `op = +` then `op = *` pattern where `equals` dispatches through the current operator.

3. **Route 1 auto-heap-promotion** (the big one) — a captured variable written in ANY closure is heap-promoted in its enclosing scope. All readers — sibling closures, outer code, escaping closures — share one cell. Ruby/Groovy capture-by-reference semantics without source-level `ref()` cells. Built on top of the by-value shipped in v0.66.0; read-only captures unchanged.

Narrative context: this PR is the compiler-side foundation for the `contrib/aether_ui` toolkit being developed on `feature/aether-ui`. That branch will depend on these three features for its `example_calculator.ae` to compile elegantly.

## Type of Change
- [x] New feature (×3, see above)
- [x] Bug fix (six edge cases found and fixed during coverage build-out)

## Testing

**26 new regression tests** added across `tests/syntax/test_closure_*.ae` and `tests/syntax/test_per_symbol_import*.ae`:

| Test | Covers |
|---|---|
| `test_per_symbol_import` | Trailing-component import form |
| `test_per_symbol_import_multi` | Parenthesised multi-symbol form |
| `test_closure_var_reassignment` | Closure var reassignment dispatch |
| `test_closure_heterogeneous_reassignment` | Different closure shapes |
| `test_closure_mutable_capture_probe` | Route 1 simple mutation |
| `test_closure_mixed_readers_and_writer` | Non-local promotion analysis |
| `test_closure_outer_writes_interleaved` | Outer scope also deref-routes |
| `test_closure_multiple_writers` | Multiple writing closures share cell |
| `test_closure_mixed_captures` | Read-only + mutated in one closure |
| `test_closure_mutable_param_capture` | Function parameter promotion |
| `test_closure_string_promotion` | Non-int types |
| `test_closure_nested_block_capture` | Mutable capture in if/for blocks |
| `test_closure_calculator_shape` | Full calculator DSL pattern |
| `test_closure_user_func_promotion` | Promotion in user funcs, isolated |
| `test_closure_param_shadows_promoted` | Closure param wins over outer |
| `test_closure_promoted_as_initializer` | Promoted var as RHS of var decl |
| `test_closure_fn_param_with_promoted` | Closure passed as `fn` argument |
| `test_closure_chained_promoted` | Three-level closure chain |
| `test_closure_escape_with_promoted` | Escape-via-return + promoted |
| `test_closure_writeonly_is_local` | Python-style shadow rule (updated) |
| `test_closure_in_actor_handler` | Route 1 in actor message handlers |
| `test_closure_in_actor_state` | Actor state holds closure |
| `test_closure_reassign_leaks_env` | Pin intentional-leak-for-safety |
| `test_closure_reassign_after_box` | Paired escape-safety check |
| `test_closure_return_promoted` | Return promoted value directly |
| `test_closure_promoted_in_trailing_block` | Promoted capture across DSL block |
| `test_closure_declared_in_trailing_block` | Closure inside trailing block |
| `test_closure_recursive_promoted` | Recursive func + promoted param |
| `test_closure_null_init_promoted` | Null-initialised capture |

- [x] Added tests for new functionality (26 new tests)
- [x] All tests pass: `make test-ae` → 242 passed, 0 failed
- [x] `make ci` → all 9 steps green (Linux GCC)
- [ ] macOS / Windows — marked `[skip actions]`; Paul's macOS tests pending before full CI run
- [x] Tested locally on Linux (Chromebook x86_64)

## Performance Impact
- [x] No performance impact in the common case

Read-only captures (the vast majority) are unchanged. Route 1 promotion only fires when a closure writes a captured variable, trading a stack local for a heap `int*` cell. Generated code for the calculator-tui TUI example is byte-identical to main; only the hypothetical "mutable capture" pattern sees new codegen.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated — known limitation on closures mutating actor state documented in `tests/syntax/README_closure_actor_state_limitation.md`

## Known limitations

1. **Closure inside actor handler that mutates actor state field** — currently miscompiled to a stale-local access, no compile-time error. Documented with a workaround (copy state to arm-local, mutate, copy back). Fixing requires threading `self` through the closure's env; separate PR.

2. **Closure-var reassignment leaks the previous env** — documented in `test_closure_reassign_leaks_env` and paired with `test_closure_reassign_after_box` to pin why. Fix requires escape analysis; separate PR.

3. **Concurrent access to a promoted cell across actors/threads** — no synchronisation on the heap cell. Out of scope, routed to maintainer.

## Commit Log (10 commits)

```
4ef12c1 test: additional coverage for edge cases + known limitation [skip actions — Paul's macOS tests pending]
f084d14 fix+test: Route 1 in actor handlers + reassign-leak trade-off pinned
6698a62 fix: write-only capture promotion uses top-level-scope lookup
bf51609 fix+test: Route 1 edge cases surfaced by deeper coverage
3726f7f feat: Route 1 auto-heap-promotion for mutable closure captures
20031d7 test: four failing acceptance tests for Route 1 mutable-capture model
1a67715 feat: closure-var reassignment dispatches through current closure
8be9b05 test: failing regression for closure-var reassignment dispatch
ebd7975 feat: per-symbol imports — `import mod.sym` and bare-name rewriting
618220d test: failing regression for per-symbol import
```

Each feature uses a test-then-feat shape (failing regression test first, then the implementation that turns it green) so reviewers can see the acceptance target before the code. Subsequent `fix+test:` commits added coverage that surfaced edge cases, which were fixed in-place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)