### PR TITLE
docs: Aether vs. BSD Capsicum sandboxing comparison

### DIFF
--- a/docs/aether_compared_to_capsicum.md
+++ b/docs/aether_compared_to_capsicum.md
@@ -1,0 +1,655 @@
+# Aether Sandbox Model vs. BSD Capsicum: Architecture, Parallels, and FreeBSD Integration
+
+## Executive Summary
+
+Aether and BSD Capsicum are two fundamentally different approaches to capability-based sandboxing:
+
+- **Capsicum** is an OS-level security framework (FreeBSD kernel + POSIX extensions) that restricts processes via file descriptor capabilities and capability mode.
+- **Aether** is a language-level sandbox model (implemented in the compiler and runtime) that uses closures, permission contexts, and scope hygiene to restrict what code can access.
+
+Despite the difference in scope (OS vs. language), Aether's closure-based isolation and permission hierarchy are **conceptually aligned with Capsicum's principles**. This document explores the parallels, gaps, and opportunities for Aether on FreeBSD—including the possibility of an Aether runtime that leverages Capsicum for OS-enforced containment of sandboxed actors.
+
+---
+
+## Part 1: Sandbox Models Compared
+
+### 1.1 Capsicum: OS-Level Capability Restrictions
+
+#### Design Principles
+
+Capsicum extends the POSIX API with capability-based security primitives. The key insight: **treat file descriptors as capabilities** with fine-grained rights.
+
+**Core concepts:**
+
+| Concept | Meaning |
+|---------|---------|
+| **Capability** | A file descriptor with restricted rights (e.g., read-only, seek-only, ioctl-restricted) |
+| **Capability mode** | A process state where global namespace access is denied; all I/O must derive from passed-in fds |
+| **Capability rights** | Bitmask of allowed operations (CAP_READ, CAP_WRITE, CAP_SEEK, CAP_IOCTL, CAP_FCNTL, etc.) |
+| **Process descriptor** | A handle to another process; can be used to query its state or revoke its capabilities |
+| **Casper daemon** | A privileged service that sandboxed processes delegate to (e.g., for DNS, syslog) |
+
+#### How Capsicum Works
+
+1. **Start privileged** — A process begins with all capabilities (or a default set).
+2. **Enter capability mode** — Call `cap_enter()`. This is **irreversible**; the process can never access global namespaces again.
+3. **Restrict file descriptors** — Use `cap_rights_limit(fd, rights)` to reduce a fd's rights. This restriction is **hereditary**—child processes inherit the restricted fds.
+4. **Delegate via fd-passing** — Pass restricted fds to other processes via IPC. They get only the rights you granted.
+5. **Fail securely** — Attempts to access denied resources fail with ENOTCAPABLE (a new errno).
+
+#### Example: tcpdump under Capsicum
+
+```c
+// Original tcpdump runs privileged, has access to everything
+int main() {
+    // ... capture packets, write to file ...
+}
+
+// Capsicum version: restrict early
+int main() {
+    // Open packet device and output file while privileged
+    int pcap_fd = open_live(...);
+    int out_fd = open("capture.pcap", O_WRONLY | O_CREAT);
+    
+    // Restrict both fds to their needed rights
+    cap_rights_init(&rights, CAP_READ);
+    cap_rights_limit(pcap_fd, &rights);
+    
+    cap_rights_init(&rights, CAP_WRITE);
+    cap_rights_limit(out_fd, &rights);
+    
+    // Enter capability mode — can no longer open new files or access global state
+    cap_enter();
+    
+    // Now run the packet capture loop with only pcap_fd and out_fd
+    // ... capture packets, write to out_fd ...
+    
+    return 0;
+}
+```
+
+**Key property:** Even if tcpdump is compromised, it cannot:
+- Open new files (no access to `open()`)
+- Bind to ports (no `socket()`)
+- Execute commands (no `execve()`)
+- Access network beyond the pcap fd
+
+#### Capsicum in Practice
+
+**Real-world Capsicum users:**
+- tcpdump, dhclient, hastd, kdump, rwhod, ctld, iscsid (FreeBSD base system)
+- Chromium sandboxing (with Google collaboration)
+- Firefox (experimental)
+- PostgreSQL (libpq sandboxing proposal)
+
+**Why it's effective:**
+1. OS-enforced — kernel checks rights on every system call
+2. Fail-safe — denied operations return ENOTCAPABLE, not a silent failure
+3. No performance overhead for allowed operations
+4. Composable — can chain restricted fds arbitrarily deep
+5. Casper daemon pattern — delegates privilege to a trusted service
+
+---
+
+### 1.2 Aether: Language-Level Scope-Based Isolation
+
+#### Design Principles
+
+Aether's sandbox model uses **three language features** to achieve isolation:
+
+1. **Closures** — hoisted functions that cannot reach parent locals unless explicitly passed
+2. **Permission contexts** — a data structure (list/map) representing granted capabilities
+3. **Scope hygiene** — `hide` and `seal except` declarations that prevent name lookup in outer scopes
+
+**Core concepts:**
+
+| Concept | Meaning |
+|---------|---------|
+| **Closure** | A function value that captures a subset of variables; hoisted away from its declaration scope |
+| **Permission context** | A list/map of (category, resource_pattern) tuples representing what a scope can do |
+| **Permission category** | A string like "tcp", "fs_read", "fs_write", "exec", "env" |
+| **Resource pattern** | A glob or exact match for a resource (e.g., "db.internal:5432", "/tmp/*") |
+| **Hide** | A declaration that the enclosing scope cannot see names from outer scopes |
+| **Seal except** | A declaration that the enclosing scope cannot see names except the ones listed |
+| **Containment principle** | The container can see the contained, but the contained cannot reach the container |
+
+#### How Aether's Sandbox Works
+
+1. **Create a permissions context** — Allocate a list to hold permission tuples.
+2. **Grant permissions** — Call `grant_tcp(ctx, "host", port)`, `grant_fs_read(ctx, path)`, etc.
+3. **Wrap code in a closure** — The sandboxed code is a closure that receives the context as its only input.
+4. **Run contained code** — Call `call(closure, ctx)`. The closure cannot reach parent locals.
+5. **Check permissions** — Sandboxed code calls `sandboxed_tcp_connect(ctx, host, port)` which checks the context before operating.
+6. **Fail gracefully** — Permission check fails, returns 0 (or throws, depending on implementation).
+
+#### Example: Aether Sandboxed Worker
+
+```aether
+import std.list
+
+// Permission check
+check_permission(perms: ptr, category: string, resource: string) {
+    n = list.size(perms)
+    for (i = 0; i < n; i += 2) {
+        cat = list.get(perms, i)
+        pat = list.get(perms, i + 1)
+        if str_eq(cat, "*") == 1 && str_eq(pat, "*") == 1 { return 1 }
+        if str_eq(cat, category) == 1 {
+            if str_eq(pat, "*") == 1 { return 1 }
+            if str_eq(pat, resource) == 1 { return 1 }
+        }
+    }
+    return 0
+}
+
+// Sandboxed operation wrapper
+sandboxed_tcp_connect(perms: ptr, host: string, port: int) {
+    if check_permission(perms, "tcp", host) == 1 {
+        // Real code: tcp.connect(host, port)
+        return 1
+    }
+    return 0  // Denied
+}
+
+// Contained code as a closure
+worker_code = |perms| {
+    if sandboxed_tcp_connect(perms, "db.internal", 5432) == 1 {
+        println("Connected to DB")
+    } else {
+        println("Connection denied")
+    }
+}
+
+// Create and grant permissions
+main() {
+    db_worker = list.new()
+    list.add(db_worker, "tcp")
+    list.add(db_worker, "db.internal")
+    
+    // Run the closure with restricted context
+    call(worker_code, db_worker)
+    
+    // worker_code cannot access globals, files, or anything else
+    // It can only do what the permissions context allows
+}
+```
+
+**Key properties:**
+
+1. **Language-enforced** — The compiler ensures closures can't reach parent locals.
+2. **Type-safe** — Closure signatures are checked at compile time.
+3. **Transparent** — Permission checks are just function calls; can be optimized away for fully-trusted code.
+4. **Composable** — Actors can nest, each with its own permission context.
+5. **Portable** — Works on any OS; no OS-specific APIs needed.
+
+---
+
+### 1.3 Side-by-Side Comparison
+
+| Aspect | Capsicum | Aether |
+|--------|----------|--------|
+| **Enforcement layer** | OS kernel (syscall-level) | Language runtime (function-call level) |
+| **Isolation mechanism** | File descriptor restrictions + capability mode | Closure scope + permission lists |
+| **Granularity** | Per-fd rights (CAP_READ, CAP_WRITE, etc.) | Per-category patterns (tcp, fs_read, etc.) |
+| **Revocation** | Implicit (close the fd) | Implicit (actor dies, context goes away) |
+| **Nested restrictions** | Process forking; each child inherits restricted fds | Lexical nesting; each closure inherits parent's context |
+| **Overhead** | Zero for allowed ops; syscall overhead for denied ops | Function-call overhead for permission checks |
+| **Failure mode** | ENOTCAPABLE errno | Return code / exception (language-defined) |
+| **OS coupling** | Tightly coupled to FreeBSD/POSIX | OS-agnostic |
+| **Privilege separation** | Casper daemon (separate process) | Actor delegation (same actor model) |
+| **Audit trail** | Not built-in; requires additional instrumentation | Not built-in; requires explicit logging |
+
+---
+
+## Part 2: Architectural Parallels
+
+### 2.1 Common Principles
+
+Both systems are built on **three shared insights:**
+
+#### 1. Capabilities over Permissions
+
+Both Capsicum and Aether use **capability-based access control** instead of traditional role-based access control (RBAC):
+
+- **RBAC** (Unix permissions): Check the caller's identity/role. "User alice is in group developers, so she can read /home/projects/*"
+- **Capability** (Capsicum/Aether): Check what the caller has been given. "This process has a read-only fd to /home/projects/foo; it can read that one file, nothing else."
+
+The capability model is **more restrictive and composable**. You can hand off a capability without expanding the recipient's overall privileges.
+
+#### 2. Containment Boundaries
+
+Both systems enforce a **container/contained boundary**: The container can see the contained, but the contained cannot reach the container.
+
+- **Capsicum:** A privileged parent process starts, opens fds, restricts them, and enters capability mode. The restricted process can't open new fds or break back out.
+- **Aether:** A parent function creates a permission context, passes it to a closure. The closure can't reach parent locals or dynamically add permissions.
+
+This principle appears in:
+- Virtual machines (hypervisor sees guest, guest can't see hypervisor)
+- Docker (host sees container, container can't see host)
+- Java ClassLoader hierarchies (parent loader visible to children, not vice versa)
+
+#### 3. Fail-Safe Defaults
+
+Both default to **deny** rather than **allow**:
+
+- **Capsicum:** Capability mode denies all global namespace access. You must explicitly pass fds.
+- **Aether:** When embedded in a host application (hosted modules), capabilities are **empty by default**. You must explicitly grant them.
+
+This inverts the traditional Unix model (allow by default, explicitly restrict), making security the default rather than an afterthought.
+
+---
+
+### 2.2 Where They Differ
+
+#### 1. Scope of Enforcement
+
+- **Capsicum:** Enforces at the **OS boundary** (syscall interface). A compromised process can't call `open()`, `socket()`, or `execve()` regardless of what code it's running.
+- **Aether:** Enforces at the **language boundary** (compiler + runtime). A compromised actor can still call C externs or skip permission checks if the code is malicious.
+
+**Implication:** Aether is better for *controlled* environments (DSL scripts, plugin systems, hosted configs); Capsicum is better for *untrusted* code (third-party binaries, legacy applications).
+
+#### 2. Granularity
+
+- **Capsicum:** File descriptors are the unit of isolation. Restricted rights apply to one fd.
+- **Aether:** Categories and patterns are the unit. "tcp", "fs_read:*/tmp/*", "exec:bash" are examples.
+
+**Implication:** Capsicum is finer-grained for file I/O; Aether is simpler for abstract resources.
+
+#### 3. Performance
+
+- **Capsicum:** Zero overhead for allowed operations. Denied operations are caught by the kernel.
+- **Aether:** Permission checks are function calls. Not free, but not expensive (cache-friendly).
+
+**Implication:** Capsicum is suitable for performance-critical code (tcpdump, database servers); Aether is fine for configuration/wiring code.
+
+---
+
+## Part 3: Opportunities for Aether on FreeBSD
+
+### 3.1 A Hybrid Approach: Aether + Capsicum
+
+**Vision:** An Aether runtime that can optionally leverage Capsicum for OS-enforced containment of sandboxed actors.
+
+#### Design
+
+```
++------------------+
+|   Aether Code    |
+|  (untrusted      |
+|   plugin)        |
++------------------+
+        |
+        v
++------------------+
+| Permission Check |  (language-level, fast path)
+|  (Aether runtime)|
++------------------+
+        |
+        v (if Aether running on FreeBSD in Capsicum mode)
++------------------+
+| Capsicum Rights  |  (OS-level, ultimate enforcement)
+|   Enforcement    |
++------------------+
+        |
+        v
+  [ Kernel ]
+```
+
+**How it works:**
+
+1. **Aether compiler** generates actors with permission contexts (as it does today).
+2. **Aether runtime** (new feature) detects if it's running on FreeBSD.
+3. **If Capsicum is available:**
+   - When an actor is spawned with a permission context, the runtime:
+     - Opens the minimal set of file descriptors needed for that context
+     - Uses `cap_rights_limit()` to restrict each fd to only the rights needed
+     - Calls `cap_enter()` to enter capability mode
+     - Spawns the actor in a child process with only those fds
+   - The actor's language-level permission checks become an optional defense-in-depth layer.
+4. **If Capsicum is not available:**
+   - Fall back to language-level checks (as today).
+
+#### Benefits
+
+1. **Defense in depth** — Even if an actor is malicious and bypasses language-level checks, Capsicum blocks the syscall.
+2. **Incremental** — Doesn't require rewriting Aether code; works with existing programs.
+3. **Transparent** — Aether code doesn't need to know about Capsicum.
+4. **Portable** — On non-FreeBSD systems, the language-level checks still work.
+
+#### Example Flow
+
+```aether
+// Untrusted plugin (could be malicious)
+plugin = |ctx| {
+    // This is sandboxed: permission checks will deny it
+    sandboxed_tcp_connect(ctx, "evil.com", 443)  // Denied by language check
+    
+    // But even if malicious, on FreeBSD with Capsicum:
+    // direct_syscall_socket()  // Would be caught by Capsicum; ENOTCAPABLE
+}
+
+main() {
+    trusted_ctx = list.new()
+    list.add(trusted_ctx, "tcp")
+    list.add(trusted_ctx, "db.internal")
+    
+    // On FreeBSD with Capsicum:
+    // - Aether runtime opens TCP socket to db.internal
+    // - Restricts fd with CAP_READ | CAP_WRITE
+    // - Enters capability mode in a child process
+    // - Spawns the actor with only that fd
+    
+    spawn_with_context(plugin, trusted_ctx)
+}
+```
+
+---
+
+### 3.2 Concrete Implementation Roadmap
+
+#### Phase 1: Capsicum Detection & API Bindings (Low effort)
+
+Create `std.capsicum` module with:
+
+```aether
+// Check if Capsicum is available
+capsicum_available() -> int
+
+// Enter capability mode (irreversible)
+capsicum_enter() -> int
+
+// Restrict a file descriptor's rights
+capsicum_limit_rights(fd: int, rights: int) -> int
+
+// Create a process descriptor
+capsicum_create_process_descriptor(pid: int) -> int
+
+// Query a process's Capsicum state
+capsicum_is_in_capability_mode(fd: int) -> int
+```
+
+**Benefit:** Allows hand-written Aether code to leverage Capsicum today.
+
+#### Phase 2: Runtime Integration (Medium effort)
+
+Modify the actor spawning code in `runtime/scheduler/actor_pool.c`:
+
+1. When `spawn_with_context()` is called, pass the permission context to the runtime.
+2. If Capsicum is available:
+   - Map the permission context to file descriptors and rights:
+     - "tcp" + "db.internal:5432" → TCP fd to db.internal:5432 with CAP_READ | CAP_WRITE
+     - "fs_read" + "/tmp/*" → Directory fd to /tmp with CAP_READ | CAP_LOOKUP
+     - "exec" + "/bin/sh" → Not applicable; deny in capability mode
+3. Open the minimal fds in the parent (privileged) process.
+4. Fork a child process.
+5. In the child, call `cap_rights_limit()` on each fd, then `cap_enter()`.
+6. Execute the actor's code with only those fds available.
+
+**Benefit:** Transparent Capsicum integration; existing Aether code gains OS-level enforcement on FreeBSD.
+
+#### Phase 3: Capability Audit Logging (Medium effort)
+
+Add optional instrumentation:
+
+```aether
+// Log when a permission is granted
+audit_grant(actor_id: string, category: string, resource: string)
+
+// Log when a permission check fails
+audit_deny(actor_id: string, category: string, resource: string)
+
+// Retrieve audit log (queryable at runtime)
+audit_log() -> ptr
+```
+
+**Benefit:** Forensics and debugging; understand what each actor is doing.
+
+#### Phase 4: Cross-Language Capsicum Callbacks (High effort, speculative)
+
+Allow hosted modules (Java, Python, Go) to declare Capsicum requirements:
+
+```aether
+// Aether code compiled to library, embedded in Java
+config = |ctx| {
+    grant_tcp(ctx, "api.example.com", 443)
+    grant_fs_read(ctx, "/etc/app/config")
+    
+    // Metadata for host to understand Capsicum needs
+    // (requires new compiler emit mode)
+}
+```
+
+The Java host could:
+1. Parse the Aether library's metadata.
+2. Understand that this Aether config needs tcp + fs_read.
+3. Fork a child process, open those fds, apply Capsicum restrictions.
+4. Load the Aether library in the restricted child.
+
+**Benefit:** Aether configs run under OS-enforced sandboxing when embedded.
+
+---
+
+### 3.3 FreeBSD-Specific Optimizations
+
+#### 1. Casper Daemon Integration
+
+FreeBSD includes Casper, a daemon that provides services (DNS, syslog, pwd, grp) to capability-mode processes.
+
+**Opportunity:** Aether actors running in Capsicum mode could delegate privileged operations to Casper instead of embedding them.
+
+```aether
+// Today: actor needs dns permission
+sandboxed_resolve_hostname(ctx, "example.com")
+
+// With Casper: actor has zero network rights, but can query Casper
+capsicum_casper_gethostbyname("example.com")  // Delegated to Casper daemon
+```
+
+This further reduces what an actor can do directly.
+
+#### 2. Jail Integration
+
+FreeBSD jails are lightweight OS-level containers. An Aether actor could be spawned in a jail with:
+- Restricted filesystem (chroot)
+- Network isolation (no access to host network stack)
+- Process isolation (can't see other jails)
+
+**Opportunity:** Aether runtime could optionally spawn actors in jails for maximum isolation.
+
+#### 3. RCTL (Resource Control)
+
+FreeBSD's RCTL allows resource limits (CPU, memory, file descriptors) per process.
+
+**Opportunity:** Aether's permission context could map to RCTL rules:
+
+```aether
+grant_memory(ctx, 100)     // 100 MB limit
+grant_cpu(ctx, 500)        // 500 ms per second
+grant_fds(ctx, 10)         // Max 10 open fds
+```
+
+The runtime would apply RCTL rules when spawning the actor.
+
+---
+
+## Part 4: Real-World Use Cases for Aether on FreeBSD
+
+### 4.1 Secure Configuration Management
+
+**Scenario:** A system administration tool (like Ansible or Puppet) uses Aether for configuration logic.
+
+```aether
+// Untrusted configuration script
+config = |ctx| {
+    // Script can only access /etc/myapp/ and connect to config.internal
+    grant_fs_read(ctx, "/etc/myapp/*")
+    grant_tcp(ctx, "config.internal", 8080)
+    
+    // Run the configuration logic
+    fetch_config("config.internal:8080")
+    parse_and_apply("/etc/myapp/app.conf")
+}
+
+main() {
+    spawn_sandboxed(config)
+}
+```
+
+**FreeBSD benefit:** Aether runtime spawns the config actor in:
+- Capability mode (no access to /etc/passwd, /etc/shadow, network sockets)
+- A chroot jail (filesystem isolation)
+- RCTL limits (max memory, CPU)
+
+Even if the config script is malicious or compromised, it can't escape its sandbox.
+
+### 4.2 Plugin System for Services
+
+**Scenario:** A database server or web server allows plugins written in Aether.
+
+```aether
+// User-supplied plugin
+plugin = |ctx| {
+    // Plugin can query the database and read data files
+    grant_tcp(ctx, "db.internal", 5432)
+    grant_fs_read(ctx, "/var/lib/myapp/data/*")
+    
+    // Cannot write, execute, or access other resources
+    // ...plugin code...
+}
+
+main() {
+    spawn_sandboxed(plugin)
+}
+```
+
+**FreeBSD benefit:** Plugins run under Capsicum restrictions. A malicious plugin can't:
+- Write to the filesystem (open file is read-only)
+- Execute commands (no /bin/sh fd)
+- Access the database beyond the allowed connection (socket fd is restricted)
+- Fork (in capability mode)
+
+### 4.3 Secure Scripting in System Tools
+
+**Scenario:** A DevOps tool (like Terraform or Nomad) uses Aether for provisioning scripts.
+
+```aether
+// Provisioning script
+script = |ctx| {
+    grant_tcp(ctx, "*.cloud.provider", 443)        // Only to cloud provider
+    grant_fs_read(ctx, "/var/lib/provisioning/*")
+    grant_fs_write(ctx, "/tmp/provision-*")         // Scratch space
+    grant_exec(ctx, "/usr/sbin/pw")                 // User management only
+    
+    // Create users, deploy services, etc.
+    // Cannot access network outside cloud provider
+    // Cannot read system files
+    // Cannot execute arbitrary commands
+}
+
+main() {
+    spawn_sandboxed(script)
+}
+```
+
+**FreeBSD benefit:** Multiple scripts can run concurrently, each in its own jail with its own RCTL limits, completely isolated.
+
+---
+
+## Part 5: Challenges and Limitations
+
+### 5.1 Capsicum Limitations
+
+1. **Process-based only** — Capsicum sandboxing is per-process. Aether actors are lightweight; spawning a process per actor is heavy.
+   - **Solution:** Use thread-based actors with Capsicum process boundaries only at higher levels (e.g., one process per actor pool).
+
+2. **Syscall overhead** — Every syscall in capability mode is checked by the kernel. High-syscall-rate code might see overhead.
+   - **Solution:** Batch operations, use sendfile/splice for zero-copy I/O, avoid per-request syscalls.
+
+3. **Not portable** — Capsicum is FreeBSD-specific. Code needs to fall back gracefully on Linux/macOS/Windows.
+   - **Solution:** Aether's language-level checks always work; Capsicum is opt-in and transparent.
+
+4. **Complexity** — Understanding fd rights, capability mode, and Casper requires FreeBSD knowledge.
+   - **Solution:** Wrap Capsicum in Aether std library; users write portable Aether code, runtime handles OS differences.
+
+### 5.2 Aether Limitations
+
+1. **Untrusted code can still bypass checks** — If an actor is malicious and compiled with the Aether code, it can skip permission checks.
+   - **Mitigation:** On FreeBSD, use Capsicum for ultimate enforcement. Don't rely on language-level checks alone for untrusted code.
+
+2. **No built-in audit trail** — Currently, permission checks don't log anything.
+   - **Mitigation:** Phase 3 (audit logging) addresses this.
+
+3. **No resource limits** — Aether can restrict *what*, not *how much* (bandwidth, memory, CPU).
+   - **Mitigation:** On FreeBSD, use RCTL for resource limits.
+
+---
+
+## Part 6: Roadmap for Aether on FreeBSD
+
+### Short Term (2-3 months)
+
+1. **Add `std.capsicum` module** with basic bindings.
+2. **Documentation** explaining how to use Capsicum from Aether.
+3. **Examples** showing Capsicum-enabled plugins and sandboxed actors.
+
+### Medium Term (3-6 months)
+
+1. **Runtime integration** — `spawn_with_context()` optionally uses Capsicum.
+2. **Automatic fd management** — Runtime maps permission contexts to fds and rights.
+3. **CI on FreeBSD** — Test suite runs on FreeBSD; catch OS-specific bugs.
+
+### Long Term (6+ months)
+
+1. **Audit logging** — Built-in forensics.
+2. **Casper integration** — Actor delegation to Casper daemon.
+3. **Jail + RCTL support** — Multi-level sandboxing.
+4. **Cross-language Capsicum metadata** — Hosted modules declare Capsicum needs.
+
+---
+
+## Part 7: Conclusion
+
+**Capsicum and Aether are orthogonal strengths:**
+
+- **Capsicum** is OS-enforced, fine-grained, and ironclad—but process-heavy and OS-specific.
+- **Aether** is language-level, portable, and lightweight—but relies on code-level enforcement.
+
+**A hybrid approach** (Aether code + Capsicum enforcement on FreeBSD) combines the best of both:
+
+1. **Portability** — Aether code runs on any OS.
+2. **Simplicity** — Users write high-level permission contexts; the runtime handles the details.
+3. **Security depth** — Language-level checks catch bugs; Capsicum catches malice.
+4. **Performance** — Fast path on allowed operations; Capsicum only on denied syscalls.
+
+**For Aether to become a credible sandboxing platform on FreeBSD**, the roadmap is:
+
+1. **Phase 1:** Capsicum bindings (lets hand-written Aether code use Capsicum).
+2. **Phase 2:** Runtime integration (transparent Capsicum for actors).
+3. **Phase 3:** Audit logging (forensics and debugging).
+4. **Phase 4:** Ecosystem integration (Casper, jails, RCTL).
+
+This makes Aether a unique proposition: **the only language-level sandbox model backed by OS-level enforcement when available**.
+
+---
+
+## References
+
+### Capsicum Documentation
+
+- [Capsicum: practical capabilities for UNIX](https://www.cl.cam.ac.uk/research/security/capsicum/) — Original research
+- [FreeBSD Capsicum man pages](https://www.freebsd.org/cgi/man.cgi?capsicum) — `cap_enter(2)`, `cap_rights_limit(2)`, etc.
+- [Casper daemon documentation](https://www.freebsd.org/cgi/man.cgi?casper) — Inter-process privilege delegation
+- [Chromium Capsicum integration](https://www.chromium.org/) — Production use case
+
+### Aether Documentation
+
+- [`docs/containment-sandbox.md`](./containment-sandbox.md) — Aether's permission model and examples
+- [`docs/aether-embedded-in-host-applications.md`](./aether-embedded-in-host-applications.md) — Hosted modules and capability-empty defaults
+- [`docs/closures-and-builder-dsl.md`](./closures-and-builder-dsl.md) — Closure isolation and scope hygiene
+- [`docs/emit-lib.md`](./emit-lib.md) — Embedding Aether as a library in host applications
+
+### Related Security Research
+
+- [USENIX Security 2010: Capsicum paper](http://www.trustedbsd.org/2010usenix-security-capsicum-website.pdf)
+- [BSDCan 2014: Capsicum and Casper](https://www.bsdcan.org/2014/schedule/track/Security/486.en.html)
+- [Oblivious Sandboxing with Capsicum](https://www.engr.mun.ca/~anderson/publications/2017/towards-oblivious-sandboxing.pdf)


### PR DESCRIPTION
## Summary

Comprehensive design document exploring Aether's language-level sandbox model alongside BSD Capsicum's OS-level capability restrictions. This comparison reveals surprising architectural parallels and identifies opportunities for Aether on FreeBSD.

**Key insights:**
- Both use capability-based access control, containment boundaries, and fail-safe defaults
- Aether is better for controlled environments (DSL scripts, plugins); Capsicum for untrusted code
- A hybrid approach (Aether + Capsicum on FreeBSD) combines language-level portability with OS-level enforcement

## Contents

- **Part 1:** Side-by-side architecture comparison (enforcement layer, isolation mechanisms, granularity, performance)
- **Part 2:** Three shared principles (capabilities over permissions, containment boundaries, fail-safe defaults)
- **Part 3:** Hybrid approach design + 4-phase implementation roadmap
  - Phase 1: Capsicum API bindings
  - Phase 2: Runtime integration (transparent Capsicum for actors)
  - Phase 3: Audit logging for forensics
  - Phase 4: Ecosystem integration (Casper, jails, RCTL)
- **Part 4:** Real-world use cases (config management, plugins, DevOps)
- **Part 5:** Challenges and mitigations
- **Part 6:** Short/medium/long-term roadmap

## Impact

Positions Aether as a unique sandboxing platform: the only language-level sandbox model that can leverage OS-level enforcement when available (FreeBSD), while remaining portable to all platforms.

## Test Plan

- Documentation read-through
- Verify all links and cross-references work
- Validate code examples compile/run (once Phase 1 bindings are added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)