### PR TITLE
fix(test-ae): invoke shell tests via bash, not sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ test-ae: compiler ae stdlib
 	xargs -P $(NPROC) -I{} "$$script" "{}" "$$tmpdir" "$$root"; \
 	for sh_test in $$(find tests/integration -name 'test_*.sh' 2>/dev/null | sort); do \
 		name=$$(echo "$$sh_test" | sed 's|tests/||;s|/|_|g;s|\.sh$$||'); \
-		if sh "$$sh_test" >"$$tmpdir/run_$$name.out" 2>"$$tmpdir/run_$$name.err"; then \
+		if bash "$$sh_test" >"$$tmpdir/run_$$name.out" 2>"$$tmpdir/run_$$name.err"; then \
 			echo "  [PASS] $$name"; touch "$$tmpdir/PASS_$$name"; \
 		else \
 			echo "  [FAIL] $$name (shell test)"; \


### PR DESCRIPTION
## Summary

Fixes Buildkite failure reported on the self-hosted Linux NUC:

\`\`\`
tests/integration/tuple_destructure_cross_module/test_tuple_destructure_cross_module.sh:
27: set: Illegal option -o pipefail
\`\`\`

The script's shebang is \`#!/bin/bash\` (it uses \`set -euo pipefail\`, heredoc-with-quoted-marker, \`\$(cd \"\$(dirname \"\$0\")\" ...)\` ). But the test runner at \`Makefile:362\` executed it via \`sh \"\$\$sh_test\"\`. On the Buildkite container \`/bin/sh\` is dash, which doesn't understand \`-o pipefail\`.

The test passed locally because most distros symlink \`sh\` → \`bash\`, and on GHA Linux the same. Broke only on the self-hosted NUC where \`sh\` is genuinely dash.

## Fix

Respect the shebang. Run the test under \`bash\` instead of \`sh\`. Bash is ambient on every Linux container (and the Makefile already uses it explicitly at line 1340 for \`contrib/aether_ui/tests/test_driver.sh\`), so no new dependency.

## Repro confirmed locally

\`\`\`
\$ sh tests/integration/tuple_destructure_cross_module/...sh
set: Illegal option -o pipefail

\$ bash tests/integration/tuple_destructure_cross_module/...sh
PASS
\`\`\`

After the fix, \`make test-ae\` picks up the test as a \`[PASS]\` and the full sweep is zero-FAIL.

## Test plan

- [ ] Buildkite green on the self-hosted NUC (the one that previously failed)
- [ ] \`make test-ae\` zero-FAIL locally
- [ ] No regression in any other shell test (the change applies to every \`tests/integration/test_*.sh\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)