### PR TITLE
docs(std.os): document process-spawn surface; mark next-steps P1/P3 as shipped [skip actions]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Changed
+
+- **Documented `std.os` process-spawn surface — fills a tier-coverage gap** (`LLM.md`, `docs/stdlib-api.md`, `docs/next-steps.md`). The `os.run` / `os.run_capture` / `os_execv` family shipped in PR #148 + #289 but documentation was thin: `docs/stdlib-api.md` had only a "see PR #148" pointer, `docs/next-steps.md` still listed `os.run` as a P1 to-do, and `LLM.md` had no idiom-level entry — meaning a future LLM asked "how do I spawn a child binary in Aether?" would grep the stdlib instead of getting the answer immediately. Three updates: (1) `LLM.md` gains a one-line idiom under "Idioms that keep biting" calling out `os.run_capture(prog, argv, env) -> (stdout, exit_code, stderr)` as the canonical answer with no need to propose a `std.process` module; (2) `docs/stdlib-api.md` gets a new "Process spawn (argv-based, no shell)" subsection with full signatures, return shapes, a worked git-rev-parse example, capability/Windows portability notes, and a callout that the API is currently synchronous (no streaming stdin / incremental stdout); (3) `docs/next-steps.md` marks the P1 (`os.run`) and P3 (`argv0` + `execv`) sections as **SHIPPED** with banners pointing at the stdlib reference, retaining the original rationale as historical context. No code changes.
+
 ## [0.117.0]
 
 ### Fixed

--- a/LLM.md
+++ b/LLM.md
@@ -141,6 +141,14 @@ plays that role), no interfaces.
   as `ptr`, Aether sees only the leading bytes up to the first
   NUL. This is why `fs.read_binary` has a paired `_length()`
   accessor, not a single-return.
+- **Spawning a child binary uses `std.os`, not a separate process
+  module.** `os.run_capture(prog, argv, env) -> (stdout: string,
+  exit_code: int, stderr: string)` is the canonical "fork + exec +
+  wait + capture" — argv-based, no shell, binary-safe. Sibling
+  externs: `os_run` (no capture, just exit code), `os_system`
+  (legacy `system(3)` shell-out, prefer `run_capture`),
+  `os_execv` (replace current process). Don't propose a new
+  `std.process` — the surface is already there.
 
 ## Working with downstream users
 

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -31,7 +31,13 @@ for the common "did it fail?" case.
 Missing primitives that keep biting real users when they try to write
 tool-style Aether programs. Ordered by impact.
 
-### P1 — `os.run` / `os.run_capture` (argv-based process execution)
+### ~~P1~~ — `os.run` / `os.run_capture` (argv-based process execution) — **SHIPPED**
+
+> **Status: shipped (PR #148, exit-code tuple in #289).** See
+> [Process spawn (argv-based, no shell)](stdlib-api.md#process-spawn-argv-based-no-shell)
+> in the stdlib reference for current signatures and a worked example.
+> Section retained below for the original rationale; rationale-as-roadmap
+> rather than as a to-do.
 
 `os.system` and `os.exec` both take a single command string and hand it
 to `/bin/sh -c` (or `cmd.exe /c` on Windows). That works for trivial
@@ -44,19 +50,19 @@ The fix is a pair of argv-based APIs that bypass the shell entirely:
 
 ```aether
 // Just exit code
-code, err = os.run(["git", "clone", repo_url, target_dir])
+code = os.run(prog, argv, env)
 
 // Exit code + stdout + stderr
-code, stdout, stderr, err = os.run_capture(["ls", "-la", path_with_spaces])
+stdout, exit_code, stderr = os.run_capture(prog, argv, env)
 ```
 
 **Implementation:**
 - POSIX: `fork()` + `execvp()` + `waitpid()`. `run_capture` uses `pipe()` + non-blocking drain.
-- Windows: `CreateProcessW()` with a properly escaped command-line buffer (`CommandLineToArgvW` rules), or the `lpApplicationName` form for the no-escape path. Capture variant uses `CreatePipe()` with inherited handles.
-- `argv` accepts an Aether `list` or array of strings; no shell involved.
+- Windows: currently uses POSIX-fallback shims; native `CreateProcessW()` backend tracked separately.
+- `argv` is a `list<ptr>` of strings; no shell involved.
 
-Keep `os.system` and `os.exec` for the shell-required cases (pipe-to-grep,
-redirection, etc.) but make `os.run` the recommended default.
+`os.system` and `os.exec` remain for the shell-required cases (pipe-to-grep,
+redirection, etc.); `os.run` / `os.run_capture` are the recommended defaults.
 
 ### P2 — `fs_glob` Windows port to `FindFirstFileW`
 
@@ -70,7 +76,13 @@ and a recursive `dirent.h` walker. Needs:
 - Dot-prefix filtering consistent with POSIX (hidden files excluded by
   default, matches `..` correctly)
 
-### P3 — `aether.argv0` builtin + `os.execv` wrapper
+### ~~P3~~ — `aether.argv0` builtin + `os.execv` wrapper — **SHIPPED**
+
+> **Status: shipped.** Surfaces are `os.argv0()` (and `aether_argv0()`
+> for null-discriminating callers) and `os_execv(prog, argv_list)`.
+> See [Argv discovery](stdlib-api.md#argv-discovery) and
+> [Process replacement](stdlib-api.md#process-replacement) in the
+> stdlib reference. Section retained below for the original rationale.
 
 Two small additions that unblock "re-exec self with different args"
 and "know where the binary lives" patterns common in CLI tools:

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -292,6 +292,47 @@ Raw externs: `io_read_file_raw`, `io_write_file_raw`, `io_append_file_raw`, `io_
 - `os.exec(cmd)` → `(string, string)` — Run a command and capture stdout; returns `(output, err)` tuple
 - `os.getenv(name)` → `string` — Read environment variable; returns null if unset
 
+The shell-execution path passes `cmd` to `/bin/sh -c` (`cmd.exe /c` on Windows), which means quoting, glob expansion, and `$VAR` interpolation all happen before the child sees the string. **Prefer `os.run_capture` (below)** for any input that touches user data — it skips the shell entirely and is binary-safe.
+
+### Process spawn (argv-based, no shell)
+
+The argv-based path is the recommended way to launch a child binary. Argv is passed as a list of strings, no shell sits in the middle, paths with spaces / quotes / `$`-signs are safe, and there's no command-injection surface for user-provided values.
+
+- `os.run(prog, argv, env)` → `int` — Spawn `prog`, wait for it to finish, return the exit code. `argv` is a `list<ptr>` of C strings (element 0 is conventionally the program name; the OS sees this as `argv[0]` for the child). `env` is the same shape, or `null` to inherit. `prog` is looked up on `PATH` if it does not contain a slash.
+
+- `os.run_capture(prog, argv, env)` → `(stdout: string, exit_code: int, stderr: string)` — Same as `os.run`, but captures the child's stdout and stderr. The child's three outputs come back as a single tuple. The `exit_code` slot lets callers distinguish "ran cleanly" (`exit_code == 0`) from "ran but exited non-zero" — important for tools like `diff3 -m` (returns 1 on conflicts), `grep` (returns 1 on no-match), or `gcc` (returns non-zero on compile errors), where non-zero is meaningful information rather than a hard failure.
+
+Raw externs (rarely needed directly; the wrappers above are idiomatic):
+
+- `os_run(prog, argv, env)` → `int` — Same as `os.run`.
+- `os_run_capture_raw(prog, argv, env)` → `string` — Captures stdout only; exit code is discarded. Use `os.run_capture` instead unless the exit code is genuinely irrelevant.
+- `os_run_capture_status_raw(prog, argv, env)` → `(string, int, string)` — The tuple-returning extern that `os.run_capture` wraps.
+
+Worked example:
+
+```aether
+import std.os
+import std.list
+
+main() {
+    argv = list.new()
+    _ = list.add(argv, "git")
+    _ = list.add(argv, "rev-parse")
+    _ = list.add(argv, "HEAD")
+
+    stdout, exit_code, stderr = os.run_capture("git", argv, null)
+    if exit_code != 0 {
+        println("git failed (${exit_code}): ${stderr}")
+        return
+    }
+    println("HEAD is ${stdout}")
+}
+```
+
+**Capabilities and Windows portability:** `os.run` / `os.run_capture` require the `--with=os` capability when building with `--emit=lib` (capability-empty by default). Windows MSYS2 / mingw-w64 currently uses POSIX-fallback shims; a native `CreateProcessW` backend is tracked separately. The function signatures and return shapes are stable across the current Windows fallback and the future native backend.
+
+**Synchronous, no streaming.** The current API blocks until the child exits and returns the entire captured stdout / stderr. There is no streaming-stdin or incremental-stdout-read path today; if you need to feed input to a child, write your input to a temp file and have the child read from there, or pipe through a shell wrapper.
+
 ### Argv discovery
 
 - `aether_args_count()` → `int` — Number of command-line arguments
@@ -305,7 +346,7 @@ Typical use: a tool that needs to find its own binary (to locate sibling helpers
 
 - `os_execv(prog, argv_list)` → `int` — Replace the current process image with `prog`, passing an explicit argv list. `argv_list` is a `list<ptr>` of C strings (element 0 is argv[0] for the new program). On success this call **never returns**; on failure it returns `-1` and the current process keeps running. `prog` is looked up on `PATH` if it does not contain a slash. Not available on Windows — returns `-1`.
 
-Paired with `os_run` / `os_run_capture` (see PR #148), this gives Aether programs a full argv-based process-launch surface with no shell in the middle, so paths with spaces, quotes, or `$`-signs are safe. Stdio is flushed before the exec, so pre-exec diagnostics are not lost.
+Paired with `os.run` / `os.run_capture` (see [Process spawn](#process-spawn-argv-based-no-shell) above), this gives Aether programs a full argv-based process-launch surface with no shell in the middle, so paths with spaces, quotes, or `$`-signs are safe. Stdio is flushed before the exec, so pre-exec diagnostics are not lost.
 
 Example:
 


### PR DESCRIPTION
## Summary

Documentation-only PR. No code changes.

`std.os.run_capture` (the canonical \"spawn a child binary, capture stdout/stderr, get exit code\" answer) shipped in PR #148 and got the (stdout, exit_code, stderr) tuple in #289, but the documentation tiers were thin enough that a future reader (or LLM) asked the question would grep the stdlib instead of getting the answer immediately.

## What changed

| File | Change |
|---|---|
| `LLM.md` | New idiom-level bullet calling out `os.run_capture(prog, argv, env) -> (stdout, exit_code, stderr)` as the canonical answer with explicit \"don't propose a new `std.process`.\" |
| `docs/stdlib-api.md` | New \"Process spawn (argv-based, no shell)\" subsection with full signatures, return shapes (the tuple shape was undocumented), worked git-rev-parse example, raw-extern listing, capability + Windows portability notes, sync-only-no-streaming callout. Fixes the dangling \"see PR #148\" reference in \"Process replacement\". |
| `docs/next-steps.md` | P1 (`os.run`) and P3 (`argv0` + `execv`) sections marked **SHIPPED** with status banners pointing at the stdlib reference. Original rationale kept below as historical context. P1 example block updated to use the actual shipped signatures (positional argv/env, not list-literal syntax that didn't match). |
| `CHANGELOG.md` | Entry under `[current]`, category `Changed`. |

## `[skip actions]`

Docs-only — no code touched, no CI value in burning the matrix. The bare `[skip actions]` tag in the commit message tells GitHub Actions to skip.

## Test plan

- [x] No code touched; no \`make ci\` run (intentional)
- [x] All link anchors used (`#process-spawn-argv-based-no-shell`, `#argv-discovery`, `#process-replacement`) match section headings in their target files
- [x] CHANGELOG entry under `[current]` per CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)