### PR TITLE
feat(json): object-key iteration — size / key_at / value_at / entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.json` object-key iteration** (`std/json/aether_json.h`, `std/json/aether_json.c`, `std/json/module.ae`). Four new C accessors — `json_object_size_raw`, `json_object_key_at`, `json_object_key_len_at`, `json_object_value_at` — expose the parallel-array storage that `JsonObjBlock` already keeps. Two Aether wrappers — `json.object_size(obj)` and `json.object_entry(obj, i)` with Go-style `(key, value, err)` return — cover the common loop case. Iteration order is insertion order across both parse and builder paths (documented explicitly in `docs/json-parser-design.md`). Fills a gap vs. every other general-purpose JSON library (cJSON, nlohmann::json, serde_json, Python `json`) so callers can enumerate prop maps, path-keyed dicts, headers, and other JSON where the keys themselves are user data. Regression test: `tests/regression/test_json_object_iter.ae` — empty object, single key, parse-order preservation, builder-order preservation, negative/OOB index, non-object rejection, nested iteration, 32-key stress through `obj_reserve`'s growth path.
+
 ## [0.78.0]
 
 ### Changed

--- a/docs/json-parser-design.md
+++ b/docs/json-parser-design.md
@@ -266,6 +266,16 @@ common case; tiny objects waste a few unused pointers which round-off
 into the arena anyway. Old buffers become arena garbage until the arena
 is freed — waste is bounded by `O(final size)` per container.
 
+**Iteration order.** The parallel-array layout means objects iterate
+in insertion order by construction — the parser appends to the tail as
+it reads each `key: value` pair, and the builder's `json_object_set_raw`
+does the same on first insert. The public iteration API
+(`json_object_size_raw` / `json_object_key_at` / `json_object_value_at`,
+and the Aether-side `object_entry(obj, i)` wrapper) commits to this
+order: parsed JSON iterates in the order keys appeared in the source,
+built JSON iterates in the order `object_set` was called. Callers that
+need sorted iteration copy the keys and sort.
+
 ## JsonValue sizing
 
 ```c

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -472,6 +472,10 @@ Raw extern: `json_parse_raw`.
 - `json.object_get(obj, key)` - Get value by key (key is a raw string)
 - `json.object_set(obj, key, value)` - Set key-value pair
 - `json.object_has(obj, key)` - Check if key exists (returns 1/0)
+- `json.object_size(obj)` - Number of entries (`0` for empty, `-1` if not an object)
+- `json.object_entry(obj, i)` - `(key, value, err)` for the i-th entry; keys
+  are yielded in insertion order (same as parsed input; same as the order
+  `object_set` was called). Mutating `obj` during iteration is not supported.
 
 **Array Operations:**
 - `json.array_get(arr, index)` - Get value at index

--- a/std/json/aether_json.c
+++ b/std/json/aether_json.c
@@ -1302,6 +1302,39 @@ int json_object_has(JsonValue* obj, const char* key) {
     return json_object_get_raw(obj, key) != NULL;
 }
 
+// Object-key iteration. Empty objects have blk == NULL (obj_reserve
+// allocates the block lazily on the first set), so the NULL guard is
+// load-bearing, not defensive.
+
+int json_object_size_raw(JsonValue* obj) {
+    if (!obj || obj->type != JSON_OBJECT) return -1;
+    return (int)obj->data.obj.count;
+}
+
+const char* json_object_key_at(JsonValue* obj, int i) {
+    if (!obj || obj->type != JSON_OBJECT) return NULL;
+    if (i < 0 || (uint32_t)i >= obj->data.obj.count) return NULL;
+    const JsonObjBlock* blk = obj->data.obj.blk;
+    if (!blk) return NULL;
+    return blk->keys[i];
+}
+
+int json_object_key_len_at(JsonValue* obj, int i) {
+    if (!obj || obj->type != JSON_OBJECT) return -1;
+    if (i < 0 || (uint32_t)i >= obj->data.obj.count) return -1;
+    const JsonObjBlock* blk = obj->data.obj.blk;
+    if (!blk) return -1;
+    return (int)blk->key_lens[i];
+}
+
+JsonValue* json_object_value_at(JsonValue* obj, int i) {
+    if (!obj || obj->type != JSON_OBJECT) return NULL;
+    if (i < 0 || (uint32_t)i >= obj->data.obj.count) return NULL;
+    JsonObjBlock* blk = obj->data.obj.blk;
+    if (!blk) return NULL;
+    return blk->values[i];
+}
+
 JsonValue* json_array_get_raw(JsonValue* arr, int index) {
     if (!arr || arr->type != JSON_ARRAY) return NULL;
     if (index < 0 || (uint32_t)index >= arr->data.arr.count) return NULL;

--- a/std/json/aether_json.h
+++ b/std/json/aether_json.h
@@ -59,6 +59,38 @@ JsonValue* json_object_get_raw(JsonValue* obj, const char* key);
 int json_object_set_raw(JsonValue* obj, const char* key, JsonValue* value);
 int json_object_has(JsonValue* obj, const char* key);
 
+// Object-key iteration. Keys are yielded in insertion order: the order
+// they appeared in the parsed JSON, and the order `json_object_set_raw`
+// was called on builder-constructed objects. Mutating the object during
+// iteration is not supported — the observed order is undefined and
+// entries may be skipped or revisited. Indices are valid in [0, size).
+
+// Number of entries in the object. Returns -1 if `obj` is not a
+// JSON_OBJECT — distinguishable from "empty object" (returns 0).
+// Named `_raw` for consistency with the other object accessors, and
+// so the Aether-side wrapper `object_size` doesn't collide with it
+// after module-prefix mangling.
+int json_object_size_raw(JsonValue* obj);
+
+// Key at index `i` — a borrowed, NUL-terminated pointer into the
+// object's internal storage, valid until json_free(root) is called.
+// Returns NULL if `obj` is not a JSON_OBJECT or `i` is out of range.
+// Keys are NUL-terminated even for inputs parsed via json_parse_raw_n
+// (the parser arena-copies each key and writes a trailing '\0').
+const char* json_object_key_at(JsonValue* obj, int i);
+
+// Length of the key at index `i`, matching json_object_key_at(obj, i).
+// Returns -1 if `obj` is not a JSON_OBJECT or `i` is out of range.
+// Useful for callers that want to avoid an extra strlen; JSON per
+// RFC 8259 disallows embedded NULs in keys, so strlen is also correct.
+int json_object_key_len_at(JsonValue* obj, int i);
+
+// Value at index `i` — borrowed from the object. Returns NULL only
+// when `obj` is not a JSON_OBJECT or `i` is out of range. A valid
+// entry whose value is a JSON null still returns a non-NULL JsonValue*;
+// use json_is_null() to distinguish that from the out-of-range NULL.
+JsonValue* json_object_value_at(JsonValue* obj, int i);
+
 JsonValue* json_array_get_raw(JsonValue* arr, int index);
 // Returns 1 on success, 0 if `arr` is not a JSON_ARRAY, null value,
 // or allocation failure. Ownership of `value` transfers to the array.

--- a/std/json/module.ae
+++ b/std/json/module.ae
@@ -33,6 +33,9 @@ extern json_get_string_raw(value: ptr) -> string
 extern json_object_get_raw(obj: ptr, key: string) -> ptr
 extern json_object_set_raw(obj: ptr, key: string, value: ptr) -> int
 extern json_object_has(obj: ptr, key: string) -> int
+extern json_object_size_raw(obj: ptr) -> int
+extern json_object_key_at(obj: ptr, i: int) -> string
+extern json_object_value_at(obj: ptr, i: int) -> ptr
 
 // ---- array operations (raw externs) ----
 extern json_array_get_raw(arr: ptr, index: int) -> ptr
@@ -113,6 +116,41 @@ object_set(obj: ptr, key: string, value: ptr) -> {
         return "not an object"
     }
     return ""
+}
+
+// Number of entries in a JSON object.
+// Returns 0 for an empty object, -1 if `obj` is not a JSON_OBJECT.
+object_size(obj: ptr) -> int {
+    return json_object_size_raw(obj)
+}
+
+// Read the (key, value) pair at index `i` in iteration order. Keys
+// are yielded in insertion order — the order they appeared in parsed
+// JSON input, or the order `object_set` was called for a built object.
+//
+// - (key, value, "")                  : index in range
+// - ("", null, "index out of range")  : i < 0 or i >= object_size(obj)
+// - ("", null, "not an object")       : `obj` is not a JSON_OBJECT
+//
+// The key is an owned string; the value is borrowed from `obj` and
+// must not be json.free'd separately, nor used after `obj` is freed.
+// Mutating `obj` during iteration is not supported: order becomes
+// unpredictable and entries may be skipped or revisited.
+object_entry(obj: ptr, i: int) -> {
+    if json_type(obj) != 5 {
+        return "", null, "not an object"
+    }
+    n = json_object_size_raw(obj)
+    if i < 0 {
+        return "", null, "index out of range"
+    }
+    if i >= n {
+        return "", null, "index out of range"
+    }
+    raw_key = json_object_key_at(obj, i)
+    owned_key = string_concat(raw_key, "")
+    v = json_object_value_at(obj, i)
+    return owned_key, v, ""
 }
 
 // Index into a JSON array.

--- a/tests/regression/test_json_object_iter.ae
+++ b/tests/regression/test_json_object_iter.ae
@@ -1,0 +1,200 @@
+// Regression: object-key iteration.
+//
+// std.json exposes object_get / object_has / object_set but nothing
+// that enumerates the keys of an object — painful when the keys are
+// user data (prop maps, path-keyed dicts, headers, etc.). This test
+// pins the new accessors:
+//
+//   object_size(obj)         -> int
+//   object_entry(obj, i)     -> (key, value, err)
+//
+// Iteration order is insertion order; out-of-range and non-object
+// yield the documented error shapes.
+
+import std.json
+import std.string
+
+main() {
+    print("=== JSON object-key iteration ===\n\n")
+
+    // ---- Test 1: empty object ------------------------------------
+
+    print("Test 1: empty object\n")
+    j_empty, _ = json.parse("{}")
+    n_empty = json.object_size(j_empty)
+    if n_empty != 0 {
+        println("  FAIL: empty object_size should be 0, got ${n_empty}")
+        exit(1)
+    }
+    _, _, err_oob_empty = json.object_entry(j_empty, 0)
+    if err_oob_empty == "" {
+        print("  FAIL: object_entry(empty, 0) must signal out-of-range\n")
+        exit(1)
+    }
+    print("  PASS: empty object has size 0 and out-of-range at index 0\n")
+
+    // ---- Test 2: single key --------------------------------------
+
+    print("\nTest 2: single key\n")
+    j_one, _ = json.parse("{\"only\": 42}")
+    if json.object_size(j_one) != 1 {
+        print("  FAIL: single-key object_size must be 1\n")
+        exit(1)
+    }
+    k0, v0, e0 = json.object_entry(j_one, 0)
+    if e0 != "" {
+        println("  FAIL: object_entry(j_one, 0) returned err: ${e0}")
+        exit(1)
+    }
+    if k0 != "only" {
+        println("  FAIL: expected key 'only', got '${k0}'")
+        exit(1)
+    }
+    if json.get_int(v0) != 42 {
+        print("  FAIL: value at key 'only' should be 42\n")
+        exit(1)
+    }
+    print("  PASS: single key round-trips\n")
+
+    // ---- Test 3: insertion order preserved through parse ---------
+
+    print("\nTest 3: parsed object preserves key order\n")
+    j_ord, _ = json.parse("{\"b\": 1, \"a\": 2, \"c\": 3}")
+    if json.object_size(j_ord) != 3 {
+        print("  FAIL: parsed 3-key object_size\n")
+        exit(1)
+    }
+    keys_parsed = ""
+    i = 0
+    while i < 3 {
+        kk, _, _ = json.object_entry(j_ord, i)
+        keys_parsed = string_concat(keys_parsed, kk)
+        i = i + 1
+    }
+    if keys_parsed != "bac" {
+        println("  FAIL: parsed key order should be 'bac', got '${keys_parsed}'")
+        exit(1)
+    }
+    print("  PASS: parsed order = 'bac' (insertion, NOT sorted)\n")
+
+    // ---- Test 4: insertion order preserved through builder -------
+
+    print("\nTest 4: built object preserves key order\n")
+    j_built = json.create_object()
+    json.object_set(j_built, "x", json.create_number(1.0))
+    json.object_set(j_built, "y", json.create_number(2.0))
+    json.object_set(j_built, "z", json.create_number(3.0))
+    keys_built = ""
+    i2 = 0
+    while i2 < json.object_size(j_built) {
+        kb, _, _ = json.object_entry(j_built, i2)
+        keys_built = string_concat(keys_built, kb)
+        i2 = i2 + 1
+    }
+    if keys_built != "xyz" {
+        println("  FAIL: built key order should be 'xyz', got '${keys_built}'")
+        exit(1)
+    }
+    print("  PASS: built order = 'xyz'\n")
+
+    // ---- Test 5: negative index signals out-of-range -------------
+
+    print("\nTest 5: negative index\n")
+    _, _, err_neg = json.object_entry(j_ord, -1)
+    if err_neg == "" {
+        print("  FAIL: object_entry(_, -1) must signal an error\n")
+        exit(1)
+    }
+    print("  PASS: negative index yields error\n")
+
+    // ---- Test 6: out-of-range positive index ---------------------
+
+    print("\nTest 6: positive OOB index\n")
+    _, _, err_oob = json.object_entry(j_ord, 99)
+    if err_oob == "" {
+        print("  FAIL: object_entry(_, 99) must signal an error\n")
+        exit(1)
+    }
+    print("  PASS: too-large index yields error\n")
+
+    // ---- Test 7: object_size on a non-object -> -1 --------------
+
+    print("\nTest 7: non-object returns -1\n")
+    j_arr, _ = json.parse("[1,2,3]")
+    if json.object_size(j_arr) != -1 {
+        print("  FAIL: object_size on an array should be -1\n")
+        exit(1)
+    }
+    _, _, err_notobj = json.object_entry(j_arr, 0)
+    if err_notobj == "" {
+        print("  FAIL: object_entry on an array must signal error\n")
+        exit(1)
+    }
+    print("  PASS: non-object rejected cleanly\n")
+
+    // ---- Test 8: nested — outer values are themselves objects ----
+
+    print("\nTest 8: nested object iteration\n")
+    j_nest, _ = json.parse("{\"outer\": {\"a\": 1, \"b\": 2}, \"other\": {\"c\": 3}}")
+    // Find "outer" via iteration (not object_get, which would bypass the new API).
+    nested_val = null
+    i5 = 0
+    while i5 < json.object_size(j_nest) {
+        kn, vn, _ = json.object_entry(j_nest, i5)
+        if kn == "outer" {
+            nested_val = vn
+        }
+        i5 = i5 + 1
+    }
+    if nested_val == null {
+        print("  FAIL: iteration didn't find 'outer'\n")
+        exit(1)
+    }
+    if json.object_size(nested_val) != 2 {
+        print("  FAIL: nested object size\n")
+        exit(1)
+    }
+    k_a, v_a, _ = json.object_entry(nested_val, 0)
+    if k_a != "a" {
+        println("  FAIL: nested[0] key should be 'a', got '${k_a}'")
+        exit(1)
+    }
+    if json.get_int(v_a) != 1 {
+        print("  FAIL: nested[0] value should be 1\n")
+        exit(1)
+    }
+    print("  PASS: nested objects iterate cleanly\n")
+
+    // ---- Test 9: stress — 32 keys through builder + iterate ------
+
+    print("\nTest 9: 32-key stress (builder path, exercises obj_reserve growth)\n")
+    j_big = json.create_object()
+    i3 = 0
+    while i3 < 32 {
+        // Key is "k${i3}" — string interpolation builds the owned string.
+        k = "k${i3}"
+        json.object_set(j_big, k, json.create_number(i3))
+        i3 = i3 + 1
+    }
+    if json.object_size(j_big) != 32 {
+        print("  FAIL: 32-key build: object_size\n")
+        exit(1)
+    }
+    i4 = 0
+    while i4 < 32 {
+        expected_key = "k${i4}"
+        kx, vx, _ = json.object_entry(j_big, i4)
+        if kx != expected_key {
+            println("  FAIL: index ${i4} key should be '${expected_key}', got '${kx}'")
+            exit(1)
+        }
+        if json.get_int(vx) != i4 {
+            println("  FAIL: value at index ${i4} should be ${i4}")
+            exit(1)
+        }
+        i4 = i4 + 1
+    }
+    print("  PASS: 32 keys iterated, insertion-order preserved, values intact\n")
+
+    print("\n=== All object-iteration tests passed ===\n")
+}


### PR DESCRIPTION
`std.json` currently has `object_get` / `object_set` / `object_has` but no way to enumerate an object's keys. That's fine when the schema is known at compile time, but painful when the **keys themselves are user data** — prop maps, path-keyed dicts, HTTP headers, config blobs, and similar. Every other general-purpose JSON library (cJSON, nlohmann::json, `encoding/json`, `serde_json`, Python `json`, JS `Object.keys`) exposes this.

Pure API exposure — no parser changes, no storage changes. The `JsonObjBlock` parallel-array layout already keeps `keys[]` / `key_lens[]` / `values[]` in the right shape and the parser/builder already populate them in insertion order. This just adds the accessors.

## New API

**C side (`std/json/aether_json.h`):**
```c
int          json_object_size_raw(JsonValue* obj);   // -1 if not JSON_OBJECT
const char*  json_object_key_at(JsonValue*, int);    // borrowed, NUL-terminated
int          json_object_key_len_at(JsonValue*, int);
JsonValue*   json_object_value_at(JsonValue*, int);  // borrowed; non-NULL even for JSON_NULL values
```

The `_raw` suffix on `json_object_size_raw` matches the existing convention (`json_object_get_raw`, `json_object_set_raw`) and — the functional reason — avoids a C-level name collision after Aether's module-prefix mangling: `json.object_size` mangles to `json_object_size`, which would shadow the extern. Found the hard way, surfaced as a segfault on the first empty-object test before the rename.

**Aether side (`std/json/module.ae`):**
```aether
json.object_size(obj) -> int
json.object_entry(obj, i) -> (key, value, err)
```

`object_entry` uses the Go-style `(key, value, err)` return that matches the rest of the module. Errors: `"index out of range"` for `i < 0` or `i >= size`, `"not an object"` for a non-`JSON_OBJECT` arg. Key is an owned string; value is borrowed from the object.

## Iteration order

**Insertion order.** Parsed JSON iterates in the order keys appeared in the source; built JSON iterates in the order `object_set` was called. Documented explicitly in `docs/json-parser-design.md`'s container-representation section. Callers that need sorted iteration copy the keys and sort — same as every other library.

## Mutation during iteration

Not supported. Set during iterate = undefined order. Documented on both the C and Aether sides. Won't crash on it, but may skip or revisit entries.

## Test plan

- [x] `make ci` green (full suite with `-Werror`, ASAN, Valgrind)
- [x] `make test-json-conformance`: 95/95 `y_*` + 188/188 `n_*` (parser unchanged — this is a sanity check, not a new test)
- [x] 288 `.ae` tests pass (one new test added)
- [x] Rebased on latest `origin/main` (799662d, v0.78.0)

## Regression test coverage

`tests/regression/test_json_object_iter.ae` — 9 test cases:

1. Empty object: `size == 0`, `entry(obj, 0)` returns out-of-range error
2. Single key: `size == 1`, key + value round-trip
3. Parsed `{"b":1, "a":2, "c":3}` iterates as `b, a, c` (insertion, NOT sorted)
4. Built object with `x, y, z` calls iterates as `x, y, z`
5. Negative index: error, doesn't crash
6. Out-of-range positive index: error
7. `object_size` on a JSON_ARRAY returns -1; `object_entry` on an array errors
8. Nested objects: iterate outer, find a value, iterate it in turn
9. 32-key stress through builder: exercises `obj_reserve`'s growth path, asserts key `k${i}` and value `i` at each index

## Non-goals

- Sorted iteration (insertion order only — copy & sort client-side if needed)
- Mutation during iteration (documented unsupported)
- Reverse iteration (loop `i` from `size - 1` down)
- Opaque iterator struct (indices are sufficient)

## Motivation

Came up in an external port trying to drop a `-lcjson` dependency — the server's response format uses `{name: value, ...}` where prop-names are data and there's no way to enumerate them without adding keys to a separate `"keys": []` side-channel. This closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)