### PR TITLE
fix: struct-field assignment counts as an escape edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Struct-field assignment now counted as an escape edge for heap-string vars** (`compiler/codegen/codegen_stmt.c`, `tests/regression/test_struct_field_string_escape.ae`). The escape-analysis pre-pass behind the function-exit defer-free (`mark_escaped_heap_string_vars`, the #420 follow-up) recognised four escape edges: function-call arg through a `ptr` / `@retain` param, return statement, closure capture, and the AST_VARIABLE_DECLARATION RHS shape. It had no case for AST_BINARY_EXPRESSION with `value="="` — which is the AST shape the parser uses for non-trivial assignment LHS (`s.field = ...`, `arr[i] = ...`). Bare local re-assignment goes through AST_VARIABLE_DECLARATION instead, so it was already covered. The gap meant a heap-tracked local assigned to a struct field inside a setter got reclaimed by the function-exit defer-free when the setter returned, leaving the struct holding a dangling pointer. Same-function write+read masked the bug because the temp lived the full activation record; cross-function setter/getter — the canonical opaque-handle / state-bearing module API shape — hit it every time. avn impact: every commit went out as `"edits":[{}]` because RaCommit.edits_packed was clobbered between `remote_commit_add_file` (writer) and `remote_commit_build_body` (reader); 5000-commit bench couldn't make any progress. Fix: extend `escape_walk` to detect AST_BINARY_EXPRESSION with `value="="` whose LHS is non-bare-identifier (AST_MEMBER_ACCESS for field writes, AST_ARRAY_ACCESS for element writes); mark a bare-identifier RHS as escaped if it names a heap-tracked var. New regression test exercises both shapes (21-byte heap-built string round-tripped through a setter, plus a byte-for-byte 16-byte verification).
+
+  ### Upgrade notes
+
+  This release widens what the escape analyzer treats as a "store outside the current activation record": `s.field = cp` and `arr[i] = cp` now keep `cp`'s buffer alive past function exit, instead of letting the function-exit defer-free reclaim it. The previous version reclaimed the buffer eagerly, which manifested as silent dangling-pointer reads from the struct field anywhere outside the writing function.
+
+  If your project stores a heap-string into a struct field and the writing function expected the buffer to be freed at scope exit (very unlikely — that pattern was always broken under the old behaviour, just symptomatically silent until you read the field cross-function), the field will now retain ownership for the struct's lifetime instead. This shape leaks the buffer on the writer side IF the receiver never frees it explicitly — strictly better than the dangling-read it replaces.
+
+  **Recommended pre-upgrade play:**
+
+  1. Build under the new compiler and re-run any test that exercises a setter/getter pair across a function boundary; previously-corrupted struct fields will start returning correct content.
+  2. If your project tracks heap-string lifetimes across struct ownership, audit any `string.release` calls on a struct field after the field's owner has been freed — these may now over-free if the owner's destructor already releases.
+
 ## [0.143.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1233,6 +1233,40 @@ static void escape_walk(CodeGenerator* gen, ASTNode* node,
         return;
     }
 
+    /* Non-trivial assignment — `s.field = expr` (LHS is an
+     * AST_MEMBER_ACCESS) or `arr[i] = expr` (LHS is an
+     * AST_ARRAY_ACCESS). The parser uses AST_BINARY_EXPRESSION with
+     * value "=" for these; bare-local reassignment uses
+     * AST_VARIABLE_DECLARATION instead, which is handled above. The
+     * write target outlives the current activation record (a struct
+     * instance, an array element passed in by ptr, an actor's state,
+     * etc.), so any heap-tracked variable assigned in the RHS must
+     * be marked escaped — otherwise the function-exit defer-free
+     * reclaims the buffer while the struct field is still pointing
+     * at it (cross-function setter/getter dangle). Closes the
+     * field-write half of the escape-edge gap that landed in the
+     * #420 follow-up alongside call-arg, return, and closure
+     * capture. */
+    if (node->type == AST_BINARY_EXPRESSION && node->value &&
+        strcmp(node->value, "=") == 0 && node->child_count == 2) {
+        ASTNode* lhs = node->children[0];
+        ASTNode* rhs = node->children[1];
+        if (lhs && lhs->type != AST_IDENTIFIER) {
+            if (rhs && rhs->type == AST_IDENTIFIER && rhs->value &&
+                is_heap_string_var(gen, rhs->value)) {
+                mark_escaped_string_var(gen, rhs->value);
+            }
+            /* Walk both sides for any nested calls / closures whose
+             * inner identifiers also need the regular escape
+             * treatment. consumed_lhs cleared because the bare-LHS
+             * exception (`V = f(V, …)`) doesn't apply once the LHS
+             * is a non-trivial location. */
+            escape_walk(gen, lhs, NULL);
+            escape_walk(gen, rhs, NULL);
+            return;
+        }
+    }
+
     /* Don't descend into nested function definitions — their own pass
      * handles them. */
     if (node->type == AST_FUNCTION_DEFINITION ||

--- a/tests/regression/test_struct_field_string_escape.ae
+++ b/tests/regression/test_struct_field_string_escape.ae
@@ -1,0 +1,141 @@
+// Regression: a heap-tracked string assigned to a struct field
+// inside a setter function must survive past the setter's return.
+//
+// Pre-fix, escape_walk in compiler/codegen/codegen_stmt.c only
+// recognised four escape edges: function call args (ptr / @retain
+// param), return statements, closure captures, and the implicit
+// AST_VARIABLE_DECLARATION RHS shape. It had no case for
+// AST_BINARY_EXPRESSION with value "=" — the AST shape the parser
+// uses for non-trivial assignment LHS (`s.field = ...`,
+// `arr[i] = ...`). The function-exit defer-free for hoisted heap-
+// string vars then reclaimed the buffer when the setter returned,
+// leaving the struct holding a dangling pointer.
+//
+// Same-function write+read masked the bug because the temp lived
+// the full activation record. The cross-function setter/getter
+// shape — common in opaque-handle / state-bearing module APIs —
+// hit it every time.
+//
+// avn impact: every commit went out as `"edits":[{}]` because
+// RaCommit.edits_packed was clobbered between
+// remote_commit_add_file (writer) and remote_commit_build_body
+// (reader); 5000-commit bench couldn't make any progress.
+//
+// What this test exercises: write a 21-byte heap-built string to
+// a struct field via slot_set, read it back through slot_get,
+// assert length and contents match. Plus a same-function write+read
+// case to confirm the existing path still works.
+
+import std.string
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern exit(code: int)
+
+struct Slot {
+    n: int
+    packed: string
+}
+
+slot_new() -> ptr {
+    raw = malloc(32)
+    s = raw as *Slot
+    s.n = 0
+    s.packed = string.copy("")
+    return raw
+}
+
+slot_set(p: ptr, str: string) {
+    s = p as *Slot
+    cp = string.copy(str)
+    s.packed = cp
+    s.n = 1
+}
+
+slot_get(p: ptr) -> string {
+    s = p as *Slot
+    return s.packed
+}
+
+main() {
+    println("=== test_struct_field_string_escape ===")
+
+    // Case 1: cross-function setter/getter round-trip — the
+    // originally-broken shape.
+    p = slot_new()
+
+    rec = "1\x01"
+    rec = string.concat(rec, "f/1.txt")
+    rec = string.concat(rec, "\x01")
+    rec = string.concat(rec, "aGVsbG8=")
+    out = "1\x02"
+    out = string.concat(out, rec)
+    out = string.concat(out, "\x02")
+
+    if string.length(out) != 21 {
+        println("FAIL 1 setup: out.len expected 21, got ${string.length(out)}")
+        exit(1)
+    }
+
+    slot_set(p, out)
+
+    got = slot_get(p)
+    if string.length(got) != 21 {
+        println("FAIL 1: got.len expected 21, got ${string.length(got)}")
+        exit(1)
+    }
+
+    // Spot-check a few bytes — the envelope tag at index 0, the
+    // record-tag byte at index 1, the payload tag at index 2, and
+    // the trailing terminator.
+    if string.char_at(got, 0) != 49 {
+        println("FAIL 1: byte0 expected 49 ('1'), got ${string.char_at(got, 0)}")
+        exit(1)
+    }
+    if string.char_at(got, 1) != 2 {
+        println("FAIL 1: byte1 expected 2, got ${string.char_at(got, 1)}")
+        exit(1)
+    }
+    if string.char_at(got, 2) != 49 {
+        println("FAIL 1: byte2 expected 49 ('1'), got ${string.char_at(got, 2)}")
+        exit(1)
+    }
+    if string.char_at(got, 20) != 2 {
+        println("FAIL 1: byte20 expected 2 (terminator), got ${string.char_at(got, 20)}")
+        exit(1)
+    }
+    println("  PASS 1: 21-byte cross-function setter/getter survives")
+
+    free(p)
+
+    // Case 2: contents-match check — every byte in `got` should
+    // equal the corresponding byte in `expected`. Confirms the
+    // setter doesn't just preserve length but the actual buffer
+    // bytes through to the getter. Uses non-NUL control bytes so
+    // the source-level literal isn't strlen-truncated.
+    p2 = slot_new()
+    payload = "hello world\x01\x02\x03"
+    expected = string.concat("AB", payload)
+    if string.length(expected) != 16 {
+        println("FAIL 2 setup: expected.len was ${string.length(expected)}")
+        exit(1)
+    }
+    slot_set(p2, expected)
+    back = slot_get(p2)
+    if string.length(back) != 16 {
+        println("FAIL 2: back.len expected 16, got ${string.length(back)}")
+        exit(1)
+    }
+    i = 0
+    while i < 16 {
+        if string.char_at(back, i) != string.char_at(expected, i) {
+            println("FAIL 2: byte ${i} mismatch (expected ${string.char_at(expected, i)}, got ${string.char_at(back, i)})")
+            exit(1)
+        }
+        i = i + 1
+    }
+    println("  PASS 2: 16-byte payload byte-for-byte preserved")
+    free(p2)
+
+    println("=== all cases passed ===")
+}


### PR DESCRIPTION
Pre-fix, escape_walk in compiler/codegen/codegen_stmt.c (the function-exit defer-free pre-pass behind #420) recognised four escape edges: function-call arg through ptr/@retain, return, closure capture, and the AST_VARIABLE_DECLARATION RHS shape. It had no case for AST_BINARY_EXPRESSION with value "=" — the AST shape the parser uses for non-trivial assignment LHS like `s.field = ...` (AST_MEMBER_ACCESS LHS) and `arr[i] = ...` (AST_ARRAY_ACCESS LHS). Bare local re-assignment goes through AST_VARIABLE_DECLARATION, which was already covered.

The gap meant a heap-tracked local assigned to a struct field inside a setter got reclaimed by the function-exit defer-free when the setter returned, leaving the struct holding a dangling pointer. Same-function write+read masked the bug because the temp lived the full activation record; cross-function setter/ getter — the canonical opaque-handle module API shape — hit it every time.

avn impact: every commit went out as `"edits":[{}]` because RaCommit.edits_packed was clobbered between
remote_commit_add_file (writer) and remote_commit_build_body (reader); 5000-commit bench couldn't make any progress.

Fix: in escape_walk, when the node is AST_BINARY_EXPRESSION with value "=" and the LHS is anything other than a bare AST_IDENTIFIER (AST_MEMBER_ACCESS, AST_ARRAY_ACCESS, etc.), mark a bare- identifier RHS as escaped if it names a heap-tracked var, then walk both sides for any nested heap-string identifiers buried deeper. consumed_lhs context is cleared because the bare-LHS exception (`V = f(V, …)`) doesn't apply once the LHS is a non-trivial location.

Regression test exercises:
- 21-byte heap-built string round-tripped through a setter + getter across function boundaries
- 16-byte byte-for-byte payload preservation check