### PR TITLE
fix: sibling bare-block scope — restore declared_var_count across AST_BLOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Sibling bare `{ }` blocks sharing a local name now compile cleanly** (`compiler/codegen/codegen_stmt.c`). Two blocks each declaring `src` compiled to C where the first block emitted `const char* src = ...;` but the second emitted a bare `src = ...;` reassignment — C scope had already dropped the first `src` at the first `}`, so gcc errored with `'src' undeclared`. Codegen's `declared_var_count` wasn't saved/restored across the bare AST_BLOCK path even though the if/else path already did this correctly. Fix: mirror the if/else save/restore pattern for AST_BLOCK. Regression test: `tests/syntax/test_sibling_block_scope.ae`.
+
 ## [0.76.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -2208,7 +2208,15 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             fprintf(gen->output, "/* ERROR: Generic spawn_actor() not supported - use type-specific spawn functions */\n");
             break;
             
-        case AST_BLOCK:
+        case AST_BLOCK: {
+            // Save declared_var_count before the block. Variables declared
+            // inside the block live in its C `{ ... }` scope and must not
+            // leak to sibling statements that follow — otherwise a sibling
+            // bare-block writing the same name is codegen'd as a
+            // reassignment (no type on LHS) even though C scope already
+            // closed the earlier declaration. This mirrors what the
+            // AST_IF_STATEMENT path does at the `if`/`else` branch boundaries.
+            int saved_var_count = gen->declared_var_count;
             print_line(gen, "{");
             indent(gen);
             enter_scope(gen);  // Track defer scope
@@ -2218,7 +2226,9 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             exit_scope(gen);  // Emit defers and pop scope
             unindent(gen);
             print_line(gen, "}");
+            gen->declared_var_count = saved_var_count;
             break;
+        }
         
         case AST_REPLY_STATEMENT:
             if (stmt->child_count > 0) {

--- a/tests/syntax/test_sibling_block_scope.ae
+++ b/tests/syntax/test_sibling_block_scope.ae
@@ -1,0 +1,25 @@
+// Regression: two sibling `{ }` blocks each declaring the same local
+// name must each own its declaration. Previously the codegen tracked
+// "declared" names globally across siblings (it does save/restore
+// across if/else — same problem class, just missed for bare blocks),
+// so the first block emitted `const char* src = ...;` and the second
+// emitted `src = ...;` without a declaration — failing with gcc's
+// "'src' undeclared" because C block scope already closed the first
+// `src` when the first `}` fired.
+
+main() {
+    // Two sibling bare blocks each with their own `src`.
+    { src = "a"; println(src) }
+    { src = "b"; println(src) }
+
+    // Same shape with an int, and three siblings deep.
+    { n = 1; println(n) }
+    { n = 2; println(n) }
+    { n = 3; println(n) }
+
+    // Block after sibling should see no leaked `src` either.
+    // Declaring `src` at function scope now is a fresh local —
+    // must not collide with the block-local ones above.
+    src = "outer"
+    println(src)
+}


### PR DESCRIPTION
Addresses **claim #10** in `AETHER_ISSUES.md`. Plus along the way I re-ran claims #13, #14, #15, #16 on v0.76.0 and confirmed they're all now resolved by earlier work (no longer reproduce) — see summary at the bottom.

## The bug

```aether
main() {
    { src = "a"; println(src) }
    { src = "b"; println(src) }
}
```

The first block correctly emitted `const char* src = "a";` and marked `src` declared in `gen->declared_var_count`. The second block saw "src is already declared" and emitted a bare `src = "b";` reassignment. But C scope already closed the first declaration at the first `}`, so gcc errored with `'src' undeclared` — the reporter's claim #10.

## The fix

The if/else path at `codegen_stmt.c:1365` already does the right thing: it snapshots `declared_var_count` on entry and restores it on exit so each branch's locals don't leak to the sibling branch or to the sibling statement after the if. The bare AST_BLOCK path didn't have the same save/restore. This PR adds it.

One-line fix plus bookkeeping in the `case AST_BLOCK:` arm of `generate_statement`.

## Test plan

- [x] `make ci` green (full 8-step suite with `-Werror`, ASAN, Valgrind)
- [x] New regression test `tests/syntax/test_sibling_block_scope.ae` covers:
  - Two sibling `{ }` blocks each with a local `src: string`
  - Three sibling `{ }` blocks each with a local `n: int`
  - A function-scope `src = "outer"` declared after the blocks (must not collide)
- [x] All 254 existing `.ae` tests still pass
- [x] Rebased on latest `origin/main` (14d52e3, v0.76.0)

## Generated C before / after

**Before:**
```c
{ const char* src = "a"; printf("%s", src); }
{ src = "b"; printf("%s", src); }      // <-- 'src' undeclared
```

**After:**
```c
{ const char* src = "a"; printf("%s", src); }
{ const char* src = "b"; printf("%s", src); }      // fresh decl, own scope
```

## Side-effect of this PR: `AETHER_ISSUES.md` bulk resolution

While investigating, I re-ran every open claim against v0.76.0. Results:

| # | Claim | Result on v0.76.0 |
|---|---|---|
| 13 | Recursive string-returning fn | ✅ Works with `-> string` annotation; also works without |
| 14 | Extern-return-type poisoning | ✅ Does not reproduce — both `svnae_count` calls return 11 |
| 15 | `!` on non-bool int | ✅ Does not reproduce — `if !some_cond()` works |
| 16 | 6-param extern drops last arg | ✅ Does not reproduce — declaration has all 6 params |

Only #10 still bit. So the four remaining "blocker" claims in the reporter's original doc were mostly downstream effects of what PRs #190/#192 fixed. `AETHER_ISSUES.md` (working doc at repo root) is updated accordingly but not in this PR's commit graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)