### PR TITLE
fix: three closure bugs surfaced by aether_ui work (forward-decl, nested-return, trailing capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Closure body references a later-numbered closure** (`compiler/codegen/codegen_expr.c`). A closure's body can construct inline closure literals and pass them as arguments to other functions. Each lambda gets its own `_closure_fn_N` in the emitted C. When the outer closure is numbered before its inline lambdas, its body referenced `_closure_fn_N` symbols that hadn't been declared yet at that point in the file (`'_closure_fn_N' undeclared` error). `emit_closure_definitions` now runs in two passes: pass 1 emits every env typedef and every function prototype, pass 2 emits bodies and constructors. A closure body can reference any `_closure_fn_N` by name regardless of numbering. Three helpers extracted for readability: `resolve_closure_return_type`, `emit_closure_signature`, `emit_closure_env_typedef`. Regression test: `tests/syntax/test_closure_forward_references.ae`.
+
+- **Nested lambda's `return` mis-typed the enclosing closure** (`compiler/codegen/codegen_func.c`). `has_return_value` walked an AST subtree looking for return statements with values. A nested lambda's `return` bubbled up through the recursive walk and mis-typed the enclosing closure as `int` — producing `static int _closure_fn_N(...) { ...; }` with no return statement, undefined behavior caught by `-Wreturn-type`. One-line fix: `has_return_value` now stops at `AST_CLOSURE` boundaries so a nested closure's return belongs to that closure, not to any enclosing scope. Regression test: `tests/integration/closure_nested_return/` (compiles the generated C with `-Werror=return-type` and requires a clean build).
+
+- **Captures across nested trailing blocks** (`compiler/codegen/codegen_expr.c`). A variable declared inside a trailing block (e.g. `root = grid() { c = 42; ... }`) lives in the enclosing function's scope because trailing blocks are inlined at the call site, not hoisted. Previously a closure inside a sibling or nested trailing block could not capture such variables — capture discovery stopped at ANY `AST_CLOSURE`, including trailing-block closures (value == `"trailing"`), so names declared inside one trailing block were invisible to inner closures (`'c' undeclared` in generated C). Two scope-analysis helpers updated: `subtree_declares` now recurses through trailing-block closures while stopping at real closures; a new `scope_declares_at_top_level` helper is used by `is_top_level_decl_in_function` to walk trailing blocks but NOT nested if/for/while blocks — preserving the Python-style rule that `v = ref_get(num)` inside `if key == EQUAL { ... }` stays a block-local (examples/calculator-tui.ae still builds cleanly). Regression test: `tests/integration/closure_trailing_block_capture/`.
+
+  Design note worth flagging: the nested-trailing-block fix was subtler than it looked. A naive "recurse everywhere" version broke calculator-tui. The final version threads the needle — trailing blocks are transparent to scope lookup (they inline at the call site), but nested if/for/while blocks still aren't. That's the right answer mechanically (it matches how trailing blocks work at codegen time) but it's the kind of detail that could surface a different corner case later. Tracked in `docs/closure-lifetime-bugs.md` bugs 6-8.
+
 ## [0.67.0]
 
 ### Added

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -778,8 +778,145 @@ static const char* lookup_var_c_type(CodeGenerator* gen, const char* var_name, c
     return "int"; // fallback
 }
 
-// Emit all hoisted closure environment structs and static functions
+// Resolve a closure's C return type from its body. Extracted so the
+// pre-pass (forward declarations) and main pass (bodies) agree on the
+// same signature. A closure with no return-value statements is void.
+// A closure whose return expression is `call(<captured_closure>)` gets
+// resolved through the captured closure's own body — the typechecker
+// leaves those as TYPE_INT by default which is almost always wrong for
+// call-of-call chains.
+static const char* resolve_closure_return_type(CodeGenerator* gen, int ci) {
+    ASTNode* closure = gen->closures[ci].closure_node;
+    const char* parent_func = gen->closures[ci].parent_func;
+    ASTNode* body_check = NULL;
+    for (int i = closure->child_count - 1; i >= 0; i--) {
+        if (closure->children[i] && closure->children[i]->type == AST_BLOCK) {
+            body_check = closure->children[i];
+            break;
+        }
+    }
+    int has_return = body_check ? has_return_value(body_check) : 0;
+    if (!has_return) return "void";
+    const char* ret_type = "int";
+    ASTNode* ret_expr = find_first_return_expr(body_check);
+    int resolved = 0;
+    if (ret_expr && ret_expr->type == AST_FUNCTION_CALL && ret_expr->value &&
+        strcmp(ret_expr->value, "call") == 0 &&
+        ret_expr->child_count >= 1 &&
+        ret_expr->children[0] &&
+        ret_expr->children[0]->type == AST_IDENTIFIER &&
+        ret_expr->children[0]->value) {
+        const char* callee = ret_expr->children[0]->value;
+        for (int cvi = 0; cvi < gen->closure_var_count; cvi++) {
+            if (gen->closure_var_map[cvi].var_name &&
+                strcmp(gen->closure_var_map[cvi].var_name, callee) == 0) {
+                int callee_id = gen->closure_var_map[cvi].closure_id;
+                for (int cj = 0; cj < gen->closure_count; cj++) {
+                    if (gen->closures[cj].id != callee_id) continue;
+                    ASTNode* callee_node = gen->closures[cj].closure_node;
+                    ASTNode* callee_body = NULL;
+                    for (int k = callee_node->child_count - 1; k >= 0; k--) {
+                        if (callee_node->children[k] &&
+                            callee_node->children[k]->type == AST_BLOCK) {
+                            callee_body = callee_node->children[k];
+                            break;
+                        }
+                    }
+                    ASTNode* callee_ret = callee_body ? find_first_return_expr(callee_body) : NULL;
+                    if (callee_ret) {
+                        if (callee_ret->node_type && callee_ret->node_type->kind != TYPE_UNKNOWN) {
+                            ret_type = get_c_type(callee_ret->node_type);
+                            resolved = 1;
+                        } else if (callee_ret->type == AST_IDENTIFIER && callee_ret->value) {
+                            ret_type = lookup_var_c_type(gen, callee_ret->value,
+                                                         gen->closures[cj].parent_func);
+                            resolved = 1;
+                        }
+                    }
+                    break;
+                }
+                break;
+            }
+        }
+    }
+    if (!resolved && ret_expr) {
+        if (ret_expr->node_type && ret_expr->node_type->kind != TYPE_UNKNOWN) {
+            ret_type = get_c_type(ret_expr->node_type);
+        } else if (ret_expr->type == AST_IDENTIFIER && ret_expr->value) {
+            ret_type = lookup_var_c_type(gen, ret_expr->value, parent_func);
+        }
+    }
+    return ret_type;
+}
+
+// Emit just the signature (no trailing `;` or `{`) of a closure function.
+// Caller appends `;\n` for forward decls or ` {\n` for bodies.
+static void emit_closure_signature(CodeGenerator* gen, int ci, const char* ret_type) {
+    int id = gen->closures[ci].id;
+    ASTNode* closure = gen->closures[ci].closure_node;
+    fprintf(gen->output, "static %s _closure_fn_%d(_closure_env_%d* _env", ret_type, id, id);
+    for (int i = 0; i < closure->child_count; i++) {
+        ASTNode* p = closure->children[i];
+        if (p && p->type == AST_CLOSURE_PARAM) {
+            const char* ptype = "int";
+            if (p->node_type) {
+                ptype = get_c_type(p->node_type);
+            }
+            fprintf(gen->output, ", %s %s", ptype, safe_c_name(p->value));
+        }
+    }
+    fprintf(gen->output, ")");
+}
+
+// Emit the env typedef for a closure.
+static void emit_closure_env_typedef(CodeGenerator* gen, int ci) {
+    int id = gen->closures[ci].id;
+    char** captures = gen->closures[ci].captures;
+    int cap_count = gen->closures[ci].capture_count;
+    const char* parent_func = gen->closures[ci].parent_func;
+    char** parent_promoted = NULL;
+    int parent_promoted_count = 0;
+    get_promoted_names_for_func(gen, parent_func, &parent_promoted, &parent_promoted_count);
+    fprintf(gen->output, "typedef struct {\n");
+    if (cap_count == 0) {
+        fprintf(gen->output, "    int _dummy;\n");
+    } else {
+        for (int i = 0; i < cap_count; i++) {
+            const char* ctype = lookup_var_c_type(gen, captures[i], parent_func);
+            int is_promoted = 0;
+            for (int p = 0; p < parent_promoted_count; p++) {
+                if (parent_promoted[p] && strcmp(parent_promoted[p], captures[i]) == 0) {
+                    is_promoted = 1;
+                    break;
+                }
+            }
+            if (is_promoted) {
+                fprintf(gen->output, "    %s* %s;\n", ctype, safe_c_name(captures[i]));
+            } else {
+                fprintf(gen->output, "    %s %s;\n", ctype, safe_c_name(captures[i]));
+            }
+        }
+    }
+    fprintf(gen->output, "} _closure_env_%d;\n\n", id);
+}
+
+// Emit all hoisted closure environment structs and static functions.
+// Two passes: pass 1 emits every env typedef and every function
+// prototype so a closure body can reference a later-numbered closure
+// (e.g. when an inline `|a,b| { ... }` lambda is passed as an argument
+// inside the outer closure's body). Pass 2 emits bodies + MSVC
+// constructor helpers.
 void emit_closure_definitions(CodeGenerator* gen) {
+    // Pass 1: forward declarations.
+    for (int ci = 0; ci < gen->closure_count; ci++) {
+        emit_closure_env_typedef(gen, ci);
+        const char* ret_type = resolve_closure_return_type(gen, ci);
+        emit_closure_signature(gen, ci, ret_type);
+        fprintf(gen->output, ";\n");
+    }
+    if (gen->closure_count > 0) fprintf(gen->output, "\n");
+
+    // Pass 2: bodies and constructors.
     for (int ci = 0; ci < gen->closure_count; ci++) {
         int id = gen->closures[ci].id;
         ASTNode* closure = gen->closures[ci].closure_node;
@@ -793,114 +930,9 @@ void emit_closure_definitions(CodeGenerator* gen) {
         int parent_promoted_count = 0;
         get_promoted_names_for_func(gen, parent_func, &parent_promoted, &parent_promoted_count);
 
-        // Emit environment struct (even if empty, for uniform calling convention)
-        fprintf(gen->output, "typedef struct {\n");
-        if (cap_count == 0) {
-            fprintf(gen->output, "    int _dummy;\n");
-        } else {
-            for (int i = 0; i < cap_count; i++) {
-                const char* ctype = lookup_var_c_type(gen, captures[i], parent_func);
-                int is_promoted = 0;
-                for (int p = 0; p < parent_promoted_count; p++) {
-                    if (parent_promoted[p] && strcmp(parent_promoted[p], captures[i]) == 0) {
-                        is_promoted = 1;
-                        break;
-                    }
-                }
-                if (is_promoted) {
-                    fprintf(gen->output, "    %s* %s;\n", ctype, safe_c_name(captures[i]));
-                } else {
-                    fprintf(gen->output, "    %s %s;\n", ctype, safe_c_name(captures[i]));
-                }
-            }
-        }
-        fprintf(gen->output, "} _closure_env_%d;\n\n", id);
-
-        // Determine return type. If the body has a return with a value,
-        // try to infer the C type from the returned expression — otherwise
-        // fall back to int. (The old hardcode to int broke any closure that
-        // returned a string or pointer.) A closure with no return-value
-        // statements is void.
-        int has_return = 0;
-        ASTNode* body_check = NULL;
-        for (int i = closure->child_count - 1; i >= 0; i--) {
-            if (closure->children[i] && closure->children[i]->type == AST_BLOCK) {
-                body_check = closure->children[i];
-                break;
-            }
-        }
-        if (body_check) {
-            has_return = has_return_value(body_check);
-        }
-        const char* ret_type = "void";
-        if (has_return) {
-            ret_type = "int";
-            ASTNode* ret_expr = find_first_return_expr(body_check);
-            // Prefer resolving through a known captured-closure target when
-            // the returned value is call(<captured>) — the typechecker leaves
-            // that as TYPE_INT by default, which is almost always wrong.
-            int resolved = 0;
-            if (ret_expr && ret_expr->type == AST_FUNCTION_CALL && ret_expr->value &&
-                strcmp(ret_expr->value, "call") == 0 &&
-                ret_expr->child_count >= 1 &&
-                ret_expr->children[0] &&
-                ret_expr->children[0]->type == AST_IDENTIFIER &&
-                ret_expr->children[0]->value) {
-                const char* callee = ret_expr->children[0]->value;
-                for (int ci = 0; ci < gen->closure_var_count; ci++) {
-                    if (gen->closure_var_map[ci].var_name &&
-                        strcmp(gen->closure_var_map[ci].var_name, callee) == 0) {
-                        int callee_id = gen->closure_var_map[ci].closure_id;
-                        for (int cj = 0; cj < gen->closure_count; cj++) {
-                            if (gen->closures[cj].id != callee_id) continue;
-                            ASTNode* callee_node = gen->closures[cj].closure_node;
-                            ASTNode* callee_body = NULL;
-                            for (int k = callee_node->child_count - 1; k >= 0; k--) {
-                                if (callee_node->children[k] &&
-                                    callee_node->children[k]->type == AST_BLOCK) {
-                                    callee_body = callee_node->children[k];
-                                    break;
-                                }
-                            }
-                            ASTNode* callee_ret = callee_body ? find_first_return_expr(callee_body) : NULL;
-                            if (callee_ret) {
-                                if (callee_ret->node_type && callee_ret->node_type->kind != TYPE_UNKNOWN) {
-                                    ret_type = get_c_type(callee_ret->node_type);
-                                    resolved = 1;
-                                } else if (callee_ret->type == AST_IDENTIFIER && callee_ret->value) {
-                                    ret_type = lookup_var_c_type(gen, callee_ret->value,
-                                                                 gen->closures[cj].parent_func);
-                                    resolved = 1;
-                                }
-                            }
-                            break;
-                        }
-                        break;
-                    }
-                }
-            }
-            if (!resolved && ret_expr) {
-                if (ret_expr->node_type && ret_expr->node_type->kind != TYPE_UNKNOWN) {
-                    ret_type = get_c_type(ret_expr->node_type);
-                } else if (ret_expr->type == AST_IDENTIFIER && ret_expr->value) {
-                    ret_type = lookup_var_c_type(gen, ret_expr->value, parent_func);
-                }
-            }
-        }
-
-        // Emit static function
-        fprintf(gen->output, "static %s _closure_fn_%d(_closure_env_%d* _env", ret_type, id, id);
-        for (int i = 0; i < closure->child_count; i++) {
-            ASTNode* p = closure->children[i];
-            if (p && p->type == AST_CLOSURE_PARAM) {
-                const char* ptype = "int"; // default
-                if (p->node_type) {
-                    ptype = get_c_type(p->node_type);
-                }
-                fprintf(gen->output, ", %s %s", ptype, safe_c_name(p->value));
-            }
-        }
-        fprintf(gen->output, ") {\n");
+        const char* ret_type = resolve_closure_return_type(gen, ci);
+        emit_closure_signature(gen, ci, ret_type);
+        fprintf(gen->output, " {\n");
 
         // Find body first so we can detect which captures are mutated.
         ASTNode* body = NULL;

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -122,6 +122,64 @@ static ASTNode* find_receive_arm_by_name(ASTNode* node, const char* func_name) {
     return NULL;
 }
 
+// Forward declaration — subtree_declares is defined below but used here
+// to recurse through trailing-block closures while stopping at real
+// closures.
+static int subtree_declares(ASTNode* node, const char* var_name);
+
+// Does a block declare `var_name` at its top-level, treating trailing-
+// block closures as transparent (their contents inline at the call site)
+// but if/for/while blocks and real closures as opaque? Used by
+// is_top_level_decl_in_function so that a declaration inside a trailing
+// block (e.g. `root = grid() { c = 42 }`) is recognised as living in
+// the enclosing function's scope, while a declaration inside
+// `if cond { v = ... }` correctly stays block-local.
+static int scope_declares_at_top_level(ASTNode* block, const char* var_name) {
+    if (!block) return 0;
+    for (int k = 0; k < block->child_count; k++) {
+        ASTNode* s = block->children[k];
+        if (!s) continue;
+        if ((s->type == AST_VARIABLE_DECLARATION ||
+             s->type == AST_CONST_DECLARATION) &&
+            s->value && strcmp(s->value, var_name) == 0) {
+            return 1;
+        }
+        // Var decls whose initializer is a function call with a trailing
+        // block: `root = grid() { ... }`. The trailing block's body is
+        // part of the enclosing function's scope. Look into it.
+        // Same for bare function-call expression statements with trailing
+        // blocks.
+        ASTNode* call = NULL;
+        if (s->type == AST_VARIABLE_DECLARATION && s->child_count > 0 &&
+            s->children[0] && s->children[0]->type == AST_FUNCTION_CALL) {
+            call = s->children[0];
+        } else if (s->type == AST_EXPRESSION_STATEMENT && s->child_count > 0 &&
+                   s->children[0] && s->children[0]->type == AST_FUNCTION_CALL) {
+            call = s->children[0];
+        } else if (s->type == AST_FUNCTION_CALL) {
+            call = s;
+        }
+        if (call) {
+            for (int ci = 0; ci < call->child_count; ci++) {
+                ASTNode* arg = call->children[ci];
+                if (arg && arg->type == AST_CLOSURE &&
+                    arg->value && strcmp(arg->value, "trailing") == 0) {
+                    // Trailing block's body is this closure's (last) AST_BLOCK child.
+                    for (int bi = arg->child_count - 1; bi >= 0; bi--) {
+                        if (arg->children[bi] && arg->children[bi]->type == AST_BLOCK) {
+                            if (scope_declares_at_top_level(arg->children[bi], var_name)) {
+                                return 1;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
 // Is `var_name` declared at the TOP level of the given function's body
 // block (or as a parameter) — i.e. in the function's "own" lexical scope,
 // not inside a nested if/for/while block? This is the scope that closures
@@ -170,18 +228,15 @@ static int is_top_level_decl_in_function(ASTNode* program, const char* func_name
             }
         }
         // Only TOP-LEVEL statements of the body block count — not nested
-        // if/for/while bodies.
+        // if/for/while bodies. But trailing-block closures ARE top-level
+        // for scoping purposes: they inline at the call site, so a
+        // declaration inside a trailing block binds in the enclosing
+        // function's scope. Walk through trailing blocks only, not
+        // through if/for/while blocks or real closures.
         for (int j = 0; j < top->child_count; j++) {
             ASTNode* body = top->children[j];
             if (!body || body->type != AST_BLOCK) continue;
-            for (int k = 0; k < body->child_count; k++) {
-                ASTNode* s = body->children[k];
-                if (s && (s->type == AST_VARIABLE_DECLARATION ||
-                          s->type == AST_CONST_DECLARATION) &&
-                    s->value && strcmp(s->value, var_name) == 0) {
-                    return 1;
-                }
-            }
+            if (scope_declares_at_top_level(body, var_name)) return 1;
         }
         return 0;
     }
@@ -193,7 +248,14 @@ static int is_top_level_decl_in_function(ASTNode* program, const char* func_name
 // to an inner scope, not the enclosing function's.
 static int subtree_declares(ASTNode* node, const char* var_name) {
     if (!node) return 0;
-    if (node->type == AST_CLOSURE) return 0;
+    // Stop at real closures — their locals don't belong to the enclosing
+    // function. But trailing-block closures (value == "trailing") are
+    // inlined at the call site, so they DO contribute declarations to
+    // the enclosing function's scope and must be traversed.
+    if (node->type == AST_CLOSURE &&
+        !(node->value && strcmp(node->value, "trailing") == 0)) {
+        return 0;
+    }
     if ((node->type == AST_VARIABLE_DECLARATION || node->type == AST_CONST_DECLARATION) &&
         node->value && strcmp(node->value, var_name) == 0) {
         return 1;

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -94,9 +94,15 @@ TypeKind lookup_extern_param_kind(CodeGenerator* gen, const char* func_name, int
     return TYPE_UNKNOWN;
 }
 
-// Check if an AST subtree contains a return statement with a value
+// Check if an AST subtree contains a return statement with a value.
+// Stops at AST_CLOSURE boundaries: a nested lambda's `return` belongs
+// to that lambda, not to the enclosing function/closure. Without this
+// stop, `|| { inner = |x| { return x*2 }; call(inner, 3) }` would have
+// its outer closure mis-typed as returning-int (picking up inner's
+// `return`) when the outer actually has no return statement of its own.
 int has_return_value(ASTNode* node) {
     if (!node) return 0;
+    if (node->type == AST_CLOSURE) return 0;
     if (node->type == AST_RETURN_STATEMENT && node->child_count > 0 && node->children[0]) {
         // Print statements don't count as "return values" - they're void
         if (node->children[0]->type == AST_PRINT_STATEMENT) {

--- a/docs/closure-lifetime-bugs.md
+++ b/docs/closure-lifetime-bugs.md
@@ -5,7 +5,13 @@ handling and env lifetime, plus a chained typechecker hole that surfaced
 once the first four were fixed. All five landed together in a single PR
 because testing any one in isolation was blocked by the others.
 
-Regression tests live at `tests/syntax/test_closure_*.ae`.
+Three more closure-related bugs surfaced during the aether_ui toolkit
+work: emission-ordering for cross-referenced closures, nested-lambda
+return-type bubble-up, and captures across trailing blocks. All three
+are fixed on main.
+
+Regression tests live at `tests/syntax/test_closure_*.ae` and
+`tests/integration/closure_*/`.
 
 ## The bugs
 
@@ -87,6 +93,51 @@ declarations whose initializer is such a call. `closure_var_map` seeding
 is extended to inherit a closure id through `w = f()` when `f` ends
 `return <closure_var>`, so chains like `w = build_pair(); call(w)`
 resolve correctly.
+
+### 6. Closure body references a later-numbered closure
+
+A closure's body can construct inline closure literals and pass them
+as arguments to other functions. Each lambda gets its own
+`_closure_fn_N` in the emitted C. When the outer closure is numbered
+before its inline lambdas, its body referenced `_closure_fn_N`
+symbols that hadn't been declared yet at that point in the file.
+Error: `'_closure_fn_N' undeclared`.
+
+**Fix:** `emit_closure_definitions` now runs in two passes. Pass 1
+emits every env typedef and every function prototype. Pass 2 emits
+bodies and constructors. A closure body can reference any
+`_closure_fn_N` by name regardless of numbering.
+
+### 7. Nested lambda's return mis-typed the enclosing closure
+
+`has_return_value` walked an AST subtree looking for return
+statements with values. A nested lambda's `return` bubbled up and
+mis-typed the enclosing closure as `int`, producing a
+`static int _closure_fn_N(...) { ...; }` with no return statement —
+undefined behavior caught by `-Wreturn-type`.
+
+**Fix:** `has_return_value` stops at `AST_CLOSURE` boundaries. A
+nested closure's return belongs to that closure, not to any
+enclosing scope.
+
+### 8. Captures across nested trailing blocks
+
+A variable declared inside a trailing block (e.g.
+`root = grid() { c = 42; ... }`) lives in the enclosing function's
+scope because trailing blocks are inlined at the call site, not
+hoisted. A closure inside a sibling or nested trailing block should
+be able to capture such variables. Previously, capture discovery
+stopped at `AST_CLOSURE` boundaries including trailing-block
+closures (value == `"trailing"`), so names declared inside one
+trailing block were invisible to inner closures.
+
+**Fix:** scope-analysis helpers treat trailing-block closures
+transparently while still stopping at real closures.
+`subtree_declares` recurses through trailing blocks; a new
+`scope_declares_at_top_level` helper is used by
+`is_top_level_decl_in_function` to walk trailing blocks but NOT
+nested if/for/while blocks — preserving the "fresh body-local in
+nested block" Python-style rule that `calculator-tui` relies on.
 
 ## Code layout
 

--- a/tests/integration/closure_nested_return/nested_return.ae
+++ b/tests/integration/closure_nested_return/nested_return.ae
@@ -1,0 +1,13 @@
+// Input for test_closure_nested_return.sh:
+// Outer closure has no return statement. It constructs an inner closure
+// that DOES return. Under the fix, outer is typed `void`. Without the
+// fix, outer is typed `int` but has no return statement — the generated
+// C fails `-Wreturn-type -Werror`.
+
+main() {
+    outer = || {
+        inner = |x: int| { return x * 2 }
+        call(inner, 3)
+    }
+    call(outer)
+}

--- a/tests/integration/closure_nested_return/test_closure_nested_return.sh
+++ b/tests/integration/closure_nested_return/test_closure_nested_return.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Regression: has_return_value must stop at AST_CLOSURE boundaries so a
+# nested lambda's `return` doesn't bubble up and mis-type the enclosing
+# closure. Without the fix, the outer closure is declared `static int`
+# but has no return statement; gcc flags this with -Wreturn-type.
+#
+# Compile the generated C with -Wreturn-type -Werror and require a
+# clean build. If the bug regresses, this test goes red.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AETHERC="$ROOT/build/aetherc"
+
+SRC="$SCRIPT_DIR/nested_return.ae"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+C_FILE="$TMPDIR/out.c"
+if ! "$AETHERC" "$SRC" "$C_FILE" >"$TMPDIR/cc.log" 2>&1; then
+    echo "  [FAIL] aetherc codegen"
+    cat "$TMPDIR/cc.log"
+    exit 1
+fi
+
+# Compile the generated C with strict return-type checking. The fix
+# being regressed turns a nested lambda's return into the enclosing
+# closure's return type, causing a static int with no return path.
+# `-Werror=return-type` alone (not a blanket -Wall -Wextra -Werror)
+# avoids blessing the compiler's other warning decisions.
+if ! gcc -Werror=return-type \
+         -I"$ROOT/runtime" -I"$ROOT/std" -I"$ROOT/std/io" \
+         -c "$C_FILE" -o "$TMPDIR/out.o" 2>"$TMPDIR/gcc.log"; then
+    echo "  [FAIL] gcc -Werror=return-type on generated C"
+    cat "$TMPDIR/gcc.log" | head -20
+    exit 1
+fi
+
+echo "  [PASS] closure_nested_return: outer closure is correctly void"

--- a/tests/integration/closure_trailing_block_capture/capture_from_trailing.ae
+++ b/tests/integration/closure_trailing_block_capture/capture_from_trailing.ae
@@ -1,0 +1,43 @@
+// Input for test_closure_trailing_block_capture.sh:
+// A variable declared inside a trailing block; a closure inside a
+// nested trailing block reads it. Trailing blocks are inlined at the
+// call site, so `c`'s binding lives in main's scope — the inner closure
+// should capture `c` like any other main-scope local.
+//
+// Without the fix: `error: 'c' undeclared` in the generated C, because
+// capture discovery's subtree_declares stops at AST_CLOSURE boundaries
+// (including trailing-block closures). With the fix: trailing-block
+// closures are transparent to scope analysis.
+
+import std.list
+
+grid(_ctx: ptr) {
+    return _ctx
+}
+
+row(_ctx: ptr) {
+    return _ctx
+}
+
+btn_do(_ctx: ptr, action: fn) {
+    list.add(_ctx, box_closure(action))
+}
+
+main() {
+    actions = list.new()
+    defer list.free(actions)
+    root = grid(actions) {
+        c = 42                  // declared in an outer trailing block
+        row(actions) {           // nested trailing block
+            btn_do(actions, || { return c })   // inner closure reads c
+        }
+    }
+    // Retrieve and invoke the closure to verify c's value was captured.
+    boxed = list.get(actions, 0)
+    fn = unbox_closure(boxed)
+    r = call(fn)
+    if r != 42 {
+        println("FAIL: expected 42, got:")
+        println(r)
+    }
+}

--- a/tests/integration/closure_trailing_block_capture/test_closure_trailing_block_capture.sh
+++ b/tests/integration/closure_trailing_block_capture/test_closure_trailing_block_capture.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Regression: captures across nested trailing blocks.
+#
+# A variable declared in a trailing block is bound in the enclosing
+# function's scope (trailing blocks are inlined at the call site, not
+# hoisted). A closure inside a sibling or nested trailing block should
+# be able to capture such variables. Previously, capture discovery's
+# subtree_declares stopped at ANY AST_CLOSURE — including trailing-block
+# closures (value == "trailing") — so names declared inside one trailing
+# block were invisible to inner closures that needed to capture them.
+#
+# Surfaced by contrib/aether_ui/example_canvas.ae (aether-ui branch).
+# Without the fix: `error: 'c' undeclared` at the closure body.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+SRC="$SCRIPT_DIR/capture_from_trailing.ae"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BIN="$TMPDIR/capture"
+
+if ! "$AE" build "$SRC" -o "$BIN" >"$TMPDIR/build.log" 2>&1; then
+    echo "  [FAIL] ae build — capture across trailing block rejected"
+    head -20 "$TMPDIR/build.log"
+    exit 1
+fi
+
+if ! "$BIN" >"$TMPDIR/run.out" 2>&1; then
+    echo "  [FAIL] binary exited non-zero"
+    cat "$TMPDIR/run.out"
+    exit 1
+fi
+
+if grep -q "FAIL:" "$TMPDIR/run.out"; then
+    echo "  [FAIL] runtime assertion failed"
+    cat "$TMPDIR/run.out"
+    exit 1
+fi
+
+echo "  [PASS] closure_trailing_block_capture: c=42 seen by inner closure"

--- a/tests/syntax/test_closure_forward_references.ae
+++ b/tests/syntax/test_closure_forward_references.ae
@@ -1,0 +1,35 @@
+// Regression: a closure's body constructs and passes other closure
+// literals as arguments to a user function. The C emission must
+// forward-declare all _closure_fn_N functions before emitting any
+// closure body, so that closure N's body can reference closure M for
+// any M — without depending on source-order or the order the
+// discovery pass chose to number them.
+//
+// Without forward decls: `error: '_closure_fn_M' undeclared`.
+//
+// Surfaced by contrib/aether_ui/example_calculator.ae's
+// `call(apply_op, |a,b| { return a + b })` pattern — the outer
+// callback passes an inline lambda to another closure. That shape is
+// common enough in any DSL that the compiler must handle it.
+
+extern exit(code: int)
+
+invoke(f: fn, g: fn, x: int) {
+    r1 = call(f, x)
+    r2 = call(g, x)
+    return r1 + r2
+}
+
+main() {
+    // outer's body constructs and passes two inline lambdas. Each
+    // lambda gets its own _closure_fn_N. Some of them will be
+    // numbered after outer.
+    outer = |x: int| {
+        return invoke(|a: int| { return a * 2 }, |a: int| { return a + 100 }, x)
+    }
+
+    r = call(outer, 5)
+    // 5*2 + (5+100) = 10 + 105 = 115
+    if r != 115 { println("FAIL: expected 115, got:"); println(r); exit(1) }
+    println("ok")
+}


### PR DESCRIPTION
## Description

Three independent closure bugs, each surfaced while preparing the `feature/aether-ui` toolkit branch but recreated on main so they're guarded by tests on the main timeline — independent of whatever happens with the UI branch. Each fix is a test-then-feat pair so reviewers can see the acceptance target before the code.

### Bug 1 — closure body references a later-numbered closure
A closure's body constructs inline closure literals and passes them as arguments. Each lambda gets its own `_closure_fn_N`. When the outer is numbered before its inline lambdas, its body references symbols that haven't been declared yet at that point in the emitted C. Error: `'_closure_fn_N' undeclared`.

**Surfaces:** `call(apply_op, |a,b| { return a + b })` pattern in `contrib/aether_ui/example_calculator.ae`.

**Fix:** `emit_closure_definitions` runs in two passes. Pass 1 emits every env typedef + function prototype; pass 2 emits bodies + constructors. Three helpers extracted (`resolve_closure_return_type`, `emit_closure_signature`, `emit_closure_env_typedef`) so both passes share the exact same signature logic.

### Bug 2 — nested lambda's `return` mis-typed the enclosing closure
`has_return_value` walked the AST looking for return statements. A nested lambda's `return` bubbled up and mis-typed the enclosing closure as `int` — producing `static int _closure_fn_N(...) { ...; }` without a return. Undefined behavior, caught by `-Wreturn-type`.

**Fix:** one-line — `has_return_value` stops at `AST_CLOSURE` boundaries.

### Bug 3 — captures across nested trailing blocks
A variable declared inside a trailing block (`root = grid() { c = 42; ... }`) lives in the enclosing function's scope because trailing blocks inline at the call site. Previously, a closure inside a nested trailing block couldn't capture such variables — scope-analysis helpers stopped at ALL `AST_CLOSURE` nodes, including trailing-block closures (value == `"trailing"`). Error: `'c' undeclared` in generated C.

**Fix:** scope-analysis helpers treat trailing-block closures transparently while still stopping at real closures. `subtree_declares` recurses through trailing blocks; a new `scope_declares_at_top_level` helper is used by `is_top_level_decl_in_function` to walk trailing blocks but NOT nested if/for/while blocks — preserving the "fresh body-local in nested block" Python-style rule that `examples/calculator-tui.ae` relies on.

Design note: the naive "recurse everywhere" version of this fix broke calculator-tui. The final version threads the needle correctly — trailing blocks are transparent (they inline at codegen time), if/for/while blocks aren't.

## Type of Change
- [x] Bug fix (×3)

## Testing

Six new regression tests (3 test-then-fix pairs):

| Test | Covers |
|---|---|
| `tests/syntax/test_closure_forward_references.ae` | Bug 1 forward-decl ordering |
| `tests/integration/closure_nested_return/` | Bug 2 nested-return type bubble-up (compiles generated C with `-Werror=return-type`) |
| `tests/integration/closure_trailing_block_capture/` | Bug 3 captures across nested trailing blocks |

- [x] Added tests for new functionality (3 new regression tests, 6 commits test-then-fix)
- [x] All tests pass: `make test-ae` → 247 passed, 0 failed
- [x] `make ci` → all 9 steps green (Linux x86_64, GCC)
- [ ] Valgrind — Docker CI handles
- [x] Tested locally on Linux

## Performance Impact
- [x] No performance impact

Bug 1's two-pass emission duplicates the signature text (once as prototype, once as body header) — that's a few extra writes per closure at compile time, constant-factor overhead only. Runtime output is unchanged. Bug 2 and Bug 3 are pure correctness fixes with no structural codegen change.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] `docs/closure-lifetime-bugs.md` updated with bugs 6-8
- [x] `CHANGELOG.md` entry under `[current]`

## Commits (8)

```
f33da7f changelog: three closure-nested fixes under [current]
0469a6e docs: document bugs 6-8 (forward-decl, nested-return, trailing capture)
a1c8425 fix: trailing-block scopes are transparent to capture discovery
dd8bb7e test: failing regression for captures across nested trailing blocks
a096063 fix: has_return_value stops at AST_CLOSURE boundaries
e2746f8 test: failing regression for nested-lambda return-type bubble-up
d73ece5 fix: closure forward declarations enable later-numbered references
c8a4e2c test: failing regression for closure forward-decl ordering
```

Each `test:` commit demonstrates the bug. Each `fix:` commit turns that test green without regressing existing tests. Individual commits can be bisected / reverted cleanly if needed.

## Relation to feature/aether-ui

The aether-ui branch (PR #178) also contains these three fixes via a larger combined commit (`69b9b17` + `f6cbd65`). Landing them on main first via this PR means:

1. Bugs are guarded on the main timeline by the regression tests.
2. When aether-ui rebases onto the updated main, its commit `69b9b17` can be dropped — these fixes are already in.
3. If aether-ui work gets delayed, these compiler fixes still benefit any other user patterns that hit the same bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)