### PR TITLE
ci(buildkite): add self-hosted Linux GCC leg

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,32 @@
+# Buildkite pipeline — runs alongside GitHub Actions, not instead of.
+#
+# Today: one step — Linux GCC `make ci`. This is the cheapest leg to
+# validate the Buildkite → self-hosted-agent round-trip, and if the
+# tick is green we've proven the whole plumbing works end-to-end
+# without any platform-coverage loss (GHA still runs the full matrix
+# in parallel; this is a duplicate, on purpose, until we trust it).
+#
+# Tomorrow, after this goes green reliably: promote the slower
+# Linux-only legs (Valgrind, ASan, contrib/host) off GHA onto this
+# agent to claw back actions-minutes. Windows + macOS legs stay on
+# GHA — the self-hosted agent is x86_64 Linux only.
+#
+# Agent targeting: `agents: { aether: "1" }` routes to the Aether
+# buildkite-agent container. A separate tsyne agent on the same
+# machine carries different tags and won't pick this up.
+
+steps:
+  - label: ":hammer: Linux / GCC `make ci`"
+    command: make ci
+    agents:
+      aether: "1"
+    # ccache / build/obj are local-disk-backed in the agent's volumes,
+    # so incremental rebuilds between runs are fast. No explicit cache
+    # plugin needed; the agent-level build directory persists.
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        # Flaky network during apt / gh fetch is the only retryable
+        # class. Anything else should fail loud.
+        - exit_status: -1  # agent lost
+          limit: 1


### PR DESCRIPTION
## Summary

Adds `.buildkite/pipeline.yml` with one step — **Linux GCC `make ci`** — targeted at a self-hosted Buildkite agent (x86_64 Linux, Ubuntu 22.04, in a podman container on a Fedora 43 / Bazzite NUC). Runs **alongside** GitHub Actions; does not replace anything.

Draft because the Buildkite → repo webhook isn't necessarily wired up yet on your side. The YAML is ready; once you create the Aether pipeline in Buildkite and point it at this repo, pushes/PRs will light up the self-hosted leg.

## Why duplicate a GHA leg

Validating the round-trip first. If this tick goes green reliably for a few weeks, we promote the slower Linux-only legs (Valgrind, ASan, contrib/host bridges) off GHA onto the self-hosted agent to recover the minutes that actually matter. Windows + macOS stay on GHA.

## What already exists on the NUC (done side-by-side with this PR)

- **`~/Dockerfile.aether-agent`** — derived from `buildkite/agent:3-ubuntu`, installs gcc, clang, make, bc, pkg-config, zlib1g-dev, libssl-dev, libsqlite3-dev, valgrind, plus the contrib/host bridges dev-libs (lua, python, ruby, perl, duktape, tcl, go). Separate from the existing `Dockerfile.buildkite-agent` (tsyne project) so the package sets don't cross-contaminate.
- **`buildkite-agent-aether` container** — running, registered with tags `queue=default-queue, aether=1`, restart-on-failure, its own `buildkite-aether-builds` + `buildkite-aether-cache` volumes. Shares the Buildkite cluster token with the existing tsyne agent on the same host but advertises different tags, so pipelines route deterministically.

## Out of scope for this PR

- Removing the equivalent GHA leg (do that in a follow-up once this is trusted)
- Promoting expensive legs off GHA (Valgrind, ASan, contrib/host) — separate PR
- Windows / macOS support — self-hosted agent is Linux only by design

## Test plan

- [x] Agent container running: `podman ps | grep aether` on the NUC
- [x] Agent registered: seen in Buildkite UI as `b85aa2ee37ba-1` with tags `queue=default-queue, aether=1`
- [x] Toolchain verified inside container: gcc 11.4, clang 14, zlib 1.2.11, openssl 3.0.2, sqlite3 3.37.2, valgrind 3.18.1
- [ ] First job runs green against this PR (requires Buildkite pipeline to be wired to the repo webhook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)