### PR TITLE
feat(http): tolerate externally-constructed Request/Response pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`std.http` request/response accessors now tolerate externally-constructed pointers** (`std/net/aether_http_server.c`). Host C code that owns the HTTP dispatch loop (parses the wire format, builds `HttpRequest` / `HttpServerResponse` structs, calls an Aether handler to populate them) previously crashed on the first `http_response_set_header` or `http_response_json` because `http_response_set_header` strdup'd into a NULL `header_keys` array — `http_response_create` allocates those lazily, but a C-allocated response has them zero. Fix: lazy-allocate header_keys/values on first `set_header` when NULL. Plus defensive NULL-guards across the request-side accessors (`http_get_header`, `http_get_query_param`, `http_request_method`/`path`/`body`/`query`) so a partially-populated request from a dispatch shim doesn't NULL-deref on the unset fields. No tagging, no runtime type check — the pointers just work as long as the struct layout matches `std/net/aether_http_server.h`. Regression test: `tests/integration/http_external_ptr/` — 9 cases covering a C-allocated request fed to Aether accessors and a bare calloc'd response mutated by Aether setters then read back in C.
+
 ## [0.80.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ test-ae: compiler ae stdlib
 	printf 'fi\n'                                                                                   >> "$$script"; \
 	chmod +x "$$script"; \
 	root=$$(pwd); \
-	find tests/syntax tests/compiler tests/integration tests/regression -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -path 'tests/integration/reserved_keyword_error/*' -prune -o -path 'tests/integration/ae_run_cflags/*' -prune -o -path 'tests/integration/bin_path_match/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
+	find tests/syntax tests/compiler tests/integration tests/regression -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -path 'tests/integration/reserved_keyword_error/*' -prune -o -path 'tests/integration/ae_run_cflags/*' -prune -o -path 'tests/integration/bin_path_match/*' -prune -o -path 'tests/integration/http_external_ptr/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
 	xargs -P $(NPROC) -I{} "$$script" "{}" "$$tmpdir" "$$root"; \
 	for sh_test in $$(find tests/integration -name 'test_*.sh' 2>/dev/null | sort); do \
 		name=$$(echo "$$sh_test" | sed 's|tests/||;s|/|_|g;s|\.sh$$||'); \

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -297,7 +297,9 @@ HttpRequest* http_parse_request(const char* raw_request) {
 }
 
 const char* http_get_header(HttpRequest* req, const char* key) {
+    if (!req || !key || !req->header_keys || !req->header_values) return NULL;
     for (int i = 0; i < req->header_count; i++) {
+        if (!req->header_keys[i]) continue;
         if (strcasecmp(req->header_keys[i], key) == 0) {
             return req->header_values[i];
         }
@@ -306,6 +308,7 @@ const char* http_get_header(HttpRequest* req, const char* key) {
 }
 
 const char* http_get_query_param(HttpRequest* req, const char* key) {
+    if (!req || !key) return NULL;
     if (!req->query_string) return NULL;
     
     // Parse query params on demand
@@ -385,12 +388,27 @@ HttpServerResponse* http_response_create() {
 }
 
 void http_response_set_status(HttpServerResponse* res, int code) {
+    if (!res) return;
     res->status_code = code;
     free(res->status_text);
     res->status_text = strdup(http_status_text(code));
 }
 
 void http_response_set_header(HttpServerResponse* res, const char* key, const char* value) {
+    if (!res || !key || !value) return;
+
+    // Lazy-allocate the header arrays. http_response_create() sets them
+    // up eagerly, but external callers constructing the response struct
+    // themselves (e.g. a C dispatch layer that wants to hand a response
+    // into Aether handlers) only zero the struct. Without this, the
+    // strdup-into-NULL below was a crash on the first header write.
+    if (!res->header_keys || !res->header_values) {
+        res->header_keys = (char**)calloc(50, sizeof(char*));
+        res->header_values = (char**)calloc(50, sizeof(char*));
+        res->header_count = 0;
+        if (!res->header_keys || !res->header_values) return;
+    }
+
     // Check if header exists, update it
     for (int i = 0; i < res->header_count; i++) {
         if (strcasecmp(res->header_keys[i], key) == 0) {
@@ -399,7 +417,7 @@ void http_response_set_header(HttpServerResponse* res, const char* key, const ch
             return;
         }
     }
-    
+
     // Add new header (max 50)
     if (res->header_count >= 50) return;
     res->header_keys[res->header_count] = strdup(key);
@@ -408,6 +426,7 @@ void http_response_set_header(HttpServerResponse* res, const char* key, const ch
 }
 
 void http_response_set_body(HttpServerResponse* res, const char* body) {
+    if (!res || !body) return;
     free(res->body);
     res->body = strdup(body);
     res->body_length = strlen(body);
@@ -1278,20 +1297,25 @@ void http_server_set_actor_handler(HttpServer* server, void (*step_fn)(void*),
 }
 
 // Request accessors (for Aether .ae code via opaque ptr)
+// Request field accessors. Each guards against NULL at both the struct
+// and the field level so a partially-populated HttpRequest (e.g. one
+// built by a C dispatch shim that didn't touch every field) doesn't
+// crash downstream string ops. Empty string is the "absent" sentinel
+// — consistent with Aether's Go-style string conventions.
 const char* http_request_method(HttpRequest* req) {
-    return req ? req->method : "";
+    return (req && req->method) ? req->method : "";
 }
 
 const char* http_request_path(HttpRequest* req) {
-    return req ? req->path : "";
+    return (req && req->path) ? req->path : "";
 }
 
 const char* http_request_body(HttpRequest* req) {
-    return req ? req->body : "";
+    return (req && req->body) ? req->body : "";
 }
 
 const char* http_request_query(HttpRequest* req) {
-    return req ? req->query_string : "";
+    return (req && req->query_string) ? req->query_string : "";
 }
 
 #endif // AETHER_HAS_NETWORKING

--- a/tests/integration/http_external_ptr/probe.ae
+++ b/tests/integration/http_external_ptr/probe.ae
@@ -1,0 +1,144 @@
+// Regression: std.http request/response accessors work on
+// externally-constructed HttpRequest / HttpServerResponse pointers —
+// not just on objects the runtime's own dispatch loop allocated.
+//
+// The svn-aether port (~scm/subversion/subversion) is the motivating
+// case: a C dispatch layer parses the wire format, builds the
+// request, invokes an Aether handler, and serializes the response
+// the Aether handler populated. Every step crosses the FFI boundary
+// as a bare `ptr`.
+//
+// This test pins:
+//   1. Request-side accessors (http_get_header, http_get_query_param,
+//      http_request_method, http_request_path) work on a request
+//      allocated and populated by C code.
+//   2. Response-side setters (http_response_set_status,
+//      http_response_json, http_response_set_header) work on a
+//      response that is just `calloc(sizeof(HttpServerResponse))`
+//      with every field zeroed. The setters lazy-allocate the
+//      header arrays so the handler can fill the response without
+//      going through http_response_create().
+
+import std.http
+import std.string
+
+extern probe_make_request() -> ptr
+extern probe_make_bare_response() -> ptr
+extern probe_res_status(p: ptr) -> int
+extern probe_res_body(p: ptr) -> string
+extern probe_res_header_count(p: ptr) -> int
+extern probe_free_request(p: ptr)
+extern probe_free_response(p: ptr)
+
+main() {
+    print("=== http external-ptr interop ===\n\n")
+
+    // ---- Request-side ----------------------------------------------
+
+    req = probe_make_request()
+
+    print("Test 1: http_get_header on C-constructed request\n")
+    val = http_get_header(req, "X-Test")
+    if val == null {
+        print("  FAIL: null\n")
+        exit(1)
+    }
+    if string.equals(val, "hi") != 1 {
+        print("  FAIL: wrong value\n")
+        exit(1)
+    }
+    print("  PASS: X-Test = hi\n")
+
+    print("\nTest 2: http_get_header on a missing key returns null\n")
+    missing = http_get_header(req, "X-Does-Not-Exist")
+    if missing != null {
+        print("  FAIL: expected null\n")
+        exit(1)
+    }
+    print("  PASS: missing header returns null\n")
+
+    print("\nTest 3: http_request_method\n")
+    m = http_request_method(req)
+    if string.equals(m, "GET") != 1 {
+        print("  FAIL\n")
+        exit(1)
+    }
+    print("  PASS: GET\n")
+
+    print("\nTest 4: http_request_path\n")
+    p = http_request_path(req)
+    if string.equals(p, "/api/foo") != 1 {
+        print("  FAIL\n")
+        exit(1)
+    }
+    print("  PASS: /api/foo\n")
+
+    print("\nTest 5: http_get_query_param\n")
+    q = http_get_query_param(req, "x")
+    if q == null {
+        print("  FAIL: null\n")
+        exit(1)
+    }
+    if string.equals(q, "1") != 1 {
+        print("  FAIL: wrong\n")
+        exit(1)
+    }
+    print("  PASS: x=1\n")
+
+    // ---- Request-side null-safety ---------------------------------
+
+    print("\nTest 6: http_get_header on null request returns null\n")
+    null_val = http_get_header(null, "X-Test")
+    if null_val != null {
+        print("  FAIL: expected null\n")
+        exit(1)
+    }
+    print("  PASS\n")
+
+    // ---- Response-side: lazy-allocation ---------------------------
+    //
+    // This is the main fix. A calloc'd HttpServerResponse has
+    // header_keys/values = NULL. Before the fix, set_status was
+    // OK (it only touches status_code + status_text), but the
+    // FIRST set_header (which http_response_json does implicitly
+    // for Content-Type) would strdup into a NULL array and crash.
+
+    print("\nTest 7: http_response_set_status on bare response\n")
+    res = probe_make_bare_response()
+    http_response_set_status(res, 201)
+    if probe_res_status(res) != 201 {
+        print("  FAIL: status didn't stick\n")
+        exit(1)
+    }
+    print("  PASS: status = 201\n")
+
+    print("\nTest 8: http_response_json on bare response (lazy-allocates headers)\n")
+    http_response_json(res, "{\"ok\":true}")
+    body = probe_res_body(res)
+    if string.equals(body, "{\"ok\":true}") != 1 {
+        println("  FAIL: body '${body}'")
+        exit(1)
+    }
+    if probe_res_header_count(res) < 2 {
+        // set_body + set_header("Content-Type") + set_header("Content-Length")
+        // means at least 2 headers after json().
+        print("  FAIL: expected at least 2 headers\n")
+        exit(1)
+    }
+    print("  PASS: body + Content-Type + Content-Length all landed\n")
+
+    print("\nTest 9: http_response_set_header on bare response\n")
+    res2 = probe_make_bare_response()
+    http_response_set_header(res2, "X-Custom", "custom-value")
+    if probe_res_header_count(res2) != 1 {
+        print("  FAIL: expected 1 header\n")
+        exit(1)
+    }
+    print("  PASS: single header landed on bare response\n")
+
+    probe_free_response(res)
+    probe_free_response(res2)
+    probe_free_request(req)
+
+    print("\n=== All external-ptr interop tests passed ===\n")
+}

--- a/tests/integration/http_external_ptr/shim.c
+++ b/tests/integration/http_external_ptr/shim.c
@@ -1,0 +1,94 @@
+/* Shim that constructs HttpRequest / HttpServerResponse on the C side
+ * and hands pointers to Aether. Mirrors what a C dispatch layer would
+ * do when it owns the HTTP parse/serialize loop and wants an Aether
+ * function to fill in handler logic.
+ *
+ * Field layout MUST match std/net/aether_http_server.h. If the runtime
+ * struct layout changes, this test catches it.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    char* method;
+    char* path;
+    char* query_string;
+    char* http_version;
+    char** header_keys;
+    char** header_values;
+    int header_count;
+    char* body;
+    size_t body_length;
+    char** param_keys;
+    char** param_values;
+    int param_count;
+} HttpRequest;
+
+typedef struct {
+    int status_code;
+    char* status_text;
+    char** header_keys;
+    char** header_values;
+    int header_count;
+    char* body;
+    size_t body_length;
+} HttpServerResponse;
+
+void* probe_make_request(void) {
+    HttpRequest* r = calloc(1, sizeof(*r));
+    r->method       = strdup("GET");
+    r->path         = strdup("/api/foo");
+    r->query_string = strdup("x=1&y=two");
+    r->http_version = strdup("HTTP/1.1");
+    r->header_keys   = calloc(2, sizeof(char*));
+    r->header_values = calloc(2, sizeof(char*));
+    r->header_keys[0] = strdup("X-Test");   r->header_values[0] = strdup("hi");
+    r->header_keys[1] = strdup("X-Other");  r->header_values[1] = strdup("bye");
+    r->header_count = 2;
+    r->body = strdup("");
+    r->body_length = 0;
+    return r;
+}
+
+/* An intentionally-bare response: status_text, header_keys,
+ * header_values, body all NULL. http_response_set_* must tolerate this
+ * and lazy-allocate, otherwise a C dispatch layer calling into Aether
+ * handlers to populate the response is guaranteed to crash on the
+ * first setter call. */
+void* probe_make_bare_response(void) {
+    return calloc(1, sizeof(HttpServerResponse));
+}
+
+int         probe_res_status(void* p) { return ((HttpServerResponse*)p)->status_code; }
+const char* probe_res_body(void* p)   {
+    HttpServerResponse* r = p;
+    return r->body ? r->body : "";
+}
+int         probe_res_header_count(void* p) {
+    return ((HttpServerResponse*)p)->header_count;
+}
+
+void probe_free_request(void* p) {
+    HttpRequest* r = p;
+    if (!r) return;
+    free(r->method); free(r->path); free(r->query_string); free(r->http_version);
+    for (int i = 0; i < r->header_count; i++) {
+        free(r->header_keys[i]); free(r->header_values[i]);
+    }
+    free(r->header_keys); free(r->header_values);
+    free(r->body);
+    free(r);
+}
+
+void probe_free_response(void* p) {
+    HttpServerResponse* r = p;
+    if (!r) return;
+    free(r->status_text);
+    for (int i = 0; i < r->header_count; i++) {
+        free(r->header_keys[i]); free(r->header_values[i]);
+    }
+    free(r->header_keys); free(r->header_values);
+    free(r->body);
+    free(r);
+}

--- a/tests/integration/http_external_ptr/test_http_external_ptr.sh
+++ b/tests/integration/http_external_ptr/test_http_external_ptr.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Regression: std.http request/response accessors work on externally-
+# constructed HttpRequest / HttpServerResponse pointers. See probe.ae
+# for the test matrix.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP] test_http_external_ptr on Windows"; exit 0 ;;
+esac
+
+TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
+
+if ! "$ROOT/build/ae" build "$SCRIPT_DIR/probe.ae" -o "$TMPDIR/probe" \
+        --extra "$SCRIPT_DIR/shim.c" >"$TMPDIR/build.log" 2>&1; then
+    echo "  [FAIL] http_external_ptr: build failed"
+    sed 's/^/    /' "$TMPDIR/build.log" | head -15
+    exit 1
+fi
+
+if ! "$TMPDIR/probe" >"$TMPDIR/run.log" 2>&1; then
+    echo "  [FAIL] http_external_ptr: probe exited non-zero"
+    sed 's/^/    /' "$TMPDIR/run.log" | head -30
+    exit 1
+fi
+
+if ! grep -q "All external-ptr interop tests passed" "$TMPDIR/run.log"; then
+    echo "  [FAIL] http_external_ptr: didn't reach the final PASS line"
+    sed 's/^/    /' "$TMPDIR/run.log" | head -30
+    exit 1
+fi
+
+echo "  [PASS] http_external_ptr: 9 cases"


### PR DESCRIPTION
Addresses **item 2** of `stdlib_wish.md` (the round-2 wish list from the svn-aether port): let `std.http` accessors work on `HttpRequest` / `HttpServerResponse` pointers that a C dispatch layer constructed, not just objects the runtime's own route dispatch allocated.

## The claim, and what was actually happening

The wish list said:
> *The std.http wrappers assume the runtime's own dispatch constructed the object via internal APIs that tag the pointer somehow. From Aether I can't take those pointers and call `http_get_header` on them.*

**Investigation showed no tagging exists.** The accessors take `HttpRequest*` / `HttpServerResponse*` directly — PODs, no magic word. A C shim that allocates the struct and passes the pointer to Aether should just work.

But **two concrete bugs** made the pattern fail for a `calloc(sizeof(HttpServerResponse))`-from-C response:

1. **`http_response_set_header` assumed header arrays were pre-allocated.** `http_response_create` malloc's `header_keys` / `header_values` to capacity 50. A calloc'd response has them NULL. `set_header` did `res->header_keys[res->header_count] = strdup(key)` — NULL-deref on first call. Since `http_response_json` internally calls `set_header` twice (for Content-Type and via `set_body` for Content-Length), any handler that used `http_response_json` on a C-allocated response crashed.

2. **Request-side accessors didn't NULL-guard fields.** A dispatch shim that set `method` / `path` but left `body` unset (common for GET) would hand Aether a request where `http_request_body(req)` deref'd a NULL field pointer.

## Fix

- **`http_response_set_header`**: lazy-allocate `header_keys` / `header_values` when NULL. Idempotent, non-breaking for existing callers that went through `http_response_create`.
- **`http_get_header`, `http_get_query_param`**: NULL-guard both the request and the backing arrays.
- **`http_request_method` / `path` / `body` / `query`**: return `""` instead of dereferencing a NULL field.
- **`http_response_set_status` / `set_body`**: defensive NULL-guards for consistency (weren't crashes in practice — `free(NULL)` + `strdup` were safe — but cheap and matches the pattern).

No tagging added. No runtime type check added. The struct-layout requirement stays — host C needs to match `std/net/aether_http_server.h`.

## Test plan

- [x] `make ci` green (full 8-step suite with `-Werror`, ASAN, Valgrind)
- [x] 292 `.ae` tests pass (one new integration test added)
- [x] Rebased on latest `origin/main` (`5abda87`, v0.80.0)

**New regression test** — `tests/integration/http_external_ptr/`:

- `shim.c` — replicates the `HttpRequest` / `HttpServerResponse` field layouts exactly (if the runtime struct changes, this test catches the drift).
- `probe.ae` — 9 cases:
  1. `http_get_header` on a C-constructed request.
  2. Missing header returns null.
  3. `http_request_method` round-trips.
  4. `http_request_path` round-trips.
  5. `http_get_query_param` parses correctly.
  6. `http_get_header(null, ...)` returns null (doesn't crash).
  7. `http_response_set_status` on a bare `calloc`'d response.
  8. `http_response_json` on a bare response — exercises the lazy-allocate path.
  9. `http_response_set_header` on a bare response — direct lazy-allocate.
- `test_http_external_ptr.sh` — shell wrapper; skipped on Windows (same as `emit_lib_banned`).

## What this unblocks

The wish list claims ~1200 lines of C dispatch + handler glue in the svn-aether port can move to Aether once `std.http` accessors tolerate external pointers. That's now possible — the port can `calloc` a response, pass it into an Aether handler, call `http_response_set_status` / `http_response_json`, and get back a populated struct ready to serialize.

## What's still *not* in scope

Per the wish list's own "non-asks": **no** runtime type-check on the pointer, **no** full ownership of the HTTP server lifecycle in Aether, **no** callback registration from Aether into the C dispatch loop. This PR is narrow: make the accessors tolerate a calloc'd-from-C struct. That's what unblocks the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)