### PR TITLE
fix: Enable snapshot release downloads by publishing (not draft)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,7 +539,7 @@ jobs:
           Latest commit: `${{ env.COMMIT }}`
           VERSION file: `${{ env.VERSION }}`
         prerelease: false
-        draft: true
+        draft: false
         files: |
           aether-source.tar.gz
           aether-source.zip


### PR DESCRIPTION
The snapshot release workflow was creating draft releases, which prevents GitHub from serving downloads. The documented URL `https://github.com/aether-lang-org/aether/releases/download/snapshot/aether-source.tar.gz` doesn't work because draft releases don't have downloadable assets.

Changed `draft: true` to `draft: false` to publish the release and enable downloads.