### PR TITLE
fix(stdlib): is_aether_string OOB-safe + c-interop length-clamp hazard docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.98.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Fixed
+
+- **`is_aether_string` no longer reads past the end of short string allocations** (`std/string/aether_string.h`, `tests/runtime/test_runtime_strings.c`). Pre-fix, the magic-byte check did a 4-byte read at offset 0 — on a 1- or 2-byte malloc'd `char*` (the kind `_aether_interp` produces for short interpolation pieces) that overshoots the allocation and trips ASan. Real-world impact was nil (allocators round small mallocs up to 16-byte blocks, so the OOB read landed in mapped memory and the magic check returned false correctly), but it prevented clean ASan builds for any binary that handles short strings — i.e. most of them. Fix: short-circuit byte-by-byte. The first byte of the magic (`0xDE` little-endian) mismatches for ~99.6% of arbitrary inputs, so the dispatch reads exactly one byte and returns. On the rare 1/256 case where byte 0 matches, validate that the rest of the header looks plausible (non-negative ref_count, capacity ≥ length, non-NULL data) — this also catches the 1-in-2^32 chance of arbitrary content beginning with the full magic before any downstream `s->data` deref. Found by ASan run on a downstream port (svn-aether) chasing a different bug; the OOB was incidental but worth fixing on its own.
+
+### Documentation
+
+- **`docs/c-interop.md` — length-clamp hazard for C shims taking `string` parameters** (`docs/c-interop.md`). The auto-unwrap from #297 means a C shim's `string` parameter arrives as payload bytes, not the AetherString header. A common defensive pattern — `min(caller_len, aether_string_length(s))` to clamp the length "to be safe" — is fatal post-#297: `aether_string_length` falls through to `strlen` on the unwrapped pointer and silently truncates at the first embedded NUL. The downstream svn-aether port hit this in `aether_pristine_concat_binary`, producing corrupted pristine files on disk. Documented the hazard and the correct rule (trust the caller's length; don't re-derive). Cross-references the existing `ptr`-typed-parameter escape hatch for shims that genuinely need to dispatch on the header.
 
 ## [0.98.0]
 

--- a/docs/c-interop.md
+++ b/docs/c-interop.md
@@ -438,6 +438,31 @@ extern parse_with_explicit_length(s: ptr) -> int
 
 The C function then takes `const void*` (or `const AetherString*`) and goes through the helpers manually. This is the escape hatch for any FFI shim that needs binary-safe length reads — declaring `s: string` would auto-unwrap and `aether_string_length` would fall back to `strlen`, truncating at the first NUL.
 
+**Length-clamp hazard for binary content.** Once the auto-unwrap has fired, a C shim that receives a `string`-typed parameter has only payload bytes — no header, no stored length. A common defensive pattern is fatal here:
+
+```c
+// HAZARD post-#297. `s` is auto-unwrapped payload; aether_string_length
+// falls through to strlen() on binary content and truncates at NUL.
+int shim(const char* s, int caller_len) {
+    int n = aether_string_length(s);   // falls through to strlen!
+    int safe = (caller_len < n) ? caller_len : n;  // wrong on binary
+    return process(s, safe);
+}
+```
+
+Pre-#297 the AetherString header leaked through into the shim, and the dispatch inside `aether_string_length` correctly returned the stored length. Post-#297 the header is stripped at the call site, the dispatch falls through to `strlen`, and binary content gets truncated at the first embedded NUL — silently producing corrupted output on disk / in messages / etc.
+
+**Rule:** when a C shim takes a `string` parameter from Aether AND an explicit length, **trust the length**. Don't re-derive via `aether_string_length(s)` — that path is now unreachable for header-bearing values (auto-unwrap stripped the header), and the strlen fallback corrupts binary content. The Aether-side caller knows the length; pass it across the boundary.
+
+```c
+// CORRECT — caller-supplied length is the source of truth.
+int shim(const char* s, int len) {
+    return process(s, len);
+}
+```
+
+If a shim genuinely needs to dispatch on the header (e.g. for a polymorphic API where the caller might pass either a literal or a wrapped string and the length isn't known to the caller), declare its parameter as `ptr` to opt out of auto-unwrap, and dispatch via `aether_string_data` / `aether_string_length` manually.
+
 ### Aether-side string-builder return types
 
 Aether-side primitives that build strings split into two camps:

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -15,11 +15,36 @@ typedef struct AetherString {
     char* data;
 } AetherString;
 
-// Check if a pointer is an AetherString (vs raw char*)
+// Check if a pointer is an AetherString (vs raw char*).
+//
+// Reads bytes from the pointer to look for the magic header. Done
+// byte-by-byte with short-circuit so that for the 99.6% of inputs
+// whose first byte mismatches, we read exactly one byte — keeping
+// the dispatch ASan-clean on short string allocations like "hi" (2
+// bytes) or "x" (1 byte) where a naive `s->magic` 4-byte read
+// overshoots the allocation.
+//
+// On a confirmed magic match, also validate that the rest of the
+// header looks like a real AetherString — non-negative ref_count,
+// capacity ≥ length, non-NULL data — to harden against the 1-in-2^32
+// chance that arbitrary content happens to begin with the magic
+// bytes. This catches spurious dispatch before we deref s->data.
 static inline int is_aether_string(const void* ptr) {
     if (!ptr) return 0;
+    const unsigned char* p = (const unsigned char*)ptr;
+    /* Magic 0xAE57C0DE in little-endian = DE C0 57 AE. */
+    if (p[0] != 0xDE) return 0;
+    if (p[1] != 0xC0) return 0;
+    if (p[2] != 0x57) return 0;
+    if (p[3] != 0xAE) return 0;
+    /* All four bytes matched. Validate the header for plausibility
+     * to reject coincidental magic-bytes-in-payload before any
+     * downstream s->data deref. */
     const AetherString* s = (const AetherString*)ptr;
-    return s->magic == AETHER_STRING_MAGIC;
+    if (s->ref_count < 0) return 0;
+    if (s->capacity < s->length) return 0;
+    if (!s->data) return 0;
+    return 1;
 }
 
 // String creation

--- a/tests/runtime/test_runtime_strings.c
+++ b/tests/runtime/test_runtime_strings.c
@@ -121,3 +121,35 @@ TEST_CATEGORY(string_large, TEST_CATEGORY_STDLIB) {
     ASSERT_EQ(999, string_length(s));
     string_free(s);
 }
+
+/* Regression test: is_aether_string must NOT read past the end of a
+ * short allocation. Pre-fix, a 4-byte magic read on a 1- or 2-byte
+ * malloc tripped ASan even though the result was correct. The fix
+ * short-circuits on the first non-magic byte (DE in little-endian),
+ * which is the case for ~99.6% of arbitrary inputs. Validated with
+ * `gcc -fsanitize=address` — see PR notes. Without instrumentation,
+ * the previous code worked by accident: most allocators round small
+ * mallocs up to a 16-byte block, so the OOB read landed in mapped
+ * memory. Under ASan with byte-precise tracking, it aborted. */
+TEST_CATEGORY(is_aether_string_short_alloc_safe, TEST_CATEGORY_STDLIB) {
+    /* 1-byte allocation that doesn't start with 0xDE. */
+    char* one = (char*)malloc(1);
+    one[0] = 'x';
+    ASSERT_EQ(0, is_aether_string(one));
+    free(one);
+
+    /* 2-byte allocation. */
+    char* two = (char*)malloc(2);
+    two[0] = 'h';
+    two[1] = 'i';
+    ASSERT_EQ(0, is_aether_string(two));
+    free(two);
+
+    /* NULL pointer must short-circuit before any read. */
+    ASSERT_EQ(0, is_aether_string(NULL));
+
+    /* A real AetherString must still be detected. */
+    AetherString* s = string_from_cstr("hello");
+    ASSERT_EQ(1, is_aether_string(s));
+    string_free(s);
+}


### PR DESCRIPTION
## Summary

Two related boundary-hardening changes surfaced by an ASan run on the downstream svn-aether port. (The same run diagnosed why their 0.99 toolchain bump was crashing — that turned out to be port-side, but ASan also caught these upstream issues.)

### 1. `is_aether_string` no longer reads past the end of short string allocations

Pre-fix, the magic-byte check did a 4-byte read at offset 0. On a 1- or 2-byte malloc'd `char*` (the kind `_aether_interp` produces for short interpolation pieces) that overshoots the allocation. Real-world impact was nil — allocators round small mallocs up to ≥16 bytes so the OOB read landed in mapped memory and the magic check returned false correctly — but it prevented clean ASan builds for any binary that handles short strings (i.e. most of them).

**Fix**: short-circuit byte by byte. The first magic byte (`0xDE` little-endian) mismatches for ~99.6% of arbitrary inputs, so the dispatch reads exactly one byte and returns. On the rare 1/256 case where byte 0 matches, validate that the rest of the header looks plausible (non-negative `ref_count`, `capacity ≥ length`, non-NULL `data`) — this also catches the 1-in-2^32 chance of arbitrary content beginning with the full magic before any downstream `s->data` deref.

### 2. `docs/c-interop.md` — length-clamp hazard for C shims taking `string` parameters

The auto-unwrap from #297 means a C shim's `string` parameter arrives as payload bytes, not the AetherString header. A common defensive pattern is fatal here:

```c
int n = aether_string_length(s);          // falls through to strlen!
int safe = (caller_len < n) ? caller_len : n;
```

`strlen` on binary content truncates at the first embedded NUL, silently corrupting downstream work. The svn-aether port hit this in `aether_pristine_concat_binary`, producing corrupted pristine files on disk. Documented the rule (trust caller's length; don't re-derive) and cross-referenced the existing `ptr`-typed-parameter escape hatch for shims that genuinely need to dispatch on the header.

## Test plan
- [x] New regression test `is_aether_string_short_alloc_safe` in `tests/runtime/test_runtime_strings.c` — covers 1-byte alloc, 2-byte alloc, NULL, and a real AetherString. Verified ASan-clean with `gcc -fsanitize=address`.
- [x] Existing `aether_string_to_c_extern` and `aether_string_ffi_unwrap` integration tests still pass (no regression on the #297 contract).
- [x] `make ci` green locally — 357/357 Aether tests + 193/193 C unit tests + all 10 phases.

## Stdlib audit
Grepped `std/` and `contrib/` for the hazard pattern. `zlib_unwrap_bytes` / `fs_unwrap_bytes` / `cryptography_unwrap_bytes` have the same length-fallback shape but their public callers all reject `length<0`, so the `strlen` fallback is unreachable. No in-tree shim needs the fix.

## CHANGELOG
- `[current]` section restored (was stale at `[0.98.0]`); two entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)