### PR TITLE
std.http.client: post_json + response_body_json sugar (closes #240)

### DIFF
--- a/contrib/climate_http_tests/test_climate_record_then_replay.ae
+++ b/contrib/climate_http_tests/test_climate_record_then_replay.ae
@@ -45,6 +45,7 @@ import std.fs
 extern file_exists(path: string) -> int
 import std.string
 import std.io
+import std.json
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int

--- a/contrib/climate_http_tests/test_climate_via_vcr.ae
+++ b/contrib/climate_http_tests/test_climate_via_vcr.ae
@@ -28,6 +28,7 @@ import std.http
 import std.http.client
 import std.string
 import std.fs
+import std.json
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int

--- a/docs/notes/compiler_notes_from_vcr_port.md
+++ b/docs/notes/compiler_notes_from_vcr_port.md
@@ -96,7 +96,7 @@ behavior is correct.)
 
 ---
 
-## 3. Actor state-type inference fragile under import-order changes
+## 3. Actor state-type inference fragile under import-order changes [RESOLVED 2026-04-26 in PR #238]
 
 **Symptom**: this pattern works in one test file and fails in another
 with seemingly identical code:
@@ -158,7 +158,12 @@ wrapper foo` pair in the stdlib shrinks to one line.
 
 ---
 
-## 5. Tuple return-type annotation flaky for multi-return funcs
+## 5. Tuple return-type annotation flaky for multi-return funcs [RESOLVED 2026-04-26 in PR #238]
+
+The cross-module tuple destructure case from issue #240's JSON sugar
+work compiles cleanly: `parsed, perr = client.response_body_json(resp)`,
+`echoed_ct, sctterr = json.get_string(ct_node)`, etc. all work first
+time without the `-> {` workaround.
 
 **Symptom**: declaring an explicit `-> (int, string)` annotation on a
 function and then destructuring its result fails:

--- a/std/http/README.md
+++ b/std/http/README.md
@@ -85,6 +85,34 @@ the common "GET with auth headers" and "POST and inspect status"
 shapes. They're pure Aether on top of the v2 builder — same
 expressiveness, fewer call-site lines.
 
+JSON round-trip helpers compose the same way:
+
+```ae
+import std.http.client
+import std.json
+
+payload = json_create_object()
+json_object_set_raw(payload, "name", json_create_string("alice"))
+
+resp, err = client.post_json("https://api.example.com/users", payload)
+if err == "" {
+    parsed, perr = client.response_body_json(resp)
+    if perr == "" {
+        // walk parsed; caller owns it.
+        json_free(parsed)
+    }
+    client.response_free(resp)
+}
+json_free(payload)
+```
+
+`post_json` marshals the value via `json.stringify`, sets
+`Content-Type` and `Accept` to `application/json`, and returns the
+same `(resp, err)` shape as `send_request` — non-2xx status is still
+the caller's call. `response_body_json` wraps `response_body` +
+`json.parse`, returning `(value, "")` on success or `(null, error)`
+when the body isn't valid JSON.
+
 ## Server — routing + actor wiring
 
 ```ae

--- a/std/http/client/module.ae
+++ b/std/http/client/module.ae
@@ -45,6 +45,22 @@
 // opt out and block forever (rarely what you want; preserved as the
 // v1 wrappers' behaviour). Negative values are an error.
 
+// std.json is pulled in for the v2.1 JSON sugar wrappers
+// (post_json / response_body_json) at the bottom of this file.
+// The core builder + send + response surface above doesn't depend
+// on it — callers that don't touch JSON pay no cost beyond the
+// import.
+import std.json
+
+exports (
+    request, set_header, set_body, set_timeout, request_free,
+    send_request,
+    response_status, response_body, response_error,
+    response_header, response_headers, response_free,
+    get_with_headers, post_with_status,
+    post_json, response_body_json
+)
+
 // ---- Raw externs ----
 // HttpRequest is opaque. Build → set_* → send → free in that order.
 // HttpResponse carries the same shape the v1 wrappers return; reuse
@@ -223,4 +239,68 @@ post_with_status(url: string, body: string, content_type: string) -> {
     rbody_copy = string_concat(rbody, "")
     response_free(resp)
     return rbody_copy, status, ""
+}
+
+// ---- JSON sugar (issue #240) ----------------------------------------
+//
+// Two helpers for the common "POST a JSON body, parse the JSON
+// response" round-trip. Pure Aether on top of v2 + std.json — no
+// new C externs.
+//
+//   import std.http.client
+//   import std.json
+//
+//   value = json.create_object()
+//   json.object_set_string(value, "name", "alice")
+//   resp, err = client.post_json("https://api.example.com/users", value)
+//   if err == "" {
+//       parsed, perr = client.response_body_json(resp)
+//       if perr == "" {
+//           // walk parsed
+//           json.free(parsed)
+//       }
+//       client.response_free(resp)
+//   }
+//   json.free(value)
+//
+// Like send_request, post_json's err covers transport-level failures
+// only — non-2xx HTTP status leaves err == "" and the caller checks
+// response_status(resp). response_body_json's err covers JSON parse
+// failures (the response was received fine but the body wasn't valid
+// JSON).
+
+// POST a JSON value to `url`. Marshals via json.stringify, sets
+// Content-Type + Accept to application/json, fires the request.
+// Same (resp, err) shape as send_request. Caller frees resp via
+// response_free, and json.free's the value they passed in (we
+// don't take ownership of it).
+//
+// The request handle's lifetime is fully internal — we allocate
+// it on entry and `defer request_free` it so the cleanup pairs
+// visually with the allocation and survives every return path.
+post_json(url: string, value: ptr) -> {
+    body_str, sferr = json.stringify(value)
+    if sferr != "" { return null, sferr }
+
+    req = request("POST", url)
+    if req == null { return null, "request build failed" }
+    defer request_free(req)
+
+    set_timeout(req, 30)
+    set_header(req, "Content-Type", "application/json")
+    set_header(req, "Accept",       "application/json")
+    body_len = string_length(body_str)
+    set_body(req, body_str, body_len, "application/json")
+
+    return send_request(req)
+}
+
+// Parse the response body as JSON. Returns (value, "") on success,
+// (null, parse_error) when the body isn't valid JSON. Doesn't free
+// the response — the caller still owns it (so they can read other
+// accessors like response_status before/after parsing). Caller owns
+// the returned value and must json.free it.
+response_body_json(resp: ptr) -> {
+    body = response_body(resp)
+    return json.parse(body)
 }

--- a/tests/integration/test_http_client_v2.ae
+++ b/tests/integration/test_http_client_v2.ae
@@ -20,6 +20,7 @@
 import std.http.client
 import std.http
 import std.string
+import std.json
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
@@ -86,6 +87,28 @@ handle_slow(req: ptr, res: ptr, ud: ptr) {
     sleep(3000)
     http.response_set_status(res, 200)
     http.response_set_body(res, "late")
+}
+
+// JSON sugar handlers (issue #240). The echo handler asserts that
+// the client set Content-Type: application/json and emits a
+// well-formed JSON response keyed off what it received. The broken
+// handler emits non-JSON regardless of the request — used to drive
+// response_body_json's parse-failure path.
+handle_json_echo(req: ptr, res: ptr, ud: ptr) {
+    ctype = http.get_header(req, "Content-Type")
+    body  = http.request_body(req)
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "application/json")
+    // Synthesise a small object that proves the round-trip preserved
+    // both the request's content-type header and its body.
+    out = "{\"echoed_ct\":\"${ctype}\",\"echoed_body\":${body}}"
+    http.response_set_body(res, out)
+}
+
+handle_json_broken(req: ptr, res: ptr, ud: ptr) {
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "application/json")
+    http.response_set_body(res, "this is not { valid json")
 }
 
 // ------------------------------------------------------------------
@@ -156,6 +179,8 @@ main() {
     http.server_get (raw, "/broken",                 handle_broken,       0)
     http.server_post(raw, "/echo-length",            handle_echo_length,  0)
     http.server_get (raw, "/slow",                   handle_slow,         0)
+    http.server_post(raw, "/json-echo",              handle_json_echo,    0)
+    http.server_get (raw, "/json-broken",            handle_json_broken,  0)
 
     // Hand the server to an actor that calls server_start (blocking).
     // SchedHelper spawned first to satisfy the >=2-actor scheduler
@@ -269,6 +294,82 @@ main() {
         exit(1)
     }
     print("  PASS\n")
+
+    // ---- Test 8: post_json round-trip (issue #240) ----
+    // Build a small JSON object, POST it to /json-echo, parse the
+    // response, assert the server received Content-Type: application/json
+    // and the body we sent. json_* externs are flat-namespaced (no
+    // wrapper for create_object / object_set_raw etc. yet); call them
+    // directly. The error legs of object_get / get_string come back
+    // as (value, err) tuples per std.json's idiom.
+    print("\nTest 8: post_json round-trip\n")
+    name_val = json_create_string("alice")
+    age_val  = json_create_number(30.0)
+    payload  = json_create_object()
+    json_object_set_raw(payload, "name", name_val)
+    json_object_set_raw(payload, "age",  age_val)
+    resp8, err8 = client.post_json("${base_url()}/json-echo", payload)
+    if err8 != "" { println("  FAIL post_json: ${err8}"); exit(1) }
+    if client.response_status(resp8) != 200 {
+        println("  FAIL status ${client.response_status(resp8)}"); exit(1)
+    }
+    parsed8, perr8 = client.response_body_json(resp8)
+    if perr8 != "" { println("  FAIL parse: ${perr8}"); exit(1) }
+    ct_node, gctterr = json.object_get(parsed8, "echoed_ct")
+    if gctterr != "" { println("  FAIL no echoed_ct: ${gctterr}"); exit(1) }
+    echoed_ct, sctterr = json.get_string(ct_node)
+    if sctterr != "" { println("  FAIL get_string ct: ${sctterr}"); exit(1) }
+    if string.contains(echoed_ct, "application/json") != 1 {
+        println("  FAIL echoed_ct '${echoed_ct}' missing application/json")
+        exit(1)
+    }
+    echoed_body, ebgerr = json.object_get(parsed8, "echoed_body")
+    if ebgerr != "" { println("  FAIL no echoed_body: ${ebgerr}"); exit(1) }
+    eb_name_node, ebnnerr = json.object_get(echoed_body, "name")
+    if ebnnerr != "" { println("  FAIL no echoed name: ${ebnnerr}"); exit(1) }
+    eb_name, ebnsstrerr = json.get_string(eb_name_node)
+    if ebnsstrerr != "" { println("  FAIL get_string name: ${ebnsstrerr}"); exit(1) }
+    if eb_name != "alice" {
+        println("  FAIL round-tripped name '${eb_name}' != 'alice'"); exit(1)
+    }
+    json_free(parsed8)
+    client.response_free(resp8)
+    json_free(payload)
+    print("  PASS: round-trip preserved Content-Type and body\n")
+
+    // ---- Test 9: response_body_json happy path ----
+    // Use post_json with a trivial payload to drive a JSON response,
+    // then verify response_body_json parses it cleanly.
+    print("\nTest 9: response_body_json happy path\n")
+    p9 = json_create_object()
+    resp9, err9 = client.post_json("${base_url()}/json-echo", p9)
+    if err9 != "" { println("  FAIL: ${err9}"); exit(1) }
+    parsed9, perr9 = client.response_body_json(resp9)
+    if perr9 != "" { println("  FAIL parse: ${perr9}"); exit(1) }
+    if parsed9 == null { println("  FAIL parsed9 null"); exit(1) }
+    json_free(parsed9)
+    client.response_free(resp9)
+    json_free(p9)
+    print("  PASS: parsed cleanly\n")
+
+    // ---- Test 10: response_body_json malformed JSON surfaces err ----
+    print("\nTest 10: response_body_json on malformed JSON\n")
+    req10 = client.request("GET", "${base_url()}/json-broken")
+    client.set_timeout(req10, 5)
+    resp10, err10 = client.send_request(req10)
+    client.request_free(req10)
+    if err10 != "" { println("  FAIL transport: ${err10}"); exit(1) }
+    parsed10, perr10 = client.response_body_json(resp10)
+    if perr10 == "" {
+        println("  FAIL: expected parse error, got success")
+        exit(1)
+    }
+    if parsed10 != null {
+        println("  FAIL: expected null value on parse failure")
+        exit(1)
+    }
+    client.response_free(resp10)
+    print("  PASS: parse error surfaced as '${perr10}'\n")
 
     print("\n=== All std.http.client v2 tests passed ===\n")
     // Explicit exit because the SrvActor's accept loop would

--- a/tests/integration/test_vcr_format_options.ae
+++ b/tests/integration/test_vcr_format_options.ae
@@ -24,6 +24,7 @@ import std.http.client
 import std.fs
 import std.string
 import std.io
+import std.json
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int

--- a/tests/integration/test_vcr_static_content.ae
+++ b/tests/integration/test_vcr_static_content.ae
@@ -20,6 +20,7 @@ import std.http
 import std.http.client
 import std.fs
 import std.string
+import std.json
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int

--- a/tests/integration/test_vcr_strict_match.ae
+++ b/tests/integration/test_vcr_strict_match.ae
@@ -23,6 +23,7 @@ import std.http
 import std.http.client
 import std.string
 import std.fs
+import std.json
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int

--- a/tests/integration/test_vcr_strict_match_body.ae
+++ b/tests/integration/test_vcr_strict_match_body.ae
@@ -16,6 +16,7 @@ import std.http
 import std.http.client
 import std.string
 import std.fs
+import std.json
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int


### PR DESCRIPTION
## Summary

- Two thin wrappers on top of v2 + `std.json`: `client.post_json(url, value)` and `client.response_body_json(resp)`. Pure Aether, no new C externs.
- Three new test cases (#8/#9/#10) in `tests/integration/test_http_client_v2.ae`: post_json round-trip, response_body_json happy path, response_body_json on malformed JSON.
- README updated with a worked example.

Closes #240.

## What landed

```ae
client.post_json(url, value)      -> (resp, err)
client.response_body_json(resp)   -> (value, err)
```

`post_json` marshals via `json.stringify`, sets `Content-Type` + `Accept` to `application/json`, fires through `send_request`, returns the same `(resp, err)` shape — caller still drives non-2xx status interpretation. `response_body_json` wraps `response_body` + `json.parse`, returning `(value, "")` on success or `(null, parse_error)` when the body isn't valid JSON.

## Side benefit: PR #238's type-inference fix is paying off

The cross-module tuple destructure pattern was a recurring footgun during the C→Aether VCR port — `parsed, err = json.parse(s)` inside a function called from another module would produce `'json.parse' returns 'UNKNOWN', not a tuple` errors that needed structural workarounds (inlining, dropping `-> {` annotations).

The new test cases use this pattern heavily (`parsed8, perr8 = client.response_body_json(resp8)`, `echoed_ct, sctterr = json.get_string(ct_node)`, etc.) and compile clean first try. `compiler_notes_from_vcr_port.md` is updated to mark notes #3 (actor state-type fragility) and #5 (tuple return-type annotation) as `[RESOLVED 2026-04-26 in PR #238]`.

Notes #1 (interpolation buffer recycling) and #2 (if-branch scope leak) are still open and have repros in this branch's diff history.

## Cascade

Importing `std.http.client` now transitively requires `std.json` knowledge in any file that imports the client module — the merger walks the module's body and sees `json.stringify` / `json.parse` references. Six existing tests under `tests/integration/` and `contrib/climate_http_tests/` gained an `import std.json` line. Same shape as the `std.fs` cascade during the VCR port; a transitive-import resolver (issue would be filed if it isn't already) would eliminate this.

## Test plan

- [ ] Buildkite CI green on Linux (GCC + Clang)
- [ ] All 10 v2 client cases pass (the 7 from before + 3 new)
- [ ] All 6 VCR integration tests still pass
- [ ] Both climate tests still pass
- [ ] Stdlib archive rebuilds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)