### PR TITLE
docs: promote "Config IS Code" to README + LLM.md

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -52,7 +52,27 @@ Erlang's actor syntax, compiling via C.**
   C functions with no VM behind them, so there's no run-time hook
   for the block to reach back through. `hide` / `seal except` are
   compile-time, and the grant list is the closure's only handle to
-  privileged operations.
+  privileged operations. The trailing-block + `builder` shape is
+  Aether's lever for **pseudo-declarative nirvana**: the call site
+  reads like a config file (bare setters, no constructor noise, no
+  parameter threading) while the body is full Aether underneath —
+  control flow, env lookups, library calls, the lot. Levels 1-2
+  (YAML, HCL) are readable but powerless; Level 3 (Pulumi/CDK) is
+  powerful but reads like glue code; Aether's closure-DSL is the
+  one step beyond that gives both. This is what makes the next
+  bullet possible.
+- **NOT a YAML/HCL/Helm host** (related) — and won't be. Building on
+  the closure-DSL above, Aether's pitch for server-shaped libraries
+  is **config IS code**: don't ship a YAML loader, expose your
+  start-surface as a closure-DSL block and let the operator's
+  "config" be a `.ae` file they run with `ae run`. Same file is
+  config + validation + conditionals + entry point; no second
+  parser, no template language, no embedded scripting hack.
+  Sandboxing (`--emit=lib --with=...`, `hide`, `seal except`)
+  keeps untrusted configs safe — the same machinery that makes the
+  embedded-DSL case work. If a downstream user asks "should we add
+  a YAML config loader?", point them at `docs/config-is-code.md`
+  and the trailing-block DSL pattern.
 
 Sandbox more info: Full comparison (who brings what — Pony's per-reference
   granularity, Java SecManager's policy-file ancestry, gVisor's
@@ -71,6 +91,12 @@ plays that role), no interfaces.
   top 40 lines at session start to know what just landed.
 - `docs/emit-lib.md` — the capability-opt-in doc. Canonical reference
   for why `std.fs` is banned under `--emit=lib` by default.
+- `docs/config-is-code.md` — the "don't ship a YAML loader" pitch.
+  Library authors with a "start the thing" surface should expose
+  it as a trailing-block DSL, not a config-file format. Pair with
+  `docs/closures-and-builder-dsl.md` for the mechanism. `docs/cic-help.md`
+  is the (proposed, unimplemented) `ae help <script>` companion that
+  catches operator-side mistakes in those scripts.
 - `docs/next-steps.md` — roadmap. P1/P2/P3/P4 are ordered; `fs.copy` /
   `fs.move` / `fs.chmod` / `fs.symlink` / `fs.realpath` are P4. Check
   here before speccing a new stdlib addition.

--- a/README.md
+++ b/README.md
@@ -361,6 +361,26 @@ The compiler distinguishes them at parse time, which is what makes the sandboxin
 
 Inspired by Smalltalk blocks, Ruby's blocks/procs, Groovy closures, and Kotlin/SwiftUI's trailing-block DSLs. See [Closures and Builder DSL](docs/closures-and-builder-dsl.md) for the builder-context mechanism, ref cells, and full DSL pattern.
 
+## Config IS Code
+
+**Don't ship a YAML loader.** If your Aether library has a "start the thing" surface — HTTP server, daemon, agent, scheduler, test rig — expose it as a closure-DSL block and let the operator's "config" be a `.ae` file they run with `ae run`. The pattern collapses YAML → templating → second-language-DSL (HCL, Helm) → embedded-scripting all into one thing: real Aether, type-checked, sandboxable, with the full stdlib available when the operator needs it.
+
+```aether
+import avnserver
+
+main() {
+    avnserver.serve {
+        host("127.0.0.1")
+        port(9990)
+        superuser_token(env("SUPER_TOKEN"))   // computed at config time
+        repo("alpha", "/srv/alpha")
+        repo("beta",  "/srv/beta")
+    }
+}
+```
+
+Same file is config, validation, conditional logic, and the entry point. No second parser, no second type system, no template language. Sandboxing (`--emit=lib --with=...`, `hide`, `seal except`) keeps it safe to accept untrusted configs as the embedded-DSL case demands. See [Config IS Code](docs/config-is-code.md) for the full progression (YAML → HCL → Pulumi → here) and library-author recipe.
+
 ## Runtime Configuration
 
 When embedding the Aether runtime in a C application, configure optimizations at startup:


### PR DESCRIPTION
## Summary

- Surfaces the **Config IS Code** pattern (currently buried in `docs/config-is-code.md`) at the top-level entry points so readers and future-LLM-sessions actually find it.
- **README**: new `## Config IS Code` section after Closures and Builder DSL — catchy one-liner (\"Don't ship a YAML loader.\"), a worked `serve { ... }` snippet showing env interpolation + repeatable setters + entry-point-in-one-file, and a link to the full pattern doc.
- **LLM.md**:
  - Reordered the closure-DSL bullet to come before the config-is-code bullet, and gave it a **pseudo-declarative nirvana** framing (call site reads like config, body is full Aether) plus the Levels 1/2/3 → here progression to set up the next bullet.
  - New **NOT a YAML/HCL/Helm host (related)** bullet that opens with \"Building on the closure-DSL above\" so the dependency is explicit. Codifies the stance for future \"should we add YAML config?\" requests — point at `docs/config-is-code.md`.
  - Added `docs/config-is-code.md` to \"Files/dirs worth knowing,\" with `docs/cic-help.md` mentioned as the (proposed, unimplemented) operator-help companion.

`cic-help.md` is deliberately **not** promoted to the same level — it's still proposed/unimplemented and tracked as #414/#415. The live pattern is config-is-code.md.

## Test plan

- [x] `git diff --check` — no whitespace damage.
- [ ] README renders correctly on GitHub (visual check post-merge).
- [ ] No code or build changes; CI is doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)