### PR TITLE
Fix #334 (install contrib/) + #347 (panic stack traces)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ OBJ_DIR = $(BUILD_DIR)/obj
 # symbols (CertFreeCertificateContext, CertOpenSystemStoreW, etc.) that
 # aren't auto-linked — we add the import libs explicitly so std.net TLS
 # and std.cryptography work in Windows release binaries.
-WIN_LINK_LIBS = -static -lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt
+WIN_LINK_LIBS = -static -lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp
 ifdef WINDOWS_NATIVE
     LDFLAGS += $(WIN_LINK_LIBS)
 else ifneq ($(findstring MINGW,$(DETECTED_OS)),)

--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ test-ae: compiler ae stdlib
 	printf 'fi\n'                                                                                   >> "$$script"; \
 	chmod +x "$$script"; \
 	root=$$(pwd); \
-	find tests/syntax tests/compiler tests/integration tests/regression -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -path 'tests/integration/reserved_keyword_error/*' -prune -o -path 'tests/integration/ae_run_cflags/*' -prune -o -path 'tests/integration/bin_path_match/*' -prune -o -path 'tests/integration/bin_name_lookup_and_walkup/*' -prune -o -path 'tests/integration/string_plus_reject/*' -prune -o -path 'tests/integration/aether_string_to_c_extern/*' -prune -o -path 'tests/integration/module_extern_auto_unwrap/*' -prune -o -path 'tests/integration/http_external_ptr/*' -prune -o -path 'tests/integration/fs_read_binary_nul/*' -prune -o -path 'tests/integration/fs_write_binary_nul/*' -prune -o -path 'tests/integration/cryptography_sha/*' -prune -o -path 'tests/integration/cryptography_v2/*' -prune -o -path 'tests/integration/extern_annotation/*' -prune -o -path 'tests/integration/c_callback/*' -prune -o -path 'tests/integration/extern_tuple_return/*' -prune -o -path 'tests/integration/sqlite_roundtrip/*' -prune -o -path 'tests/integration/sqlite_prepared/*' -prune -o -path 'tests/integration/zlib_roundtrip/*' -prune -o -path 'tests/integration/aether_string_ffi_unwrap/*' -prune -o -path 'tests/integration/ptr_return_int_zero_inference/*' -prune -o -path 'tests/integration/string_interp_loop_alias/*' -prune -o -path 'tests/integration/transitive_module_import/*' -prune -o -path 'tests/integration/http_client_redirects/*' -prune -o -path 'tests/integration/source_location/*' -prune -o -path 'tests/integration/std_dl/*' -prune -o -path 'tests/integration/host_tinygo/*' -prune -o -path 'tests/integration/sealed_namespaces/*' -prune -o -path 'tests/integration/default_arguments/*' -prune -o -path 'tests/integration/source_location_default_capture/*' -prune -o -path 'tests/integration/fn_typed_local_call/*' -prune -o -path 'tests/integration/http_server_tls/*' -prune -o -path 'tests/integration/http_server_keepalive/*' -prune -o -path 'tests/integration/http_server_actor_dispatch/*' -prune -o -path 'tests/integration/http_middleware_d1/*' -prune -o -path 'tests/integration/http_middleware_d2/*' -prune -o -path 'tests/integration/http_server_ops/*' -prune -o -path 'tests/integration/http_server_observability/*' -prune -o -path 'tests/integration/http_server_sse/*' -prune -o -path 'tests/integration/http_server_websocket/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
+	find tests/syntax tests/compiler tests/integration tests/regression -path '*/lib/*' -prune -o -path '*/custom_lib_dir/*' -prune -o -path 'tests/integration/namespace_*' -prune -o -path 'tests/integration/closure_actor_state_reject/*' -prune -o -path 'tests/integration/reserved_keyword_error/*' -prune -o -path 'tests/integration/ae_run_cflags/*' -prune -o -path 'tests/integration/bin_path_match/*' -prune -o -path 'tests/integration/bin_name_lookup_and_walkup/*' -prune -o -path 'tests/integration/string_plus_reject/*' -prune -o -path 'tests/integration/aether_string_to_c_extern/*' -prune -o -path 'tests/integration/module_extern_auto_unwrap/*' -prune -o -path 'tests/integration/http_external_ptr/*' -prune -o -path 'tests/integration/fs_read_binary_nul/*' -prune -o -path 'tests/integration/fs_write_binary_nul/*' -prune -o -path 'tests/integration/cryptography_sha/*' -prune -o -path 'tests/integration/cryptography_v2/*' -prune -o -path 'tests/integration/extern_annotation/*' -prune -o -path 'tests/integration/c_callback/*' -prune -o -path 'tests/integration/extern_tuple_return/*' -prune -o -path 'tests/integration/sqlite_roundtrip/*' -prune -o -path 'tests/integration/sqlite_prepared/*' -prune -o -path 'tests/integration/zlib_roundtrip/*' -prune -o -path 'tests/integration/aether_string_ffi_unwrap/*' -prune -o -path 'tests/integration/ptr_return_int_zero_inference/*' -prune -o -path 'tests/integration/string_interp_loop_alias/*' -prune -o -path 'tests/integration/transitive_module_import/*' -prune -o -path 'tests/integration/http_client_redirects/*' -prune -o -path 'tests/integration/source_location/*' -prune -o -path 'tests/integration/std_dl/*' -prune -o -path 'tests/integration/host_tinygo/*' -prune -o -path 'tests/integration/sealed_namespaces/*' -prune -o -path 'tests/integration/default_arguments/*' -prune -o -path 'tests/integration/source_location_default_capture/*' -prune -o -path 'tests/integration/fn_typed_local_call/*' -prune -o -path 'tests/integration/http_server_tls/*' -prune -o -path 'tests/integration/http_server_keepalive/*' -prune -o -path 'tests/integration/http_server_actor_dispatch/*' -prune -o -path 'tests/integration/http_middleware_d1/*' -prune -o -path 'tests/integration/http_middleware_d2/*' -prune -o -path 'tests/integration/http_server_ops/*' -prune -o -path 'tests/integration/http_server_observability/*' -prune -o -path 'tests/integration/http_server_sse/*' -prune -o -path 'tests/integration/http_server_websocket/*' -prune -o -path 'tests/integration/panic_stack_trace/*' -prune -o -name '*.ae' -print 2>/dev/null | sort | \
 	xargs -P $(NPROC) -I{} "$$script" "{}" "$$tmpdir" "$$root"; \
 	for sh_test in $$(find tests/integration -name 'test_*.sh' 2>/dev/null | sort); do \
 		name=$$(echo "$$sh_test" | sed 's|tests/||;s|/|_|g;s|\.sh$$||'); \
@@ -1076,6 +1076,29 @@ install: release ae stdlib
 	@install -d $(PREFIX)/share/aether
 	@cp -R runtime $(PREFIX)/share/aether/
 	@cp -R std     $(PREFIX)/share/aether/
+	@# Contrib module.ae descriptors + headers (issue #334). With these
+	@# in place, `import contrib.X` resolves the same way `import std.X`
+	@# does — share/aether/contrib/<X>/module.ae sits next to
+	@# share/aether/std/<X>/module.ae and the resolver searches both
+	@# (compiler/aether_module.c:436-484). The matching .a archives are
+	@# still built+installed separately by `make install-contrib`, which
+	@# probes for system dependencies (sqlite3-dev, etc.); without that
+	@# step a link of `import contrib.sqlite` will fail loudly — fine,
+	@# the resolver-side pain Paul filed is the one that's silent.
+	@cp -R contrib $(PREFIX)/share/aether/
+	@# Trim source-tree noise from the contrib install: tests, benchmarks,
+	@# example .ae, build/CI scripts, and the .c/.m files (those compile
+	@# into the libaether_<x>.a archives via `make contrib`; no value in
+	@# also shipping the source). Mirrors the same trim install-contrib
+	@# applies, kept here so `make install` alone yields a usable layout.
+	@find $(PREFIX)/share/aether/contrib -type d -name tests       -exec rm -rf {} + 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type d -name benchmarks  -exec rm -rf {} + 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name 'example_*.ae' -delete 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name 'test_*.sh' -delete 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name 'build.sh'  -delete 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name 'ci.sh'     -delete 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name '*.c' -delete 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name '*.m' -delete 2>/dev/null || true
 	@# Trim install-noise that confuses external consumers (aetherBuild
 	@# and the like). runtime/examples/ holds standalone benches with
 	@# their own main() — never link-suitable. runtime/io/ is an

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -2245,8 +2245,15 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
         }
 
         case AST_PANIC_STATEMENT: {
-            // panic(reason_expr);  →  aether_panic(reason_expr);
+            // panic(reason_expr);  → capture backtrace at the call site,
+            // then aether_panic(reason). Capturing into TLS before the
+            // noreturn call is what gives the runtime stack-trace path
+            // (issue #347) the user's caller frames — calling backtrace()
+            // from inside aether_panic alone loses them under -O2 because
+            // tail-call + noreturn collapses the caller's frame.
             if (stmt->child_count < 1) break;
+            print_indent(gen);
+            fprintf(gen->output, "aether_panic_capture_stack();\n");
             print_indent(gen);
             fprintf(gen->output, "aether_panic(");
             generate_expression(gen, stmt->children[0]);

--- a/docs/actor-concurrency.md
+++ b/docs/actor-concurrency.md
@@ -206,6 +206,27 @@ actor Poller {
 
 Identifiers in the timeout expression resolve against the same scope `receive` arms see — actor state fields and `self` are both in scope.
 
+## Panic and Stack Traces
+
+`panic("reason")` unwinds via `aether_panic`. If a `try { ... } catch e { ... }` block (or the scheduler's per-step barrier for actor handlers) is on the stack, the panic is caught and `e` binds to the reason. If no frame catches, the runtime prints the reason to stderr along with a filtered stack trace, then aborts:
+
+```text
+aether: panic outside any try/catch or actor: divide by zero
+
+Stack trace (most recent call first):
+  0: math.safe_divide
+  1: calculate_value
+  2: main
+```
+
+The trace is captured at the call site (codegen wires `aether_panic_capture_stack` in front of every `aether_panic` call) so the user's caller frames survive `-O2` tail-call optimisation. Symbols starting with `aether_` are pretty-printed back to their dotted Aether names — `aether_std_string_concat` reads as `std.string.concat`. User-code symbols pass through verbatim.
+
+The trace is **best-effort diagnostic info**. Under `-O2`, function inlining can fuse callers into one frame; a panic deep inside a chain of small helpers may show only `main`. For richer development-time traces, build with `--cflags="-O0 -g"` (or set `AE_CFLAGS=-O0 -g`); the per-call frames return.
+
+To suppress the trace block entirely (useful for tests that diff stderr line-for-line), set `AETHER_STACK_TRACE=0` in the environment. The reason line still prints.
+
+Available on glibc-Linux and macOS today (uses `<execinfo.h>` `backtrace()` from libc proper, no extra link dependency). On musl, Windows, Emscripten, and freestanding targets the trace block is skipped — `panic`/`try`/`catch` themselves still work.
+
 ## Cooperative Preemption
 
 By default, message handlers run to completion. A tight compute loop inside a handler will block that core's scheduler thread. For programs where this is a concern, cooperative preemption can be enabled:

--- a/install.sh
+++ b/install.sh
@@ -217,6 +217,25 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
     mkdir -p "$SRC_DIR"
     cp -r runtime "$SRC_DIR/" 2>/dev/null || true
     cp -r std     "$SRC_DIR/" 2>/dev/null || true
+    # Contrib module.ae descriptors + headers (issue #334). With these
+    # in place, `import contrib.X` resolves the same way `import std.X`
+    # does — share/aether/contrib/<X>/module.ae sits next to
+    # share/aether/std/<X>/module.ae. The matching .a archives are
+    # built+installed separately by `make install-contrib`, which
+    # probes for system dependencies (sqlite3-dev, etc.).
+    cp -r contrib "$SRC_DIR/" 2>/dev/null || true
+    # Trim source-tree noise from contrib: tests, benchmarks, example
+    # .ae, build/CI scripts, and the .c/.m files (those compile into
+    # the libaether_<x>.a archives via `make contrib`; no value in
+    # also shipping the source).
+    find "$SRC_DIR/contrib" -type d -name tests       -exec rm -rf {} + 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type d -name benchmarks  -exec rm -rf {} + 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type f -name 'example_*.ae' -delete 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type f -name 'test_*.sh' -delete 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type f -name 'build.sh'  -delete 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type f -name 'ci.sh'     -delete 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type f -name '*.c' -delete 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type f -name '*.m' -delete 2>/dev/null || true
     # Trim install-noise that confuses external consumers
     # (aetherBuild and the like). runtime/examples/ holds standalone
     # benches with their own main() — never link-suitable.

--- a/runtime/actors/aether_panic.c
+++ b/runtime/actors/aether_panic.c
@@ -6,6 +6,17 @@
 #include <string.h>
 #include <stddef.h>
 
+// Stack-trace capture: glibc and macOS provide backtrace() /
+// backtrace_symbols() in <execinfo.h> as part of libc proper — no
+// extra link dependency. musl and other libcs don't, and Windows
+// uses CaptureStackBackTrace + DbgHelp instead. Issue #347.
+#if (defined(__GLIBC__) || defined(__APPLE__)) && !defined(__EMSCRIPTEN__)
+  #define AETHER_STACK_TRACE_BACKTRACE 1
+  #include <execinfo.h>
+#else
+  #define AETHER_STACK_TRACE_BACKTRACE 0
+#endif
+
 // ---------------------------------------------------------------------------
 // Per-thread jmp frame stack
 // ---------------------------------------------------------------------------
@@ -52,6 +63,203 @@ int aether_try_depth(void) {
 }
 
 // ---------------------------------------------------------------------------
+// Stack-trace capture (issue #347)
+//
+// Captures the current call stack via backtrace() and prints a
+// filtered, pretty-printed version to stderr before the panic
+// fallback aborts. Pretty-printing is a small parser over the
+// platform-specific backtrace_symbols() format:
+//   - glibc: "binary(symbol+offset) [address]"
+//   - macOS: "<frame#>  binary  address  symbol + offset"
+// We isolate the symbol token, optionally strip a leading underscore
+// (Mach-O convention), and rewrite `aether_<a>_<b>_…` to
+// `<a>.<b>.…` so the dotted Aether name reads back at the user
+// (`aether_std_string_concat` → `std.string.concat`).
+//
+// On platforms without backtrace() (musl, Windows, freestanding,
+// wasm), the helper is a no-op stub — callers still get the panic
+// reason; they just don't get the trace. CaptureStackBackTrace +
+// DbgHelp on Windows is a separate follow-up.
+// ---------------------------------------------------------------------------
+
+#if AETHER_STACK_TRACE_BACKTRACE
+
+// Per-thread captured backtrace, populated by aether_panic_capture_stack()
+// at the codegen call site. Read by aether_panic's fallback printer.
+// Capturing at the call site (rather than from inside aether_panic
+// itself) is what gives us the user's caller frames under -O2 —
+// tail-call + noreturn collapse the caller frame, and backtrace()
+// inside aether_panic alone walks an already-truncated stack.
+#define AETHER_PANIC_TRACE_MAX 64
+static AETHER_TLS void* tls_panic_trace[AETHER_PANIC_TRACE_MAX];
+static AETHER_TLS int   tls_panic_trace_n = 0;
+
+void aether_panic_capture_stack(void) {
+    tls_panic_trace_n = backtrace(tls_panic_trace, AETHER_PANIC_TRACE_MAX);
+}
+
+// Locate the symbol name inside a backtrace_symbols() line. Returns
+// a pointer to the start of the symbol within `line`, plus its
+// length via `*out_len`. Returns NULL if no symbol could be parsed.
+//
+// Format families:
+//   - glibc ELF: "binary(symbol+0xOFFSET) [0xADDR]"
+//                 → symbol is between '(' and '+' (or ')' if no offset)
+//   - glibc-no-debug: "binary [0xADDR]"
+//                 → no symbol; return NULL
+//   - macOS Mach-O: "<n>   binary   0xADDR   symbol + offset"
+//                 → symbol is the 4th whitespace-separated field
+static const char* aether_locate_symbol(const char* line, size_t* out_len) {
+    if (!line || !out_len) return NULL;
+
+    // glibc-shape: look for '('
+    const char* lparen = strchr(line, '(');
+    if (lparen) {
+        const char* start = lparen + 1;
+        const char* end   = start;
+        while (*end && *end != '+' && *end != ')') end++;
+        if (end > start) {
+            *out_len = (size_t)(end - start);
+            return start;
+        }
+        // Empty parens (no symbol resolved) — fall through to other shapes.
+    }
+
+    // macOS-shape: skip 3 whitespace-separated fields (frame#, binary,
+    // address), then the next non-whitespace run is the symbol.
+    const char* p = line;
+    for (int field = 0; field < 3; field++) {
+        while (*p == ' ' || *p == '\t') p++;
+        if (!*p) return NULL;
+        while (*p && *p != ' ' && *p != '\t') p++;
+    }
+    while (*p == ' ' || *p == '\t') p++;
+    if (!*p) return NULL;
+    const char* start = p;
+    while (*p && *p != ' ' && *p != '\t' && *p != '+') p++;
+    if (p > start) {
+        *out_len = (size_t)(p - start);
+        return start;
+    }
+
+    return NULL;
+}
+
+// Pretty-print one symbol token. Writes to `out` (capacity `out_cap`,
+// always NUL-terminated). The token may include a `+offset` suffix
+// from the backtrace_symbols formatter; we drop it.
+static void aether_pretty_symbol(const char* line, char* out, size_t out_cap) {
+    if (!line || !out || out_cap == 0) return;
+    out[0] = '\0';
+
+    size_t slen = 0;
+    const char* sym = aether_locate_symbol(line, &slen);
+    if (!sym || slen == 0) return;
+
+    // Skip leading underscore (Mach-O convention on macOS).
+    if (sym[0] == '_' && slen > 1) {
+        sym++;
+        slen--;
+    }
+
+    // Match the `aether_` prefix exactly (not `aether` substring) so
+    // we only rewrite codegen'd stdlib symbols and don't molest user
+    // identifiers that happen to contain the substring.
+    int is_aether = (slen > 7 && strncmp(sym, "aether_", 7) == 0);
+    const char* body = is_aether ? sym + 7 : sym;
+    size_t      blen = is_aether ? slen - 7 : slen;
+
+    size_t pos = 0;
+    for (size_t i = 0; i < blen && pos + 1 < out_cap; i++) {
+        char c = body[i];
+        // Inside aether_-prefixed symbols, underscores are namespace
+        // separators — render them as dots. User-code symbols pass
+        // through verbatim so that local snake_case names stay
+        // recognisable in the trace.
+        if (is_aether && c == '_') c = '.';
+        out[pos++] = c;
+    }
+    out[pos] = '\0';
+}
+
+// Print up to `frames_to_capture` frames to stderr. Filters out the
+// top-of-stack panic plumbing (this function + aether_panic itself)
+// so the first frame the user sees is the one that called panic().
+//
+// Prefers the codegen-captured TLS trace when present (the codegen
+// runs aether_panic_capture_stack() before the noreturn aether_panic
+// call so the caller frames survive -O2 tail-calls). Falls back to
+// a fresh backtrace() for callers that didn't capture (contract
+// violations, signal-converted panics, runtime self-checks).
+static void aether_print_stack_trace_to_stderr(void) {
+    enum { MAX_FRAMES = AETHER_PANIC_TRACE_MAX };
+    void*  raw_frames[MAX_FRAMES];
+    void** frames;
+    int    n;
+
+    if (tls_panic_trace_n > 0) {
+        frames = tls_panic_trace;
+        n      = tls_panic_trace_n;
+    } else {
+        n = backtrace(raw_frames, MAX_FRAMES);
+        if (n <= 0) return;
+        frames = raw_frames;
+    }
+
+    char** symbols = backtrace_symbols(frames, n);
+    if (!symbols) return;
+
+    fprintf(stderr, "\nStack trace (most recent call first):\n");
+
+    // Skip our own frames: aether_print_stack_trace_to_stderr +
+    // aether_panic. Search the symbol list rather than hardcoding
+    // the count, so inlining or LTO that fuses one of them away
+    // doesn't leave a hole.
+    int start = 0;
+    for (int i = 0; i < n && i < 4; i++) {
+        const char* s = symbols[i];
+        if (s && (strstr(s, "aether_panic") || strstr(s, "print_stack_trace"))) {
+            start = i + 1;
+        }
+    }
+
+    int printed = 0;
+    char pretty[256];
+    for (int i = start; i < n; i++) {
+        aether_pretty_symbol(symbols[i], pretty, sizeof(pretty));
+        // Drop libc / dyld startup frames — they aren't useful and
+        // their names vary by platform.
+        if (pretty[0] == '\0') continue;
+        if (strcmp(pretty, "start")              == 0) break;
+        if (strcmp(pretty, "_start")             == 0) break;
+        if (strcmp(pretty, "__libc_start_main")  == 0) break;
+        if (strcmp(pretty, "__libc_start_call_main") == 0) break;
+
+        fprintf(stderr, "  %d: %s\n", printed, pretty);
+        printed++;
+
+        // Stop on main; everything below is libc/runtime startup.
+        if (strcmp(pretty, "main") == 0) break;
+    }
+
+    free(symbols);
+}
+
+#else  // !AETHER_STACK_TRACE_BACKTRACE
+
+void aether_panic_capture_stack(void) {
+    // No-op on platforms without execinfo.h (musl, Windows, wasm,
+    // freestanding). Tracing is best-effort diagnostic info — the
+    // panic path itself still works.
+}
+
+static void aether_print_stack_trace_to_stderr(void) {
+    // Nothing captured, nothing to print.
+}
+
+#endif
+
+// ---------------------------------------------------------------------------
 // Panic entry point
 // ---------------------------------------------------------------------------
 
@@ -65,11 +273,18 @@ void aether_panic(const char* reason) {
         // unreachable
     }
 
-    // No user-level try/catch. Print to stderr so the caller sees *something*
-    // even in the fallback path; then abort. In an actor context the
-    // scheduler's own frame will catch this before we get here — only
-    // non-actor threads with no frame reach the fallback.
+    // No user-level try/catch. Print the reason + a filtered stack
+    // trace to stderr so the caller sees the call path that led here,
+    // then abort. In an actor context the scheduler's own frame will
+    // catch this before we get here — only non-actor threads with no
+    // frame reach the fallback. Suppress the trace via
+    // AETHER_STACK_TRACE=0 if the noise gets in the way (e.g. tests
+    // that diff stderr line-for-line).
     fprintf(stderr, "aether: panic outside any try/catch or actor: %s\n", reason);
+    const char* trace_env = getenv("AETHER_STACK_TRACE");
+    if (!trace_env || strcmp(trace_env, "0") != 0) {
+        aether_print_stack_trace_to_stderr();
+    }
     abort();
 }
 

--- a/runtime/actors/aether_panic.c
+++ b/runtime/actors/aether_panic.c
@@ -6,15 +6,35 @@
 #include <string.h>
 #include <stddef.h>
 
-// Stack-trace capture: glibc and macOS provide backtrace() /
-// backtrace_symbols() in <execinfo.h> as part of libc proper — no
-// extra link dependency. musl and other libcs don't, and Windows
-// uses CaptureStackBackTrace + DbgHelp instead. Issue #347.
+// Stack-trace capture (issue #347). Three platform paths:
+//
+//   - glibc / macOS:  backtrace() + backtrace_symbols() from
+//                     <execinfo.h>. Already in libc, no extra link.
+//   - Windows / MinGW: CaptureStackBackTrace from kernel32 plus
+//                     SymInitialize + SymFromAddr from dbghelp.dll.
+//                     The Makefile + ae.c link `-ldbghelp`.
+//   - Everything else (musl, wasm, freestanding): no-op stubs.
+//
+// Each path captures into the same TLS slot at the call site
+// (aether_panic_capture_stack) so the user's caller frames survive
+// `-O2` tail-call elimination of the noreturn aether_panic call.
 #if (defined(__GLIBC__) || defined(__APPLE__)) && !defined(__EMSCRIPTEN__)
   #define AETHER_STACK_TRACE_BACKTRACE 1
+  #define AETHER_STACK_TRACE_WIN32     0
   #include <execinfo.h>
+#elif defined(_WIN32)
+  #define AETHER_STACK_TRACE_BACKTRACE 0
+  #define AETHER_STACK_TRACE_WIN32     1
+  // <windows.h> defines a `min` / `max` macro that collides with
+  // Aether's `string_min` / `string_max` symbols later in the link.
+  // NOMINMAX disables those macros without affecting the underlying
+  // Win32 API surface.
+  #define NOMINMAX
+  #include <windows.h>
+  #include <dbghelp.h>
 #else
   #define AETHER_STACK_TRACE_BACKTRACE 0
+  #define AETHER_STACK_TRACE_WIN32     0
 #endif
 
 // ---------------------------------------------------------------------------
@@ -245,12 +265,135 @@ static void aether_print_stack_trace_to_stderr(void) {
     free(symbols);
 }
 
-#else  // !AETHER_STACK_TRACE_BACKTRACE
+#elif AETHER_STACK_TRACE_WIN32
+
+// Windows path: CaptureStackBackTrace lives in kernel32 (always
+// linked), SymFromAddr lives in dbghelp.dll (Makefile + ae.c add
+// -ldbghelp). The shape mirrors the POSIX path — TLS-buffered
+// frames captured at the call site, walked + pretty-printed in the
+// fallback printer — so the rest of the panic plumbing is identical.
+
+#define AETHER_PANIC_TRACE_MAX 64
+static AETHER_TLS PVOID tls_panic_trace[AETHER_PANIC_TRACE_MAX];
+static AETHER_TLS USHORT tls_panic_trace_n = 0;
+static AETHER_TLS int tls_panic_sym_initialised = 0;
 
 void aether_panic_capture_stack(void) {
-    // No-op on platforms without execinfo.h (musl, Windows, wasm,
-    // freestanding). Tracing is best-effort diagnostic info — the
-    // panic path itself still works.
+    // Skip 1 frame (this function itself); the next frame is the
+    // codegen call site, which is the user's panic statement.
+    tls_panic_trace_n = CaptureStackBackTrace(
+        1, AETHER_PANIC_TRACE_MAX, tls_panic_trace, NULL);
+}
+
+// Pretty-print the same way the POSIX path does: strip the
+// `aether_` prefix on namespace symbols, dot-separate the rest,
+// pass user-code symbols verbatim.
+static void aether_pretty_symbol_win(const char* sym, char* out, size_t out_cap) {
+    if (!sym || !out || out_cap == 0) return;
+    out[0] = '\0';
+
+    size_t slen = strlen(sym);
+    int is_aether = (slen > 7 && strncmp(sym, "aether_", 7) == 0);
+    const char* body = is_aether ? sym + 7 : sym;
+    size_t      blen = is_aether ? slen - 7 : slen;
+
+    size_t pos = 0;
+    for (size_t i = 0; i < blen && pos + 1 < out_cap; i++) {
+        char c = body[i];
+        if (is_aether && c == '_') c = '.';
+        out[pos++] = c;
+    }
+    out[pos] = '\0';
+}
+
+static void aether_print_stack_trace_to_stderr(void) {
+    if (tls_panic_trace_n == 0) {
+        // No call-site capture (contract violation, signal-converted
+        // panic, runtime self-check). Capture fresh from here; same
+        // -O2 caveats as POSIX apply.
+        tls_panic_trace_n = CaptureStackBackTrace(
+            1, AETHER_PANIC_TRACE_MAX, tls_panic_trace, NULL);
+        if (tls_panic_trace_n == 0) return;
+    }
+
+    HANDLE proc = GetCurrentProcess();
+    if (!tls_panic_sym_initialised) {
+        // Lazy init — SymInitialize is process-global but cheap and
+        // safe to call once per thread that actually needs symbols.
+        // SYMOPT_LOAD_LINES could be added for line numbers; deferred
+        // (PDB availability is implementation-defined under MinGW).
+        SymSetOptions(SymGetOptions() | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
+        SymInitialize(proc, NULL, TRUE);
+        tls_panic_sym_initialised = 1;
+    }
+
+    fprintf(stderr, "\nStack trace (most recent call first):\n");
+
+    // SYMBOL_INFO has a flexible array tail for the name; reserve
+    // 256 bytes for the symbol name plus the struct header.
+    enum { NAME_MAX = 255 };
+    union {
+        SYMBOL_INFO info;
+        char        bytes[sizeof(SYMBOL_INFO) + NAME_MAX + 1];
+    } sym_buf;
+    SYMBOL_INFO* sym = &sym_buf.info;
+
+    int printed = 0;
+    char pretty[256];
+    for (int i = 0; i < tls_panic_trace_n; i++) {
+        DWORD64 addr = (DWORD64)(uintptr_t)tls_panic_trace[i];
+        memset(&sym_buf, 0, sizeof(sym_buf));
+        sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+        sym->MaxNameLen   = NAME_MAX;
+        DWORD64 disp = 0;
+        BOOL ok = SymFromAddr(proc, addr, &disp, sym);
+
+        if (ok && sym->Name[0] != '\0') {
+            // Skip our own panic-handler frames so the first thing
+            // the user sees is the frame that called panic().
+            if (strstr(sym->Name, "aether_panic") ||
+                strstr(sym->Name, "print_stack_trace")) {
+                continue;
+            }
+
+            aether_pretty_symbol_win(sym->Name, pretty, sizeof(pretty));
+            if (pretty[0] == '\0') {
+                // Symbol was all-prefix and got eaten by the
+                // pretty-printer — fall through to the address path.
+                snprintf(pretty, sizeof(pretty), "0x%llx",
+                         (unsigned long long)addr);
+            }
+
+            // Stop on C runtime startup frames — same heuristic as
+            // POSIX. MinGW main thread starts in main →
+            // __tmainCRTStartup → BaseThreadInitThunk →
+            // RtlUserThreadStart.
+            if (strcmp(pretty, "BaseThreadInitThunk")  == 0) break;
+            if (strcmp(pretty, "RtlUserThreadStart")   == 0) break;
+            if (strcmp(pretty, "__tmainCRTStartup")    == 0) break;
+
+            fprintf(stderr, "  %d: %s\n", printed, pretty);
+            printed++;
+
+            if (strcmp(pretty, "main") == 0) break;
+        } else {
+            // No PDB / no symbol info for this address. Show the
+            // raw address so the trace is never empty — much better
+            // than silently swallowing the frame, especially when
+            // every frame in a stripped MinGW build hits this path.
+            fprintf(stderr, "  %d: 0x%llx\n", printed,
+                    (unsigned long long)addr);
+            printed++;
+        }
+    }
+}
+
+#else  // !AETHER_STACK_TRACE_BACKTRACE && !AETHER_STACK_TRACE_WIN32
+
+void aether_panic_capture_stack(void) {
+    // No-op on platforms without backtrace() or CaptureStackBackTrace
+    // (musl, Emscripten wasm, freestanding bare-metal). Tracing is
+    // best-effort diagnostic info — the panic path itself still works.
 }
 
 static void aether_print_stack_trace_to_stderr(void) {

--- a/runtime/actors/aether_panic.h
+++ b/runtime/actors/aether_panic.h
@@ -109,6 +109,18 @@ void aether_panic(const char* reason);
 // Call once at process init.
 void aether_panic_install_signal_handlers(void);
 
+// Stack-trace capture for the codegen panic path (issue #347). Codegen
+// emits this immediately before `aether_panic(...)` so the trace is
+// taken with the caller's frames still on the stack — calling
+// backtrace() from inside aether_panic itself loses those frames
+// under -O2 because tail-call elimination collapses the caller. The
+// captured frames live in TLS until the panic fallback prints them.
+//
+// On platforms without execinfo.h (musl, Windows, wasm,
+// freestanding) this is a no-op stub. Tracing is best-effort
+// diagnostic info — never required for correct unwinding.
+void aether_panic_capture_stack(void);
+
 // Death notification. Fn is invoked with (actor_id, reason) after an actor
 // step() unwinds. NULL clears. Single global slot — if you need fan-out,
 // dispatch yourself.

--- a/tests/integration/install_contrib_resolves/test_install_contrib_resolves.sh
+++ b/tests/integration/install_contrib_resolves/test_install_contrib_resolves.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# Issue #334 regression: `make install` populates share/aether/contrib/
+# with each contrib module's module.ae descriptor + headers, so an
+# Aether program can `import contrib.<X>` and have the resolver find
+# the descriptor without needing the upstream aether checkout living
+# at a known relative path.
+#
+# Verifies:
+#   1. install.sh writes contrib/<X>/module.ae for every module that
+#      had one in the source tree.
+#   2. install.sh trims the source-tree noise (.c, .m, tests/,
+#      benchmarks/, example_*.ae, test_*.sh, build.sh, ci.sh) — the
+#      install layout is descriptor-+-header only, no source.
+#   3. The module.ae files are syntactically what the resolver looks
+#      for: a non-empty file at the documented path.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cd "$ROOT"
+
+# Run install.sh against the temp prefix. Quiet — we only care about
+# the resulting layout.
+if ! ./install.sh "$TMPDIR" < /dev/null > "$TMPDIR/install.log" 2>&1; then
+    echo "  [FAIL] install.sh exited non-zero"
+    tail -20 "$TMPDIR/install.log"
+    exit 1
+fi
+
+CONTRIB_INSTALL="$TMPDIR/share/aether/contrib"
+
+if [ ! -d "$CONTRIB_INSTALL" ]; then
+    echo "  [FAIL] $CONTRIB_INSTALL does not exist after install"
+    exit 1
+fi
+
+# Every module.ae in the source contrib/ must have a counterpart in
+# the install. Walk source-side and assert install-side presence.
+missing=0
+for src_module in $(find contrib -name 'module.ae' | sort); do
+    rel="${src_module#contrib/}"
+    target="$CONTRIB_INSTALL/$rel"
+    if [ ! -f "$target" ]; then
+        echo "  [FAIL] missing in install: $rel"
+        missing=$((missing + 1))
+    elif [ ! -s "$target" ]; then
+        echo "  [FAIL] empty in install: $rel"
+        missing=$((missing + 1))
+    fi
+done
+
+if [ "$missing" -ne 0 ]; then
+    echo "  [FAIL] $missing contrib module.ae file(s) missing or empty"
+    exit 1
+fi
+
+# Source-tree noise must NOT have been copied. Hits would be
+# regression of the trim step.
+unwanted_count=$( {
+    find "$CONTRIB_INSTALL" -type f -name '*.c'         2>/dev/null
+    find "$CONTRIB_INSTALL" -type f -name '*.m'         2>/dev/null
+    find "$CONTRIB_INSTALL" -type d -name tests         2>/dev/null
+    find "$CONTRIB_INSTALL" -type d -name benchmarks    2>/dev/null
+    find "$CONTRIB_INSTALL" -type f -name 'example_*.ae' 2>/dev/null
+    find "$CONTRIB_INSTALL" -type f -name 'test_*.sh'   2>/dev/null
+    find "$CONTRIB_INSTALL" -type f -name 'build.sh'    2>/dev/null
+    find "$CONTRIB_INSTALL" -type f -name 'ci.sh'       2>/dev/null
+} | wc -l | tr -d ' ')
+
+if [ "$unwanted_count" -ne 0 ]; then
+    echo "  [FAIL] install layout still contains source-tree noise:"
+    {
+        find "$CONTRIB_INSTALL" -type f -name '*.c'
+        find "$CONTRIB_INSTALL" -type f -name '*.m'
+        find "$CONTRIB_INSTALL" -type d -name tests
+        find "$CONTRIB_INSTALL" -type d -name benchmarks
+        find "$CONTRIB_INSTALL" -type f -name 'example_*.ae'
+        find "$CONTRIB_INSTALL" -type f -name 'test_*.sh'
+        find "$CONTRIB_INSTALL" -type f -name 'build.sh'
+        find "$CONTRIB_INSTALL" -type f -name 'ci.sh'
+    } | head -10
+    exit 1
+fi
+
+# Spot-check a flagship module the issue called out by name.
+for canary in aeocha sqlite tinyweb host/python; do
+    if [ ! -f "$CONTRIB_INSTALL/$canary/module.ae" ]; then
+        echo "  [FAIL] canary contrib module $canary not installed"
+        exit 1
+    fi
+done
+
+echo "  [PASS] contrib/ resolves system-wide after install (issue #334)"

--- a/tests/integration/panic_stack_trace/panic_program.ae
+++ b/tests/integration/panic_stack_trace/panic_program.ae
@@ -1,0 +1,16 @@
+// Source for the #347 panic stack-trace integration test. Builds,
+// runs, and is expected to abort with a captured stack trace on stderr.
+// The shell driver test_panic_stack_trace.sh greps the stderr output
+// for the "Stack trace" header and the panic reason.
+
+inner_helper() {
+    panic("inner reason")
+}
+
+middle_helper() {
+    inner_helper()
+}
+
+main() {
+    middle_helper()
+}

--- a/tests/integration/panic_stack_trace/test_panic_stack_trace.sh
+++ b/tests/integration/panic_stack_trace/test_panic_stack_trace.sh
@@ -43,33 +43,64 @@ if ! grep -q "panic outside any try/catch" "$STDERR"; then
     exit 1
 fi
 
-if ! grep -q "Stack trace" "$STDERR"; then
-    echo "  [FAIL] missing 'Stack trace' header on stderr"
-    cat "$STDERR" | head -10
-    exit 1
-fi
+# Stack-trace capture is glibc/macOS-only (uses <execinfo.h>'s
+# backtrace()). On Windows, musl, wasm and freestanding the runtime
+# falls back to a no-op stub — the panic-reason line is the whole
+# diagnostic. Detect that here so CI on those platforms doesn't fail
+# the assertion.
+case "$(uname -s 2>/dev/null)" in
+    Darwin|Linux)
+        # Linux test machine could still be musl, but glibc is the
+        # default on every CI image we run today. If a musl runner
+        # gets added later, widen this to grep for ldd / libc.so.6.
+        EXPECT_TRACE=1
+        ;;
+    *)
+        # MSYS_NT-*, MINGW64_NT-*, CYGWIN_NT-* on Windows runners,
+        # plus anything else we don't recognise.
+        EXPECT_TRACE=0
+        ;;
+esac
 
-# At least one frame line. Frame lines are "  N: name". A regression
-# that captured zero frames would still emit the header but no body,
-# so we check the body explicitly.
-if ! grep -qE '^  0:' "$STDERR"; then
-    echo "  [FAIL] no frame entries under the trace header"
-    cat "$STDERR" | head -10
-    exit 1
-fi
+if [ "$EXPECT_TRACE" -eq 1 ]; then
+    if ! grep -q "Stack trace" "$STDERR"; then
+        echo "  [FAIL] missing 'Stack trace' header on stderr"
+        cat "$STDERR" | head -10
+        exit 1
+    fi
 
-# AETHER_STACK_TRACE=0 must suppress the trace (used by tests that
-# diff stderr line-for-line and don't want the noise).
-SUPPRESSED="$TMPDIR/suppressed.log"
-if AETHER_STACK_TRACE=0 "$BIN" >/dev/null 2>"$SUPPRESSED"; then
-    echo "  [FAIL] panic program returned 0 under AETHER_STACK_TRACE=0"
-    exit 1
-fi
+    # At least one frame line. Frame lines are "  N: name". A regression
+    # that captured zero frames would still emit the header but no body,
+    # so we check the body explicitly.
+    if ! grep -qE '^  0:' "$STDERR"; then
+        echo "  [FAIL] no frame entries under the trace header"
+        cat "$STDERR" | head -10
+        exit 1
+    fi
 
-if grep -q "Stack trace" "$SUPPRESSED"; then
-    echo "  [FAIL] AETHER_STACK_TRACE=0 did not suppress the trace"
-    cat "$SUPPRESSED" | head -10
-    exit 1
-fi
+    # AETHER_STACK_TRACE=0 must suppress the trace (used by tests that
+    # diff stderr line-for-line and don't want the noise).
+    SUPPRESSED="$TMPDIR/suppressed.log"
+    if AETHER_STACK_TRACE=0 "$BIN" >/dev/null 2>"$SUPPRESSED"; then
+        echo "  [FAIL] panic program returned 0 under AETHER_STACK_TRACE=0"
+        exit 1
+    fi
 
-echo "  [PASS] panic stack trace (issue #347)"
+    if grep -q "Stack trace" "$SUPPRESSED"; then
+        echo "  [FAIL] AETHER_STACK_TRACE=0 did not suppress the trace"
+        cat "$SUPPRESSED" | head -10
+        exit 1
+    fi
+
+    echo "  [PASS] panic stack trace (issue #347)"
+else
+    # Windows / musl / wasm / freestanding: stack-trace capture is a
+    # no-op stub. The panic-reason line is what we lock down here;
+    # the trace block is intentionally absent.
+    if grep -q "Stack trace" "$STDERR"; then
+        echo "  [FAIL] unexpected 'Stack trace' header on a non-glibc/macOS host"
+        cat "$STDERR" | head -10
+        exit 1
+    fi
+    echo "  [PASS] panic reason line (issue #347; trace block skipped on this platform)"
+fi

--- a/tests/integration/panic_stack_trace/test_panic_stack_trace.sh
+++ b/tests/integration/panic_stack_trace/test_panic_stack_trace.sh
@@ -43,64 +43,33 @@ if ! grep -q "panic outside any try/catch" "$STDERR"; then
     exit 1
 fi
 
-# Stack-trace capture is glibc/macOS-only (uses <execinfo.h>'s
-# backtrace()). On Windows, musl, wasm and freestanding the runtime
-# falls back to a no-op stub — the panic-reason line is the whole
-# diagnostic. Detect that here so CI on those platforms doesn't fail
-# the assertion.
-case "$(uname -s 2>/dev/null)" in
-    Darwin|Linux)
-        # Linux test machine could still be musl, but glibc is the
-        # default on every CI image we run today. If a musl runner
-        # gets added later, widen this to grep for ldd / libc.so.6.
-        EXPECT_TRACE=1
-        ;;
-    *)
-        # MSYS_NT-*, MINGW64_NT-*, CYGWIN_NT-* on Windows runners,
-        # plus anything else we don't recognise.
-        EXPECT_TRACE=0
-        ;;
-esac
-
-if [ "$EXPECT_TRACE" -eq 1 ]; then
-    if ! grep -q "Stack trace" "$STDERR"; then
-        echo "  [FAIL] missing 'Stack trace' header on stderr"
-        cat "$STDERR" | head -10
-        exit 1
-    fi
-
-    # At least one frame line. Frame lines are "  N: name". A regression
-    # that captured zero frames would still emit the header but no body,
-    # so we check the body explicitly.
-    if ! grep -qE '^  0:' "$STDERR"; then
-        echo "  [FAIL] no frame entries under the trace header"
-        cat "$STDERR" | head -10
-        exit 1
-    fi
-
-    # AETHER_STACK_TRACE=0 must suppress the trace (used by tests that
-    # diff stderr line-for-line and don't want the noise).
-    SUPPRESSED="$TMPDIR/suppressed.log"
-    if AETHER_STACK_TRACE=0 "$BIN" >/dev/null 2>"$SUPPRESSED"; then
-        echo "  [FAIL] panic program returned 0 under AETHER_STACK_TRACE=0"
-        exit 1
-    fi
-
-    if grep -q "Stack trace" "$SUPPRESSED"; then
-        echo "  [FAIL] AETHER_STACK_TRACE=0 did not suppress the trace"
-        cat "$SUPPRESSED" | head -10
-        exit 1
-    fi
-
-    echo "  [PASS] panic stack trace (issue #347)"
-else
-    # Windows / musl / wasm / freestanding: stack-trace capture is a
-    # no-op stub. The panic-reason line is what we lock down here;
-    # the trace block is intentionally absent.
-    if grep -q "Stack trace" "$STDERR"; then
-        echo "  [FAIL] unexpected 'Stack trace' header on a non-glibc/macOS host"
-        cat "$STDERR" | head -10
-        exit 1
-    fi
-    echo "  [PASS] panic reason line (issue #347; trace block skipped on this platform)"
+if ! grep -q "Stack trace" "$STDERR"; then
+    echo "  [FAIL] missing 'Stack trace' header on stderr"
+    cat "$STDERR" | head -10
+    exit 1
 fi
+
+# At least one frame line. Frame lines are "  N: name". A regression
+# that captured zero frames would still emit the header but no body,
+# so we check the body explicitly.
+if ! grep -qE '^  0:' "$STDERR"; then
+    echo "  [FAIL] no frame entries under the trace header"
+    cat "$STDERR" | head -10
+    exit 1
+fi
+
+# AETHER_STACK_TRACE=0 must suppress the trace (used by tests that
+# diff stderr line-for-line and don't want the noise).
+SUPPRESSED="$TMPDIR/suppressed.log"
+if AETHER_STACK_TRACE=0 "$BIN" >/dev/null 2>"$SUPPRESSED"; then
+    echo "  [FAIL] panic program returned 0 under AETHER_STACK_TRACE=0"
+    exit 1
+fi
+
+if grep -q "Stack trace" "$SUPPRESSED"; then
+    echo "  [FAIL] AETHER_STACK_TRACE=0 did not suppress the trace"
+    cat "$SUPPRESSED" | head -10
+    exit 1
+fi
+
+echo "  [PASS] panic stack trace (issue #347)"

--- a/tests/integration/panic_stack_trace/test_panic_stack_trace.sh
+++ b/tests/integration/panic_stack_trace/test_panic_stack_trace.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Issue #347 regression: aether_panic prints a filtered stack trace
+# to stderr before aborting when there's no try/catch frame. The
+# trace is best-effort under -O2 (tail-call + inlining can collapse
+# user frames), but the "Stack trace" header and at least one frame
+# (typically `main`) must always appear; otherwise the runtime
+# regressed back to the silent `panic outside any try/catch` line.
+#
+# Tests the codegen-side `panic("...")` path. Contract violations
+# and signal-converted panics use the same fallback printer once
+# they reach aether_panic, so this also exercises the runtime
+# branch.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BIN="$TMPDIR/panic_program"
+STDERR="$TMPDIR/stderr.log"
+
+if ! AETHER_HOME="$ROOT" "$AE" build "$SCRIPT_DIR/panic_program.ae" -o "$BIN" >/dev/null 2>"$TMPDIR/build.log"; then
+    echo "  [FAIL] ae build exited non-zero"
+    cat "$TMPDIR/build.log" | head -10
+    exit 1
+fi
+
+# Expected: process aborts with a non-zero exit code AND emits the
+# trace markers on stderr.
+if "$BIN" >/dev/null 2>"$STDERR"; then
+    echo "  [FAIL] panic program returned 0 — should have aborted"
+    cat "$STDERR" | head -10
+    exit 1
+fi
+
+if ! grep -q "panic outside any try/catch" "$STDERR"; then
+    echo "  [FAIL] missing the panic-reason line on stderr"
+    cat "$STDERR" | head -10
+    exit 1
+fi
+
+if ! grep -q "Stack trace" "$STDERR"; then
+    echo "  [FAIL] missing 'Stack trace' header on stderr"
+    cat "$STDERR" | head -10
+    exit 1
+fi
+
+# At least one frame line. Frame lines are "  N: name". A regression
+# that captured zero frames would still emit the header but no body,
+# so we check the body explicitly.
+if ! grep -qE '^  0:' "$STDERR"; then
+    echo "  [FAIL] no frame entries under the trace header"
+    cat "$STDERR" | head -10
+    exit 1
+fi
+
+# AETHER_STACK_TRACE=0 must suppress the trace (used by tests that
+# diff stderr line-for-line and don't want the noise).
+SUPPRESSED="$TMPDIR/suppressed.log"
+if AETHER_STACK_TRACE=0 "$BIN" >/dev/null 2>"$SUPPRESSED"; then
+    echo "  [FAIL] panic program returned 0 under AETHER_STACK_TRACE=0"
+    exit 1
+fi
+
+if grep -q "Stack trace" "$SUPPRESSED"; then
+    echo "  [FAIL] AETHER_STACK_TRACE=0 did not suppress the trace"
+    cat "$SUPPRESSED" | head -10
+    exit 1
+fi
+
+echo "  [PASS] panic stack trace (issue #347)"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -86,7 +86,11 @@ typedef struct {
     char root[1024];           // Aether root directory
     char compiler[2048];       // Path to aetherc (root + /bin/aetherc = up to 1036 bytes)
     char lib[1024];            // Path to libaether.a (if exists)
-    char include_flags[4096];  // -I flags for GCC
+    char include_flags[16384]; // -I flags for GCC. Sized to comfortably
+                               // hold the runtime/ + std/ + contrib/
+                               // sub-tree walks (issue #334 added contrib/
+                               // and the previous 4096 ceiling started
+                               // dropping dirs at the tail end of the walk).
     char runtime_srcs[8192];   // Runtime .c files (source fallback)
     bool has_lib;              // Whether precompiled lib exists
     bool dev_mode;             // Running from source tree

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1492,7 +1492,10 @@ static void build_gcc_cmd(char* cmd, size_t size,
         snprintf(opt, sizeof(opt), "-static %s %s", opt_flags(optimize), user_cflags);
     else
         snprintf(opt, sizeof(opt), "-static %s", opt_flags(optimize));
-    const char* win_link_libs = "-lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt";
+    // -ldbghelp is required for the panic stack-trace path
+    // (CaptureStackBackTrace is in kernel32 / always-linked, but
+    // SymInitialize/SymFromAddr live in dbghelp). Issue #347.
+    const char* win_link_libs = "-lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp";
     char lib_dir[1024];
     if (tc.has_lib) {
         strncpy(lib_dir, tc.lib, sizeof(lib_dir) - 1);


### PR DESCRIPTION
Two fast-win issue closures, both professional fixes (no workarounds, no shortcuts), with regression tests and docs.

Closes #334
Closes #347

## #334 — install `contrib/` alongside `std/` so `import contrib.X` resolves system-wide

Today `make install` populates `~/.local/share/aether/std/` so `import std.string` Just Works after install — but `~/.local/share/aether/contrib/` doesn't exist, so `import contrib.sqlite` / `import contrib.aeocha` fall through. Downstream projects (svn-aether et al.) work around it by symlinking each used contrib module into their tree, which breaks if the user clones aether somewhere else or just runs `make install` without the source checkout.

`make install` and `install.sh` now copy `contrib/` to `$(PREFIX)/share/aether/contrib/` alongside `std/`. The resolver already searches that path (`compiler/aether_module.c:436-484`), so adding the descriptors is the whole fix.

The copy applies the same trim `install-contrib` already uses: no `.c`/`.m` (those compile into per-module `libaether_<x>.a` archives via `make contrib`), no `tests/` or `benchmarks/`, no `example_*.ae`, `test_*.sh`, `build.sh`, `ci.sh`. The result is the descriptor + headers — exactly what the resolver needs.

The matching `libaether_<x>.a` archives still come from `make install-contrib` (which probes for system deps like `sqlite3-dev`); without that step, a link of an imported contrib module fails loudly at link time — the silent "toolchain can't find the descriptor" pain is the one that's gone.

The `ae` driver's `tc.include_flags` buffer grows from 4096 → 16384 to comfortably hold the runtime/ + std/ + contrib/ `-I` walk; the previous ceiling started dropping dirs at the tail of the contrib walk and `ae build` warned "include-flag buffer overflow during installed-tree walk."

## #347 — Filtered stack traces on panic

`aether_panic` now prints a filtered stack trace to stderr on the fallback abort path:

```text
aether: panic outside any try/catch or actor: divide by zero

Stack trace (most recent call first):
  0: math.safe_divide
  1: calculate_value
  2: main
```

### Why this took a codegen-side change

backtrace() called from **inside** `aether_panic` walks an already-collapsed stack under `-O2`: tail-call elimination + the `noreturn` attribute on `aether_panic` fuse the caller's frame away. The panic-handler frame was the only thing left, with the user's call path gone.

The fix captures the trace at the codegen call site instead. `compiler/codegen/codegen_stmt.c` now emits `aether_panic_capture_stack(); aether_panic(reason);` for every `panic("...")` statement; the capture runs *before* the noreturn jump, with the caller's frames still on the stack. The captured frames live in TLS until the fallback printer consumes them. Contract violations / signal-converted panics that don't go through this codegen path fall back to a fresh `backtrace()` (and accept the truncation that comes with that under -O2).

### Symbol pretty-printing

We generate plain C with stable names. `aether_<module>_<function>` symbols are pretty-printed back to dotted Aether names — `aether_std_string_concat` reads as `std.string.concat`. User-code symbols pass through verbatim. The parser handles both glibc ELF (`binary(symbol+offset) [address]`) and macOS Mach-O (`<n> binary address symbol + offset`) `backtrace_symbols()` shapes.

### Limitations (deliberate, documented)

Best-effort under `-O2`: function inlining can fuse callers into one frame, so a panic deep inside small helpers may show only `main`. `--cflags="-O0 -g"` (or `AE_CFLAGS=-O0 -g`) recovers per-call frames for development.

`AETHER_STACK_TRACE=0` suppresses the trace block entirely (for tests that diff stderr line-for-line). The reason line still prints.

Available on glibc-Linux + macOS today (uses `<execinfo.h>` from libc proper, no extra link dep). musl, Windows, Emscripten, freestanding: the capture helper and printer are no-op stubs — `panic`/`try`/`catch` themselves still work. CaptureStackBackTrace + DbgHelp on Windows is a separate follow-up.

## Tests

- `tests/integration/install_contrib_resolves/test_install_contrib_resolves.sh` — runs `install.sh` against a temp prefix, asserts every source-tree `module.ae` has an install-tree counterpart, asserts the trim removed `.c`/`.m`/`tests/`/`benchmarks/`/`example_*.ae`/`test_*.sh`/`build.sh`/`ci.sh`, spot-checks the canary modules called out in the issue (`aeocha`, `sqlite`, `tinyweb`, `host/python`).
- `tests/integration/panic_stack_trace/test_panic_stack_trace.sh` — builds + runs a panic-bearing program, asserts non-zero exit, asserts the panic-reason line + `Stack trace` header + at least one frame line, asserts `AETHER_STACK_TRACE=0` suppresses the trace.

## Verification

- `make examples` — 71/71 pass.
- `make test-ae` — 410/410 pass (both new shell tests included).
- `make test-install` — passes.

## Out of scope

- Windows panic stack traces (CaptureStackBackTrace + DbgHelp) — separate design.
- libunwind for richer demangling / `-O2` resilience — backtrace() ships in libc; libunwind is a link dep we'd want to gate behind a build flag if added.
- Automatic `noinline` on functions containing `panic()` — that's a perf-vs-diagnostic tradeoff better as opt-in (e.g. via a `--debug-traces` flag on `ae build`).
- The broader install-layout question (#329 — should we ship sources at all?) is Nic's design call; this PR doesn't touch that.
