### PR TITLE
perf(make): link examples against libaether.a + parallelise — make examples drops from 4m19s to 6.4s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -649,38 +649,51 @@ examples: compiler ae
 	@echo ===================================
 	@.\build\ae.exe examples
 else
-examples: compiler
+examples: compiler ae stdlib
 	@echo "==================================="
 	@echo "  Building Aether Examples"
+	@echo "  Parallel: $(NPROC) jobs"
 	@echo "==================================="
 	@$(MKDIR) $(BUILD_DIR)/examples $(BUILD_DIR)/examples/basics $(BUILD_DIR)/examples/actors $(BUILD_DIR)/examples/applications $(BUILD_DIR)/examples/c-interop $(BUILD_DIR)/examples/stdlib
-	@pass=0; fail=0; \
-	for src in $$(find examples -name '*.ae' | grep -v '/lib/' | grep -v '/packages/' | grep -v '/embedded-java/' | grep -v '/host-.*-demo\.ae$$' | sort); do \
-		name=$$(echo $$src | sed 's|examples/||;s|\.ae$$||'); \
-		dir=$$(dirname $$src); \
-		extra_c=""; \
-		if [ -d "$$dir" ]; then \
-			extra_c=$$(find "$$dir" -maxdepth 1 -name '*.c' 2>/dev/null | tr '\n' ' '); \
-		fi; \
-		printf "  %-30s " "$$name"; \
-		out_c="$(BUILD_DIR)/examples/$$name.c"; \
-		if ! ./build/aetherc$(EXE_EXT) $$src $$out_c 2>/tmp/ae_err.txt; then \
-			echo "FAIL (aetherc)"; \
-			cat /tmp/ae_err.txt 2>/dev/null | head -5; \
-			fail=$$((fail + 1)); \
-		elif ! $(CC) $(CFLAGS) $$out_c $$extra_c $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) \
-		         -o $(BUILD_DIR)/examples/$$name$(EXE_EXT) $(LDFLAGS) 2>/tmp/cc_err.txt; then \
-			echo "FAIL (gcc)"; \
-			cat /tmp/cc_err.txt 2>/dev/null | head -20; \
-			fail=$$((fail + 1)); \
-		else \
-			echo "OK"; \
-			pass=$$((pass + 1)); \
-		fi; \
-	done; \
+	@tmpdir=$$(mktemp -d); \
+	script="$$tmpdir/build_one.sh"; \
+	printf '#!/bin/sh\n'                                                                            > "$$script"; \
+	printf 'src="$$1"; tmpdir="$$2"; root="$$3"\n'                                                  >> "$$script"; \
+	printf 'name=$$(echo "$$src" | sed "s|examples/||;s|\\.ae$$||")\n'                              >> "$$script"; \
+	printf 'key=$$(echo "$$name" | sed "s|/|_|g")\n'                                                >> "$$script"; \
+	printf 'dir=$$(dirname "$$src")\n'                                                              >> "$$script"; \
+	printf 'extra_c=""\n'                                                                           >> "$$script"; \
+	printf 'if [ -d "$$dir" ]; then\n'                                                              >> "$$script"; \
+	printf '  extra_c=$$(find "$$dir" -maxdepth 1 -name "*.c" 2>/dev/null | tr "\\n" " ")\n'        >> "$$script"; \
+	printf 'fi\n'                                                                                   >> "$$script"; \
+	printf 'out_c="$$root/$(BUILD_DIR)/examples/$$name.c"\n'                                        >> "$$script"; \
+	printf 'mkdir -p "$$(dirname "$$out_c")"\n'                                                     >> "$$script"; \
+	printf 'if ! "$$root/build/aetherc$(EXE_EXT)" "$$src" "$$out_c" 2>"$$tmpdir/$$key.aetherc.err"; then\n' >> "$$script"; \
+	printf '  printf "  %%-30s %%s\\n" "$$name" "FAIL (aetherc)"\n'                                 >> "$$script"; \
+	printf '  head -5 "$$tmpdir/$$key.aetherc.err"\n'                                               >> "$$script"; \
+	printf '  touch "$$tmpdir/FAIL_$$key"\n'                                                        >> "$$script"; \
+	printf '  exit 1\n'                                                                             >> "$$script"; \
+	printf 'fi\n'                                                                                   >> "$$script"; \
+	printf 'if ! $(CC) $(CFLAGS) "$$out_c" $$extra_c "$$root/$(BUILD_DIR)/libaether.a" -o "$$root/$(BUILD_DIR)/examples/$$name$(EXE_EXT)" $(LDFLAGS) 2>"$$tmpdir/$$key.gcc.err"; then\n' >> "$$script"; \
+	printf '  printf "  %%-30s %%s\\n" "$$name" "FAIL (gcc)"\n'                                     >> "$$script"; \
+	printf '  head -20 "$$tmpdir/$$key.gcc.err"\n'                                                  >> "$$script"; \
+	printf '  touch "$$tmpdir/FAIL_$$key"\n'                                                        >> "$$script"; \
+	printf '  exit 1\n'                                                                             >> "$$script"; \
+	printf 'fi\n'                                                                                   >> "$$script"; \
+	printf 'printf "  %%-30s %%s\\n" "$$name" "OK"\n'                                               >> "$$script"; \
+	printf 'touch "$$tmpdir/PASS_$$key"\n'                                                          >> "$$script"; \
+	chmod +x "$$script"; \
+	root=$$(pwd); \
+	find examples -name '*.ae' \
+	    | grep -v '/lib/' | grep -v '/packages/' | grep -v '/embedded-java/' | grep -v '/host-.*-demo\.ae$$' \
+	    | sort \
+	    | xargs -P $(NPROC) -I{} "$$script" "{}" "$$tmpdir" "$$root"; \
+	pass=$$(ls "$$tmpdir"/PASS_* 2>/dev/null | wc -l | tr -d ' '); \
+	fail=$$(ls "$$tmpdir"/FAIL_* 2>/dev/null | wc -l | tr -d ' '); \
 	echo ""; \
 	echo "  $$pass passed, $$fail failed"; \
 	echo "  Binaries in $(BUILD_DIR)/examples/"; \
+	rm -rf "$$tmpdir"; \
 	if [ "$$fail" -gt 0 ]; then exit 1; fi
 endif
 


### PR DESCRIPTION
## Summary

Two changes to the macOS / Linux branch of the `examples:` Makefile target. The `WINDOWS_NATIVE` branch is **unchanged** — it routes through `./build/ae.exe examples` which uses its own example-build path.

### Change 1 — Link against `libaether.a` instead of recompiling the stdlib for every example

Before:

```make
$(CC) $(CFLAGS) $$out_c $$extra_c \
      $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) \
      -o $(BUILD_DIR)/examples/$$name $(LDFLAGS)
```

After:

```make
$(CC) $(CFLAGS) "$$out_c" $$extra_c \
      "$$root/$(BUILD_DIR)/libaether.a" \
      -o "$$root/$(BUILD_DIR)/examples/$$name$(EXE_EXT)" $(LDFLAGS)
```

The previous shape recompiled ~23,339 LOC of runtime + stdlib C **once per example**, despite `build/libaether.a` already containing every one of those objects. The `examples:` target now declares `stdlib` as a dependency so the lib is guaranteed present. `ae build` and `make test-ae` already use this pipeline via `tc.has_lib`; the inline gcc invocation in `examples:` was the one place that optimisation was missed.

### Change 2 — Parallelise with `xargs -P $(NPROC)`

Mirrors the existing `test-ae` pattern: emit a per-example builder script to a tmpdir, pipe `find` into `xargs -P $(NPROC) -I{}`, aggregate per-example PASS/FAIL marker files, and print the same `$pass passed, $fail failed` summary as before. The `extra_c` mechanism (FFI shim `.c` files) is preserved verbatim — those are user code, not stdlib.

## Result (macOS arm64, M-class CPU, 8 cores)

| | Wall time | CPU | Shape |
|---|---|---|---|
| **Before** | 4m 19.27s | 73% | sequential, source-recompile |
| **After** | **6.41s** | 202% | parallel, libaether.a-link |

~**40x speedup**, all **69 / 69** examples still pass. The `[6/10] Building examples` step in `make ci` drops from minutes to seconds.

## Out of scope (deferred follow-ups)

- `lsp:` and `test:` / `test-asan:` / `test-memory:` Makefile targets also recompile stdlib from source. Not fixed here because they're one-off binaries — savings are ~20–30s per run rather than per-example, and they additionally link `COMPILER_LIB_SRC` (not in `libaether.a`), making the swap less clean.
- Lazy module-merging in `aetherc` (every imported module's full body cloned into the program AST before typechecking, even for transitive deps never referenced). Bigger architectural change; its own PR.
- Build-output caching (`foo.ae` + `libaether.a` unchanged → reuse binary). `ccache` covers most of this; focused PR if a real workflow needs it.
- Default `-O0` for `ae build` (currently `-O2`). Would roughly halve gcc time on small programs at the cost of codegen quality. Better as a `--quick` flag — separate change.

## Test plan

- [ ] `make ci` green on the new branch (10 phases; `[6/10] Building examples` is the proof point).
- [ ] `make examples` on macOS arm64 — wall-time well under a minute, summary reads `69 passed, 0 failed`.
- [ ] `make examples-run` — every binary executes and prints its expected output.
- [ ] GHA matrix green: Linux GCC, Linux Clang, macOS ARM64, macOS x86_64. Windows targets are unaffected (separate code path).