### PR TITLE
fix: head/patch wrappers (#241) + per-symbol/namespace import coexistence (#252)

### DIFF
--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -262,6 +262,15 @@ static int selective_import_modules_count = 0;
 // the non-selective import semantics.
 static char* selective_import_modules[MAX_SELECTIVE_IMPORTS];
 
+// Tracks namespaces that ALSO have a non-selective import in the same
+// file. When both forms coexist (`import std.fs.file_exists` followed
+// by `import std.fs`), the non-selective form makes the whole namespace
+// accessible — the per-symbol form just adds bare-name binding.
+// Without this, is_selective_import_blocked rejected fs.read because
+// fs had a filter from the per-symbol import. Issue #252.
+static char* nonselective_import_modules[MAX_SELECTIVE_IMPORTS];
+static int nonselective_import_modules_count = 0;
+
 static void selective_import_reset(void) {
     for (int i = 0; i < selective_import_count; i++) {
         free(selective_imports[i].namespace);
@@ -272,6 +281,26 @@ static void selective_import_reset(void) {
         free(selective_import_modules[i]);
     }
     selective_import_modules_count = 0;
+    for (int i = 0; i < nonselective_import_modules_count; i++) {
+        free(nonselective_import_modules[i]);
+    }
+    nonselective_import_modules_count = 0;
+}
+
+static void selective_import_mark_nonselective(const char* ns) {
+    for (int i = 0; i < nonselective_import_modules_count; i++) {
+        if (strcmp(nonselective_import_modules[i], ns) == 0) return;
+    }
+    if (nonselective_import_modules_count < MAX_SELECTIVE_IMPORTS) {
+        nonselective_import_modules[nonselective_import_modules_count++] = strdup(ns);
+    }
+}
+
+static int has_nonselective_import(const char* ns) {
+    for (int i = 0; i < nonselective_import_modules_count; i++) {
+        if (strcmp(nonselective_import_modules[i], ns) == 0) return 1;
+    }
+    return 0;
 }
 
 static void selective_import_mark_module(const char* ns) {
@@ -300,10 +329,17 @@ static int module_has_selective_filter(const char* ns) {
 }
 
 // Returns 1 if the user wrote a selective import for `ns` AND `func_name`
-// is not in the selection list. Returns 0 when there's no filter or when
-// the name is in the list. Used only at qualified-call sites.
+// is not in the selection list. Returns 0 when there's no filter, when
+// the name is in the list, or when the user *also* wrote a non-selective
+// import of the same namespace (in which case the whole namespace is
+// accessible — the per-symbol form just adds the bare-name binding).
+// Used only at qualified-call sites.
 static int is_selective_import_blocked(const char* ns, const char* func_name) {
     if (!module_has_selective_filter(ns)) return 0;
+    // If a non-selective import exists for this namespace, it overrides
+    // the filter — fs.read should resolve when both `import std.fs.file_exists`
+    // and `import std.fs` are present. Issue #252.
+    if (has_nonselective_import(ns)) return 0;
     for (int i = 0; i < selective_import_count; i++) {
         if (strcmp(selective_imports[i].namespace, ns) == 0 &&
             strcmp(selective_imports[i].func_name, func_name) == 0) {
@@ -1251,9 +1287,16 @@ int typecheck_program(ASTNode* program) {
                     // so qualified calls to functions not in it get rejected.
                     // Does not affect unqualified resolution inside merged
                     // stdlib function bodies.
+                    //
+                    // Otherwise (non-selective), mark the namespace as
+                    // having full access — required so a non-selective
+                    // import after a per-symbol import of the same module
+                    // gives the whole namespace back. Issue #252.
+                    int is_selective = 0;
                     if (child->child_count > 0) {
                         ASTNode* first_sel = child->children[0];
                         if (first_sel && first_sel->type == AST_IDENTIFIER) {
+                            is_selective = 1;
                             for (int sk = 0; sk < child->child_count; sk++) {
                                 ASTNode* sel = child->children[sk];
                                 if (sel && sel->type == AST_IDENTIFIER && sel->value) {
@@ -1261,6 +1304,9 @@ int typecheck_program(ASTNode* program) {
                                 }
                             }
                         }
+                    }
+                    if (!is_selective) {
+                        selective_import_mark_nonselective(module_name);
                     }
 
                     // Look up cached module from orchestrator

--- a/std/http/client/module.ae
+++ b/std/http/client/module.ae
@@ -58,7 +58,8 @@ exports (
     response_status, response_body, response_error,
     response_header, response_headers, response_free,
     get_with_headers, post_with_status,
-    post_json, response_body_json
+    post_json, response_body_json,
+    head, patch
 )
 
 // ---- Raw externs ----
@@ -303,4 +304,59 @@ post_json(url: string, value: ptr) -> {
 response_body_json(resp: ptr) -> {
     body = response_body(resp)
     return json.parse(body)
+}
+
+// HEAD a URL. Returns (status, headers_block, err) — HEAD responses
+// have no body by spec, so a dedicated wrapper saves the caller from
+// the request-handle-and-response-free dance for the common
+// "does this URL exist / what's Content-Length / Content-Type"
+// use case.
+//
+// `headers_block` is the raw header text (\r\n-separated "Name: value"
+// lines), same shape as response_headers() returns. Callers wanting
+// a single value can use string.contains / string.index_of, or fall
+// back to the request builder + response_header(resp, name) for
+// case-insensitive single-header lookup. (Issue #241 originally
+// proposed a typed map; we don't have a string→string map shape in
+// the language today that composes with the raw-text-block accessor,
+// so the string form keeps the wrapper one-line and lets callers
+// grep — same trade-off get_with_headers / post_with_status make.)
+//
+// Implementation note: doesn't use `defer request_free(req)` because
+// the codegen for `defer` + multi-value returns is broken today
+// (issue #254). Instead does manual cleanup at each return site.
+//
+// Closes #241 (HEAD half).
+head(url: string) -> {
+    req = request("HEAD", url)
+    if req == null { return 0, "", "request build failed" }
+    set_timeout(req, 30)
+    resp, err = send_request(req)
+    if err != "" {
+        request_free(req)
+        return 0, "", err
+    }
+    status = response_status(resp)
+    headers = response_headers(resp)
+    headers_copy = string_concat(headers, "")
+    response_free(resp)
+    request_free(req)
+    return status, headers_copy, ""
+}
+
+// PATCH (RFC 5789) — partial-update verb common in REST APIs
+// (GitHub, GitLab, Stripe). Same shape as send_request. Body
+// length is computed from the string; binary payloads with
+// embedded NULs need the bare builder + set_body(..., explicit_length).
+//
+// Closes #241 (PATCH half).
+patch(url: string, body: string, content_type: string) -> {
+    req = request("PATCH", url)
+    if req == null { return null, "request build failed" }
+    set_timeout(req, 30)
+    body_len = string_length(body)
+    set_body(req, body, body_len, content_type)
+    resp, err = send_request(req)
+    request_free(req)
+    return resp, err
 }

--- a/tests/integration/test_http_client_v2.ae
+++ b/tests/integration/test_http_client_v2.ae
@@ -111,6 +111,27 @@ handle_json_broken(req: ptr, res: ptr, ud: ptr) {
     http.response_set_body(res, "this is not { valid json")
 }
 
+// HEAD/PATCH handlers (issue #241). /head-target sets Content-Length
+// and an X-Marker header so the test can verify head() returns the
+// raw header block. /patch-echo echoes the request method + body
+// back so the test can verify patch() actually fired a PATCH.
+handle_head_target(req: ptr, res: ptr, ud: ptr) {
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "X-Marker", "head-marker-value")
+    http.response_set_header(res, "Content-Length", "42")
+    // No body — HEAD by spec, but the server framework lets us set
+    // one anyway. The client should treat this as headers-only.
+    http.response_set_body(res, "")
+}
+
+handle_patch_echo(req: ptr, res: ptr, ud: ptr) {
+    method = http.request_method(req)
+    body   = http.request_body(req)
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "method=${method} body=${body}")
+}
+
 // ------------------------------------------------------------------
 // Server actor — owns the blocking accept loop. The companion
 // SchedHelper is empty-on-purpose: the multicore scheduler needs
@@ -181,6 +202,8 @@ main() {
     http.server_get (raw, "/slow",                   handle_slow,         0)
     http.server_post(raw, "/json-echo",              handle_json_echo,    0)
     http.server_get (raw, "/json-broken",            handle_json_broken,  0)
+    http.server_add_route(raw, "HEAD",  "/head-target", handle_head_target, 0)
+    http.server_add_route(raw, "PATCH", "/patch-echo",  handle_patch_echo,  0)
 
     // Hand the server to an actor that calls server_start (blocking).
     // SchedHelper spawned first to satisfy the >=2-actor scheduler
@@ -370,6 +393,39 @@ main() {
     }
     client.response_free(resp10)
     print("  PASS: parse error surfaced as '${perr10}'\n")
+
+    // ---- Test 11: head() returns (status, headers, err) tuple ----
+    // Issue #241. /head-target sets X-Marker and Content-Length;
+    // the wrapper should hand back the header block as a string.
+    print("\nTest 11: head() shorthand\n")
+    h_status, h_headers, h_err = client.head("${base_url()}/head-target")
+    if h_err != "" { println("  FAIL transport: ${h_err}"); exit(1) }
+    if h_status != 200 { println("  FAIL status ${h_status}"); exit(1) }
+    if string.contains(h_headers, "X-Marker: head-marker-value") != 1 {
+        println("  FAIL headers missing X-Marker; got '${h_headers}'")
+        exit(1)
+    }
+    print("  PASS: 200 + X-Marker present\n")
+
+    // ---- Test 12: patch() sends PATCH method, echoed by server ----
+    // Issue #241. /patch-echo echoes "method=PATCH body=...".
+    print("\nTest 12: patch() shorthand\n")
+    p_resp, p_err = client.patch("${base_url()}/patch-echo",
+                                 "patch-payload", "text/plain")
+    if p_err != "" { println("  FAIL transport: ${p_err}"); exit(1) }
+    p_body = client.response_body(p_resp)
+    p_status = client.response_status(p_resp)
+    if p_status != 200 { println("  FAIL status ${p_status}"); exit(1) }
+    if string.contains(p_body, "method=PATCH") != 1 {
+        println("  FAIL: expected method=PATCH; got '${p_body}'")
+        exit(1)
+    }
+    if string.contains(p_body, "body=patch-payload") != 1 {
+        println("  FAIL: expected body=patch-payload; got '${p_body}'")
+        exit(1)
+    }
+    client.response_free(p_resp)
+    print("  PASS: PATCH method + body round-tripped\n")
 
     print("\n=== All std.http.client v2 tests passed ===\n")
     // Explicit exit because the SrvActor's accept loop would

--- a/tests/regression/test_per_symbol_namespace_coexist.ae
+++ b/tests/regression/test_per_symbol_namespace_coexist.ae
@@ -1,0 +1,54 @@
+// Regression for issue #252: per-symbol import + namespace import
+// of the same module both work in the same file.
+//
+// Pre-fix: `import std.fs.file_exists` (parser-rewritten to
+// selective form `import std.fs (file_exists)`) registered fs as
+// having a selective filter. A subsequent qualified call like
+// `fs.read("...")` was rejected by is_selective_import_blocked
+// even when the user *also* added `import std.fs` to restore the
+// full namespace.
+//
+// Fix in compiler/analysis/typechecker.c: track non-selective
+// imports separately and use them as an override in the blocking
+// check.
+//
+// Note: this regression doesn't cover the `import std.fs` alone
+// case (no per-symbol form) — that path has always worked. The
+// regression is specifically the *coexistence* of both forms.
+
+import std.fs.file_exists
+import std.fs
+import std.string
+
+extern exit(code: int)
+
+// Write a small file so the test isn't dependent on host filesystem
+// state. /tmp is universally writable on every CI runner we use.
+main() {
+    werr = fs.write("/tmp/per_symbol_repro_marker", "marker\n")
+    if werr != "" {
+        println("FAIL: setup write: ${werr}")
+        exit(1)
+    }
+
+    // Per-symbol form: file_exists callable bare.
+    if file_exists("/tmp/per_symbol_repro_marker") != 1 {
+        println("FAIL: file_exists should be 1 on the file we just wrote")
+        exit(1)
+    }
+
+    // Namespace form: fs.read callable through the namespace.
+    // Pre-fix this E0301'd; that's the regression we're guarding.
+    contents, rerr = fs.read("/tmp/per_symbol_repro_marker")
+    if rerr != "" {
+        println("FAIL: fs.read: ${rerr}")
+        exit(1)
+    }
+    if string.length(contents) != 7 {
+        println("FAIL: expected 7 bytes, got ${string.length(contents)}")
+        exit(1)
+    }
+
+    fs.delete("/tmp/per_symbol_repro_marker")
+    println("PASS")
+}


### PR DESCRIPTION
## Summary

Two small fixes bundled in one PR to reduce CI cost:

- **Closes #241** — `client.head(url)` and `client.patch(url, body, content_type)` sugar wrappers in `std.http.client`. Pure Aether on top of the v2 builder, no new C externs.
- **Closes #252** — `import std.fs.file_exists` no longer shadows a same-module `import std.fs`. Both forms now coexist in the same file.

Also retroactively closes (no code, comment-only):
- **#247** — docs catch-up was already done in PR #248
- **#251** — stdlib archive timestamps couldn't reproduce; was a misread of a C-side rebuild requirement during the VCR port

## Issue #241 — head() and patch()

```ae
status, headers_block, err = client.head(url)
resp, err = client.patch(url, body, content_type)
```

`head()` returns the raw header block as a string (saves the caller from the request-handle-and-response-free dance for the common "does this URL exist / what's Content-Length / Content-Type" use case). `patch()` matches `send_request`'s `(resp, err)` shape — same as `post()` would.

Implementation deviation from the issue: I'd planned to use `defer request_free(req)` for cleanup, but the codegen for `defer` + multi-value return is broken — emits `_builder_ret` of the first slot's type instead of the tuple type. Filed as #254. Manual cleanup-at-each-return-site instead, with an inline comment pointing at the issue.

## Issue #252 — per-symbol + namespace coexistence

Pre-fix:

```ae
import std.fs.file_exists   // OK on its own
import std.fs               // also OK on its own
main() {
    if file_exists("foo") == 1 { ... }       // resolves
    contents, err = fs.read("bar")            // E0301: Undefined function 'fs.read'
}
```

The per-symbol import marked `fs` as having a selective filter. A subsequent `fs.read(...)` was rejected by `is_selective_import_blocked` because the filter was still active even though the user *also* wrote a non-selective import to restore full namespace access.

Fix: track non-selective imports separately, use them as an override in the blocking check. ~30 LOC in `compiler/analysis/typechecker.c`. The selective-import allowlist still applies when only the per-symbol form is used (existing behavior preserved).

## Tests

- `tests/integration/test_http_client_v2.ae` — Tests 11 (head) and 12 (patch) added; the v2 client probe suite is now 12 cases all passing.
- `tests/regression/test_per_symbol_namespace_coexist.ae` — new regression for #252. Writes a marker file, calls bare-name `file_exists()` AND `fs.read()` in the same file, asserts both work.

321/321 `.ae` integration tests pass; 191/191 C unit tests pass.

## Test plan

- [ ] Buildkite green on Linux (GCC + Clang)
- [ ] No regression in any existing test
- [ ] `make ci` zero-FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)