### PR TITLE
fix(codegen/runtime/stdlib): struct fields + actor messages + list/map heap-string ownership (#465 + #466 + #467)

### DIFF
--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1980,6 +1980,18 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
      * fs.read_binary, …) print their payload bytes rather than the
      * struct header. Plain char* values pass through unchanged. */
     print_line(gen, "extern const char* aether_string_data(const void* s);");
+    print_line(gen, "extern size_t aether_string_length(const void* s);");
+    /* Issue #466: actor message heap-string deep-copy at send time.
+     * `string_new_with_length` clones the source bytes into a fresh
+     * refcounted AetherString. Exposed here so the message-send
+     * codegen doesn't re-emit the prototype at every call site.
+     * `string_release` is NOT declared here — it's already declared
+     * later by the extern-registry pass (parameter type `const char*`,
+     * not `const void*`). Adding our own would create a conflicting-
+     * types error at the registry's re-declaration. The
+     * <Msg>_release_fields function uses string_release after the
+     * registry's declaration is visible. */
+    print_line(gen, "extern void* string_new_with_length(const char* data, int length);");
     print_line(gen, "static inline const char* _aether_safe_str(const void* s) {");
     print_line(gen, "    if (!s) return \"(null)\";");
     print_line(gen, "    return aether_string_data(s);");
@@ -2695,15 +2707,8 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
                         }
                     }
                     if (msg_has_string_field) {
-                        /* Forward-declared via the Aether-side
-                         * `string_release` extern (matches the
-                         * std/string/aether_string.c signature:
-                         * `void string_release(const void*)`).
-                         * The duplicate `extern void string_release`
-                         * here would conflict with that earlier
-                         * decl, so we just reference the symbol —
-                         * the C compiler picks up the earlier
-                         * prototype.  */
+                        /* `string_release` prototype is emitted in
+                         * the codegen prologue (codegen.c). */
                         print_line(gen, "static inline void %s_release_fields(%s* m) {",
                                    child->value, child->value);
                         indent(gen);

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -485,6 +485,37 @@ static int try_emit_heap_string_exit_free(CodeGenerator* gen, ASTNode* deferred)
     return 1;
 }
 
+/* Struct-destructor defer carrier (#465). Annotation:
+ *   "struct_destroy:<varname>:<StructName>"
+ * Pushed by the struct-local-declaration site in codegen_stmt.c
+ * for every local struct variable whose definition has at least
+ * one heap-string field. The emitted defer calls the auto-
+ * generated <StructName>_destroy(&<varname>) function, which
+ * walks every `_heap_<field>` tracker and frees the matching
+ * field's buffer if set. */
+static int try_emit_struct_destroy(CodeGenerator* gen, ASTNode* deferred) {
+    if (!deferred || !deferred->annotation) return 0;
+    const char* prefix = "struct_destroy:";
+    size_t plen = strlen(prefix);
+    if (strncmp(deferred->annotation, prefix, plen) != 0) return 0;
+    const char* rest = deferred->annotation + plen;
+    /* Split "<varname>:<StructName>" on the last colon — struct
+     * names don't contain colons, var names shouldn't either. */
+    const char* sep = strchr(rest, ':');
+    if (!sep || !sep[1]) return 0;
+    size_t var_len = (size_t)(sep - rest);
+    if (var_len == 0 || var_len > 200) return 0;
+    char var_buf[256];
+    memcpy(var_buf, rest, var_len);
+    var_buf[var_len] = '\0';
+    const char* struct_name = sep + 1;
+    print_indent(gen);
+    fprintf(gen->output,
+            "/* deferred */ %s_destroy(&%s);\n",
+            struct_name, var_buf);
+    return 1;
+}
+
 // Emit deferred statements for current scope only (in reverse order)
 void emit_defers_for_scope(CodeGenerator* gen) {
     if (gen->scope_depth <= 0) return;
@@ -496,6 +527,7 @@ void emit_defers_for_scope(CodeGenerator* gen) {
         ASTNode* deferred = gen->defer_stack[i];
         if (deferred) {
             if (try_emit_heap_string_exit_free(gen, deferred)) continue;
+            if (try_emit_struct_destroy(gen, deferred)) continue;
             print_indent(gen);
             fprintf(gen->output, "/* deferred */ ");
             generate_statement(gen, deferred);
@@ -575,6 +607,7 @@ void emit_all_defers_protected(CodeGenerator* gen, char** protected_names, int p
             continue;
         }
         if (try_emit_heap_string_exit_free(gen, deferred)) continue;
+        if (try_emit_struct_destroy(gen, deferred)) continue;
         print_indent(gen);
         fprintf(gen->output, "/* deferred */ ");
         generate_statement(gen, deferred);

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -2674,13 +2674,59 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
                     unindent(gen);
                     print_line(gen, "} %s;", child->value);
                     print_line(gen, "");
-                    
+
+                    /* Per-message heap-string-field release function
+                     * (#466). Walked by the receive-handler dispatch
+                     * before `aether_free_message` so the deep-
+                     * copied AetherString allocations the sender
+                     * stamped in (codegen_expr.c send-side) are
+                     * reclaimed when the recipient is done with the
+                     * message. No-op for messages with no string
+                     * fields; the codegen_actor.c dispatch skips
+                     * the call in that case via
+                     * `message_has_string_field`. */
+                    int msg_has_string_field = 0;
+                    for (int fi = 0; fi < child->child_count; fi++) {
+                        ASTNode* f = child->children[fi];
+                        if (f && f->type == AST_MESSAGE_FIELD &&
+                            f->node_type && f->node_type->kind == TYPE_STRING) {
+                            msg_has_string_field = 1;
+                            break;
+                        }
+                    }
+                    if (msg_has_string_field) {
+                        /* Forward-declared via the Aether-side
+                         * `string_release` extern (matches the
+                         * std/string/aether_string.c signature:
+                         * `void string_release(const void*)`).
+                         * The duplicate `extern void string_release`
+                         * here would conflict with that earlier
+                         * decl, so we just reference the symbol —
+                         * the C compiler picks up the earlier
+                         * prototype.  */
+                        print_line(gen, "static inline void %s_release_fields(%s* m) {",
+                                   child->value, child->value);
+                        indent(gen);
+                        print_line(gen, "if (!m) return;");
+                        for (int fi = 0; fi < child->child_count; fi++) {
+                            ASTNode* f = child->children[fi];
+                            if (f && f->type == AST_MESSAGE_FIELD &&
+                                f->node_type && f->node_type->kind == TYPE_STRING) {
+                                print_line(gen, "if (m->%s) { string_release(m->%s); m->%s = (const char*)0; }",
+                                           f->value, f->value, f->value);
+                            }
+                        }
+                        unindent(gen);
+                        print_line(gen, "}");
+                        print_line(gen, "");
+                    }
+
                     // Generate type-specific memory pool for this message type
                     print_line(gen, "// Type-specific memory pool for %s", child->value);
                     print_line(gen, "// DECLARE_TYPE_POOL(%s)", child->value);
                     print_line(gen, "// DECLARE_TLS_POOL(%s)", child->value);
                     print_line(gen, "");
-                    
+
                     register_message_type(gen->message_registry, child->value, first_field);
 
                     // Emit to header if enabled

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1992,6 +1992,22 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
      * <Msg>_release_fields function uses string_release after the
      * registry's declaration is visible. */
     print_line(gen, "extern void* string_new_with_length(const char* data, int length);");
+    /* Issue #467: list / map heap-string-value owning-add helpers.
+     * Prototypes emitted here so codegen can route `list.add(l,
+     * heap_str)` / `map.put(m, k, heap_str)` calls to these symbols
+     * even when the user's source doesn't `import std.list` /
+     * `import std.collections` (the inline-extern shape some tests
+     * use to declare just the raw functions). The stdlib archive
+     * always contains the symbols.
+     *
+     * Parameter types match the extern-registry's pass exactly —
+     * `void*` not `const void*` — so a duplicate decl from the
+     * registry (when the source DOES import the module) doesn't
+     * conflict. The header's `const void*` declaration is the
+     * source-of-truth for consumers in C; the registry maps Aether's
+     * `ptr` to `void*` without const, which is what this matches. */
+    print_line(gen, "extern int list_add_string_owned(void* list, void* item);");
+    print_line(gen, "extern int map_put_string_owned(void* map, const char* key, void* value);");
     print_line(gen, "static inline const char* _aether_safe_str(const void* s) {");
     print_line(gen, "    if (!s) return \"(null)\";");
     print_line(gen, "    return aether_string_data(s);");
@@ -2707,8 +2723,16 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
                         }
                     }
                     if (msg_has_string_field) {
-                        /* `string_release` prototype is emitted in
-                         * the codegen prologue (codegen.c). */
+                        /* Forward-declare `string_release` here so the
+                         * generated release_fields function compiles
+                         * even on tests that don't `import std.string`
+                         * (and therefore don't get the extern
+                         * registry's prototype). The duplicate-but-
+                         * matching declaration is tolerated by C —
+                         * matches the registry's
+                         * `void string_release(const char*)` exactly
+                         * when std.string IS imported. */
+                        print_line(gen, "extern void string_release(const char*);");
                         print_line(gen, "static inline void %s_release_fields(%s* m) {",
                                    child->value, child->value);
                         indent(gen);

--- a/compiler/codegen/codegen_actor.c
+++ b/compiler/codegen/codegen_actor.c
@@ -567,6 +567,35 @@ void generate_actor_definition(CodeGenerator* gen, ASTNode* actor) {
                             print_line(gen, "if (_msg_data) {");
                             indent(gen);
                             print_line(gen, "%s_handle_%s(self, _msg_data);", actor->value, pattern->value);
+                            /* Release heap-string fields the sender
+                             * deep-copied at send time (#466). The
+                             * <Msg>_release_fields function is
+                             * emitted alongside the message struct
+                             * iff the message has at least one
+                             * string field; we always call it here
+                             * — for messages without string fields
+                             * the function isn't emitted and the C
+                             * compiler will reject this call,
+                             * but for the single-int path we land
+                             * here only when the message struct was
+                             * heap-allocated (non-inline path),
+                             * which by construction means the
+                             * message has at least one non-int
+                             * field. For inline (single-int)
+                             * messages this branch fires only when
+                             * _msg_data is non-NULL — same shape,
+                             * so the release_fields function is
+                             * always available. */
+                            if (msg_def) {
+                                int msg_has_string = 0;
+                                for (MessageFieldDef* f = msg_def->fields; f; f = f->next) {
+                                    if (f->type_kind == TYPE_STRING) { msg_has_string = 1; break; }
+                                }
+                                if (msg_has_string) {
+                                    print_line(gen, "%s_release_fields((%s*)_msg_data);",
+                                               pattern->value, pattern->value);
+                                }
+                            }
                             print_line(gen, "aether_free_message(_msg_data);");
                             unindent(gen);
                             print_line(gen, "} else {");
@@ -579,6 +608,18 @@ void generate_actor_definition(CodeGenerator* gen, ASTNode* actor) {
                         } else {
                             // Two-field inline: reconstruct from payload_int + payload_ptr
                             print_line(gen, "%s_handle_%s(self, _msg_data);", actor->value, pattern->value);
+                            /* Same release-fields call as the single-
+                             * int branch above (#466). */
+                            if (msg_def) {
+                                int msg_has_string = 0;
+                                for (MessageFieldDef* f = msg_def->fields; f; f = f->next) {
+                                    if (f->type_kind == TYPE_STRING) { msg_has_string = 1; break; }
+                                }
+                                if (msg_has_string) {
+                                    print_line(gen, "%s_release_fields((%s*)_msg_data);",
+                                               pattern->value, pattern->value);
+                                }
+                            }
                             print_line(gen, "aether_free_message(_msg_data);");
                         }
                         print_line(gen, "return;");

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -3030,20 +3030,37 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             fprintf(gen->output, "}");
             break;
         
-        case AST_STRUCT_LITERAL:
+        case AST_STRUCT_LITERAL: {
+            /* Struct-field heap-string ownership (#465): for each
+             * field-init whose expression is heap-classified, also
+             * emit `._heap_<field> = 1` so the auto-emitted
+             * <Struct>_destroy() reclaims the buffer at scope exit.
+             * Plain initializers (literal strings, scalars) default
+             * to _heap_<field> = 0 via C99 designated-init's zero-
+             * fill of unmentioned fields. */
             fprintf(gen->output, "(%s){", expr->value);
+            int emitted = 0;
             for (int i = 0; i < expr->child_count; i++) {
                 ASTNode* field_init = expr->children[i];
                 if (field_init && field_init->type == AST_ASSIGNMENT) {
-                    if (i > 0) fprintf(gen->output, ", ");
+                    if (emitted > 0) fprintf(gen->output, ", ");
                     fprintf(gen->output, ".%s = ", field_init->value);
                     if (field_init->child_count > 0) {
                         generate_expression(gen, field_init->children[0]);
+                    }
+                    emitted++;
+                    /* If the init is heap-classified, also set the
+                     * hidden tracker. */
+                    if (field_init->child_count > 0 &&
+                        is_heap_string_expr(gen, field_init->children[0])) {
+                        fprintf(gen->output, ", ._heap_%s = 1", field_init->value);
+                        emitted++;
                     }
                 }
             }
             fprintf(gen->output, "}");
             break;
+        }
         
         case AST_ARRAY_ACCESS:
             if (expr->child_count >= 2) {

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -3131,7 +3131,43 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                     }
                                 }
                             }
-                            fprintf(gen->output, " }; aether_send_message(");
+                            fprintf(gen->output, " }; ");
+                            /* Deep-copy heap-string fields (#466).
+                             * The shallow `_msg.text = original_ptr`
+                             * assignment leaves the receiver pointing
+                             * at the sender's heap; the sender's
+                             * defer-free / reassign-wrapper would
+                             * dangle the receiver's pointer. Re-stamp
+                             * each string field with a refcounted
+                             * AetherString clone via string_new_with_
+                             * length, sized from the source's
+                             * length-aware header so binary content
+                             * with embedded NULs round-trips intact.
+                             * The receiver's <Msg>_release_fields
+                             * call (emitted at the receive-handler
+                             * dispatch) string_releases the clone
+                             * when the message is consumed. */
+                            int has_str = 0;
+                            for (MessageFieldDef* f = msg_def->fields; f; f = f->next) {
+                                if (f->type_kind == TYPE_STRING) { has_str = 1; break; }
+                            }
+                            if (has_str) {
+                                fprintf(gen->output, "extern void* string_new_with_length(const char*, int); "
+                                                     "extern const char* aether_string_data(const void*); "
+                                                     "extern size_t aether_string_length(const void*); ");
+                                for (MessageFieldDef* f = msg_def->fields; f; f = f->next) {
+                                    if (f->type_kind == TYPE_STRING) {
+                                        fprintf(gen->output,
+                                                "if (_msg.%s) { "
+                                                "size_t _ml = aether_string_length(_msg.%s); "
+                                                "_msg.%s = (const char*)string_new_with_length("
+                                                "aether_string_data(_msg.%s), (int)_ml); "
+                                                "} ",
+                                                f->name, f->name, f->name, f->name);
+                                    }
+                                }
+                            }
+                            fprintf(gen->output, "aether_send_message(");
                             emit_send_target(gen, target, "void*");
                             fprintf(gen->output, ", &_msg, sizeof(%s)); }", message->value);
                         }

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2583,31 +2583,33 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                      *     `err = list.add(...)` assignment. Wrap in
                      *     a ternary that preserves the string-return
                      *     contract: `(owned(...) ? "" : "<err>")`. */
-                    int route_to_owned = 0;
-                    int is_list_add = 0, is_list_add_raw = 0;
-                    int is_map_put  = 0, is_map_put_raw  = 0;
-                    if (strcmp(c_func_name, "list_add_raw") == 0)    { is_list_add_raw = 1; route_to_owned = 1; }
-                    else if (strcmp(c_func_name, "list_add") == 0)   { is_list_add     = 1; route_to_owned = 1; }
-                    else if (strcmp(c_func_name, "map_put_raw") == 0){ is_map_put_raw  = 1; route_to_owned = 1; }
-                    else if (strcmp(c_func_name, "map_put") == 0)    { is_map_put      = 1; route_to_owned = 1; }
-
-                    if (route_to_owned) {
-                        int val_idx = (is_list_add || is_list_add_raw) ? 1 : 2;
-                        int expected_arg_count = (is_list_add || is_list_add_raw) ? 2 : 3;
+                    /* Classify the callee: list-shape (2 args, value
+                     * at index 1) vs map-shape (3 args, value at
+                     * index 2); wrapper (`list_add` / `map_put`
+                     * returns string) vs raw extern (`list_add_raw`
+                     * / `map_put_raw` returns int). */
+                    int is_list_shape = (strcmp(c_func_name, "list_add_raw") == 0 ||
+                                         strcmp(c_func_name, "list_add") == 0);
+                    int is_map_shape  = (strcmp(c_func_name, "map_put_raw") == 0 ||
+                                         strcmp(c_func_name, "map_put") == 0);
+                    int is_wrapper    = (strcmp(c_func_name, "list_add") == 0 ||
+                                         strcmp(c_func_name, "map_put") == 0);
+                    if (is_list_shape || is_map_shape) {
+                        int val_idx           = is_list_shape ? 1 : 2;
+                        int expected_arg_count = is_list_shape ? 2 : 3;
                         if (expr->child_count == expected_arg_count) {
                             ASTNode* val = expr->children[val_idx];
                             if (val && is_heap_string_expr(gen, val)) {
-                                int wrapper = (is_list_add || is_map_put);
-                                if (wrapper) {
+                                if (is_wrapper) {
                                     fprintf(gen->output, "(");
                                 }
-                                if (is_list_add || is_list_add_raw) {
+                                if (is_list_shape) {
                                     fprintf(gen->output, "list_add_string_owned(");
                                     generate_expression(gen, expr->children[0]);
                                     fprintf(gen->output, ", (void*)");
                                     generate_expression(gen, val);
                                     fprintf(gen->output, ")");
-                                    if (wrapper) {
+                                    if (is_wrapper) {
                                         fprintf(gen->output, " ? \"\" : \"list.add failed\")");
                                     }
                                 } else {
@@ -2618,7 +2620,7 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                     fprintf(gen->output, ", (void*)");
                                     generate_expression(gen, val);
                                     fprintf(gen->output, ")");
-                                    if (wrapper) {
+                                    if (is_wrapper) {
                                         fprintf(gen->output, " ? \"\" : \"map.put failed\")");
                                     }
                                 }

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2564,43 +2564,66 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                      * in the list (escape walker suppressed the
                      * source's free; list_free didn't walk
                      * elements) — leak. */
-                    if ((strcmp(c_func_name, "list_add_raw") == 0 ||
-                         strcmp(c_func_name, "list_add") == 0) &&
-                        expr->child_count == 2) {
-                        ASTNode* val = expr->children[1];
-                        if (val && is_heap_string_expr(gen, val)) {
-                            /* Cast through void* to silence the
-                             * `const char* → void*` qualifier-
-                             * discard warning the extern prototype
-                             * triggers. */
-                            fprintf(gen->output, "list_add_string_owned(");
-                            generate_expression(gen, expr->children[0]);
-                            fprintf(gen->output, ", (void*)");
-                            generate_expression(gen, val);
-                            fprintf(gen->output, ")");
-                            break;
-                        }
-                    }
+                    /* List & map heap-string-value auto-routing (#467).
+                     *
+                     * `list.add(l, heap)` / `map.put(m, k, heap)`
+                     * lands here. When the value arg is a heap-
+                     * classified string, route to the `_string_owned`
+                     * variant so the container retains + releases at
+                     * free time. Two callee shapes to handle:
+                     *
+                     *   - `_raw` externs (`list_add_raw`, `map_put_raw`)
+                     *     return `int`. The owned variant also returns
+                     *     `int` — direct rewrite.
+                     *   - Wrapper functions (`list_add`, `map_put`)
+                     *     return `string` (the Go-style `"" | error`
+                     *     shape). The owned variant returns `int`, so
+                     *     a direct rewrite would change the return
+                     *     type and break the caller's
+                     *     `err = list.add(...)` assignment. Wrap in
+                     *     a ternary that preserves the string-return
+                     *     contract: `(owned(...) ? "" : "<err>")`. */
+                    int route_to_owned = 0;
+                    int is_list_add = 0, is_list_add_raw = 0;
+                    int is_map_put  = 0, is_map_put_raw  = 0;
+                    if (strcmp(c_func_name, "list_add_raw") == 0)    { is_list_add_raw = 1; route_to_owned = 1; }
+                    else if (strcmp(c_func_name, "list_add") == 0)   { is_list_add     = 1; route_to_owned = 1; }
+                    else if (strcmp(c_func_name, "map_put_raw") == 0){ is_map_put_raw  = 1; route_to_owned = 1; }
+                    else if (strcmp(c_func_name, "map_put") == 0)    { is_map_put      = 1; route_to_owned = 1; }
 
-                    /* Map heap-string-value auto-routing (#467).
-                     * `map.put(m, k, heap_string_expr)` lands here
-                     * (after the Aether wrapper). When the value
-                     * arg is a heap-classified string, route to
-                     * map_put_string_owned so the map retains the
-                     * value and releases it at map.free. */
-                    if ((strcmp(c_func_name, "map_put_raw") == 0 ||
-                         strcmp(c_func_name, "map_put") == 0) &&
-                        expr->child_count == 3) {
-                        ASTNode* val = expr->children[2];
-                        if (val && is_heap_string_expr(gen, val)) {
-                            fprintf(gen->output, "map_put_string_owned(");
-                            generate_expression(gen, expr->children[0]);
-                            fprintf(gen->output, ", (const char*)");
-                            generate_expression(gen, expr->children[1]);
-                            fprintf(gen->output, ", (void*)");
-                            generate_expression(gen, val);
-                            fprintf(gen->output, ")");
-                            break;
+                    if (route_to_owned) {
+                        int val_idx = (is_list_add || is_list_add_raw) ? 1 : 2;
+                        int expected_arg_count = (is_list_add || is_list_add_raw) ? 2 : 3;
+                        if (expr->child_count == expected_arg_count) {
+                            ASTNode* val = expr->children[val_idx];
+                            if (val && is_heap_string_expr(gen, val)) {
+                                int wrapper = (is_list_add || is_map_put);
+                                if (wrapper) {
+                                    fprintf(gen->output, "(");
+                                }
+                                if (is_list_add || is_list_add_raw) {
+                                    fprintf(gen->output, "list_add_string_owned(");
+                                    generate_expression(gen, expr->children[0]);
+                                    fprintf(gen->output, ", (void*)");
+                                    generate_expression(gen, val);
+                                    fprintf(gen->output, ")");
+                                    if (wrapper) {
+                                        fprintf(gen->output, " ? \"\" : \"list.add failed\")");
+                                    }
+                                } else {
+                                    fprintf(gen->output, "map_put_string_owned(");
+                                    generate_expression(gen, expr->children[0]);
+                                    fprintf(gen->output, ", (const char*)");
+                                    generate_expression(gen, expr->children[1]);
+                                    fprintf(gen->output, ", (void*)");
+                                    generate_expression(gen, val);
+                                    fprintf(gen->output, ")");
+                                    if (wrapper) {
+                                        fprintf(gen->output, " ? \"\" : \"map.put failed\")");
+                                    }
+                                }
+                                break;
+                            }
                         }
                     }
 

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2552,6 +2552,58 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         break;
                     }
 
+                    /* List owned-string element auto-routing (#467).
+                     * `list.add(l, heap_string_expr)` (a.k.a.
+                     * `list_add_raw` after the Aether wrapper's
+                     * `list_add(list_add_raw(...))` dispatch
+                     * collapses) lands here. When the second arg is
+                     * a heap-classified string expression, route to
+                     * `list_add_string_owned` so the list retains
+                     * the value and releases it at `list.free`
+                     * time. Pre-fix, the heap-string lived forever
+                     * in the list (escape walker suppressed the
+                     * source's free; list_free didn't walk
+                     * elements) — leak. */
+                    if ((strcmp(c_func_name, "list_add_raw") == 0 ||
+                         strcmp(c_func_name, "list_add") == 0) &&
+                        expr->child_count == 2) {
+                        ASTNode* val = expr->children[1];
+                        if (val && is_heap_string_expr(gen, val)) {
+                            /* Cast through void* to silence the
+                             * `const char* → void*` qualifier-
+                             * discard warning the extern prototype
+                             * triggers. */
+                            fprintf(gen->output, "list_add_string_owned(");
+                            generate_expression(gen, expr->children[0]);
+                            fprintf(gen->output, ", (void*)");
+                            generate_expression(gen, val);
+                            fprintf(gen->output, ")");
+                            break;
+                        }
+                    }
+
+                    /* Map heap-string-value auto-routing (#467).
+                     * `map.put(m, k, heap_string_expr)` lands here
+                     * (after the Aether wrapper). When the value
+                     * arg is a heap-classified string, route to
+                     * map_put_string_owned so the map retains the
+                     * value and releases it at map.free. */
+                    if ((strcmp(c_func_name, "map_put_raw") == 0 ||
+                         strcmp(c_func_name, "map_put") == 0) &&
+                        expr->child_count == 3) {
+                        ASTNode* val = expr->children[2];
+                        if (val && is_heap_string_expr(gen, val)) {
+                            fprintf(gen->output, "map_put_string_owned(");
+                            generate_expression(gen, expr->children[0]);
+                            fprintf(gen->output, ", (const char*)");
+                            generate_expression(gen, expr->children[1]);
+                            fprintf(gen->output, ", (void*)");
+                            generate_expression(gen, val);
+                            fprintf(gen->output, ")");
+                            break;
+                        }
+                    }
+
                     /* Argument-temp lifetime wrap. Any heap-returning
                      * AST_FUNCTION_CALL appearing in argument position
                      * is an anonymous heap allocation with no consumer
@@ -3152,9 +3204,11 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                 if (f->type_kind == TYPE_STRING) { has_str = 1; break; }
                             }
                             if (has_str) {
-                                fprintf(gen->output, "extern void* string_new_with_length(const char*, int); "
-                                                     "extern const char* aether_string_data(const void*); "
-                                                     "extern size_t aether_string_length(const void*); ");
+                                /* Prototypes (string_new_with_length,
+                                 * aether_string_data, aether_string_
+                                 * length) are emitted once in the
+                                 * codegen prologue (codegen.c) — no
+                                 * per-call-site re-declaration. */
                                 for (MessageFieldDef* f = msg_def->fields; f; f = f->next) {
                                     if (f->type_kind == TYPE_STRING) {
                                         fprintf(gen->output,
@@ -3229,7 +3283,28 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                             }
                         }
 
-                        fprintf(gen->output, " }; void* _ask_r = scheduler_ask_message(");
+                        fprintf(gen->output, " }; ");
+
+                        /* Deep-copy heap-string request-message fields
+                         * (#466). Same shape as the AST_SEND_FIRE_
+                         * FORGET path — the request message carries
+                         * the sender's local heap-string pointers
+                         * into the receiver's mailbox; without deep-
+                         * copy the sender's defer-free dangles the
+                         * receiver's references. */
+                        for (MessageFieldDef* f = msg_def->fields; f; f = f->next) {
+                            if (f->type_kind == TYPE_STRING) {
+                                fprintf(gen->output,
+                                        "if (_msg.%s) { "
+                                        "size_t _ml = aether_string_length(_msg.%s); "
+                                        "_msg.%s = (const char*)string_new_with_length("
+                                        "aether_string_data(_msg.%s), (int)_ml); "
+                                        "} ",
+                                        f->name, f->name, f->name, f->name);
+                            }
+                        }
+
+                        fprintf(gen->output, "void* _ask_r = scheduler_ask_message(");
                         emit_send_target(gen, target, "ActorBase*");
                         fprintf(gen->output, ", &_msg, sizeof(%s), %d); ", message->value, timeout_ms);
 

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -1302,13 +1302,32 @@ void generate_struct_definition(CodeGenerator* gen, ASTNode* struct_def) {
     // Generate C struct
     print_line(gen, "typedef struct %s {", struct_def->value);
     indent(gen);
-    
-    // Generate fields
+
+    /* Heap-string ownership tracking for struct fields (#465).
+     *
+     * For each `string`-typed field, we emit a sibling
+     * `int _heap_<fieldname>` companion tracker so the matching
+     * reassign-wrapper at field-write sites can `free` the
+     * previous value when (and only when) it was heap-allocated.
+     * The struct's auto-emitted `<Name>_destroy()` (below) reads
+     * the same trackers to free heap fields at scope exit.
+     *
+     * The hidden trackers grow the struct by 4 bytes per string
+     * field. For pure-Aether structs this is acceptable; for
+     * structs that cross an FFI boundary, callers that
+     * hand-declare the struct in C won't have the trackers — they
+     * get the same field-only layout they already had (the trackers
+     * sit after the declared fields, so up-to-and-including the
+     * last user-declared field the offsets match). Strict-ABI
+     * structs that need binary stability can opt out by declaring
+     * fields as `ptr` instead of `string` (no tracker emitted). */
+    int has_string_field = 0;
+    int first_string_idx = -1;
     for (int i = 0; i < struct_def->child_count; i++) {
         ASTNode* field = struct_def->children[i];
         if (field->type == AST_STRUCT_FIELD) {
             print_indent(gen);
-            
+
             // Handle array types specially
             if (field->node_type && field->node_type->kind == TYPE_ARRAY) {
                 // For arrays: type fieldname[size];
@@ -1323,10 +1342,84 @@ void generate_struct_definition(CodeGenerator* gen, ASTNode* struct_def) {
                 generate_type(gen, field->node_type);
                 fprintf(gen->output, " %s;\n", field->value);
             }
+
+            if (field->node_type && field->node_type->kind == TYPE_STRING) {
+                has_string_field = 1;
+                if (first_string_idx < 0) first_string_idx = i;
+            }
         }
     }
-    
+
+    /* Append the heap-tracker fields AFTER all user-declared fields
+     * so the struct's user-visible layout (offsets of the named
+     * fields) stays stable. */
+    if (has_string_field) {
+        for (int i = 0; i < struct_def->child_count; i++) {
+            ASTNode* field = struct_def->children[i];
+            if (field->type == AST_STRUCT_FIELD &&
+                field->node_type && field->node_type->kind == TYPE_STRING) {
+                print_indent(gen);
+                fprintf(gen->output, "int _heap_%s;\n", field->value);
+            }
+        }
+    }
+
     unindent(gen);
     print_line(gen, "} %s;", struct_def->value);
+
+    /* Auto-emit a destructor `<Name>_destroy(<Name>* s)` that
+     * walks every heap-string field and frees the buffer when the
+     * matching tracker is set. Called from the scope-exit defer
+     * for local struct variables (codegen_stmt.c pushes the
+     * defer at struct-literal initialization sites). Idempotent —
+     * each free zeroes the tracker so a second call no-ops. */
+    if (has_string_field) {
+        print_line(gen, "static inline void %s_destroy(%s* s) {",
+                   struct_def->value, struct_def->value);
+        indent(gen);
+        print_line(gen, "if (!s) return;");
+        for (int i = 0; i < struct_def->child_count; i++) {
+            ASTNode* field = struct_def->children[i];
+            if (field->type == AST_STRUCT_FIELD &&
+                field->node_type && field->node_type->kind == TYPE_STRING) {
+                print_line(gen, "if (s->_heap_%s) { free((void*)s->%s); s->%s = (const char*)0; s->_heap_%s = 0; }",
+                           field->value, field->value, field->value, field->value);
+            }
+        }
+        unindent(gen);
+        print_line(gen, "}");
+    }
     print_line(gen, "");
+}
+
+/* Predicate: does `struct_def` have any string-typed field that
+ * needs heap-ownership tracking? Used by the codegen_stmt.c
+ * struct-local-declaration site to decide whether to push the
+ * function-exit destructor defer. */
+int struct_has_heap_string_field(ASTNode* struct_def) {
+    if (!struct_def || struct_def->type != AST_STRUCT_DEFINITION) return 0;
+    for (int i = 0; i < struct_def->child_count; i++) {
+        ASTNode* field = struct_def->children[i];
+        if (field && field->type == AST_STRUCT_FIELD &&
+            field->node_type && field->node_type->kind == TYPE_STRING) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Lookup helper: find an AST_STRUCT_DEFINITION by struct name in
+ * the program AST. Returns NULL if not found. Used by the codegen
+ * site to decide whether a local-struct declaration needs the
+ * destructor-defer push. */
+ASTNode* find_struct_definition_by_name(ASTNode* program, const char* name) {
+    if (!program || !name) return NULL;
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* c = program->children[i];
+        if (c && c->type == AST_STRUCT_DEFINITION &&
+            c->value && strcmp(c->value, name) == 0) {
+            return c;
+        }
+    }
+    return NULL;
 }

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -164,6 +164,17 @@ const char* get_builder_factory(CodeGenerator* gen, const char* func_name);
 
 /* Function/struct generation (codegen_func.c) */
 int has_return_value(ASTNode* node);
+
+/* Struct-field heap-string ownership (#465). The struct typedef
+ * emitter (generate_struct_definition) appends a hidden
+ * `int _heap_<field>` tracker per `string`-typed field, and a
+ * `<Name>_destroy()` function. The statement-codegen consumes
+ * these helpers at struct-local declaration sites (push the
+ * scope-exit destroy defer) and at field-write sites (emit the
+ * reassign-wrapper free). */
+int struct_has_heap_string_field(ASTNode* struct_def);
+ASTNode* find_struct_definition_by_name(ASTNode* program, const char* name);
+
 /* @c_callback annotation helpers (#235). A function declared with
    `@c_callback aether_name(...)` (or `@c_callback("c_sym") aether_name(...)`)
    gets a stable, externally-visible C symbol so it can be passed across

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -902,6 +902,78 @@ static void emit_return_escape_drains_for_unreturned(CodeGenerator* gen,
     }
 }
 
+/* Struct-field heap-string assignment helper (#465).
+ *
+ * For an assignment `<var>.<field> = <rhs>` where `<var>` is a
+ * struct local whose definition has `<field>: string`, emit:
+ *
+ *     { const char* _tmp_old = <var>.<field>;
+ *       <var>.<field> = <rhs>;
+ *       if (<var>._heap_<field>) free((void*)_tmp_old);
+ *       <var>._heap_<field> = <rhs_is_heap>; }
+ *
+ * Returns 1 if the wrap was emitted (caller skips the bare
+ * assignment), 0 if the LHS shape isn't one of the recognised
+ * struct-field patterns (caller falls through to the existing
+ * bare-assignment emission). */
+static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNode* rhs) {
+    if (!gen || !lhs || !rhs) return 0;
+    if (lhs->type != AST_MEMBER_ACCESS || !lhs->value) return 0;
+    if (lhs->child_count != 1 || !lhs->children[0]) return 0;
+    if (lhs->children[0]->type != AST_IDENTIFIER || !lhs->children[0]->value) return 0;
+    ASTNode* obj = lhs->children[0];
+    Type* obj_type = obj->node_type;
+    if (!obj_type || obj_type->kind != TYPE_STRUCT || !obj_type->struct_name) return 0;
+    if (!gen->program) return 0;
+    ASTNode* sdef = find_struct_definition_by_name(gen->program, obj_type->struct_name);
+    if (!sdef) return 0;
+    ASTNode* matching_field = NULL;
+    for (int fi = 0; fi < sdef->child_count; fi++) {
+        ASTNode* f = sdef->children[fi];
+        if (f && f->type == AST_STRUCT_FIELD &&
+            f->value && strcmp(f->value, lhs->value) == 0) {
+            matching_field = f;
+            break;
+        }
+    }
+    if (!matching_field || !matching_field->node_type ||
+        matching_field->node_type->kind != TYPE_STRING) return 0;
+
+    int rhs_is_heap = is_heap_string_expr(gen, rhs);
+    print_indent(gen);
+    fprintf(gen->output,
+            "{ const char* _tmp_old = %s.%s; %s.%s = ",
+            obj->value, lhs->value,
+            obj->value, lhs->value);
+    generate_expression(gen, rhs);
+    fprintf(gen->output,
+            "; if (%s._heap_%s) free((void*)_tmp_old); "
+            "%s._heap_%s = %d; }\n",
+            obj->value, lhs->value,
+            obj->value, lhs->value,
+            rhs_is_heap ? 1 : 0);
+    return 1;
+}
+
+/* Struct-reassignment helper (#465). For `<var> = <struct_literal>`
+ * where `<var>` is a struct local with heap-string fields, emit
+ * `<Struct>_destroy(&<var>)` BEFORE the bare assignment so the
+ * previous struct's heap fields are reclaimed. Returns 1 if a
+ * destroy call was emitted; the caller still proceeds with the
+ * bare assignment emission afterward. */
+static int emit_struct_destroy_before_reassign(CodeGenerator* gen,
+                                                const char* var_name,
+                                                Type* var_type) {
+    if (!gen || !var_name || !var_type) return 0;
+    if (var_type->kind != TYPE_STRUCT || !var_type->struct_name) return 0;
+    if (!gen->program) return 0;
+    ASTNode* sdef = find_struct_definition_by_name(gen->program, var_type->struct_name);
+    if (!sdef || !struct_has_heap_string_field(sdef)) return 0;
+    print_indent(gen);
+    fprintf(gen->output, "%s_destroy(&%s);\n", var_type->struct_name, var_name);
+    return 1;
+}
+
 /* Should the return statement at this site route its value through
  * the uniform-heap shim? True when: the enclosing function is not
  * main, the return is single-value, the function is classifier-
@@ -1768,7 +1840,44 @@ static void hoist_loop_vars(CodeGenerator* gen, ASTNode* body) {
                 }
                 const char* c_type = get_c_type(var_type);
                 print_indent(gen);
-                fprintf(gen->output, "%s %s;\n", c_type, child->value);
+                /* Zero-initialize struct hoists so the first-iteration
+                 * struct-destroy call (#465) sees zero `_heap_<field>`
+                 * trackers instead of stack-uninitialised garbage.
+                 * Without this, the first `b = Box { ... }` inside the
+                 * loop body runs `Box_destroy(&b)` on uninit memory
+                 * and may free a garbage pointer. The {0} initialiser
+                 * is C99-portable and a no-op for non-struct types
+                 * either (the C compiler does the right thing). */
+                if (var_type && var_type->kind == TYPE_STRUCT) {
+                    fprintf(gen->output, "%s %s = {0};\n", c_type, child->value);
+                    /* Push the function-exit struct-destroy defer
+                     * here too — the in-loop reassignment path
+                     * doesn't run the first-declaration codegen
+                     * that normally pushes the defer (the var is
+                     * already-declared via this hoist). Without
+                     * this, the final loop-iteration's heap fields
+                     * never get reclaimed at function exit. */
+                    if (var_type->struct_name && gen->program) {
+                        ASTNode* sdef = find_struct_definition_by_name(
+                            gen->program, var_type->struct_name);
+                        if (sdef && struct_has_heap_string_field(sdef)) {
+                            char annot[300];
+                            snprintf(annot, sizeof(annot),
+                                     "struct_destroy:%s:%s",
+                                     child->value, var_type->struct_name);
+                            ASTNode* carrier = create_ast_node(
+                                AST_EXPRESSION_STATEMENT, NULL,
+                                child->line, child->column);
+                            if (carrier) {
+                                if (carrier->annotation) free(carrier->annotation);
+                                carrier->annotation = strdup(annot);
+                                push_defer(gen, carrier);
+                            }
+                        }
+                    }
+                } else {
+                    fprintf(gen->output, "%s %s;\n", c_type, child->value);
+                }
             }
         }
         // Recurse into nested blocks (e.g., if inside while)
@@ -2784,6 +2893,23 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                         fprintf(gen->output, " _heap_%s = 1; }\n", stmt->value);
                     } else {
                         // Plain non-string assignment.
+                        /* Struct-reassignment heap cleanup (#465).
+                         * `b = Box { ... }` overwrites the struct
+                         * wholesale; without an explicit destroy of
+                         * the previous instance, every heap-string
+                         * field's old buffer leaks. Emit
+                         * `<Struct>_destroy(&<var>)` before the bare
+                         * assignment so any prior heap fields are
+                         * reclaimed. The struct's literal initializer
+                         * (codegen_expr.c AST_STRUCT_LITERAL) sets
+                         * the new `_heap_<field>` bits so the next
+                         * destroy at function exit fires correctly. */
+                        Type* vtype = stmt->node_type;
+                        if ((!vtype || vtype->kind != TYPE_STRUCT) &&
+                            stmt->child_count > 0 && stmt->children[0]) {
+                            vtype = stmt->children[0]->node_type;
+                        }
+                        emit_struct_destroy_before_reassign(gen, stmt->value, vtype);
                         fprintf(gen->output, "%s", stmt->value);
                         if (stmt->child_count > 0) {
                             fprintf(gen->output, " = ");
@@ -2927,6 +3053,32 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                                stmt->children[0]->value) {
                         // Message/struct constructor — use the constructor name as type
                         fprintf(gen->output, "%s %s", stmt->children[0]->value, stmt->value);
+                        /* Struct-field heap-string ownership (#465).
+                         * Push a function-exit defer that calls the
+                         * auto-emitted <Struct>_destroy(&<var>) to
+                         * free any heap-owned string fields. The
+                         * destroy function is no-op for structs
+                         * without heap-string fields, but we only
+                         * push the defer when the field set actually
+                         * needs cleanup (skips the no-op call). */
+                        if (stmt->children[0]->type == AST_STRUCT_LITERAL && gen->program) {
+                            ASTNode* sdef = find_struct_definition_by_name(
+                                gen->program, stmt->children[0]->value);
+                            if (sdef && struct_has_heap_string_field(sdef)) {
+                                char annot[300];
+                                snprintf(annot, sizeof(annot),
+                                         "struct_destroy:%s:%s",
+                                         stmt->value, stmt->children[0]->value);
+                                ASTNode* carrier = create_ast_node(
+                                    AST_EXPRESSION_STATEMENT, NULL,
+                                    stmt->line, stmt->column);
+                                if (carrier) {
+                                    if (carrier->annotation) free(carrier->annotation);
+                                    carrier->annotation = strdup(annot);
+                                    push_defer(gen, carrier);
+                                }
+                            }
+                        }
                     } else {
                         // Determine the best type for this variable
                         Type* var_type = stmt->node_type;
@@ -3266,6 +3418,15 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                         }
                     }
                 }
+
+                /* Struct-field heap-string ownership (#465). Helper
+                 * handles both AST_ASSIGNMENT and AST_EXPRESSION_
+                 * STATEMENT-wrapping-BINARY-`=` shapes (the parser
+                 * lands at different node types depending on whether
+                 * the LHS is a struct field vs. an array element vs.
+                 * a bare local — keep both paths routed through the
+                 * same wrapper). */
+                if (emit_struct_field_heap_assign(gen, lhs, rhs)) break;
 
                 // Generate the assignment itself
                 gen->generating_lvalue = 1;
@@ -4166,6 +4327,21 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
         case AST_EXPRESSION_STATEMENT:
             if (stmt->child_count > 0) {
                 ASTNode* inner = stmt->children[0];
+
+                /* Struct-field heap-string ownership (#465). Many
+                 * parsers land `<var>.<field> = <rhs>` as
+                 * AST_EXPRESSION_STATEMENT > AST_BINARY_EXPRESSION
+                 * (op="=") rather than AST_ASSIGNMENT. Same wrapper
+                 * applies — route through the helper before any
+                 * other expression handling. */
+                if (inner && inner->type == AST_BINARY_EXPRESSION &&
+                    inner->value && strcmp(inner->value, "=") == 0 &&
+                    inner->child_count == 2) {
+                    if (emit_struct_field_heap_assign(gen, inner->children[0],
+                                                       inner->children[1])) {
+                        break;
+                    }
+                }
 
                 // Check if this function call has a trailing block
                 int has_trailing = 0;

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -4719,9 +4719,28 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                                 }
                             }
                         }
+                        fprintf(gen->output, " }; ");
+
+                        /* Deep-copy heap-string reply-message fields
+                         * (#466). The reply message crosses an actor
+                         * boundary back to the asker; without deep-
+                         * copy the asker's reply-extraction reads
+                         * the handler's heap-string after the
+                         * handler's defer-free has run. */
+                        for (MessageFieldDef* f = msg_def->fields; f; f = f->next) {
+                            if (f->type_kind == TYPE_STRING) {
+                                fprintf(gen->output,
+                                        "if (_reply.%s) { "
+                                        "size_t _ml = aether_string_length(_reply.%s); "
+                                        "_reply.%s = (const char*)string_new_with_length("
+                                        "aether_string_data(_reply.%s), (int)_ml); "
+                                        "} ",
+                                        f->name, f->name, f->name, f->name);
+                            }
+                        }
 
                         // Send reply back to the waiting asker via the scheduler reply slot.
-                        fprintf(gen->output, " }; scheduler_reply((ActorBase*)self, &_reply, sizeof(%s)); }\n",
+                        fprintf(gen->output, "scheduler_reply((ActorBase*)self, &_reply, sizeof(%s)); }\n",
                                 reply_expr->value);
                     } else {
                         print_line(gen, "/* ERROR: unknown reply message type %s */", reply_expr->value);

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -1,6 +1,7 @@
 #include "aether_collections.h"
 #include "../../runtime/aether_resource_caps.h"
 #include "../../runtime/aether_value_kind.h"
+#include "../string/aether_string.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -9,12 +10,23 @@
  * aether_config.c. Hosts holding an opaque AetherValue* can probe
  * it safely (low-address guard + magic check) to discriminate map /
  * list / scalar without a schema lookup. The struct layout is
- * private to this TU; the magic must remain the first field. */
+ * private to this TU; the magic must remain the first field.
+ *
+ * `owns_string_elements` (#467): set by `list_add_string_owned`
+ * when the codegen-emitted call site recognises the added value
+ * as a heap-string expression. While set, `list_free` walks every
+ * element and calls `string_release` before freeing the backing
+ * array — so heap strings stored in the list are reclaimed cleanly
+ * rather than leaking. Mixed lists (heap-string + non-string
+ * elements) aren't supported by this flag — Aether-side
+ * codegen always knows the static type at each call site and
+ * routes accordingly. */
 struct ArrayList {
     uint32_t _kind_magic;       /* = AETHER_KIND_LIST_MAGIC */
     void** items;
     int size;
     int capacity;
+    int owns_string_elements;
 };
 
 ArrayList* list_new() {
@@ -26,6 +38,7 @@ ArrayList* list_new() {
     list->items = NULL;
     list->size = 0;
     list->capacity = 0;
+    list->owns_string_elements = 0;
     return list;
 }
 
@@ -48,6 +61,32 @@ int list_add_raw(ArrayList* list, void* item) {
 
     list->items[list->size++] = item;
     return 1;
+}
+
+/* Heap-string-aware add (#467). Retains the AetherString so the
+ * sender's reassign-wrapper / function-exit defer doesn't dangle
+ * the list's reference, and tags the list as owning its string
+ * elements so `list_free` releases them. Codegen routes
+ * `list.add(l, <heap_string_expr>)` here when the static type of
+ * the value is `string` and the expression is heap-classified
+ * (string.concat, _aether_interp, heap-returning user fn, etc.).
+ *
+ * For literal-string adds (`list.add(l, "literal")`), codegen
+ * stays on the plain `list_add_raw` path — literals don't need
+ * retain and the list shouldn't release them at free time.
+ *
+ * Mixed lists (one heap-string add followed by a literal add or a
+ * plain int add) aren't covered by this flag — Aether's type
+ * system pins each list to a single element type at the call site,
+ * so codegen can pick the right path consistently. */
+int list_add_string_owned(ArrayList* list, const void* item) {
+    if (!list) return 0;
+    /* Retain on add — if the source local is later reassigned or
+     * goes out of scope, the list's reference keeps the buffer
+     * alive. No-op on plain (non-AetherString) char* pointers. */
+    if (item) string_retain(item);
+    list->owns_string_elements = 1;
+    return list_add_raw(list, (void*)item);
 }
 
 void* list_get_raw(ArrayList* list, int index) {
@@ -80,6 +119,30 @@ void list_clear(ArrayList* list) {
 
 void list_free(ArrayList* list) {
     if (!list) return;
+    /* Owned heap-string elements (#467): walk and release each
+     * before freeing the backing array. Two element shapes:
+     *
+     *   - AetherString* (magic-tagged): `string_release` decrements
+     *     refcount, frees struct + data at zero.
+     *   - plain `char*` heap (e.g. from `string_concat`): plain
+     *     `free()` reclaims it.
+     *
+     * `is_aether_string` (byte-by-byte magic probe, ASan-clean on
+     * short literals) discriminates. Plain pointers from
+     * `string_concat` etc. don't carry the magic header; AetherStrings
+     * from `string_new_with_length` etc. do. */
+    if (list->owns_string_elements && list->items) {
+        for (int i = 0; i < list->size; i++) {
+            void* it = list->items[i];
+            if (!it) continue;
+            if (is_aether_string(it)) {
+                string_release(it);
+            } else {
+                free(it);
+            }
+            list->items[i] = NULL;
+        }
+    }
     /* Clear the kind-magic so a use-after-free probe via
      * aether_value_kind() returns AETHER_KIND_UNKNOWN rather than
      * false-matching the freed-but-still-readable memory. Defense
@@ -117,6 +180,11 @@ struct HashMap {
     HashMapEntry** buckets;
     int capacity;
     int size;
+    /* #467: set by `map_put_string_owned` when the put value is a
+     * heap-string. map_clear walks entries and releases each
+     * value (in addition to releasing the key, which it always
+     * does). Same semantics as ArrayList's `owns_string_elements`. */
+    int owns_string_values;
 };
 
 // djb2. Also returns length via an out-param so callers don't walk the
@@ -149,6 +217,7 @@ HashMap* map_new() {
     map->_kind_magic = AETHER_KIND_MAP_MAGIC;
     map->capacity = HASHMAP_INITIAL_CAPACITY;
     map->size = 0;
+    map->owns_string_values = 0;
     map->buckets = (HashMapEntry**)aether_caps_calloc(
         (size_t)map->capacity, sizeof(HashMapEntry*));
     if (!map->buckets) { aether_caps_free(map, sizeof(HashMap)); return NULL; }
@@ -225,6 +294,49 @@ int map_put_raw(HashMap* map, const char* key, void* value) {
     return 1;
 }
 
+/* Heap-string-aware put (#467). Mirrors list_add_string_owned for
+ * map values: retains the value (AetherString refcount bump),
+ * tags the map as owning string values, then stores via the plain
+ * map_put_raw path. map_clear / map_free walk owned-string maps
+ * and release each value before freeing the bucket entries.
+ *
+ * The key is always owned by the map (string_new'd at put time,
+ * released at clear time) — unchanged from map_put_raw. The
+ * value is what this variant adds heap-string tracking for.
+ *
+ * Codegen routes `map.put(m, k, heap_string_expr)` here when the
+ * value is heap-classified (string.concat, string interp, heap-
+ * returning user-fn). Plain literals stay on map_put_raw. */
+int map_put_string_owned(HashMap* map, const char* key, const void* value) {
+    if (!map) return 0;
+    if (value) string_retain(value);
+    map->owns_string_values = 1;
+    /* If the put REPLACES an existing entry, the previous value
+     * needs releasing too — otherwise replacement leaks the old
+     * heap string. Walk to find any existing entry. */
+    if (value || map->size > 0) {
+        unsigned int key_len = 0;
+        unsigned int hash = hash_cstr_len(key, &key_len);
+        unsigned int index = hash % (unsigned int)map->capacity;
+        HashMapEntry* entry = map->buckets[index];
+        while (entry) {
+            if (entry->hash == hash && key_equals(entry, key, key_len)) {
+                if (entry->value) {
+                    if (is_aether_string(entry->value)) {
+                        string_release(entry->value);
+                    } else {
+                        free(entry->value);
+                    }
+                }
+                entry->value = (void*)value;
+                return 1;
+            }
+            entry = entry->next;
+        }
+    }
+    return map_put_raw(map, key, (void*)value);
+}
+
 void* map_get_raw(HashMap* map, const char* key) {
     if (!map || !key) return NULL;
 
@@ -286,6 +398,16 @@ void map_clear(HashMap* map) {
         while (entry) {
             HashMapEntry* next = entry->next;
             string_release(entry->key);
+            /* #467: release heap-string values too when the map
+             * is in owns_string_values mode. Same shape as
+             * list_free's element walk. */
+            if (map->owns_string_values && entry->value) {
+                if (is_aether_string(entry->value)) {
+                    string_release(entry->value);
+                } else {
+                    free(entry->value);
+                }
+            }
             aether_caps_free(entry, sizeof(HashMapEntry));
             entry = next;
         }

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -26,7 +26,16 @@ struct ArrayList {
     void** items;
     int size;
     int capacity;
-    int owns_string_elements;
+    /* #467: per-element heap-string-ownership tracking. Parallel
+     * array to `items` (allocated lazily alongside the items
+     * array's first grow). `owned_flags[i] == 1` means
+     * `items[i]` was added via list_add_string_owned and should
+     * be released by list_free; `owned_flags[i] == 0` means the
+     * caller retains ownership (literals, int-cast-to-ptr, etc.).
+     * The two paths can coexist in a single list — mixing is
+     * safe by construction. NULL on a fresh list that has never
+     * had an owned-put; first owned-put allocates it. */
+    int* owned_flags;
 };
 
 ArrayList* list_new() {
@@ -38,13 +47,26 @@ ArrayList* list_new() {
     list->items = NULL;
     list->size = 0;
     list->capacity = 0;
-    list->owns_string_elements = 0;
+    list->owned_flags = NULL;
     return list;
 }
 
 // list_add_raw returns 1 on success, 0 on failure (realloc error or
 // null list). The Aether wrapper `list.add` in std.list/std.collections
 // turns the 0 into an error string.
+/* Grow `list->owned_flags` to match `list->capacity`. Idempotent.
+ * Returns 1 on success, 0 on alloc failure. Called lazily — the
+ * flags array is only allocated when the first owned-put happens
+ * on a list. Plain-only-element lists (literals, ints) never
+ * allocate the flags array. */
+static int list_grow_owned_flags(ArrayList* list) {
+    if (!list || list->capacity == 0) return 1;
+    if (list->owned_flags) return 1;
+    list->owned_flags = (int*)aether_caps_calloc(
+        (size_t)list->capacity, sizeof(int));
+    return list->owned_flags ? 1 : 0;
+}
+
 int list_add_raw(ArrayList* list, void* item) {
     if (!list) return 0;
 
@@ -56,37 +78,67 @@ int list_add_raw(ArrayList* list, void* item) {
                                                        old_bytes, new_bytes);
         if (!new_items) return 0;
         list->items = new_items;
+        /* Mirror the grow in owned_flags when present. New slots
+         * get value 0 (caller-owned default). */
+        if (list->owned_flags) {
+            size_t old_fbytes = (size_t)list->capacity * sizeof(int);
+            size_t new_fbytes = (size_t)new_capacity * sizeof(int);
+            int* new_flags = (int*)aether_caps_realloc(list->owned_flags,
+                                                       old_fbytes, new_fbytes);
+            if (!new_flags) return 0;
+            /* Zero the new tail explicitly — aether_caps_realloc
+             * doesn't zero-fill the extension. */
+            memset((char*)new_flags + old_fbytes, 0, new_fbytes - old_fbytes);
+            list->owned_flags = new_flags;
+        }
         list->capacity = new_capacity;
     }
 
-    list->items[list->size++] = item;
+    list->items[list->size] = item;
+    if (list->owned_flags) list->owned_flags[list->size] = 0;
+    list->size++;
     return 1;
 }
 
 /* Heap-string-aware add (#467). Retains the AetherString so the
  * sender's reassign-wrapper / function-exit defer doesn't dangle
- * the list's reference, and tags the list as owning its string
- * elements so `list_free` releases them. Codegen routes
- * `list.add(l, <heap_string_expr>)` here when the static type of
- * the value is `string` and the expression is heap-classified
- * (string.concat, _aether_interp, heap-returning user fn, etc.).
+ * the list's reference, and tags this specific element as owned
+ * so `list_free` releases it. Codegen routes `list.add(l, <heap_
+ * string_expr>)` here when the static type of the value is
+ * `string` and the expression is heap-classified.
  *
- * For literal-string adds (`list.add(l, "literal")`), codegen
- * stays on the plain `list_add_raw` path — literals don't need
- * retain and the list shouldn't release them at free time.
- *
- * Mixed lists (one heap-string add followed by a literal add or a
- * plain int add) aren't covered by this flag — Aether's type
- * system pins each list to a single element type at the call site,
- * so codegen can pick the right path consistently. */
+ * Per-element ownership lets a single list mix owned heap strings
+ * with literals / ints. Each element's `owned_flags[i]` tracks
+ * its own ownership independently. */
 int list_add_string_owned(ArrayList* list, const void* item) {
     if (!list) return 0;
-    /* Retain on add — if the source local is later reassigned or
-     * goes out of scope, the list's reference keeps the buffer
-     * alive. No-op on plain (non-AetherString) char* pointers. */
     if (item) string_retain(item);
-    list->owns_string_elements = 1;
-    return list_add_raw(list, (void*)item);
+    /* Lazy-allocate the flags array on first owned-put. */
+    if (!list->owned_flags) {
+        if (list->capacity > 0) {
+            list->owned_flags = (int*)aether_caps_calloc(
+                (size_t)list->capacity, sizeof(int));
+            if (!list->owned_flags) {
+                /* Best-effort: still store the item even if flag
+                 * tracking failed; the buffer will leak on free
+                 * rather than crash. */
+            }
+        }
+    }
+    int slot = list->size;  /* the index list_add_raw will use */
+    int ok = list_add_raw(list, (void*)item);
+    if (!ok) return 0;
+    /* The first owned-put may have triggered the lazy alloc above
+     * AFTER the items array existed but BEFORE list_add_raw's
+     * grow path — flags array may still be NULL if list->capacity
+     * was 0 at lazy-alloc time. Retry now that list_add_raw has
+     * grown capacity. */
+    if (!list->owned_flags && list->capacity > 0) {
+        list->owned_flags = (int*)aether_caps_calloc(
+            (size_t)list->capacity, sizeof(int));
+    }
+    if (list->owned_flags) list->owned_flags[slot] = 1;
+    return 1;
 }
 
 void* list_get_raw(ArrayList* list, int index) {
@@ -120,19 +172,14 @@ void list_clear(ArrayList* list) {
 void list_free(ArrayList* list) {
     if (!list) return;
     /* Owned heap-string elements (#467): walk and release each
-     * before freeing the backing array. Two element shapes:
-     *
-     *   - AetherString* (magic-tagged): `string_release` decrements
-     *     refcount, frees struct + data at zero.
-     *   - plain `char*` heap (e.g. from `string_concat`): plain
-     *     `free()` reclaims it.
-     *
-     * `is_aether_string` (byte-by-byte magic probe, ASan-clean on
-     * short literals) discriminates. Plain pointers from
-     * `string_concat` etc. don't carry the magic header; AetherStrings
-     * from `string_new_with_length` etc. do. */
-    if (list->owns_string_elements && list->items) {
+     * `owned_flags[i] == 1` element before freeing the backing
+     * array. Per-element tracking lets owned heap strings coexist
+     * with literals / ints in the same list — only the owned
+     * slots get released. AetherString (magic-tagged) goes through
+     * string_release; plain heap char* goes through libc free. */
+    if (list->owned_flags && list->items) {
         for (int i = 0; i < list->size; i++) {
+            if (!list->owned_flags[i]) continue;
             void* it = list->items[i];
             if (!it) continue;
             if (is_aether_string(it)) {
@@ -142,6 +189,11 @@ void list_free(ArrayList* list) {
             }
             list->items[i] = NULL;
         }
+    }
+    if (list->owned_flags) {
+        aether_caps_free(list->owned_flags,
+                         (size_t)list->capacity * sizeof(int));
+        list->owned_flags = NULL;
     }
     /* Clear the kind-magic so a use-after-free probe via
      * aether_value_kind() returns AETHER_KIND_UNKNOWN rather than
@@ -173,6 +225,15 @@ typedef struct HashMapEntry {
     struct HashMapEntry*  next;
     unsigned int          hash;    // cached so resize doesn't recompute
     unsigned int          key_len; // cached so key_equals can prefilter
+    /* #467: per-entry heap-string-value ownership. Set to 1 by
+     * `map_put_string_owned`; cleared by `map_put_raw` (or by
+     * an owned-put that finds a prior unowned entry, etc.). At
+     * map_clear / map_free / map_remove time, only entries with
+     * value_owned == 1 have their value released — mixing owned
+     * (heap concat results) and unowned (literal strings, int-
+     * cast-to-ptr) values on the same map is safe by construction:
+     * each entry knows who owns it. */
+    int                   value_owned;
 } HashMapEntry;
 
 struct HashMap {
@@ -180,11 +241,6 @@ struct HashMap {
     HashMapEntry** buckets;
     int capacity;
     int size;
-    /* #467: set by `map_put_string_owned` when the put value is a
-     * heap-string. map_clear walks entries and releases each
-     * value (in addition to releasing the key, which it always
-     * does). Same semantics as ArrayList's `owns_string_elements`. */
-    int owns_string_values;
 };
 
 // djb2. Also returns length via an out-param so callers don't walk the
@@ -217,7 +273,6 @@ HashMap* map_new() {
     map->_kind_magic = AETHER_KIND_MAP_MAGIC;
     map->capacity = HASHMAP_INITIAL_CAPACITY;
     map->size = 0;
-    map->owns_string_values = 0;
     map->buckets = (HashMapEntry**)aether_caps_calloc(
         (size_t)map->capacity, sizeof(HashMapEntry*));
     if (!map->buckets) { aether_caps_free(map, sizeof(HashMap)); return NULL; }
@@ -275,7 +330,19 @@ int map_put_raw(HashMap* map, const char* key, void* value) {
         // Hash check is a cheap prefilter before key_equals (which
         // still runs memcmp for false hash collisions).
         if (entry->hash == hash && key_equals(entry, key, key_len)) {
+            /* #467: if the entry was previously owned-put, release
+             * the prior heap-string before overwriting with the
+             * (unowned) new value. Subsequent map.free won't see
+             * the dropped allocation since value_owned is reset. */
+            if (entry->value_owned && entry->value) {
+                if (is_aether_string(entry->value)) {
+                    string_release(entry->value);
+                } else {
+                    free(entry->value);
+                }
+            }
             entry->value = value;
+            entry->value_owned = 0;
             return 1;
         }
         entry = entry->next;
@@ -285,10 +352,11 @@ int map_put_raw(HashMap* map, const char* key, void* value) {
     if (!new_entry) return 0;
     new_entry->key = string_new(key);
     if (!new_entry->key) { aether_caps_free(new_entry, sizeof(HashMapEntry)); return 0; }
-    new_entry->value   = value;
-    new_entry->hash    = hash;
-    new_entry->key_len = key_len;
-    new_entry->next    = map->buckets[index];
+    new_entry->value       = value;
+    new_entry->value_owned = 0;
+    new_entry->hash        = hash;
+    new_entry->key_len     = key_len;
+    new_entry->next        = map->buckets[index];
     map->buckets[index] = new_entry;
     map->size++;
     return 1;
@@ -308,20 +376,22 @@ int map_put_raw(HashMap* map, const char* key, void* value) {
  * value is heap-classified (string.concat, string interp, heap-
  * returning user-fn). Plain literals stay on map_put_raw. */
 int map_put_string_owned(HashMap* map, const char* key, const void* value) {
-    if (!map) return 0;
+    if (!map || !key) return 0;
     if (value) string_retain(value);
-    map->owns_string_values = 1;
-    /* If the put REPLACES an existing entry, the previous value
-     * needs releasing too — otherwise replacement leaks the old
-     * heap string. Walk to find any existing entry. */
-    if (value || map->size > 0) {
+
+    /* Replace path: walk the bucket. If the key exists, release
+     * the previous value when it was previously owned, then store
+     * the new value with value_owned=1. If the previous put was
+     * unowned (literal / int-cast-to-ptr), DON'T release it —
+     * the caller never expected ownership transfer for that path. */
+    if (map->size > 0) {
         unsigned int key_len = 0;
         unsigned int hash = hash_cstr_len(key, &key_len);
         unsigned int index = hash % (unsigned int)map->capacity;
         HashMapEntry* entry = map->buckets[index];
         while (entry) {
             if (entry->hash == hash && key_equals(entry, key, key_len)) {
-                if (entry->value) {
+                if (entry->value_owned && entry->value) {
                     if (is_aether_string(entry->value)) {
                         string_release(entry->value);
                     } else {
@@ -329,12 +399,24 @@ int map_put_string_owned(HashMap* map, const char* key, const void* value) {
                     }
                 }
                 entry->value = (void*)value;
+                entry->value_owned = 1;
                 return 1;
             }
             entry = entry->next;
         }
     }
-    return map_put_raw(map, key, (void*)value);
+
+    /* Fresh entry: insert via map_put_raw, then flip the new
+     * entry's value_owned. map_put_raw guarantees the inserted
+     * entry is at the head of the bucket. */
+    int ok = map_put_raw(map, key, (void*)value);
+    if (!ok) return 0;
+    unsigned int key_len = 0;
+    unsigned int hash = hash_cstr_len(key, &key_len);
+    unsigned int index = hash % (unsigned int)map->capacity;
+    HashMapEntry* head = map->buckets[index];
+    if (head) head->value_owned = 1;
+    return 1;
 }
 
 void* map_get_raw(HashMap* map, const char* key) {
@@ -377,6 +459,16 @@ void map_remove(HashMap* map, const char* key) {
             }
 
             string_release(entry->key);
+            /* #467: release the value too when this entry was
+             * owned-put. Otherwise map_remove of an owned-put
+             * entry leaks the heap string. */
+            if (entry->value_owned && entry->value) {
+                if (is_aether_string(entry->value)) {
+                    string_release(entry->value);
+                } else {
+                    free(entry->value);
+                }
+            }
             aether_caps_free(entry, sizeof(HashMapEntry));
             map->size--;
             return;
@@ -398,10 +490,12 @@ void map_clear(HashMap* map) {
         while (entry) {
             HashMapEntry* next = entry->next;
             string_release(entry->key);
-            /* #467: release heap-string values too when the map
-             * is in owns_string_values mode. Same shape as
-             * list_free's element walk. */
-            if (map->owns_string_values && entry->value) {
+            /* #467: release the value only when this specific
+             * entry was owned-put. Per-entry tracking lets a
+             * single map carry owned heap-strings + unowned
+             * literals / int-cast-to-ptr values without
+             * crashing on free of the latter. */
+            if (entry->value_owned && entry->value) {
                 if (is_aether_string(entry->value)) {
                     string_release(entry->value);
                 } else {

--- a/std/collections/aether_collections.h
+++ b/std/collections/aether_collections.h
@@ -10,6 +10,18 @@ typedef struct IntArray IntArray;
 
 ArrayList* list_new();
 int list_add_raw(ArrayList* list, void* item);
+
+/* Heap-string-aware add (#467). Retains the value (AetherString
+ * refcount bump), tags the list as owning string elements, then
+ * stores the pointer. list_free walks owned-string lists and
+ * releases each element before freeing the backing array.
+ *
+ * Codegen routes `list.add(list, expr)` here when `expr` is a
+ * heap-classified string expression (string.concat, string
+ * interp, heap-returning user-fn, heap-tracked local). Plain
+ * literals stay on `list_add_raw` (no retain, list won't release
+ * at free). */
+int list_add_string_owned(ArrayList* list, const void* item);
 // Return element at `index`, or NULL for out-of-bounds / null list. The
 // Aether wrapper `list.get` in std/collections/module.ae turns these into
 // Go-style `(value, err)` returns.
@@ -22,6 +34,14 @@ void list_free(ArrayList* list);
 
 HashMap* map_new();
 int map_put_raw(HashMap* map, const char* key, void* value);
+
+/* Heap-string-aware put (#467). Retains the value and tags the
+ * map so map_free / map_clear release each string value before
+ * freeing the bucket entries. Codegen routes
+ * `map.put(m, k, heap_string_expr)` here when the value is heap-
+ * classified. Plain literals stay on map_put_raw (no retain, map
+ * won't release at free). */
+int map_put_string_owned(HashMap* map, const char* key, const void* value);
 // Return value for `key`, or NULL for absent / null-input. The Aether
 // wrapper `map.get` distinguishes "absent" (null, "") from wrong-input
 // (null, "null map").

--- a/std/collections/module.ae
+++ b/std/collections/module.ae
@@ -26,6 +26,13 @@ exports (
 // ---- ArrayList raw externs ----
 extern list_new() -> ptr
 extern list_add_raw(list: ptr, item: ptr) -> int
+// Heap-string-aware add (#467). Retains the value, tags the list,
+// stores the pointer. list_free releases owned-string elements
+// before freeing the backing array. Codegen auto-routes
+// `list.add(l, heap_string_expr)` here when the value is heap-
+// classified — direct callers pick this when they want explicit
+// ownership transfer.
+extern list_add_string_owned(list: ptr, item: ptr) -> int
 extern list_get_raw(list: ptr, index: int) -> ptr
 extern list_set(list: ptr, index: int, item: ptr)
 extern list_size(list: ptr) -> int
@@ -41,6 +48,9 @@ extern map_new() -> ptr
 // annotation, the function-exit defer-free would free the bytes
 // while the map still holds a reference. See #420 follow-up.
 extern map_put_raw(map: ptr, key: @retain string, value: ptr) -> int
+// Heap-string-aware put (#467). Retains the value and tags the
+// map so map_free releases each string value before freeing.
+extern map_put_string_owned(map: ptr, key: @retain string, value: ptr) -> int
 extern map_get_raw(map: ptr, key: string) -> ptr
 extern map_has(map: ptr, key: string) -> int
 extern map_remove(map: ptr, key: string)

--- a/std/list/module.ae
+++ b/std/list/module.ae
@@ -7,13 +7,18 @@
 //     returns.
 
 exports (
-    list_new, list_add_raw, list_get_raw, list_set, list_size,
+    list_new, list_add_raw, list_add_string_owned, list_get_raw, list_set, list_size,
     list_remove, list_clear, list_free,
     add, get
 )
 
 extern list_new() -> ptr
 extern list_add_raw(list: ptr, item: ptr) -> int
+// Heap-string-aware add (#467). Retains the value and tags the
+// list so list_free releases each string element before freeing
+// the backing array. Codegen auto-routes `list.add(l, heap_string_expr)`
+// here when the value is heap-classified.
+extern list_add_string_owned(list: ptr, item: ptr) -> int
 extern list_get_raw(list: ptr, index: int) -> ptr
 extern list_set(list: ptr, index: int, item: ptr)
 extern list_size(list: ptr) -> int

--- a/std/map/module.ae
+++ b/std/map/module.ae
@@ -7,13 +7,17 @@
 //     returns.
 
 exports (
-    map_new, map_put_raw, map_get_raw, map_has, map_remove,
+    map_new, map_put_raw, map_put_string_owned, map_get_raw, map_has, map_remove,
     map_size, map_clear, map_free, map_keys_raw, map_keys_free,
     put, get, keys
 )
 
 extern map_new() -> ptr
 extern map_put_raw(map: ptr, key: string, value: ptr) -> int
+// Heap-string-aware put (#467). Retains the value and tags the
+// map so map_free releases each string value before freeing.
+// Codegen auto-routes `map.put(m, k, heap_string_expr)` here.
+extern map_put_string_owned(map: ptr, key: string, value: ptr) -> int
 extern map_get_raw(map: ptr, key: string) -> ptr
 extern map_has(map: ptr, key: string) -> int
 extern map_remove(map: ptr, key: string)

--- a/tests/regression/test_actor_message_heap_string.ae
+++ b/tests/regression/test_actor_message_heap_string.ae
@@ -1,0 +1,45 @@
+// #466 — actor message heap-string ownership protocol.
+//
+// Pre-fix: sending a message with a heap-string field shallow-
+// copied the pointer. Sender's local heap got freed on reassign /
+// scope-exit; receiver's mailbox copy of the pointer dangled. The
+// existing escape-suppression at the heap-string-tracker keeps
+// the buffer alive but never frees it (UAF avoided by leak).
+//
+// Post-fix: every heap-string message field is deep-copied at the
+// SEND site (refcounted AetherString). Sender's local heap is
+// freed normally; receiver's deep-copied AetherString is released
+// when the message is freed by the runtime.
+
+import std.string
+
+extern exit(code: int)
+
+message Greeting { text: string }
+
+actor Greeter {
+    state count = 0
+
+    receive {
+        Greeting(text) -> {
+            count = count + string.length(text)
+        }
+    }
+}
+
+main() {
+    println("=== test_actor_message_heap_string ===")
+
+    g = spawn_Greeter(0)
+
+    j = 0
+    while j < 5000 {
+        msg_text = string.concat("hello-", "world")
+        g ! Greeting { text: msg_text }
+        msg_text = ""
+        j = j + 1
+    }
+
+    println("  PASS: 5000 sends with heap-string field stable")
+    println("=== all cases passed ===")
+}

--- a/tests/regression/test_list_heap_string_ownership.ae
+++ b/tests/regression/test_list_heap_string_ownership.ae
@@ -1,0 +1,37 @@
+// #467 — list element heap-string ownership.
+//
+// Pre-fix: `list.add(l, string.concat(...))` stored the heap pointer
+// opaquely. The sender's escape walker marked the value escaped (so
+// sender's defer-free skipped), and `list.free(l)` only freed the
+// backing array — not the elements. Net: every added heap string
+// leaked forever.
+//
+// Post-fix: codegen routes `list.add(l, heap_string_expr)` to
+// `list_add_string_owned` (retain + tag the list as owning string
+// elements). `list_free` walks owned-string lists and releases each
+// element before freeing the array.
+
+import std.list
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== test_list_heap_string_ownership ===")
+
+    j = 0
+    while j < 5000 {
+        l = list.new()
+        list.add(l, string.concat("item-", "value"))
+        list.add(l, string.concat("two-", "value"))
+        list.add(l, string.concat("three-", "value"))
+        if list.size(l) != 3 {
+            println("FAIL iter ${j}: size=${list.size(l)}")
+            exit(1)
+        }
+        list.free(l)
+        j = j + 1
+    }
+    println("  PASS: 5000 list.add + list.free iterations stable")
+    println("=== all cases passed ===")
+}

--- a/tests/regression/test_map_heap_string_value.ae
+++ b/tests/regression/test_map_heap_string_value.ae
@@ -1,0 +1,41 @@
+// #467 — map element heap-string-value ownership.
+//
+// Pre-fix: `map.put(m, k, string.concat(...))` stored the heap
+// pointer opaquely. map_free released the keys but not the values,
+// leaking every heap-string value forever.
+//
+// Post-fix: codegen routes `map.put(m, k, heap_string_expr)` to
+// `map_put_string_owned` (retain + tag the map). map_clear/map_free
+// walks owned-string maps and releases each value before freeing
+// the bucket entries.
+
+import std.map
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== test_map_heap_string_value ===")
+
+    j = 0
+    while j < 5000 {
+        m = map.new()
+        map.put(m, "first", string.concat("v1-", "concat"))
+        map.put(m, "second", string.concat("v2-", "concat"))
+        map.put(m, "third", string.concat("v3-", "concat"))
+        if map.size(m) != 3 {
+            println("FAIL iter ${j}: size=${map.size(m)}")
+            exit(1)
+        }
+        // Replace one value to exercise the put-replaces-old path.
+        map.put(m, "second", string.concat("v2-", "updated"))
+        if map.size(m) != 3 {
+            println("FAIL iter ${j}: size after replace=${map.size(m)}")
+            exit(1)
+        }
+        map.free(m)
+        j = j + 1
+    }
+    println("  PASS: 5000 map.put + map.free iterations stable")
+    println("=== all cases passed ===")
+}

--- a/tests/regression/test_struct_field_heap_multi.ae
+++ b/tests/regression/test_struct_field_heap_multi.ae
@@ -1,0 +1,33 @@
+// #465 follow-up — struct with multiple heap-string fields.
+// Verifies the auto-destructor walks every tracked field.
+
+import std.string
+
+extern exit(code: int)
+
+struct Pair {
+    first: string
+    second: string
+}
+
+main() {
+    println("=== test_struct_field_heap_multi ===")
+
+    p = Pair { first: "", second: "" }
+    j = 0
+    while j < 5000 {
+        p.first = string.concat("a", "b")
+        p.second = string.concat("x", "y")
+        if string.length(p.first) != 2 {
+            println("FAIL iter ${j}: first len=${string.length(p.first)}")
+            exit(1)
+        }
+        if string.length(p.second) != 2 {
+            println("FAIL iter ${j}: second len=${string.length(p.second)}")
+            exit(1)
+        }
+        j = j + 1
+    }
+    println("  PASS: 5000 iters with two heap fields stable")
+    println("=== all cases passed ===")
+}

--- a/tests/regression/test_struct_field_heap_tracking.ae
+++ b/tests/regression/test_struct_field_heap_tracking.ae
@@ -1,0 +1,60 @@
+// Regression for issue #465 — struct-field heap-string ownership
+// tracking. Pre-fix: `b.value = string.concat(...)` had no tracker
+// and no destructor, so every assignment leaked the previous value
+// and the final value leaked at scope exit.
+//
+// Post-fix: each `string`-typed struct field has a hidden
+// `_heap_<field>` companion tracker emitted into the struct's C
+// definition, the reassign-wrapper frees the previous value
+// uniformly, and the auto-emitted `<Struct>_destroy(&local)` runs
+// at function exit to free the final allocation.
+//
+// 5000 iterations of (struct ctor + heap field reassign) probes
+// the hot path. Run under macOS `leaks(1)` and ASan; both must
+// report zero leaks.
+
+import std.string
+
+extern exit(code: int)
+
+struct Box {
+    label: string
+}
+
+main() {
+    println("=== test_struct_field_heap_tracking ===")
+
+    // Single struct, mutate the field with heap values in a loop.
+    b = Box { label: "" }
+    j = 0
+    while j < 5000 {
+        b.label = string.concat("box-", "world")
+        if string.length(b.label) != 9 {
+            println("FAIL iter ${j}: length=${string.length(b.label)}")
+            exit(1)
+        }
+        j = j + 1
+    }
+    println("  PASS: 5000 b.label = string.concat(...) iterations stable")
+
+    // Fresh struct each iteration — exercises the destructor at
+    // each outer scope (well, here all in main; the next test
+    // would put this in a callee).
+    k = 0
+    while k < 5000 {
+        b2 = Box { label: string.concat("k=", "x") }
+        if string.length(b2.label) != 3 {
+            println("FAIL iter k=${k}: length=${string.length(b2.label)}")
+            exit(1)
+        }
+        b2.label = string.concat("y", "z")
+        if string.length(b2.label) != 2 {
+            println("FAIL iter k=${k} after reassign: length=${string.length(b2.label)}")
+            exit(1)
+        }
+        k = k + 1
+    }
+    println("  PASS: 5000 fresh-struct-per-iter + reassign stable")
+
+    println("=== all cases passed ===")
+}


### PR DESCRIPTION
## Summary

Closes the three architectural follow-ups filed against PR #459 / PR #469 — the high-priority issues that the audit identified as remaining leak surfaces after the v0.149 lucky-UAF / uniform-heap return-escape contract landed.

| Issue | Surface | Pre-fix behaviour | Post-fix |
|---|---|---|---|
| #465 | Struct fields holding heap strings | `b.field = string.concat(...)` leaked the previous value AND the final value at scope exit | Hidden per-field trackers + auto-emitted destructor + reassign-wrapper-free + scope-exit destroy defer |
| #466 | Actor message heap-string fields | Shallow-copied at send → receiver dangled OR escape-suppression leaked the buffer forever | Send-side deep-copy via refcounted AetherString; per-message-type `_release_fields` walked by the receive-dispatch before `aether_free_message` |
| #467 | List / map heap-string elements | `list.add(l, string.concat(...))` / `map.put(m, k, heap_string)` leaked every element forever — `list_free` / `map_clear` only freed the backing arrays, not the contents | New `list_add_string_owned` / `map_put_string_owned` retain + tag; `list_free` / `map_clear` walk and release owned-string elements |

## Verification

Every test below runs leak-clean under macOS `leaks(1)`:

| Test | Iterations | Pre-fix leaks | Post-fix |
|---|---|---|---|
| `test_struct_field_heap_tracking.ae` | 5000 × `b.label = string.concat(...)` + 5000 × `b2 = Box {...}` | thousands | **0** |
| `test_struct_field_heap_multi.ae` | 5000 × two-field struct mutation | thousands | **0** |
| `test_actor_message_heap_string.ae` | 5000 cross-actor sends + sender-side `text = ""` reassign | thousands | **0** |
| `test_list_heap_string_ownership.ae` | 5000 × 3 `list.add(l, heap)` + `list.free(l)` | 15000 | **0** |
| `test_map_heap_string_value.ae` | 5000 × 3 `map.put(m, k, heap)` + 1 replace + `map.free(m)` | thousands | **0** |

## Commit-by-commit

### `95ae09a` — #465 struct-field heap-string ownership

**Mechanism**: hidden `int _heap_<field>` trackers appended to each user-defined struct typedef (after the user-declared fields so FFI consumers' field offsets stay stable), plus an auto-emitted `<Name>_destroy(<Name>* s)` that walks every tracker and frees set fields. Reassign-wrappers at field-write sites (both AST_ASSIGNMENT and AST_EXPRESSION_STATEMENT > AST_BINARY_EXPRESSION) free the old value and update the tracker. Struct-literal init sets `._heap_<field> = 1` for heap-classified initialisers; C99 zero-fill handles the rest. Whole-struct reassignment (`b = Box {...}`) calls `<Box>_destroy(&b)` before the bare assignment so the previous instance's heap fields are reclaimed. Two destroy-defer push sites: first-time `AST_VARIABLE_DECLARATION` with struct-literal init, and `hoist_loop_vars`'s struct hoist for loop-body-first-assigned variables. Hoisted struct locals are now zero-initialised (`Box b2 = {0};`) so the first-iteration destroy reads zero trackers instead of stack-uninitialised garbage.

### `62bf5c6` — #466 actor message heap-string ownership protocol

Refcounted-AetherString deep-copy. Each `AST_MESSAGE_DEFINITION` with at least one `string` field gains a static-inline `<MsgName>_release_fields(<MsgName>* m)`. Send-side (AST_SEND_FIRE_FORGET heap path): after the message struct is initialised, every string field is re-stamped via `string_new_with_length(aether_string_data(orig), aether_string_length(orig))` so the receiver gets its own refcounted copy. Receive-side: the actor dispatch injects `<MsgName>_release_fields((<Msg>*)_msg_data)` before `aether_free_message`. The sender's normal heap-string-tracker reclaims the original buffer.

### `c65d6e8` — #467 list/map element ownership + #466 extensions

**#467**: `list_add_string_owned` / `map_put_string_owned` (retain + tag the container). `list_free` / `map_clear` walks and discriminates each element via `is_aether_string()` — AetherString → `string_release`, plain heap `char*` → libc `free`. `map_put_string_owned` also handles the replace path (releases old value before storing new). Codegen intercepts `list_add` / `list_add_raw` / `map_put` / `map_put_raw` calls and routes to the owned variant when the value arg is heap-classified.

**#466 extensions**: deep-copy now fires on `AST_SEND_ASK` (request-message string fields) and `AST_REPLY_STATEMENT` (handler-side reply messages), not just FIRE_FORGET.

**Cleanup over prior #466 commit**: the `string_new_with_length` / `aether_string_data` / `aether_string_length` prototypes were being re-emitted inline at every send call site (a workaround) — moved to the codegen prologue once. The `<Msg>_release_fields` helper no longer redeclares `string_release` inline (was triggering a conflicting-types error with the extern registry's later prototype).

## Tests

5 new regression tests under `tests/regression/`:
- `test_struct_field_heap_tracking.ae`
- `test_struct_field_heap_multi.ae`
- `test_actor_message_heap_string.ae`
- `test_list_heap_string_ownership.ae`
- `test_map_heap_string_value.ae`

All run leak-clean under macOS `leaks(1)`. Verified via macOS `leaks --atExit` on each binary.

## Out of scope (filed as follow-ups)

- Struct returns: a `Box` returned from a function (`fn make_box() -> Box { ... }`) has its destructor fire at the callee's scope exit BEFORE the return propagates — broken. Needs caller-side destructor invocation. Same shape as the uniform-heap return-escape contract from PR #459 but applied to structs.
- Mixed-element lists: `list.add(l, literal); list.add(l, heap_concat)` tags the list owning-string-elements at the second call, but `list.free` would crash trying to free the literal (read-only segment). Codegen currently routes only heap-classified expressions to the owned variant; mixed lists are outside the contract until the type-system enforces homogeneity.
- Borrowed-element opt-out: users who want the container to NOT own string elements need to call `list.add_raw` explicitly.
- Single-int inline message path: single-int messages can't have string fields by construction, so deep-copy doesn't apply. Documented.

## Verification (in-progress)

- [x] All 5 new regression tests pass under default build.
- [x] All 5 tests run leak-clean under macOS `leaks(1)`.
- [x] Builds clean with zero compile warnings.
- [ ] Full integration suite (running in background — will update).
- [ ] Linux CI green (gcc + clang).
- [ ] Windows CI green (MinGW64).

## Closes

- Closes #465
- Closes #466
- Closes #467
