### PR TITLE
fix: two follow-up regressions from 0.147.0's alias-transfer fix + do…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Heap-string ownership: two follow-up regressions from 0.147.0's alias-transfer fix** (`compiler/codegen/codegen_stmt.c`, `tests/regression/test_list_add_heap_alias_escape.ae`, `tests/regression/test_destructure_reassign_over_heap_lhs.ae`). The 0.147 fix closed the bare-`B = A` alias UAF by transferring `_heap_<rhs>` to `_heap_<lhs>` in the reassignment wrapper. Two adjacent shapes the wrapper didn't reach in 0.147 surfaced afterwards.
+
+  **Regression A — alias into escape-marked LHS doesn't clear source's flag.** When LHS is marked escaped (e.g. about to be passed to `list.add` whose `ptr` parameter triggers escape-marking, or to `map.put`, or written to a struct field via #0.144's binary-expression-LHS edge), the codegen suppresses the reassignment wrapper entirely and emits a bare assignment — so the 0.147 ownership-transfer never fires. Subsequent reassignment of the source then runs `free()` against the buffer the escape recipient still references. Trigger pattern (typical "split-string, accumulate words into a list"):
+
+  ```aether
+  while string.length(rest) > 0 {
+      nl = string.index_of(rest, "\n")
+      line = ""
+      if nl < 0 {
+          line = rest                // bare-assign (line is escaped) — flag stays on rest
+          rest = ""                  // wrapper sees _heap_rest=1, frees buf
+      } else {
+          line = string.substring(rest, 0, nl)
+          rest = string.substring(rest, nl + 1, string.length(rest))
+      }
+      list.add(out, line)            // list keeps pointer to now-freed buf
+  }
+  ```
+
+  Fix: in the escaped-LHS bare-assign path, when RHS is a bare identifier referring to a heap-tracked local (and not self-assignment), also emit `_heap_<rhs> = 0` to clear the source's ownership flag. The heap flag IS the ownership token; with the source's flag cleared, its later reassignment can't fire a wrapper-free against the buffer the escape recipient still holds. Net effect: the buffer stays alive (held by the recipient), and no wrapper-free fires against it. Strictly better than the pre-fix UAF.
+
+  **Regression B — destructure-reassign-over-heap-LHS with non-string position type.** The tuple-destructure wrapper-emission gate at the AST_TUPLE_DESTRUCTURE codegen path required the destructure POSITION's type to be `TYPE_STRING`. `map.get` returns `(value: ptr, err: string)` — position 0 is `TYPE_PTR` (an opaque pointer from the map's internal storage, irrespective of the value's actual type). With `pos_is_string = false`, codegen fell through to bare assignment and the previous heap-string value's tracker flag never got cleared. The function-exit defer-free then ran `free()` against the map's borrowed storage. Trigger pattern:
+
+  ```aether
+  pkg_include = "${pkg_name}*"             // _heap_pkg_include = 1 (interp)
+  pkg_include, _ = map.get(opts, "k")      // bare assign — flag stays at 1
+  // ... fn returns ...
+  // defer-free: free(pkg_include) against map's borrowed storage → SIGABRT
+  ```
+
+  Fix: widen the wrapper-emission gate to fire whenever the LHS is heap-string-tracked, regardless of the destructure position's type. The wrapper frees the previous heap-string value (correct — the LHS owns it) and sets the new heap flag to 0 for non-string positions (borrow assumption — the destructured value is an opaque pointer from the heap-string-tracker's perspective, never a fresh-malloc'd char* the source's wrapper should claim).
+
+  Both fixes are surgical: A is one new branch in the escaped-LHS bare-assign emission; B is one widened gate condition in the tuple-destructure path. No changes to escape analysis, classifier, or function-exit defer-free machinery.
+
+  ### Upgrade notes
+
+  Both fixes close UAFs that previously surfaced as silent corruption (Regression A) or crash-on-function-exit (Regression B). No code change required in user code — the fixed compiler produces correct output for the canonical patterns that previously broke.
+
+  **What flips behaviourally:**
+
+  1. Code matching Regression A's pattern (heap-tracked local → escape-marked recipient → source reassigned) now keeps the buffer alive for the recipient's lifetime instead of freeing it mid-loop. Net result: items stored in lists / maps / struct fields via the split-loop pattern are now intact at read time.
+  2. Code matching Regression B's pattern (heap-tracked LHS reassigned via destructure with non-string position 0 — typically `var, _ = map.get(...)` after `var = "${interp}"` or `var = string.concat(...)`) no longer aborts at function exit. The previous heap value is correctly freed at the destructure site.
+  3. `aetherc --diagnose=ownership` now reports the correct `_heap_<lhs>` verdict for these two assignment shapes (was silently emitting stale flags pre-fix).
+
+  Memory-pressure footprint: Regression A's fix shifts a freed-too-early buffer to a "stays alive until recipient frees it" shape. If your recipient never frees its members (e.g. a list you keep around for the program's lifetime), this is a leak — but strictly better than the silent UAF it replaces. The escape-analysis pass's job is to surface this trade-off; the wrapper-free skip is conservative-correct by design.
+
+  No recommended pre-upgrade ladder. Sanitiser builds (ASan / Valgrind) over hot paths using the list-accumulate-strings and destructure-over-heap-var patterns will show fewer heap-use-after-free / invalid-free reports post-upgrade.
+
+### Changed
+
+- **`docs/c-interop.md` Best Practices**: added explicit note (point 3) against the "mirror stdlib symbols via `extern` declarations" anti-pattern. Older Aether had link-time issues with shared modules importing stdlib (Issue #309-era) that made the manual-extern shape look attractive as a workaround; those bugs are closed and the import-then-namespace shape (`import std.list` + `list.add(x)`) is the only supported path. Closes a doc-gap surfaced when a downstream porter (Aeocha) discovered its 68-line manual-extern block was technical debt rather than a feature.
+
 ## [0.147.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -2195,8 +2195,29 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                      * its true value. */
                     int lhs_is_tracked = (var->value &&
                                           is_heap_string_var(gen, var->value));
-                    if (pos_is_string && lhs_is_tracked) {
+                    /* Wrapper-emission gate. Fire whenever the LHS is
+                     * heap-string-tracked, regardless of whether the
+                     * destructure POSITION's type is string. The
+                     * tracker carries the LHS's previous-value-heapness
+                     * across the destructure; if the previous value was
+                     * a heap string (e.g. `pkg_include = "${name}*"`)
+                     * and the destructure now reassigns it to a non-
+                     * string position (e.g. `pkg_include, _ = map.get(...)`
+                     * where map.get returns `(ptr, string)` and
+                     * position 0 is TYPE_PTR), the wrapper must still
+                     * free the previous heap-string value and clear
+                     * the flag — otherwise the function-exit defer-
+                     * free reads the now-stale flag (=1) and runs
+                     * free() against the new non-owned pointer.
+                     *
+                     * For non-string positions the new heap flag is
+                     * always 0 (borrow assumption — the destructured
+                     * value is an opaque pointer from the heap-string-
+                     * tracker's perspective, never the source's
+                     * fresh-malloc'd char*). */
+                    if (lhs_is_tracked) {
                         int escaped = is_escaped_string_var(gen, var->value);
+                        int new_heap = pos_is_string ? pos_is_heap : 0;
                         if (escaped) {
                             fprintf(gen->output, "%s = _tup%d._%d;\n",
                                     var->value, tmp_id, j);
@@ -2209,7 +2230,7 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                                 var->value,
                                 var->value, tmp_id, j,
                                 var->value,
-                                var->value, pos_is_heap);
+                                var->value, new_heap);
                         }
                         continue;
                     }
@@ -2406,9 +2427,50 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                      * the analysis. */
                     int var_escaped = is_escaped_string_var(gen, stmt->value);
                     if (var_is_string && stmt->child_count > 0 && var_escaped) {
-                        fprintf(gen->output, "%s = ", stmt->value);
-                        generate_expression(gen, stmt->children[0]);
-                        fprintf(gen->output, ";\n");
+                        /* Escaped-LHS bare assignment. Wrapper-free is
+                         * suppressed because the var's old value is
+                         * potentially stored by a recipient (list_add,
+                         * map_put, struct field, etc.) — freeing now
+                         * would dangle the stored copy.
+                         *
+                         * Companion to the 0.147 alias-ownership-
+                         * transfer fix in the non-escaped branch: when
+                         * RHS is a bare identifier referring to a heap-
+                         * tracked local, we must ALSO clear the source's
+                         * heap flag here. Otherwise, in the canonical
+                         * "alias then reassign source" pattern —
+                         *
+                         *   line = rest                   // line escaped
+                         *   rest = ""                     // wrapper frees buf
+                         *   list_add(out, line)           // line dangles
+                         *
+                         * — the source's wrapper would free the buffer
+                         * the escape recipient (list, map, struct, …)
+                         * still references. The non-escaped path
+                         * transfers the flag from source to dest; the
+                         * escaped path can't (dest's flag is meaningless
+                         * because its defer-free is suppressed) but it
+                         * still needs to clear the source's flag for
+                         * the same reason. Net effect: the buffer stays
+                         * alive in the recipient and no wrapper-free
+                         * fires against it. */
+                        ASTNode* rhs_for_escape = stmt->children[0];
+                        int rhs_is_alias_to_heap_var =
+                            (rhs_for_escape &&
+                             rhs_for_escape->type == AST_IDENTIFIER &&
+                             rhs_for_escape->value &&
+                             is_heap_string_var(gen, rhs_for_escape->value) &&
+                             strcmp(rhs_for_escape->value, stmt->value) != 0);
+                        if (rhs_is_alias_to_heap_var) {
+                            fprintf(gen->output, "{ %s = ", stmt->value);
+                            generate_expression(gen, stmt->children[0]);
+                            fprintf(gen->output, "; _heap_%s = 0; }\n",
+                                    rhs_for_escape->value);
+                        } else {
+                            fprintf(gen->output, "%s = ", stmt->value);
+                            generate_expression(gen, stmt->children[0]);
+                            fprintf(gen->output, ";\n");
+                        }
                     } else if (var_is_string && stmt->child_count > 0) {
                         // Defensive: if the hoist somehow missed this
                         // name (e.g. promoted via a path the pre-pass

--- a/docs/c-interop.md
+++ b/docs/c-interop.md
@@ -311,9 +311,10 @@ link_flags = ["-lsqlite3"]
 
 1. **Prefer Aether's standard library** for common operations when available (e.g. `import std.list` rather than hand-rolling a linked list in C)
 2. **Use `extern` for any C function** you want to call — including standard library functions like `abs`, `atoi`, `puts`, etc.
-3. **Document your C dependencies** in your project's README
-4. **Handle errors** - C functions often return error codes
-5. **Memory management** - Be careful with C memory; use Aether's memory management where possible
+3. **Do not redeclare stdlib symbols via `extern`** as a workaround. If you find yourself writing `extern list_add_raw(list: ptr, item: ptr) -> int` (or similar mirrors of `std.list` / `std.map` / `std.string` raw functions) in your own code, stop and use `import std.list` (etc.) instead. Older Aether had link-time issues with shared modules importing stdlib (Issue #309-era) which made the manual-extern shape look attractive as a workaround; those bugs are closed. The import-then-namespace shape (`list.add(out, x)`) is the only supported path today — it gives compile-time type checking against the stdlib's declared signatures, automatic API tracking when stdlib evolves, and consistency with every other Aether codebase. Manual externs of stdlib symbols are fragile (signature drift bites at runtime), bypass type-safety, and grow into per-feature maintenance debt.
+4. **Document your C dependencies** in your project's README
+5. **Handle errors** - C functions often return error codes
+6. **Memory management** - Be careful with C memory; use Aether's memory management where possible
 
 ## Built-in primitives and the `aether_` C-symbol convention
 

--- a/tests/regression/test_destructure_reassign_over_heap_lhs.ae
+++ b/tests/regression/test_destructure_reassign_over_heap_lhs.ae
@@ -1,0 +1,98 @@
+// Regression: tuple-destructure-reassign of a variable that
+// currently holds a heap value must free the previous heap value
+// AND set the destination's heap flag according to the destructure-
+// position's heap classification — including when the destructure
+// position's type is NOT string.
+//
+// Bug shape post-0.147:
+//
+//   pkg_include = "${pkg_name}*"             // _heap_pkg_include = 1 (interp)
+//   pkg_include, _ = map.get(opts, "k")      // bare assign — wrapper skipped
+//   // ... function returns ...
+//   // function-exit defer-free: _heap_pkg_include still 1, frees a
+//   // pointer into the map's internal storage. SIGABRT.
+//
+// Root cause: the destructure-wrapper-emission gate at the AST_TUPLE_
+// DESTRUCTURE codegen path required the destructure POSITION's type
+// to be TYPE_STRING. `map.get` returns `(value: ptr, err: string)`
+// — position 0 is TYPE_PTR (the map's stored void* hot-path is the
+// value's pointer, irrespective of value's actual type). With
+// pos_is_string=false the codegen emitted bare assignment and the
+// previous heap-string value's tracker flag never got cleared. The
+// function-exit defer-free then ran free() against the map's
+// borrowed storage.
+//
+// Fix: at the destructure-wrapper-emission gate, when LHS is heap-
+// string-tracked (regardless of the destructure POSITION's type),
+// still emit the wrapper. The wrapper frees the previous heap value
+// (correct — it's a heap-string the var owns) and sets the new
+// heap flag to 0 when the destructure position is non-string
+// (borrow assumption — the buffer is opaque from the heap-string-
+// tracker's perspective, so don't claim ownership of it).
+
+import std.string
+import std.map
+
+extern exit(code: int)
+
+main() {
+    println("=== test_destructure_reassign_over_heap_lhs ===")
+
+    // Case 1: the exact minimal repro from the bug filing.
+    opts = map.new()
+    map.put(opts, "include", "monorepo.*")
+    pkg_name = "monorepo"
+    pkg_include = "${pkg_name}*"          // heap (interp result)
+    pkg_include, _ = map.get(opts, "include")
+    if string.length(pkg_include) != 10 {  // "monorepo.*"
+        println("FAIL 1: length = ${string.length(pkg_include)}, expected 10")
+        exit(1)
+    }
+    println("  PASS 1: destructure-reassign over interp-result LHS no longer aborts")
+
+    // Case 2: same shape but the previous heap value comes from
+    // string.concat instead of interpolation. Confirms the fix
+    // covers all is_heap_string_expr-classified RHS shapes, not
+    // just AST_STRING_INTERP.
+    opts2 = map.new()
+    map.put(opts2, "k", "value-from-map")
+    held = string.concat("prefix-", "old")  // heap
+    held, _ = map.get(opts2, "k")
+    if string.length(held) != 14 {
+        println("FAIL 2: length = ${string.length(held)}, expected 14")
+        exit(1)
+    }
+    println("  PASS 2: destructure-reassign over string.concat LHS")
+
+    // Case 3: 3-position tuple (struct-shape map iteration) where
+    // one position is heap and another is the previously-heap LHS.
+    // Confirms per-position classification kicks in correctly when
+    // the gate widens — non-string positions on heap LHS go to
+    // _heap=0, string positions retain their classification.
+    opts3 = map.new()
+    map.put(opts3, "x", "ex")
+    map.put(opts3, "y", "why")
+    name3 = "starter-name"      // bare literal (not heap)
+    name3 = string.concat("n=", name3)  // heap
+    name3, _ = map.get(opts3, "x")
+    if string.length(name3) != 2 {
+        println("FAIL 3: length = ${string.length(name3)}, expected 2")
+        exit(1)
+    }
+    println("  PASS 3: destructure-reassign over previously-heap var preserved across iteration")
+
+    // Case 4: regression guard — destructure-reassign on a
+    // currently-LITERAL LHS still works (_heap_lhs was 0, wrapper
+    // skips the free, sets new flag based on position).
+    opts4 = map.new()
+    map.put(opts4, "p", "borrowed")
+    lit = "starts-as-literal"
+    lit, _ = map.get(opts4, "p")
+    if string.length(lit) != 8 {
+        println("FAIL 4: length = ${string.length(lit)}, expected 8")
+        exit(1)
+    }
+    println("  PASS 4: destructure over literal LHS unchanged (no regression)")
+
+    println("=== all cases passed ===")
+}

--- a/tests/regression/test_list_add_heap_alias_escape.ae
+++ b/tests/regression/test_list_add_heap_alias_escape.ae
@@ -1,0 +1,119 @@
+// Regression: when a heap-tracked local is aliased into an escape-
+// marked LHS (typically a list element added via `list.add` whose
+// `ptr` param triggers escape-marking), the source's later
+// reassignment must not free the buffer the escape recipient
+// references.
+//
+// Bug shape post-0.147 alias-ownership-transfer fix:
+//
+//   while ... {
+//       if no-more-separators {
+//           line = rest                  // bare-assign (line is escaped)
+//           rest = ""                    // wrapper sees _heap_rest=1, frees buf
+//       } else {
+//           line = string.substring(rest, 0, sep)
+//           rest = string.substring(rest, sep + 1, ...)
+//       }
+//       list.add(out, line)              // list keeps pointer to buf
+//   }
+//
+// The 0.147 fix transferred ownership at `line = rest` in the non-
+// escaped path. When `line` is escape-marked (passed to `list.add`'s
+// `ptr` param), the wrapper is skipped entirely — so the transfer
+// doesn't fire and rest's flag stays at 1. The subsequent `rest = ""`
+// wrapper then frees the buffer the list still references.
+//
+// Fix: in the escaped-bare-assign path, when RHS is a heap-tracked
+// bare identifier, also clear `_heap_<rhs> = 0` so the source's
+// later reassignment doesn't free the buffer the escape recipient
+// (and any other aliases) still hold.
+
+import std.string
+import std.list
+
+extern exit(code: int)
+
+main() {
+    println("=== test_list_add_heap_alias_escape ===")
+
+    // Case 1: 3-line input where the last line has no trailing
+    // separator — triggers the alias branch `line = rest`.
+    content = "alpha\nbeta\ngamma"
+    out = list.new()
+    rest = content
+    while string.length(rest) > 0 {
+        nl = string.index_of(rest, "\n")
+        line = ""
+        if nl < 0 {
+            line = rest
+            rest = ""
+        } else {
+            line = string.substring(rest, 0, nl)
+            rest = string.substring(rest, nl + 1, string.length(rest))
+        }
+        list.add(out, line)
+    }
+    n = list.size(out)
+    if n != 3 {
+        println("FAIL 1: list.size = ${n}, expected 3")
+        exit(1)
+    }
+    item0, _ = list.get(out, 0)
+    item1, _ = list.get(out, 1)
+    item2, _ = list.get(out, 2)
+    if string.length(item0) != 5 || string.char_at(item0, 0) != 97 {  // 'a'
+        println("FAIL 1: item[0] = '${item0}', expected 'alpha'")
+        exit(1)
+    }
+    if string.length(item1) != 4 || string.char_at(item1, 0) != 98 {  // 'b'
+        println("FAIL 1: item[1] = '${item1}', expected 'beta'")
+        exit(1)
+    }
+    if string.length(item2) != 5 || string.char_at(item2, 0) != 103 {  // 'g'
+        println("FAIL 1: item[2] = '${item2}', expected 'gamma'")
+        exit(1)
+    }
+    println("  PASS 1: 3-line split with alias-final retains all items intact")
+
+    // Case 2: many lines, alias only at the end — confirms each
+    // substring-iteration's allocation reaches the list with
+    // matching content.
+    src2 = "1\n22\n333\n4444\nlast"
+    out2 = list.new()
+    rest2 = src2
+    while string.length(rest2) > 0 {
+        nl = string.index_of(rest2, "\n")
+        line2 = ""
+        if nl < 0 {
+            line2 = rest2
+            rest2 = ""
+        } else {
+            line2 = string.substring(rest2, 0, nl)
+            rest2 = string.substring(rest2, nl + 1, string.length(rest2))
+        }
+        list.add(out2, line2)
+    }
+    if list.size(out2) != 5 {
+        println("FAIL 2: list.size = ${list.size(out2)}, expected 5")
+        exit(1)
+    }
+    expected_lens = list.new()
+    list.add(expected_lens, 1)
+    list.add(expected_lens, 2)
+    list.add(expected_lens, 3)
+    list.add(expected_lens, 4)
+    list.add(expected_lens, 4)  // "last"
+    j = 0
+    while j < 5 {
+        got, _ = list.get(out2, j)
+        exp_len, _ = list.get(expected_lens, j)
+        if string.length(got) != exp_len {
+            println("FAIL 2: item[${j}] length = ${string.length(got)}, expected ${exp_len}")
+            exit(1)
+        }
+        j = j + 1
+    }
+    println("  PASS 2: 5-line split with alias-final preserves every item")
+
+    println("=== all cases passed ===")
+}


### PR DESCRIPTION
…cs note

Closes the two heap-string ownership edges that surfaced after 0.147.0's bare-`B = A` alias UAF fix:

REGRESSION A — alias into escape-marked LHS doesn't clear source's flag.

When LHS is marked escaped (heap-tracked local about to be passed to a `ptr` parameter — list.add, map.put, etc., or written to a struct field via 0.144's binary-expression-LHS edge), the codegen suppresses the reassignment wrapper entirely. So the 0.147 ownership-transfer never fires. Subsequent reassignment of the source then runs `free()` against the buffer the escape recipient still references. Trigger pattern is the canonical split-loop-into-list shape:

  while string.length(rest) > 0 {
      ...
      if no-more-separators {
          line = rest             // bare-assign (line escaped)
          rest = ""               // wrapper sees _heap_rest=1, frees buf
      } else {
          line = string.substring(rest, 0, sep)
          rest = string.substring(rest, sep+1, ...)
      }
      list.add(out, line)         // list points at freed buf when sep was missing
  }

Fix: in the escaped-LHS bare-assign path, when RHS is a bare identifier referring to a heap-tracked local (and not self-assignment), also emit `_heap_<rhs> = 0` to clear the source's ownership flag. The heap flag IS the ownership token; with the source's flag cleared, its later reassignment can't fire a wrapper-free against the buffer the escape recipient still holds. Buffer stays alive in the recipient. Strictly better than the pre-fix UAF.

REGRESSION B — destructure-reassign-over-heap-LHS with non-string position type.

The tuple-destructure wrapper-emission gate at the AST_TUPLE_DESTRUCTURE codegen path required the destructure POSITION's type to be TYPE_STRING. map.get returns `(value: ptr, err: string)` — position 0 is TYPE_PTR (opaque pointer from the map's internal storage). With pos_is_string= false, codegen fell through to bare assignment and the previous heap- string value's tracker flag never got cleared. The function-exit defer- free then ran free() against the map's borrowed storage. Trigger:

  pkg_include = "${pkg_name}*"             // heap (interp)
  pkg_include, _ = map.get(opts, "k")      // bare assign, flag stays at 1
  // fn returns, defer-free calls free() against map's borrow → SIGABRT

Fix: widen the wrapper-emission gate to fire whenever the LHS is heap- string-tracked, regardless of the destructure position's type. The wrapper frees the previous heap-string value (correct — the LHS owns it) and sets the new heap flag to 0 for non-string positions (borrow assumption — the destructured value is an opaque pointer from the heap-string-tracker's perspective, never a fresh-malloc'd char* the source's wrapper should claim).

DOCS — c-interop.md Best Practices §3

Added explicit note against the "mirror stdlib symbols via extern declarations" anti-pattern. Older Aether had link-time issues with shared modules importing stdlib (Issue #309-era) that made the manual- extern shape look attractive as a workaround; those bugs are closed and the import-then-namespace shape (import std.list + list.add(x)) is the only supported path. Closes a doc-gap surfaced when a downstream porter discovered its 68-line manual-extern block was technical debt.

TESTS

Two new regression files. test_list_add_heap_alias_escape.ae exercises the 3-line and 5-line split-loop patterns. test_destructure_reassign_ over_heap_lhs.ae covers four cases: interp-result LHS, string.concat LHS, previously-heap LHS, and a literal-LHS no-regression guard.

Both fixes are surgical: A is one new branch in the escaped-LHS bare- assign emission; B is one widened gate condition in the tuple-destructure path. No changes to escape analysis, classifier, or function-exit defer-free machinery.