### PR TITLE
fix: tuple-destructure classifier resolves cross-module callees; json…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Tuple-destructure heap classification now resolves cross-module callees + json wrappers refactored to uniform-heap return shapes** (`compiler/codegen/codegen_stmt.c`, `std/json/module.ae`, `tests/regression/test_json_get_string_loop_leak.ae`). Two coupled fixes that together close the residual heap-tracker gap surfaced in `further-bug-fix4.md`'s 2026-05-10 update — avn's 5000-commit bench retained ~666 MB just from `b64, _ = json.get_string(jcontent)` because that destructure's wrapper emitted `_heap_b64 = 0` and the function-exit defer-free skipped it.
+
+  - **Cross-module callee dot-normalisation at the destructure-time analyzer lookup.** `function_def_returns_heap_at` runs against the callee's function definition fetched by `find_function_definition_by_name(gen->program, rhs->value)`. Source-level callees land in the AST in dotted form (`"json.get_string"`) but the merged user-fn lives in the program AST under the underscored namespace-prefixed name (`"json_get_string"`). Pre-fix the lookup missed every cross-module call, the per-position analyzer never ran, and `pos_is_heap` fell back to 0 even when the callee was uniformly heap-classifiable. Routed `rhs->value` through `codegen_normalise_callee` first — same dot-normalisation pattern `is_heap_string_expr` already uses on its hardcoded fast-path lookups. The fix also unlocks classifier-correctness for every other `module.fn`-style cross-module destructure in user code.
+
+  - **Stdlib json wrappers refactored to uniform-heap return shapes.** `json.parse`, `json.parse_strict`, `json.stringify`, `json.get_string`, `json.object_entry` previously returned a bare literal `""` on one side of the if-else (failure path) and `string_concat(raw, "")` on the other (success path). `function_def_returns_heap_at`'s AND-fold then yielded non-heap at the affected position (conservative correctness — a mixed-shape position can't be eager-freed at compile time without a runtime header dispatch we don't have), so the destructure wrapper never fired in the success path's hot loop. Refactored each return to inline `string_concat(...)` at every string position — `string_concat("", "")` on the cheap failure side, `string_concat(raw, "")` on the success side — so the AND-fold yields heap uniformly. Tiny extra allocation on the failure side (a one-byte heap empty string) in exchange for the success-side leak going away. Also surfaced as a side-effect: where the success path used to write through an intermediate `owned = string_concat(...)` local before returning `owned, ""`, `is_heap_string_expr` couldn't follow the bare-identifier-at-return shape back to its assignment — so the rewrite also inlines the `string_concat` call directly at the return position. Same shape for every wrapper this touched.
+
+  ### Upgrade notes
+
+  This release tightens the per-position tuple-destructure heap classifier: cross-module user-fn callees now resolve correctly, and `json.parse` / `json.parse_strict` / `json.stringify` / `json.get_string` / `json.object_entry` now classify their string return positions uniformly as heap. The previous version's destructure wrapper at every `_, _ = json.<fn>(...)` call site emitted `_heap_<lhs> = 0` and the function-exit defer-free skipped the var, so the owned-string copy leaked across loop iterations and to process exit.
+
+  If your project loops over `json.get_string` / `json.parse` / `json.parse_strict` / `json.stringify` / `json.object_entry` and stores the destructured string result somewhere outside the destructure scope (struct field, list, map, actor message field, closure capture) without the escape-analyzer recognising it — the previous compiler tolerated this as a slow leak; this release will now `free()` that string at function exit, dangling whatever pointer the recipient stored. This shape is a use-after-free.
+
+  **Recommended pre-upgrade play:**
+
+  1. Run `aetherc --diagnose=ownership` over your project to surface every `_heap_<lhs> = 1`-flipped variable that touches a `json.*` destructure.
+  2. For each, check whether the value is handed to a `ptr`-parameter (already escape-marked), returned (already escape-marked), captured by a closure (already escape-marked), assigned to a struct field (escape-marked as of #0.144 — fix landed last release), or stored some other way the analyzer doesn't yet catch (e.g. raw stuffing into an opaque arena). The last case is the dangerous one; rewrite to take a copy.
+  3. Re-run your sanitiser builds (ASan or Valgrind) on the destructure-heavy hot paths after rebuilding.
+
+  Conservative migration: if any of your code does `_, payload = json.get_string(v); some_extern_that_keeps_payload(payload)` without an `@retain` annotation on the recipient's parameter, the recipient will now read freed memory. Annotate the recipient `@retain` (so the escape walker marks `payload` escaped) or take an explicit copy.
+
 ## [0.144.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1983,8 +1983,22 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
              * assignment shape regardless of the flag. */
             ASTNode* callee_def = NULL;
             if (rhs && rhs->type == AST_FUNCTION_CALL && rhs->value) {
-                callee_def = find_function_definition_by_name(gen->program,
-                                                              rhs->value);
+                /* Source-level callees land in the AST in dotted form
+                 * (`"json.get_string"`) but the merged user-fn lives in
+                 * the program AST under the underscored namespace-
+                 * prefixed name (`"json_get_string"`). Without
+                 * normalisation the lookup misses every cross-module
+                 * callee, the per-position structural analyzer never
+                 * runs, and the destructure wrapper falls back to
+                 * `_heap_<lhs> = 0` even when the callee was uniform-
+                 * heap-classifiable. Same dot-normalisation pattern
+                 * `is_heap_string_expr` already uses on its hardcoded
+                 * fast-path lookups. */
+                char fn_norm[256];
+                const char* fn = codegen_normalise_callee(rhs->value,
+                                                          fn_norm,
+                                                          sizeof(fn_norm));
+                callee_def = find_function_definition_by_name(gen->program, fn);
             }
 
             // Generate: type a = _tmp._0; type b = _tmp._1; ...

--- a/std/json/module.ae
+++ b/std/json/module.ae
@@ -92,14 +92,25 @@ extern string_concat(a: string, b: string) -> string
 // failure. The error is a position-qualified message like
 // "expected ':' at 3:17". Caller owns the returned value and must free
 // with json.free.
-parse(json_str: string) -> {
+//
+// Heap-classification shape: position 1 (the error message) is heap on
+// both return paths so the destructure wrapper at the call site fires
+// uniformly. The failure path uses string_concat(json_last_error(), "")
+// for an owned copy; the success path uses string_concat("", "") for
+// a (tiny) empty heap string. Without both paths returning heap,
+// function_def_returns_heap_at's AND-fold would mark position 1
+// non-heap and every destructure of `_, err = json.parse(...)` would
+// leak the success-path "" allocation — except the success "" was
+// already a literal so there'd be nothing TO leak, only an over-free
+// risk on the failure path. The uniform-heap shape sidesteps the
+// classifier's mixed-path conservatism. See # further-bug-fix4 for
+// the wider context.
+parse(json_str: string) -> (ptr, string) {
     value = json_parse_raw(json_str)
     if value == null {
-        err = json_last_error()
-        err_owned = string_concat(err, "")
-        return null, err_owned
+        return null, string_concat(json_last_error(), "")
     }
-    return value, ""
+    return value, string_concat("", "")
 }
 
 // Issue #392 — structured-error variant of `parse`. Returns the
@@ -116,12 +127,10 @@ parse(json_str: string) -> {
 parse_strict(json_str: string) -> (ptr, int, string) {
     value = json_parse_raw(json_str)
     if value == null {
-        kind = json_last_error_kind()
-        msg = json_last_error()
-        msg_owned = string_concat(msg, "")
-        return null, kind, msg_owned
+        return null, json_last_error_kind(),
+               string_concat(json_last_error(), "")
     }
-    return value, KIND_OK, ""
+    return value, KIND_OK, string_concat("", "")
 }
 
 // Programmatic accessors for the most recent parse failure on this
@@ -136,25 +145,34 @@ last_error_col()  -> int { return json_last_error_col()  }
 // Serialize a JSON value to a compact string. Returns (string, "") on
 // success, ("", error) on failure. The returned string is a refcounted
 // Aether string — no manual free required.
-stringify(value: ptr) -> {
+//
+// Uniform-heap shape on both positions: see `parse` for the rationale.
+stringify(value: ptr) -> (string, string) {
     raw = json_stringify_raw(value)
     if raw == null {
-        return "", "stringify failed"
+        return string_concat("", ""), string_concat("stringify failed", "")
     }
-    owned = string_concat(raw, "")
-    return owned, ""
+    return string_concat(raw, ""), string_concat("", "")
 }
 
 // Read the string payload out of a JSON value. Returns (string, "") on
 // success, ("", error) if `value` is not a JSON_STRING. The returned
 // string is an owned copy — safe to hold past a json.free of the value.
-get_string(value: ptr) -> {
+//
+// Uniform-heap shape on both positions. This is the high-volume avn
+// hot-path identified in `further-bug-fix4.md`: every `b64, _ =
+// json.get_string(jcontent)` in a commit loop is a ~133 KB
+// allocation per call. Pre-refactor the failure-path literal `""`
+// at position 0 made `function_def_returns_heap_at` AND-fold to
+// non-heap, so the destructure wrapper at the call site never set
+// `_heap_b64 = 1` and the function-exit defer-free never ran. avn's
+// 5000-commit bench retained ~666 MB just from this site.
+get_string(value: ptr) -> (string, string) {
     raw = json_get_string_raw(value)
     if raw == null {
-        return "", "not a string"
+        return string_concat("", ""), string_concat("not a string", "")
     }
-    owned = string_concat(raw, "")
-    return owned, ""
+    return string_concat(raw, ""), string_concat("", "")
 }
 
 // Look up `key` in a JSON object.
@@ -200,21 +218,26 @@ object_size(obj: ptr) -> int {
 // must not be json.free'd separately, nor used after `obj` is freed.
 // Mutating `obj` during iteration is not supported: order becomes
 // unpredictable and entries may be skipped or revisited.
-object_entry(obj: ptr, i: int) -> {
+// Uniform-heap shape on positions 0 (key) and 2 (error message): all
+// return paths use string_concat so the per-position structural
+// analyzer marks both as heap. The success path's `owned_key` is the
+// big one — iterating a large object via object_entry without this
+// would leak a key allocation per iteration. See `parse` for the
+// wider rationale.
+object_entry(obj: ptr, i: int) -> (string, ptr, string) {
     if json_type(obj) != 5 {
-        return "", null, "not an object"
+        return string_concat("", ""), null, string_concat("not an object", "")
     }
     n = json_object_size_raw(obj)
     if i < 0 {
-        return "", null, "index out of range"
+        return string_concat("", ""), null, string_concat("index out of range", "")
     }
     if i >= n {
-        return "", null, "index out of range"
+        return string_concat("", ""), null, string_concat("index out of range", "")
     }
-    raw_key = json_object_key_at(obj, i)
-    owned_key = string_concat(raw_key, "")
-    v = json_object_value_at(obj, i)
-    return owned_key, v, ""
+    return string_concat(json_object_key_at(obj, i), ""),
+           json_object_value_at(obj, i),
+           string_concat("", "")
 }
 
 // Index into a JSON array.

--- a/tests/regression/test_json_get_string_loop_leak.ae
+++ b/tests/regression/test_json_get_string_loop_leak.ae
@@ -1,0 +1,86 @@
+// Regression: a tight loop destructuring json.get_string in 0.143.0
+// retained the per-iteration owned-string allocation forever, even
+// when the destructured LHS went out of scope at the loop bottom.
+//
+// Two bugs in one site:
+//
+// 1. json.get_string was declared `-> {` (inferred return type), so
+//    the function's `node_type` was UNKNOWN/non-tuple. The per-
+//    position structural-escape analyzer at codegen_stmt.c bailed
+//    out at the `node_type->kind != TYPE_TUPLE` guard, fell back to
+//    pos_is_heap=0, and the destructure wrapper emitted
+//    `_heap_s = 0` — so the wrapper free was dead and the function-
+//    exit defer-free skipped the var.
+//
+// 2. Even with explicit `-> (string, string)`, the failure-path
+//    return was `return "", "not a string"` (bare literals at every
+//    position), so `function_def_returns_heap_at`'s AND-fold across
+//    both return paths yielded non-heap at position 0 — conservative
+//    correctness, but a leak in practice. Mixed (heap, literal)
+//    return-paths cannot be classified at compile time without a
+//    runtime header dispatch we don't have yet.
+//
+// Fix (in `std/json/module.ae`): refactor json.parse, parse_strict,
+// stringify, get_string, object_entry to use `string_concat(..., "")`
+// on *every* string return position. This makes the AND-fold yield
+// heap uniformly, the destructure wrapper fires, and the per-iteration
+// allocation gets freed on the next iteration. Tiny extra alloc on
+// the failure path (an empty heap string ~1 byte) in exchange.
+//
+// A third coordinated bug was in the destructure-site callee lookup
+// itself: `find_function_definition_by_name(gen->program, rhs->value)`
+// didn't dot-normalise, so cross-module callees (`json.get_string`)
+// never resolved to their merged-in `json_get_string` definition;
+// the per-position analyzer never ran for any cross-module call.
+// Fixed by routing `rhs->value` through `codegen_normalise_callee`
+// first, mirroring the pattern is_heap_string_expr already uses.
+//
+// What this test exercises: 5000-iteration loop of json.get_string
+// destructure. Pre-fix would retain ~5000 × 12-byte owned-string
+// allocations indefinitely. Post-fix the wrapper free fires every
+// iteration and RSS stays bounded.
+
+import std.json
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== test_json_get_string_loop_leak ===")
+
+    val, kind, msg = json.parse_strict("{\"x\":\"hello world\"}")
+    if kind != 0 {
+        println("FAIL: parse_strict failed: ${msg}")
+        exit(1)
+    }
+    xv, _ = json.object_get(val, "x")
+
+    // 5000 destructure iterations. The wrapper, if firing correctly,
+    // frees the previous `s` allocation on each reassignment.
+    // Without the fix this loop retains 5000 owned-string allocations
+    // (~5000 × ~12 bytes ≈ 60 KB) until process exit; small but the
+    // shape scales linearly with payload size in the real avn caller.
+    i = 0
+    last_first_byte = 0
+    while i < 5000 {
+        s, err = json.get_string(xv)
+        if string.length(err) != 0 {
+            println("FAIL iter ${i}: get_string returned err: ${err}")
+            exit(1)
+        }
+        if string.length(s) != 11 {
+            println("FAIL iter ${i}: expected len 11, got ${string.length(s)}")
+            exit(1)
+        }
+        last_first_byte = string.char_at(s, 0)
+        i = i + 1
+    }
+    if last_first_byte != 104 {  // 'h'
+        println("FAIL: last_first_byte expected 104, got ${last_first_byte}")
+        exit(1)
+    }
+    println("  PASS: 5000 json.get_string destructures, content preserved")
+
+    json.free(val)
+    println("=== test passed ===")
+}


### PR DESCRIPTION
… wrappers heap-uniform

Two coupled fixes that together close the residual heap-tracker gap surfaced in further-bug-fix4.md's 2026-05-10 update — avn's 5000-commit bench retained ~666 MB just from `b64, _ = json.get_string(jcontent)` because that destructure's wrapper emitted `_heap_b64 = 0` and the function-exit defer-free skipped it.

1. Cross-module callee dot-normalisation at the destructure-time analyzer lookup. function_def_returns_heap_at runs against the callee's function definition fetched by find_function_definition_by_name(gen->program, rhs->value). Source-level callees land in the AST in dotted form (`"json.get_string"`) but the merged user-fn lives in the program AST under the underscored namespace-prefixed name (`"json_get_string"`). Pre-fix the lookup missed every cross-module call, the per-position analyzer never ran, and pos_is_heap fell back to 0. Routed rhs->value through codegen_normalise_callee first — same pattern is_heap_string_expr already uses on its hardcoded fast-path lookups. Unlocks classifier-correctness for every other `module.fn`-style cross-module destructure in user code.

2. Stdlib json wrappers refactored to uniform-heap return shapes. json.parse, parse_strict, stringify, get_string, object_entry previously returned a bare literal `""` on the failure path and `string_concat(raw, "")` on the success path. The AND-fold then yielded non-heap at the affected position (conservative correctness — a mixed-shape position can't be eager-freed at compile time without a runtime header dispatch we don't have), so the destructure wrapper never fired in the success path's hot loop. Refactored to inline `string_concat(...)` at every string return position — `string_concat("", "")` on the cheap failure side, `string_concat(raw, "")` on the success side. Tiny extra allocation on the failure side in exchange for the success-side leak going away. Also inlines the `string_concat` call directly at the return position so is_heap_string_expr sees an AST_FUNCTION_CALL at the return position rather than a bare-identifier-at-return shape it can't follow back.

Regression test: 5000-iteration json.get_string destructure loop; content preserved each iteration, no per-iteration retention.

CHANGELOG entry includes an `### Upgrade notes` block — this change tightens what the heap-tracker frees, which can flip latent UAFs in downstream code that stored a json.get_string result outside the destructure scope without escape-analyzer visibility.