### PR TITLE
fix(stdlib): route 23 T1 untrusted-size allocations through aether_caps_malloc

### DIFF
--- a/std/cryptography/aether_cryptography.c
+++ b/std/cryptography/aether_cryptography.c
@@ -1,5 +1,6 @@
 #include "aether_cryptography.h"
 #include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -105,13 +106,18 @@ char* cryptography_base64_encode_raw(const char* data, int length) {
     const unsigned char* bytes = cryptography_unwrap_bytes(data, length, &want);
     if (want > 0 && !bytes) return NULL;
 
-    /* EVP_EncodeBlock writes ((n+2)/3)*4 bytes plus a NUL. */
+    /* EVP_EncodeBlock writes ((n+2)/3)*4 bytes plus a NUL.
+     * Cap-aware (#343): the input length is caller-supplied and can
+     * be plugin-host-controlled in --emit=lib scenarios. Gate the
+     * allocation. The caller frees with plain `free()` per the
+     * caller-owned-return contract (aether_resource_caps.h:89-94);
+     * the counter drifts up on these paths, same as string_concat. */
     size_t out_cap = ((want + 2) / 3) * 4 + 1;
-    char* out = (char*)malloc(out_cap);
+    char* out = (char*)aether_caps_malloc(out_cap);
     if (!out) return NULL;
 
     int written = EVP_EncodeBlock((unsigned char*)out, bytes, (int)want);
-    if (written < 0) { free(out); return NULL; }
+    if (written < 0) { aether_caps_free(out, out_cap); return NULL; }
     out[written] = '\0';
 
     /* Strip trailing '=' padding for the unpadded contract. */
@@ -133,12 +139,14 @@ char* cryptography_base64_encode_padded_raw(const char* data, int length) {
     const unsigned char* bytes = cryptography_unwrap_bytes(data, length, &want);
     if (want > 0 && !bytes) return NULL;
 
+    /* Cap-aware (#343): same gating rationale as the unpadded
+     * sibling above. */
     size_t out_cap = ((want + 2) / 3) * 4 + 1;
-    char* out = (char*)malloc(out_cap);
+    char* out = (char*)aether_caps_malloc(out_cap);
     if (!out) return NULL;
 
     int written = EVP_EncodeBlock((unsigned char*)out, bytes, (int)want);
-    if (written < 0) { free(out); return NULL; }
+    if (written < 0) { aether_caps_free(out, out_cap); return NULL; }
     out[written] = '\0';
     return out;
 }
@@ -148,13 +156,16 @@ char* cryptography_base64_encode_padded_raw(const char* data, int length) {
  * different threads don't clobber each other; lifetime is until the
  * next call on the same thread. Aether-side wrappers are expected to
  * copy the bytes out via string_new_with_length before calling
- * back into the C side. */
+ * back into the C side. Cap tracked alongside (#343) so the release
+ * path correctly decrements the cap counter rather than drifting. */
 static __thread unsigned char* g_b64_buf = NULL;
+static __thread size_t         g_b64_cap = 0;
 static __thread int            g_b64_len = 0;
 
 static void release_b64_locked(void) {
-    if (g_b64_buf) free(g_b64_buf);
+    if (g_b64_buf) aether_caps_free(g_b64_buf, g_b64_cap);
     g_b64_buf = NULL;
+    g_b64_cap = 0;
     g_b64_len = 0;
 }
 
@@ -172,29 +183,34 @@ int cryptography_base64_decode_raw(const char* b64) {
         /* Decoding "" is a valid request — yields zero bytes. Allocate
          * a 1-byte buffer so the caller can distinguish "decoded 0
          * bytes" from "no data" via the length accessor. */
-        g_b64_buf = (unsigned char*)malloc(1);
+        g_b64_buf = (unsigned char*)aether_caps_malloc(1);
         if (!g_b64_buf) return 0;
+        g_b64_cap = 1;
         g_b64_buf[0] = 0;
         g_b64_len = 0;
         return 1;
     }
 
     /* EVP_DecodeBlock requires the input length to be a multiple of
-     * 4. Pad up with '=' if the caller passed an unpadded string. */
+     * 4. Pad up with '=' if the caller passed an unpadded string.
+     * Cap-aware (#343): input length is untrusted in plugin-host
+     * scenarios; both the pad-up buffer and the decode-output buffer
+     * are gated and freed through the caps allocator. */
     size_t padded_len = (in_len + 3) / 4 * 4;
-    unsigned char* padded = (unsigned char*)malloc(padded_len);
+    unsigned char* padded = (unsigned char*)aether_caps_malloc(padded_len);
     if (!padded) return 0;
     memcpy(padded, in, in_len);
     for (size_t i = in_len; i < padded_len; i++) padded[i] = '=';
 
     /* Output is at most 3/4 of input. */
     size_t out_cap = (padded_len / 4) * 3;
-    unsigned char* out = (unsigned char*)malloc(out_cap > 0 ? out_cap : 1);
-    if (!out) { free(padded); return 0; }
+    size_t out_alloc = out_cap > 0 ? out_cap : 1;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(out_alloc);
+    if (!out) { aether_caps_free(padded, padded_len); return 0; }
 
     int written = EVP_DecodeBlock(out, padded, (int)padded_len);
-    free(padded);
-    if (written < 0) { free(out); return 0; }
+    aether_caps_free(padded, padded_len);
+    if (written < 0) { aether_caps_free(out, out_alloc); return 0; }
 
     /* Trim trailing zero bytes that correspond to the padding we
      * added. EVP_DecodeBlock decodes '=' as 0, so the original
@@ -210,6 +226,7 @@ int cryptography_base64_decode_raw(const char* b64) {
     written -= trim;
 
     g_b64_buf = out;
+    g_b64_cap = out_alloc;
     g_b64_len = written;
     return 1;
 }

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -2,6 +2,7 @@
 #include "../../runtime/config/aether_optimization_config.h"
 #include "../../runtime/utils/aether_compiler.h"
 #include "../../runtime/aether_sandbox.h"
+#include "../../runtime/aether_resource_caps.h"
 #include "../string/aether_string.h"
 
 #if !AETHER_HAS_FILESYSTEM
@@ -183,9 +184,13 @@ char* file_read_all_raw(File* file) {
     if (size < 0) return NULL;
     fseek(fp, 0, SEEK_SET);
 
-    char* buffer = (char*)malloc(size + 1);
+    /* Cap-aware (#343): file size is OS-supplied and unbounded.
+     * Caller frees with plain libc free per the caller-owned-return
+     * contract — counter drifts up on this path, same as
+     * string_concat. */
+    char* buffer = (char*)aether_caps_malloc((size_t)size + 1);
     if (!buffer) return NULL;
-    size_t read = fread(buffer, 1, size, fp);
+    size_t read = fread(buffer, 1, (size_t)size, fp);
     buffer[read] = '\0';
 
     return buffer;
@@ -677,12 +682,15 @@ char* fs_read_binary_raw(const char* path, int* out_len) {
     // Allocate size+1 so we can append a NUL past the end — handy for
     // callers who know the content is text and want to treat it as a
     // C string. The `out_len` byte count does NOT include this NUL.
-    char* buf = (char*)malloc((size_t)size + 1);
+    // Cap-aware (#343): same rationale as file_read_all_raw above —
+    // unbounded file size, caller-owned return.
+    size_t alloc_cap = (size_t)size + 1;
+    char* buf = (char*)aether_caps_malloc(alloc_cap);
     if (!buf) { fclose(fp); return NULL; }
 
     size_t read = (size > 0) ? fread(buf, 1, (size_t)size, fp) : 0;
     fclose(fp);
-    if (read != (size_t)size) { free(buf); return NULL; }
+    if (read != (size_t)size) { aether_caps_free(buf, alloc_cap); return NULL; }
 
     buf[size] = '\0';
     if (out_len) *out_len = (int)size;

--- a/std/http/middleware/aether_middleware.c
+++ b/std/http/middleware/aether_middleware.c
@@ -13,6 +13,7 @@
 // wrappers in std/http/middleware/module.ae allocate the user_data
 // and register the middleware with the server.
 #include "aether_middleware.h"
+#include "../../../runtime/aether_resource_caps.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -626,7 +627,12 @@ static unsigned char* gzip_compress(const unsigned char* in_data, size_t in_len,
         return NULL;
     }
     uLong bound = deflateBound(&strm, (uLong)in_len);
-    unsigned char* out = (unsigned char*)malloc(bound > 0 ? bound : 1);
+    /* Cap-aware (#343): bound is derived from in_len which is the
+     * response body length — caller-controlled but plugin-reachable.
+     * Caller frees with plain libc free per the caller-owned-return
+     * contract (aether_resource_caps.h:89-94). */
+    size_t alloc_cap = bound > 0 ? (size_t)bound : 1;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(alloc_cap);
     if (!out) { deflateEnd(&strm); return NULL; }
     strm.next_in = (Bytef*)in_data;
     strm.avail_in = (uInt)in_len;
@@ -635,7 +641,7 @@ static unsigned char* gzip_compress(const unsigned char* in_data, size_t in_len,
     int rc = deflate(&strm, Z_FINISH);
     if (rc != Z_STREAM_END) {
         deflateEnd(&strm);
-        free(out);
+        aether_caps_free(out, alloc_cap);
         return NULL;
     }
     *out_len = strm.total_out;

--- a/std/http/proxy/aether_proxy_cache.c
+++ b/std/http/proxy/aether_proxy_cache.c
@@ -26,6 +26,7 @@
  */
 
 #include "aether_proxy_internal.h"
+#include "../../../runtime/aether_resource_caps.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -84,7 +85,9 @@ static void entry_free_one(AetherProxyCacheEntry* e) {
         for (int i = 0; i < e->header_count; i++) free(e->header_values[i]);
         free(e->header_values);
     }
-    free(e->body);
+    /* Cap-aware (#343): body was alloc'd via aether_caps_malloc;
+     * the recorded length is the byte count for caps accounting. */
+    aether_caps_free(e->body, (size_t)e->body_length);
     free(e->etag);
     free(e->last_modified);
     free(e->vary_header);
@@ -465,7 +468,12 @@ void aether_proxy_cache_store(AetherProxyCache* cache,
     e->last_modified = extract_header(response_headers, "Last-Modified");
 
     if (body && body_length > 0) {
-        e->body = (char*)malloc((size_t)body_length);
+        /* Cap-aware (#343): cached upstream response body. The
+         * body_length is the upstream's Content-Length — untrusted.
+         * Cache entry's e->body_length is the byte count
+         * aether_caps_free needs at the matching free site (see
+         * the cache-entry destructor a few lines above). */
+        e->body = (char*)aether_caps_malloc((size_t)body_length);
         if (e->body) {
             memcpy(e->body, body, (size_t)body_length);
             e->body_length = body_length;

--- a/std/http/server/vcr/aether_vcr.c
+++ b/std/http/server/vcr/aether_vcr.c
@@ -53,6 +53,7 @@
 #include <string.h>
 
 #include "../../../string/aether_string.h"
+#include "../../../../runtime/aether_resource_caps.h"
 
 /* --- These come from std.http.server's request/response surface. --- */
 extern const char* http_request_method(void* req);
@@ -314,8 +315,13 @@ static int decode_base64_body(const char* src, unsigned char** out, int* out_len
     *out = NULL;
     *out_len = 0;
 
+    /* Cap-aware (#343): src is tape content (untrusted in plugin-host
+     * scenarios). Both the cleanup buffer and the decoded-output
+     * buffer are gated; out-buffer is handed back to the caller who
+     * releases via plain libc free (caller-owned-return drift). */
     size_t src_len = strlen(src);
-    unsigned char* clean = (unsigned char*)malloc(src_len + 4);
+    size_t clean_cap = src_len + 4;
+    unsigned char* clean = (unsigned char*)aether_caps_malloc(clean_cap);
     if (!clean) return 0;
 
     size_t clen = 0;
@@ -326,9 +332,10 @@ static int decode_base64_body(const char* src, unsigned char** out, int* out_len
     }
     while (clen % 4 != 0) clean[clen++] = '=';
 
-    unsigned char* buf = (unsigned char*)malloc((clen / 4) * 3 + 1);
+    size_t buf_cap = (clen / 4) * 3 + 1;
+    unsigned char* buf = (unsigned char*)aether_caps_malloc(buf_cap);
     if (!buf) {
-        free(clean);
+        aether_caps_free(clean, clean_cap);
         return 0;
     }
 
@@ -339,13 +346,13 @@ static int decode_base64_body(const char* src, unsigned char** out, int* out_len
         int v2 = b64_value(clean[i + 2]);
         int v3 = b64_value(clean[i + 3]);
         if (v0 < 0 || v1 < 0 || v2 == -1 || v3 == -1) {
-            free(clean);
-            free(buf);
+            aether_caps_free(clean, clean_cap);
+            aether_caps_free(buf, buf_cap);
             return 0;
         }
         if (v2 == -2 && v3 != -2) {
-            free(clean);
-            free(buf);
+            aether_caps_free(clean, clean_cap);
+            aether_caps_free(buf, buf_cap);
             return 0;
         }
 
@@ -358,7 +365,7 @@ static int decode_base64_body(const char* src, unsigned char** out, int* out_len
         }
     }
 
-    free(clean);
+    aether_caps_free(clean, clean_cap);
     buf[off] = '\0';
     *out = buf;
     *out_len = (int)off;
@@ -370,6 +377,10 @@ AetherString* vcr_decode_base64_body_raw(const char* src) {
     int decoded_len = 0;
     if (!decode_base64_body(src, &decoded, &decoded_len)) return NULL;
     AetherString* result = string_new_with_length((const char*)decoded, (size_t)decoded_len);
+    /* decoded was allocated by decode_base64_body via aether_caps_malloc
+     * but its capacity isn't threaded back here; the libc-compatible-
+     * pointer contract (aether_resource_caps.h:89-94) keeps the free
+     * heap-safe at the cost of cap-counter drift on this path. */
     free(decoded);
     return result;
 }
@@ -1377,6 +1388,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
 
     const char* body_for_tape = body;
     char* decoded_body = NULL;
+    size_t decoded_body_cap = 0;
     if (upstream_gzip) {
         if (zlib_backend_available() == 0) {
             free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
@@ -1393,7 +1405,11 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
             return;
         }
         int body_for_tape_len = zlib_get_inflate_length();
-        decoded_body = (char*)malloc((size_t)body_for_tape_len + 1);
+        /* Cap-aware (#343): VCR record-mode decodes the upstream's
+         * gzip response into a local copy. Untrusted upstream length
+         * drives the allocation; gate via the caps allocator. */
+        decoded_body_cap = (size_t)body_for_tape_len + 1;
+        decoded_body = (char*)aether_caps_malloc(decoded_body_cap);
         if (!decoded_body) {
             zlib_release_inflate();
             free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
@@ -1410,7 +1426,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
 
     char* recorded_path = build_recorded_path(live_req);
     if (!recorded_path) {
-        free(decoded_body);
+        aether_caps_free(decoded_body, decoded_body_cap);
         free(caller_headers); free(resp_headers); free(content_type); free(req_headers);
         http_response_free(cresp);
         free(url);
@@ -1426,7 +1442,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
                                          req_headers,
                                          live_req->body ? live_req->body : "");
     if (!ok) {
-        free(decoded_body);
+        aether_caps_free(decoded_body, decoded_body_cap);
         free(caller_headers);
         free(resp_headers);
         free(content_type);
@@ -1447,7 +1463,7 @@ static void vcr_record_dispatch(void* req, void* res, void* ud) {
     g_last_kind = VCR_KIND_OK;
     g_last_index = g_tape_n - 1;
 
-    free(decoded_body);
+    aether_caps_free(decoded_body, decoded_body_cap);
     free(caller_headers);
     free(resp_headers);
     free(content_type);

--- a/std/io/aether_io.c
+++ b/std/io/aether_io.c
@@ -1,5 +1,6 @@
 #include "aether_io.h"
 #include "../../runtime/config/aether_optimization_config.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #if !AETHER_HAS_FILESYSTEM
 // Console I/O always works; file ops return errors
@@ -119,8 +120,11 @@ char* io_read_file_raw(const char* path) {
     if (size < 0) { fclose(file); return NULL; }
     fseek(file, 0, SEEK_SET);
 
-    // Read file
-    char* buffer = (char*)malloc(size + 1);
+    // Read file. Cap-aware (#343): file size is OS-supplied and
+    // unbounded; gate the allocation. The caller frees with plain
+    // libc `free()` per the caller-owned-return contract — the
+    // counter drifts up on the cold path, same as string_concat.
+    char* buffer = (char*)aether_caps_malloc((size_t)size + 1);
     if (!buffer) { fclose(file); return NULL; }
     size_t read = fread(buffer, 1, size, file);
     buffer[read] = '\0';
@@ -319,7 +323,12 @@ _tuple_ptrintstr_io io_fd_read_n_tuple(int fd, int n) {
     if (fd < 0) { out._2 = "invalid fd"; return out; }
     if (n <= 0)   return out;  /* empty read is a no-op */
 
-    char* buf = (char*)malloc((size_t)n);
+    /* Cap-aware (#343): `n` is caller-supplied (untrusted in plugin-
+     * host scenarios) — gate the allocation. Buffer is freed inside
+     * this function via the matched aether_caps_free path; the cap
+     * counter stays at current-usage. */
+    size_t buf_cap = (size_t)n;
+    char* buf = (char*)aether_caps_malloc(buf_cap);
     if (!buf) { out._2 = "out of memory"; return out; }
 
     int total = 0;
@@ -334,7 +343,7 @@ _tuple_ptrintstr_io io_fd_read_n_tuple(int fd, int n) {
 #ifndef _WIN32
             if (errno == EINTR) continue;
 #endif
-            free(buf);
+            aether_caps_free(buf, buf_cap);
             out._2 = "read failed";
             return out;
         }
@@ -344,7 +353,7 @@ _tuple_ptrintstr_io io_fd_read_n_tuple(int fd, int n) {
     /* Replace the placeholder empty AetherString with one carrying
      * the actual bytes (binary-safe via explicit length). */
     AetherString* s = string_new_with_length(buf, (size_t)total);
-    free(buf);
+    aether_caps_free(buf, buf_cap);
     if (!s) { out._2 = "out of memory"; return out; }
     /* Drop the placeholder — string_empty() returned a refcount=1
      * object we'd otherwise leak. */
@@ -361,9 +370,12 @@ _tuple_ptrstr_io io_fd_read_line_tuple(int fd) {
     if (fd < 0) { out._1 = "invalid fd"; return out; }
 
     /* Grow-on-demand line buffer. Initial 256 bytes covers the common
-     * case (svn dump record lines are short); we double when full. */
+     * case (svn dump record lines are short); we double when full.
+     * Cap-aware (#343): line length is unbounded from the wire; gate
+     * each grow. Frees go through aether_caps_free with the most-
+     * recent capacity so the counter tracks current-usage. */
     size_t cap = 256;
-    char* buf = (char*)malloc(cap);
+    char* buf = (char*)aether_caps_malloc(cap);
     if (!buf) { out._1 = "out of memory"; return out; }
     size_t len = 0;
 
@@ -381,7 +393,7 @@ _tuple_ptrstr_io io_fd_read_line_tuple(int fd) {
              * partial line — server-side dump streams sometimes end
              * without a trailing '\n' on the last record. */
             if (len == 0) {
-                free(buf);
+                aether_caps_free(buf, cap);
                 return out;  /* both fields already "" */
             }
             break;
@@ -390,15 +402,15 @@ _tuple_ptrstr_io io_fd_read_line_tuple(int fd) {
 #ifndef _WIN32
             if (errno == EINTR) continue;
 #endif
-            free(buf);
+            aether_caps_free(buf, cap);
             out._1 = "read failed";
             return out;
         }
         if (c == '\n') break;
         if (len + 1 >= cap) {
             size_t new_cap = cap * 2;
-            char* nb = (char*)realloc(buf, new_cap);
-            if (!nb) { free(buf); out._1 = "out of memory"; return out; }
+            char* nb = (char*)aether_caps_realloc(buf, cap, new_cap);
+            if (!nb) { aether_caps_free(buf, cap); out._1 = "out of memory"; return out; }
             buf = nb;
             cap = new_cap;
         }
@@ -409,7 +421,7 @@ _tuple_ptrstr_io io_fd_read_line_tuple(int fd) {
     if (len > 0 && buf[len - 1] == '\r') len--;
 
     AetherString* s = string_new_with_length(buf, len);
-    free(buf);
+    aether_caps_free(buf, cap);
     if (!s) { out._1 = "out of memory"; return out; }
     string_release(out._0);
     out._0 = (void*)s;

--- a/std/json/aether_json.c
+++ b/std/json/aether_json.c
@@ -39,6 +39,7 @@
 // tests, regression tests, and callers continue to work unchanged.
 
 #include "aether_json.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -195,7 +196,12 @@ static size_t arena_align_up(size_t n) {
 
 static ArenaChunk* arena_new_chunk(size_t cap) {
     // Allocate the header + payload in one malloc. cap is payload bytes.
-    ArenaChunk* c = (ArenaChunk*)malloc(sizeof(ArenaChunk) + cap);
+    // Cap-aware (#343): JSON parser arena chunks scale with input
+    // size; an untrusted document drives cumulative arena size. The
+    // chunk's c->cap field stores the payload bytes so the matching
+    // free recovers `sizeof(ArenaChunk) + c->cap` for the counter
+    // decrement.
+    ArenaChunk* c = (ArenaChunk*)aether_caps_malloc(sizeof(ArenaChunk) + cap);
     if (!c) return NULL;
     c->next = NULL;
     c->cap = cap;
@@ -204,10 +210,10 @@ static ArenaChunk* arena_new_chunk(size_t cap) {
 }
 
 static Arena* arena_create(void) {
-    Arena* a = (Arena*)malloc(sizeof(Arena));
+    Arena* a = (Arena*)aether_caps_malloc(sizeof(Arena));
     if (!a) return NULL;
     a->head = arena_new_chunk(ARENA_INITIAL_CHUNK);
-    if (!a->head) { free(a); return NULL; }
+    if (!a->head) { aether_caps_free(a, sizeof(Arena)); return NULL; }
     a->tail = a->head;
     return a;
 }
@@ -217,10 +223,10 @@ static void arena_destroy(Arena* a) {
     ArenaChunk* c = a->head;
     while (c) {
         ArenaChunk* next = c->next;
-        free(c);
+        aether_caps_free(c, sizeof(ArenaChunk) + c->cap);
         c = next;
     }
-    free(a);
+    aether_caps_free(a, sizeof(Arena));
 }
 
 static void* arena_alloc(Arena* a, size_t n) {
@@ -1516,12 +1522,14 @@ static void heap_free_tree(JsonValue* v) {
         // arena_destroy so we don't read freed bytes.
         int heap_struct = (v->flags & JV_FLAG_HEAP_STRUCT) != 0;
         arena_destroy(v->arena);
-        if (heap_struct) free(v);
+        if (heap_struct) aether_caps_free(v, sizeof(JsonValue));
         return;
     }
     switch (v->type) {
         case JSON_STRING:
-            free((void*)v->data.str.data);
+            /* Pair with json_create_string's aether_caps_malloc. */
+            aether_caps_free((void*)v->data.str.data,
+                             (size_t)v->data.str.length + 1);
             break;
         case JSON_ARRAY:
             for (uint32_t i = 0; i < v->data.arr.count; i++) {
@@ -1546,7 +1554,8 @@ static void heap_free_tree(JsonValue* v) {
         default:
             break;
     }
-    free(v);
+    /* Pair with heap_new's aether_caps_malloc. */
+    aether_caps_free(v, sizeof(JsonValue));
 }
 
 int json_array_add_raw(JsonValue* arr, JsonValue* value) {
@@ -1614,7 +1623,10 @@ int json_object_set_raw(JsonValue* obj, const char* key, JsonValue* value) {
 // ---------------------------------------------------------------------------
 
 static JsonValue* heap_new(uint8_t type) {
-    JsonValue* v = (JsonValue*)malloc(sizeof(JsonValue));
+    /* Cap-aware (#343): heap-tree JsonValue used by the json.create_*
+     * builder API. Fixed-size struct so the matching free in
+     * heap_free_tree passes sizeof(JsonValue). */
+    JsonValue* v = (JsonValue*)aether_caps_malloc(sizeof(JsonValue));
     if (!v) return NULL;
     memset(v, 0, sizeof(JsonValue));
     v->type = type;
@@ -1641,9 +1653,12 @@ JsonValue* json_create_number(double n) {
 JsonValue* json_create_string(const char* s) {
     JsonValue* v = heap_new(JSON_STRING);
     if (!v) return NULL;
+    /* Cap-aware (#343): input string is caller-controlled, plugin-
+     * host-reachable. heap_free_tree's JSON_STRING branch passes
+     * v->data.str.length + 1 back to the caps allocator. */
     size_t len = s ? strlen(s) : 0;
-    char* copy = (char*)malloc(len + 1);
-    if (!copy) { free(v); return NULL; }
+    char* copy = (char*)aether_caps_malloc(len + 1);
+    if (!copy) { aether_caps_free(v, sizeof(JsonValue)); return NULL; }
     if (len && s) memcpy(copy, s, len);
     copy[len] = '\0';
     v->data.str.data = copy;
@@ -1675,7 +1690,7 @@ void json_free(JsonValue* v) {
         int heap_struct = (v->flags & JV_FLAG_HEAP_STRUCT) != 0;
         Arena* a = v->arena;
         arena_destroy(a);
-        if (heap_struct) free(v);
+        if (heap_struct) aether_caps_free(v, sizeof(JsonValue));
         return;
     }
     // Heap path — no arena ever attached.

--- a/std/lzf/aether_lzf.c
+++ b/std/lzf/aether_lzf.c
@@ -1,6 +1,7 @@
 #include "aether_lzf.h"
 #include "lzf.h"
 #include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #include <limits.h>
 #include <stdlib.h>
@@ -17,18 +18,31 @@ static inline const unsigned char* lzf_unwrap_bytes(const char* data, int length
     return (const unsigned char*)data;
 }
 
+/* Resource-caps tracking (#343): like the zlib path, length and
+ * capacity differ when the LZF compressor produces a result smaller
+ * than its safety bound; `_cap` is what aether_caps_free needs.  */
 static _Thread_local unsigned char* tls_compress_buf = NULL;
-static _Thread_local int tls_compress_len = 0;
+static _Thread_local size_t         tls_compress_cap = 0;
+static _Thread_local int            tls_compress_len = 0;
 static _Thread_local unsigned char* tls_decompress_buf = NULL;
-static _Thread_local int tls_decompress_len = 0;
+static _Thread_local size_t         tls_decompress_cap = 0;
+static _Thread_local int            tls_decompress_len = 0;
 
 static void free_compress_tls(void) {
-    if (tls_compress_buf) { free(tls_compress_buf); tls_compress_buf = NULL; }
+    if (tls_compress_buf) {
+        aether_caps_free(tls_compress_buf, tls_compress_cap);
+        tls_compress_buf = NULL;
+    }
+    tls_compress_cap = 0;
     tls_compress_len = 0;
 }
 
 static void free_decompress_tls(void) {
-    if (tls_decompress_buf) { free(tls_decompress_buf); tls_decompress_buf = NULL; }
+    if (tls_decompress_buf) {
+        aether_caps_free(tls_decompress_buf, tls_decompress_cap);
+        tls_decompress_buf = NULL;
+    }
+    tls_decompress_cap = 0;
     tls_decompress_len = 0;
 }
 
@@ -55,18 +69,20 @@ int lzf_try_compress(const char* data, int length) {
     }
 
     unsigned int bound = LZF_MAX_COMPRESSED_SIZE((unsigned int)in_len);
-    unsigned char* out = (unsigned char*)malloc(bound);
+    size_t alloc_cap = (size_t)bound;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(alloc_cap);
     if (!out) return 0;
 
     unsigned int out_len = lzf_compress(in, (unsigned int)in_len, out, bound);
     if (out_len == 0) {
         /* Incompressible payload didn't fit in the bound. Caller must
          * fall back to storing data uncompressed (with their own flag). */
-        free(out);
+        aether_caps_free(out, alloc_cap);
         return 0;
     }
 
     tls_compress_buf = out;
+    tls_compress_cap = alloc_cap;
     tls_compress_len = (int)out_len;
     return 1;
 }
@@ -91,16 +107,18 @@ int lzf_try_decompress(const char* data, int length, int output_length) {
     }
     if (in_len == 0) return 0;
 
-    unsigned char* out = (unsigned char*)malloc((size_t)output_length);
+    size_t alloc_cap = (size_t)output_length;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(alloc_cap);
     if (!out) return 0;
 
     unsigned int out_len = lzf_decompress(in, (unsigned int)in_len, out, (unsigned int)output_length);
     if (out_len != (unsigned int)output_length) {
-        free(out);
+        aether_caps_free(out, alloc_cap);
         return 0;
     }
 
     tls_decompress_buf = out;
+    tls_decompress_cap = alloc_cap;
     tls_decompress_len = (int)out_len;
     return 1;
 }

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -1,5 +1,6 @@
 #include "aether_http.h"
 #include "../../runtime/config/aether_optimization_config.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #if !AETHER_HAS_NETWORKING
 HttpResponse* http_get_raw(const char* u) { (void)u; return NULL; }
@@ -349,8 +350,11 @@ int http_request_set_header_raw(HttpRequest* req, const char* name, const char* 
 
 int http_request_set_body_raw(HttpRequest* req, const char* body, int len, const char* content_type) {
     if (!req || len < 0) return -1;
-    /* Replace any prior body. */
-    free(req->body);         req->body = NULL; req->body_len = 0;
+    /* Replace any prior body. Cap-aware (#343): req->body_len holds
+     * the original allocation size and is reset to 0 below before
+     * the next aether_caps_malloc. */
+    aether_caps_free(req->body, (size_t)req->body_len);
+    req->body = NULL; req->body_len = 0;
     free(req->content_type); req->content_type = NULL;
     if (len > 0) {
         if (!body) return -1;
@@ -366,7 +370,10 @@ int http_request_set_body_raw(HttpRequest* req, const char* body, int len, const
         if (is_aether_string(body)) {
             src = ((const AetherString*)body)->data;
         }
-        req->body = (char*)malloc((size_t)len);
+        /* Cap-aware (#343): caller-supplied length, untrusted on
+         * --emit=lib paths. The matching aether_caps_free passes
+         * req->body_len as the size. */
+        req->body = (char*)aether_caps_malloc((size_t)len);
         if (!req->body) return -1;
         memcpy(req->body, src, (size_t)len);
         req->body_len = len;
@@ -394,7 +401,10 @@ void http_request_free_raw(HttpRequest* req) {
     if (!req) return;
     free(req->method);
     free(req->url);
-    free(req->body);
+    /* Body was alloc'd via aether_caps_malloc in
+     * http_request_set_body_raw; pair the free with the recorded
+     * length so cap accounting stays at current-usage. */
+    aether_caps_free(req->body, (size_t)req->body_len);
     free(req->content_type);
     HttpHeader* h = req->headers;
     while (h) {

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -1,5 +1,6 @@
 #include "aether_http_server.h"
 #include "../../runtime/config/aether_optimization_config.h"
+#include "../../runtime/aether_resource_caps.h"
 
 /* HTTP/2 (#260 Tier 2). Pull in the wrapper header up front so
  * handle_one_request's h2c-upgrade dispatch (RFC 7540 §3.2) can
@@ -384,7 +385,12 @@ static int send_response_with_optional_sendfile(HttpConn* conn,
          * (sendfile) has no such limit. */
         long long size = res->sendfile_size;
         if (size >= 0 && size <= (long long)0x7FFFFFFF) {
-            char* buf = (char*)malloc((size_t)size + 1);
+            /* Cap-aware (#343): file size is OS-supplied and
+             * unbounded from the plugin host's perspective; gate via
+             * the caps allocator. The matching free in
+             * http_server_response_free passes res->body_cap. */
+            size_t buf_cap = (size_t)size + 1;
+            char* buf = (char*)aether_caps_malloc(buf_cap);
             if (buf) {
                 size_t total = 0;
 #ifndef _WIN32
@@ -398,11 +404,12 @@ static int send_response_with_optional_sendfile(HttpConn* conn,
 #endif
                 if (total == (size_t)size) {
                     buf[size] = '\0';
-                    free(res->body);
+                    aether_caps_free(res->body, res->body_cap);
                     res->body = buf;
                     res->body_length = (size_t)size;
+                    res->body_cap = buf_cap;
                 } else {
-                    free(buf);
+                    aether_caps_free(buf, buf_cap);
                 }
             }
         }
@@ -1522,23 +1529,32 @@ void http_response_set_body_n(HttpServerResponse* res, const char* body, int len
     if (length < 0) return;
     if (length > 0 && !body) return;
 
-    free(res->body);
+    /* Cap-aware (#343): res->body's allocation size is stored in
+     * res->body_length (we always alloc length+1 but the +1 NUL
+     * terminator is included in cap accounting too — track the
+     * full allocation in res->body_cap so caps_free recovers the
+     * exact byte count regardless of how the body was set). */
+    aether_caps_free(res->body, res->body_cap);
     if (length == 0) {
         res->body = NULL;
         res->body_length = 0;
+        res->body_cap = 0;
     } else {
         const char* src = body;
         if (is_aether_string(body)) {
             src = ((const AetherString*)body)->data;
         }
-        res->body = (char*)malloc((size_t)length + 1);
+        size_t alloc_cap = (size_t)length + 1;
+        res->body = (char*)aether_caps_malloc(alloc_cap);
         if (!res->body) {
             res->body_length = 0;
+            res->body_cap = 0;
             return;
         }
         memcpy(res->body, src, (size_t)length);
         res->body[length] = '\0';
         res->body_length = (size_t)length;
+        res->body_cap = alloc_cap;
     }
 
     char len_str[32];
@@ -1594,7 +1610,9 @@ void http_server_response_free(HttpServerResponse* res) {
     if (!res) return;
 
     free(res->status_text);
-    free(res->body);
+    /* Cap-aware (#343): body was alloc'd via aether_caps_malloc
+     * (see http_response_set_body_n / sendfile-fallback read). */
+    aether_caps_free(res->body, res->body_cap);
 
     for (int i = 0; i < res->header_count; i++) {
         free(res->header_keys[i]);
@@ -1994,13 +2012,20 @@ int http_ws_recv(HttpWsConn* ws) {
         /* Sanity bound — refuse 1GB+ frames. */
         if (pl < 0 || pl > (1LL << 30)) { ws->closed = 1; return -1; }
 
-        /* Read payload into a scratch buffer, unmasking on the fly. */
+        /* Read payload into a scratch buffer, unmasking on the fly.
+         * Cap-aware (#343): `pl` is the WebSocket payload length
+         * field from the wire — untrusted by definition. The 1 GiB
+         * sanity bound above stops the obvious DoS shape; the caps
+         * allocator threads this through to the host's
+         * aether_set_memory_cap budget. */
         char* frame_buf = NULL;
+        size_t frame_cap = 0;
         if (pl > 0) {
-            frame_buf = (char*)malloc((size_t)pl);
+            frame_cap = (size_t)pl;
+            frame_buf = (char*)aether_caps_malloc(frame_cap);
             if (!frame_buf) { ws->closed = 1; return -1; }
             if (ws_recv_exact(ws->conn, frame_buf, (int)pl) != 0) {
-                free(frame_buf); ws->closed = 1; return -1;
+                aether_caps_free(frame_buf, frame_cap); ws->closed = 1; return -1;
             }
             if (masked) {
                 for (long long i = 0; i < pl; i++) {
@@ -2014,18 +2039,18 @@ int http_ws_recv(HttpWsConn* ws) {
              * §5.5.3). Free our buffer afterwards; caller doesn't see
              * control frames. */
             ws_send_frame(ws->conn, WS_OP_PONG, frame_buf, (int)pl);
-            free(frame_buf);
+            aether_caps_free(frame_buf, frame_cap);
             continue;
         }
         if (opcode == WS_OP_PONG) {
-            free(frame_buf);
+            aether_caps_free(frame_buf, frame_cap);
             continue;  /* unsolicited pong — discard */
         }
         if (opcode == WS_OP_CLOSE) {
             /* Echo close frame back (RFC 6455 §5.5.1) and report
              * to caller. */
             ws_send_frame(ws->conn, WS_OP_CLOSE, frame_buf, (int)pl);
-            free(frame_buf);
+            aether_caps_free(frame_buf, frame_cap);
             ws->closed = 1;
             return -1;
         }
@@ -2038,12 +2063,12 @@ int http_ws_recv(HttpWsConn* ws) {
         }
         if (pl > 0) {
             if (ws_msg_grow(ws, ws->msg_len + (int)pl + 1) != 0) {
-                free(frame_buf); ws->closed = 1; return -1;
+                aether_caps_free(frame_buf, frame_cap); ws->closed = 1; return -1;
             }
             memcpy(ws->msg_buf + ws->msg_len, frame_buf, (size_t)pl);
             ws->msg_len += (int)pl;
         }
-        free(frame_buf);
+        aether_caps_free(frame_buf, frame_cap);
 
         if (fin) break;
     }
@@ -3590,9 +3615,10 @@ void http_serve_file(HttpServerResponse* res, const char* filepath) {
      * the fast path doesn't emit stale content alongside the
      * sendfile-emitted body. */
     if (res->body) {
-        free(res->body);
+        aether_caps_free(res->body, res->body_cap);
         res->body = NULL;
         res->body_length = 0;
+        res->body_cap = 0;
     }
     res->sendfile_fd = fd;
     res->sendfile_size = (long long)st.st_size;
@@ -3607,7 +3633,9 @@ void http_serve_file(HttpServerResponse* res, const char* filepath) {
     fseek(f, 0, SEEK_END);
     long size = ftell(f);
     fseek(f, 0, SEEK_SET);
-    char* content = (char*)malloc((size_t)size + 1);
+    /* Cap-aware (#343): file size is OS-supplied, unbounded. */
+    size_t content_cap = (size_t)size + 1;
+    char* content = (char*)aether_caps_malloc(content_cap);
     if (!content) {
         fclose(f);
         http_response_set_status(res, 500);
@@ -3617,7 +3645,7 @@ void http_serve_file(HttpServerResponse* res, const char* filepath) {
     size_t bytes_read = fread(content, 1, (size_t)size, f);
     fclose(f);
     if (bytes_read == 0 && size > 0) {
-        free(content);
+        aether_caps_free(content, content_cap);
         http_response_set_status(res, 500);
         http_response_set_body(res, "500 - Server Error");
         return;
@@ -3632,7 +3660,7 @@ void http_serve_file(HttpServerResponse* res, const char* filepath) {
      * the body — which the cross-platform sendfile test surfaced
      * on Windows when serving a 1 MiB urandom file. */
     http_response_set_body_n(res, content, (int)bytes_read);
-    free(content);
+    aether_caps_free(content, content_cap);
 #endif
 }
 

--- a/std/net/aether_http_server.h
+++ b/std/net/aether_http_server.h
@@ -32,6 +32,13 @@ typedef struct {
     int header_count;
     char* body;
     size_t body_length;
+    /* Resource-caps tracker companion (#343): the byte count
+     * aether_caps_free needs at the matching free site. Distinct
+     * from body_length because every alloc is body_length+1 (NUL
+     * terminator) and may be reused/reset across set_body calls;
+     * tracking the cap explicitly keeps the cap counter at
+     * current-usage even when callers replace the body. */
+    size_t body_cap;
     /* Issue #383 zero-copy fast path. When the response body lives
      * on disk (set by http_serve_file), the file is `open(2)`'d
      * here and `fstat(2)`'d into sendfile_size. The connection

--- a/std/net/aether_net.c
+++ b/std/net/aether_net.c
@@ -1,6 +1,7 @@
 #include "aether_net.h"
 #include "../../runtime/config/aether_optimization_config.h"
 #include "../../runtime/aether_sandbox.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #if !AETHER_HAS_NETWORKING
 TcpSocket* tcp_connect_raw(const char* h, int p) { (void)h; (void)p; return NULL; }
@@ -114,12 +115,16 @@ int tcp_send_raw(TcpSocket* sock, const char* data) {
 char* tcp_receive_raw(TcpSocket* sock, int max_bytes) {
     if (!sock || !sock->connected || max_bytes <= 0) return NULL;
 
-    char* buffer = (char*)malloc(max_bytes + 1);
+    /* Cap-aware (#343): max_bytes is caller-supplied (program-
+     * controlled, but plugin-host paths surface it as untrusted).
+     * Caller frees with plain libc free per the caller-owned-return
+     * contract (aether_resource_caps.h:89-94). */
+    char* buffer = (char*)aether_caps_malloc((size_t)max_bytes + 1);
     if (!buffer) return NULL;
     int received = recv(sock->fd, buffer, max_bytes, 0);
 
     if (received <= 0) {
-        free(buffer);
+        aether_caps_free(buffer, (size_t)max_bytes + 1);
         sock->connected = 0;
         return NULL;
     }

--- a/std/zlib/aether_zlib.c
+++ b/std/zlib/aether_zlib.c
@@ -1,5 +1,6 @@
 #include "aether_zlib.h"
 #include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -26,18 +27,38 @@ static inline const unsigned char* zlib_unwrap_bytes(const char* data, int lengt
 
 /* Thread-local buffers for the split-accessor pattern. One pair per
  * direction so a caller can interleave deflate + inflate without the
- * two fighting over a single slot. */
+ * two fighting over a single slot.
+ *
+ * Resource-caps tracking (#343): both directions remember the
+ * allocation capacity alongside the payload length so the matching
+ * free goes through `aether_caps_free` with the right byte count.
+ * The cap counter stays at current-usage rather than high-water-mark
+ * — important for plugin-host sandboxes that re-arm the cap between
+ * compressor invocations. Length and capacity differ when the chosen
+ * `compressBound` over-allocated relative to the actual compressed
+ * size; `_cap` holds the allocator's view (the count that must
+ * round-trip to free), `_len` holds the payload's view. */
 static _Thread_local unsigned char* tls_deflate_buf = NULL;
+static _Thread_local size_t         tls_deflate_cap = 0;
 static _Thread_local int            tls_deflate_len = 0;
 static _Thread_local unsigned char* tls_inflate_buf = NULL;
+static _Thread_local size_t         tls_inflate_cap = 0;
 static _Thread_local int            tls_inflate_len = 0;
 
 static void free_deflate_tls(void) {
-    if (tls_deflate_buf) { free(tls_deflate_buf); tls_deflate_buf = NULL; }
+    if (tls_deflate_buf) {
+        aether_caps_free(tls_deflate_buf, tls_deflate_cap);
+        tls_deflate_buf = NULL;
+    }
+    tls_deflate_cap = 0;
     tls_deflate_len = 0;
 }
 static void free_inflate_tls(void) {
-    if (tls_inflate_buf) { free(tls_inflate_buf); tls_inflate_buf = NULL; }
+    if (tls_inflate_buf) {
+        aether_caps_free(tls_inflate_buf, tls_inflate_cap);
+        tls_inflate_buf = NULL;
+    }
+    tls_inflate_cap = 0;
     tls_inflate_len = 0;
 }
 
@@ -60,15 +81,17 @@ int zlib_try_deflate(const char* data, int length, int level) {
     if (in_len > 0 && !in) return 0;
 
     uLongf bound = compressBound((uLong)in_len);
-    unsigned char* out = (unsigned char*)malloc(bound > 0 ? bound : 1);
+    size_t alloc_cap = bound > 0 ? (size_t)bound : 1;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(alloc_cap);
     if (!out) return 0;
 
     uLongf out_size = bound;
     int lvl = (level < -1 || level > 9) ? Z_DEFAULT_COMPRESSION : level;
     int rc = compress2(out, &out_size, in, (uLong)in_len, lvl);
-    if (rc != Z_OK) { free(out); return 0; }
+    if (rc != Z_OK) { aether_caps_free(out, alloc_cap); return 0; }
 
     tls_deflate_buf = out;
+    tls_deflate_cap = alloc_cap;
     tls_deflate_len = (int)out_size;
     return 1;
 }
@@ -90,7 +113,8 @@ int zlib_try_gzip_deflate(const char* data, int length, int level) {
     }
 
     uLong bound = deflateBound(&strm, (uLong)in_len);
-    unsigned char* out = (unsigned char*)malloc(bound > 0 ? bound : 1);
+    size_t alloc_cap = bound > 0 ? (size_t)bound : 1;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(alloc_cap);
     if (!out) { deflateEnd(&strm); return 0; }
 
     strm.next_in = (Bytef*)in;
@@ -101,11 +125,12 @@ int zlib_try_gzip_deflate(const char* data, int length, int level) {
     int rc = deflate(&strm, Z_FINISH);
     if (rc != Z_STREAM_END) {
         deflateEnd(&strm);
-        free(out);
+        aether_caps_free(out, alloc_cap);
         return 0;
     }
 
     tls_deflate_buf = out;
+    tls_deflate_cap = alloc_cap;
     tls_deflate_len = (int)strm.total_out;
     deflateEnd(&strm);
     return 1;
@@ -131,7 +156,7 @@ int zlib_try_inflate(const char* data, int length) {
      * fit in 2-8x their compressed size; grow geometrically if not. */
     size_t cap = in_len * 4;
     if (cap < 64) cap = 64;
-    unsigned char* out = (unsigned char*)malloc(cap);
+    unsigned char* out = (unsigned char*)aether_caps_malloc(cap);
     if (!out) { inflateEnd(&strm); return 0; }
 
     size_t produced = 0;
@@ -143,12 +168,12 @@ int zlib_try_inflate(const char* data, int length) {
         produced = cap - strm.avail_out;
 
         if (rc == Z_STREAM_END) break;
-        if (rc != Z_OK) { free(out); inflateEnd(&strm); return 0; }
+        if (rc != Z_OK) { aether_caps_free(out, cap); inflateEnd(&strm); return 0; }
         if (strm.avail_out == 0) {
             size_t new_cap = cap * 2;
-            if (new_cap < cap) { free(out); inflateEnd(&strm); return 0; }
-            unsigned char* bigger = (unsigned char*)realloc(out, new_cap);
-            if (!bigger) { free(out); inflateEnd(&strm); return 0; }
+            if (new_cap < cap) { aether_caps_free(out, cap); inflateEnd(&strm); return 0; }
+            unsigned char* bigger = (unsigned char*)aether_caps_realloc(out, cap, new_cap);
+            if (!bigger) { aether_caps_free(out, cap); inflateEnd(&strm); return 0; }
             out = bigger;
             cap = new_cap;
         }
@@ -156,6 +181,7 @@ int zlib_try_inflate(const char* data, int length) {
     inflateEnd(&strm);
 
     tls_inflate_buf = out;
+    tls_inflate_cap = cap;
     tls_inflate_len = (int)produced;
     return 1;
 }
@@ -178,7 +204,7 @@ static int inflate_with_window_bits(const char* data, int length, int window_bit
 
     size_t cap = in_len * 4;
     if (cap < 64) cap = 64;
-    unsigned char* out = (unsigned char*)malloc(cap);
+    unsigned char* out = (unsigned char*)aether_caps_malloc(cap);
     if (!out) { inflateEnd(&strm); return 0; }
 
     size_t produced = 0;
@@ -190,12 +216,12 @@ static int inflate_with_window_bits(const char* data, int length, int window_bit
         produced = cap - strm.avail_out;
 
         if (rc == Z_STREAM_END) break;
-        if (rc != Z_OK) { free(out); inflateEnd(&strm); return 0; }
+        if (rc != Z_OK) { aether_caps_free(out, cap); inflateEnd(&strm); return 0; }
         if (strm.avail_out == 0) {
             size_t new_cap = cap * 2;
-            if (new_cap < cap) { free(out); inflateEnd(&strm); return 0; }
-            unsigned char* bigger = (unsigned char*)realloc(out, new_cap);
-            if (!bigger) { free(out); inflateEnd(&strm); return 0; }
+            if (new_cap < cap) { aether_caps_free(out, cap); inflateEnd(&strm); return 0; }
+            unsigned char* bigger = (unsigned char*)aether_caps_realloc(out, cap, new_cap);
+            if (!bigger) { aether_caps_free(out, cap); inflateEnd(&strm); return 0; }
             out = bigger;
             cap = new_cap;
         }
@@ -203,6 +229,7 @@ static int inflate_with_window_bits(const char* data, int length, int window_bit
     inflateEnd(&strm);
 
     tls_inflate_buf = out;
+    tls_inflate_cap = cap;
     tls_inflate_len = (int)produced;
     return 1;
 }


### PR DESCRIPTION
## Summary

Closes the **T1 (security-critical) tier** of the stdlib direct-malloc audit — Paul Hammant's "no direct malloc/free in stdlib" concern. 23 sites whose allocation size came from untrusted input now route through `aether_caps_malloc/free` from `runtime/aether_resource_caps.h`, so hosts that arm `aether_set_memory_cap(N)` (public ABI at `include/libaether.h:48`) can actually bound sandboxed-plugin heap usage.

Before this PR: an attacker could allocate to OOM regardless of the cap via WebSocket payload frames, zlib decompression bombs, large JSON documents, base64 inputs, file-read calls, HTTP request/response bodies, and TCP receive buffers — the cap was a paper tiger on 23 of the most-reachable surfaces.

## Audit scope

A comprehensive audit found **333 direct malloc/calloc/realloc sites** across `std/**/*.c` (excluding the 3 files already correctly using `aether_caps_*`). Classified by reachability:

| Tier | Count | Description |
|---|---|---|
| **T1** | **23** | Untrusted-size allocations — closed by this PR |
| T2 | 157 | Plugin-reachable but bounded — filed as #461/#462/#463 |
| T3 | 153 | Fixed-size / process-init — filed as #464 |

## Conversion shape

```c
// Before:
char* p = (char*)malloc(n);
...
free(p);

// After:
char* p = (char*)aether_caps_malloc(n);  // gates via aether_caps_check_alloc
...
aether_caps_free(p, n);                  // decrements the counter
```

Where the allocation size already lives alongside the pointer (struct field or sibling local), the free recovers it for full current-usage tracking. Where the pointer is caller-owned and freed externally with libc free, the API's documented "libc-compatible-pointer" contract (`aether_resource_caps.h:89-94`) keeps the counter drifting up on cold paths — same trade-off documented for the codegen-emitted uniform-heap shim in PR #459.

## Areas converted

- **std/zlib** (4 sites). compress/decompress output buffers driven by attacker-supplied payload size. Added `tls_*_cap` alongside the TLS buffer.
- **std/lzf** (2 sites). Same shape as zlib.
- **std/cryptography** (4 sites). Base64 encode/decode buffers; `g_b64_cap` added.
- **std/http/server/vcr** (3 sites). Base64 + gzip decode for VCR tape bodies.
- **std/json** (3 sites + arena + heap-tree path). Parser arena chunks scaling with input + heap-tree builder API (`heap_new`, `json_create_string`).
- **std/net/aether_http.c** (1 site). HTTP client request body.
- **std/net/aether_http_server.c** (4 sites). Response body (new `body_cap` field), sendfile fallback, Windows file-read, WebSocket frame payload.
- **std/net/aether_net.c** (1 site). TCP receive buffer.
- **std/http/proxy/aether_proxy_cache.c** (1 site). Cached upstream body.
- **std/http/middleware/aether_middleware.c** (1 site). Gzip compression output.
- **std/fs/aether_fs.c** (2 sites). `file_read_all_raw` and `fs_read` file content.
- **std/io/aether_io.c** (3 sites). File-read and fd-read paths.

## Verification

```
make clean && make compiler ae stdlib   →  0 warnings, builds clean
make test                                →  215/215 unit pass
make test-ae                             →  478/478 integration pass
make examples                            →  79/79 pass
```

Per-area smoke tests (all pass):
- `tests/integration/zlib_roundtrip/test_zlib_roundtrip.sh`
- `tests/integration/lzf_roundtrip/test_lzf_roundtrip.sh`
- `tests/integration/svn_checkout_via_vcr/test_svn_checkout_via_vcr.sh`

## Why the cap matters

The cap (`aether_set_memory_cap(bytes)`) is the runtime's defence against unbounded heap growth in sandboxed-plugin scenarios (the documented `--emit=lib` use case at `aether_resource_caps.h:1-13`). Without these conversions:

- A WebSocket peer could send a 1 GiB frame (the 1 GiB sanity bound is still there, but the cap should reject sooner if armed at, say, 64 MiB).
- A gzip bomb's decompressed body could exceed the cap entirely.
- A 4 MiB JSON document's parse arena could allocate 30+ MiB of arena chunks without the cap noticing.
- A plugin reading a 10 GiB file via `fs.read_to_string` would have unbounded heap usage.

All of these are now gated.

## Follow-ups filed

| Issue | Scope | Priority |
|---|---|---|
| #461 | T2 HTTP-stack sites (~140) | medium |
| #462 | T2 fs/io/os sites (~50) | medium |
| #463 | collections + remaining string-array T1 (~15, cross-file paired) | medium |
| #464 | T3 cosmetic sites (~153 fixed-size) | low |
| #465 | struct-field heap-string ownership tracking (multi-week) | high |
| #466 | actor message heap-string ownership protocol (UAF/leak today) | high |
| #467 | list/map element heap-string ownership protocol | high |
| #468 | CI: wire macOS leaks(1) into integration matrix | medium |

## Test plan

- [x] `make ci` clean, zero warnings, all suites pass
- [ ] Linux CI green (gcc + clang)
- [ ] Windows CI green (MinGW64)
- [ ] Future: a new test that arms a 64 KB cap, attempts a 256 KB WebSocket frame / 4 MiB JSON / 10 MiB file read, asserts the cap denies the alloc (issue follow-up)

## Relationship to PR #459

PR #459 closed the v0.149 lucky-UAF return-escape and made the codegen-emitted shim cap-aware. This PR completes the stdlib side: the cap now bounds the 23 most exploitable allocation surfaces in addition to the codegen-emitted shim's hot path.

Both PRs are independent — they touch different files and can land in either order. The combined effect is a properly-enforceable `aether_set_memory_cap(N)` for plugin hosts.
