### PR TITLE
fix(codegen): closure-local tuple destructure of a captured outer-scope name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **aetherc codegen: closure-local tuple destructure of a captured outer-scope name** (`compiler/codegen/codegen_expr.c`, `compiler/codegen/codegen_stmt.c`, `tests/regression/test_closure_shadow_tuple_destructure.ae`). When a closure body destructured a tuple into names that shadowed outer-scope variables also captured by the closure (e.g. `out, status, _ = sh(cmd)` inside an `it()` callback whose outer `main()` had its own `out, status, err = sh(...)`), codegen emitted `name = _tup._N` against the captured-by-reference slot — a `T**` from the closure env. Result: a `[-Wincompatible-pointer-types]` C warning and a startup segfault before any user output as soon as the closure body next dereferenced the captured slot. Two fix sites: `is_assigned_to` (in `codegen_expr.c`) now treats `AST_TUPLE_DESTRUCTURE` targets as writes for promotion analysis, so the outer name gets heap-promoted; the `AST_TUPLE_DESTRUCTURE` emit (in `codegen_stmt.c`) now mirrors the `AST_VARIABLE_DECLARATION` Route-1 path — declares `T* x = malloc(...); *x = _tup._N` at the outer first-use and `*x = _tup._N` at the closure-body reassignment, with a defer-free queued at scope exit. Reported by the svn-aether porter as closure-shadow-tuple-destructure (Round 238/239) — the diagnostic was non-obvious (silent segfault, no "shadowing" hint) and the natural test-driver pattern (top-of-main shell prep + per-`it()` shell assertions, all using the same `out, status, err` triple) hit it immediately. Workaround that's no longer needed: rename the outer destructure's targets to `prep_out_`/`prep_st_`/`prep_err_`.
+
 ## [0.125.0]
 
 ### Added

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -372,6 +372,21 @@ static int is_assigned_to(ASTNode* node, const char* name) {
         strcmp(node->value, name) == 0) {
         return 1;
     }
+    // Tuple destructure assigns to each non-discard target; if `name` is
+    // any of them, treat as assignment for promotion analysis. Without
+    // this, `out, status, _ = sh(...)` inside a closure body would
+    // miscompile against an unpromoted outer-scope `out` (closure-shadow
+    // -tuple-destructure bug, svn-aether porter Round 238/239).
+    if (node->type == AST_TUPLE_DESTRUCTURE && node->child_count >= 2) {
+        int var_count = node->child_count - 1;
+        for (int j = 0; j < var_count; j++) {
+            ASTNode* var = node->children[j];
+            if (var && var->value && strcmp(var->value, name) == 0 &&
+                strcmp(var->value, "_") != 0) {
+                return 1;
+            }
+        }
+    }
     for (int i = 0; i < node->child_count; i++) {
         if (is_assigned_to(node->children[i], name)) return 1;
     }

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -915,7 +915,53 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                     var_type = get_c_type(var->node_type);
                 }
                 print_indent(gen);
+                // Promoted-capture aware destructure: same routing as the
+                // AST_VARIABLE_DECLARATION single-name path. At first use
+                // declare the heap cell + defer free; on reassignment write
+                // through the cell. Without this, a closure-body destructure
+                // of a captured name miscompiled as `name = _tup._N` against
+                // a `T**` slot — produced a -Wincompatible-pointer-types
+                // warning and a runtime segfault on the next deref of the
+                // captured slot (closure-shadow-tuple-destructure, svn-aether
+                // porter Round 238/239). The matching is_assigned_to fix in
+                // codegen_expr.c teaches the promotion analysis to see
+                // tuple-destructure targets as writes.
+                if (is_promoted_capture(gen, var->value)) {
+                    if (!is_var_declared(gen, var->value)) {
+                        const char* c_type = var_type && var_type[0] ? var_type : "int";
+                        fprintf(gen->output,
+                                "%s* %s = malloc(sizeof(%s)); *%s = _tup%d._%d;\n",
+                                c_type, var->value, c_type, var->value, tmp_id, j);
+                        mark_var_declared(gen, var->value);
+                        ASTNode* free_call = create_ast_node(AST_FUNCTION_CALL, "free",
+                            stmt->line, stmt->column);
+                        ASTNode* arg = create_ast_node(AST_IDENTIFIER, var->value,
+                            stmt->line, stmt->column);
+                        if (arg->annotation) free(arg->annotation);
+                        arg->annotation = strdup("raw_promoted");
+                        add_child(free_call, arg);
+                        ASTNode* expr_stmt = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
+                            stmt->line, stmt->column);
+                        add_child(expr_stmt, free_call);
+                        push_defer(gen, expr_stmt);
+                    } else {
+                        fprintf(gen->output, "*%s = _tup%d._%d;\n", var->value, tmp_id, j);
+                    }
+                    continue;
+                }
                 if (is_var_declared(gen, var->value)) {
+                    int destruct_is_env_cap = 0;
+                    for (int ec = 0; ec < gen->current_env_capture_count; ec++) {
+                        if (gen->current_env_captures[ec] &&
+                            strcmp(gen->current_env_captures[ec], var->value) == 0) {
+                            destruct_is_env_cap = 1;
+                            break;
+                        }
+                    }
+                    if (destruct_is_env_cap) {
+                        fprintf(gen->output, "_env->%s = _tup%d._%d;\n", var->value, tmp_id, j);
+                        continue;
+                    }
                     fprintf(gen->output, "%s = _tup%d._%d;\n", var->value, tmp_id, j);
                 } else {
                     mark_var_declared(gen, var->value);

--- a/tests/regression/test_closure_shadow_tuple_destructure.ae
+++ b/tests/regression/test_closure_shadow_tuple_destructure.ae
@@ -1,0 +1,52 @@
+// Regression: closure-local tuple destructure used to silently
+// miscompile when the destructure targets shadowed an outer-scope
+// variable also captured by the closure.
+//
+// Symptom (pre-fix): codegen emitted `name = _tup._N` against the
+// captured-by-reference slot (a `T**`), producing a
+// -Wincompatible-pointer-types C warning and a startup segfault
+// before any user output. Reported by the svn-aether porter as
+// closure-shadow-tuple-destructure (Round 238/239).
+//
+// Fix sites:
+//   - compiler/codegen/codegen_expr.c — is_assigned_to now treats
+//     AST_TUPLE_DESTRUCTURE targets as assignments, so promotion
+//     analysis sees them and heap-cells the outer slot.
+//   - compiler/codegen/codegen_stmt.c — AST_TUPLE_DESTRUCTURE
+//     emits `T* x = malloc(...); *x = _tup._N` at the outer
+//     declaration site (when promoted) and `*x = _tup._N` at
+//     subsequent writes (closure body), mirroring the
+//     AST_VARIABLE_DECLARATION single-name path.
+//
+// This test compiles cleanly (no warnings), runs without crashing,
+// and produces the expected aeocha pass.
+
+import contrib.aeocha
+import std.os
+import std.string
+
+extern list_new() -> ptr
+extern list_add_raw(list: ptr, item: ptr) -> int
+
+mywrap(cmd: string) -> {
+    argv = list_new()
+    list_add_raw(argv, "-c")
+    list_add_raw(argv, cmd)
+    out, status, err = os.run_capture("/bin/bash", argv, null)
+    return out, status, err
+}
+
+main() {
+    fw = aeocha.init()
+    // Outer destructure declares out/status/err. The closure below
+    // captures `out` and re-destructures with the same name —
+    // pre-fix, this segfaulted before any test output.
+    out, status, err = mywrap("echo hello")
+    aeocha.describe(fw, "tuple-destructure shadow") {
+        aeocha.it("re-destructures captured names without crashing") callback {
+            out, status, _ = mywrap("echo world")
+            aeocha.expect_stdout_contains(fw, out, "world", "world reached body")
+        }
+    }
+    aeocha.run_summary(fw)
+}

--- a/tests/regression/test_closure_shadow_tuple_destructure.ae
+++ b/tests/regression/test_closure_shadow_tuple_destructure.ae
@@ -32,11 +32,22 @@ mywrap(cmd: string) -> {
     argv = list_new()
     list_add_raw(argv, "-c")
     list_add_raw(argv, cmd)
-    out, status, err = os.run_capture("/bin/bash", argv, null)
+    out, status, err = os.run_capture("/bin/sh", argv, null)
     return out, status, err
 }
 
 main() {
+    // Skip on Windows — the codegen miscompile being regressed is
+    // platform-independent, but the repro relies on /bin/sh -c to
+    // produce captured stdout. MSYS2 doesn't ship /bin/sh in a shape
+    // compatible with os.run_capture's argv contract, and the same
+    // fix sites are exercised by the POSIX runners. Same skip pattern
+    // as test_run_capture_status.ae.
+    if os_getenv("OS") == "Windows_NT" {
+        println("SKIP: test_closure_shadow_tuple_destructure — /bin/sh -c not POSIX-shaped on Windows")
+        return
+    }
+
     fw = aeocha.init()
     // Outer destructure declares out/status/err. The closure below
     // captures `out` and re-destructures with the same name —


### PR DESCRIPTION
## Summary

- A closure body that destructured a tuple into names also captured from the enclosing scope used to silently miscompile and segfault at startup. Symptom: C codegen emitted `name = _tup._N` against the captured-by-reference slot (a `T**` pulled from the closure env), producing a `-Wincompatible-pointer-types` warning and a runtime segfault on the next deref of the captured slot. Reported by the svn-aether porter as closure-shadow-tuple-destructure (Round 238/239).
- Two fix sites — `is_assigned_to` (`codegen_expr.c`) now treats `AST_TUPLE_DESTRUCTURE` targets as writes for promotion analysis, and the `AST_TUPLE_DESTRUCTURE` emit (`codegen_stmt.c`) now mirrors `AST_VARIABLE_DECLARATION`'s Route-1 promoted-capture path: `T* x = malloc(...); *x = _tup._N` + defer-free at the outer declaration site, `*x = _tup._N` at the closure-body reassignment.
- New regression test (`tests/regression/test_closure_shadow_tuple_destructure.ae`) mirrors the porter's repro and compiles+runs cleanly post-fix.

## Why it bit porters

The pre-fix diagnostic was a silent segfault before any user output, with only an obscure C-level `-Wincompatible-pointer-types` to hint at the cause. The natural test-driver pattern — top-of-`main()` shell prep + per-`it()` shell assertions, all using the same `out, status, err` triple — collided with itself immediately. Documented workaround was rename-the-outer (`prep_out_`/`prep_st_`/`prep_err_`); that's no longer needed.

## Test plan

- [x] Porter's 22-line repro: was segfault, now passes
- [x] `tests/regression/test_closure_shadow_tuple_destructure.ae` — new regression, green
- [x] `contrib/aeocha/example_self_test.ae` — 11/11, no regression
- [x] `tests/regression/test_closure_extern_ordering.ae` — passes (sibling closure-codegen test)
- [x] All `tests/syntax/test_closure_*.ae` (sampled) — pass
- [x] All `tests/syntax/test_*tuple*.ae` — pass
- [ ] Full CI (`make ci` / `make ci-coop`) on Linux + macOS + Windows runners

## Related

- `closure-extern-ordering.md` — different bug, same family (closures + codegen go wrong); fixed in 0.123.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)