### PR TITLE
fix: three parser/build ergonomics issues surfaced by an external port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Two function calls on either side of `!=`/`==` inside an `if`/`while`/`for`/`match` condition no longer miscompile** (`compiler/parser/parser.c`, `compiler/parser/parser.h`). The parser greedily consumed the `{` that starts an if/while body as a trailing-closure argument attached to the rightmost call in the condition. An innocuous pattern like `while i < n { if f(a) != f(b) { return 0 }; i = i + 1 }` compiled to C where `return 0` was silently dropped, `i = i + 1` moved inside the `if`, and the loop became infinite — no compile error. New `parser->in_condition` flag is raised while parsing an if/while condition, a paren-less `match` subject, and a range-based for's end-expression; inside it, `func(args) { ... }` is parsed without the trailing block. Explicit trailing-block forms (`callback { }`, `|params| { }`) still work because they can't plausibly be mistaken for a statement body. Regression test: `tests/syntax/test_call_on_both_sides_of_comparison.ae`.
+
+- **Reserved-keyword identifier errors now name the keyword and suggest a rename** (`compiler/parser/parser.c`). `extern f(code: int, message: string)` produced `Expected IDENTIFIER, got MESSAGE_KEYWORD`, and `message = "hello"` produced `Expected statement in block` — both forcing the user to consult the lexer to figure out which name collided. New `token_is_reserved_keyword()` helper detects an alphanumeric token whose lexer type isn't `TOKEN_IDENTIFIER`; `expect_token` (identifier sites) and `parse_block` (statement-head site) now emit `'message' is a reserved keyword and cannot be used as an identifier; rename it (e.g. 'message_' or 'msg')`. Regression test: `tests/integration/reserved_keyword_error/` (extern parameter name and local variable name, both with `message`).
+
+- **`aether.toml` `[build] cflags` now apply to `ae run` too** (`tools/ae.c`). `user_cflags` was gated behind `optimize`, so `ae build` picked up the release build's cflags but `ae run` silently dropped them. That broke any project whose extern C shims relied on a `-D<feature>` flag or a `-Wno-<warning>` suppression — the `ae build` succeeded and `ae run` failed on the same source. Removed the gate; `get_cflags()` applies on every path. Regression test: `tests/integration/ae_run_cflags/` uses a shim.c with a `#error` that fires unless the TOML's `-DAE_CFLAGS_TEST_MARKER=1` reaches the compile.
+
 ## [0.75.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ test-ae: compiler ae stdlib
 	printf 'fi\n'                                                                                   >> "$$script"; \
 	chmod +x "$$script"; \
 	root=$$(pwd); \
-	find tests/syntax tests/compiler tests/integration -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
+	find tests/syntax tests/compiler tests/integration -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -path 'tests/integration/reserved_keyword_error/*' -prune -o -path 'tests/integration/ae_run_cflags/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
 	xargs -P $(NPROC) -I{} "$$script" "{}" "$$tmpdir" "$$root"; \
 	for sh_test in $$(find tests/integration -name 'test_*.sh' 2>/dev/null | sort); do \
 		name=$$(echo "$$sh_test" | sed 's|tests/||;s|/|_|g;s|\.sh$$||'); \

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -47,14 +47,39 @@ Token* advance_token(Parser* parser) {
     return parser->tokens[parser->current_token++];
 }
 
+// True when `token`'s source text looks like a reserved keyword (all
+// alphanumeric/underscore, starts with a letter). Used to generate a
+// friendlier error than "Expected IDENTIFIER, got MESSAGE_KEYWORD"
+// when a user picks a name that collides with the grammar. Skips
+// TOKEN_IDENTIFIER itself and anything whose value is punctuation.
+static int token_is_reserved_keyword(Token* token) {
+    if (!token || !token->value || token->type == TOKEN_IDENTIFIER) return 0;
+    const char* s = token->value;
+    if (!((*s >= 'a' && *s <= 'z') || (*s >= 'A' && *s <= 'Z') || *s == '_')) return 0;
+    for (const char* p = s + 1; *p; p++) {
+        if (!((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+              (*p >= '0' && *p <= '9') || *p == '_')) return 0;
+    }
+    return 1;
+}
+
 Token* expect_token(Parser* parser, AeTokenType expected) {
     Token* token = peek_token(parser);
     if (!token || token->type != expected) {
         char error_msg[256];
-        snprintf(error_msg, sizeof(error_msg), 
-                "Expected %s, got %s", 
+        if (expected == TOKEN_IDENTIFIER && token_is_reserved_keyword(token)) {
+            // User picked a reserved keyword as an identifier name —
+            // point at the keyword and suggest a rename so they don't
+            // have to guess which grammar slot was wanted.
+            snprintf(error_msg, sizeof(error_msg),
+                "'%s' is a reserved keyword and cannot be used as an identifier; rename it (e.g. '%s_' or 'msg')",
+                token->value, token->value);
+        } else {
+            snprintf(error_msg, sizeof(error_msg),
+                "Expected %s, got %s",
                 token_type_to_string(expected),
                 token ? token_type_to_string(token->type) : "EOF");
+        }
         parser_error(parser, error_msg);
         return NULL;
     }
@@ -2178,12 +2203,25 @@ ASTNode* parse_block(Parser* parser) {
             add_child(block, stmt);
         } else {
             // Prevent infinite loops on unexpected tokens inside blocks.
-            parser_error(parser, "Expected statement in block");
+            // If the block-head token is a reserved keyword being used as
+            // if it were an identifier (e.g. `message = "hello"`), point
+            // at it directly instead of the generic "expected statement"
+            // that leaves users guessing.
+            Token* stmt_head = peek_token(parser);
+            if (stmt_head && token_is_reserved_keyword(stmt_head)) {
+                char msg[256];
+                snprintf(msg, sizeof(msg),
+                    "'%s' is a reserved keyword and cannot be used as an identifier; rename it (e.g. '%s_' or 'msg')",
+                    stmt_head->value, stmt_head->value);
+                parser_error(parser, msg);
+            } else {
+                parser_error(parser, "Expected statement in block");
+            }
             if (parser->current_token == start_token) {
                 advance_token(parser);
             }
         }
-        
+
         if (is_at_end(parser)) break;
     }
     

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -16,6 +16,7 @@ Parser* create_parser(Token** tokens, int token_count) {
     parser->current_token = 0;
     parser->suppress_errors = 0;  // By default, show errors
     parser->parsing_builder = 0;
+    parser->in_condition = 0;
     return parser;
 }
 
@@ -894,8 +895,16 @@ static ASTNode* parse_postfix_expression(Parser* parser) {
                     if (trailing) {
                         add_child(func_call, trailing);
                     }
-                } else if (next_tok && next_tok->type == TOKEN_LEFT_BRACE) {
+                } else if (next_tok && next_tok->type == TOKEN_LEFT_BRACE &&
+                           !parser->in_condition) {
                     // Trailing block without params: func(args) { body }
+                    //
+                    // Suppressed when we're parsing an if/while/for condition:
+                    // the `{` there is the start of the statement's body, not
+                    // a trailing closure attached to the rightmost call. Eating
+                    // it here would swallow the real body and produce silently
+                    // wrong code (e.g. an infinite while loop because the
+                    // increment statement becomes the if-body).
                     ASTNode* trailing = create_ast_node(AST_CLOSURE, "trailing",
                                                          next_tok->line, next_tok->column);
                     trailing->node_type = create_type(TYPE_FUNCTION);
@@ -1322,7 +1331,10 @@ ASTNode* parse_python_style_declaration(Parser* parser) {
 
 ASTNode* parse_if_statement(Parser* parser) {
     advance_token(parser); // if
+    int saved_in_condition = parser->in_condition;
+    parser->in_condition = 1;
     ASTNode* condition = parse_expression(parser);
+    parser->in_condition = saved_in_condition;
     if (!condition) return NULL;
     
     ASTNode* then_branch = parse_statement(parser);
@@ -1356,7 +1368,13 @@ ASTNode* parse_for_loop(Parser* parser) {
         ASTNode* start_expr = parse_expression(parser);
         if (!start_expr) return NULL;
         if (!expect_token(parser, TOKEN_DOTDOT)) return NULL;
+        // end_expr is terminated by `{` (the loop body) — the same
+        // trailing-block ambiguity if/while have. See parse_if_statement
+        // for the rationale.
+        int saved_in_condition = parser->in_condition;
+        parser->in_condition = 1;
         ASTNode* end_expr = parse_expression(parser);
+        parser->in_condition = saved_in_condition;
         if (!end_expr) return NULL;
 
         ASTNode* body = parse_statement(parser);
@@ -1453,7 +1471,10 @@ ASTNode* parse_for_loop(Parser* parser) {
 
 ASTNode* parse_while_loop(Parser* parser) {
     advance_token(parser); // while
+    int saved_in_condition = parser->in_condition;
+    parser->in_condition = 1;
     ASTNode* condition = parse_expression(parser);
+    parser->in_condition = saved_in_condition;
     if (!condition) return NULL;
     
     ASTNode* body = parse_statement(parser);
@@ -1569,10 +1590,16 @@ ASTNode* parse_case_statement(Parser* parser) {
 //   }
 ASTNode* parse_match_statement(Parser* parser) {
     advance_token(parser); // consume 'match'
-    
-    // Parse the expression to match on (parens optional)
+
+    // Parse the expression to match on (parens optional). When there are
+    // no parens, the `{` that follows introduces the match arms — the same
+    // trailing-block ambiguity if/while have. Guarding the condition flag
+    // keeps `match f(x) { ... }` from eating the arms as a closure on f.
     int has_paren = match_token(parser, TOKEN_LEFT_PAREN);
+    int saved_in_condition = parser->in_condition;
+    if (!has_paren) parser->in_condition = 1;
     ASTNode* expression = parse_expression(parser);
+    parser->in_condition = saved_in_condition;
     if (!expression) return NULL;
     if (has_paren && !expect_token(parser, TOKEN_RIGHT_PAREN)) return NULL;
 

--- a/compiler/parser/parser.h
+++ b/compiler/parser/parser.h
@@ -11,6 +11,10 @@ typedef struct {
     int current_token;
     int suppress_errors;  // Flag to suppress error messages (for testing)
     int parsing_builder;  // Flag: inside builder function definition (enables 'with' clause)
+    int in_condition;     // Flag: inside if/while/for condition — suppresses
+                          // trailing-block parsing on function calls so the
+                          // `{` belongs to the if/while body, not a trailing
+                          // closure on the last call in the condition.
 } Parser;
 
 // Parser functions

--- a/tests/integration/ae_run_cflags/aether.toml
+++ b/tests/integration/ae_run_cflags/aether.toml
@@ -1,0 +1,7 @@
+[build]
+cflags = "-DAE_CFLAGS_TEST_MARKER=1"
+
+[[bin]]
+name = "probe"
+path = "probe.ae"
+extra_sources = ["shim.c"]

--- a/tests/integration/ae_run_cflags/probe.ae
+++ b/tests/integration/ae_run_cflags/probe.ae
@@ -1,0 +1,13 @@
+// Exercises the [build] cflags from aether.toml. The adjacent shim.c
+// requires AE_CFLAGS_TEST_MARKER to be defined (via -D in cflags) or
+// the #error fires and the C compile fails.
+extern ae_cflags_probe_value() -> int
+
+main() {
+    v = ae_cflags_probe_value()
+    if v != 1 {
+        println("FAIL: probe value wrong")
+        exit(1)
+    }
+    println("OK")
+}

--- a/tests/integration/ae_run_cflags/shim.c
+++ b/tests/integration/ae_run_cflags/shim.c
@@ -1,0 +1,7 @@
+/* Fails to compile unless the cflags from aether.toml are applied,
+ * because the test marker must be defined. */
+#ifndef AE_CFLAGS_TEST_MARKER
+#error "AE_CFLAGS_TEST_MARKER not defined — aether.toml [build] cflags was not applied to this build path"
+#endif
+
+int ae_cflags_probe_value(void) { return AE_CFLAGS_TEST_MARKER; }

--- a/tests/integration/ae_run_cflags/test_ae_run_cflags.sh
+++ b/tests/integration/ae_run_cflags/test_ae_run_cflags.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Regression: `aether.toml` [build] cflags are applied on both `ae build`
+# (release/optimize) AND `ae run` (non-optimize) paths. Previously only
+# the release path picked them up, so users had to drop warnings or
+# defines that their extern C shims relied on.
+#
+# The adjacent shim.c contains a #error that fires unless the cflags
+# from aether.toml's [build] section define AE_CFLAGS_TEST_MARKER.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+fail=0
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Build into tmpdir (keeps tests/ clean). `ae run` on the .ae file from
+# the project dir so aether.toml is picked up.
+cd "$SCRIPT_DIR" || exit 1
+
+# Test 1: ae build picks up the cflags (this was already working).
+build_log="$tmpdir/build.log"
+if ! "$AE" build probe.ae -o "$tmpdir/probe_build" >"$build_log" 2>&1; then
+    echo "  [FAIL] ae_run_cflags: ae build rejected the project; cflags were not applied"
+    sed 's/^/    /' "$build_log" | head -10
+    fail=1
+else
+    if ! "$tmpdir/probe_build" > "$tmpdir/build.out" 2>&1 || ! grep -q "^OK$" "$tmpdir/build.out"; then
+        echo "  [FAIL] ae_run_cflags: ae build produced a binary but the probe returned wrong value"
+        sed 's/^/    /' "$tmpdir/build.out" | head -5
+        fail=1
+    else
+        echo "  [PASS] ae_run_cflags: ae build applies [build] cflags"
+    fi
+fi
+
+# Test 2: ae run picks up the same cflags — this is the regression.
+# `ae run` compiles and executes in one step; success means cflags reached
+# the compile step AND the program returned 0 AND stdout contained "OK".
+run_log="$tmpdir/run.log"
+if ! "$AE" run probe.ae >"$run_log" 2>&1; then
+    echo "  [FAIL] ae_run_cflags: ae run failed — cflags likely not applied to the ae-run path"
+    sed 's/^/    /' "$run_log" | head -15
+    fail=1
+elif ! grep -q "^OK$" "$run_log"; then
+    echo "  [FAIL] ae_run_cflags: ae run succeeded but probe did not print OK"
+    sed 's/^/    /' "$run_log" | head -10
+    fail=1
+else
+    echo "  [PASS] ae_run_cflags: ae run applies [build] cflags"
+fi
+
+exit $fail

--- a/tests/integration/reserved_keyword_error/message_as_local.ae
+++ b/tests/integration/reserved_keyword_error/message_as_local.ae
@@ -1,0 +1,6 @@
+// A reserved keyword (`message`) used as a local variable name — must
+// fail to compile, but with a helpful error that names the keyword.
+main() {
+    message = "hello"
+    println(message)
+}

--- a/tests/integration/reserved_keyword_error/message_as_param.ae
+++ b/tests/integration/reserved_keyword_error/message_as_param.ae
@@ -1,0 +1,9 @@
+// A reserved keyword (`message`) used as a parameter name — must fail
+// to compile, but with a helpful error that names the offending
+// keyword and suggests a rename.
+extern svnae_error_create(code: int, message: string) -> ptr
+
+main() {
+    p = svnae_error_create(1, "boom")
+    println("ok")
+}

--- a/tests/integration/reserved_keyword_error/test_reserved_keyword_error.sh
+++ b/tests/integration/reserved_keyword_error/test_reserved_keyword_error.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Regression: using a reserved keyword (`message`, `state`, `send`, ...)
+# where an identifier is expected must fail to compile with an error
+# that (a) names the offending keyword, and (b) suggests renaming.
+# Previously the parser emitted "Expected IDENTIFIER, got <TOKEN_NAME>"
+# which didn't mention the actual source text and made it hard to tell
+# what was wrong without reading the grammar.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AETHERC="$ROOT/build/aetherc"
+
+fail=0
+
+check_case() {
+    src="$1"
+    label="$2"
+    tmpdir="$(mktemp -d)"
+    log="$tmpdir/cc.log"
+
+    # aetherc reports parse errors on stderr but currently exits 0;
+    # inspect the log rather than the return code. The acceptance
+    # criteria are (1) an error IS reported, and (2) it names the
+    # offending keyword and suggests renaming.
+    "$AETHERC" "$src" "$tmpdir/out.c" >"$log" 2>&1
+
+    if ! grep -q '^error' "$log"; then
+        echo "  [FAIL] $label: aetherc reported no error for a reserved-keyword identifier"
+        fail=1
+        rm -rf "$tmpdir"
+        return
+    fi
+
+    if ! grep -qi "reserved" "$log" || ! grep -q "message" "$log"; then
+        echo "  [FAIL] $label: error message doesn't mention 'reserved' + 'message'"
+        echo "        got:"
+        sed 's/^/          /' "$log" | head -8
+        fail=1
+        rm -rf "$tmpdir"
+        return
+    fi
+
+    if ! grep -qi "rename" "$log"; then
+        echo "  [FAIL] $label: error message doesn't suggest renaming"
+        sed 's/^/          /' "$log" | head -8
+        fail=1
+        rm -rf "$tmpdir"
+        return
+    fi
+
+    echo "  [PASS] $label"
+    rm -rf "$tmpdir"
+}
+
+check_case "$SCRIPT_DIR/message_as_param.ae"  "reserved_keyword_error: extern parameter name"
+check_case "$SCRIPT_DIR/message_as_local.ae"  "reserved_keyword_error: local variable name"
+
+exit $fail

--- a/tests/syntax/test_call_on_both_sides_of_comparison.ae
+++ b/tests/syntax/test_call_on_both_sides_of_comparison.ae
@@ -1,0 +1,73 @@
+// Regression: `if call_a() != call_b() { body }` must parse as an
+// if-statement whose condition is the `!=` comparison and whose body
+// is the `{ body }` block. Previously the parser consumed the `{` as
+// a trailing-block argument attached to `call_b()` (the rightmost
+// call in the condition), leaving the if-statement with only its
+// post-block siblings as its true body — so programs like
+//
+//     while i < n {
+//         if f(a) != f(b) { return 0 }
+//         i = i + 1
+//     }
+//
+// compiled to generated C where `return 0` never fired and the loop
+// increment moved inside the `if`, producing an infinite loop.
+//
+// The bug fires with ANY function call (user function OR extern), not
+// just extern calls — this test uses a plain user function so it
+// doesn't depend on std.string semantics.
+
+g(x: int) { return x + 1 }
+
+// Case A: if with calls on both sides of !=
+diff_count(a: int, b: int, limit: int) {
+    i = 0
+    d = 0
+    while i < limit {
+        if g(a) != g(b) { d = d + 1 }
+        i = i + 1
+    }
+    return d
+}
+
+// Case B: while-cond with calls on both sides of !=, plus return inside if
+first_diff(a: int, b: int, limit: int) {
+    i = 0
+    while i < limit {
+        if g(a) != g(b) { return i }
+        i = i + 1
+    }
+    return -1
+}
+
+main() {
+    // Both inputs equal — no differences.
+    if diff_count(5, 5, 3) != 0 {
+        println("FAIL: diff_count(5,5,3) should be 0")
+        exit(1)
+    }
+    println("PASS: diff_count(5,5,3) = 0")
+
+    // Different inputs — every iteration a mismatch.
+    if diff_count(5, 7, 3) != 3 {
+        println("FAIL: diff_count(5,7,3) should be 3")
+        exit(1)
+    }
+    println("PASS: diff_count(5,7,3) = 3")
+
+    // Equal — first_diff returns -1 (loop completes without early return).
+    // If the `return i` got eaten into the wrong block and the loop body
+    // never incremented, this either hangs or returns the wrong value.
+    if first_diff(5, 5, 3) != -1 {
+        println("FAIL: first_diff equal should be -1")
+        exit(1)
+    }
+    println("PASS: first_diff(5,5,3) = -1")
+
+    // Different — first_diff returns 0 on first iteration.
+    if first_diff(5, 7, 3) != 0 {
+        println("FAIL: first_diff differ should be 0")
+        exit(1)
+    }
+    println("PASS: first_diff(5,7,3) = 0")
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1058,8 +1058,12 @@ static void build_gcc_cmd(char* cmd, size_t size,
     const char* link_flags = get_link_flags();
     const char* extra = extra_files ? extra_files : "";
 
-    // User cflags from aether.toml applied only for release builds (ae build)
-    const char* user_cflags = optimize ? get_cflags() : "";
+    // User cflags from aether.toml apply to every build path — `ae build`,
+    // `ae run`, and any internal invocation. Previously they were gated
+    // behind `optimize` (only the release path picked them up), which
+    // meant `-D<feature>` flags and warning-suppression that extern C
+    // shims relied on silently broke `ae run`.
+    const char* user_cflags = get_cflags();
 
 #ifdef _WIN32
     // Ensure GCC is available (auto-downloads WinLibs on first run if needed).


### PR DESCRIPTION
Three independent defects surfaced by an external reviewer porting a C codebase to Aether. Each has a failing-test-first commit followed by a minimal fix. Four commits total (three fixes + CHANGELOG), `make ci` green.

## Fix 1 — Trailing-block parsing eats the if-body when a call appears on both sides of `!=`

**Severity: blocker — silently wrong, no compile error.**

```aether
while i < n {
    if f(a) != f(b) { return 0 }
    i = i + 1
}
```
compiled to C where the `{` after `f(b)` was consumed as a trailing-closure argument on `f(b)`, the `return 0` was dropped, and `i = i + 1` ended up inside the `if`. The loop ran forever. **Not extern-specific** — any user function on both sides reproduces it.

**Fix:** new `Parser::in_condition` flag raised while parsing an if/while condition, a paren-less `match` subject, and a range-based for's end-expression. Inside the flag, `func(args) { body }` drops the trailing block so the `{` belongs to the statement parser. Explicit trailing-block forms (`callback { }`, `|params| { }`) still work — their leading keyword/pipe disambiguates them from a body start.

**Test:** `tests/syntax/test_call_on_both_sides_of_comparison.ae` covers the exact shape that hung before, plus a variant with `return` inside the `if`.

## Fix 2 — Error messages now name a reserved keyword used as an identifier

**Severity: minor — docs/ergonomic.**

`extern f(code: int, message: string)` produced `Expected IDENTIFIER, got MESSAGE_KEYWORD`. `message = "hello"` produced `Expected statement in block`. Neither named the offending source text, forcing the user to read `compiler/parser/lexer.c` to discover which name collided.

**Fix:** new helper `token_is_reserved_keyword()` detects non-`IDENTIFIER` tokens whose source text is alphanumeric. Two call sites swapped to a clear message: `'message' is a reserved keyword and cannot be used as an identifier; rename it (e.g. 'message_' or 'msg')`.

**Test:** `tests/integration/reserved_keyword_error/` — two `.ae` fixtures (extern parameter name and local variable name), both with `message`, driven by a shell wrapper that asserts the error mentions `reserved` + `message` + `rename`.

## Fix 3 — `aether.toml` `[build] cflags` now apply to `ae run`

**Severity: minor — silent gap between invocation paths.**

`get_cflags()` was gated behind `optimize` in `build_gcc_cmd`, so release builds (`ae build`) picked up project cflags but `ae run` silently dropped them. A project whose extern C shim needed `-DFEATURE_X` or a warning-suppression flag compiled under `ae build` and failed under `ae run`.

**Fix:** one-line change — always apply `get_cflags()`.

**Test:** `tests/integration/ae_run_cflags/` uses a shim.c with a `#error` that fires unless the TOML's `-DAE_CFLAGS_TEST_MARKER=1` reaches the compiler. Shell test exercises both `ae build` and `ae run`.

## Test plan

- [x] `make ci` green (full 8-step suite with `-Werror`, ASAN, Valgrind)
- [x] 253 `.ae` tests pass (three new tests, zero regressions)
- [x] Rebased on latest `origin/main` (9866251, v0.75.0)

## Out of scope

A fourth defect from the same reviewer — `extra_sources` in `[[bin]]` not picked up for some invocation shapes — turned out to be three separate sub-bugs (absolute-path match, bin-name lookup, no `aether.toml` walk-up). They need a design call on the resolution order and are better as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)