### PR TITLE
fix(makefile): release target bakes AETHER_VERSION so installed aetherc reports correct version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`make release` now bakes the correct `AETHER_VERSION` into the release binary** (`Makefile`). The `release` target's hand-rolled `gcc` invocation was missing `-DAETHER_VERSION=\"$(VERSION)\"`, so `build/aetherc-release` (which `make install` ships as `$(PREFIX)/bin/aetherc`) reported the dev sentinel `v0.0.0-dev` regardless of the git tag. Surfaced after installing 0.116.0 — `aetherc --version` showed `v0.0.0-dev` while `ae version` correctly showed `0.116.0`. Fix: add the flag to the release target's gcc line, matching what the main `$(CFLAGS)` (line 133) already does for the dev build path. The dev `build/aetherc` was unaffected.
+
 ## [0.116.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1019,7 +1019,16 @@ release: clean
 	@echo "==================================="
 	@$(MKDIR) build
 	@echo "Compiling with -O3 -DNDEBUG -flto -Werror..."
+	@# -DAETHER_VERSION baked in from the same $(VERSION) the rest of
+	@# the build uses (highest git tag → VERSION file fallback). Without
+	@# this, compiler/aetherc.c falls back to the `v0.0.0-dev` sentinel,
+	@# and since `make install` ships this exact binary as
+	@# $(PREFIX)/bin/aetherc, every installed compiler reported the
+	@# wrong version. The dev-build aetherc (compiled via the standard
+	@# $(CFLAGS) pattern rule on line 133) has the flag and is correct;
+	@# only the release-target hand-rolled gcc invocation was missing it.
 	@$(CC) -O3 -DNDEBUG -flto -Werror -Icompiler -Iruntime -Istd -Istd/collections \
+		-DAETHER_VERSION=\"$(VERSION)\" \
 		$(COMPILER_SRC) $(STD_SRC) $(COLLECTIONS_SRC) \
 		-o build/aetherc-release$(EXE_EXT) $(LDFLAGS)
 ifeq ($(DETECTED_OS),Linux)


### PR DESCRIPTION
## Summary

`build/aetherc-release` (the binary `make install` ships as `\$(PREFIX)/bin/aetherc`) was reporting `v0.0.0-dev` regardless of the git tag, because the `release` target's hand-rolled `gcc` invocation was missing `-DAETHER_VERSION=\"\$(VERSION)\"`.

Surfaced after installing v0.116.0 from a freshly-pulled main:

```
$ ~/.local/bin/aetherc --version
Aether Compiler v0.0.0-dev      ← wrong
$ ~/.local/bin/ae version
ae 0.116.0 (Aether Language)    ← correct
```

The dev `build/aetherc` (built via the standard `\$(CFLAGS)` pattern rule on line 133) had the flag and reported v0.116.0 correctly. Only `aetherc-release` was affected — the bug was in the release target's gcc line at `Makefile:1022`.

## Fix

One-line addition: `-DAETHER_VERSION=\"\$(VERSION)\"` in the release target's gcc invocation, matching `\$(CFLAGS)`.

## Test plan

- [x] Before fix: `make release && build/aetherc-release --version` → `Aether Compiler v0.0.0-dev`
- [x] After fix: `make release && build/aetherc-release --version` → `Aether Compiler v0.116.0`
- [x] `make ci` — 10/10 steps green
- [ ] Cross-platform CI matrix — Makefile-only change, gcc command-line difference; very low platform risk but matrix runs on PR.

## Why this matters

Every install since whenever this was introduced has shipped with a stale-version `aetherc`. Doesn't break compilation (the version is informational) but it makes `aetherc --version` useless for debugging "what version is this user running" and undermines the version drift detection LLM.md flags as important (\"if `aetherc --version` disagrees with CHANGELOG `[current]` ... local tags are behind\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)