### PR TITLE
fix: reject closures that mutate actor state fields (L4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Closure inside actor handler writing a state field is now rejected at compile time** (`compiler/codegen/codegen_expr.c`). Closures inside actor receive arms have no access to `self`, so a write like `inc = || { count = count + 1 }` (where `count` is an actor `state` field) compiled to a stale local read — a silent wrong answer. Codegen now walks every closure body inside every receive arm and, for each write to a state field, emits a compile-time error pointing at the offending line with a suggestion to use the arm-local workaround. New helper `aether_error_full()` in `compiler/aether_error.c` for line-numbered errors with suggestion + context + code. `aetherc` now checks `aether_error_count()` after codegen (compared against pre-codegen count, so legacy parser-noise tests don't regress) and aborts the build instead of leaving a half-written `.c` behind. Regression test: `tests/integration/closure_actor_state_reject/`. L4 in `docs/closure-lifetime-bugs.md`.
+
+### Changed
+
+- **`docs/closure-lifetime-bugs.md`**: enumerated all five currently-tracked closure limitations (L1–L5), split the previous lumped "Known limitations" paragraph into per-limit sections with minimal reproducer, workaround, and proper-fix shape for each. Added a note on L1 explaining why a trivial `intptr_t` widening in the generic `call()` dispatch doesn't fix the truncation (the destination variable's C type is pinned via the symbol table, not just the AST, so a real fix needs typechecker work).
+
 ## [0.69.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ test-ae: compiler ae stdlib
 	printf 'fi\n'                                                                                   >> "$$script"; \
 	chmod +x "$$script"; \
 	root=$$(pwd); \
-	find tests/syntax tests/compiler tests/integration -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
+	find tests/syntax tests/compiler tests/integration -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
 	xargs -P $(NPROC) -I{} "$$script" "{}" "$$tmpdir" "$$root"; \
 	for sh_test in $$(find tests/integration -name 'test_*.sh' 2>/dev/null | sort); do \
 		name=$$(echo "$$sh_test" | sed 's|tests/||;s|/|_|g;s|\.sh$$||'); \

--- a/compiler/aether_error.c
+++ b/compiler/aether_error.c
@@ -293,6 +293,25 @@ void aether_error_in_context(const char* message, int line, int column, const ch
     aether_error_report(&error);
 }
 
+// Richest variant: all four fields (message, suggestion, context, code).
+// filename and source_code are pulled from the global init state so the
+// caller doesn't have to.
+void aether_error_full(const char* message, int line, int column,
+                       const char* suggestion, const char* context,
+                       AetherErrorCode code) {
+    AetherError error = {
+        .filename = current_filename,
+        .source_code = current_source,
+        .line = line,
+        .column = column,
+        .message = message,
+        .suggestion = suggestion,
+        .context = context,
+        .code = code
+    };
+    aether_error_report(&error);
+}
+
 void aether_error_with_code(const char* message, int line, int column, AetherErrorCode code) {
     AetherError error = {
         .filename = current_filename,

--- a/compiler/aether_error.h
+++ b/compiler/aether_error.h
@@ -43,6 +43,10 @@ void aether_error_simple(const char* message, int line, int column);
 void aether_error_with_suggestion(const char* message, int line, int column, const char* suggestion);
 void aether_error_in_context(const char* message, int line, int column, const char* context);
 void aether_error_with_code(const char* message, int line, int column, AetherErrorCode code);
+// All four fields. filename + source come from the global init state.
+void aether_error_full(const char* message, int line, int column,
+                       const char* suggestion, const char* context,
+                       AetherErrorCode code);
 
 // Terminal color support: disabled by NO_COLOR env var or non-tty stderr
 const char* aether_color_reset(void);

--- a/compiler/aetherc.c
+++ b/compiler/aetherc.c
@@ -692,6 +692,7 @@ int compile_source(const char* input_path, const char* output_path) {
     if (preempt_mode) codegen->preempt_loops = 1;
     codegen->emit_exe = emit_exe ? 1 : 0;
     codegen->emit_lib = emit_lib ? 1 : 0;
+    int errors_before_codegen = aether_error_count();
     generate_program(codegen, program);
     fclose(output);
     if (header_output) {
@@ -699,6 +700,27 @@ int compile_source(const char* input_path, const char* output_path) {
     }
     if (header_path) {
         free(header_path);
+    }
+
+    // If codegen reported new errors (e.g. L4 closure/state validation),
+    // abort with a non-zero exit so callers see the compile failure rather
+    // than a half-written output file. Only count errors reported by
+    // codegen itself — parse-phase errors are handled separately to avoid
+    // regressing legacy tests that silently tolerate parser noise.
+    if (aether_error_count() > errors_before_codegen) {
+        report_compilation_failure();
+        // Remove the partial output to avoid downstream build steps
+        // picking up an incomplete file.
+        remove(output_path);
+        module_registry_shutdown();
+        free_ast_node(program);
+        for (int i = 0; i < token_count; i++) {
+            free_token(tokens[i]);
+        }
+        free_parser(parser);
+        free_code_generator(codegen);
+        free(source);
+        return 0;
     }
 
     if (verbose_mode) {

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1513,6 +1513,11 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     // closure functions can call user-defined functions without
     // implicit function declaration errors (C99+).
     discover_closures(gen, program);
+    // L4 validation: reject closures inside actor handlers that write
+    // to actor state fields. aether_error_report increments the error
+    // count; aetherc.c should check aether_error_count() after
+    // generate_program returns and bail if non-zero.
+    validate_closure_state_mutations(gen, program);
     if (gen->closure_count > 0) {
         print_line(gen, "// Closure definitions");
         emit_closure_definitions(gen);

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -170,6 +170,10 @@ CodeGenerator* create_code_generator(FILE* output);
 CodeGenerator* create_code_generator_with_header(FILE* output, FILE* header, const char* header_path);
 void free_code_generator(CodeGenerator* gen);
 void generate_program(CodeGenerator* gen, ASTNode* program);
+/* L4 validation: reject closures inside actor handlers that write to
+   actor state fields. Call before generate_program. Returns 1 on
+   success, 0 if errors were reported (compilation should abort). */
+int validate_closure_state_mutations(CodeGenerator* gen, ASTNode* program);
 
 // Header generation (for C embedding)
 void emit_header_prologue(CodeGenerator* gen, const char* guard_name);

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1,4 +1,5 @@
 #include "codegen_internal.h"
+#include "../aether_error.h"
 
 // ---- Closure support ----
 
@@ -758,6 +759,102 @@ void discover_closures(CodeGenerator* gen, ASTNode* node) {
     propagate_call_return_types(gen, node);
     // Third pass: compute which captures need heap promotion per function.
     compute_promoted_captures(gen);
+}
+
+// Find the enclosing AST_ACTOR_DEFINITION that contains `arm_node`.
+// Returns NULL if arm_node isn't inside any actor.
+static ASTNode* find_enclosing_actor(ASTNode* root, ASTNode* arm_node) {
+    if (!root || !arm_node) return NULL;
+    if (root->type == AST_ACTOR_DEFINITION) {
+        // Check if arm_node is a descendant of this actor.
+        for (int i = 0; i < root->child_count; i++) {
+            ASTNode* child = root->children[i];
+            if (!child) continue;
+            if (child == arm_node) return root;
+            // Dive one level deeper — the receive block sits under actor,
+            // arms sit under the receive block.
+            for (int j = 0; j < child->child_count; j++) {
+                if (child->children[j] == arm_node) return root;
+            }
+        }
+    }
+    for (int i = 0; i < root->child_count; i++) {
+        ASTNode* found = find_enclosing_actor(root->children[i], arm_node);
+        if (found) return found;
+    }
+    return NULL;
+}
+
+// L4 validation: a closure inside an actor handler that writes to an
+// actor state field is currently miscompiled (the closure has no access
+// to `self`, so `state_field = ...` emits a stale-local write). Until
+// threading self through the closure env is implemented, reject the
+// pattern at compile time with a clear error. Returns 0 on failure
+// (errors were reported via aether_error_report), 1 otherwise.
+int validate_closure_state_mutations(CodeGenerator* gen, ASTNode* program) {
+    int ok = 1;
+    for (int ci = 0; ci < gen->closure_count; ci++) {
+        const char* parent_func = gen->closures[ci].parent_func;
+        if (!parent_func || strncmp(parent_func, "__recv_arm_", 11) != 0) continue;
+
+        // Find the arm node, then its enclosing actor.
+        ASTNode* arm = find_receive_arm_by_name(program, parent_func);
+        if (!arm) continue;
+        ASTNode* actor = find_enclosing_actor(program, arm);
+        if (!actor) continue;
+
+        // Collect state field names: AST_STATE_DECLARATION or
+        // AST_VARIABLE_DECLARATION children of the actor with
+        // annotation marking them as state vars. Actors typically list
+        // state decls as top-level children of AST_ACTOR_DEFINITION.
+        const char* state_names[64];
+        int state_count = 0;
+        for (int j = 0; j < actor->child_count && state_count < 64; j++) {
+            ASTNode* c = actor->children[j];
+            if (!c || !c->value) continue;
+            if (c->type == AST_STATE_DECLARATION ||
+                (c->type == AST_VARIABLE_DECLARATION && c->annotation &&
+                 strcmp(c->annotation, "state") == 0)) {
+                state_names[state_count++] = c->value;
+            }
+        }
+        if (state_count == 0) continue;
+
+        // Walk the closure body looking for assignments to any of the
+        // state field names.
+        ASTNode* closure = gen->closures[ci].closure_node;
+        ASTNode* body = NULL;
+        for (int k = closure->child_count - 1; k >= 0; k--) {
+            if (closure->children[k] && closure->children[k]->type == AST_BLOCK) {
+                body = closure->children[k];
+                break;
+            }
+        }
+        if (!body) continue;
+
+        for (int n = 0; n < state_count; n++) {
+            if (!is_assigned_to(body, state_names[n])) continue;
+            // Report error. Location: closure node.
+            char msg[512];
+            const char* actor_name = actor->value ? actor->value : "actor";
+            snprintf(msg, sizeof(msg),
+                "closure inside actor '%s' handler writes state field '%s' — "
+                "not yet supported (closures can't mutate actor state; the "
+                "closure has no access to self)",
+                actor_name, state_names[n]);
+            char suggestion[256];
+            snprintf(suggestion, sizeof(suggestion),
+                "copy '%s' into an arm-local, mutate the local, then write "
+                "back. See tests/syntax/README_closure_actor_state_limitation.md "
+                "for the workaround pattern.",
+                state_names[n]);
+            aether_error_full(msg, closure->line, closure->column,
+                              suggestion, "in actor handler",
+                              AETHER_ERR_ACTOR_ERROR);
+            ok = 0;
+        }
+    }
+    return ok;
 }
 
 // Search a single function node for `var_name` as either a parameter

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -72,6 +72,10 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main);
 /* Closure support (codegen_expr.c) */
 void discover_closures(CodeGenerator* gen, ASTNode* node);
 void emit_closure_definitions(CodeGenerator* gen);
+/* L4 validation: reject closures inside actor handlers that write to
+   actor state fields. Run after discover_closures, before codegen.
+   Returns 1 on success, 0 if errors were reported. */
+int validate_closure_state_mutations(CodeGenerator* gen, ASTNode* program);
 /* Route 1 promotion queries (populated by discover_closures): */
 void get_promoted_names_for_func(CodeGenerator* gen, const char* func_name,
                                  char*** out_names, int* out_count);

--- a/docs/closure-lifetime-bugs.md
+++ b/docs/closure-lifetime-bugs.md
@@ -10,6 +10,11 @@ work: emission-ordering for cross-referenced closures, nested-lambda
 return-type bubble-up, and captures across trailing blocks. All three
 are fixed on main.
 
+Five limitations remain — three around dynamic `call()` dispatch (L1,
+L2, L3), one correctness hazard in closures inside actor handlers
+(L4), and one memory leak on closure-var reassignment (L5). All are
+tracked in the "Known limitations" section below.
+
 Regression tests live at `tests/syntax/test_closure_*.ae` and
 `tests/integration/closure_*/`.
 
@@ -153,17 +158,116 @@ Nearly all changes are in the codegen layer. The typechecker is unchanged.
 
 ## Known limitations
 
-Bug 5's `call()` type propagation resolves patterns where the target
-closure can be statically identified at codegen time:
+Three limits are currently unfixed. Two (L1/L2/L3 collectively) are
+ergonomic gaps with workarounds; two (L4, L5) are correctness hazards
+worth flagging. All of them wait on larger language work.
 
-- `x = || { ... }; call(x)` — direct literal assignment.
-- `x = f(); call(x)` where `f` ends `return <closure_var>`.
+### L1. `call(x)` where `x` comes from a list
 
-Patterns that still fall through to the `int` default: closures retrieved
-dynamically from a list, closures chosen via `match`/`if`, closures
-threaded through multiple intermediate function calls. A proper fix needs
-either a parameterised closure type (`fn[T]`) or full return-type
-propagation through the typechecker — out of scope here.
+```aether
+handlers = list.new()
+list.add(handlers, box_closure(|_| { return "hello" }))
+...
+boxed = list.get(handlers, 0)
+h = unbox_closure(boxed)
+r = call(h)                   // h's return type is unknown at codegen
+```
+
+`call(h)` falls back to generic dispatch: `((int(*)(void*))h.fn)(h.env)`
+— it assumes `int` return even if the stored closure returns a string
+or pointer. Strings get their pointer truncated; pointers become
+garbage.
+
+**Workaround:** use a direct-literal closure variable when possible:
+`action = |_| { ... }; call(action)` is statically resolved. Or accept
+that `int`-returning dynamic closures are the only safely dispatchable
+kind today.
+
+### L2. `call(x)` where `x` is chosen via `match`/`if`
+
+```aether
+op = if user_wants_add { add_fn } else { mul_fn }
+r = call(op, 3, 4)            // op's closure id is not knowable
+```
+
+Same failure mode as L1. `closure_var_map` records a single closure id
+per name, so branch-selected closures fall through to generic dispatch
+with the `int` default.
+
+### L3. `call(x)` where `x` is threaded through intermediate functions
+
+```aether
+x = setup()                   // setup returns a closure
+y = wrap(x)                   // wrap takes fn, returns fn
+r = call(y)                   // y's underlying closure is two hops away
+```
+
+`closure_var_map`'s `w = f()` inheritance (Bug 5's partial fix) only
+handles one hop when `f`'s body ends `return <closure_var>`. Multi-hop
+chains fall through to generic dispatch.
+
+**Proper fix for L1/L2/L3:** parameterised closure types (`fn[T]`, like
+Rust's `Fn(i32) -> i32`) or full typechecker return-type propagation.
+Either is a medium-sized language feature. The current cheap mitigation
+is Bug L1.5 below.
+
+### L4. Closure inside actor handler mutating actor state
+
+```aether
+actor Counter {
+    state count = 0
+    receive {
+        Go() -> {
+            inc = || { count = count + 1 }   // tries to mutate state
+            call(inc)
+        }
+    }
+}
+```
+
+Closures inside actor handlers correctly capture and mutate arm-local
+variables (Route 1 + arm promotion — tested by
+`tests/syntax/test_closure_in_actor_handler.ae`). But when the closure
+writes a name that's an actor **state field**, the compiler silently
+emits broken code: the closure doesn't know about `self`, so state
+accesses become unscoped local reads. No compile-time error yet — the
+user gets silent wrong answers.
+
+**Workaround:** copy state into an arm-local first, mutate that, then
+write back. See `tests/syntax/README_closure_actor_state_limitation.md`
+for the full pattern.
+
+**Proper fix:** thread `self` through the closure's env. Medium-sized
+codegen change. Interim fix worth doing: reject the pattern at compile
+time with a clear error so users don't silently hit it.
+
+### L5. Closure-var reassignment leaks the previous env
+
+```aether
+op = |x: int| { return x + 1 }
+op = |x: int| { return x * 2 }  // old env (malloc'd) is leaked
+```
+
+When a closure variable is reassigned, the auto-defer-free fires only
+on the first assignment (to avoid double-free at scope exit, since
+reassignment overwrites `.env` in the variable). The previous env's
+heap block is unreachable — leaked.
+
+**Why not just free on reassignment:** the old env may still be
+reachable via a `box_closure()` copy or another closure's transitive
+capture. Without escape analysis we can't tell if it's safe to free,
+so we lean safe (leak) over unsafe (UAF).
+
+Paired tests pin this trade-off:
+
+- `tests/syntax/test_closure_reassign_leaks_env.ae` — 100-iteration
+  reassignment loop exits cleanly.
+- `tests/syntax/test_closure_reassign_after_box.ae` — box_closure'd
+  copy survives reassignment of the source variable.
+
+**Proper fix:** escape analysis. Track whether a closure variable has
+been captured or stored anywhere before the reassignment; if not, free
+on reassignment. Larger change; deferred.
 
 ## Why the UI calculator works
 

--- a/docs/closure-lifetime-bugs.md
+++ b/docs/closure-lifetime-bugs.md
@@ -10,10 +10,11 @@ work: emission-ordering for cross-referenced closures, nested-lambda
 return-type bubble-up, and captures across trailing blocks. All three
 are fixed on main.
 
-Five limitations remain — three around dynamic `call()` dispatch (L1,
-L2, L3), one correctness hazard in closures inside actor handlers
-(L4), and one memory leak on closure-var reassignment (L5). All are
-tracked in the "Known limitations" section below.
+Five limitations are tracked — three around dynamic `call()` dispatch
+(L1, L2, L3), one correctness hazard in closures inside actor handlers
+(L4), and one memory leak on closure-var reassignment (L5). L4 is now
+rejected at compile time with a clear error; the rest are documented
+in the "Known limitations" section below.
 
 Regression tests live at `tests/syntax/test_closure_*.ae` and
 `tests/integration/closure_*/`.
@@ -158,9 +159,10 @@ Nearly all changes are in the codegen layer. The typechecker is unchanged.
 
 ## Known limitations
 
-Three limits are currently unfixed. Two (L1/L2/L3 collectively) are
-ergonomic gaps with workarounds; two (L4, L5) are correctness hazards
-worth flagging. All of them wait on larger language work.
+L1/L2/L3 are ergonomic gaps with workarounds; L5 is a correctness
+hazard worth flagging. L4 was previously in this list — it's now a
+compile-time error instead of a silent wrong answer (see L4 below).
+All remaining limits wait on larger language work.
 
 ### L1. `call(x)` where `x` comes from a list
 
@@ -182,6 +184,17 @@ garbage.
 `action = |_| { ... }; call(action)` is statically resolved. Or accept
 that `int`-returning dynamic closures are the only safely dispatchable
 kind today.
+
+**Why a quick `intptr_t` widening doesn't fix it:** the obvious patch —
+emit `((intptr_t(*)(void*))h.fn)(h.env)` instead of `((int(*)(void*))`
+— fixes the cast in isolation but leaves `r`'s declared C type as
+`int`, so the return narrows right back. Widening `r` requires changing
+the variable's registration in the symbol table (not just the AST
+decl); downstream `print(r)` looks up `r`'s type from the symbol table
+and picks `%d` for anything registered as `TYPE_INT`. Propagating
+`TYPE_PTR` through the AST alone was attempted — it segfaulted four
+existing tests whose `call(x)` returns are used in arithmetic or
+comparisons. A real fix threads through the typechecker.
 
 ### L2. `call(x)` where `x` is chosen via `match`/`if`
 
@@ -208,8 +221,8 @@ chains fall through to generic dispatch.
 
 **Proper fix for L1/L2/L3:** parameterised closure types (`fn[T]`, like
 Rust's `Fn(i32) -> i32`) or full typechecker return-type propagation.
-Either is a medium-sized language feature. The current cheap mitigation
-is Bug L1.5 below.
+Either is a medium-sized language feature — until it lands, the
+workaround sections on each limit apply.
 
 ### L4. Closure inside actor handler mutating actor state
 
@@ -218,7 +231,7 @@ actor Counter {
     state count = 0
     receive {
         Go() -> {
-            inc = || { count = count + 1 }   // tries to mutate state
+            inc = || { count = count + 1 }   // rejected at compile time
             call(inc)
         }
     }
@@ -228,18 +241,24 @@ actor Counter {
 Closures inside actor handlers correctly capture and mutate arm-local
 variables (Route 1 + arm promotion — tested by
 `tests/syntax/test_closure_in_actor_handler.ae`). But when the closure
-writes a name that's an actor **state field**, the compiler silently
-emits broken code: the closure doesn't know about `self`, so state
-accesses become unscoped local reads. No compile-time error yet — the
-user gets silent wrong answers.
+writes a name that's an actor **state field**, the closure has no
+access to `self`, so state accesses would compile to unscoped local
+reads — a silent wrong answer.
+
+**Current status (as of this branch):** codegen walks every closure
+body inside every actor receive-arm and, for each write to a state
+field, emits a compile-time error pointing at the offending line with
+a suggestion to use the arm-local workaround. Regression pinned by
+`tests/integration/closure_actor_state_reject/`.
 
 **Workaround:** copy state into an arm-local first, mutate that, then
 write back. See `tests/syntax/README_closure_actor_state_limitation.md`
 for the full pattern.
 
-**Proper fix:** thread `self` through the closure's env. Medium-sized
-codegen change. Interim fix worth doing: reject the pattern at compile
-time with a clear error so users don't silently hit it.
+**Proper fix:** thread `self` through the closure's env so state
+writes compile to `self->field = ...`. Medium-sized codegen change;
+until it lands, the compile-time rejection prevents silent wrong
+answers.
 
 ### L5. Closure-var reassignment leaks the previous env
 

--- a/tests/integration/closure_actor_state_reject/mutates_state.ae
+++ b/tests/integration/closure_actor_state_reject/mutates_state.ae
@@ -1,0 +1,24 @@
+// L4: closure inside an actor handler tries to mutate an actor state
+// field. This compiles on pre-fix main but silently emits broken code
+// (the closure doesn't have `self`, so `count = count + 1` refers to
+// an uninitialised stack local). After the fix, the compiler rejects
+// this with a clear error.
+
+message Go {}
+
+actor Counter {
+    state count = 0
+
+    receive {
+        Go() -> {
+            inc = || { count = count + 1 }   // mutates state — rejected
+            call(inc)
+        }
+    }
+}
+
+main() {
+    c = spawn(Counter())
+    c ! Go {}
+    wait_for_idle()
+}

--- a/tests/integration/closure_actor_state_reject/test_closure_actor_state_reject.sh
+++ b/tests/integration/closure_actor_state_reject/test_closure_actor_state_reject.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# L4: compile-time rejection of closures that mutate actor state fields.
+#
+# The proper fix — threading `self` through the closure env so state
+# mutations route to `self->field` — is larger language work. In the
+# meantime, users would silently get wrong answers (the closure writes
+# to an unscoped stack local that reads as 0). This test confirms the
+# compiler rejects the pattern at compile time with a clear error
+# instead.
+#
+# The error must mention the offending field name AND the actor name
+# so the user can find the site quickly, AND point at the workaround
+# (README_closure_actor_state_limitation.md).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AETHERC="$ROOT/build/aetherc"
+
+SRC="$SCRIPT_DIR/mutates_state.ae"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# The compiler MUST fail. A successful compile means the bug is back.
+if "$AETHERC" "$SRC" "$TMPDIR/out.c" >"$TMPDIR/err.log" 2>&1; then
+    echo "  [FAIL] aetherc accepted a closure that mutates actor state — L4 regressed"
+    exit 1
+fi
+
+# The error should reference the field name.
+if ! grep -q "count" "$TMPDIR/err.log"; then
+    echo "  [FAIL] error message doesn't mention the offending field name 'count'"
+    cat "$TMPDIR/err.log"
+    exit 1
+fi
+
+# The error should mention actor state or point at the workaround doc.
+if ! grep -qE "actor state|state field|README_closure_actor_state" "$TMPDIR/err.log"; then
+    echo "  [FAIL] error message doesn't explain actor-state context or point at workaround"
+    cat "$TMPDIR/err.log"
+    exit 1
+fi
+
+echo "  [PASS] closure_actor_state_reject: closure mutating actor state is rejected"


### PR DESCRIPTION
## Summary

- **L4 is now a compile-time error, not a silent wrong answer.** Closures inside actor receive arms have no access to `self`, so writing an actor state field (`inc = || { count = count + 1 }`) compiled to a stale local read. Codegen now walks every closure body in every receive arm, flags each state-field write with a line-numbered error + suggestion to use the arm-local workaround, and `aetherc` aborts instead of leaving a half-written `.c`.
- **`docs/closure-lifetime-bugs.md`** now enumerates all five tracked limitations (L1–L5) each with a minimal reproducer + workaround + proper-fix shape. Also includes a note on L1 explaining why a trivial `intptr_t` widening doesn't actually fix the truncation (the destination variable's C type is pinned via the symbol table, not just the AST — a real fix needs typechecker work).
- New helper `aether_error_full()` for line-numbered errors with suggestion + context + code. `aetherc` compares post-codegen error count against the pre-codegen count so legacy tests whose parsers report silent noise don't regress.

## Test plan

- [x] `make ci` green (full 8-step suite with `-Werror`, ASAN, Valgrind)
- [x] `tests/integration/closure_actor_state_reject/` regression test: aetherc must fail with an error mentioning the state field name and the README workaround pointer
- [x] All 248 existing `.ae` tests still pass
- [x] Rebased on latest `origin/main` (9f95923, v0.70.0)

## Error output example

```
error[E0600]: closure inside actor 'Counter' handler writes state field 'count' — not yet supported (closures can't mutate actor state; the closure has no access to self)
  --> mutates_state.ae:14:21
14 |             inc = || { count = count + 1 }
   |                     ^ help: copy 'count' into an arm-local, mutate the local, then write back. See tests/syntax/README_closure_actor_state_limitation.md for the workaround pattern.
   = note: in actor handler
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)