### PR TITLE
VCR record-mode hardening with SVN checkout tape equivalence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,3 +473,60 @@ jobs:
           aether-*.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ================================================================== #
+  # SNAPSHOT — publish main HEAD sources to a stable snapshot URL      #
+  # ================================================================== #
+  snapshot:
+    name: Update snapshot (main HEAD)
+    runs-on: ubuntu-latest
+    if: |
+      github.ref == 'refs/heads/main' &&
+      !startsWith(github.event.head_commit.message, 'chore: release')
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Create source archives
+      run: |
+        VERSION=$(cat VERSION | tr -d '[:space:]')
+        COMMIT=$(git rev-parse --short HEAD)
+        git archive --format=tar.gz \
+          --prefix=aether-source/ \
+          HEAD > aether-source.tar.gz
+        git archive --format=zip \
+          --prefix=aether-source/ \
+          HEAD > aether-source.zip
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "COMMIT=$COMMIT" >> "$GITHUB_ENV"
+
+    - name: Update snapshot release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: snapshot
+        name: "Snapshot (main HEAD)"
+        body: |
+          **Always-fresh source archives from `main` branch.**
+
+          Updated on every merge. Use for builds that track Aether HEAD.
+
+          ```bash
+          curl -L https://github.com/aether-lang-org/aether/releases/download/snapshot/aether-source.tar.gz | tar xz
+          cd aether-source
+          make compiler ae stdlib
+          ```
+
+          Latest commit: `${{ env.COMMIT }}`
+          VERSION file: `${{ env.VERSION }}`
+        prerelease: true
+        draft: false
+        files: |
+          aether-source.tar.gz
+          aether-source.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.http.server.vcr` record-mode hardening** (`std/http/server/vcr/`, `tests/integration/test_vcr_*.ae`). Adds live forwarding record mode, all-method VCR coverage, record/playback diagnostics, Servirtium-style drift failure via `flush_and_fail_if_changed`, gzip normalize/restore for `Content-Encoding: gzip`, and updated VCR documentation/test coverage maps. Supporting HTTP fixes make client response bodies and server `response_set_body_n` binary-safe for gzip payloads.
+
 ## [0.128.0]
 
 ### Added

--- a/docs/http-vcr.md
+++ b/docs/http-vcr.md
@@ -17,8 +17,9 @@ medium.
   runs replay from the tape — no network, no flakiness, no rate
   limits, no upstream-changed-overnight surprises.
 - **Pin upstream behavior.** The tape becomes a contract: if the
-  upstream service changes its response shape, the re-record
-  check catches the byte-level diff (`vcr.flush_or_check`).
+  upstream service changes its response shape, the re-record checks
+  catch the byte-level diff (`vcr.flush_or_check` or
+  `vcr.flush_and_fail_if_changed`).
 - **Run UI tests offline.** Static-content mounts let
   Selenium/Cypress/Playwright pull CSS/JS/images straight from
   disk without each one polluting the tape.
@@ -33,6 +34,8 @@ medium.
 import std.http.server.vcr
 import std.http
 import std.http.client
+
+extern http_server_stop(server: ptr)
 
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
@@ -53,6 +56,33 @@ main() {
     body, err = http.get("http://127.0.0.1:18099/things/42")
 
     vcr.eject(raw)
+}
+```
+
+## Quick start (record)
+
+```aether
+import std.http.server.vcr
+import std.http
+import std.http.client
+
+main() {
+    raw = vcr.load_record("tests/tapes/my.tape",
+                          "https://supplier.example.test", 18100)
+    http.server_start_background(raw)
+
+    // The SUT/client library points at http://127.0.0.1:18100.
+    // VCR forwards to the supplier and records the interaction.
+    req = client.request("GET", "http://127.0.0.1:18100/things/42")
+    resp, err = client.send_request(req)
+    client.request_free(req)
+    client.response_free(resp)
+
+    // Servirtium-style drift check: stop the recorder, write the new
+    // tape to the normal path, but return an error if it differs so
+    // the test fails and git diff shows the change directly.
+    http_server_stop(raw)
+    ferr = vcr.flush_and_fail_if_changed("tests/tapes/my.tape")
 }
 ```
 
@@ -99,13 +129,26 @@ they're part of the format, not markdown escaping.
 | Feature                           | Functions                                   |
 |-----------------------------------|---------------------------------------------|
 | **Replay** (load + serve)         | `vcr.load`, `vcr.eject`, `vcr.tape_length`  |
-| **Record** (capture + flush)      | `vcr.record`, `vcr.record_full`, `vcr.flush` |
-| **Re-record check**               | `vcr.flush_or_check`                        |
+| **Record server**                 | `vcr.load_record`, `vcr.eject_record`       |
+| **Direct capture + flush**        | `vcr.record`, `vcr.record_full`, `vcr.record_full_response`, `vcr.clear_recording`, `vcr.flush` |
+| **Re-record checks**              | `vcr.flush_or_check`, `vcr.flush_and_fail_if_changed` |
 | **Notes** (per-interaction)       | `vcr.note`                                  |
-| **Redactions** (scrub at flush)   | `vcr.redact`, `vcr.clear_redactions`, `vcr.FIELD_PATH`, `vcr.FIELD_RESPONSE_BODY` |
-| **Strict request matching**       | `vcr.last_error`, `vcr.clear_last_error`    |
+| **Redactions / unredactions**     | `vcr.redact`, `vcr.clear_redactions`, `vcr.unredact`, `vcr.clear_unredactions` |
+| **Header removal**                | `vcr.remove_header`, `vcr.clear_header_removals` |
+| **Strict request matching**       | `vcr.last_error`, `vcr.clear_last_error`, `vcr.last_kind`, `vcr.last_index`, `vcr.reset_cursor`, `vcr.set_strict_headers` |
 | **Static-content mounts**         | `vcr.static_content`, `vcr.clear_static_content` |
 | **Optional markdown formats**     | `vcr.emphasize_http_verbs`, `vcr.indent_code_blocks`, `vcr.clear_format_options` |
+
+Field selectors for mutations: `vcr.FIELD_PATH`,
+`vcr.FIELD_REQUEST_HEADERS`, `vcr.FIELD_REQUEST_BODY`,
+`vcr.FIELD_RESPONSE_HEADERS`, `vcr.FIELD_RESPONSE_BODY`.
+
+Gzip policy: record mode treats `Content-Encoding: gzip` as a
+transport encoding. The caller receives the upstream gzip response,
+but the tape stores the decoded body and omits `Content-Encoding` /
+`Content-Length`. Playback serves decoded bodies by default and
+restores gzip plus `Vary: Accept-Encoding` when the caller sends
+`Accept-Encoding: gzip`.
 
 ## Servirtium roadmap status
 
@@ -121,8 +164,8 @@ new implementations at https://servirtium.dev. Aether's
 | 4    | Re-record byte-diff check                     | ✓ |
 | 5    | Multiple-interaction handling                 | ✓ |
 | 6    | Library extracted to its own module           | ✓ |
-| 7    | Other HTTP verbs (POST/PUT/DELETE/PATCH)      | ✓ |
-| 8    | Mutation operations (redactions)              | ✓ |
+| 7    | Other HTTP verbs                              | ✓ |
+| 8    | Mutation operations                           | ✓ |
 | 9    | Per-interaction Notes                         | ✓ |
 | 10   | Strict request matching + last-error surface  | ✓ |
 | 11   | Static-content serving                        | ✓ |
@@ -191,6 +234,11 @@ where this implementation drifted from the spec).
 | Test file                                              | What it exercises |
 |--------------------------------------------------------|-------------------|
 | `tests/integration/test_vcr_redactions.ae`             | Step 8 — flush-time scrubbing of body / path |
+| `tests/integration/test_vcr_unredactions.ae`           | Step 8/10 — playback unredactions and header removals |
+| `tests/integration/test_vcr_verbs.ae`                  | Step 7 — POST/PUT/HEAD/DELETE/OPTIONS/TRACE/PATCH plus GET-with-body |
+| `tests/integration/test_vcr_drift_fail.ae`             | Step 4 — overwrite-and-fail drift behavior |
+| `tests/integration/test_vcr_record_last_error.ae`      | Step 3/10 — record-mode diagnostics |
+| `tests/integration/test_vcr_gzip_normalize.ae`         | Step 3 — gzip normalize/restore |
 | `tests/integration/test_vcr_notes.ae`                  | Step 9 — per-interaction `[Note]` blocks |
 | `tests/integration/test_vcr_strict_match.ae`           | Step 10 — header mismatch surfaces via `last_error` |
 | `tests/integration/test_vcr_strict_match_body.ae`      | Step 10 — body mismatch surfaces via `last_error` |

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -287,75 +287,30 @@ issue when scheduled):
   build; revisit if the wire-size profile differs.
 - **HTTP/3 / QUIC.** Out of scope for #260; would be its own issue.
 
-## VCR recorder — transparent MITM forwarder
+## VCR recorder — delivered first cut
 
-`std.http.server.vcr` ships replay (load tape → server replays
-recorded responses) and the storage primitives (`vcr.record`,
-`vcr.record_full`, `vcr.flush`). What's missing is the **recording
-proxy** — an in-process forwarder that:
+`std.http.server.vcr` now has record mode in `std`:
+`vcr.load_record(tape_path, upstream_base, port)` binds a normal HTTP
+server, forwards inbound requests upstream using `std.http.client`,
+returns the upstream response to the caller, and records the
+interaction into the same in-memory tape used by playback. It is not
+an HTTP proxy (`HTTP_PROXY` / `CONNECT`) and does not use browser/CORS
+tricks; the SUT is simply configured to use the VCR base URL as its
+supplier URL.
 
-1. Accepts inbound HTTP from a client (svn, curl, http test
-   harness, or any application configured to point at it).
-2. Forwards each request upstream to the real service, rewriting
-   the Host header `127.0.0.1:PORT` → upstream hostname before
-   sending so the upstream sees a normal request.
-3. Captures the request + response as they pass through, calling
-   `vcr.record_full(...)` to append the interaction.
-4. Returns the upstream's response back to the original client.
-5. On stop, flushes the captured interactions to a tape file via
-   `vcr.flush(path)`.
+Delivered supporting pieces:
 
-**Shape (transparent MITM, not a proxy or CORS trick):** from the
-client's POV the recorder *is* the upstream — same URL, same hostname
-in the URL bar / config, same response shapes. The client doesn't
-know it's being intercepted. Not an HTTP proxy in the
-`HTTP_PROXY=...` / `CONNECT`-method sense; not a browser-side CORS
-workaround. Just a normal HTTP server that happens to forward and
-capture everything that flies through it.
+- wildcard method/path route for both record and playback
+- all-method coverage, including custom/WebDAV-style methods
+- redactions, unredactions, header removals, and notes
+- record/playback diagnostics through `last_error`, `last_kind`, and `last_index`
+- `flush_or_check()` for `.actual` comparison workflows
+- `flush_and_fail_if_changed()` for Servirtium-style "write new tape and fail" drift
+- gzip normalize/restore for `Content-Encoding: gzip`
 
-**Why a separate piece, not a flag on `vcr.load()`:** the recorder
-pulls in `std.http.client` (for outbound) on top of the existing
-`std.http` server side that VCR already uses for replay. Different
-config (upstream URL + scheme), different lifecycle (records on
-incoming, vs replay's load-once-then-serve), and conceptually
-client-of-its-own-server. Belongs alongside but distinct from the
-replay dispatcher.
-
-**Placement:** likely `contrib/vcrrecord/` rather than
-`std/http/server/vcr/` — recorder is a developer testing tool with
-opinionated shape (which headers to redact at record time, how to
-canonicalize User-Agent / Date / UUID for re-recording stability),
-which is contrib-shaped per `docs/stdlib-vs-contrib.md`. Storage
-stays in std (the tape format is the stable interop format).
-
-**Open design questions** (resolved when a real recording use case
-shows up):
-
-- Header-redaction surface: is `vcr.redact()` (already in std)
-  enough, or does the recorder want a record-time hook surface
-  like Java Servirtium's `InteractionManipulations`? The Java
-  interface is broad (URL rewrite, single-header rewrite, body
-  rewrite, allowlist/denylist) but most svn-flavoured uses boil
-  down to "pin User-Agent, replace UUID and Date in stored
-  response headers." Defer the broader hook surface until a second
-  recording use case demands it.
-- HTTPS upstream: the recorder needs `client.send_request` against
-  HTTPS upstreams (svn.apache.org, GitHub APIs, etc). `std.http.client`
-  has TLS support; recorder just needs to default to upstream
-  scheme detection.
-- Dual mode: should one VCR instance switch between record and
-  replay (Java Servirtium model) or are they separate constructs
-  (closer to the existing `vcr.load` shape)? Java's mode-flip is
-  convenient; the cost is config complexity. Two constructs is
-  simpler.
-
-Driven by a real recording use case rather than anticipation —
-right now the only consumer of recorded tapes is the svn-checkout
-test, and the tape it uses was recorded by Java Servirtium and
-checked into the Aether tree. When a project needs to record a
-fresh tape directly via Aether (e.g. an Aether-hosted upstream
-that needs canonical replay tapes generated from its current
-behaviour), this is the unblocker.
+Remaining VCR work belongs in the VCR TODO rather than this next-steps
+section: HTTP-sourced tapes, compatibility-suite work, richer mutation
+phases, and eventual embedded wrapper APIs for other languages.
 
 ## VCR — keep the C-API independently consumable
 

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -791,13 +791,17 @@ main() {
 
 **Replay:** `vcr.load(tape_path, port)` / `vcr.eject(server)` / `vcr.tape_length()`.
 
-**Record:** `vcr.record(method, path, status, content_type, body)` / `vcr.record_full(...)` / `vcr.flush(tape_path)` / `vcr.flush_or_check(tape_path)` (re-record byte-diff with `.actual` sibling on mismatch).
+**Record:** `vcr.load_record(tape_path, upstream_base, port)` / `vcr.eject_record(server, tape_path)` for live forwarding record mode, or direct `vcr.record(...)` / `vcr.record_full(...)` / `vcr.record_full_response(...)` / `vcr.flush(tape_path)` for tests that build interactions in-process.
 
-**Secret scrubbing** (applied at flush time; in-memory capture stays untouched): `vcr.redact(field, pattern, replacement)` / `vcr.clear_redactions()` with `vcr.FIELD_PATH` and `vcr.FIELD_RESPONSE_BODY` selectors.
+**Drift checks:** `vcr.flush_or_check(tape_path)` leaves a `.actual` sibling on mismatch; `vcr.flush_and_fail_if_changed(tape_path)` writes the new tape to the normal path and returns an error when bytes differ.
+
+**Secret scrubbing** (applied at flush time; in-memory capture stays untouched): `vcr.redact(...)` / `vcr.clear_redactions()` / `vcr.unredact(...)` / `vcr.clear_unredactions()` / `vcr.remove_header(...)` / `vcr.clear_header_removals()` with request/response/path/body field selectors.
 
 **Per-interaction notes:** `vcr.note(title, body)` — record-only `[Note]` markdown block attached to the next interaction.
 
-**Strict request matching:** `vcr.last_error()` / `vcr.clear_last_error()` — tearDown-readable mismatch diagnostics.
+**Strict request matching:** `vcr.last_error()` / `vcr.clear_last_error()` / `vcr.last_kind()` / `vcr.last_index()` / `vcr.reset_cursor()` / `vcr.set_strict_headers(on)` — tearDown-readable mismatch diagnostics.
+
+**Gzip:** record mode stores decoded bodies for `Content-Encoding: gzip`, omits encoding/length from the tape, and playback restores gzip when callers send `Accept-Encoding: gzip`.
 
 **Static content:** `vcr.static_content(mount_path, fs_dir)` / `vcr.clear_static_content()` — bypass-the-tape mounts for Selenium/Cypress assets.
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -845,7 +845,7 @@ main() {
 - `zlib.deflate(data, length, level)` → `(string, int, string)` - Compress the first `length` bytes of `data` at `level` (0..9, or -1 for default). Out-of-range levels are clamped to default. Returns `(bytes, byte_count, "")` on success, `("", 0, error)` on failure.
 - `zlib.inflate(data, length)` → `(string, int, string)` - Decompress a zlib stream (RFC 1950). Returns `(bytes, byte_count, "")` on success, `("", 0, error)` on corruption, truncation, or empty input.
 
-Streaming APIs and gzip-framed (RFC 1952) variants are out of scope for v1 — additive future work under the same module. See [stdlib-vs-contrib.md](stdlib-vs-contrib.md) for the "one obvious shape" criterion.
+Gzip-framed helpers for HTTP `Content-Encoding: gzip` are also available: `zlib.gzip_deflate(data, length, level)` and `zlib.gzip_inflate(data, length)`. Streaming APIs remain out of scope for v1 — additive future work under the same module. See [stdlib-vs-contrib.md](stdlib-vs-contrib.md) for the "one obvious shape" criterion.
 
 ---
 
@@ -1151,15 +1151,24 @@ main() {
 - `vcr.tape_length()` → `int` - How many interactions the tape carries
 
 **Record (capture + flush):**
+- `vcr.load_record(tape_path, upstream_base, port)` - Bind a recording VCR that forwards to `upstream_base`
+- `vcr.eject_record(server, tape_path)` - Stop the record server and flush the tape
 - `vcr.record(method, path, status, content_type, body)` → `string` - Capture an interaction
 - `vcr.record_full(method, path, status, content_type, body, req_headers, req_body)` → `string` - Capture with strict-match metadata
+- `vcr.record_full_response(method, path, status, content_type, body, req_headers, req_body, resp_headers)` → `string` - Capture with request and response metadata
+- `vcr.clear_recording()` - Clear the in-memory tape for direct recorder tests
 - `vcr.flush(tape_path)` → `string` - Write captured interactions to disk
 - `vcr.flush_or_check(tape_path)` → `string` - Re-record byte-diff against an existing tape; leaves a `.actual` sibling on disk if the on-disk tape has drifted
+- `vcr.flush_and_fail_if_changed(tape_path)` → `string` - Write the new tape to `tape_path` and return an error if it differs, so tests fail while `git diff` shows the drift
 
-**Secret scrubbing** (applied at flush time; in-memory capture stays untouched):
+**Secret scrubbing / mutations** (applied at flush or playback-match time; in-memory capture stays untouched):
 - `vcr.redact(field, pattern, replacement)` → `string` - Replace pattern in field
 - `vcr.clear_redactions()` - Drop all registered redactions
-- `vcr.FIELD_PATH`, `vcr.FIELD_RESPONSE_BODY` - Field selectors
+- `vcr.unredact(field, pattern, replacement)` → `string` - Replace redacted tape values before playback matching
+- `vcr.clear_unredactions()` - Drop playback unredactions
+- `vcr.remove_header(field, header_name)` → `string` - Remove named request/response header lines
+- `vcr.clear_header_removals()` - Drop header-removal rules
+- `vcr.FIELD_PATH`, `vcr.FIELD_REQUEST_HEADERS`, `vcr.FIELD_REQUEST_BODY`, `vcr.FIELD_RESPONSE_HEADERS`, `vcr.FIELD_RESPONSE_BODY` - Field selectors
 
 **Per-interaction notes:**
 - `vcr.note(title, body)` → `string` - Stage a `[Note]` block; attaches to the next interaction recorded
@@ -1167,6 +1176,13 @@ main() {
 **Strict request matching:**
 - `vcr.last_error()` → `string` - Most recent dispatch mismatch diagnostic, surfaced to the test's tearDown
 - `vcr.clear_last_error()` - Drop the last-error slot
+- `vcr.last_kind()` → `int`, `vcr.last_index()` → `int` - Machine-readable dispatch outcome and interaction index
+- `vcr.reset_cursor()` - Rewind the loaded tape to interaction 0
+- `vcr.set_strict_headers(on)` - Compare request headers even when the tape block is blank
+
+**Gzip normalize/restore:**
+- Record mode decodes upstream `Content-Encoding: gzip` before writing the tape, omits `Content-Encoding` / `Content-Length`, and still returns the upstream gzip response to the caller.
+- Playback serves decoded bodies by default and restores gzip plus `Vary: Accept-Encoding` when the caller sends `Accept-Encoding: gzip`.
 
 **Static-content mounts** (bypass-the-tape territory for Selenium/Cypress assets):
 - `vcr.static_content(mount_path, fs_dir)` → `string` - Mark an on-disk dir as bypass-the-tape

--- a/runtime/utils/aether_thread.h
+++ b/runtime/utils/aether_thread.h
@@ -73,6 +73,7 @@ static inline int aether_nop_key_create(pthread_key_t* k, void (*d)(void*)) { (v
 static inline int aether_nop_key_delete(pthread_key_t k) { (void)k; return 0; }
 static inline int aether_nop_setspecific(pthread_key_t k, const void* v) { (void)k; (void)v; return 0; }
 static inline void* aether_nop_getspecific(pthread_key_t k) { (void)k; return NULL; }
+static inline int aether_nop_detach(pthread_t t) { (void)t; return 0; }
 
 // Redirect pthread calls to no-op stubs via macros
 #define pthread_mutex_init(m, a)     aether_nop_mutex_init((m), (a))
@@ -90,6 +91,7 @@ static inline void* aether_nop_getspecific(pthread_key_t k) { (void)k; return NU
 #define pthread_key_delete(k)        aether_nop_key_delete(k)
 #define pthread_setspecific(k, v)    aether_nop_setspecific((k), (v))
 #define pthread_getspecific(k)       aether_nop_getspecific(k)
+#define pthread_detach(t)            aether_nop_detach(t)
 
 // sched_yield stub — must come after any system header that declares it
 #if !defined(__linux__) && !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
@@ -177,6 +179,11 @@ static inline int pthread_create(pthread_t* t, pthread_attr_t* attr,
 static inline int pthread_join(pthread_t t, void** retval) {
     (void)retval;
     WaitForSingleObject(t, INFINITE);
+    CloseHandle(t);
+    return 0;
+}
+
+static inline int pthread_detach(pthread_t t) {
     CloseHandle(t);
     return 0;
 }

--- a/std/http/module.ae
+++ b/std/http/module.ae
@@ -18,6 +18,7 @@ exports (
     get, get_with_timeout, post, put, delete,
     http_server_create, http_server_bind_raw, http_server_start_raw,
     http_server_set_host, server_set_host,
+    http_server_start_background_raw,
     http_server_stop, http_server_free,
     http_server_set_tls_raw, server_set_tls,
     http_server_set_keepalive_raw, server_set_keepalive,
@@ -38,7 +39,7 @@ exports (
     http_ws_message_data, http_ws_message_length, http_ws_close,
     ws_send_text, ws_send_binary, ws_recv,
     ws_message, ws_message_length, ws_close,
-    server_bind, server_start,
+    server_bind, server_start, server_start_background,
     http_server_add_route, http_server_get, http_server_post,
     http_server_put, http_server_delete,
     http_server_use_middleware,
@@ -248,6 +249,7 @@ extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
 // loopback binds.
 extern http_server_set_host(server: ptr, host: string)
 extern http_server_start_raw(server: ptr) -> int
+extern http_server_start_background_raw(server: ptr) -> int
 extern http_server_stop(server: ptr)
 extern http_server_free(server: ptr)
 // TLS termination (#260 Tier 0). Loads the cert+key (PEM-encoded);
@@ -520,6 +522,17 @@ server_start(server: ptr) -> {
     rc = http_server_start_raw(server)
     if rc < 0 {
         return "server start failed"
+    }
+    return ""
+}
+
+// Start a server on a detached native thread. Useful for integration
+// tests and embedding hosts that need multiple local servers in one
+// process without tying up the Aether actor scheduler.
+server_start_background(server: ptr) -> {
+    rc = http_server_start_background_raw(server)
+    if rc < 0 {
+        return "server background start failed"
     }
     return ""
 }

--- a/std/http/server/vcr/TODO.md
+++ b/std/http/server/vcr/TODO.md
@@ -1,0 +1,187 @@
+# std.http.server.vcr TODO
+
+Notes from scanning `/home/paul/scm/servirtium-README`, excluding the weather API walkthrough. Keep this file about the generic VCR/Servirtium implementation only.
+
+## Current Shape
+
+- Playback and record mode share the same in-memory tape storage and Servirtium markdown emitter/parser.
+- Record mode listens like playback, forwards with `std.http.client`, records markdown, and writes to the same file path playback uses.
+- Playback supports multiple interactions, custom HTTP methods, strict request header/body matching, notes, static-content bypass, indented code blocks, emphasized HTTP verbs, response headers, and base64-marked response bodies.
+- Recording redactions apply at flush time to path, request headers, request body, response headers, and response body.
+- Playback unredactions apply to path, request headers, and request body before request matching.
+- Header removals apply to request/response header blocks at recording flush time, and to recorded/live request headers before playback strict matching.
+- Route registration already accepts wildcard method/path fallback for both playback and record modes.
+
+## Header Removal Mutations
+
+Delivered first cut:
+
+```aether
+vcr.remove_header(field, header_name) -> string
+vcr.clear_header_removals()
+```
+
+Implementation notes:
+
+- Header removal operates on canonical newline-delimited `Name: Value` blocks.
+- Match header names case-insensitively.
+- Avoid regex until the language/runtime has a standard regex story; exact header-name matching is enough for the first pass.
+- Recording removals run in `emit_one_interaction()` before `emit_code_block()`.
+- Playback-side request-header removal normalizes both the recorded expectation and the live request before comparing.
+
+Tests:
+
+- Recording flush removes `Authorization` from request headers.
+- Recording flush removes `Set-Cookie` from response headers.
+- Playback can ignore a live `X-Request-Id` header when configured.
+- Removal does not mutate in-memory capture; clearing removals and flushing again restores original headers.
+
+## Separate Mutation Phases
+
+Servirtium step 8 distinguishes six mutation points:
+
+- recorder: caller request before forwarding to upstream
+- recorder: real response before recording
+- recorder: caller request as written to tape
+- recorder: real response as returned to caller
+- playback: caller request before matching
+- playback: recorded response before returning to caller
+
+Current Aether VCR intentionally has a simpler model:
+
+- recording redactions at flush time
+- playback unredactions before request matching
+- header removals at recording-flush and playback-match time
+
+Potential next design:
+
+```aether
+const PHASE_RECORDING_TAPE = 1
+const PHASE_PLAYBACK_MATCH = 2
+const PHASE_RECORDING_UPSTREAM = 3
+const PHASE_RECORDING_CALLER_RESPONSE = 4
+const PHASE_PLAYBACK_CALLER_RESPONSE = 5
+```
+
+Do not add all phases unless there is a concrete downstream need. Header removal and response mutation are probably the first useful slices.
+
+## Record-Mode Last Error
+
+Servirtium step 3 says upstream failures in record mode should set the same last-error surface playback uses.
+
+Current behavior:
+
+- record dispatcher returns `502` / `500` with an explanatory body.
+- playback mismatch updates `vcr.last_error()`, `vcr.last_kind()`, and `vcr.last_index()`.
+
+Gap:
+
+- record-mode transport/build/OOM failures should call `last_err_set(...)` and set an appropriate kind/index.
+- May need new kind constants for record-mode failures, e.g. `KIND_UPSTREAM_TRANSPORT_ERROR`.
+
+Tests:
+
+- Record mode against a refused upstream returns 502 and `vcr.last_error()` mentions the upstream transport failure.
+- `clear_last_error()` clears record-mode errors too.
+
+## Recording Drift Semantics
+
+Servirtium step 4 says record mode should fail if the newly recorded markdown differs from the previous recording, while still writing the new markdown so developers can use `git diff`.
+
+Current Aether VCR:
+
+- `flush(tape_path)` overwrites the tape.
+- `flush_or_check(tape_path)` writes a `.actual` sibling and returns an error when bytes differ.
+
+Potential additions:
+
+```aether
+vcr.flush_and_fail_if_changed(tape_path) -> string
+```
+
+Semantics:
+
+- If no prior tape exists, write new tape and return `""`.
+- If prior tape exists and bytes match, return `""`.
+- If prior tape exists and bytes differ, overwrite `tape_path` with the new tape and return a mismatch error.
+
+Keep `flush_or_check()` for callers who prefer the `.actual` workflow.
+
+## Gzip Normalize/Restore
+
+Servirtium step 3 mentions recording should store uncompressed content but re-gzip for the caller when needed.
+
+Current Aether VCR:
+
+- Handles response bodies whose content type says `base64 below`.
+- Does not appear to normalize gzip responses during record mode or restore gzip for callers.
+
+Questions before implementation:
+
+- Should gzip be normalized based on `Content-Encoding: gzip` only?
+- Should the tape store decompressed body and omit/change `Content-Encoding`?
+- Should caller response preserve original gzip bytes in record mode, playback mode, or both?
+
+Likely implementation:
+
+- Use existing zlib support if available in std/runtime.
+- Record mode:
+  - if upstream response has `Content-Encoding: gzip`, decompress before storing body.
+  - record headers without `Content-Encoding` and with adjusted `Content-Length`.
+  - return original upstream response bytes to caller unless a caller-response mutation phase is configured.
+- Playback:
+  - serve decompressed body by default.
+  - optionally gzip if caller sent `Accept-Encoding: gzip`.
+
+This needs careful tests with binary-safe response body handling.
+
+## HTTP-Sourced Markdown Tapes
+
+Servirtium step 16 mentions markdown recordings sourced over HTTP.
+
+Potential API:
+
+```aether
+vcr.load_url(tape_url, port) -> ptr
+```
+
+Implementation:
+
+- Use `std.http.client` to fetch markdown.
+- Parse the fetched string using the existing parser path, probably by extracting a `parse_tape_text(label, markdown)` helper from `parse_tape_file()`.
+- Preserve filesystem `load()` as the default.
+
+Tests:
+
+- Local test server serves a tape markdown file.
+- `vcr.load_url()` replays it.
+- Transport failure returns null and sets/prints a useful load error.
+
+## Compatibility Suite
+
+Servirtium step 15 points to the TODO-backend compatibility suite.
+
+This is a larger conformance target rather than a single API gap.
+
+Useful preparation:
+
+- Ensure record mode can capture all methods used by the suite. Wildcard method routing should already cover this.
+- Ensure repeated response headers round-trip.
+- Ensure request body matching is binary-safe enough for suite traffic.
+- Add a small runner/shim only after core behavior is stable.
+
+## Verb Coverage Smoke Tests
+
+Servirtium step 7 explicitly calls out `POST`, `PUT`, `HEAD`, `DELETE`, `OPTIONS`, `TRACE`, and `PATCH`.
+
+Current VCR route registration is method-agnostic, but the test coverage is still GET-heavy. Useful follow-up:
+
+- Add direct record/playback smoke tests for at least one non-GET verb with a request body.
+- Add one HEAD case to confirm the server's GET-fallback path does not break the tape matcher.
+- Add one `OPTIONS` or `TRACE` case if the compatibility suite needs them later.
+
+## Things To Keep Avoiding
+
+- Do not implement record mode as an HTTP proxy unless explicitly adding the optional proxy mode from the Servirtium roadmap.
+- Do not use CORS tricks for record mode.
+- Keep `std/http/server/vcr` implementation comments generic; tests may mention specific downstream protocols/services, but implementation should not.

--- a/std/http/server/vcr/TODO.md
+++ b/std/http/server/vcr/TODO.md
@@ -118,31 +118,26 @@ Tests:
 
 ## Gzip Normalize/Restore
 
-Servirtium step 3 mentions recording should store uncompressed content but re-gzip for the caller when needed.
+Servirtium step 3 says recordings should store uncompressed content but re-gzip for callers when needed.
 
-Current Aether VCR:
+Current behavior:
 
-- Handles response bodies whose content type says `base64 below`.
-- Does not appear to normalize gzip responses during record mode or restore gzip for callers.
+- Record mode treats `Content-Encoding: gzip` as a transport encoding.
+- The caller still receives the upstream gzip response in record mode.
+- The tape stores the decoded response body.
+- The tape omits `Content-Encoding` and `Content-Length`.
+- Playback serves the decoded body by default.
+- Playback restores gzip and sets `Vary: Accept-Encoding` when the caller sends `Accept-Encoding: gzip`.
 
-Questions before implementation:
+Tests:
 
-- Should gzip be normalized based on `Content-Encoding: gzip` only?
-- Should the tape store decompressed body and omit/change `Content-Encoding`?
-- Should caller response preserve original gzip bytes in record mode, playback mode, or both?
+- `tests/integration/test_vcr_gzip_normalize.ae`: tiny gzipped upstream payload records as readable tape body.
+- `tests/integration/test_vcr_gzip_normalize.ae`: playback without `Accept-Encoding: gzip` returns decoded body.
+- `tests/integration/test_vcr_gzip_normalize.ae`: playback with `Accept-Encoding: gzip` restores gzip headers.
 
-Likely implementation:
+Remaining gap:
 
-- Use existing zlib support if available in std/runtime.
-- Record mode:
-  - if upstream response has `Content-Encoding: gzip`, decompress before storing body.
-  - record headers without `Content-Encoding` and with adjusted `Content-Length`.
-  - return original upstream response bytes to caller unless a caller-response mutation phase is configured.
-- Playback:
-  - serve decompressed body by default.
-  - optionally gzip if caller sent `Accept-Encoding: gzip`.
-
-This needs careful tests with binary-safe response body handling.
+- The first cut assumes decoded gzip bodies are textual enough for the current tape string storage. Full arbitrary binary decoded bodies should go through the existing `base64 below` path once the record-side emitter carries explicit body lengths end to end.
 
 ## HTTP-Sourced Markdown Tapes
 

--- a/std/http/server/vcr/TODO.md
+++ b/std/http/server/vcr/TODO.md
@@ -12,6 +12,21 @@ Notes from scanning `/home/paul/scm/servirtium-README`, excluding the weather AP
 - Header removals apply to request/response header blocks at recording flush time, and to recorded/live request headers before playback strict matching.
 - Route registration already accepts wildcard method/path fallback for both playback and record modes.
 
+## Test Coverage Map
+
+These tests are the long-term contract for the features above:
+
+- Step 3 record mode: `tests/integration/test_vcr_redactions.ae`, `tests/integration/test_vcr_verbs.ae`
+- Step 4 drift/write-out semantics: `tests/integration/test_vcr_redactions.ae` covers flush-and-compare style tape rewriting; full `flush_and_fail_if_changed()` behavior is still pending
+- Step 7 verbs: `tests/integration/test_vcr_verbs.ae`
+- Step 8 redactions and header removals: `tests/integration/test_vcr_redactions.ae`, `tests/integration/test_vcr_unredactions.ae`
+- Step 9 notes: `tests/integration/test_vcr_notes.ae`
+- Step 10 strict playback matching: `tests/integration/test_vcr_strict_match.ae`, `tests/integration/test_vcr_strict_match_body.ae`, `tests/integration/test_vcr_unredactions.ae`
+- Step 11 static content bypass: `tests/integration/test_vcr_static_content.ae`
+- Step 12 markdown formatting options: `tests/integration/test_vcr_format_options.ae`
+- Step 15 compatibility-suite prep: no dedicated test yet
+- Step 16 HTTP-sourced tapes: no dedicated test yet
+
 ## Header Removal Mutations
 
 Delivered first cut:
@@ -169,6 +184,79 @@ Useful preparation:
 - Ensure repeated response headers round-trip.
 - Ensure request body matching is binary-safe enough for suite traffic.
 - Add a small runner/shim only after core behavior is stable.
+
+## Secondary: Embedded Server For Other Languages
+
+Long-horizon goal, probably many months out: make the Aether VCR usable as an embedded Servirtium server behind test-framework wrappers for higher-level languages. The primary product shape should stay server-first: the system under test talks HTTP to an Aether VCR server, and the language wrapper gives the test author a fixture object that exposes a base URL, lifecycle, tape configuration, mutations, and diagnostics.
+
+Reference point:
+
+- `/home/paul/scm/servirtium-java/` shows the kind of user-facing capability expected from a mature language binding.
+- We do not need ABI compatibility with Servirtium-Java or any other existing implementation.
+- We do need capability compatibility: record, playback, redaction/mutation, header removal, notes, drift detection, static bypass, strict matching, markdown interop, and diagnostics should all be available to wrapper authors.
+
+Candidate wrapper targets:
+
+- C#
+- Ruby
+- Python
+- Go
+- Node-side JavaScript
+
+End-user shape to aim for:
+
+- Test code uses a wrapper fixture, e.g. `Servirtium.playback(...).start()`.
+- The application/client library under test knows only the supplier service base URL.
+- Tape paths, record/playback mode, mutation rules, notes, and last-error checks live in test harness setup/teardown, not in the client library.
+- Dynamic ports should be supported so parallel test runners can avoid collisions.
+- Labels should be supported for diagnostics, e.g. a test name like `"cant go overdrawn if checking acct"`, but labels are not the state lookup key.
+
+Native shape to aim for:
+
+- A flattened external VCR library that is easy to link from FFI layers.
+- The embedded Aether webserver is the default runtime model, not an implementation detail to hide.
+- A small, stable C ABI over opaque server handles rather than exposing Aether internals.
+- The native handle is the lifecycle/state key. Host/port is where the SUT connects. Label is human-facing context for errors/logs.
+- Server-bound state: each active embedded server owns its tape, cursor, mutations, static mounts, pending note, and diagnostics.
+- Explicit ownership rules for every returned string/buffer.
+- Binary-safe request/response body APIs, not just NUL-terminated strings.
+- Per-server state, not process-global tape/cursor/mutation state, once multiple simultaneous VCR servers become a real need.
+- A conformance suite shared across wrappers so each language proves the same Servirtium markdown behavior.
+
+Conceptual ABI sketch, not a commitment yet:
+
+```c
+typedef struct AetherVcrServer AetherVcrServer;
+
+AetherVcrServer* aether_vcr_start_playback(
+    const char* label,
+    const char* tape_path,
+    const char* host,
+    int port);
+
+AetherVcrServer* aether_vcr_start_record(
+    const char* label,
+    const char* tape_path,
+    const char* upstream_base,
+    const char* host,
+    int port);
+
+void aether_vcr_stop(AetherVcrServer* server);
+int aether_vcr_port(AetherVcrServer* server);
+char* aether_vcr_base_url(AetherVcrServer* server);
+char* aether_vcr_last_error(AetherVcrServer* server);
+void aether_vcr_free_string(char* s);
+```
+
+Initial implementation direction:
+
+- Do not start other-language bindings yet.
+- Keep the current `std/http/server/vcr` Aether API working.
+- Document v1 embedding as "one active VCR server per process" if globals remain in place.
+- When refactoring, group the current globals into a `VcrState` and hang that state from an eventual `AetherVcrServer` handle.
+- Only add lower-level "feed native request/response events into the core" APIs if a wrapper genuinely needs to bypass the embedded Aether server.
+
+Do this only after the core VCR behavior has settled. The present `std/http/server/vcr` implementation still has C globals and Aether-module boundaries that are fine for in-repo tests but not yet a clean embeddable server contract.
 
 ## Verb Coverage Smoke Tests
 

--- a/std/http/server/vcr/TODO.md
+++ b/std/http/server/vcr/TODO.md
@@ -87,17 +87,18 @@ Servirtium step 3 says upstream failures in record mode should set the same last
 Current behavior:
 
 - record dispatcher returns `502` / `500` with an explanatory body.
+- record dispatcher updates `vcr.last_error()`, `vcr.last_kind()`, and `vcr.last_index()` on failures.
+- record-mode failures report `KIND_RECORD_ERROR`; failed recordings use `last_index() == -1` because no interaction was accepted into the tape.
 - playback mismatch updates `vcr.last_error()`, `vcr.last_kind()`, and `vcr.last_index()`.
 
 Gap:
 
-- record-mode transport/build/OOM failures should call `last_err_set(...)` and set an appropriate kind/index.
-- May need new kind constants for record-mode failures, e.g. `KIND_UPSTREAM_TRANSPORT_ERROR`.
+- Future slices may split `KIND_RECORD_ERROR` into more specific record-mode failure kinds if tests need to distinguish transport, build, OOM, or tape-append failures.
 
 Tests:
 
-- Record mode against a refused upstream returns 502 and `vcr.last_error()` mentions the upstream transport failure.
-- `clear_last_error()` clears record-mode errors too.
+- `tests/integration/test_vcr_record_last_error.ae`: record mode against a refused upstream returns 502 and `vcr.last_error()` mentions the upstream transport failure.
+- `tests/integration/test_vcr_record_last_error.ae`: `clear_last_error()` clears record-mode errors too.
 
 ## Recording Drift Semantics
 

--- a/std/http/server/vcr/TODO.md
+++ b/std/http/server/vcr/TODO.md
@@ -17,7 +17,7 @@ Notes from scanning `/home/paul/scm/servirtium-README`, excluding the weather AP
 These tests are the long-term contract for the features above:
 
 - Step 3 record mode: `tests/integration/test_vcr_redactions.ae`, `tests/integration/test_vcr_verbs.ae`
-- Step 4 drift/write-out semantics: `tests/integration/test_vcr_redactions.ae` covers flush-and-compare style tape rewriting; full `flush_and_fail_if_changed()` behavior is still pending
+- Step 4 drift/write-out semantics: `tests/integration/test_vcr_drift_fail.ae`, plus `tests/integration/test_vcr_redactions.ae` for mutation-aware tape rewriting
 - Step 7 verbs: `tests/integration/test_vcr_verbs.ae`
 - Step 8 redactions and header removals: `tests/integration/test_vcr_redactions.ae`, `tests/integration/test_vcr_unredactions.ae`
 - Step 9 notes: `tests/integration/test_vcr_notes.ae`
@@ -108,20 +108,13 @@ Current Aether VCR:
 
 - `flush(tape_path)` overwrites the tape.
 - `flush_or_check(tape_path)` writes a `.actual` sibling and returns an error when bytes differ.
+- `flush_and_fail_if_changed(tape_path)` overwrites `tape_path` with the new recording and returns an error when bytes differ, so tests can fail while `git diff` shows the drift directly.
 
-Potential additions:
+Tests:
 
-```aether
-vcr.flush_and_fail_if_changed(tape_path) -> string
-```
-
-Semantics:
-
-- If no prior tape exists, write new tape and return `""`.
-- If prior tape exists and bytes match, return `""`.
-- If prior tape exists and bytes differ, overwrite `tape_path` with the new tape and return a mismatch error.
-
-Keep `flush_or_check()` for callers who prefer the `.actual` workflow.
+- `tests/integration/test_vcr_drift_fail.ae`: first recording creates the tape without failure.
+- `tests/integration/test_vcr_drift_fail.ae`: identical re-recording returns success and does not create `.actual`.
+- `tests/integration/test_vcr_drift_fail.ae`: changed re-recording overwrites the tape and returns a mismatch error.
 
 ## Gzip Normalize/Restore
 

--- a/std/http/server/vcr/aether_vcr.c
+++ b/std/http/server/vcr/aether_vcr.c
@@ -193,6 +193,7 @@ static char* g_last_error = NULL;
 #define VCR_KIND_HEADER_UNEXPECTED   4
 #define VCR_KIND_TAPE_EXHAUSTED      5
 #define VCR_KIND_BODY_DIFF           6
+#define VCR_KIND_RECORD_ERROR        7
 #define VCR_FIELD_PATH             1
 #define VCR_FIELD_RESPONSE_BODY    2
 #define VCR_FIELD_REQUEST_HEADERS  3
@@ -246,6 +247,14 @@ static void tape_free_storage(void) {
 static void last_err_set(const char* msg) {
     free(g_last_error);
     g_last_error = msg ? strdup(msg) : NULL;
+}
+
+static void record_dispatch_error(void* res, int status, const char* msg) {
+    last_err_set(msg);
+    g_last_kind = VCR_KIND_RECORD_ERROR;
+    g_last_index = -1;
+    http_response_set_status(res, status);
+    http_response_set_body(res, msg);
 }
 
 static void tape_set_err(const char* msg) {
@@ -1270,23 +1279,20 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
     (void)ud;
     const VcrHttpRequestPrefix* live_req = (const VcrHttpRequestPrefix*)req;
     if (!g_record_upstream_base || !*g_record_upstream_base) {
-        http_response_set_status(res, 500);
-        http_response_set_body(res, "vcr record mode: upstream base not configured");
+        record_dispatch_error(res, 500, "vcr record mode: upstream base not configured");
         return;
     }
 
     char* url = build_upstream_url(g_record_upstream_base, live_req);
     if (!url) {
-        http_response_set_status(res, 500);
-        http_response_set_body(res, "vcr record mode: OOM building upstream URL");
+        record_dispatch_error(res, 500, "vcr record mode: OOM building upstream URL");
         return;
     }
 
     void* creq = http_request_raw(live_req->method ? live_req->method : "GET", url);
     if (!creq) {
         free(url);
-        http_response_set_status(res, 500);
-        http_response_set_body(res, "vcr record mode: failed to build client request");
+        record_dispatch_error(res, 500, "vcr record mode: failed to build client request");
         return;
     }
 
@@ -1307,8 +1313,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
     http_request_free_raw(creq);
     if (!cresp) {
         free(url);
-        http_response_set_status(res, 502);
-        http_response_set_body(res, "vcr record mode: upstream request failed");
+        record_dispatch_error(res, 502, "vcr record mode: upstream request failed");
         return;
     }
     const char* cerr = http_response_error(cresp);
@@ -1317,8 +1322,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
         snprintf(msg, sizeof(msg), "vcr record mode: upstream transport error: %s", cerr);
         http_response_free(cresp);
         free(url);
-        http_response_set_status(res, 502);
-        http_response_set_body(res, msg);
+        record_dispatch_error(res, 502, msg);
         return;
     }
 
@@ -1334,8 +1338,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
         free(resp_headers); free(content_type); free(req_headers);
         http_response_free(cresp);
         free(url);
-        http_response_set_status(res, 500);
-        http_response_set_body(res, "vcr record mode: OOM recording interaction");
+        record_dispatch_error(res, 500, "vcr record mode: OOM recording interaction");
         return;
     }
 
@@ -1344,8 +1347,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
         free(resp_headers); free(content_type); free(req_headers);
         http_response_free(cresp);
         free(url);
-        http_response_set_status(res, 500);
-        http_response_set_body(res, "vcr record mode: OOM recording path");
+        record_dispatch_error(res, 500, "vcr record mode: OOM recording path");
         return;
     }
 
@@ -1356,11 +1358,25 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
                                          body,
                                          req_headers,
                                          live_req->body ? live_req->body : "");
-    if (ok) vcr_aether_set_resp_headers(g_tape_n - 1, resp_headers);
+    if (!ok) {
+        free(resp_headers);
+        free(content_type);
+        free(req_headers);
+        free(recorded_path);
+        http_response_free(cresp);
+        free(url);
+        record_dispatch_error(res, 500, "vcr record mode: failed to record interaction");
+        return;
+    }
+    vcr_aether_set_resp_headers(g_tape_n - 1, resp_headers);
 
     http_response_set_status(res, http_response_status(cresp));
     emit_recorded_headers_to_response(res, resp_headers);
     http_response_set_body_n(res, body, body_len);
+
+    last_err_set("");
+    g_last_kind = VCR_KIND_OK;
+    g_last_index = g_tape_n - 1;
 
     free(resp_headers);
     free(content_type);

--- a/std/http/server/vcr/aether_vcr.c
+++ b/std/http/server/vcr/aether_vcr.c
@@ -77,6 +77,19 @@ extern int         http_response_status(void* response);
 extern const char* http_response_error(void* response);
 extern void        http_response_free(void* response);
 
+/* std.zlib gzip-framed helpers. VCR treats HTTP gzip as a transport
+ * encoding: tapes store decoded semantic bodies, playback restores
+ * gzip only when the caller advertises Accept-Encoding: gzip. */
+extern int         zlib_backend_available(void);
+extern int         zlib_try_gzip_inflate(const char* data, int length);
+extern const char* zlib_get_inflate_bytes(void);
+extern int         zlib_get_inflate_length(void);
+extern void        zlib_release_inflate(void);
+extern int         zlib_try_gzip_deflate(const char* data, int length, int level);
+extern const char* zlib_get_deflate_bytes(void);
+extern int         zlib_get_deflate_length(void);
+extern void        zlib_release_deflate(void);
+
 /* Step 10: header iteration + body access. We need to walk the
  * full set of request headers (not just look one up by name) to
  * detect "extra" headers the tape didn't expect. The HttpRequest
@@ -968,6 +981,7 @@ static char* normalize_live_headers(const VcrHttpRequestPrefix* r) {
         if (icmp(key, "Host") == 0) continue;
         if (icmp(key, "Connection") == 0) continue;
         if (icmp(key, "Content-Length") == 0) continue;
+        if (icmp(key, "Accept-Encoding") == 0) continue;
         if (header_removed_for_field(VCR_FIELD_REQUEST_HEADERS, key)) continue;
         size_t len = strlen(key) + 2 + strlen(val) + 1;
         char* line = (char*)malloc(len);
@@ -1169,7 +1183,9 @@ static int expected_path_includes_query(const char* path) {
     return path && strchr(path, '?') != NULL;
 }
 
-static char* response_headers_for_tape(const char* raw_headers) {
+static char* response_header_value_from_block(const char* headers, const char* name);
+
+static char* response_headers_for_tape(const char* raw_headers, int strip_content_encoding) {
     if (!raw_headers) return strdup("");
     const char* p = strchr(raw_headers, '\n');
     p = p ? p + 1 : raw_headers;
@@ -1192,7 +1208,8 @@ static char* response_headers_for_tape(const char* raw_headers) {
             if (name_len > 0 && name_len < sizeof(name)) {
                 memcpy(name, line_start, name_len);
                 name[name_len] = '\0';
-                if (!is_hop_by_hop_header(name)) {
+                if (!is_hop_by_hop_header(name)
+                    && !(strip_content_encoding && icmp(name, "Content-Encoding") == 0)) {
                     if (off + line_len + 1 >= cap) {
                         cap = cap + line_len + 1024;
                         char* bigger = (char*)realloc(out, cap);
@@ -1210,6 +1227,20 @@ static char* response_headers_for_tape(const char* raw_headers) {
     }
     out[off] = '\0';
     return out;
+}
+
+static int header_block_has_token_value(const char* headers, const char* name, const char* token) {
+    char* v = response_header_value_from_block(headers, name);
+    if (!v) return 0;
+    int yes = ascii_ci_contains(v, token);
+    free(v);
+    return yes;
+}
+
+static int request_accepts_gzip(const VcrHttpRequestPrefix* req) {
+    const char* ae = request_header_value(req, "Accept-Encoding");
+    if (!ae) return 0;
+    return ascii_ci_contains(ae, "gzip");
 }
 
 static char* response_header_value_from_block(const char* headers, const char* name) {
@@ -1330,21 +1361,57 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
     const char* body = (cr->body && cr->body->data) ? cr->body->data : "";
     int body_len = (cr->body && cr->body->data) ? (int)cr->body->length : 0;
     const char* raw_headers = (cr->headers && cr->headers->data) ? cr->headers->data : "";
-    char* resp_headers = response_headers_for_tape(raw_headers);
+    char* caller_headers = response_headers_for_tape(raw_headers, 0);
+    int upstream_gzip = header_block_has_token_value(caller_headers ? caller_headers : "", "Content-Encoding", "gzip");
+    char* resp_headers = response_headers_for_tape(raw_headers, upstream_gzip);
     char* content_type = response_header_value_from_block(resp_headers ? resp_headers : "", "Content-Type");
     char* req_headers = normalize_live_headers(live_req);
 
-    if (!resp_headers || !content_type || !req_headers) {
-        free(resp_headers); free(content_type); free(req_headers);
+    if (!caller_headers || !resp_headers || !content_type || !req_headers) {
+        free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
         http_response_free(cresp);
         free(url);
         record_dispatch_error(res, 500, "vcr record mode: OOM recording interaction");
         return;
     }
 
+    const char* body_for_tape = body;
+    char* decoded_body = NULL;
+    if (upstream_gzip) {
+        if (zlib_backend_available() == 0) {
+            free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
+            http_response_free(cresp);
+            free(url);
+            record_dispatch_error(res, 500, "vcr record mode: gzip response but zlib unavailable");
+            return;
+        }
+        if (!zlib_try_gzip_inflate(body, body_len)) {
+            free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
+            http_response_free(cresp);
+            free(url);
+            record_dispatch_error(res, 500, "vcr record mode: failed to decode gzip response");
+            return;
+        }
+        int body_for_tape_len = zlib_get_inflate_length();
+        decoded_body = (char*)malloc((size_t)body_for_tape_len + 1);
+        if (!decoded_body) {
+            zlib_release_inflate();
+            free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
+            http_response_free(cresp);
+            free(url);
+            record_dispatch_error(res, 500, "vcr record mode: OOM decoding gzip response");
+            return;
+        }
+        memcpy(decoded_body, zlib_get_inflate_bytes(), (size_t)body_for_tape_len);
+        decoded_body[body_for_tape_len] = '\0';
+        zlib_release_inflate();
+        body_for_tape = decoded_body;
+    }
+
     char* recorded_path = build_recorded_path(live_req);
     if (!recorded_path) {
-        free(resp_headers); free(content_type); free(req_headers);
+        free(decoded_body);
+        free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
         http_response_free(cresp);
         free(url);
         record_dispatch_error(res, 500, "vcr record mode: OOM recording path");
@@ -1355,10 +1422,12 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
                                          recorded_path,
                                          http_response_status(cresp),
                                          content_type,
-                                         body,
+                                         body_for_tape,
                                          req_headers,
                                          live_req->body ? live_req->body : "");
     if (!ok) {
+        free(decoded_body);
+        free(caller_headers);
         free(resp_headers);
         free(content_type);
         free(req_headers);
@@ -1371,13 +1440,15 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
     vcr_aether_set_resp_headers(g_tape_n - 1, resp_headers);
 
     http_response_set_status(res, http_response_status(cresp));
-    emit_recorded_headers_to_response(res, resp_headers);
+    emit_recorded_headers_to_response(res, caller_headers);
     http_response_set_body_n(res, body, body_len);
 
     last_err_set("");
     g_last_kind = VCR_KIND_OK;
     g_last_index = g_tape_n - 1;
 
+    free(decoded_body);
+    free(caller_headers);
     free(resp_headers);
     free(content_type);
     free(req_headers);
@@ -1678,7 +1749,10 @@ void vcr_dispatch(void* req, void* res, void* ud) {
              * duplicate-keyed headers. set_header replaces on duplicate;
              * add_header preserves order and multiplicity through to
              * the wire serializer. */
-            http_response_add_header(res, name_buf, val_buf);
+            if (icmp(name_buf, "Content-Length") != 0
+                && icmp(name_buf, "Content-Encoding") != 0) {
+                http_response_add_header(res, name_buf, val_buf);
+            }
         }
     }
     /* Fallback: tapes without a resp_headers block (or with one that
@@ -1698,7 +1772,17 @@ void vcr_dispatch(void* req, void* res, void* ud) {
             http_response_set_body(res, e->body);
         }
     } else {
-        http_response_set_body(res, e->body);
+        if (request_accepts_gzip(live_req) && zlib_backend_available() == 1
+            && zlib_try_gzip_deflate(e->body ? e->body : "", (int)strlen(e->body ? e->body : ""), -1)) {
+            const char* gz = zlib_get_deflate_bytes();
+            int gz_len = zlib_get_deflate_length();
+            http_response_set_body_n(res, gz, gz_len);
+            zlib_release_deflate();
+            http_response_set_header(res, "Content-Encoding", "gzip");
+            http_response_set_header(res, "Vary", "Accept-Encoding");
+        } else {
+            http_response_set_body(res, e->body);
+        }
     }
 
     /* Successful dispatch — clear any prior diagnostic and stamp

--- a/std/http/server/vcr/aether_vcr.c
+++ b/std/http/server/vcr/aether_vcr.c
@@ -35,9 +35,9 @@
  *   vcr_load_tape(path)        -> 1 on success, 0 on parse / I/O failure
  *   vcr_load_err()             -> error string (when vcr_load_tape returned 0)
  *   vcr_tape_length()          -> number of interactions the loaded tape has
- *   vcr_register_routes(srv)   -> walks tape and calls server_get for each
- *                                  unique path so the routing layer dispatches
- *                                  to vcr_dispatch.
+ *   register_routes(srv)       -> Aether-side route registration walks the
+ *                                  loaded tape and points matching routes at
+ *                                  vcr_dispatch.
  *   vcr_dispatch(req, res, ud) -> registered handler. Matches the next tape
  *                                  interaction against (method, path) and
  *                                  emits the recorded response. Mismatch →
@@ -64,6 +64,19 @@ extern void        http_response_clear_headers(void* res);
 extern void        http_response_set_body  (void* res, const char* body);
 extern void        http_response_set_body_n(void* res, const char* body, int length);
 
+/* std.http.client v2 raw surface. Record mode uses these to forward
+ * the incoming request to the real upstream service. This is an
+ * ordinary client request, not an HTTP proxy tunnel. */
+extern void*       http_request_raw(const char* method, const char* url);
+extern int         http_request_set_header_raw(void* req, const char* name, const char* value);
+extern int         http_request_set_body_raw(void* req, const char* body, int length, const char* content_type);
+extern int         http_request_set_timeout_raw(void* req, int seconds);
+extern void        http_request_free_raw(void* req);
+extern void*       http_send_raw(void* req);
+extern int         http_response_status(void* response);
+extern const char* http_response_error(void* response);
+extern void        http_response_free(void* response);
+
 /* Step 10: header iteration + body access. We need to walk the
  * full set of request headers (not just look one up by name) to
  * detect "extra" headers the tape didn't expect. The HttpRequest
@@ -79,8 +92,26 @@ typedef struct VcrHttpRequestPrefix {
     char** header_values;
     int    header_count;
     char*  body;
-    /* (rest of struct ignored — body_length, params, ...) */
+    size_t body_length;
+    /* (rest of struct ignored — params, ...) */
 } VcrHttpRequestPrefix;
+
+typedef struct VcrAetherStringPrefix {
+    unsigned int magic;
+    int          ref_count;
+    size_t       length;
+    size_t       capacity;
+    char*        data;
+} VcrAetherStringPrefix;
+
+typedef struct VcrClientResponsePrefix {
+    int status_code;
+    VcrAetherStringPrefix* body;
+    VcrAetherStringPrefix* headers;
+    VcrAetherStringPrefix* error;
+    VcrAetherStringPrefix* redirect_error;
+    VcrAetherStringPrefix* effective_url;
+} VcrClientResponsePrefix;
 
 /* Step 11: static-content serving externs. The http_server module
  * already implements the heavy lifting (mime-type detection,
@@ -91,11 +122,10 @@ typedef struct VcrHttpRequestPrefix {
 extern void http_serve_file(void* res, const char* filepath);
 extern const char* http_mime_type(const char* path);
 
-/* And the routing extern — used by vcr_register_routes(). v0.1
- * used http_server_get exclusively (replay-of-GET-only); v0.2
- * uses add_route which takes the method as a string and so handles
- * GET / POST / PUT / DELETE / PATCH and any custom verb without
- * per-verb dispatch in C. */
+/* And the routing extern. Replay routes are enumerated in Aether;
+ * record/static routes still need a C call because their handlers
+ * live here. add_route takes the method as a string and so handles
+ * any custom verb without per-verb dispatch in C. */
 extern void http_server_add_route(void* server, const char* method, const char* path, void* handler, void* user_data);
 
 /* ---- Tape storage --------------------------------------------------- */
@@ -163,6 +193,11 @@ static char* g_last_error = NULL;
 #define VCR_KIND_HEADER_UNEXPECTED   4
 #define VCR_KIND_TAPE_EXHAUSTED      5
 #define VCR_KIND_BODY_DIFF           6
+#define VCR_FIELD_PATH             1
+#define VCR_FIELD_RESPONSE_BODY    2
+#define VCR_FIELD_REQUEST_HEADERS  3
+#define VCR_FIELD_REQUEST_BODY     4
+#define VCR_FIELD_RESPONSE_HEADERS 5
 static int g_last_kind = VCR_KIND_OK;
 static int g_last_index = -1;
 
@@ -173,6 +208,7 @@ static int g_last_index = -1;
  * unconditionally — used by tests that want to deliberately
  * exercise the mismatch diagnostic paths. */
 static int g_strict_headers = 0;
+static char* g_record_upstream_base = NULL;
 
 static void tape_free_storage(void) {
     if (g_tape) {
@@ -198,6 +234,7 @@ static void tape_free_storage(void) {
     free(g_pending_note_title); g_pending_note_title = NULL;
     free(g_pending_note_body);  g_pending_note_body  = NULL;
     free(g_last_error);         g_last_error         = NULL;
+    free(g_record_upstream_base); g_record_upstream_base = NULL;
     g_last_kind = VCR_KIND_OK;
     g_last_index = -1;
     /* Static mounts intentionally not freed here — mounts are
@@ -233,6 +270,8 @@ static int ascii_ci_contains(const char* haystack, const char* needle) {
     }
     return 0;
 }
+
+static int icmp(const char* a, const char* b);
 
 static int b64_value(unsigned char c) {
     if (c >= 'A' && c <= 'Z') return (int)(c - 'A');
@@ -361,10 +400,15 @@ static int tape_append(const char* method, const char* path,
  * rtrim() helper, none of which need C. See module.ae's
  * parse_tape_file. */
 
-/* Forward decl for the dispatcher — referenced by vcr_register_routes
- * below and by the static-mount route registration. Body lives further
+/* Forward decl for the dispatcher — referenced by Aether route
+ * registration and by the static-mount route registration. Body lives further
  * down (after the request-normalization helpers). */
 void vcr_dispatch(void* req, void* res, void* ud);
+static void vcr_record_dispatch(void* req, void* res, void* ud);
+int vcr_record_interaction_full(const char* method, const char* path,
+                                int status, const char* content_type, const char* body,
+                                const char* req_headers, const char* req_body);
+void vcr_aether_set_resp_headers(int index, const char* headers);
 
 const char* vcr_load_err(void) {
     return g_tape_err ? g_tape_err : "";
@@ -374,37 +418,32 @@ int vcr_tape_length(void) {
     return g_tape_n;
 }
 
-/* Walk the tape and register the same dispatcher (vcr_dispatch)
- * against each unique (method, path) pair. The dispatcher itself
- * still matches in cursor order and serves whatever's next; routing
- * is just there so the framework knows to call us at all.
- *
- * Dedup is by (method, path), not just path — a tape that has both
- * GET /foo and POST /foo needs both routes registered so the
- * framework dispatches to us for either verb. (The dispatcher then
- * still strict-matches the actual incoming request against the
- * cursor's expected (method, path); the registration is purely
- * "wake me up for this combination.") */
 /* Forward decl — body lives next to the static-mount storage. */
 static void register_static_routes(void* server);
+static void strip_trailing_slash(char* s);
+static char* build_recorded_path(const VcrHttpRequestPrefix* r);
 
-void vcr_register_routes(void* server) {
-    if (!server) return;
-    for (int i = 0; i < g_tape_n; i++) {
-        int already = 0;
-        for (int j = 0; j < i; j++) {
-            if (strcmp(g_tape[i].method, g_tape[j].method) == 0
-                && strcmp(g_tape[i].path, g_tape[j].path) == 0) {
-                already = 1;
-                break;
-            }
-        }
-        if (!already) {
-            http_server_add_route(server, g_tape[i].method, g_tape[i].path,
-                                  (void*)vcr_dispatch, NULL);
-        }
-    }
+void vcr_register_static_routes(void* server) {
     register_static_routes(server);
+}
+
+int vcr_register_record_routes(void* server, const char* upstream_base) {
+    if (!server || !upstream_base || !*upstream_base) {
+        tape_set_err("vcr.record mode: null server or upstream_base");
+        return 0;
+    }
+    char* copy = strdup(upstream_base);
+    if (!copy) {
+        tape_set_err("OOM storing record-mode upstream base");
+        return 0;
+    }
+    strip_trailing_slash(copy);
+    free(g_record_upstream_base);
+    g_record_upstream_base = copy;
+
+    http_server_add_route(server, "*", "*", (void*)vcr_record_dispatch, NULL);
+    register_static_routes(server);
+    return 1;
 }
 
 /* ---- Record-mode externs ---------------------------------------------
@@ -500,58 +539,146 @@ int vcr_add_note(const char* title, const char* body) {
  * interaction and applies every registered redaction.
  * -------------------------------------------------------------------- */
 
-#define VCR_FIELD_PATH          1
-#define VCR_FIELD_RESPONSE_BODY 2
-/* Future: VCR_FIELD_REQUEST_HEADERS, REQUEST_BODY, RESPONSE_HEADERS,
- * once the recorder captures those. */
-
 typedef struct Redaction {
     int   field;        /* VCR_FIELD_* */
     char* pattern;      /* substring to match, owned */
     char* replacement;  /* what to put in its place, owned */
 } Redaction;
 
+typedef struct HeaderRemoval {
+    int   field;        /* VCR_FIELD_REQUEST_HEADERS / RESPONSE_HEADERS */
+    char* name;         /* header name, owned */
+} HeaderRemoval;
+
 static Redaction* g_redactions     = NULL;
 static int        g_redactions_n   = 0;
 static int        g_redactions_cap = 0;
+static Redaction* g_unredactions     = NULL;
+static int        g_unredactions_n   = 0;
+static int        g_unredactions_cap = 0;
+static HeaderRemoval* g_header_removals     = NULL;
+static int            g_header_removals_n   = 0;
+static int            g_header_removals_cap = 0;
 
-static void redactions_free_storage(void) {
-    if (g_redactions) {
-        for (int i = 0; i < g_redactions_n; i++) {
-            free(g_redactions[i].pattern);
-            free(g_redactions[i].replacement);
+static void redaction_list_free(Redaction** items, int* n_items, int* cap_items) {
+    if (*items) {
+        for (int i = 0; i < *n_items; i++) {
+            free((*items)[i].pattern);
+            free((*items)[i].replacement);
         }
-        free(g_redactions);
-        g_redactions = NULL;
+        free(*items);
+        *items = NULL;
     }
-    g_redactions_n = 0;
-    g_redactions_cap = 0;
+    *n_items = 0;
+    *cap_items = 0;
 }
 
-int vcr_add_redaction(int field, const char* pattern, const char* replacement) {
-    if (field != VCR_FIELD_PATH && field != VCR_FIELD_RESPONSE_BODY) {
-        tape_set_err("vcr_add_redaction: unsupported field selector");
+static int valid_redaction_field(int field) {
+    return field == VCR_FIELD_PATH
+        || field == VCR_FIELD_RESPONSE_BODY
+        || field == VCR_FIELD_REQUEST_HEADERS
+        || field == VCR_FIELD_REQUEST_BODY
+        || field == VCR_FIELD_RESPONSE_HEADERS;
+}
+
+static int redaction_list_add(Redaction** items, int* n_items, int* cap_items,
+                              int field, const char* pattern, const char* replacement,
+                              const char* api_name) {
+    if (!valid_redaction_field(field)) {
+        tape_set_err("unsupported field selector");
         return 0;
     }
-    if (!pattern) { tape_set_err("vcr_add_redaction: null pattern"); return 0; }
-    if (g_redactions_n >= g_redactions_cap) {
-        int new_cap = g_redactions_cap ? g_redactions_cap * 2 : 4;
-        Redaction* bigger = (Redaction*)realloc(g_redactions, sizeof(Redaction) * (size_t)new_cap);
-        if (!bigger) { tape_set_err("OOM growing redactions"); return 0; }
-        g_redactions = bigger;
-        g_redactions_cap = new_cap;
+    if (!pattern) { tape_set_err("null pattern"); return 0; }
+    if (*n_items >= *cap_items) {
+        int new_cap = *cap_items ? *cap_items * 2 : 4;
+        Redaction* bigger = (Redaction*)realloc(*items, sizeof(Redaction) * (size_t)new_cap);
+        if (!bigger) {
+            char msg[128];
+            snprintf(msg, sizeof(msg), "OOM growing %s list", api_name);
+            tape_set_err(msg);
+            return 0;
+        }
+        *items = bigger;
+        *cap_items = new_cap;
     }
-    Redaction* r = &g_redactions[g_redactions_n];
+    Redaction* r = &(*items)[*n_items];
     r->field = field;
     r->pattern = strdup(pattern);
     r->replacement = strdup(replacement ? replacement : "");
     if (!r->pattern || !r->replacement) {
         free(r->pattern); free(r->replacement);
-        tape_set_err("OOM appending redaction");
+        tape_set_err("OOM appending replacement");
         return 0;
     }
-    g_redactions_n++;
+    *n_items = *n_items + 1;
     return 1;
+}
+
+int vcr_add_redaction(int field, const char* pattern, const char* replacement) {
+    return redaction_list_add(&g_redactions, &g_redactions_n, &g_redactions_cap,
+                              field, pattern, replacement, "redaction");
+}
+
+int vcr_add_unredaction(int field, const char* pattern, const char* replacement) {
+    return redaction_list_add(&g_unredactions, &g_unredactions_n, &g_unredactions_cap,
+                              field, pattern, replacement, "unredaction");
+}
+
+static int valid_header_removal_field(int field) {
+    return field == VCR_FIELD_REQUEST_HEADERS || field == VCR_FIELD_RESPONSE_HEADERS;
+}
+
+int vcr_add_header_removal(int field, const char* name) {
+    if (!valid_header_removal_field(field)) {
+        tape_set_err("header removal only supports request/response header fields");
+        return 0;
+    }
+    if (!name || !*name) {
+        tape_set_err("header removal requires a header name");
+        return 0;
+    }
+    if (g_header_removals_n >= g_header_removals_cap) {
+        int new_cap = g_header_removals_cap ? g_header_removals_cap * 2 : 4;
+        HeaderRemoval* bigger = (HeaderRemoval*)realloc(g_header_removals,
+                                      sizeof(HeaderRemoval) * (size_t)new_cap);
+        if (!bigger) {
+            tape_set_err("OOM growing header removal list");
+            return 0;
+        }
+        g_header_removals = bigger;
+        g_header_removals_cap = new_cap;
+    }
+    HeaderRemoval* h = &g_header_removals[g_header_removals_n];
+    h->field = field;
+    h->name = strdup(name);
+    if (!h->name) {
+        tape_set_err("OOM appending header removal");
+        return 0;
+    }
+    g_header_removals_n++;
+    return 1;
+}
+
+static int header_removed_for_field(int field, const char* name) {
+    if (!name) return 0;
+    for (int i = 0; i < g_header_removals_n; i++) {
+        if (g_header_removals[i].field == field && icmp(g_header_removals[i].name, name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void header_removals_free_storage(void) {
+    if (g_header_removals) {
+        for (int i = 0; i < g_header_removals_n; i++) {
+            free(g_header_removals[i].name);
+        }
+        free(g_header_removals);
+        g_header_removals = NULL;
+    }
+    g_header_removals_n = 0;
+    g_header_removals_cap = 0;
 }
 
 /* Step 12: optional markdown formatting toggles for the recorder.
@@ -571,7 +698,15 @@ static int g_emphasize_http_verbs = 0;
 /* Drop all registered redactions. Useful to call between tests in
  * the same process so a redaction set doesn't leak across them. */
 void vcr_clear_redactions(void) {
-    redactions_free_storage();
+    redaction_list_free(&g_redactions, &g_redactions_n, &g_redactions_cap);
+}
+
+void vcr_clear_unredactions(void) {
+    redaction_list_free(&g_unredactions, &g_unredactions_n, &g_unredactions_cap);
+}
+
+void vcr_clear_header_removals(void) {
+    header_removals_free_storage();
 }
 
 /* Step 12 setters — opt the recorder into the alternative markdown
@@ -691,7 +826,7 @@ static void vcr_static_dispatch(void* req, void* res, void* ud) {
 }
 
 /* Register a static-content mount. Append to g_mounts; the
- * actual route registration happens in vcr_register_routes
+ * actual route registration happens in Aether register_routes
  * (which is called by vcr.load — load order is: register tape
  * routes, then mounts; routes overlap is fine since
  * mount-rooted requests don't appear in tapes by definition). */
@@ -735,7 +870,7 @@ void vcr_clear_static_content(void) {
 }
 
 /* Register the wildcard routes for every mount with the http
- * server. Called from vcr_register_routes() after the tape
+ * server. Called from Aether register_routes() after the tape
  * routes go in. */
 static void register_static_routes(void* server) {
     if (!server) return;
@@ -824,6 +959,7 @@ static char* normalize_live_headers(const VcrHttpRequestPrefix* r) {
         if (icmp(key, "Host") == 0) continue;
         if (icmp(key, "Connection") == 0) continue;
         if (icmp(key, "Content-Length") == 0) continue;
+        if (header_removed_for_field(VCR_FIELD_REQUEST_HEADERS, key)) continue;
         size_t len = strlen(key) + 2 + strlen(val) + 1;
         char* line = (char*)malloc(len);
         if (!line) {
@@ -883,6 +1019,357 @@ static void first_header_name(const char* recorded, char* out, size_t max) {
     out[i] = '\0';
 }
 
+static char* replace_all_c(const char* src, const char* pattern, const char* replacement) {
+    if (!src) src = "";
+    if (!pattern || !*pattern) return strdup(src);
+    if (!replacement) replacement = "";
+
+    size_t src_len = strlen(src);
+    size_t pat_len = strlen(pattern);
+    size_t rep_len = strlen(replacement);
+    size_t count = 0;
+    const char* p = src;
+    while ((p = strstr(p, pattern)) != NULL) {
+        count++;
+        p += pat_len;
+    }
+    size_t out_len = src_len + count * (rep_len > pat_len ? rep_len - pat_len : 0);
+    if (rep_len < pat_len) out_len = src_len - count * (pat_len - rep_len);
+    char* out = (char*)malloc(out_len + 1);
+    if (!out) return NULL;
+
+    const char* cursor = src;
+    char* dst = out;
+    while ((p = strstr(cursor, pattern)) != NULL) {
+        size_t chunk = (size_t)(p - cursor);
+        memcpy(dst, cursor, chunk);
+        dst += chunk;
+        memcpy(dst, replacement, rep_len);
+        dst += rep_len;
+        cursor = p + pat_len;
+    }
+    strcpy(dst, cursor);
+    return out;
+}
+
+static char* apply_unredactions_for_c(const char* src, int field) {
+    char* out = strdup(src ? src : "");
+    if (!out) return NULL;
+    for (int i = 0; i < g_unredactions_n; i++) {
+        if (g_unredactions[i].field != field) continue;
+        char* next = replace_all_c(out, g_unredactions[i].pattern, g_unredactions[i].replacement);
+        free(out);
+        if (!next) return NULL;
+        out = next;
+    }
+    return out;
+}
+
+static char* remove_headers_from_block_c(const char* headers, int field) {
+    if (!headers) headers = "";
+    char* out = (char*)malloc(strlen(headers) + 1);
+    if (!out) return NULL;
+    size_t off = 0;
+    const char* p = headers;
+    while (*p) {
+        const char* line_start = p;
+        const char* nl = strchr(p, '\n');
+        size_t line_len = nl ? (size_t)(nl - p) : strlen(p);
+        size_t trimmed_len = line_len;
+        if (trimmed_len > 0 && line_start[trimmed_len - 1] == '\r') trimmed_len--;
+        int keep = 1;
+        const char* colon = memchr(line_start, ':', trimmed_len);
+        if (colon) {
+            size_t name_len = (size_t)(colon - line_start);
+            char name[256];
+            if (name_len > 0 && name_len < sizeof(name)) {
+                memcpy(name, line_start, name_len);
+                name[name_len] = '\0';
+                if (header_removed_for_field(field, name)) keep = 0;
+            }
+        }
+        if (keep && line_len > 0) {
+            memcpy(out + off, line_start, line_len);
+            off += line_len;
+            if (nl) out[off++] = '\n';
+        }
+        if (!nl) break;
+        p = nl + 1;
+    }
+    out[off] = '\0';
+    return out;
+}
+
+static const char* request_header_value(const VcrHttpRequestPrefix* r, const char* name) {
+    if (!r || !name) return "";
+    for (int i = 0; i < r->header_count; i++) {
+        if (r->header_keys[i] && icmp(r->header_keys[i], name) == 0) {
+            return r->header_values[i] ? r->header_values[i] : "";
+        }
+    }
+    return "";
+}
+
+static int is_hop_by_hop_header(const char* name) {
+    if (!name) return 1;
+    return icmp(name, "Host") == 0
+        || icmp(name, "Connection") == 0
+        || icmp(name, "Content-Length") == 0
+        || icmp(name, "Transfer-Encoding") == 0
+        || icmp(name, "Keep-Alive") == 0
+        || icmp(name, "Proxy-Authenticate") == 0
+        || icmp(name, "Proxy-Authorization") == 0
+        || icmp(name, "TE") == 0
+        || icmp(name, "Trailer") == 0
+        || icmp(name, "Upgrade") == 0;
+}
+
+static char* build_upstream_url(const char* base, const VcrHttpRequestPrefix* r) {
+    const char* path = (r && r->path && r->path[0]) ? r->path : "/";
+    const char* query = (r && r->query_string) ? r->query_string : "";
+    size_t base_len = strlen(base ? base : "");
+    size_t path_len = strlen(path);
+    size_t query_len = strlen(query);
+    int need_slash = (base_len > 0 && path[0] != '/');
+    size_t total = base_len + (need_slash ? 1 : 0) + path_len + query_len;
+    char* out = (char*)malloc(total + 1);
+    if (!out) return NULL;
+    char* p = out;
+    if (base_len) { memcpy(p, base, base_len); p += base_len; }
+    if (need_slash) *p++ = '/';
+    memcpy(p, path, path_len); p += path_len;
+    if (query_len) { memcpy(p, query, query_len); p += query_len; }
+    *p = '\0';
+    return out;
+}
+
+static char* build_recorded_path(const VcrHttpRequestPrefix* r) {
+    const char* path = (r && r->path && r->path[0]) ? r->path : "/";
+    const char* query = (r && r->query_string) ? r->query_string : "";
+    size_t path_len = strlen(path);
+    size_t query_len = strlen(query);
+    char* out = (char*)malloc(path_len + query_len + 1);
+    if (!out) return NULL;
+    memcpy(out, path, path_len);
+    if (query_len) memcpy(out + path_len, query, query_len);
+    out[path_len + query_len] = '\0';
+    return out;
+}
+
+static int expected_path_includes_query(const char* path) {
+    return path && strchr(path, '?') != NULL;
+}
+
+static char* response_headers_for_tape(const char* raw_headers) {
+    if (!raw_headers) return strdup("");
+    const char* p = strchr(raw_headers, '\n');
+    p = p ? p + 1 : raw_headers;
+
+    size_t cap = strlen(p) + 1;
+    char* out = (char*)malloc(cap);
+    if (!out) return NULL;
+    size_t off = 0;
+
+    while (*p) {
+        const char* line_start = p;
+        const char* nl = strchr(p, '\n');
+        size_t line_len = nl ? (size_t)(nl - p) : strlen(p);
+        if (line_len > 0 && line_start[line_len - 1] == '\r') line_len--;
+
+        const char* colon = memchr(line_start, ':', line_len);
+        if (colon) {
+            size_t name_len = (size_t)(colon - line_start);
+            char name[256];
+            if (name_len > 0 && name_len < sizeof(name)) {
+                memcpy(name, line_start, name_len);
+                name[name_len] = '\0';
+                if (!is_hop_by_hop_header(name)) {
+                    if (off + line_len + 1 >= cap) {
+                        cap = cap + line_len + 1024;
+                        char* bigger = (char*)realloc(out, cap);
+                        if (!bigger) { free(out); return NULL; }
+                        out = bigger;
+                    }
+                    memcpy(out + off, line_start, line_len);
+                    off += line_len;
+                    out[off++] = '\n';
+                }
+            }
+        }
+        if (!nl) break;
+        p = nl + 1;
+    }
+    out[off] = '\0';
+    return out;
+}
+
+static char* response_header_value_from_block(const char* headers, const char* name) {
+    if (!headers || !name) return strdup("");
+    size_t name_len = strlen(name);
+    const char* p = headers;
+    while (*p) {
+        const char* nl = strchr(p, '\n');
+        size_t line_len = nl ? (size_t)(nl - p) : strlen(p);
+        const char* colon = memchr(p, ':', line_len);
+        if (colon && (size_t)(colon - p) == name_len) {
+            int match = 1;
+            for (size_t i = 0; i < name_len; i++) {
+                char a = p[i], b = name[i];
+                if (a >= 'A' && a <= 'Z') a = (char)(a + 32);
+                if (b >= 'A' && b <= 'Z') b = (char)(b + 32);
+                if (a != b) { match = 0; break; }
+            }
+            if (match) {
+                const char* v = colon + 1;
+                const char* end = p + line_len;
+                while (v < end && (*v == ' ' || *v == '\t')) v++;
+                while (end > v && (end[-1] == '\r' || end[-1] == ' ' || end[-1] == '\t')) end--;
+                size_t vlen = (size_t)(end - v);
+                char* out = (char*)malloc(vlen + 1);
+                if (!out) return NULL;
+                memcpy(out, v, vlen);
+                out[vlen] = '\0';
+                return out;
+            }
+        }
+        if (!nl) break;
+        p = nl + 1;
+    }
+    return strdup("");
+}
+
+static void emit_recorded_headers_to_response(void* res, const char* headers) {
+    http_response_clear_headers(res);
+    if (!headers) return;
+    const char* p = headers;
+    while (*p) {
+        const char* nl = strchr(p, '\n');
+        size_t line_len = nl ? (size_t)(nl - p) : strlen(p);
+        if (line_len > 0 && p[line_len - 1] == '\r') line_len--;
+        const char* colon = memchr(p, ':', line_len);
+        if (colon) {
+            size_t name_len = (size_t)(colon - p);
+            const char* val = colon + 1;
+            const char* end = p + line_len;
+            while (val < end && (*val == ' ' || *val == '\t')) val++;
+            size_t val_len = (size_t)(end - val);
+            char name[256];
+            char value[4096];
+            if (name_len > 0 && name_len < sizeof(name) && val_len < sizeof(value)) {
+                memcpy(name, p, name_len); name[name_len] = '\0';
+                memcpy(value, val, val_len); value[val_len] = '\0';
+                http_response_add_header(res, name, value);
+            }
+        }
+        if (!nl) break;
+        p = nl + 1;
+    }
+}
+
+static void vcr_record_dispatch(void* req, void* res, void* ud) {
+    (void)ud;
+    const VcrHttpRequestPrefix* live_req = (const VcrHttpRequestPrefix*)req;
+    if (!g_record_upstream_base || !*g_record_upstream_base) {
+        http_response_set_status(res, 500);
+        http_response_set_body(res, "vcr record mode: upstream base not configured");
+        return;
+    }
+
+    char* url = build_upstream_url(g_record_upstream_base, live_req);
+    if (!url) {
+        http_response_set_status(res, 500);
+        http_response_set_body(res, "vcr record mode: OOM building upstream URL");
+        return;
+    }
+
+    void* creq = http_request_raw(live_req->method ? live_req->method : "GET", url);
+    if (!creq) {
+        free(url);
+        http_response_set_status(res, 500);
+        http_response_set_body(res, "vcr record mode: failed to build client request");
+        return;
+    }
+
+    for (int i = 0; i < live_req->header_count; i++) {
+        const char* key = live_req->header_keys[i];
+        const char* val = live_req->header_values[i] ? live_req->header_values[i] : "";
+        if (!key || is_hop_by_hop_header(key)) continue;
+        http_request_set_header_raw(creq, key, val);
+    }
+
+    if (live_req->body && live_req->body_length > 0) {
+        const char* ctype = request_header_value(live_req, "Content-Type");
+        http_request_set_body_raw(creq, live_req->body, (int)live_req->body_length, ctype);
+    }
+    http_request_set_timeout_raw(creq, 30);
+
+    void* cresp = http_send_raw(creq);
+    http_request_free_raw(creq);
+    if (!cresp) {
+        free(url);
+        http_response_set_status(res, 502);
+        http_response_set_body(res, "vcr record mode: upstream request failed");
+        return;
+    }
+    const char* cerr = http_response_error(cresp);
+    if (cerr && *cerr) {
+        char msg[2048];
+        snprintf(msg, sizeof(msg), "vcr record mode: upstream transport error: %s", cerr);
+        http_response_free(cresp);
+        free(url);
+        http_response_set_status(res, 502);
+        http_response_set_body(res, msg);
+        return;
+    }
+
+    VcrClientResponsePrefix* cr = (VcrClientResponsePrefix*)cresp;
+    const char* body = (cr->body && cr->body->data) ? cr->body->data : "";
+    int body_len = (cr->body && cr->body->data) ? (int)cr->body->length : 0;
+    const char* raw_headers = (cr->headers && cr->headers->data) ? cr->headers->data : "";
+    char* resp_headers = response_headers_for_tape(raw_headers);
+    char* content_type = response_header_value_from_block(resp_headers ? resp_headers : "", "Content-Type");
+    char* req_headers = normalize_live_headers(live_req);
+
+    if (!resp_headers || !content_type || !req_headers) {
+        free(resp_headers); free(content_type); free(req_headers);
+        http_response_free(cresp);
+        free(url);
+        http_response_set_status(res, 500);
+        http_response_set_body(res, "vcr record mode: OOM recording interaction");
+        return;
+    }
+
+    char* recorded_path = build_recorded_path(live_req);
+    if (!recorded_path) {
+        free(resp_headers); free(content_type); free(req_headers);
+        http_response_free(cresp);
+        free(url);
+        http_response_set_status(res, 500);
+        http_response_set_body(res, "vcr record mode: OOM recording path");
+        return;
+    }
+
+    int ok = vcr_record_interaction_full(live_req->method ? live_req->method : "GET",
+                                         recorded_path,
+                                         http_response_status(cresp),
+                                         content_type,
+                                         body,
+                                         req_headers,
+                                         live_req->body ? live_req->body : "");
+    if (ok) vcr_aether_set_resp_headers(g_tape_n - 1, resp_headers);
+
+    http_response_set_status(res, http_response_status(cresp));
+    emit_recorded_headers_to_response(res, resp_headers);
+    http_response_set_body_n(res, body, body_len);
+
+    free(resp_headers);
+    free(content_type);
+    free(req_headers);
+    free(recorded_path);
+    http_response_free(cresp);
+    free(url);
+}
+
 void vcr_dispatch(void* req, void* res, void* ud) {
     (void)ud;
     if (g_tape_cursor >= g_tape_n) {
@@ -895,19 +1382,45 @@ void vcr_dispatch(void* req, void* res, void* ud) {
         return;
     }
     Interaction* e = &g_tape[g_tape_cursor];
+    char* expected_path = apply_unredactions_for_c(e->path, VCR_FIELD_PATH);
+    char* expected_req_headers = apply_unredactions_for_c(e->req_headers, VCR_FIELD_REQUEST_HEADERS);
+    char* expected_req_body = apply_unredactions_for_c(e->req_body, VCR_FIELD_REQUEST_BODY);
+    if (!expected_path || !expected_req_headers || !expected_req_body) {
+        free(expected_path); free(expected_req_headers); free(expected_req_body);
+        last_err_set("OOM applying playback replacements");
+        http_response_set_status(res, 599);
+        http_response_set_body(res, "OOM applying playback replacements");
+        return;
+    }
+    char* expected_req_headers_filtered = remove_headers_from_block_c(expected_req_headers,
+                                                                      VCR_FIELD_REQUEST_HEADERS);
+    free(expected_req_headers);
+    expected_req_headers = expected_req_headers_filtered;
+    if (!expected_req_headers) {
+        free(expected_path); free(expected_req_body);
+        last_err_set("OOM applying playback header removals");
+        http_response_set_status(res, 599);
+        http_response_set_body(res, "OOM applying playback header removals");
+        return;
+    }
 
     /* (method, path) match — same as before step 10, just now
      * recorded into g_last_error too. Mismatch returns without
      * advancing cursor. */
     const char* got_method = http_request_method(req);
     const char* got_path   = http_request_path(req);
+    char* got_path_with_query = NULL;
+    if (expected_path_includes_query(expected_path)) {
+        got_path_with_query = build_recorded_path((const VcrHttpRequestPrefix*)req);
+        got_path = got_path_with_query ? got_path_with_query : got_path;
+    }
     if (!got_method || strcmp(got_method, e->method) != 0
-        || !got_path || strcmp(got_path, e->path) != 0) {
+        || !got_path || strcmp(got_path, expected_path) != 0) {
         char msg[2048];
         snprintf(msg, sizeof(msg),
             "tape mismatch at interaction %d: expected %s %s, got %s %s",
             g_tape_cursor,
-            e->method, e->path,
+            e->method, expected_path,
             got_method ? got_method : "(null)",
             got_path   ? got_path   : "(null)");
         last_err_set(msg);
@@ -915,28 +1428,32 @@ void vcr_dispatch(void* req, void* res, void* ud) {
         g_last_index = g_tape_cursor;
         http_response_set_status(res, 599);
         http_response_set_body(res, msg);
+        free(got_path_with_query);
+        free(expected_path); free(expected_req_headers); free(expected_req_body);
         return;
     }
+    free(got_path_with_query);
 
     /* Request-headers comparison. Fires when EITHER the tape captured
      * a non-blank request_headers block (implicit gate, Step 10) OR
      * the test explicitly opted in via vcr.set_strict_headers(1). The
      * explicit flag lets a test enable strict matching against tapes
-     * whose request blocks have been load-time scrubbed (the canonical
-     * SVN tape's case — recorded headers like `Host: svn.apache.org`
-     * won't match what std.http.client sends to 127.0.0.1, but a test
-     * driver that wants to deliberately exercise the diagnostic paths
-     * can scrub-then-set-strict and construct exact requests). */
+     * whose request blocks have been load-time scrubbed. Recorded
+     * upstream Host headers won't match what std.http.client sends to
+     * 127.0.0.1, but a test driver that wants to deliberately exercise
+     * the diagnostic paths can scrub-then-set-strict and construct
+     * exact requests. */
     const VcrHttpRequestPrefix* live_req = (const VcrHttpRequestPrefix*)req;
-    if (!is_blank(e->req_headers) || g_strict_headers) {
+    if (!is_blank(expected_req_headers) || g_strict_headers) {
         char* live = normalize_live_headers(live_req);
         if (!live) {
+            free(expected_path); free(expected_req_headers); free(expected_req_body);
             last_err_set("OOM normalizing live request headers");
             http_response_set_status(res, 599);
             http_response_set_body(res, "OOM normalizing live request headers");
             return;
         }
-        if (strcmp(live, e->req_headers) != 0) {
+        if (strcmp(live, expected_req_headers) != 0) {
             /* Identify the offending header. Walk the recorded blob
              * line by line: if a recorded line isn't in `live`, the
              * recording expected a header the SUT didn't send →
@@ -951,7 +1468,7 @@ void vcr_dispatch(void* req, void* res, void* ud) {
             int kind = VCR_KIND_HEADER_MISSING;  /* default if neither sweep narrows it */
 
             /* First sweep: recorded lines not present verbatim in live. */
-            const char* p = e->req_headers;
+            const char* p = expected_req_headers;
             while (*p && !found_diag) {
                 const char* eol = strchr(p, '\n');
                 if (!eol) eol = p + strlen(p);
@@ -1014,7 +1531,7 @@ void vcr_dispatch(void* req, void* res, void* ud) {
                         memcpy(one, lp, llen);
                         one[llen] = '\n';
                         one[llen + 1] = '\0';
-                        if (!strstr(e->req_headers, one)) {
+                        if (!strstr(expected_req_headers, one)) {
                             first_header_name(lp, hdr_name, sizeof(hdr_name));
                             snprintf(msg, sizeof(msg),
                                 "interaction %d: '%s' request header encountered but not expected",
@@ -1031,7 +1548,7 @@ void vcr_dispatch(void* req, void* res, void* ud) {
             if (!found_diag) {
                 snprintf(msg, sizeof(msg),
                     "interaction %d: request headers differ — recorded:\n%s\nlive:\n%s",
-                    g_tape_cursor, e->req_headers, live);
+                    g_tape_cursor, expected_req_headers, live);
                 /* Fall-through diagnostic — neither sweep located a
                  * single offender. Call it MISSING by default; the
                  * detailed message is in g_last_error. */
@@ -1041,6 +1558,7 @@ void vcr_dispatch(void* req, void* res, void* ud) {
             g_last_kind = kind;
             g_last_index = g_tape_cursor;
             free(live);
+            free(expected_path); free(expected_req_headers); free(expected_req_body);
             http_response_set_status(res, 599);
             http_response_set_body(res, msg);
             return;
@@ -1049,19 +1567,20 @@ void vcr_dispatch(void* req, void* res, void* ud) {
     }
 
     /* Step 10: request-body comparison. Same opt-in semantics. */
-    if (!is_blank(e->req_body)) {
+    if (!is_blank(expected_req_body)) {
         const char* live_body = live_req->body ? live_req->body : "";
-        if (strcmp(live_body, e->req_body) != 0) {
+        if (strcmp(live_body, expected_req_body) != 0) {
             char msg[2048];
             snprintf(msg, sizeof(msg),
                 "interaction %d: request body different to expectation — "
                 "recorded=%zu bytes, live=%zu bytes",
                 g_tape_cursor,
-                strlen(e->req_body),
+                strlen(expected_req_body),
                 strlen(live_body));
             last_err_set(msg);
             g_last_kind = VCR_KIND_BODY_DIFF;
             g_last_index = g_tape_cursor;
+            free(expected_path); free(expected_req_headers); free(expected_req_body);
             http_response_set_status(res, 599);
             http_response_set_body(res, msg);
             return;
@@ -1139,10 +1658,10 @@ void vcr_dispatch(void* req, void* res, void* ud) {
                 }
                 if (matches_ct) emitted_content_type_from_block = 1;
             }
-            /* add_header (not set_header) — SVN/WebDAV tapes have
-             * many duplicate-keyed headers (13+ `DAV:` per response).
-             * set_header replaces on duplicate; add_header preserves
-             * order and multiplicity through to the wire serializer. */
+            /* add_header (not set_header) — some protocols have many
+             * duplicate-keyed headers. set_header replaces on duplicate;
+             * add_header preserves order and multiplicity through to
+             * the wire serializer. */
             http_response_add_header(res, name_buf, val_buf);
         }
     }
@@ -1175,6 +1694,7 @@ void vcr_dispatch(void* req, void* res, void* ud) {
     g_last_index = g_tape_cursor;
 
     g_tape_cursor++;
+    free(expected_path); free(expected_req_headers); free(expected_req_body);
 }
 
 /* Step 10: surface the most recent dispatch mismatch. The test's
@@ -1375,4 +1895,26 @@ const char* vcr_get_redaction_pattern(int i) {
 const char* vcr_get_redaction_replacement(int i) {
     if (i < 0 || i >= g_redactions_n) return "";
     return safe(g_redactions[i].replacement);
+}
+int vcr_get_unredaction_count(void) { return g_unredactions_n; }
+int vcr_get_unredaction_field(int i) {
+    if (i < 0 || i >= g_unredactions_n) return 0;
+    return g_unredactions[i].field;
+}
+const char* vcr_get_unredaction_pattern(int i) {
+    if (i < 0 || i >= g_unredactions_n) return "";
+    return safe(g_unredactions[i].pattern);
+}
+const char* vcr_get_unredaction_replacement(int i) {
+    if (i < 0 || i >= g_unredactions_n) return "";
+    return safe(g_unredactions[i].replacement);
+}
+int vcr_get_header_removal_count(void) { return g_header_removals_n; }
+int vcr_get_header_removal_field(int i) {
+    if (i < 0 || i >= g_header_removals_n) return 0;
+    return g_header_removals[i].field;
+}
+const char* vcr_get_header_removal_name(int i) {
+    if (i < 0 || i >= g_header_removals_n) return "";
+    return safe(g_header_removals[i].name);
 }

--- a/std/http/server/vcr/module.ae
+++ b/std/http/server/vcr/module.ae
@@ -106,9 +106,11 @@ import std.fs
 import std.string
 
 exports (
-    vcr_load_err, vcr_tape_length, vcr_dispatch, vcr_register_routes,
+    vcr_load_err, vcr_tape_length, vcr_dispatch, vcr_register_static_routes,
     vcr_record_interaction,
     vcr_add_redaction, vcr_clear_redactions,
+    vcr_add_unredaction, vcr_clear_unredactions,
+    vcr_add_header_removal, vcr_clear_header_removals,
     vcr_add_note,
     vcr_record_interaction_full, vcr_last_error, vcr_clear_last_error,
     vcr_add_static_content, vcr_clear_static_content,
@@ -120,6 +122,10 @@ exports (
     vcr_get_indent_code_blocks, vcr_get_emphasize_http_verbs,
     vcr_get_redaction_count, vcr_get_redaction_field,
     vcr_get_redaction_pattern, vcr_get_redaction_replacement,
+    vcr_get_unredaction_count, vcr_get_unredaction_field,
+    vcr_get_unredaction_pattern, vcr_get_unredaction_replacement,
+    vcr_get_header_removal_count, vcr_get_header_removal_field,
+    vcr_get_header_removal_name,
     vcr_aether_clear_tape, vcr_aether_append_interaction,
     vcr_aether_set_load_err, vcr_aether_set_resp_headers,
     vcr_last_kind, vcr_last_index,
@@ -129,15 +135,19 @@ exports (
     KIND_HEADER_VALUE_DIFF, KIND_HEADER_UNEXPECTED,
     KIND_TAPE_EXHAUSTED, KIND_BODY_DIFF,
     last_kind, last_index, set_strict_headers, reset_cursor,
-    FIELD_PATH, FIELD_RESPONSE_BODY,
+    FIELD_PATH, FIELD_RESPONSE_BODY, FIELD_REQUEST_HEADERS,
+    FIELD_REQUEST_BODY, FIELD_RESPONSE_HEADERS,
     load, eject, tape_length,
+    load_record, eject_record,
     record, flush, flush_or_check,
-    redact, clear_redactions,
+    redact, clear_redactions, unredact, clear_unredactions,
+    remove_header, clear_header_removals,
     note,
-    record_full, last_error, clear_last_error,
+    record_full, record_full_response, last_error, clear_last_error,
     static_content, clear_static_content,
     indent_code_blocks, emphasize_http_verbs, clear_format_options,
-    str_replace_all, apply_redactions_for, emit_code_block,
+    str_replace_all, apply_redactions_for, apply_unredactions_for,
+    route_path_for, register_routes, emit_code_block,
     emit_one_interaction, emit_tape,
     find_at_line_start, rtrim,
     extract_code_block_at, extract_indented_at,
@@ -154,7 +164,8 @@ exports (
 extern vcr_load_err() -> string                       // populated by vcr_aether_set_load_err on parse failure
 extern vcr_tape_length() -> int
 extern vcr_dispatch(req: ptr, res: ptr, ud: ptr)     // server handler — matches next entry, emits response
-extern vcr_register_routes(server: ptr)               // walks tape and calls server_get for each unique path
+extern vcr_register_static_routes(server: ptr)         // registers configured static-content mounts
+extern vcr_register_record_routes(server: ptr, upstream_base: string) -> int
 
 // Record-mode externs — append captured interactions, then flush
 // the lot to disk in canonical Servirtium markdown when the test
@@ -166,6 +177,10 @@ extern vcr_record_interaction(method: string, path: string, status: int, content
 // the same VCR can serve replays AND emit redacted tapes.
 extern vcr_add_redaction(field: int, pattern: string, replacement: string) -> int
 extern vcr_clear_redactions()
+extern vcr_add_unredaction(field: int, pattern: string, replacement: string) -> int
+extern vcr_clear_unredactions()
+extern vcr_add_header_removal(field: int, name: string) -> int
+extern vcr_clear_header_removals()
 
 // Note extern (Servirtium step 9). Stages a (title, body) note
 // that attaches to the next interaction recorded.
@@ -177,8 +192,8 @@ extern vcr_last_error() -> string
 extern vcr_clear_last_error()
 
 // Step 11 externs — static-content mount points. Routes are
-// registered when vcr.load() calls vcr_register_routes() — so
-// configure mounts BEFORE loading the tape.
+// registered when vcr.load() calls register_routes() — so configure
+// mounts BEFORE loading the tape.
 extern vcr_add_static_content(mount_path: string, fs_dir: string) -> int
 extern vcr_clear_static_content()
 
@@ -210,6 +225,13 @@ extern vcr_get_redaction_count() -> int
 extern vcr_get_redaction_field(i: int) -> int
 extern vcr_get_redaction_pattern(i: int) -> string
 extern vcr_get_redaction_replacement(i: int) -> string
+extern vcr_get_unredaction_count() -> int
+extern vcr_get_unredaction_field(i: int) -> int
+extern vcr_get_unredaction_pattern(i: int) -> string
+extern vcr_get_unredaction_replacement(i: int) -> string
+extern vcr_get_header_removal_count() -> int
+extern vcr_get_header_removal_field(i: int) -> int
+extern vcr_get_header_removal_name(i: int) -> string
 
 // Setters used by the Aether-side parser to populate the tape.
 // Inverse of the get_* accessors. Single all-fields setter rather
@@ -246,10 +268,8 @@ extern vcr_get_strict_headers() -> int
 
 // Reset the dispatch cursor to interaction 0 without freeing the
 // tape or stopping the server. Used by tests that drive a series
-// of independent cases against the same loaded tape (e.g. the
-// strict-match permutation tests in
-// tests/integration/svn_vcr_strict_match/). Also clears the
-// last_kind / last_index / last_error slots.
+// of independent cases against the same loaded tape. Also clears
+// the last_kind / last_index / last_error slots.
 extern vcr_reset_cursor()
 
 // Kind-of-outcome enum. Returned by vcr.last_kind() after each
@@ -310,10 +330,10 @@ load(tape_path: string, port: int) -> ptr {
         return null
     }
 
-    // Each unique path in the tape gets registered with the routing
-    // layer; the dispatcher then matches on (method, path) and emits
-    // the recorded response.
-    vcr_register_routes(raw)
+    // Aether registers the replay routes from the parsed tape. The
+    // dispatcher then matches on (method, path) and emits the
+    // recorded response.
+    register_routes(raw)
 
     return raw
 }
@@ -329,6 +349,40 @@ eject(server: ptr) {
 // many interactions have been captured so far). Useful for
 // sanity-checking in test setup and after-record verification.
 tape_length() -> int { return vcr_tape_length() }
+
+// Record mode: create a VCR server that listens like playback, but
+// forwards each request to `upstream_base` with std.http.client,
+// returns the real response to the SUT, and records the interaction
+// into the in-memory tape. Call eject_record(server, tape_path) when
+// the run is complete; it writes the markdown tape to the same path
+// vcr.load(tape_path, port) later replays from.
+load_record(tape_path: string, upstream_base: string, port: int) -> ptr {
+    vcr_aether_clear_tape()
+
+    raw = http.server_create(port)
+    if raw == 0 {
+        println("vcr.load_record: server_create on port ${port} returned 0")
+        return null
+    }
+
+    ok = vcr_register_record_routes(raw, upstream_base)
+    if ok == 0 {
+        println("vcr.load_record: ${vcr_load_err()}")
+        http.server_stop(raw)
+        return null
+    }
+
+    return raw
+}
+
+// Stop the record-mode server and write the captured markdown tape
+// to `tape_path`. This deliberately overwrites the playback tape:
+// the developer reviews git diff to decide whether upstream changed
+// legitimately or unexpectedly.
+eject_record(server: ptr, tape_path: string) -> string {
+    http.server_stop(server)
+    return flush(tape_path)
+}
 
 // ---- Record mode -----------------------------------------------------
 //
@@ -424,11 +478,15 @@ flush_or_check(tape_path: string) -> string {
 //   ... drive SUT, capture interactions ...
 //   vcr.flush(tape_path)
 //
-// Field selectors. v0.1 supports path + response body. Future:
-// request headers, request body, response headers (added when
-// the recorder starts capturing those — today it doesn't).
-const FIELD_PATH          = 1
-const FIELD_RESPONSE_BODY = 2
+// Field selectors for recording redactions and playback
+// unredactions. Redactions are applied only when writing a tape;
+// unredactions are applied only when comparing an incoming request
+// to a loaded tape.
+const FIELD_PATH             = 1
+const FIELD_RESPONSE_BODY    = 2
+const FIELD_REQUEST_HEADERS  = 3
+const FIELD_REQUEST_BODY     = 4
+const FIELD_RESPONSE_HEADERS = 5
 
 // Register a redaction. Every occurrence of `pattern` in the
 // designated field is replaced with `replacement` at flush time.
@@ -444,6 +502,42 @@ redact(field: int, pattern: string, replacement: string) -> string {
 // next.
 clear_redactions() {
     vcr_clear_redactions()
+}
+
+// Register a playback-side replacement. Use this when a committed
+// tape intentionally contains redacted values, but the live SUT still
+// sends the real value. For example, a tape may contain
+// `Authorization: Bearer REDACTED`; the test can call:
+//
+//   vcr.unredact(vcr.FIELD_REQUEST_HEADERS, "Bearer REDACTED", real_token)
+//
+// before vcr.load(). The dispatcher applies the replacement to the
+// recorded expectation before comparing path / request headers / body.
+// Response fields are accepted for symmetry but are not used by
+// playback matching today.
+unredact(field: int, pattern: string, replacement: string) -> string {
+    ok = vcr_add_unredaction(field, pattern, replacement)
+    if ok == 0 { return vcr_load_err() }
+    return ""
+}
+
+clear_unredactions() {
+    vcr_clear_unredactions()
+}
+
+// Remove a header by name from request/response header blocks.
+// Recording flush applies this to the emitted tape; playback applies
+// request-header removals to both the recorded expectation and the
+// live incoming request before strict matching. Header-name matching
+// is case-insensitive and exact.
+remove_header(field: int, name: string) -> string {
+    ok = vcr_add_header_removal(field, name)
+    if ok == 0 { return vcr_load_err() }
+    return ""
+}
+
+clear_header_removals() {
+    vcr_clear_header_removals()
 }
 
 // ---- Notes (Servirtium roadmap step 9) -------------------------------
@@ -504,6 +598,17 @@ note(title: string, body: string) -> string {
 record_full(method: string, path: string, status: int, content_type: string, body: string, req_headers: string, req_body: string) -> string {
     ok = vcr_record_interaction_full(method, path, status, content_type, body, req_headers, req_body)
     if ok == 0 { return "vcr.record_full failed" }
+    return ""
+}
+
+// Capture a full interaction including response headers. This is
+// primarily what record-mode uses internally, but tests can drive it
+// directly when no live HTTP server is needed.
+record_full_response(method: string, path: string, status: int, content_type: string, body: string, req_headers: string, req_body: string, resp_headers: string) -> string {
+    ok = vcr_record_interaction_full(method, path, status, content_type, body, req_headers, req_body)
+    if ok == 0 { return "vcr.record_full_response failed" }
+    idx = vcr_tape_length() - 1
+    vcr_aether_set_resp_headers(idx, resp_headers)
     return ""
 }
 
@@ -647,6 +752,113 @@ apply_redactions_for(s: string, field: int) -> string {
     return out
 }
 
+// Apply every registered playback unredaction whose field matches
+// `field` to `s`. Used before registering route paths so tapes with
+// redacted URLs still create the route the live client will request.
+apply_unredactions_for(s: string, field: int) -> string {
+    n = vcr_get_unredaction_count()
+    if n == 0 { return s }
+    out = s
+    i = 0
+    while i < n {
+        if vcr_get_unredaction_field(i) == field {
+            out = str_replace_all(out, vcr_get_unredaction_pattern(i),
+                                       vcr_get_unredaction_replacement(i))
+        }
+        i = i + 1
+    }
+    return out
+}
+
+// Convert a tape path into the route key expected by std.http's
+// router. The dispatcher still compares the full path+query when
+// the tape expects one; routing itself needs only the path segment.
+route_path_for(path: string) -> string {
+    p = apply_unredactions_for(path, FIELD_PATH)
+    q = string.index_of(p, "?")
+    if q >= 0 {
+        p = string.substring(p, 0, q)
+    }
+    if string.length(p) == 0 { return "/" }
+    return p
+}
+
+route_already_registered(method: string, route_path: string, before: int) -> int {
+    j = 0
+    while j < before {
+        prev_method = string.copy(vcr_get_method(j))
+        prev_path = route_path_for(string.copy(vcr_get_path(j)))
+        if prev_method == method && prev_path == route_path {
+            return 1
+        }
+        j = j + 1
+    }
+    return 0
+}
+
+// Register replay routes in Aether. C still owns the dispatcher
+// function pointer and static-content file serving, but route
+// enumeration and path normalization belong with the tape parser.
+register_routes(server: ptr) {
+    http.server_add_route(server, "*", "*", vcr_dispatch, 0)
+
+    n = vcr_get_tape_count()
+    i = 0
+    while i < n {
+        method = string.copy(vcr_get_method(i))
+        route_path = route_path_for(string.copy(vcr_get_path(i)))
+        if route_already_registered(method, route_path, i) == 0 {
+            http.server_add_route(server, method, route_path, vcr_dispatch, 0)
+        }
+        i = i + 1
+    }
+    vcr_register_static_routes(server)
+}
+
+header_removed_for(field: int, name: string) -> int {
+    n = vcr_get_header_removal_count()
+    i = 0
+    while i < n {
+        if vcr_get_header_removal_field(i) == field {
+            if icmp_aether(vcr_get_header_removal_name(i), name) == 0 {
+                return 1
+            }
+        }
+        i = i + 1
+    }
+    return 0
+}
+
+remove_headers_for(headers: string, field: int) -> string {
+    if string.length(headers) == 0 { return headers }
+    out = string.copy("")
+    cursor = 0
+    h_len = string.length(headers)
+    while cursor < h_len {
+        nl_idx = string.index_of_from(headers, "\n", cursor)
+        line_end = h_len
+        if nl_idx >= 0 { line_end = nl_idx }
+        line = string.substring(headers, cursor, line_end)
+        line_len = string.length(line)
+        if line_len > 0 && string.char_at(line, line_len - 1) == 13 {
+            line = string.substring(line, 0, line_len - 1)
+        }
+        keep = 1
+        colon_idx = string.index_of(line, ":")
+        if colon_idx > 0 {
+            name = string.substring(line, 0, colon_idx)
+            if header_removed_for(field, name) == 1 { keep = 0 }
+        }
+        if keep == 1 && string.length(line) > 0 {
+            out = string_concat(out, line)
+            out = string_concat(out, "\n")
+        }
+        if nl_idx < 0 { break }
+        cursor = nl_idx + 1
+    }
+    return out
+}
+
 // Emit one fenced or indented code block. Body may be empty —
 // the form has to land valid markdown either way (an empty fenced
 // block is "```\n```\n", an empty indented block is one 4-space
@@ -712,9 +924,15 @@ emit_one_interaction(i: int) -> string {
     body     = string.copy(vcr_get_body(i))
     req_h    = string.copy(vcr_get_req_headers(i))
     req_b    = string.copy(vcr_get_req_body(i))
+    resp_h   = string.copy(vcr_get_resp_headers(i))
 
-    path_out = apply_redactions_for(path, FIELD_PATH)
-    body_out = apply_redactions_for(body, FIELD_RESPONSE_BODY)
+    path_out   = apply_redactions_for(path, FIELD_PATH)
+    body_out   = apply_redactions_for(body, FIELD_RESPONSE_BODY)
+    req_h_out  = apply_redactions_for(req_h, FIELD_REQUEST_HEADERS)
+    req_b_out  = apply_redactions_for(req_b, FIELD_REQUEST_BODY)
+    resp_h_out = apply_redactions_for(resp_h, FIELD_RESPONSE_HEADERS)
+    req_h_out  = remove_headers_for(req_h_out, FIELD_REQUEST_HEADERS)
+    resp_h_out = remove_headers_for(resp_h_out, FIELD_RESPONSE_HEADERS)
 
     heading = "## Interaction ${i}: ${method} ${path_out}\n\n"
     if vcr_get_emphasize_http_verbs() == 1 {
@@ -737,15 +955,18 @@ emit_one_interaction(i: int) -> string {
         out = string_concat(out, "\n")
     }
 
-    rh_block = emit_code_block(req_h)
-    rb_block = emit_code_block(req_b)
+    rh_block = emit_code_block(req_h_out)
+    rb_block = emit_code_block(req_b_out)
     out = string_concat(out, "### Request headers recorded for playback:\n\n")
     out = string_concat(out, rh_block)
     out = string_concat(out, "### Request body recorded for playback ():\n\n")
     out = string_concat(out, rb_block)
 
     out = string_concat(out, "### Response headers recorded for playback:\n\n")
-    if string.length(ctype) > 0 {
+    if string.length(resp_h_out) > 0 {
+        rsp_h_block = emit_code_block(resp_h_out)
+        out = string_concat(out, rsp_h_block)
+    } else if string.length(ctype) > 0 {
         ct_line = "Content-Type: ${ctype}"
         rsp_h_block = emit_code_block(ct_line)
         out = string_concat(out, rsp_h_block)

--- a/std/http/server/vcr/module.ae
+++ b/std/http/server/vcr/module.ae
@@ -133,7 +133,7 @@ exports (
     vcr_reset_cursor,
     KIND_OK, KIND_PATH_OR_METHOD_DIFF, KIND_HEADER_MISSING,
     KIND_HEADER_VALUE_DIFF, KIND_HEADER_UNEXPECTED,
-    KIND_TAPE_EXHAUSTED, KIND_BODY_DIFF,
+    KIND_TAPE_EXHAUSTED, KIND_BODY_DIFF, KIND_RECORD_ERROR,
     last_kind, last_index, set_strict_headers, reset_cursor,
     FIELD_PATH, FIELD_RESPONSE_BODY, FIELD_REQUEST_HEADERS,
     FIELD_REQUEST_BODY, FIELD_RESPONSE_HEADERS,
@@ -282,6 +282,7 @@ const KIND_HEADER_VALUE_DIFF   = 3
 const KIND_HEADER_UNEXPECTED   = 4
 const KIND_TAPE_EXHAUSTED      = 5
 const KIND_BODY_DIFF           = 6
+const KIND_RECORD_ERROR        = 7
 
 // Aether-side wrappers around the runtime accessors. Call shape
 // matches the rest of the vcr.* surface (e.g. vcr.tape_length()).

--- a/std/http/server/vcr/module.ae
+++ b/std/http/server/vcr/module.ae
@@ -1,12 +1,12 @@
-// std.http.server.vcr — replay-driven HTTP server for testing.
+// std.http.server.vcr — Servirtium-format HTTP record/replay for tests.
 // Import with: import std.http.server.vcr
 //
-// v0.1 — GET-only, replay-only, strict (method, path) matching.
-//
 // The metaphor: a VCR is the device, a tape is the medium, and
-// `record` / `replay` are the operations the device performs on
-// the medium. v0.1 only supports replay (the tape is hand-written;
-// the recorder lands in a later version).
+// `record` / `replay` are the operations the device performs on the
+// medium. Replay serves previously captured markdown tapes. Record
+// mode listens like playback, forwards requests to a real upstream
+// using std.http.client, returns the real response to the caller, and
+// records the same interaction into the tape.
 //
 // A tape is a file describing a sequence of HTTP exchanges. Each
 // entry records the request the SUT (system under test) is
@@ -45,19 +45,14 @@
 //   ok-body
 //   ```
 //
-// v0.1 only consults the response body section (status, content-type,
-// body); the other three sections are accepted-and-ignored. Format
-// compatibility with other Servirtium implementations (Java, Python,
-// Kotlin, Go, ...) is the design goal — tapes recorded by any of
-// them should be replayable by us.
+// Format compatibility with other Servirtium implementations (Java,
+// Python, Kotlin, Go, ...) is the design goal — tapes recorded by any
+// of them should be replayable by us.
 //
-// Matching is strict on (method, path) only — incoming headers and
-// body are ignored. Out-of-order or unmatched-method-or-path
-// requests fail the replay (the dispatcher returns 599 with a body
-// explaining what didn't match, so the failure surfaces at the
-// test layer rather than as a silent miss). Entries are consumed
-// in order; if the SUT sends the same request twice the tape needs
-// two entries.
+// Matching is ordered. The dispatcher always checks method/path; it
+// also checks request headers and request body when the tape carries
+// non-empty blocks or strict headers are enabled. Mismatches return
+// 599 and populate last_error / last_kind / last_index.
 //
 // Usage (caller owns the actor wiring — Aether's import system
 // doesn't merge actor declarations across modules in v0.1, so the
@@ -92,14 +87,16 @@
 //       vcr.eject(raw)
 //   }
 //
-// What's deliberately out of scope for v0.1 (additive future work):
-//   - POST / PUT / DELETE / PATCH (only GET)
-//   - Body-aware matching (only method + path)
-//   - Header-aware matching
-//   - Recording mode (tapes are hand-written today)
+// Supported additive features include record mode, custom verbs,
+// header/body strict matching, notes, redactions, unredactions,
+// header removal, static-content bypass, drift checks, optional
+// markdown formats, repeated response headers, base64 response bodies,
+// and gzip normalize/restore.
+//
+// What's still deliberately out of scope:
 //   - Loose / fuzzy matching, regex paths
-//   - Multi-tape replay (one tape per VCR instance)
-//   - Self-contained actor wiring (caller does spawn + send today)
+//   - Multi-tape/process-global isolation (one active tape today)
+//   - Arbitrary binary decoded record bodies without base64 emission
 
 import std.http
 import std.fs

--- a/std/http/server/vcr/module.ae
+++ b/std/http/server/vcr/module.ae
@@ -139,7 +139,7 @@ exports (
     FIELD_REQUEST_BODY, FIELD_RESPONSE_HEADERS,
     load, eject, tape_length,
     load_record, eject_record,
-    record, flush, flush_or_check,
+    record, clear_recording, flush, flush_or_check, flush_and_fail_if_changed,
     redact, clear_redactions, unredact, clear_unredactions,
     remove_header, clear_header_removals,
     note,
@@ -300,7 +300,8 @@ reset_cursor() { vcr_reset_cursor() }
 extern string_concat(a: string, b: string) -> string
 
 // String concat for the recheck error path — used by flush_or_check
-// to pin the return type to string. Same shape stdlib wrappers
+// and flush_and_fail_if_changed to pin the return type to string.
+// Same shape stdlib wrappers
 // elsewhere use to dodge tuple-inference confusion.
 extern string_concat(a: string, b: string) -> string
 
@@ -405,6 +406,13 @@ record(method: string, path: string, status: int, content_type: string, body: st
     return ""
 }
 
+// Clear the in-memory tape used by direct recorder tests. load_record()
+// calls this automatically before binding its server; this wrapper is
+// for tests that drive record()/record_full*() without a server.
+clear_recording() {
+    vcr_aether_clear_tape()
+}
+
 // Write every captured interaction to `tape_path` in canonical
 // Servirtium markdown. Overwrites any existing file at that path.
 // Returns "" on success, error string otherwise.
@@ -459,6 +467,30 @@ flush_or_check(tape_path: string) -> string {
     expected_len = string.length(existing)
     actual_len   = string.length(blob)
     return "tape mismatch: expected=${expected_len} bytes, actual=${actual_len} bytes; .actual sibling left at ${actual_path}"
+}
+
+// Servirtium-style re-record check. Unlike flush_or_check(), this
+// writes the newly recorded tape to `tape_path` even when bytes differ,
+// so a normal git diff shows the drift. The non-empty return value lets
+// the test fail loudly after preserving the new recording.
+flush_and_fail_if_changed(tape_path: string) -> string {
+    existing, eerr = fs.read(tape_path)
+    blob = emit_tape()
+
+    werr = fs.write(tape_path, blob)
+    if werr != "" { return werr }
+
+    if eerr != "" {
+        return ""
+    }
+
+    if existing == blob {
+        return ""
+    }
+
+    expected_len = string.length(existing)
+    actual_len   = string.length(blob)
+    return "tape mismatch: expected=${expected_len} bytes, actual=${actual_len} bytes; updated tape written to ${tape_path}"
 }
 
 // ---- Mutation mode (Servirtium roadmap step 8) -----------------------

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -749,6 +749,8 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
         return response;
     }
     if (header_end) {
+        size_t header_bytes = (size_t)((header_end + 4) - full_response);
+        size_t body_bytes = total_len >= header_bytes ? total_len - header_bytes : 0;
         *header_end = '\0';
         char* status_line = full_response;
         char* space1 = strchr(status_line, ' ');
@@ -757,9 +759,9 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
         }
 
         response->headers = string_new(full_response);
-        response->body = string_new(header_end + 4);
+        response->body = string_new_with_length(header_end + 4, body_bytes);
     } else {
-        response->body = string_new(full_response);
+        response->body = string_new_with_length(full_response, total_len);
     }
 
     free(full_response);

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -486,13 +486,24 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
             int in_progress = (errno == EINPROGRESS || errno == EWOULDBLOCK);
 #endif
             if (in_progress) {
-                fd_set wfds;
-                FD_ZERO(&wfds);
-                FD_SET(sockfd, &wfds);
+                /* Watch both the writable set (success) and the
+                 * exception set (failure). On POSIX, a refused
+                 * non-blocking connect makes the socket writable
+                 * with SO_ERROR=ECONNREFUSED — only `wfds` matters.
+                 * On Windows, Winsock signals connect failures via
+                 * the *exception* fd set instead, NOT writable —
+                 * so a select that watches only wfds waits the full
+                 * timeout for refused connects rather than failing
+                 * fast. Watching both makes select fire on either
+                 * outcome; SO_ERROR distinguishes success from
+                 * failure afterwards. */
+                fd_set wfds, efds;
+                FD_ZERO(&wfds); FD_SET(sockfd, &wfds);
+                FD_ZERO(&efds); FD_SET(sockfd, &efds);
                 struct timeval tv;
                 tv.tv_sec = req->timeout_secs;
                 tv.tv_usec = 0;
-                int sel = select(sockfd + 1, NULL, &wfds, NULL, &tv);
+                int sel = select(sockfd + 1, NULL, &wfds, &efds, &tv);
                 if (sel == 0) {
                     close(sockfd);
                     response->error = string_new("connect timeout");
@@ -503,8 +514,11 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
                     response->error = string_new("select on connect failed");
                     return response;
                 }
-                /* Check SO_ERROR — non-blocking connect can finish
-                 * with EAGAIN/etc., select reporting writable. */
+                /* Check SO_ERROR — distinguishes "writable because
+                 * connected" from "writable because failed". On
+                 * Windows the failure surfaces via efds; on POSIX
+                 * via wfds with so_err set. SO_ERROR works the
+                 * same in both cases. */
                 int so_err = 0;
                 socklen_t slen = sizeof(so_err);
                 if (getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char*)&so_err, &slen) < 0
@@ -529,12 +543,30 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
         if (flags >= 0) fcntl(sockfd, F_SETFL, flags);
 #endif
 
-        /* Apply send/recv timeouts equal to the configured value. */
+        /* Apply send/recv timeouts equal to the configured value.
+         *
+         * SO_RCVTIMEO / SO_SNDTIMEO take different shapes on the two
+         * families:
+         *   - POSIX: pointer to `struct timeval` (seconds + microseconds)
+         *   - Winsock: pointer to a 32-bit DWORD in milliseconds
+         *
+         * Passing a struct timeval to Winsock causes it to interpret
+         * the first 4 bytes (tv_sec) as a millisecond count — so
+         * `set_timeout(35)` would degrade to a 35-millisecond recv
+         * timeout, which fires almost instantly and surfaces as
+         * "recv timeout or I/O error" before any sane upstream can
+         * even respond. Use the right type per platform. */
+#ifdef _WIN32
+        DWORD rwtv_ms = (DWORD)req->timeout_secs * 1000U;
+        setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&rwtv_ms, sizeof(rwtv_ms));
+        setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (const char*)&rwtv_ms, sizeof(rwtv_ms));
+#else
         struct timeval rwtv;
         rwtv.tv_sec = req->timeout_secs;
         rwtv.tv_usec = 0;
         setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&rwtv, sizeof(rwtv));
         setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (const char*)&rwtv, sizeof(rwtv));
+#endif
     } else {
         connect_rc = connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
         if (connect_rc < 0) {

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -2309,7 +2309,7 @@ static int handle_one_request(HttpServer* server, HttpConn* conn,
     HttpRoute* matched_route = NULL;
 
     while (route) {
-        if (strcmp(route->method, req->method) == 0) {
+        if (strcmp(route->method, req->method) == 0 || strcmp(route->method, "*") == 0) {
             if (http_route_matches(route->path_pattern, req->path, req)) {
                 matched_route = route;
                 break;
@@ -2445,7 +2445,7 @@ void http_server_dispatch_for_h2(HttpServer* server,
     HttpRoute* head_to_get = NULL;
     while (route) {
         if (http_route_matches(route->path_pattern, req->path, req)) {
-            if (strcmp(route->method, req->method) == 0) {
+            if (strcmp(route->method, req->method) == 0 || strcmp(route->method, "*") == 0) {
                 matched_route = route;
                 break;
             }

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -21,6 +21,7 @@ HttpServer* http_server_create(int p) { (void)p; return NULL; }
 int http_server_bind_raw(HttpServer* s, const char* h, int p) { (void)s; (void)h; (void)p; return -1; }
 void http_server_set_host(HttpServer* s, const char* h) { (void)s; (void)h; }
 int http_server_start_raw(HttpServer* s) { (void)s; return -1; }
+int http_server_start_background_raw(HttpServer* s) { (void)s; return -1; }
 void http_server_stop(HttpServer* s) { (void)s; }
 void http_server_free(HttpServer* s) { (void)s; }
 const char* http_server_set_tls_raw(HttpServer* s, const char* c, const char* k) {
@@ -1308,12 +1309,16 @@ void http_response_set_body_n(HttpServerResponse* res, const char* body, int len
         res->body = NULL;
         res->body_length = 0;
     } else {
+        const char* src = body;
+        if (is_aether_string(body)) {
+            src = ((const AetherString*)body)->data;
+        }
         res->body = (char*)malloc((size_t)length + 1);
         if (!res->body) {
             res->body_length = 0;
             return;
         }
-        memcpy(res->body, body, (size_t)length);
+        memcpy(res->body, src, (size_t)length);
         res->body[length] = '\0';
         res->body_length = (size_t)length;
     }
@@ -3087,6 +3092,22 @@ int http_server_start_raw(HttpServer* server) {
         }
     }
 
+    return 0;
+}
+
+static void* http_server_background_main(void* arg) {
+    HttpServer* server = (HttpServer*)arg;
+    http_server_start_raw(server);
+    return NULL;
+}
+
+int http_server_start_background_raw(HttpServer* server) {
+    if (!server) return -1;
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, http_server_background_main, server) != 0) {
+        return -1;
+    }
+    pthread_detach(tid);
     return 0;
 }
 

--- a/std/net/aether_http_server.h
+++ b/std/net/aether_http_server.h
@@ -231,6 +231,7 @@ int http_server_bind_raw(HttpServer* server, const char* host, int port);
 // binds. No-op if `host` is NULL or empty.
 void http_server_set_host(HttpServer* server, const char* host);
 int http_server_start_raw(HttpServer* server);
+int http_server_start_background_raw(HttpServer* server);
 void http_server_stop(HttpServer* server);
 void http_server_free(HttpServer* server);
 

--- a/std/zlib/aether_zlib.c
+++ b/std/zlib/aether_zlib.c
@@ -73,6 +73,44 @@ int zlib_try_deflate(const char* data, int length, int level) {
     return 1;
 }
 
+int zlib_try_gzip_deflate(const char* data, int length, int level) {
+    free_deflate_tls();
+    if (length < 0) return 0;
+
+    size_t in_len;
+    const unsigned char* in = zlib_unwrap_bytes(data, length, &in_len);
+    if (in_len > 0 && !in) return 0;
+
+    z_stream strm;
+    memset(&strm, 0, sizeof(strm));
+    int lvl = (level < -1 || level > 9) ? Z_DEFAULT_COMPRESSION : level;
+    if (deflateInit2(&strm, lvl, Z_DEFLATED, 15 + 16, 8,
+                     Z_DEFAULT_STRATEGY) != Z_OK) {
+        return 0;
+    }
+
+    uLong bound = deflateBound(&strm, (uLong)in_len);
+    unsigned char* out = (unsigned char*)malloc(bound > 0 ? bound : 1);
+    if (!out) { deflateEnd(&strm); return 0; }
+
+    strm.next_in = (Bytef*)in;
+    strm.avail_in = (uInt)in_len;
+    strm.next_out = out;
+    strm.avail_out = (uInt)bound;
+
+    int rc = deflate(&strm, Z_FINISH);
+    if (rc != Z_STREAM_END) {
+        deflateEnd(&strm);
+        free(out);
+        return 0;
+    }
+
+    tls_deflate_buf = out;
+    tls_deflate_len = (int)strm.total_out;
+    deflateEnd(&strm);
+    return 1;
+}
+
 int zlib_try_inflate(const char* data, int length) {
     free_inflate_tls();
     if (length < 0) return 0;
@@ -122,12 +160,69 @@ int zlib_try_inflate(const char* data, int length) {
     return 1;
 }
 
+static int inflate_with_window_bits(const char* data, int length, int window_bits) {
+    free_inflate_tls();
+    if (length < 0) return 0;
+
+    size_t in_len;
+    const unsigned char* in = zlib_unwrap_bytes(data, length, &in_len);
+    if (in_len == 0) return 0;
+    if (!in) return 0;
+
+    z_stream strm;
+    memset(&strm, 0, sizeof(strm));
+    strm.next_in = (Bytef*)in;
+    strm.avail_in = (uInt)in_len;
+
+    if (inflateInit2(&strm, window_bits) != Z_OK) return 0;
+
+    size_t cap = in_len * 4;
+    if (cap < 64) cap = 64;
+    unsigned char* out = (unsigned char*)malloc(cap);
+    if (!out) { inflateEnd(&strm); return 0; }
+
+    size_t produced = 0;
+    for (;;) {
+        strm.next_out = out + produced;
+        strm.avail_out = (uInt)(cap - produced);
+
+        int rc = inflate(&strm, Z_NO_FLUSH);
+        produced = cap - strm.avail_out;
+
+        if (rc == Z_STREAM_END) break;
+        if (rc != Z_OK) { free(out); inflateEnd(&strm); return 0; }
+        if (strm.avail_out == 0) {
+            size_t new_cap = cap * 2;
+            if (new_cap < cap) { free(out); inflateEnd(&strm); return 0; }
+            unsigned char* bigger = (unsigned char*)realloc(out, new_cap);
+            if (!bigger) { free(out); inflateEnd(&strm); return 0; }
+            out = bigger;
+            cap = new_cap;
+        }
+    }
+    inflateEnd(&strm);
+
+    tls_inflate_buf = out;
+    tls_inflate_len = (int)produced;
+    return 1;
+}
+
+int zlib_try_gzip_inflate(const char* data, int length) {
+    return inflate_with_window_bits(data, length, 15 + 16);
+}
+
 #else /* !AETHER_HAS_ZLIB */
 
 int zlib_try_deflate(const char* data, int length, int level) {
     (void)data; (void)length; (void)level; return 0;
 }
 int zlib_try_inflate(const char* data, int length) {
+    (void)data; (void)length; return 0;
+}
+int zlib_try_gzip_deflate(const char* data, int length, int level) {
+    (void)data; (void)length; (void)level; return 0;
+}
+int zlib_try_gzip_inflate(const char* data, int length) {
     (void)data; (void)length; return 0;
 }
 

--- a/std/zlib/aether_zlib.h
+++ b/std/zlib/aether_zlib.h
@@ -2,8 +2,7 @@
  *
  * v1 exposes two pure functions that operate on in-memory byte
  * buffers. Streaming is deliberately out of scope (separate future
- * API); gzip-framed variants are additive and will land later under
- * the same module.
+ * API). gzip-framed variants use the same split-accessor shape.
  *
  * The Aether boundary uses the split-accessor pattern (same as
  * fs.read_binary): a `try_` entry point performs the operation and
@@ -53,5 +52,12 @@ int zlib_try_inflate(const char* data, int length);
 const char* zlib_get_inflate_bytes(void);
 int         zlib_get_inflate_length(void);
 void        zlib_release_inflate(void);
+
+/* gzip-framed siblings (RFC 1952), intended for HTTP
+ * Content-Encoding: gzip. They share the same TLS output slots as
+ * deflate/inflate respectively, so the same get/release accessors
+ * apply after a successful call. */
+int zlib_try_gzip_deflate(const char* data, int length, int level);
+int zlib_try_gzip_inflate(const char* data, int length);
 
 #endif /* AETHER_ZLIB_H */

--- a/std/zlib/module.ae
+++ b/std/zlib/module.ae
@@ -1,4 +1,4 @@
-// std.zlib - One-shot zlib deflate/inflate.
+// std.zlib - One-shot zlib and gzip deflate/inflate.
 // Import with: import std.zlib
 //
 // v1 exposes two functions that operate on in-memory byte buffers:
@@ -12,9 +12,9 @@
 // via string_new_with_length, so string.length matches the reported
 // byte count.
 //
-// Streaming APIs and gzip-framed (RFC 1952) variants are out of
-// scope for v1 — additive future work under the same module. See
-// docs/stdlib-vs-contrib.md for the "one obvious shape" criterion.
+// Streaming APIs are out of scope for v1 — additive future work
+// under the same module. See docs/stdlib-vs-contrib.md for the
+// "one obvious shape" criterion.
 //
 // When the toolchain was built without zlib (AETHER_HAS_ZLIB
 // undefined), the wrappers return ("", 0, "zlib unavailable")
@@ -26,7 +26,8 @@ exports (
     zlib_release_deflate,
     zlib_try_inflate, zlib_get_inflate_bytes, zlib_get_inflate_length,
     zlib_release_inflate,
-    available, deflate, inflate
+    zlib_try_gzip_deflate, zlib_try_gzip_inflate,
+    available, deflate, inflate, gzip_deflate, gzip_inflate
 )
 
 // Probe: returns 1 when the toolchain was built with zlib detected,
@@ -49,6 +50,9 @@ extern zlib_try_inflate(data: string, length: int) -> int
 extern zlib_get_inflate_bytes() -> string
 extern zlib_get_inflate_length() -> int
 extern zlib_release_inflate()
+
+extern zlib_try_gzip_deflate(data: string, length: int, level: int) -> int
+extern zlib_try_gzip_inflate(data: string, length: int) -> int
 
 // Length-preserving string constructor from std.string — takes an
 // explicit byte count so binary payloads with embedded NULs survive
@@ -90,6 +94,38 @@ inflate(data: string, length: int) -> {
     ok = zlib_try_inflate(data, length)
     if ok == 0 {
         return "", 0, "zlib inflate failed"
+    }
+    raw = zlib_get_inflate_bytes()
+    n = zlib_get_inflate_length()
+    owned = string_new_with_length(raw, n)
+    zlib_release_inflate()
+    return owned, n, ""
+}
+
+// gzip-framed siblings (RFC 1952), intended for HTTP
+// Content-Encoding: gzip.
+gzip_deflate(data: string, length: int, level: int) -> {
+    if zlib_backend_available() == 0 {
+        return "", 0, "zlib unavailable"
+    }
+    ok = zlib_try_gzip_deflate(data, length, level)
+    if ok == 0 {
+        return "", 0, "gzip deflate failed"
+    }
+    raw = zlib_get_deflate_bytes()
+    n = zlib_get_deflate_length()
+    owned = string_new_with_length(raw, n)
+    zlib_release_deflate()
+    return owned, n, ""
+}
+
+gzip_inflate(data: string, length: int) -> {
+    if zlib_backend_available() == 0 {
+        return "", 0, "zlib unavailable"
+    }
+    ok = zlib_try_gzip_inflate(data, length)
+    if ok == 0 {
+        return "", 0, "gzip inflate failed"
     }
     raw = zlib_get_inflate_bytes()
     n = zlib_get_inflate_length()

--- a/tests/integration/test_vcr_drift_fail.ae
+++ b/tests/integration/test_vcr_drift_fail.ae
@@ -1,0 +1,120 @@
+// Servirtium step 4 drift behavior.
+//
+// flush_and_fail_if_changed() should:
+//   - create the tape on first record
+//   - pass when a fresh recording is byte-identical to the old tape
+//   - overwrite the tape but return an error when bytes changed, so
+//     tests fail while ordinary git diff shows the new recording
+
+import std.http.server.vcr
+import std.fs
+import std.io
+import std.string
+
+extern exit(code: int)
+
+tape_path() -> {
+    tmp = io.getenv("TEMP")
+    if tmp == 0 { tmp = io.getenv("TMPDIR") }
+    if tmp == 0 { tmp = "/tmp" }
+    return "${tmp}/vcr_drift_fail_test.tape"
+}
+
+assert_contains(haystack: string, needle: string, label: string) {
+    if string.contains(haystack, needle) != 1 {
+        println("FAIL: ${label}: expected '${needle}'")
+        exit(1)
+    }
+}
+
+assert_not_contains(haystack: string, needle: string, label: string) {
+    if string.contains(haystack, needle) == 1 {
+        println("FAIL: ${label}: did not expect '${needle}'")
+        exit(1)
+    }
+}
+
+record_one(body: string) {
+    vcr.clear_recording()
+    err = vcr.record_full_response("GET", "/drift", 200, "text/plain", body,
+        "Accept: text/plain\n",
+        "",
+        "Content-Type: text/plain\nX-Recorded: yes\n")
+    if err != "" {
+        println("FAIL: record_one: ${err}")
+        exit(1)
+    }
+}
+
+main() {
+    println("=== VCR drift-fail flush test ===")
+
+    TAPE_PATH = tape_path()
+    ACTUAL_PATH = "${TAPE_PATH}.actual"
+    fs.delete(TAPE_PATH)
+    fs.delete(ACTUAL_PATH)
+
+    println("Test 1: first recording creates tape without drift failure")
+    record_one("alpha\n")
+    err1 = vcr.flush_and_fail_if_changed(TAPE_PATH)
+    if err1 != "" {
+        println("FAIL: first flush returned '${err1}'")
+        exit(1)
+    }
+    disk1, rerr1 = fs.read(TAPE_PATH)
+    if rerr1 != "" {
+        println("FAIL: first read: ${rerr1}")
+        exit(1)
+    }
+    assert_contains(disk1, "alpha", "first tape body")
+    println("  PASS")
+
+    println("Test 2: identical re-record passes and does not create .actual")
+    record_one("alpha\n")
+    err2 = vcr.flush_and_fail_if_changed(TAPE_PATH)
+    if err2 != "" {
+        println("FAIL: identical flush returned '${err2}'")
+        exit(1)
+    }
+    actual2, aerr2 = fs.read(ACTUAL_PATH)
+    if aerr2 == "" {
+        println("FAIL: flush_and_fail_if_changed created .actual unexpectedly: ${actual2}")
+        exit(1)
+    }
+    println("  PASS")
+
+    println("Test 3: changed re-record overwrites tape and returns drift failure")
+    record_one("bravo\n")
+    err3 = vcr.flush_and_fail_if_changed(TAPE_PATH)
+    if err3 == "" {
+        println("FAIL: changed flush did not report drift")
+        exit(1)
+    }
+    assert_contains(err3, "tape mismatch", "drift error")
+    disk3, rerr3 = fs.read(TAPE_PATH)
+    if rerr3 != "" {
+        println("FAIL: changed read: ${rerr3}")
+        exit(1)
+    }
+    assert_contains(disk3, "bravo", "changed tape body")
+    assert_not_contains(disk3, "alpha", "old tape body after drift overwrite")
+    actual3, aerr3 = fs.read(ACTUAL_PATH)
+    if aerr3 == "" {
+        println("FAIL: drift-fail path should not leave .actual: ${actual3}")
+        exit(1)
+    }
+    println("  PASS")
+
+    println("Test 4: new recording is now the baseline")
+    record_one("bravo\n")
+    err4 = vcr.flush_and_fail_if_changed(TAPE_PATH)
+    if err4 != "" {
+        println("FAIL: post-drift baseline flush returned '${err4}'")
+        exit(1)
+    }
+    println("  PASS")
+
+    fs.delete(TAPE_PATH)
+    println("=== VCR drift-fail flush test passed ===")
+    exit(0)
+}

--- a/tests/integration/test_vcr_gzip_normalize.ae
+++ b/tests/integration/test_vcr_gzip_normalize.ae
@@ -1,0 +1,173 @@
+// VCR gzip normalization/restore.
+//
+// Record mode stores semantic, decoded response bodies in the tape
+// even when upstream used Content-Encoding: gzip. Playback serves the
+// decoded body by default, and restores gzip only when the caller asks
+// for it with Accept-Encoding: gzip.
+
+import std.http.server.vcr
+import std.http.client
+import std.http
+import std.zlib
+import std.fs
+import std.io
+import std.string
+
+extern exit(code: int)
+extern http_server_stop(server: ptr)
+
+const UPSTREAM_PORT = 18247
+const RECORD_PORT   = 18248
+const PLAYBACK_PORT = 18249
+const BODY          = "tiny gzip payload"
+
+tape_path() -> {
+    tmp = io.getenv("TEMP")
+    if tmp == 0 { tmp = io.getenv("TMPDIR") }
+    if tmp == 0 { tmp = "/tmp" }
+    return "${tmp}/vcr_gzip_normalize.tape"
+}
+
+handle_gzip(req: ptr, res: ptr, ud: ptr) {
+    gz, n, err = zlib.gzip_deflate(BODY, string.length(BODY), 1)
+    if err != "" {
+        http.response_set_status(res, 500)
+        http.response_set_body(res, err)
+        return
+    }
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_header(res, "Content-Encoding", "gzip")
+    http.response_set_header(res, "X-Upstream", "gz")
+    http.response_set_body_n(res, gz, n)
+}
+
+wait_ready(url: string) {
+    ready = 0
+    i = 0
+    while i < 200 {
+        sleep(25)
+        req = client.request("GET", url)
+        if req != null {
+            client.set_timeout(req, 1)
+            resp, err = client.send_request(req)
+            client.request_free(req)
+            if err == "" {
+                client.response_free(resp)
+                ready = 1
+                i = 200
+            }
+        }
+        i = i + 1
+    }
+    if ready == 0 {
+        println("FAIL: server not ready at ${url}")
+        exit(1)
+    }
+}
+
+main() {
+    println("=== VCR gzip normalize/restore ===")
+
+    if zlib.available() == 0 {
+        println("SKIP: zlib unavailable")
+        exit(0)
+    }
+
+    TAPE_PATH = tape_path()
+    fs.delete(TAPE_PATH)
+
+    upstream = http.server_create(UPSTREAM_PORT)
+    if upstream == 0 { println("FAIL: upstream server_create"); exit(1) }
+    http.server_get(upstream, "/gzip", handle_gzip, 0)
+    serr1 = http.server_start_background(upstream)
+    if serr1 != "" { println("FAIL: upstream start ${serr1}"); exit(1) }
+    wait_ready("http://127.0.0.1:${UPSTREAM_PORT}/gzip")
+
+    recorder = vcr.load_record(TAPE_PATH, "http://127.0.0.1:${UPSTREAM_PORT}", RECORD_PORT)
+    if recorder == null { println("FAIL: load_record"); exit(1) }
+    serr2 = http.server_start_background(recorder)
+    if serr2 != "" { println("FAIL: recorder start ${serr2}"); exit(1) }
+    sleep(250)
+
+    req1 = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/gzip")
+    client.set_timeout(req1, 5)
+    resp1, err1 = client.send_request(req1)
+    client.request_free(req1)
+    if err1 != "" { println("FAIL: record request transport ${err1}"); exit(1) }
+    if client.response_status(resp1) != 200 {
+        println("FAIL: record status ${client.response_status(resp1)}")
+        println("      body: ${client.response_body(resp1)}")
+        println("      vcr.last_error: ${vcr.last_error()}")
+        exit(1)
+    }
+    if client.response_header(resp1, "Content-Encoding") != "gzip" {
+        println("FAIL: record response did not preserve gzip header")
+        exit(1)
+    }
+    client.response_free(resp1)
+
+    ferr = vcr.eject_record(recorder, TAPE_PATH)
+    if ferr != "" { println("FAIL: eject_record ${ferr}"); exit(1) }
+
+    tape, terr = fs.read(TAPE_PATH)
+    if terr != "" { println("FAIL: read tape ${terr}"); exit(1) }
+    if string.contains(tape, BODY) != 1 {
+        println("FAIL: tape did not contain decoded body")
+        exit(1)
+    }
+    if string.contains(tape, "Content-Encoding: gzip") == 1 {
+        println("FAIL: tape recorded Content-Encoding: gzip")
+        exit(1)
+    }
+    if string.contains(tape, "Content-Length:") == 1 {
+        println("FAIL: tape recorded Content-Length")
+        exit(1)
+    }
+
+    playback = vcr.load(TAPE_PATH, PLAYBACK_PORT)
+    if playback == null { println("FAIL: load playback"); exit(1) }
+    serr3 = http.server_start_background(playback)
+    if serr3 != "" { println("FAIL: playback start ${serr3}"); exit(1) }
+    sleep(250)
+
+    req2 = client.request("GET", "http://127.0.0.1:${PLAYBACK_PORT}/gzip")
+    client.set_timeout(req2, 5)
+    resp2, err2 = client.send_request(req2)
+    client.request_free(req2)
+    if err2 != "" { println("FAIL: plain playback transport ${err2}"); exit(1) }
+    if client.response_header(resp2, "Content-Encoding") != "" {
+        println("FAIL: plain playback unexpectedly gzip encoded")
+        exit(1)
+    }
+    body2 = client.response_body(resp2)
+    if body2 != BODY {
+        println("FAIL: plain playback body '${body2}'")
+        exit(1)
+    }
+    client.response_free(resp2)
+
+    vcr.reset_cursor()
+    req3 = client.request("GET", "http://127.0.0.1:${PLAYBACK_PORT}/gzip")
+    client.set_header(req3, "Accept-Encoding", "gzip")
+    client.set_timeout(req3, 5)
+    resp3, err3 = client.send_request(req3)
+    client.request_free(req3)
+    if err3 != "" { println("FAIL: gzip playback transport ${err3}"); exit(1) }
+    if client.response_header(resp3, "Content-Encoding") != "gzip" {
+        println("FAIL: gzip playback did not restore Content-Encoding")
+        exit(1)
+    }
+    if client.response_header(resp3, "Vary") != "Accept-Encoding" {
+        println("FAIL: gzip playback did not set Vary")
+        exit(1)
+    }
+    client.response_free(resp3)
+
+    vcr.eject(playback)
+    http_server_stop(upstream)
+    fs.delete(TAPE_PATH)
+
+    println("PASS")
+    exit(0)
+}

--- a/tests/integration/test_vcr_record_last_error.ae
+++ b/tests/integration/test_vcr_record_last_error.ae
@@ -1,0 +1,117 @@
+// Record-mode diagnostics: a failed upstream request should populate
+// the same last_error / last_kind / last_index surface used by playback
+// mismatches. The recorder is acting as a normal server and using the
+// std.http.client path internally, not proxy/CORS behavior.
+
+import std.http.server.vcr
+import std.http.client
+import std.io
+import std.string
+
+extern exit(code: int)
+extern http_server_start_raw(server: ptr) -> int
+
+const RECORD_PORT = 18243
+const REFUSED_UPSTREAM = "http://127.0.0.1:1"
+
+message StartRecord { raw: ptr }
+message Noop {}
+
+actor RecordActor {
+    state s = 0
+    receive { StartRecord(raw) -> { s = raw; http_server_start_raw(raw) } }
+}
+
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+tape_path() -> {
+    tmp = io.getenv("TEMP")
+    if tmp == 0 { tmp = io.getenv("TMPDIR") }
+    if tmp == 0 { tmp = "/tmp" }
+    return "${tmp}/vcr_record_last_error.tape"
+}
+
+main() {
+    println("=== VCR record-mode last_error ===")
+    vcr.clear_last_error()
+    TAPE_PATH = tape_path()
+
+    raw = vcr.load_record(TAPE_PATH, REFUSED_UPSTREAM, RECORD_PORT)
+    if raw == null {
+        println("FAIL: vcr.load_record returned null")
+        exit(1)
+    }
+
+    spawn(SchedHelper())
+    record_actor = spawn(RecordActor())
+    record_actor ! StartRecord { raw: raw }
+    sleep(500)
+
+    req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
+    if req == null {
+        println("FAIL: client.request returned null")
+        exit(1)
+    }
+    client.set_timeout(req, 5)
+
+    resp, transport_err = client.send_request(req)
+    client.request_free(req)
+    if transport_err != "" {
+        println("FAIL: request to recorder failed: ${transport_err}")
+        exit(1)
+    }
+
+    status = client.response_status(resp)
+    body = string.copy(client.response_body(resp))
+    client.response_free(resp)
+
+    if status != 502 {
+        println("FAIL: expected recorder to return 502, got ${status}")
+        exit(1)
+    }
+    if string.contains(body, "upstream") != 1 {
+        println("FAIL: recorder response body did not mention upstream")
+        println("      actual: ${body}")
+        exit(1)
+    }
+
+    err = vcr.last_error()
+    if err == "" {
+        println("FAIL: vcr.last_error() empty after record-mode upstream failure")
+        exit(1)
+    }
+    if string.contains(err, "upstream") != 1 {
+        println("FAIL: vcr.last_error() did not mention upstream")
+        println("      actual: ${err}")
+        exit(1)
+    }
+    if vcr.last_kind() != vcr.KIND_RECORD_ERROR {
+        println("FAIL: expected KIND_RECORD_ERROR, got ${vcr.last_kind()}")
+        exit(1)
+    }
+    if vcr.last_index() != -1 {
+        println("FAIL: expected last_index -1 for failed recording, got ${vcr.last_index()}")
+        exit(1)
+    }
+
+    vcr.clear_last_error()
+    if vcr.last_error() != "" {
+        println("FAIL: clear_last_error did not clear last_error")
+        exit(1)
+    }
+    if vcr.last_kind() != vcr.KIND_OK {
+        println("FAIL: clear_last_error did not reset last_kind")
+        exit(1)
+    }
+    if vcr.last_index() != -1 {
+        println("FAIL: clear_last_error did not reset last_index")
+        exit(1)
+    }
+
+    println("PASS")
+    vcr.eject_record(raw, TAPE_PATH)
+    exit(0)
+}

--- a/tests/integration/test_vcr_record_last_error.ae
+++ b/tests/integration/test_vcr_record_last_error.ae
@@ -48,14 +48,14 @@ main() {
     spawn(SchedHelper())
     record_actor = spawn(RecordActor())
     record_actor ! StartRecord { raw: raw }
-    sleep(500)
+    sleep(1000)
 
     req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
     if req == null {
         println("FAIL: client.request returned null")
         exit(1)
     }
-    client.set_timeout(req, 5)
+    client.set_timeout(req, 15)
 
     resp, transport_err = client.send_request(req)
     client.request_free(req)

--- a/tests/integration/test_vcr_record_last_error.ae
+++ b/tests/integration/test_vcr_record_last_error.ae
@@ -7,6 +7,7 @@ import std.http.server.vcr
 import std.http.client
 import std.io
 import std.string
+import std.tcp
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
@@ -49,30 +50,57 @@ main() {
     record_actor = spawn(RecordActor())
     record_actor ! StartRecord { raw: raw }
 
-    // Wait until the listen socket is actually bound and answering.
-    // Mirrors test_http_client_v2.ae: Windows mingw CI has slower scheduler
-    // hand-off and socket setup. Poll-until-ready synchronises on the real
-    // bind event instead of guessing a timing.
+    // Wait until the listen socket is actually bound and accepting.
+    //
+    // Earlier revisions of this test polled with an HTTP GET against
+    // /will-fail, which the recorder handles by forwarding to the
+    // refused upstream and synthesising a 502. On Windows mingw CI
+    // the refused-upstream connect path is measurably slower than
+    // POSIX (Winsock can take ~3 s to surface ECONNREFUSED on
+    // loopback when filters or AV layers are in the path), so the
+    // recorder's response often arrived after the per-probe HTTP
+    // timeout fired. The previous code reported "server never
+    // reached ready state" even though the listener was bound.
+    //
+    // The right primitive is a TCP-level connect: it answers exactly
+    // the question we care about ("is the listener accepting?")
+    // without depending on the recorder's forward-and-respond timing.
+    // ECONNREFUSED while not yet bound; success the moment bind
+    // completes; no HTTP layer involved either way.
     ready = 0
     i = 0
     while i < 200 {
         sleep(25)
-        probe_req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
-        if probe_req != null {
-            client.set_timeout(probe_req, 1)
-            probe_resp, probe_err = client.send_request(probe_req)
-            client.request_free(probe_req)
-            if probe_err == "" {
-                resp = probe_resp
-                transport_err = probe_err
-                ready = 1
-                i = 200
-            }
+        sock, perr = tcp.connect("127.0.0.1", RECORD_PORT)
+        if perr == "" {
+            tcp.close(sock)
+            ready = 1
+            i = 200
         }
         i = i + 1
     }
     if ready == 0 {
         println("FAIL: server never reached ready state after 5s")
+        exit(1)
+    }
+
+    // Drive the actual request with a generous timeout. The recorder
+    // needs time to attempt the upstream forward and synthesise the
+    // 502 — on Windows that path can take several seconds because
+    // Winsock surfaces ECONNREFUSED slower than POSIX. 30 s matches
+    // the recorder's own internal upstream timeout (set in
+    // vcr_record_dispatch via http_request_set_timeout_raw(creq, 30)),
+    // plus a small cushion.
+    req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
+    if req == null {
+        println("FAIL: client.request returned null")
+        exit(1)
+    }
+    client.set_timeout(req, 35)
+    resp, transport_err = client.send_request(req)
+    client.request_free(req)
+    if transport_err != "" {
+        println("FAIL: transport error reaching recorder: ${transport_err}")
         exit(1)
     }
 

--- a/tests/integration/test_vcr_record_last_error.ae
+++ b/tests/integration/test_vcr_record_last_error.ae
@@ -49,30 +49,30 @@ main() {
     record_actor = spawn(RecordActor())
     record_actor ! StartRecord { raw: raw }
 
-    // Wait for server to start listening. On Windows, 0.0.0.0 binding
-    // may take longer to accept connections. Retry the actual request
-    // several times rather than probing.
-    resp = null
-    transport_err = ""
-    attempt = 0
-    while attempt < 30 {
-        req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
-        if req != null {
-            client.set_timeout(req, 2)
-            resp, transport_err = client.send_request(req)
-            client.request_free(req)
-            if transport_err == "" {
-                break
+    // Wait until the listen socket is actually bound and answering.
+    // Mirrors test_http_client_v2.ae: Windows mingw CI has slower scheduler
+    // hand-off and socket setup. Poll-until-ready synchronises on the real
+    // bind event instead of guessing a timing.
+    ready = 0
+    i = 0
+    while i < 200 {
+        sleep(25)
+        probe_req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
+        if probe_req != null {
+            client.set_timeout(probe_req, 1)
+            probe_resp, probe_err = client.send_request(probe_req)
+            client.request_free(probe_req)
+            if probe_err == "" {
+                resp = probe_resp
+                transport_err = probe_err
+                ready = 1
+                i = 200
             }
-            client.response_free(resp)
-            resp = null
         }
-        sleep(100)
-        attempt = attempt + 1
+        i = i + 1
     }
-
-    if resp == null {
-        println("FAIL: request to recorder failed: ${transport_err}")
+    if ready == 0 {
+        println("FAIL: server never reached ready state after 5s")
         exit(1)
     }
 

--- a/tests/integration/test_vcr_record_last_error.ae
+++ b/tests/integration/test_vcr_record_last_error.ae
@@ -49,38 +49,29 @@ main() {
     record_actor = spawn(RecordActor())
     record_actor ! StartRecord { raw: raw }
 
-    // Wait for server to start listening. Retry with backoff to handle slow CI runners.
-    connected = 0
+    // Wait for server to start listening. On Windows, 0.0.0.0 binding
+    // may take longer to accept connections. Retry the actual request
+    // several times rather than probing.
+    resp = null
+    transport_err = ""
     attempt = 0
-    while attempt < 20 && connected == 0 {
-        sleep(100)
-        req_probe = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/health")
-        if req_probe != null {
-            client.set_timeout(req_probe, 1)
-            resp_probe, err_probe = client.send_request(req_probe)
-            client.request_free(req_probe)
-            if err_probe == "" {
-                connected = 1
-                client.response_free(resp_probe)
+    while attempt < 30 {
+        req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
+        if req != null {
+            client.set_timeout(req, 2)
+            resp, transport_err = client.send_request(req)
+            client.request_free(req)
+            if transport_err == "" {
+                break
             }
+            client.response_free(resp)
+            resp = null
         }
+        sleep(100)
         attempt = attempt + 1
     }
-    if connected == 0 {
-        println("FAIL: server did not start listening within 2 seconds")
-        exit(1)
-    }
 
-    req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
-    if req == null {
-        println("FAIL: client.request returned null")
-        exit(1)
-    }
-    client.set_timeout(req, 10)
-
-    resp, transport_err = client.send_request(req)
-    client.request_free(req)
-    if transport_err != "" {
+    if resp == null {
         println("FAIL: request to recorder failed: ${transport_err}")
         exit(1)
     }

--- a/tests/integration/test_vcr_record_last_error.ae
+++ b/tests/integration/test_vcr_record_last_error.ae
@@ -48,14 +48,35 @@ main() {
     spawn(SchedHelper())
     record_actor = spawn(RecordActor())
     record_actor ! StartRecord { raw: raw }
-    sleep(1000)
+
+    // Wait for server to start listening. Retry with backoff to handle slow CI runners.
+    connected = 0
+    attempt = 0
+    while attempt < 20 && connected == 0 {
+        sleep(100)
+        req_probe = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/health")
+        if req_probe != null {
+            client.set_timeout(req_probe, 1)
+            resp_probe, err_probe = client.send_request(req_probe)
+            client.request_free(req_probe)
+            if err_probe == "" {
+                connected = 1
+                client.response_free(resp_probe)
+            }
+        }
+        attempt = attempt + 1
+    }
+    if connected == 0 {
+        println("FAIL: server did not start listening within 2 seconds")
+        exit(1)
+    }
 
     req = client.request("GET", "http://127.0.0.1:${RECORD_PORT}/will-fail")
     if req == null {
         println("FAIL: client.request returned null")
         exit(1)
     }
-    client.set_timeout(req, 15)
+    client.set_timeout(req, 10)
 
     resp, transport_err = client.send_request(req)
     client.request_free(req)

--- a/tests/integration/test_vcr_redactions.ae
+++ b/tests/integration/test_vcr_redactions.ae
@@ -13,6 +13,8 @@
 //   4. Pattern with no hits is a clean no-op
 //   5. clear_redactions() drops all registrations — a subsequent
 //      flush emits the original bytes
+//   6. request headers, request body, and response headers can be
+//      redacted too
 //
 // No HTTP server needed: we drive the capture directly via vcr.record()
 // and inspect the flushed file with std.fs.
@@ -114,7 +116,58 @@ main() {
     assert_contains(on_disk3, "Bearer-abc123-shh", "no-op redaction wiped real bytes")
     println("  PASS")
 
+    // ---- Test 4: request/response metadata fields can be scrubbed. ----
+    println("\nTest 4: request headers/body + response headers redaction")
+    vcr.clear_redactions()
+    rfull = vcr.record_full_response("POST", "/metadata", 201, "text/plain", "ok",
+        "Authorization: Bearer req-secret\nX-Trace: trace-secret\n",
+        "payload=req-secret\n",
+        "Content-Type: text/plain\nSet-Cookie: session=resp-secret\n")
+    if rfull != "" { println("  FAIL: record_full — ${rfull}"); exit(1) }
+
+    rherr = vcr.redact(vcr.FIELD_REQUEST_HEADERS, "req-secret", "REQ-REDACTED")
+    if rherr != "" { println("  FAIL: redact request headers — ${rherr}"); exit(1) }
+    rberr = vcr.redact(vcr.FIELD_REQUEST_BODY, "req-secret", "REQ-REDACTED")
+    if rberr != "" { println("  FAIL: redact request body — ${rberr}"); exit(1) }
+    sherr = vcr.redact(vcr.FIELD_RESPONSE_HEADERS, "resp-secret", "RESP-REDACTED")
+    if sherr != "" { println("  FAIL: redact response headers — ${sherr}"); exit(1) }
+
+    ferr4 = vcr.flush(TAPE_PATH)
+    if ferr4 != "" { println("  FAIL: flush metadata — ${ferr4}"); exit(1) }
+    on_disk4, derr4 = fs.read(TAPE_PATH)
+    if derr4 != "" { println("  FAIL: read metadata tape — ${derr4}"); exit(1) }
+    assert_not_contains(on_disk4, "req-secret", "request secret leaked")
+    assert_not_contains(on_disk4, "resp-secret", "response header secret leaked")
+    assert_contains(on_disk4, "Authorization: Bearer REQ-REDACTED", "request header not redacted")
+    assert_contains(on_disk4, "payload=REQ-REDACTED", "request body not redacted")
+    assert_contains(on_disk4, "Set-Cookie: session=RESP-REDACTED", "response header not redacted")
+    println("  PASS")
+
+    // ---- Test 5: whole header lines can be removed by name. ----
+    println("\nTest 5: request/response header removal")
+    herr1 = vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "authorization")
+    if herr1 != "" { println("  FAIL: remove request header — ${herr1}"); exit(1) }
+    herr2 = vcr.remove_header(vcr.FIELD_RESPONSE_HEADERS, "Set-Cookie")
+    if herr2 != "" { println("  FAIL: remove response header — ${herr2}"); exit(1) }
+    ferr5 = vcr.flush(TAPE_PATH)
+    if ferr5 != "" { println("  FAIL: flush removed headers — ${ferr5}"); exit(1) }
+    on_disk5, derr5 = fs.read(TAPE_PATH)
+    if derr5 != "" { println("  FAIL: read removed-header tape — ${derr5}"); exit(1) }
+    assert_not_contains(on_disk5, "Authorization:", "request header was not removed")
+    assert_not_contains(on_disk5, "Set-Cookie:", "response header was not removed")
+    assert_contains(on_disk5, "X-Trace: trace-secret", "unrelated request header was removed")
+
+    vcr.clear_header_removals()
+    ferr6 = vcr.flush(TAPE_PATH)
+    if ferr6 != "" { println("  FAIL: re-flush after clear removals — ${ferr6}"); exit(1) }
+    on_disk6, derr6 = fs.read(TAPE_PATH)
+    if derr6 != "" { println("  FAIL: re-read after clear removals — ${derr6}"); exit(1) }
+    assert_contains(on_disk6, "Authorization: Bearer REQ-REDACTED", "clear_header_removals did not restore request header")
+    assert_contains(on_disk6, "Set-Cookie: session=RESP-REDACTED", "clear_header_removals did not restore response header")
+    println("  PASS")
+
     println("\n=== All VCR redaction tests passed ===")
     vcr.clear_redactions()
+    vcr.clear_header_removals()
     exit(0)
 }

--- a/tests/integration/test_vcr_unredactions.ae
+++ b/tests/integration/test_vcr_unredactions.ae
@@ -1,0 +1,142 @@
+// Playback-side replacements: committed tapes may contain redacted
+// request expectations, while the live SUT sends real values.
+
+import std.http.server.vcr
+import std.http
+import std.http.client
+import std.fs
+import std.string
+import std.io
+
+extern exit(code: int)
+extern http_server_start_raw(server: ptr) -> int
+
+const PORT = 18134
+
+message StartVCR { raw: ptr }
+message Noop {}
+
+actor VCRActor {
+    state s = 0
+    receive { StartVCR(raw) -> { s = raw; http_server_start_raw(raw) } }
+}
+
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+tape_path() -> {
+    tmp = io.getenv("TEMP")
+    if tmp == 0 { tmp = io.getenv("TMPDIR") }
+    if tmp == 0 { tmp = "/tmp" }
+    return "${tmp}/vcr_unredactions_test.tape"
+}
+
+write_tape(path: string) -> string {
+    tape = <<TAPE
+## Interaction 0: GET /secret/REDACTED
+
+### Request headers recorded for playback:
+
+```
+Authorization: Bearer REDACTED
+```
+### Request body recorded for playback ():
+
+```
+```
+### Response headers recorded for playback:
+
+```
+Content-Type: text/plain
+```
+### Response body recorded for playback (200: text/plain):
+
+```
+path-ok
+```
+
+## Interaction 1: POST /body
+
+### Request headers recorded for playback:
+
+```
+```
+### Request body recorded for playback ():
+
+```
+payload=REDACTED
+```
+### Response headers recorded for playback:
+
+```
+Content-Type: text/plain
+```
+### Response body recorded for playback (201: text/plain):
+
+```
+body-ok
+```
+TAPE
+    return fs.write(path, tape)
+}
+
+main() {
+    println("=== VCR playback unredactions ===")
+    TAPE_PATH = tape_path()
+    werr = write_tape(TAPE_PATH)
+    if werr != "" { println("FAIL: write tape ${werr}"); exit(1) }
+
+    u1 = vcr.unredact(vcr.FIELD_PATH, "REDACTED", "actual")
+    if u1 != "" { println("FAIL: unredact path ${u1}"); exit(1) }
+    u2 = vcr.unredact(vcr.FIELD_REQUEST_HEADERS, "Bearer REDACTED", "Bearer actual")
+    if u2 != "" { println("FAIL: unredact headers ${u2}"); exit(1) }
+    u3 = vcr.unredact(vcr.FIELD_REQUEST_BODY, "payload=REDACTED", "payload=actual")
+    if u3 != "" { println("FAIL: unredact body ${u3}"); exit(1) }
+    h1 = vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "X-Request-Id")
+    if h1 != "" { println("FAIL: remove live request header ${h1}"); exit(1) }
+
+    raw = vcr.load(TAPE_PATH, PORT)
+    if raw == null { println("FAIL: vcr.load returned null"); exit(1) }
+
+    spawn(SchedHelper())
+    a = spawn(VCRActor())
+    a ! StartVCR { raw: raw }
+    sleep(500)
+
+    req1 = client.request("GET", "http://127.0.0.1:${PORT}/secret/actual")
+    client.set_header(req1, "Authorization", "Bearer actual")
+    client.set_header(req1, "X-Request-Id", "run-specific-value")
+    client.set_timeout(req1, 5)
+    resp1, err1 = client.send_request(req1)
+    client.request_free(req1)
+    if err1 != "" { println("FAIL: GET transport ${err1}"); exit(1) }
+    status1 = client.response_status(resp1)
+    body1 = string.copy(client.response_body(resp1))
+    client.response_free(resp1)
+    if status1 != 200 || body1 != "path-ok" {
+        println("FAIL: GET replay status=${status1} body=${body1}")
+        exit(1)
+    }
+
+    req2 = client.request("POST", "http://127.0.0.1:${PORT}/body")
+    client.set_body(req2, "payload=actual", string.length("payload=actual"), "text/plain")
+    client.set_timeout(req2, 5)
+    resp2, err2 = client.send_request(req2)
+    client.request_free(req2)
+    if err2 != "" { println("FAIL: POST transport ${err2}"); exit(1) }
+    status2 = client.response_status(resp2)
+    body2 = string.copy(client.response_body(resp2))
+    client.response_free(resp2)
+    if status2 != 201 || body2 != "body-ok" {
+        println("FAIL: POST replay status=${status2} body=${body2}")
+        exit(1)
+    }
+
+    vcr.eject(raw)
+    vcr.clear_unredactions()
+    vcr.clear_header_removals()
+    println("PASS")
+    exit(0)
+}

--- a/tests/integration/test_vcr_verbs.ae
+++ b/tests/integration/test_vcr_verbs.ae
@@ -1,0 +1,193 @@
+// Step 7 / Servirtium verb coverage smoke test.
+//
+// Goal: prove the recorder and the playback server both handle the
+// non-GET verb set the README calls out, while staying compact
+// enough to be a useful evolution test for the HTTP client/server/
+// VCR stack.
+//
+// Matrix:
+//   - POST, PUT, PATCH use request bodies
+//   - HEAD, DELETE, OPTIONS, TRACE use no request body
+//   - record phase writes a tape through the recorder API
+//   - playback mode reuses the same tape and must return the same shapes
+
+import std.http.server.vcr
+import std.http.client
+import std.io
+import std.string
+
+extern exit(code: int)
+
+const PLAYBACK_PORT  = 18242
+
+message StartPlayback { raw: ptr }
+message Noop {}
+
+actor PlaybackActor {
+    state s = 0
+    receive { StartPlayback(raw) -> { s = raw; http_server_start_raw(raw) } }
+}
+
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+tape_path() -> {
+    tmp = io.getenv("TEMP")
+    if tmp == 0 { tmp = io.getenv("TMPDIR") }
+    if tmp == 0 { tmp = "/tmp" }
+    return "${tmp}/vcr_verbs_test.tape"
+}
+
+drive_case(base_url: string, method: string, body: string, content_type: string,
+           want_status: int, want_body: string, want_header_1: string,
+           want_header_2: string) -> string {
+    req = client.request(method, "${base_url}/verbs")
+    if req == null { return "${method}: request build failed" }
+    if string.length(body) > 0 {
+        client.set_body(req, body, string.length(body), content_type)
+    }
+    client.set_timeout(req, 5)
+
+    resp, err = client.send_request(req)
+    client.request_free(req)
+    if err != "" { return "${method}: transport ${err}" }
+
+    status = client.response_status(resp)
+    got_body = string.copy(client.response_body(resp))
+    got_headers = string.copy(client.response_headers(resp))
+    client.response_free(resp)
+
+    if status != want_status {
+        return "${method}: status got ${status}, want ${want_status}"
+    }
+    if got_body != want_body {
+        return "${method}: body got '${got_body}', want '${want_body}'"
+    }
+    if want_header_1 != "" && string.contains(got_headers, want_header_1) != 1 {
+        return "${method}: missing header '${want_header_1}'"
+    }
+    if want_header_2 != "" && string.contains(got_headers, want_header_2) != 1 {
+        return "${method}: missing header '${want_header_2}'"
+    }
+    return ""
+}
+
+run_matrix(base_url: string) -> string {
+    err = drive_case(base_url, "GET", "get-body", "text/plain",
+                     200, "GET:get-body", "X-Verb: GET", "")
+    if err != "" { return err }
+
+    err = drive_case(base_url, "POST", "post-body", "text/plain",
+                     201, "POST:post-body", "X-Verb: POST", "")
+    if err != "" { return err }
+
+    err = drive_case(base_url, "PUT", "put-body", "text/plain",
+                     200, "PUT:put-body", "X-Verb: PUT", "")
+    if err != "" { return err }
+
+    err = drive_case(base_url, "HEAD", "", "",
+                     204, "", "X-Verb: HEAD", "")
+    if err != "" { return err }
+
+    err = drive_case(base_url, "DELETE", "", "",
+                     200, "DELETE:done", "X-Verb: DELETE", "")
+    if err != "" { return err }
+
+    err = drive_case(base_url, "OPTIONS", "", "",
+                     204, "", "X-Verb: OPTIONS", "Allow: POST, PUT, HEAD, DELETE, OPTIONS, TRACE, PATCH")
+    if err != "" { return err }
+
+    err = drive_case(base_url, "TRACE", "", "",
+                     200, "TRACE", "X-Verb: TRACE", "")
+    if err != "" { return err }
+
+    err = drive_case(base_url, "PATCH", "patch-body", "text/plain",
+                     202, "PATCH:patch-body", "X-Verb: PATCH", "")
+    if err != "" { return err }
+
+    return ""
+}
+
+record_case(method: string, request_body: string, status: int,
+            content_type: string, response_body: string,
+            response_headers: string) -> string {
+    err = vcr.record_full_response(method, "/verbs", status, content_type,
+                                   response_body, "", request_body,
+                                   response_headers)
+    if err != "" { return "${method}: ${err}" }
+    return ""
+}
+
+main() {
+    println("=== VCR verb coverage matrix ===")
+    TAPE_PATH = tape_path()
+
+    println("Record phase")
+    record_err = record_case("GET", "get-body", 200, "text/plain",
+                             "GET:get-body",
+                             "Content-Type: text/plain\nX-Verb: GET\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    record_err = record_case("POST", "post-body", 201, "text/plain",
+                             "POST:post-body",
+                             "Content-Type: text/plain\nX-Verb: POST\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    record_err = record_case("PUT", "put-body", 200, "text/plain",
+                             "PUT:put-body",
+                             "Content-Type: text/plain\nX-Verb: PUT\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    record_err = record_case("HEAD", "", 204, "text/plain",
+                             "", "Content-Type: text/plain\nX-Verb: HEAD\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    record_err = record_case("DELETE", "", 200, "text/plain",
+                             "DELETE:done",
+                             "Content-Type: text/plain\nX-Verb: DELETE\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    record_err = record_case("OPTIONS", "", 204, "text/plain",
+                             "",
+                             "Content-Type: text/plain\nX-Verb: OPTIONS\nAllow: POST, PUT, HEAD, DELETE, OPTIONS, TRACE, PATCH\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    record_err = record_case("TRACE", "", 200, "text/plain",
+                             "TRACE",
+                             "Content-Type: text/plain\nX-Verb: TRACE\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    record_err = record_case("PATCH", "patch-body", 202, "text/plain",
+                             "PATCH:patch-body",
+                             "Content-Type: text/plain\nX-Verb: PATCH\n")
+    if record_err != "" { println("FAIL: ${record_err}"); exit(1) }
+
+    flush_err = vcr.flush(TAPE_PATH)
+    if flush_err != "" {
+        println("FAIL: flush ${flush_err}")
+        exit(1)
+    }
+
+    println("Playback mode")
+    spawn(SchedHelper())
+    playback_raw = vcr.load(TAPE_PATH, PLAYBACK_PORT)
+    if playback_raw == null {
+        println("FAIL: vcr.load returned null")
+        exit(1)
+    }
+    playback_actor = spawn(PlaybackActor())
+    playback_actor ! StartPlayback { raw: playback_raw }
+    sleep(500)
+
+    playback_err = run_matrix("http://127.0.0.1:${PLAYBACK_PORT}")
+    if playback_err != "" {
+        println("FAIL: playback mode ${playback_err}")
+        exit(1)
+    }
+
+    println("PASS")
+    vcr.eject(playback_raw)
+    exit(0)
+}

--- a/tests/integration/test_zlib_gzip.ae
+++ b/tests/integration/test_zlib_gzip.ae
@@ -1,0 +1,50 @@
+// std.zlib gzip-framed helpers (RFC 1952), used by VCR for
+// HTTP Content-Encoding: gzip normalization.
+
+import std.zlib
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== std.zlib gzip round-trip ===")
+
+    if zlib.available() == 0 {
+        println("SKIP: zlib unavailable")
+        exit(0)
+    }
+
+    msg = "tiny gzip payload"
+    gz, ngz, cerr = zlib.gzip_deflate(msg, string.length(msg), 1)
+    if cerr != "" {
+        println("FAIL: gzip_deflate ${cerr}")
+        exit(1)
+    }
+    if ngz <= 0 {
+        println("FAIL: gzip_deflate produced ${ngz} bytes")
+        exit(1)
+    }
+
+    out, nout, ierr = zlib.gzip_inflate(gz, ngz)
+    if ierr != "" {
+        println("FAIL: gzip_inflate ${ierr}")
+        exit(1)
+    }
+    if nout != string.length(msg) {
+        println("FAIL: inflated length ${nout}")
+        exit(1)
+    }
+    if out != msg {
+        println("FAIL: inflated body '${out}'")
+        exit(1)
+    }
+
+    _, _, bad = zlib.gzip_inflate("not gzip", string.length("not gzip"))
+    if bad == "" {
+        println("FAIL: corrupt gzip input unexpectedly passed")
+        exit(1)
+    }
+
+    println("PASS")
+    exit(0)
+}


### PR DESCRIPTION
## Summary

Completes the VCR (Servirtium-style record/replay) feature for HTTP testing with:

- **Live forwarding record mode** — captures real HTTP responses while the server is running
- **All-method VCR coverage** — GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, CONNECT
- **Record/playback diagnostics** — inline reporting of what was recorded vs what's being replayed
- **Drift failure via `flush_and_fail_if_changed`** — fail the test if VCR detects divergence between tape and live
- **Binary-safe gzip handling** — normalize/restore `Content-Encoding: gzip` on request/response bodies
- **Filesystem equivalence validation** — new integration test comparing real SVN checkout against tape-replayed checkout byte-for-byte

### Changes

- `std/http/server/vcr/` — hardened record mode, base64 body encoding, gzip normalization
- `docs/http-vcr.md` — comprehensive VCR reference guide
- `tests/integration/svn_checkout_via_vcr/` — validates 17 WebDAV interactions against canonical Servirtium tape
- `tests/integration/svn_checkout_fs_equivalence/` — compares live svn.apache.org checkout vs VCR replay (POSIX-only, opt-in via env var)
- CHANGELOG updated under `[current]`

### Testing

- New VCR tests skip gracefully on Windows (POSIX tape format, bash shell scripts)
- Both tests have built-in guards for missing dependencies (ae, svn, sha256sum/shasum)
- Live SVN test is opt-in (`AETHER_RUN_LIVE_SVN_CHECKOUT_EQUIV=1`) to avoid network dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)