### PR TITLE
docs: capability/sandbox story + expand Buildkite contrib coverage

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,37 +74,40 @@
           - exit_status: -1
             limit: 1
 
-    - label: ":spider_web: contrib/tinyweb typecheck"
-      # Examples + tests that bind port 8080 are check-only on the
-      # shared agent — multiple jobs running simultaneously would
-      # collide on the port. Still catches regressions in the
-      # tinyweb module API surface that broke example_auth.ae /
-      # example_sse.ae / example_websocket.ae previously.
+    - label: ":spider_web: contrib/tinyweb compile + test"
+      # All three test files bind port 8080. Buildkite serializes
+      # jobs sharing a `concurrency_group` to `concurrency: 1`, so
+      # parallel tinyweb jobs queue rather than collide on the
+      # port. Worst case one tinyweb job waits ~10min for the
+      # previous to finish; acceptable trade for actually exercising
+      # the runtime path.
       #
-      # Intentional skips are pre-existing:
-      #   example_app/auth/composition/sse/static/websocket.ae
-      # — these reference `tinyweb.*` symbols that module.ae does
-      # not currently export. Whitelist what DOES check today so
-      # regressions in the working set fail loud.
+      # Whitelist of files (the others — example_app/auth/
+      # composition/sse/static/websocket.ae — reference `tinyweb.*`
+      # symbols that module.ae does not currently export; tracked in
+      # contrib/aeocha/TODO.md). example_inventory.ae is a DSL
+      # structure demo that exits cleanly without binding.
       command: |
         make compiler ae stdlib && \
         for f in contrib/tinyweb/example_inventory.ae \
-                 contrib/tinyweb/test_integration.ae \
                  contrib/tinyweb/test_inventory.ae \
+                 contrib/tinyweb/test_integration.ae \
                  contrib/tinyweb/test_spec.ae; do \
-            printf "  %-45s " "$$f"; \
-            if ./build/ae check "$$f" >/tmp/tw_check.err 2>&1; then \
+            printf "  %-50s " "$$f"; \
+            if ./build/ae run "$$f" >/tmp/tw_run.out 2>&1; then \
                 echo OK; \
             else \
                 echo FAIL; \
-                head -5 /tmp/tw_check.err; \
+                tail -10 /tmp/tw_run.out; \
                 exit 1; \
             fi; \
         done
       agents:
         queue: "default-queue"
         aether: "1"
-      timeout_in_minutes: 10
+      concurrency: 1
+      concurrency_group: "tinyweb-port-8080"
+      timeout_in_minutes: 15
       retry:
         automatic:
           - exit_status: -1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,13 +43,88 @@
           - exit_status: -1
             limit: 1
 
-    - label: ":link: contrib/host bridges"                                                                                                                                               
+    - label: ":link: contrib/host bridges"
       command: make contrib-host-check
-      agents:                                                                                                                                                                            
-        queue: "default-queue"                                    
+      agents:
+        queue: "default-queue"
         aether: "1"
       timeout_in_minutes: 15
       retry:
         automatic:
-          - exit_status: -1                                                                                                                                                              
+          - exit_status: -1
+            limit: 1
+
+    # ---- contrib/ per-package steps ----
+    # contrib/host is already covered above; contrib/aether_ui is
+    # covered by `make ci` step [10/10] (contrib-aether-ui-check).
+    # Steps below cover the remaining contrib packages. Kept as
+    # separate labels so a failure in one contrib doesn't mask
+    # another and the BK UI shows which contrib regressed.
+
+    - label: ":test_tube: contrib/aeocha self-test"
+      command: |
+        make compiler ae stdlib && \
+        ./build/ae run contrib/aeocha/example_self_test.ae
+      agents:
+        queue: "default-queue"
+        aether: "1"
+      timeout_in_minutes: 10
+      retry:
+        automatic:
+          - exit_status: -1
+            limit: 1
+
+    - label: ":spider_web: contrib/tinyweb typecheck"
+      # Examples + tests that bind port 8080 are check-only on the
+      # shared agent — multiple jobs running simultaneously would
+      # collide on the port. Still catches regressions in the
+      # tinyweb module API surface that broke example_auth.ae /
+      # example_sse.ae / example_websocket.ae previously.
+      #
+      # Intentional skips are pre-existing:
+      #   example_app/auth/composition/sse/static/websocket.ae
+      # — these reference `tinyweb.*` symbols that module.ae does
+      # not currently export. Whitelist what DOES check today so
+      # regressions in the working set fail loud.
+      command: |
+        make compiler ae stdlib && \
+        for f in contrib/tinyweb/example_inventory.ae \
+                 contrib/tinyweb/test_integration.ae \
+                 contrib/tinyweb/test_inventory.ae \
+                 contrib/tinyweb/test_spec.ae; do \
+            printf "  %-45s " "$$f"; \
+            if ./build/ae check "$$f" >/tmp/tw_check.err 2>&1; then \
+                echo OK; \
+            else \
+                echo FAIL; \
+                head -5 /tmp/tw_check.err; \
+                exit 1; \
+            fi; \
+        done
+      agents:
+        queue: "default-queue"
+        aether: "1"
+      timeout_in_minutes: 10
+      retry:
+        automatic:
+          - exit_status: -1
+            limit: 1
+
+    - label: ":package: contrib/sqlite roundtrip"
+      # The sqlite roundtrip is already exercised via `make ci` →
+      # `make test-ae` on the Linux/GCC and Linux/Clang steps. Broken
+      # out here as its own label so a sqlite-specific regression
+      # shows up in the BK UI without having to scan the full
+      # test-ae output. Requires libsqlite3-dev in the agent image
+      # (already present per the header comment).
+      command: |
+        make compiler ae stdlib && \
+        bash tests/integration/sqlite_roundtrip/test_sqlite_roundtrip.sh
+      agents:
+        queue: "default-queue"
+        aether: "1"
+      timeout_in_minutes: 10
+      retry:
+        automatic:
+          - exit_status: -1
             limit: 1

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ zig_minimal
 *.swp
 *.swo
 *~
+.idea/
 
 # OS
 .DS_Store

--- a/LLM.md
+++ b/LLM.md
@@ -28,26 +28,28 @@ Erlang's actor syntax, compiling via C.**
   string interpolation, pattern matching.
 - **Actor model is Erlang-ish** but message types are declared, not
   duck-typed. `receive` + `send`, not `!` / mailbox-matching.
-- **Capability discipline is a mashup of Pony object capabilities,
-  Java's removed SecurityManager, and a fraction of gVisor.** Three
+- **Has some sandboxing features build in** - Three
   layers: `--emit=lib` + `--with=` gates stdlib imports at compile
   time; `hide` / `seal except` denies enclosing names per lexical
   block; `libaether_sandbox.so` (LD_PRELOAD) checks libc calls
-  against a builder-DSL grant list.
-- **Hosts other languages slightly better than a linked lib** —
+  against a builder-DSL grant list. If you like: a mashup of Pony 
+  object capabilities, Java's removed SecurityManager, and a fraction 
+  of gVisor. 
+- **Hosts other languages** - Granted thss is only slightly better 
+  than a linked lib, 
   Aether `main()` embeds Lua/Python/Perl/Ruby/Tcl/JS in-process via
   `contrib.host.<lang>.run_sandboxed(perms, code)`;
   Java/Go/aether-hosts-aether are separate-process. Same grant list
   + LD_PRELOAD gates the hosted interpreter's libc calls too. Guest
   direction: `--emit=lib` → Python ctypes / Java Panama / Ruby
   Fiddle SDKs auto-generated from `aether_describe()`.
-- **NOT Ruby/Smalltalk/Groovy builder closures** — those interpret
-  the trailing block at runtime with full reflection access. Aether
-  compiles closures to C; `hide`/`seal except` are compile-time, and
-  the grant list is the closure's only handle to privileged
-  operations.
+- **NOT quite Ruby/Smalltalk/Groovy's builder-style closures** 
+  — those interpret the trailing block at runtime with full reflection 
+  access. Aether compiles closures to C; `hide`/`seal except` are  
+  compile-time, and the grant list is the closure's only handle to 
+  privileged operations.
 
-  Full comparison (who brings what — Pony's per-reference
+Sandbox more info: Full comparison (who brings what — Pony's per-reference
   granularity, Java SecManager's policy-file ancestry, gVisor's
   syscall scope, plus WASI/Deno/Rust) lives in
   `docs/containment-sandbox.md` → *How Aether compares to other

--- a/LLM.md
+++ b/LLM.md
@@ -28,54 +28,30 @@ Erlang's actor syntax, compiling via C.**
   string interpolation, pattern matching.
 - **Actor model is Erlang-ish** but message types are declared, not
   duck-typed. `receive` + `send`, not `!` / mailbox-matching.
-- **Capability discipline at three levels, bidirectional host interop.**
-  Module: `--emit=lib` rejects `std.fs|net|os` imports by default,
-  opt-in via `--with=fs,net,os`. Scope: `hide`/`seal except` on any
-  lexical block (closure, trailing-block DSL, actor handler) denies
-  names from enclosing scopes at compile time. Runtime:
-  `libaether_sandbox.so` (LD_PRELOAD) intercepts libc (`open*`,
-  `connect`/`bind`/`accept`, `execve`/`fork`, `mmap`/`mprotect`,
-  `dlopen`, `getenv`) against a builder-DSL grant list, inherited
-  across `execve` — covers normal-libc code, adversaries using
-  `openat2` / `io_uring` / raw `syscall()` bypass it. Aether can be
-  the guest (host-lang apps embed via `--emit=lib` → Python ctypes /
-  Java Panama / Ruby Fiddle SDKs generated from `aether_describe()`
-  manifest; Go stubbed) OR the host (embeds Lua/Python/Perl/Ruby/Tcl/JS
-  in-process via `contrib.host.<lang>.run_sandboxed(perms, code)`;
-  Java/Go/aether-hosts-aether are separate-process). `hide`/`seal
-  except` don't travel into hosted non-Aether interpreters — those
-  are contained by grants + LD_PRELOAD only; `hide`/`seal except`
-  shape the Aether-side grant-assembly block. Closest analogue: Pony
-  object capabilities, but coarser (stdlib category / name / libc
-  entry point). See `docs/emit-lib.md`, `docs/hide-and-seal.md`,
-  `docs/containment-sandbox.md`, `docs/embedded-namespaces-and-host-bindings.md`.
+- **Capability discipline is a mashup of Pony object capabilities,
+  Java's removed SecurityManager, and a fraction of gVisor.** Three
+  layers: `--emit=lib` + `--with=` gates stdlib imports at compile
+  time; `hide` / `seal except` denies enclosing names per lexical
+  block; `libaether_sandbox.so` (LD_PRELOAD) checks libc calls
+  against a builder-DSL grant list.
+- **Hosts other languages slightly better than a linked lib** —
+  Aether `main()` embeds Lua/Python/Perl/Ruby/Tcl/JS in-process via
+  `contrib.host.<lang>.run_sandboxed(perms, code)`;
+  Java/Go/aether-hosts-aether are separate-process. Same grant list
+  + LD_PRELOAD gates the hosted interpreter's libc calls too. Guest
+  direction: `--emit=lib` → Python ctypes / Java Panama / Ruby
+  Fiddle SDKs auto-generated from `aether_describe()`.
+- **NOT Ruby/Smalltalk/Groovy builder closures** — those interpret
+  the trailing block at runtime with full reflection access. Aether
+  compiles closures to C; `hide`/`seal except` are compile-time, and
+  the grant list is the closure's only handle to privileged
+  operations.
 
-  Current cross-cutting gaps (`contrib/host/TODO.md` /
-  `docs/next-steps.md` → *Host Language Bridges*): capturing
-  stdout/stderr from hosted scripts (pipe rewire vs. shared-map key
-  vs. pass-through — undecided), native shared-map bindings for
-  Perl and Ruby (currently tied-hash via `eval`, which swallows
-  writes — Python/Lua/Tcl/JS have proper native bindings), and a
-  `bytes` mode on the shared map so callers don't have to base64
-  binary payloads.
-
-  Worked examples: `examples/embedded-java/trading/` (direction 1),
-  `examples/sandbox-spawn.ae` (direction 2). Integration tests:
-  `tests/integration/namespace_{python,ruby,java}/` and
-  `tests/integration/embedded_java_trading_e2e/` (direction 1).
-  Canonical docs: `docs/embedded-namespaces-and-host-bindings.md`
-  (direction 1 / typed-SDK story),
-  `docs/aether-embedded-in-host-applications.md` (direction 1 /
-  rationale — also the YAML/HCL/Pkl/Jsonnet/Starlark comparison),
-  `docs/containment-sandbox.md` (direction 2 / how the in-process
-  checker and LD_PRELOAD share a code path).
-
-  What's novel is the combination: _most_ embeddable languages
-  (Lua, Wren, Starlark, Hermes) give you the embedding but leave
-  capability management to the host. _Most_ capability-secure
-  languages (Pony, E) don't ship polyglot SDK generators or
-  in-process interpreter bridges. Aether bundles both directions
-  behind one permissions model.
+  Full comparison (who brings what — Pony's per-reference
+  granularity, Java SecManager's policy-file ancestry, gVisor's
+  syscall scope, plus WASI/Deno/Rust) lives in
+  `docs/containment-sandbox.md` → *How Aether compares to other
+  capability / sandbox systems*.
 
 Syntax looks Go-ish at a glance (braces, `func_name(x: int) -> int`).
 Don't overshoot — there's no `go` keyword, no channels (send-to-actor

--- a/README.md
+++ b/README.md
@@ -282,6 +282,38 @@ main() {
 }
 ```
 
+## Closures and Builder DSL
+
+Aether closures take three shapes after a function call. They look similar but have different semantics — picking the right one is the language's main lever for separating DSL structure from runtime behaviour.
+
+| Mode | Syntax | Semantics |
+|------|--------|-----------|
+| **Immediate** | `func() { block }` | Runs inline at the call site — used for DSL structure |
+| **Closure** | `func() \|x\| { block }` | Real closure with explicit params, hoisted to a C function |
+| **Callback** | `func() callback { block }` | Real closure that captures enclosing scope — no params needed |
+
+```aether
+// Immediate — declarative structure, runs during construction
+panel("Settings") {
+    button("OK")
+    button("Cancel")
+}
+
+// Closure — explicit params, deferred invocation
+apply_twice(x: int, f: fn) { return call(f, call(f, x)) }
+doubler = |x: int| -> x * 2
+println(apply_twice(3, doubler))    // 12
+
+// Callback — captures from scope, runs when invoked
+counter = ref(0)
+btn("increment") callback { ref_set(counter, ref_get(counter) + 1) }
+btn("decrement") callback { ref_set(counter, ref_get(counter) - 1) }
+```
+
+The compiler distinguishes them at parse time, which is what makes the sandboxing story (above) work: `hide`/`seal except` checks happen against the hoisted form of `closure` and `callback` blocks, so a `seal except req, res` on a callback body genuinely prevents the body from reaching outer scope. Immediate blocks inherit the caller's lexical scope by design — they're structure, not callbacks.
+
+Inspired by Smalltalk blocks, Ruby's blocks/procs, Groovy closures, and Kotlin/SwiftUI's trailing-block DSLs. See [Closures and Builder DSL](docs/closures-and-builder-dsl.md) for the builder-context mechanism, ref cells, and full DSL pattern.
+
 ## Runtime Configuration
 
 When embedding the Aether runtime in a C application, configure optimizations at startup:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Aether is a compiled language that brings actor-based concurrency to systems pro
 - Type inference with optional annotations
 - Compiles to readable C for portability and C library interop
 - Lock-free message passing with adaptive optimizations
+- Three-layer capability model for sandboxing untrusted code and hosting other languages in-process — `--emit=lib` gates stdlib at compile time, `hide`/`seal except` gates scopes, LD_PRELOAD gates libc
 - Go-style result types: `a, err = func()` with `_` discard
 - Package management: `ae add host/user/repo[@version]` (GitHub, GitLab, Bitbucket, any git host)
 
@@ -43,6 +44,18 @@ The Aether runtime implements a native actor system with optimized message passi
 - **Message coalescing** for higher throughput
 - **Adaptive batching** dynamically adjusts batch sizes
 - **Direct send** for same-core actors bypasses queues
+
+### Capabilities & Sandboxing
+
+Aether is compiled, but comes with a capability system normally associated with interpreted / VM-hosted languages. Three enforcement layers:
+
+- **Compile-time module gate** — `--emit=lib` rejects `std.fs` / `std.net` / `std.os` imports by default; the host opts each in with `--with=fs,net,os`.
+- **Compile-time scope gate** — `hide <names>` and `seal except <allowlist>` on any lexical block (closure, trailing-block DSL, actor handler) block ambient names from leaking into contained code.
+- **Runtime process gate** — `libaether_sandbox.so` (LD_PRELOAD) intercepts libc (`open*`, `connect`/`bind`, `execve`, `mmap`, `dlopen`, `getenv`) against a builder-DSL grant list; inherited across `execve` to child processes.
+
+The same grant list + LD_PRELOAD also contains embedded interpreters — an Aether `main()` can host Lua, Python, Perl, Ruby, Tcl, and JavaScript in-process (`contrib.host.<lang>.run_sandboxed(perms, code)`) with the same permission model that scopes Aether's own libc calls. In the reverse direction, `--emit=lib` + `ae build --namespace` produce a `.so` plus a typed SDK (Python ctypes, Java Panama, Ruby Fiddle) so host-language apps can embed Aether without writing FFI by hand.
+
+Mashup of Pony object capabilities, Java's removed SecurityManager, and a fraction of gVisor — see [Containment Sandbox](docs/containment-sandbox.md) for the full comparison, threat model, and known bypass surface.
 
 ### Platform Portability
 - **Compile-time platform detection** via `AETHER_HAS_*` flags (threads, atomics, filesystem, networking, NUMA, SIMD, affinity)
@@ -441,7 +454,7 @@ Aether draws inspiration from:
 - **Erlang/OTP** — Actor model, message passing semantics
 - **Go** — Pragmatic tooling, simple concurrency primitives
 - **Rust** — Systems programming practices, zero-cost abstractions
-- **Pony** — Actor-based type safety concepts
+- **Pony** — Actor-based type safety concepts and object-capability model
 
 ## License
 

--- a/contrib/aeocha/TODO.md
+++ b/contrib/aeocha/TODO.md
@@ -28,3 +28,72 @@ grep "web_server\|_aether_ctx_push" build/test_tinyweb_spec.c
 - Migrate test_tinyweb_spec.ae to use the TinyWeb DSL directly
 - Add integration tests (server in actor + HTTP client round-trips)
 - Add Aeocha before/after hooks to TinyWeb tests
+
+## Make Aeocha actually feel like Mocha / Jest / Cuppa
+
+Today `contrib/aeocha/module.ae` is not importable — `import
+contrib.aeocha` followed by `aeocha.describe(...)` produces ~117 parse
+errors, because:
+
+1. **Top-level module state.** `_passed = ref(0)` / `_failed = ref(0)`
+   / `_depth = ref(0)` at module scope aren't accepted by the
+   import-expansion path. The self-test works only because the
+   framework gets *inlined* into `example_self_test.ae`, so the refs
+   end up inside `main()`. Aeocha needs an `aeocha.init() -> ptr`
+   that returns a context the caller threads through, not module
+   globals — same shape as the `_ctx` builders elsewhere.
+
+2. **`after` is a reserved keyword** (collides with the actor-receive
+   `after N ->` timeout syntax). Currently both `after` and
+   `after_each` exist as functions in `module.ae`; the bare `after`
+   has to go. `after_each` is the survivor.
+
+3. **Bare-call ergonomics need a language feature.** Even after (1)
+   and (2) are fixed, the import gives you `aeocha.describe(...)` /
+   `aeocha.it(...)` (mirrors `sqlite.open` / `http.get`), not the
+   Mocha-feel bare `describe(...)` / `it(...)`. To get bare names a
+   test framework genuinely benefits from, Aether needs an unqualified
+   import variant — `import contrib.aeocha unqualified` or
+   `use contrib.aeocha::*`. This is a compiler change (parser +
+   module resolver + symbol table), not an aeocha-side fix; deserves
+   its own design discussion before coding. Scope: probably a day's
+   work end-to-end with tests.
+
+### Target shape (after all three land)
+
+```aether
+import contrib.aeocha unqualified
+
+main() {
+    describe("Counter") {
+        before { reset() }
+
+        it("starts at zero") {
+            assert_eq(count(), 0, "initial count")
+        }
+
+        it("increments") {
+            increment()
+            assert_eq(count(), 1, "after one inc")
+        }
+    }
+}
+```
+
+No `aeocha.init()`, no `aeocha.run_summary()`, no `aeocha.` prefixes.
+That's the bar.
+
+### What this unblocks
+
+Once Aeocha is importable + bare-callable, migrate the four existing
+hand-rolled `exit(1)` test files to it:
+
+- `contrib/tinyweb/test_integration.ae` (176 LOC)
+- `contrib/tinyweb/test_inventory.ae` (316 LOC)
+- `contrib/tinyweb/test_spec.ae` (317 LOC)
+- `tests/integration/sqlite_roundtrip/probe.ae` (105 LOC)
+
+Each gets `describe`/`it` grouping, proper pass/fail counts, and
+shared before/after hooks instead of inlined per-test setup/teardown.
+The tinyweb tests in particular currently abort on first failure
+(`exit(1)`); under Aeocha they'd surface every regression in one run.

--- a/docs/containment-sandbox.md
+++ b/docs/containment-sandbox.md
@@ -1360,3 +1360,131 @@ and with no deserialization attack surface.
 A flag on `shared_map_new()` will switch values from null-terminated
 strings to length-prefixed byte arrays. Same API, same token guard,
 same freeze/revoke lifecycle. For binary data too large to base64.
+
+## How Aether compares to other capability / sandbox systems
+
+Aether's capability model runs at three levels and composes with
+bidirectional host-language interop. Useful to anchor against
+systems readers already know.
+
+### Three enforcement layers
+
+1. **Module boundary** — under `--emit=lib` the compiler rejects
+   imports of `std.fs`, `std.net`, `std.os` at build time; the host
+   opts each one in with `--with=fs[,net,os]`. See [`emit-lib.md`](emit-lib.md).
+2. **Scope boundary** — `hide <names>` and `seal except <allowlist>`
+   let any lexical block (closure, trailing-block DSL, actor
+   handler) decline to see selected enclosing names; reading,
+   assigning, or re-declaring a hidden name is a compile error, and
+   the denial travels with the block. See [`hide-and-seal.md`](hide-and-seal.md).
+3. **Runtime process boundary** — `libaether_sandbox.so` (LD_PRELOAD)
+   intercepts libc (`open*`, `connect` / `bind` / `accept`, `execve`
+   / `fork`, `mmap` / `mprotect`, `dlopen`, `getenv`) against a
+   builder-DSL grant list, inherited across `execve`. Covers
+   normal-libc code. Adversaries using `openat2` / `io_uring` /
+   `sendfile` / `execveat` / raw `syscall()` / `ptrace` bypass it
+   (enumerated in detail above under *Interception surface*).
+
+### Bidirectional host interop
+
+Aether plays either side of the embedding relationship, with the
+same permissions registry and LD_PRELOAD checker either way.
+
+- **Aether as guest** — a host-language app loads an Aether `.so`
+  built via `--emit=lib`, which carries a typed namespace manifest
+  (`aether_describe()`) used by `ae build --namespace` to generate
+  per-language SDKs. Shipped: Python (ctypes), Java (Panama, JDK
+  22+), Ruby (Fiddle). Go stubbed. Host-side is normal methods —
+  no JNI, SWIG, `MemorySegment`, or `ctypes.CDLL` boilerplate.
+  Callback model is Hohpe's *claim check*: script emits
+  `notify(event, id)`, host calls back through the typed downcall
+  API for detail. See [`embedded-namespaces-and-host-bindings.md`](embedded-namespaces-and-host-bindings.md)
+  (typed-SDK story) and [`aether-embedded-in-host-applications.md`](aether-embedded-in-host-applications.md)
+  (rationale + YAML/HCL/Pkl/Jsonnet/Starlark comparison).
+- **Aether as host** — an Aether `main()` executable embeds
+  `contrib.host.<lang>.run_sandboxed(perms, code)` for Lua, Python
+  (CPython), Perl, Ruby, Tcl, JavaScript in-process. Java, Go, and
+  aether-hosts-aether are separate-process (Aether is compiled, so
+  aether-hosts-aether uses fork+exec with LD_PRELOAD on the child).
+  `hide` / `seal except` are Aether compile-time constructs — they
+  do NOT travel into hosted non-Aether interpreters, which have
+  their own scoping; containment for those is grants + LD_PRELOAD
+  only. `hide` / `seal except` still shape the Aether-side
+  grant-assembly block and the hosting closure. See
+  `contrib/host/<lang>/README.md` and `contrib/host/TODO.md`.
+
+### What it's most like
+
+- **Pony object capabilities** — closest analogue in a systems
+  language. Aether's grants are coarser (stdlib category at the
+  module level, name at the scope level, libc entry point at the
+  runtime level); Pony attaches capability modes to individual
+  references.
+- **Java's removed SecurityManager** — same structural idea
+  (`java.policy` grants, `AccessController.doPrivileged`), same
+  layer (interpreter / VM-level check on sensitive operations).
+  Deprecated in JDK 17, removed in JDK 24 because the maintenance
+  cost outgrew the benefit in an ecosystem where most applications
+  trust their dependencies. Aether's equivalent survives because
+  the scope is narrower (the grant list is populated by a builder
+  DSL in the same codebase, not by a system-wide policy file
+  parsed from XML) and the enforcement point is libc, not the VM.
+- **A fraction of gVisor** — both intercept at a boundary
+  (gVisor's Sentry emulates syscalls; Aether's LD_PRELOAD wraps
+  libc). gVisor is kernel-level (process-scoped, every syscall)
+  and handles adversarial workloads. Aether is userspace-level
+  (libc-scoped, easily bypassed by raw `syscall()`) and handles
+  cooperative containment. gVisor gives you a hardened sandbox
+  for untrusted containers; Aether gives you a developer-ergonomic
+  permission surface for trusted-but-sandboxed plugins.
+
+### What it is NOT
+
+- **NOT Ruby / Smalltalk / Groovy's builder-style closures** —
+  those languages interpret the trailing block at runtime with
+  full access to the interpreter's reflection surface. Aether
+  compiles the closure to C; the sandbox grant list is the
+  compiled function's only handle to privileged operations.
+  `hide` / `seal except` are checked by the compiler, not by a
+  runtime SecurityManager.
+- **NOT a runtime wrapper** (WASI, gVisor, Firejail) — `--emit=lib`
+  changes what the compiler will emit at all, not what the runtime
+  will permit later.
+- **NOT a library flag** (Deno's `--allow-net`, Node's
+  experimental permission model) — those are process-wide
+  allowlists checked at API call sites. Aether's gate is at
+  compile time and at scope entry, plus an optional runtime check.
+- **NOT an annotation convention** (Rust crates, Go build tags) —
+  those require ecosystem buy-in and don't prevent a dependency
+  from pulling in what it needs. Aether rejects the import.
+
+### What's novel is the combination
+
+Most embeddable languages (Lua, Wren, Starlark, Hermes) give you
+the embedding but leave capability management to the host. Most
+capability-secure languages (Pony, E) don't ship polyglot SDK
+generators or in-process interpreter bridges. Aether bundles both
+directions (guest + host) behind one permissions model.
+
+### Cross-cutting gaps (contributor surface)
+
+Active work listed in [`../contrib/host/TODO.md`](../contrib/host/TODO.md)
+and [`next-steps.md`](next-steps.md) → *Host Language Bridges*:
+
+- Capturing stdout/stderr from hosted scripts — pipe rewire vs.
+  shared-map key vs. pass-through, design undecided.
+- Native shared-map bindings for Perl and Ruby — currently
+  tied-hash via `eval`, which swallows writes. Python, Lua, Tcl,
+  JS already have proper native C bindings.
+- `bytes` mode on the shared map — so callers don't have to
+  base64 binary payloads across the boundary.
+
+### Worked examples and tests
+
+- `examples/embedded-java/trading/` — direction 1 (Aether as
+  guest, Java host).
+- `examples/sandbox-spawn.ae`, `examples/sandbox-demo.ae` —
+  direction 2 (Aether as host).
+- `tests/integration/namespace_{python,ruby,java}/`,
+  `tests/integration/embedded_java_trading_e2e/` — per-SDK
+  regression tests for direction 1.


### PR DESCRIPTION
## Summary

Follow-up to #230. Three doc changes that surface the capability/sandbox story to different audiences, plus three new Buildkite steps covering contrib packages that weren't yet exercised on BK.

## Docs

- **`docs/containment-sandbox.md`** — new section *"How Aether compares to other capability / sandbox systems"*. Covers the three enforcement layers (compile-time module gate, compile-time scope gate, runtime libc gate), bidirectional host interop (Aether as guest via `--emit=lib` + generated SDKs; Aether as host via `contrib/host/<lang>`), ancestor comparisons (Pony object capabilities with "coarser granularity" nuance; Java's removed SecurityManager with a "why this survives where Java's didn't" argument; a fraction of gVisor framed honestly as cooperative-vs-adversarial), the "what it is NOT" comparisons (WASI, Deno, Rust), and the novel-combination claim. Canonical home for the detail — `LLM.md` and `README.md` now point here instead of duplicating.

- **`LLM.md`** — compressed the old ~48-line capability bullet into three one-liners matching the NOT Rust / NOT Go / NOT C density. Key line: *"Capability discipline is a mashup of Pony object capabilities, Java's removed SecurityManager, and a fraction of gVisor."*

- **`README.md`** — makes the capability story discoverable to humans evaluating the language. Three touches: Core Features list gains a one-line three-layer capability bullet; new *"Capabilities & Sandboxing"* subsection between Message Optimization and Platform Portability (parallel weight to the other Runtime Features subsections, with the mashup framing and a pointer to containment-sandbox.md for threat model / bypass surface); the Acknowledgments entry for Pony is upgraded from *"Actor-based type safety concepts"* to *"Actor-based type safety concepts and object-capability model"*.

## Buildkite pipeline

Three new steps after the existing `contrib/host bridges`:

- **`contrib/aeocha self-test`** — `ae run contrib/aeocha/example_self_test.ae`. 11 passing BDD cases, validates the framework dogfoods itself.
- **`contrib/tinyweb typecheck`** — `ae check` on the 4 files currently type-clean: `example_inventory.ae`, `test_integration.ae`, `test_inventory.ae`, `test_spec.ae`. 6 other examples have pre-existing `tinyweb.*` undefined-function errors — the whitelist makes regressions in the working set fail loud without masking those. Check-only, not run — every test/example binds port 8080 and would collide across parallel BK jobs.
- **`contrib/sqlite roundtrip`** — explicit label for the existing `tests/integration/sqlite_roundtrip/test_sqlite_roundtrip.sh`. Already runs via `make ci` → `make test-ae` on the GCC/Clang steps, broken out here so a sqlite regression shows up in the BK UI without scanning the full test-ae output.

Not added: `contrib/host` is already covered by the existing `contrib-host-check` step; `contrib/aether_ui` is already covered as `make ci` step 10/10. Adding either again would be duplicate work.

## Test plan

- [x] `docs/containment-sandbox.md` renders — section headings + internal links resolve
- [x] `LLM.md` diff preserves the NOT Rust / NOT Go / NOT C bullet style
- [x] `README.md` diff keeps the Runtime Features subsection layout
- [x] YAML lints clean: `python3 -c 'import yaml; yaml.safe_load(open(".buildkite/pipeline.yml"))'`
- [x] `ae run contrib/aeocha/example_self_test.ae` — 11 passing
- [x] `ae check` on all 4 tinyweb whitelisted files — all OK
- [x] `bash tests/integration/sqlite_roundtrip/test_sqlite_roundtrip.sh` — 7 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)