### PR TITLE
docs: catch-up stdlib-reference + stdlib-api + README on past week's work

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,33 +235,45 @@ aether/
 │   ├── memory/        # Arena allocators, memory pools, batch allocation
 │   ├── scheduler/     # Multi-core scheduler + cooperative single-threaded backend
 │   └── utils/         # CPU detection, SIMD, tracing, thread portability
-├── std/               # Standard library
-│   ├── string/       # String operations
-│   ├── file/         # File operations (open, read, write, delete)
-│   ├── dir/          # Directory operations (create, delete, list)
-│   ├── path/         # Path utilities (join, basename, dirname)
-│   ├── fs/           # Combined file/dir/path module
-│   ├── collections/  # List, HashMap, Vector, Set, PQueue
-│   ├── list/         # Dynamic array (ArrayList)
-│   ├── map/          # Hash map
-│   ├── json/         # JSON parser and builder
-│   ├── http/         # HTTP client and server
-│   ├── tcp/          # TCP client and server
-│   ├── net/          # Combined TCP/HTTP networking module
-│   ├── math/         # Math functions and random numbers
-│   ├── io/           # Console I/O, environment variables
-│   ├── os/           # Shell execution, command capture, env vars
-│   └── log/          # Structured logging
-├── tools/            # Developer tools
-│   ├── ae.c          # Unified CLI tool (ae command)
-│   └── apkg/         # Project tooling, TOML parser
-├── tests/            # Test suite (runtime, syntax, integration)
-├── examples/         # Example programs (.ae files)
-│   ├── basics/       # Hello world, variables, arrays, etc.
-│   ├── actors/       # Actor patterns (ping-pong, pipeline, etc.)
-│   └── applications/ # Complete applications
-├── docs/            # Documentation
-└── docker/          # Docker (CI, dev, WASM, embedded)
+├── std/                # Standard library
+│   ├── string/         # String operations
+│   ├── file/           # File operations (open, read, write, delete)
+│   ├── dir/            # Directory operations (create, delete, list)
+│   ├── path/           # Path utilities (join, basename, dirname)
+│   ├── fs/             # Combined file/dir/path module
+│   ├── collections/    # List, HashMap, Vector, Set, PQueue
+│   ├── list/           # Dynamic array (ArrayList)
+│   ├── map/            # Hash map
+│   ├── intarr/         # Fixed-size packed int buffer
+│   ├── json/           # JSON parser and builder
+│   ├── http/           # v1 HTTP client + server
+│   │   ├── client/     # v2 client (request builder, full response, JSON sugar)
+│   │   └── server/vcr/ # Servirtium-format record/replay for HTTP tests
+│   ├── tcp/            # TCP client and server
+│   ├── net/            # Combined TCP/HTTP networking module
+│   ├── cryptography/   # SHA-1, SHA-256
+│   ├── zlib/           # One-shot deflate/inflate
+│   ├── math/           # Math functions and random numbers
+│   ├── io/             # Console I/O, environment variables
+│   ├── os/             # Shell execution, command capture, env vars, ISO-8601 time
+│   └── log/            # Structured logging
+├── contrib/            # Optional / opinionated modules outside std/
+│   ├── sqlite/         # SQLite bindings (open, prepare, bind, step, column, ...)
+│   ├── tinyweb/        # Server-side request/response DSL
+│   ├── aether_ui/      # GTK4 / AppKit / Win32 widget toolkit
+│   ├── aeocha/         # Test framework
+│   ├── host/<lang>/    # Embed Lua, Python, Perl, Ruby, Tcl, JS in-process
+│   └── climate_http_tests/ # Servirtium climate-API record/replay fixtures
+├── tools/              # Developer tools
+│   ├── ae.c            # Unified CLI tool (ae command)
+│   └── apkg/           # Project tooling, TOML parser
+├── tests/              # Test suite (runtime, syntax, integration, regression)
+├── examples/           # Example programs (.ae files)
+│   ├── basics/         # Hello world, variables, arrays, etc.
+│   ├── actors/         # Actor patterns (ping-pong, pipeline, etc.)
+│   └── applications/   # Complete applications
+├── docs/               # Documentation
+└── docker/             # Docker (CI, dev, WASM, embedded)
 ```
 
 ## Language Example

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -458,6 +458,33 @@ All documented in [stdlib-module-pattern.md](stdlib-module-pattern.md).
 - `JSON_ARRAY` = 4
 - `JSON_OBJECT` = 5
 
+### What `std.json` doesn't do
+
+Coming from Go's `json.Unmarshal`, Java's Jackson, Python's `json.load` + dataclasses, or C#'s `JsonSerializer`, expect to do more by hand:
+
+- **No struct ↔ JSON mapping.** Aether has no runtime reflection — no `instanceof`, no `T.GetType()`, no `reflect.TypeOf` — so a library function that takes a struct type and a JSON tree and populates the struct fields can't exist as a stdlib API. Callers walk the tree by hand: `json.object_get(v, "name")` then `json.get_string(...)`, repeated per field. For tree-shaped or dynamically-shaped JSON the Aether code looks similar to other languages; for struct-shaped JSON it's more verbose. A future codegen step (a `--derive-json` flag on struct definitions, or a build-step macro) could close this gap without runtime reflection, but isn't shipped today.
+- **No annotations / struct tags.** `@JsonProperty("user_name")`, Go struct tags `json:"user_name,omitempty"`, etc. don't apply — there's nothing for them to attach to without struct-mapping in the first place.
+- **No streaming parse.** The whole document is buffered into the arena before the tree is walkable. For multi-gigabyte JSON, use a different tool. Documents into the tens of MB are fine.
+- **No JSON5 / comments / trailing commas.** Strict RFC 8259 only.
+- **No pretty-print on stringify.** Compact output only. Wrap with a separate prettier if you need one.
+- **No JSON Schema validation.** Validate by hand or build it on top.
+- **No arbitrary-precision numbers.** Numbers are `int` or `double`; the parser auto-falls-through to `strtod` for correctly-rounded IEEE-754 on edge cases (16+ significant digits, huge exponents) but there's no `BigDecimal` / `decimal.Decimal` equivalent for financial precision.
+- **Hard-coded depth limit of 256.** DoS protection against deeply nested JSON bombs; not configurable. Rare to hit in practice.
+
+### Other structured-data formats
+
+Beyond JSON, the stdlib has **no built-in support** for:
+
+- **YAML** — no parser. The runtime is single-language, so configuration files for Aether projects use TOML (read by the build tool internally — not a user-facing stdlib module) or hand-rolled formats.
+- **XML** — no parser. The Servirtium climate-API replay tests parse XML by hand from the WorldBank API responses (substring-extract `<double>...</double>` values from a known-shape body), not via a real DOM/SAX surface.
+- **TOML** — there's a parser at `tools/apkg/toml_parser.c` used internally by the `ae` CLI to read `aether.toml` project files. It's not exposed as `std.toml`. If a project needs TOML, copying that parser or shelling out to a host-language tool are the options today.
+- **INI** — no parser. Trivial to implement on top of `string.split` if needed.
+- **Java-style `.properties`** — no parser. Same shape as INI without sections; same advice.
+- **CSV** — no parser. `string.split(line, ",")` covers the no-quoting / no-embedded-commas case; anything more needs a real CSV parser, which isn't shipped.
+- **Protocol Buffers / MessagePack / CBOR / Avro / Thrift** — no codecs. Same reflection-gap reasoning as struct ↔ JSON: without struct introspection there's no automatic encode/decode, and a hand-written codec on top of `tcp.write` / `tcp.read` / `aether_string_data` is what you'd build.
+
+This isn't a hidden roadmap — these are absent because no downstream user has driven the need yet. If you're starting a project that needs YAML config, expect to write a parser, ship a contrib module, or shell out. The structured-data thinking in the stdlib is currently JSON-shaped and HTTP-adjacent; broader format coverage is open territory.
+
 ---
 
 ## Networking Library
@@ -542,6 +569,89 @@ main() {
 - `http.response_set_header(res, name, value)` - Set header
 
 Raw externs: `http_server_bind_raw`, `http_server_start_raw`.
+
+### HTTP Client Builder (`std.http.client`)
+
+Builder-shaped requests with full response access. The `http.get` / `http.post` / `http.put` / `http.delete` one-liners above are good for "no auth, JSON in, 200 means good" calls; reach for `std.http.client` when you need custom request headers, response-header capture, status discrimination, per-request timeouts, or methods other than the four common verbs (PROPFIND, PATCH, custom RPC verbs all work). Method is an arbitrary string. Non-2xx is not an error — the caller checks `response_status`.
+
+```aether
+import std.http.client
+
+main() {
+    req = client.request("GET", "https://api.example.com/users/42")
+    client.set_header(req, "Authorization", "Bearer abc123")
+    client.set_timeout(req, 30)
+    resp, err = client.send_request(req)
+    client.request_free(req)
+    if err != "" { return }
+    status = client.response_status(resp)
+    body   = client.response_body(resp)
+    client.response_free(resp)
+}
+```
+
+**Builder + send:**
+- `client.request(method, url)` → `ptr` - Build a request handle
+- `client.set_header(req, name, value)` → `string` - Append a request header
+- `client.set_body(req, body, length, content_type)` → `string` - Set request body (length explicit for binary safety)
+- `client.set_timeout(req, seconds)` → `string` - Per-request timeout (`0` = block forever)
+- `client.send_request(req)` → `(ptr, string)` - Fire it; `(resp, "")` on success, `(null, err)` on transport failure
+- `client.request_free(req)` - Free the request handle
+
+**Response accessors:**
+- `client.response_status(resp)` → `int`
+- `client.response_body(resp)` → `string` (binary-safe AetherString)
+- `client.response_header(resp, name)` → `string` (case-insensitive)
+- `client.response_headers(resp)` → `string` (raw header block)
+- `client.response_error(resp)` → `string`
+- `client.response_free(resp)` - Free the response
+
+**Sugar wrappers** (pure Aether on top of the builder):
+- `client.get_with_headers(url, header_pairs)` → `(string, int, string)`
+- `client.post_with_status(url, body, content_type)` → `(string, int, string)`
+- `client.post_json(url, value)` → `(ptr, string)` - Marshal value via `std.json`, set Content-Type + Accept
+- `client.response_body_json(resp)` → `(ptr, string)` - `response_body` + `json.parse` round-trip
+
+See `std/http/README.md` for design rationale and `tests/integration/test_http_client_v2.ae` for ten worked examples (header round-trip, status discrimination, binary body, timeout, transport failure, JSON sugar, malformed-JSON parse failure).
+
+### HTTP Record/Replay (`std.http.server.vcr`)
+
+Aether's implementation of [Servirtium](https://servirtium.dev) — cross-language record/replay HTTP testing. Tapes are markdown, interoperable with Java/Kotlin/Python/Go implementations of the same framework.
+
+```aether
+import std.http.server.vcr
+import std.http
+extern http_server_start_raw(server: ptr) -> int
+
+message StartVCR { raw: ptr }
+actor VCRActor { state s = 0
+    receive { StartVCR(raw) -> { s = raw; http_server_start_raw(raw) } } }
+
+main() {
+    raw = vcr.load("tests/tapes/my.tape", 18099)
+    a = spawn(VCRActor())
+    a ! StartVCR { raw: raw }
+    sleep(500)
+    body, err = http.get("http://127.0.0.1:18099/things/42")
+    vcr.eject(raw)
+}
+```
+
+**Replay:** `vcr.load(tape_path, port)` / `vcr.eject(server)` / `vcr.tape_length()`.
+
+**Record:** `vcr.record(method, path, status, content_type, body)` / `vcr.record_full(...)` / `vcr.flush(tape_path)` / `vcr.flush_or_check(tape_path)` (re-record byte-diff with `.actual` sibling on mismatch).
+
+**Secret scrubbing** (applied at flush time; in-memory capture stays untouched): `vcr.redact(field, pattern, replacement)` / `vcr.clear_redactions()` with `vcr.FIELD_PATH` and `vcr.FIELD_RESPONSE_BODY` selectors.
+
+**Per-interaction notes:** `vcr.note(title, body)` — record-only `[Note]` markdown block attached to the next interaction.
+
+**Strict request matching:** `vcr.last_error()` / `vcr.clear_last_error()` — tearDown-readable mismatch diagnostics.
+
+**Static content:** `vcr.static_content(mount_path, fs_dir)` / `vcr.clear_static_content()` — bypass-the-tape mounts for Selenium/Cypress assets.
+
+**Markdown format options:** `vcr.emphasize_http_verbs()` / `vcr.indent_code_blocks()` / `vcr.clear_format_options()` — alternative emit forms; playback tolerates either.
+
+Full surface, design notes, and the runnable test suite live in `std/http/README.md`.
 
 ### TCP Sockets (Go-style)
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -567,6 +567,32 @@ Raw extern: `json_parse_raw`.
 - `json.create_null()`, `json.create_bool(value)`, `json.create_number(value)`
 - `json.create_string(value)`, `json.create_array()`, `json.create_object()`
 
+### What `std.json` doesn't do
+
+Coming from Go's `json.Unmarshal`, Java's Jackson, Python's `json.load` + dataclasses, or C#'s `JsonSerializer`, expect to do more by hand:
+
+- **No struct ↔ JSON mapping.** Aether has no runtime reflection — no `instanceof`, no `T.GetType()`, no `reflect.TypeOf` — so a library function that takes a struct type and a JSON tree and populates the struct fields can't exist as a stdlib API. Callers walk the tree by hand: `json.object_get(v, "name")` then `json.get_string(...)`, repeated per field. For tree-shaped or dynamically-shaped JSON the Aether code looks similar to other languages; for struct-shaped JSON it's more verbose. A future codegen step (a `--derive-json` flag on struct definitions, or a build-step macro) could close this gap without runtime reflection, but isn't shipped today.
+- **No annotations / struct tags.** `@JsonProperty("user_name")`, Go struct tags `json:"user_name,omitempty"`, etc. don't apply — there's nothing for them to attach to without struct-mapping in the first place.
+- **No streaming parse.** The whole document is buffered into the arena before the tree is walkable. For multi-gigabyte JSON, use a different tool. Documents into the tens of MB are fine.
+- **No JSON5 / comments / trailing commas.** Strict RFC 8259 only.
+- **No pretty-print on stringify.** Compact output only. Wrap with a separate prettier if you need one.
+- **No JSON Schema validation.** Validate by hand or build it on top.
+- **No arbitrary-precision numbers.** Numbers are `int` or `double`; the parser falls through to `strtod` for correctly-rounded IEEE-754 on edge cases but there's no `BigDecimal` / `decimal.Decimal` equivalent for financial precision.
+
+### Other structured-data formats
+
+Beyond JSON, the stdlib has **no built-in support** for:
+
+- **YAML** — no parser. Configuration files for Aether projects use TOML (read by the build tool internally — not a user-facing stdlib module) or hand-rolled formats.
+- **XML** — no parser. The Servirtium climate-API replay tests parse XML by hand from the WorldBank API responses (substring-extract `<double>...</double>` values from a known-shape body), not via a real DOM/SAX surface.
+- **TOML** — there's a parser at `tools/apkg/toml_parser.c` used internally by the `ae` CLI to read `aether.toml` project files. It's not exposed as `std.toml`. If a project needs TOML, copying that parser or shelling out to a host-language tool are the options today.
+- **INI** — no parser. Trivial to implement on top of `string.split` if needed.
+- **Java-style `.properties`** — no parser. Same shape as INI without sections; same advice.
+- **CSV** — no parser. `string.split(line, ",")` covers the no-quoting / no-embedded-commas case; anything more needs a real CSV parser, which isn't shipped.
+- **Protocol Buffers / MessagePack / CBOR / Avro / Thrift** — no codecs. Same reflection-gap reasoning as struct ↔ JSON: without struct introspection there's no automatic encode/decode.
+
+This isn't a hidden roadmap — these are absent because no downstream user has driven the need yet. If you're starting a project that needs YAML config, expect to write a parser, ship a contrib module, or shell out. Structured-data thinking in the stdlib is currently JSON-shaped and HTTP-adjacent; broader format coverage is open territory.
+
 ---
 
 ## Cryptography (`std.cryptography`)
@@ -729,6 +755,124 @@ Raw externs: `http_server_bind_raw`, `http_server_start_raw`.
 - `http.response_set_body(res, body)` - Set response body
 - `http.response_json(res, json)` - Set JSON response
 - `http.server_response_free(res)` - Free response
+
+### HTTP Client Builder (`std.http.client`)
+
+The `http.get` / `http.post` / `http.put` / `http.delete` one-liners above are good for "no auth, JSON in, 200 means good" calls. Reach for `std.http.client` when you need custom request headers, response-header capture, status discrimination, per-request timeouts, or methods other than the four common verbs (PROPFIND, PATCH, custom RPC verbs all work).
+
+Non-2xx is **not** an error from `send_request`'s perspective — the caller branches on `response_status`. Transport-level failures (DNS, connect, TLS handshake, timeout) populate the `err` slot.
+
+```aether
+import std.http
+import std.http.client
+
+main() {
+    req = client.request("GET", "https://api.example.com/users/42")
+    client.set_header(req, "Authorization", "Bearer abc123")
+    client.set_header(req, "Accept",        "application/json")
+    client.set_timeout(req, 30)
+
+    resp, err = client.send_request(req)
+    client.request_free(req)
+    if err != "" {
+        println("transport: ${err}")
+        return
+    }
+
+    status = client.response_status(resp)        // 200, 404, ...
+    body   = client.response_body(resp)          // binary-safe AetherString
+    etag   = client.response_header(resp, "ETag") // case-insensitive lookup
+    client.response_free(resp)
+}
+```
+
+**Builder + send:**
+- `client.request(method, url)` → `ptr` - Build a request handle (method as arbitrary string)
+- `client.set_header(req, name, value)` → `string` - Append `Name: value` to outgoing headers
+- `client.set_body(req, body, length, content_type)` → `string` - Set request body (length explicit so binary payloads with embedded NULs survive)
+- `client.set_timeout(req, seconds)` → `string` - Per-request timeout (`0` = block forever)
+- `client.send_request(req)` → `(ptr, string)` - Fire the request; returns `(resp, "")` on transport success or `(null, err)` on failure
+- `client.request_free(req)` - Free the request handle
+
+**Response accessors:**
+- `client.response_status(resp)` → `int` - HTTP status code
+- `client.response_body(resp)` → `string` - Response body, binary-safe
+- `client.response_header(resp, name)` → `string` - Case-insensitive single-header lookup, `""` if absent
+- `client.response_headers(resp)` → `string` - Raw header block
+- `client.response_error(resp)` → `string` - Transport error string
+- `client.response_free(resp)` - Free the response
+
+**Sugar wrappers** (pure Aether on top of the builder, no new C externs):
+- `client.get_with_headers(url, header_pairs)` → `(string, int, string)` - GET with auth/whatever headers; returns `(body, status, err)`
+- `client.post_with_status(url, body, content_type)` → `(string, int, string)` - POST and inspect status
+- `client.post_json(url, value)` → `(ptr, string)` - Marshal a JSON value (`std.json`), set `Content-Type` + `Accept` to `application/json`, send
+- `client.response_body_json(resp)` → `(ptr, string)` - Wrap `response_body` + `json.parse`; returns `(value, "")` on success or `(null, parse_error)` on malformed JSON
+
+Full design notes live in `std/http/README.md` (why `method: string`, why non-2xx-is-not-an-error, why `send_request` not `send`); `tests/integration/test_http_client_v2.ae` is the runnable example file.
+
+### HTTP record/replay (`std.http.server.vcr`)
+
+`std.http.server.vcr` is Aether's implementation of [Servirtium](https://servirtium.dev), the cross-language record/replay HTTP testing framework. Tapes are markdown — interoperable with the Java/Kotlin/Python/Go implementations, so a tape recorded by any of them is replayable here.
+
+The metaphor: a VCR is the device, a tape is the medium, `record` / `replay` are the operations. Use cases: pin upstream API behavior, test against a real API once and forever offline, scrub secrets at flush time, run UI tests offline with static-content mounts.
+
+```aether
+import std.http.server.vcr
+import std.http
+import std.http.client
+
+extern http_server_start_raw(server: ptr) -> int
+
+message StartVCR { raw: ptr }
+actor VCRActor { state s = 0
+    receive { StartVCR(raw) -> { s = raw; http_server_start_raw(raw) } } }
+
+main() {
+    raw = vcr.load("tests/tapes/my.tape", 18099)
+    a = spawn(VCRActor())
+    a ! StartVCR { raw: raw }
+    sleep(500)
+
+    // SUT now drives http://127.0.0.1:18099 — every call served from the tape.
+    body, err = http.get("http://127.0.0.1:18099/things/42")
+
+    vcr.eject(raw)
+}
+```
+
+**Replay (load + serve):**
+- `vcr.load(tape_path, port)` - Parse tape, bind a server, register routes
+- `vcr.eject(server)` - Stop the server
+- `vcr.tape_length()` → `int` - How many interactions the tape carries
+
+**Record (capture + flush):**
+- `vcr.record(method, path, status, content_type, body)` → `string` - Capture an interaction
+- `vcr.record_full(method, path, status, content_type, body, req_headers, req_body)` → `string` - Capture with strict-match metadata
+- `vcr.flush(tape_path)` → `string` - Write captured interactions to disk
+- `vcr.flush_or_check(tape_path)` → `string` - Re-record byte-diff against an existing tape; leaves a `.actual` sibling on disk if the on-disk tape has drifted
+
+**Secret scrubbing** (applied at flush time; in-memory capture stays untouched):
+- `vcr.redact(field, pattern, replacement)` → `string` - Replace pattern in field
+- `vcr.clear_redactions()` - Drop all registered redactions
+- `vcr.FIELD_PATH`, `vcr.FIELD_RESPONSE_BODY` - Field selectors
+
+**Per-interaction notes:**
+- `vcr.note(title, body)` → `string` - Stage a `[Note]` block; attaches to the next interaction recorded
+
+**Strict request matching:**
+- `vcr.last_error()` → `string` - Most recent dispatch mismatch diagnostic, surfaced to the test's tearDown
+- `vcr.clear_last_error()` - Drop the last-error slot
+
+**Static-content mounts** (bypass-the-tape territory for Selenium/Cypress assets):
+- `vcr.static_content(mount_path, fs_dir)` → `string` - Mark an on-disk dir as bypass-the-tape
+- `vcr.clear_static_content()` - Drop all mounts
+
+**Markdown format options:**
+- `vcr.emphasize_http_verbs()` - Emit `*GET*` instead of bare `GET` in interaction headings
+- `vcr.indent_code_blocks()` - Emit 4-space-indented blocks instead of triple-backtick fences
+- `vcr.clear_format_options()` - Reset to defaults
+
+The full surface and design notes live in `std/http/README.md`. Hostile-tape compatibility fixtures from servirtium/README's `broken_recordings/` are checked in under `tests/integration/tapes/` and exercised by the strict-match integration tests.
 
 ### TCP (`std.tcp`)
 


### PR DESCRIPTION
## Summary

The past week shipped a lot of stdlib that the formal docs hadn't absorbed. \`docs/stdlib-reference.md\` and \`docs/stdlib-api.md\` only mentioned the v1 HTTP wrappers; \`README.md\`'s Project Structure block was missing several modules and \`contrib/\` entirely.

Surfaced as a real gap by [@TG0's review](https://github.com/nicolasmd87/aether/issues/240#issuecomment-4321406255) on issue #240 — concrete item already tracked in #247. This PR closes it.

## What landed in docs

### \`docs/stdlib-reference.md\`
Two new sections under Networking, after the existing HTTP block:
- **HTTP Client v2** (\`std.http.client\`) — request builder, set_header / set_body / set_timeout / send_request, response accessors (status / body / header / headers / error / free), and the v2.1 sugar (\`get_with_headers\`, \`post_with_status\`, \`post_json\`, \`response_body_json\`). Includes worked example, design rationale (\`method: string\`, non-2xx-not-an-error, binary-safe bodies), and pointer to \`std/http/README.md\` for the full design notes.
- **HTTP Record/Replay** (\`std.http.server.vcr\`) — full Servirtium step 1-12 surface broken out by feature: replay, record, mutations (redactions), notes, strict matching, static content, format toggles. Includes the standard quick-start replay example with the actor-based server lifecycle.

### \`docs/stdlib-api.md\`
Same coverage in the more compact \"API reference\" style this file uses. Function-by-function tables for v2 client builder, response accessors, v2.1 sugar; VCR feature blocks per Servirtium step. Cross-references \`tests/integration/test_http_client_v2.ae\` as the worked-example file.

### \`README.md\`
Project Structure block repaired:
- \`std/http/\` now shows \`client/\` and \`server/vcr/\` subdirs
- \`std/intarr/\`, \`std/cryptography/\`, \`std/zlib/\` added to \`std/\`'s listing
- \`std/os/\` description includes ISO-8601 time
- New \`contrib/\` block (was completely missing): sqlite, tinyweb, aether_ui, aeocha, host/<lang>, climate_http_tests

## What's NOT in this PR

- No code change. Pure docs.
- No CHANGELOG entry — the underlying features each had their own changelog entries when shipped; this is a docs catch-up, not a new feature.
- No tutorials updated — that's a bigger scope. \`docs/tutorial.md\` covers core language; the new stdlib modules don't yet have tutorial-level walkthroughs (separate question).
- Issue #247 can be closed once this merges; the \"end-user docs gating policy\" question TG0 raised is still its own discussion.

## Test plan

- [x] No code change → no test runs needed
- [x] Markdown rendering checked locally
- [ ] Reviewer eyeballs the new sections for accuracy against the actual surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)