### PR TITLE
feat(fs): fs.write_binary + fix AetherString header-leak in write_atomic/write_binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.fs.write_binary(path, data, length) -> string`** (`std/fs/module.ae`, `std/fs/aether_fs.c`, `std/fs/aether_fs.h`). Non-atomic binary write — `fopen("wb")` + `fwrite(length bytes)` + `fclose`. Completes the binary-safe I/O pair with `fs.read_binary` (v0.82.0): caller passes an explicit byte length, so payloads with embedded NULs survive the write. Cheaper than `fs.write_atomic` when a partial file on crash is acceptable (scratch writes, caches, any destination not load-bearing for another process). Regression test: `tests/integration/fs_write_binary_nul/` — seeds a 10-byte file with NUL at offset 3 via a C shim, reads it via `fs.read_binary`, writes it back via `fs.write_binary`, reads it a second time, and verifies every byte round-trips.
+
+### Fixed
+
+- **AetherString payloads now survive `fs.write_atomic` and `fs.write_binary`** (`std/fs/aether_fs.c`). Both extern impls took `const char* data` and passed it straight to `fwrite`, but callers hand in whatever pointer the Aether variable holds — which for `fs.read_binary`'s return value (and anything built via `string_new_with_length`) is an `AetherString*` struct pointer, not the payload. The first 40 bytes written to disk were the AetherString header (magic `0xAE57C0DE`, refcount, length, capacity, data-ptr), not the intended bytes. `fs.write_atomic` carried this latent bug since v0.82.0 — existing callers masked it by passing string literals (plain `char*`), which happen to point at the data directly, so the test suite didn't catch it. Fixed by adding a shared `fs_unwrap_bytes(data, length, &out_len)` helper that dispatches on `is_aether_string()` and unwraps when needed. Regression test covers both `write_binary` and `write_atomic` with a 10-byte NUL-embedded payload whose round-trip exposes the header-leak.
+
 ## [0.85.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ test-ae: compiler ae stdlib
 	printf 'fi\n'                                                                                   >> "$$script"; \
 	chmod +x "$$script"; \
 	root=$$(pwd); \
-	find tests/syntax tests/compiler tests/integration tests/regression -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -path 'tests/integration/reserved_keyword_error/*' -prune -o -path 'tests/integration/ae_run_cflags/*' -prune -o -path 'tests/integration/bin_path_match/*' -prune -o -path 'tests/integration/http_external_ptr/*' -prune -o -path 'tests/integration/fs_read_binary_nul/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
+	find tests/syntax tests/compiler tests/integration tests/regression -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -path 'tests/integration/reserved_keyword_error/*' -prune -o -path 'tests/integration/ae_run_cflags/*' -prune -o -path 'tests/integration/bin_path_match/*' -prune -o -path 'tests/integration/http_external_ptr/*' -prune -o -path 'tests/integration/fs_read_binary_nul/*' -prune -o -path 'tests/integration/fs_write_binary_nul/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
 	xargs -P $(NPROC) -I{} "$$script" "{}" "$$tmpdir" "$$root"; \
 	for sh_test in $$(find tests/integration -name 'test_*.sh' 2>/dev/null | sort); do \
 		name=$$(echo "$$sh_test" | sed 's|tests/||;s|/|_|g;s|\.sh$$||'); \

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -451,6 +451,7 @@ main() {
 
 **Functions (beyond those re-exported from `std.file`/`std.dir`/`std.path`):**
 - `fs.write_atomic(path, data, length)` → `string` - Stage to `<path>.tmp.<pid>.<n>`, fsync, rename over destination. Binary-safe via explicit length.
+- `fs.write_binary(path, data, length)` → `string` - Non-atomic `fopen("wb")` + `fwrite` + `fclose`. Binary-safe via explicit length. Cheaper than `write_atomic` when a partial file on crash is acceptable (scratch writes, caches).
 - `fs.rename(from, to)` → `string` - POSIX `rename(2)` wrapper. Atomic when source and target are on the same filesystem.
 - `fs.file_stat(path)` → `(kind, size, mtime, err)` - One `lstat(2)`; symlinks report kind 3, target is not followed.
 - `fs.read_binary(path)` → `(content, length, err)` - Length-aware read preserving embedded NULs.

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -2,6 +2,7 @@
 #include "../../runtime/config/aether_optimization_config.h"
 #include "../../runtime/utils/aether_compiler.h"
 #include "../../runtime/aether_sandbox.h"
+#include "../string/aether_string.h"
 
 #if !AETHER_HAS_FILESYSTEM
 // Stubs when filesystem is unavailable (WASM, embedded)
@@ -21,6 +22,9 @@ int fs_symlink_raw(const char* t, const char* l) { (void)t; (void)l; return 0; }
 char* fs_readlink_raw(const char* p) { (void)p; return NULL; }
 int fs_is_symlink(const char* p) { (void)p; return 0; }
 int fs_unlink_raw(const char* p) { (void)p; return 0; }
+int fs_write_binary_raw(const char* p, const char* d, int l) {
+    (void)p; (void)d; (void)l; return 0;
+}
 int fs_write_atomic_raw(const char* p, const char* d, int l) {
     (void)p; (void)d; (void)l; return 0;
 }
@@ -82,6 +86,26 @@ DirList* fs_glob_multi_raw(void* l) { (void)l; return NULL; }
     #include <dirent.h>
     #include <unistd.h>
 #endif
+
+// Unwrap the payload+length from a value that may be either an
+// AetherString* (from fs.read_binary, string_new_with_length, etc.)
+// or a plain C string literal. Extern fn signatures say `const char*`
+// but Aether passes whichever pointer the variable holds — without
+// this dispatch, AetherString inputs end up writing the struct
+// header (magic 0xAE57C0DE, refcount, length, capacity, data-ptr)
+// to disk instead of the intended bytes. When `explicit_len` is
+// non-negative the caller's length wins (used by write_binary and
+// write_atomic, which take an explicit-length param for binary safety).
+static inline const char* fs_unwrap_bytes(const char* data, int explicit_len, size_t* out_len) {
+    if (!data) { *out_len = 0; return NULL; }
+    if (is_aether_string(data)) {
+        const AetherString* s = (const AetherString*)data;
+        *out_len = (explicit_len >= 0) ? (size_t)explicit_len : s->length;
+        return s->data;
+    }
+    *out_len = (explicit_len >= 0) ? (size_t)explicit_len : strlen(data);
+    return data;
+}
 
 // File operations
 File* file_open_raw(const char* path, const char* mode) {
@@ -297,9 +321,33 @@ int fs_unlink_raw(const char* path) {
 
 #include <time.h>
 
+int fs_write_binary_raw(const char* path, const char* data, int length) {
+    if (!path || length < 0) return 0;
+    if (length > 0 && !data) return 0;
+    if (!aether_sandbox_check("fs_write", path)) return 0;
+
+    size_t want;
+    const char* bytes = fs_unwrap_bytes(data, length, &want);
+
+    FILE* fp = fopen(path, "wb");
+    if (!fp) return 0;
+
+    size_t written = (want > 0) ? fwrite(bytes, 1, want, fp) : 0;
+    int fwrite_ok = (written == want);
+    int close_ok = (fclose(fp) == 0);
+
+    // Non-atomic: on failure, the caller sees a partial file. This is
+    // the explicit contract — use fs_write_atomic_raw when that's not
+    // acceptable.
+    return (fwrite_ok && close_ok) ? 1 : 0;
+}
+
 int fs_write_atomic_raw(const char* path, const char* data, int length) {
     if (!path || length < 0) return 0;
     if (!aether_sandbox_check("fs_write", path)) return 0;
+
+    size_t want;
+    const char* bytes = fs_unwrap_bytes(data, length, &want);
 
     // Build a tmp path <path>.tmp.<pid>.<counter>. The counter keeps
     // concurrent writers from the same PID (unlikely but cheap to
@@ -320,8 +368,8 @@ int fs_write_atomic_raw(const char* path, const char* data, int length) {
     FILE* fp = fopen(tmp, "wb");
     if (!fp) return 0;
 
-    size_t written = (length > 0) ? fwrite(data, 1, (size_t)length, fp) : 0;
-    int fwrite_ok = (written == (size_t)length);
+    size_t written = (want > 0) ? fwrite(bytes, 1, want, fp) : 0;
+    int fwrite_ok = (written == want);
 
 #ifndef _WIN32
     // Flush + fsync before rename. Without fsync a power loss between

--- a/std/fs/aether_fs.h
+++ b/std/fs/aether_fs.h
@@ -55,6 +55,17 @@ char* fs_readlink_raw(const char* path);
 int   fs_is_symlink(const char* path);
 int   fs_unlink_raw(const char* path);
 
+// Non-atomic binary write to `path` — opens "wb", writes exactly
+// `length` bytes, closes. Binary-safe (embedded NULs OK) because
+// the length is explicit. Simpler and cheaper than fs_write_atomic_raw
+// when the caller doesn't need the write-to-tmp + fsync + rename
+// dance — useful for scratch files, caches, or any write where a
+// partial state on crash is acceptable. Returns 1 on success, 0 on
+// any failure (open/write/close). On failure, whatever was written
+// stays on disk — caller's responsibility to remove(2) the partial
+// file if needed.
+int fs_write_binary_raw(const char* path, const char* data, int length);
+
 // Durable write to `path`: writes to `<path>.tmp.<pid>`, fsyncs, then
 // renames over the destination. Survives a crash in the middle of a
 // write without leaving a half-finished file at `path`. Takes a

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -47,6 +47,12 @@ extern fs_readlink_raw(path: string) -> string
 extern fs_is_symlink(path: string) -> int
 extern fs_unlink_raw(path: string) -> int
 
+// Non-atomic binary write: fopen("wb") + fwrite(len bytes) + fclose.
+// Binary-safe because length is explicit. Cheaper than fs_write_atomic_raw
+// when a partial file on crash is acceptable — scratch writes, caches,
+// and anywhere the destination isn't load-bearing for another process.
+extern fs_write_binary_raw(path: string, data: string, length: int) -> int
+
 // Durable write: write-to-tmp + fsync + rename over destination.
 // Binary-safe — takes an explicit length so embedded NULs survive.
 extern fs_write_atomic_raw(path: string, data: string, length: int) -> int
@@ -251,6 +257,28 @@ glob_multi(patterns: ptr) -> {
         return null, "glob failed"
     }
     return list, ""
+}
+
+// Non-atomic binary write: open, write exactly `length` bytes,
+// close. Binary-safe — embedded NULs in `data` survive because
+// the length is explicit (unlike `fs.write` which also works for
+// AetherString inputs but trusts `string.length(content)` to
+// report the right count).
+//
+// When you want the write to be crash-safe, use `fs.write_atomic`
+// instead (stage + fsync + rename). `write_binary` skips that
+// machinery for cheaper writes to scratch paths, caches, or any
+// destination where a partial file on crash is acceptable.
+//
+// Returns "" on success, error on failure (open / write / close).
+// On failure, whatever bytes were written stay on disk — caller
+// removes the partial file if needed.
+write_binary(path: string, data: string, length: int) -> string {
+    ok = fs_write_binary_raw(path, data, length)
+    if ok == 0 {
+        return "binary write failed"
+    }
+    return ""
 }
 
 // Durable write: stage `data` into a sibling tmp file, fsync, then

--- a/tests/integration/fs_write_binary_nul/probe.ae
+++ b/tests/integration/fs_write_binary_nul/probe.ae
@@ -1,0 +1,162 @@
+// Regression: fs.write_binary preserves embedded NUL bytes.
+//
+// Complements fs.read_binary (v0.82.0) which already preserves them
+// on the read path. Together they form a complete binary-safe I/O
+// pair for pristine stores, rep-stores, and any other content-
+// addressable or variable-length binary payload.
+//
+// Strategy: the shim seeds a 10-byte file (with NUL at offset 3),
+// the probe reads it through fs.read_binary (length-aware), writes
+// it back out via fs.write_binary to a new path, and verifies every
+// byte of the second file. If write_binary strlen-truncated, the
+// round-trip file would be 3 bytes instead of 10.
+
+import std.fs
+import std.string
+import std.io
+
+extern wb_probe_write_seed(path: string) -> int
+
+main() {
+    print("=== fs.write_binary with embedded NULs ===\n\n")
+
+    tmp = io.getenv("TMPDIR")
+    if tmp == 0 { tmp = io.getenv("TEMP") }
+    if tmp == 0 { tmp = "/tmp" }
+    seed_path = "${tmp}/aether_wb_seed.bin"
+    out_path  = "${tmp}/aether_wb_out.bin"
+
+    // ---- Test 1: shim seeds a 10-byte file with NUL at offset 3 ----
+    print("Test 1: seed 10-byte file via C shim\n")
+    ok = wb_probe_write_seed(seed_path)
+    if ok != 1 {
+        print("  FAIL: shim failed to write seed file\n")
+        exit(1)
+    }
+    print("  PASS: seed file written\n")
+
+    // ---- Test 2: fs.read_binary gives a length-aware AetherString ----
+    print("\nTest 2: fs.read_binary yields length-aware 10-byte string\n")
+    data, n, rerr = fs.read_binary(seed_path)
+    if rerr != "" {
+        println("  FAIL: read_binary errored: ${rerr}")
+        exit(1)
+    }
+    if n != 10 {
+        println("  FAIL: expected length 10, got ${n}")
+        exit(1)
+    }
+    if string.length(data) != 10 {
+        println("  FAIL: AetherString length should be 10, got ${string.length(data)}")
+        exit(1)
+    }
+    print("  PASS: 10-byte length-aware string\n")
+
+    // ---- Test 3: fs.write_binary writes the full 10 bytes ----
+    print("\nTest 3: fs.write_binary with explicit length = 10\n")
+    werr = fs.write_binary(out_path, data, 10)
+    if werr != "" {
+        println("  FAIL: write_binary errored: ${werr}")
+        exit(1)
+    }
+    print("  PASS: write succeeded\n")
+
+    // ---- Test 4: read the written file back and check length ----
+    print("\nTest 4: round-trip length is 10\n")
+    rt_data, rt_n, rt_err = fs.read_binary(out_path)
+    if rt_err != "" {
+        println("  FAIL: round-trip read errored: ${rt_err}")
+        exit(1)
+    }
+    if rt_n != 10 {
+        println("  FAIL: expected 10 bytes, got ${rt_n} (strlen-truncation?)")
+        exit(1)
+    }
+    print("  PASS: 10 bytes round-tripped\n")
+
+    // ---- Test 5: every byte preserved, including the NUL ----
+    print("\nTest 5: byte-by-byte match including NUL at offset 3\n")
+    // Expected: 01 02 03 00 05 06 07 08 09 0A
+    if string.char_at(rt_data, 0) != 1  { print("  FAIL [0]\n"); exit(1) }
+    if string.char_at(rt_data, 1) != 2  { print("  FAIL [1]\n"); exit(1) }
+    if string.char_at(rt_data, 2) != 3  { print("  FAIL [2]\n"); exit(1) }
+    if string.char_at(rt_data, 3) != 0  { print("  FAIL [3] — NUL lost\n"); exit(1) }
+    if string.char_at(rt_data, 4) != 5  { print("  FAIL [4]\n"); exit(1) }
+    if string.char_at(rt_data, 5) != 6  { print("  FAIL [5]\n"); exit(1) }
+    if string.char_at(rt_data, 6) != 7  { print("  FAIL [6]\n"); exit(1) }
+    if string.char_at(rt_data, 7) != 8  { print("  FAIL [7]\n"); exit(1) }
+    if string.char_at(rt_data, 8) != 9  { print("  FAIL [8]\n"); exit(1) }
+    if string.char_at(rt_data, 9) != 10 { print("  FAIL [9]\n"); exit(1) }
+    print("  PASS: all 10 bytes round-trip, NUL at [3] preserved\n")
+
+    // ---- Test 6: write_binary with length 0 is legal (empty file) ----
+    print("\nTest 6: write_binary with length 0\n")
+    empty_path = "${tmp}/aether_wb_empty.bin"
+    err6 = fs.write_binary(empty_path, "", 0)
+    if err6 != "" {
+        println("  FAIL: empty write errored: ${err6}")
+        exit(1)
+    }
+    _, n6, _ = fs.read_binary(empty_path)
+    if n6 != 0 {
+        println("  FAIL: empty file length should be 0, got ${n6}")
+        exit(1)
+    }
+    print("  PASS: length-0 write produces empty file\n")
+    fs.delete(empty_path)
+
+    // ---- Test 7: write_binary to a missing parent dir errors ----
+    print("\nTest 7: write_binary to a non-existent parent errors\n")
+    bad_path = "${tmp}/aether_wb_no_such_dir_xyz/file.bin"
+    err7 = fs.write_binary(bad_path, data, 10)
+    if err7 == "" {
+        print("  FAIL: expected error, got success\n")
+        exit(1)
+    }
+    print("  PASS: missing parent reported\n")
+
+    // ---- Test 8: write_binary overwrites an existing file ----
+    print("\nTest 8: write_binary truncates and overwrites\n")
+    fs.write(out_path, "much longer existing content that should be replaced")
+    err8 = fs.write_binary(out_path, data, 10)
+    if err8 != "" {
+        println("  FAIL: overwrite errored: ${err8}")
+        exit(1)
+    }
+    _, n8, _ = fs.read_binary(out_path)
+    if n8 != 10 {
+        println("  FAIL: overwrite didn't truncate, got ${n8} bytes")
+        exit(1)
+    }
+    print("  PASS: overwrite truncated to exact length\n")
+
+    // ---- Test 9: fs.write_atomic preserves NULs on AetherString input ----
+    // This covers a pre-existing parallel bug in fs_write_atomic_raw:
+    // it took `const char*` and never unwrapped an AetherString, so it
+    // would have written the 40-byte struct header to disk instead of
+    // the payload if anyone had called it with read_binary's output.
+    // Existing callers passed string literals (plain char*) which
+    // masked the bug. Fixed alongside write_binary.
+    print("\nTest 9: fs.write_atomic round-trip preserves NULs\n")
+    atomic_path = "${tmp}/aether_wb_atomic.bin"
+    err9 = fs.write_atomic(atomic_path, data, 10)
+    if err9 != "" {
+        println("  FAIL: write_atomic errored: ${err9}")
+        exit(1)
+    }
+    at_data, at_n, _ = fs.read_binary(atomic_path)
+    if at_n != 10 {
+        println("  FAIL: atomic round-trip length ${at_n}, expected 10")
+        exit(1)
+    }
+    if string.char_at(at_data, 0) != 1 { print("  FAIL: atomic [0]\n"); exit(1) }
+    if string.char_at(at_data, 3) != 0 { print("  FAIL: atomic [3] NUL lost\n"); exit(1) }
+    if string.char_at(at_data, 9) != 10 { print("  FAIL: atomic [9]\n"); exit(1) }
+    print("  PASS: write_atomic also preserves NULs on AetherString input\n")
+    fs.delete(atomic_path)
+
+    fs.delete(seed_path)
+    fs.delete(out_path)
+
+    print("\n=== fs.write_binary NUL-preservation tests passed ===\n")
+}

--- a/tests/integration/fs_write_binary_nul/shim.c
+++ b/tests/integration/fs_write_binary_nul/shim.c
@@ -1,0 +1,20 @@
+/* Shim for test_fs_write_binary_nul.
+ *
+ * Writes a 10-byte binary file (with NUL at offset 3) for the probe
+ * to pick up via fs.read_binary — which returns a length-aware
+ * AetherString. The probe then passes that AetherString into
+ * fs.write_binary to verify the write path also preserves NULs.
+ * This avoids trying to return a ref-counted AetherString from C. */
+
+#include <stdio.h>
+
+int wb_probe_write_seed(const char* path) {
+    if (!path) return 0;
+    unsigned char buf[10] = { 0x01, 0x02, 0x03, 0x00, 0x05, 0x06,
+                              0x07, 0x08, 0x09, 0x0A };
+    FILE* f = fopen(path, "wb");
+    if (!f) return 0;
+    size_t wrote = fwrite(buf, 1, sizeof(buf), f);
+    fclose(f);
+    return (wrote == sizeof(buf)) ? 1 : 0;
+}

--- a/tests/integration/fs_write_binary_nul/test_fs_write_binary_nul.sh
+++ b/tests/integration/fs_write_binary_nul/test_fs_write_binary_nul.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Regression: fs.write_binary preserves embedded NUL bytes. See
+# probe.ae for the test matrix.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
+
+if ! "$ROOT/build/ae" build "$SCRIPT_DIR/probe.ae" -o "$TMPDIR/probe" \
+        --extra "$SCRIPT_DIR/shim.c" >"$TMPDIR/build.log" 2>&1; then
+    echo "  [FAIL] fs_write_binary_nul: build failed"
+    sed 's/^/    /' "$TMPDIR/build.log" | head -15
+    exit 1
+fi
+
+if ! "$TMPDIR/probe" >"$TMPDIR/run.log" 2>&1; then
+    echo "  [FAIL] fs_write_binary_nul: probe exited non-zero"
+    sed 's/^/    /' "$TMPDIR/run.log" | head -30
+    exit 1
+fi
+
+if ! grep -q "NUL-preservation tests passed" "$TMPDIR/run.log"; then
+    echo "  [FAIL] fs_write_binary_nul: didn't reach the final PASS line"
+    sed 's/^/    /' "$TMPDIR/run.log" | head -30
+    exit 1
+fi
+
+echo "  [PASS] fs_write_binary_nul: 9 cases (incl. write_atomic parallel fix)"


### PR DESCRIPTION
## Summary

- Adds `fs.write_binary(path, data, length) -> string` — non-atomic binary write (`fopen("wb")` + `fwrite(length bytes)` + `fclose`). Completes the binary-safe I/O pair with `fs.read_binary` (v0.82.0) for scratch writes, caches, and any destination where a partial file on crash is acceptable.
- **Also fixes a pre-existing latent bug in `fs.write_atomic`** — please flag this in review. Both `fs_write_binary_raw` (new) and `fs_write_atomic_raw` (since v0.82.0) took `const char* data` and passed it straight to `fwrite`. But Aether callers hand in whatever pointer the variable holds — and for `fs.read_binary`'s return value (or anything built via `string_new_with_length`), that is an `AetherString*` struct pointer, not the payload. The first 40 bytes written to disk were the struct header (magic `0xAE57C0DE`, refcount, length, capacity, data-ptr), not the intended bytes.
- `fs.write_atomic` carried this bug silently — no existing test round-tripped `read_binary → write_atomic`. All existing callers happened to pass string literals (plain `char*`), which point at the data directly, so the bug never fired in the test suite.
- Fix: shared `fs_unwrap_bytes(data, length, &out_len)` helper dispatches on `is_aether_string()` and unwraps when needed. Applied to both `write_binary` and `write_atomic`.
- New regression test `tests/integration/fs_write_binary_nul/` (9 cases) exercises both functions with a 10-byte NUL-embedded payload. Test 9 specifically covers the `write_atomic` parallel fix.

## Heads-up for the reviewer

The `write_atomic` fix is behavior-changing for anyone who was passing a length-aware AetherString (built from `read_binary` or `string_new_with_length`) — before this PR, they'd silently write garbage to disk and likely not notice until they tried to read it back through `read_binary`. After this PR, the bytes land correctly. I don't think anyone has been relying on the broken behavior — and even if they had, the "fix" is producing the bytes they intended — but worth a second look.

## Test plan

- [x] `make test-ae` — 297 passed, 0 failed (296 previous + 1 new)
- [x] `make ci` — green locally on Linux GCC
- [x] New test builds via C shim (seeds 10-byte file with NUL at offset 3) and round-trips through both `fs.write_binary` and `fs.write_atomic`
- [ ] CI matrix (Linux GCC/Clang, macOS ARM64/x86_64, Windows MSYS2, mingw-w64) — no `_WIN32` changes so expect green

🤖 Generated with [Claude Code](https://claude.com/claude-code)