### PR TITLE
fix: merge struct definitions across import boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Struct definitions in imported modules are now visible to that module's own merged function bodies** (`compiler/aether_module.c`, `tests/integration/import_struct/`). `module_merge_into_program` only cloned `AST_FUNCTION_DEFINITION` / `AST_BUILDER_FUNCTION` / `AST_CONST_DECLARATION` from imported modules into the consumer's program AST — never `AST_STRUCT_DEFINITION`. A module that exposed a `*ptr`-returning constructor whose body internally cast to its own struct (`raw as *Slot`) typechecked standalone but failed once a consumer did `import handle`, because the cloned function body's cast site resolved against an empty struct table and errored as `'Slot' is not a struct type`. Fix clones struct decls into the consumer's program AST under their bare name (no `<ns>_` prefix), with a `program_has_struct` dedup helper. Selective-import filter is bypassed for structs because a function body that casts to `*T` cannot type-check without `T` in scope. Both the main merge loop and the cross-module BFS pass (transitive deps) are extended. Unblocks the opaque-handle pattern (struct stays an internal implementation detail; only `ptr` crosses the API boundary). New integration test `tests/integration/import_struct/` exercises constructor + getter + setter round-trip across the import boundary.
+
 ## [0.139.0]
 
 ### Added

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -1076,6 +1076,25 @@ static int program_has_function(ASTNode* program, const char* prefixed_name) {
     return 0;
 }
 
+// Is a struct with the given name already a top-level child of `program`?
+// Used by module_merge_into_program to dedup struct definitions when the
+// consumer imports a module that exposes one. Imported structs share the
+// consumer's struct namespace (no `<ns>_` prefix) — see the design rationale
+// at the merge site.
+static int program_has_struct(ASTNode* program, const char* name) {
+    if (!program || !name) return 0;
+    for (int m = 0; m < program->child_count; m++) {
+        ASTNode* existing = program->children[m];
+        if (!existing) continue;
+        ASTNode* unwrapped = unwrap_export(existing);
+        if (unwrapped && unwrapped->type == AST_STRUCT_DEFINITION &&
+            unwrapped->value && strcmp(unwrapped->value, name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Walk a node looking for AST_FUNCTION_CALL targets that match a
 // "<ns>_<name>" prefix where <name> is one of the module's own function
 // names. Append unique matches into `out` (storing the bare name).
@@ -1246,6 +1265,30 @@ void module_merge_into_program(ASTNode* program) {
                 rename_intra_module_refs(clone, ns, func_names, func_count,
                                          const_names, const_count, NULL, 0);
 
+                insert_child_at(program, clone, insert_idx++);
+            } else if (decl->type == AST_STRUCT_DEFINITION && decl->value) {
+                // Struct definitions from imported modules enter the
+                // consumer's program AST under their bare name (no
+                // `<ns>_` prefix). Closes the cross-`import` struct
+                // visibility gap that blocked the opaque-handle
+                // pattern: a module exposing `new_slot() -> ptr` whose
+                // body does `s = raw as *Slot` failed to typecheck once
+                // imported, because the consumer's symbol table lacked
+                // `Slot`.
+                //
+                // Bypasses the selective-import filter on purpose: a
+                // function body that casts to `*Slot` cannot type-check
+                // without the struct in scope, so even
+                // `import handle (new_slot)` must pull in `Slot`.
+                //
+                // Dedup by name. If the consumer already has a struct
+                // with the same name (its own, or an earlier merge),
+                // we skip — name clashes between modules are out of
+                // scope here; the C compiler will surface them downstream.
+                if (program_has_struct(program, decl->value)) continue;
+
+                ASTNode* clone = clone_ast_node(decl);
+                clone->is_imported = 1;
                 insert_child_at(program, clone, insert_idx++);
             }
             // Skip AST_MAIN_FUNCTION, AST_IMPORT_STATEMENT, etc.
@@ -1479,6 +1522,17 @@ void module_merge_into_program(ASTNode* program) {
                     rename_intra_module_refs(clone, ns, func_names, func_count,
                                              const_names, const_count, NULL, 0);
 
+                    insert_child_at(program, clone, insert_idx++);
+                } else if (decl->type == AST_STRUCT_DEFINITION) {
+                    // Same shape as the direct-import struct merge above,
+                    // for transitively-reachable modules pulled in via the
+                    // BFS. A merged function body that casts to `*T` needs
+                    // T in scope regardless of which import edge brought
+                    // the function in.
+                    if (program_has_struct(program, decl->value)) continue;
+
+                    ASTNode* clone = clone_ast_node(decl);
+                    clone->is_imported = 1;
                     insert_child_at(program, clone, insert_idx++);
                 }
             }

--- a/tests/integration/import_struct/lib/handle/module.ae
+++ b/tests/integration/import_struct/lib/handle/module.ae
@@ -1,0 +1,38 @@
+// Module exposing an opaque-handle API. The struct `Slot` is an
+// implementation detail — only `*ptr` crosses the API boundary.
+// Pre-fix this module typechecked standalone but failed under
+// `import handle` from a consumer because the struct definition
+// wasn't merged into the consumer's program AST.
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+
+struct Slot {
+    value: int
+}
+
+new_slot(initial: int) -> ptr {
+    raw = malloc(16)
+    if raw == null { return null }
+    s = raw as *Slot
+    s.value = initial
+    return raw
+}
+
+slot_get(p: ptr) -> int {
+    if p == null { return 0 }
+    s = p as *Slot
+    return s.value
+}
+
+slot_set(p: ptr, v: int) -> int {
+    if p == null { return 0 }
+    s = p as *Slot
+    s.value = v
+    return 0
+}
+
+free_slot(p: ptr) -> int {
+    if p != null { free(p) }
+    return 0
+}

--- a/tests/integration/import_struct/test_import_struct.ae
+++ b/tests/integration/import_struct/test_import_struct.ae
@@ -1,0 +1,50 @@
+// Regression: cross-`import` struct visibility for the opaque-handle
+// shape. A module exposing a `*ptr`-returning constructor whose body
+// internally casts to its own struct (`raw as *Slot`) typechecks
+// standalone but pre-fix failed once a consumer did `import handle`,
+// because `module_merge_into_program` only cloned function and
+// constant decls — never struct decls — into the consumer's program
+// AST. The cast site then resolved against an empty struct table and
+// errored as "'Slot' is not a struct type". Filed by sibling project
+// avn (Subversion port) where five in-flight modules used this shape.
+//
+// What this test exercises: an imported module's struct must be
+// visible inside that module's own merged function bodies (so casts
+// resolve), and the C output must include the struct definition (so
+// field accesses on the casted ptr compile).
+
+import handle
+
+extern exit(code: int)
+
+main() {
+    println("=== test_import_struct ===")
+
+    // Test 1: constructor + getter round-trip
+    p = handle.new_slot(42)
+    if p == null {
+        println("FAIL 1: new_slot returned null")
+        exit(1)
+    }
+    got = handle.slot_get(p)
+    if got != 42 {
+        println("FAIL 1: expected 42, got ${got}")
+        exit(1)
+    }
+    println("  PASS 1: constructor + getter")
+
+    // Test 2: setter mutates through the opaque handle
+    _ = handle.slot_set(p, 100)
+    got2 = handle.slot_get(p)
+    if got2 != 100 {
+        println("FAIL 2: expected 100, got ${got2}")
+        exit(1)
+    }
+    println("  PASS 2: setter mutates")
+
+    // Test 3: clean release
+    _ = handle.free_slot(p)
+    println("  PASS 3: free_slot")
+
+    println("=== all import-struct tests passed ===")
+}


### PR DESCRIPTION
`module_merge_into_program` only cloned function and constant decls from imported modules into the consumer's program AST — never struct decls. A module exposing a `*ptr`-returning constructor whose body internally cast to its own struct typechecked standalone but failed once a consumer did `import handle`, because the cloned function body's cast site resolved against an empty struct table and errored as `'Slot' is not a struct type`.

Fix clones AST_STRUCT_DEFINITION nodes into the consumer's program AST under their bare name (no `<ns>_` prefix), with a new `program_has_struct` dedup helper. Selective-import filter is bypassed for structs because a function body that casts to `*T` cannot type-check without `T` in scope. Both the main merge loop and the cross-module BFS pass (transitive deps) are extended.

Unblocks the opaque-handle pattern (struct stays an internal implementation detail; only `ptr` crosses the API boundary). New integration test exercises constructor + getter + setter round-trip across the import boundary. `make ci` and `HARDEN=1 make ci` green.