### PR TITLE
fix: self-assign `p = p` no longer double-frees borrowed string param…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`p = p` self-assignment on a string parameter double-frees the caller's buffer** (`compiler/codegen/codegen_stmt.c`, `tests/regression/test_self_assign_param_doublefree.ae`). Hard correctness regression introduced by the Path B `is_heap_string_expr` extension that recognises bare-identifier-of-tracked-local as heap=1. The reassignment-wrapper's emission path runs `is_heap_string_expr(rhs)` to decide whether to set `_heap_<lhs> = 1` after the assignment. For `p = p`:
+
+  ```c
+  { const char* _tmp_old = p; p = p; if (_heap_p) free((void*)_tmp_old); _heap_p = 1; }
+  ```
+
+  Step (a) RHS=`p`, AST_IDENTIFIER, in heap-tracked-vars → `is_heap_string_expr` returns 1. Step (b) wrapper sets `_heap_p = 1`. Step (c) function-exit defer-free fires `free((void*)p)` — but `p` is a borrowed parameter; the caller still holds the same pointer and proceeds to read or free it → use-after-free or double-free (`free(): double free detected in tcache 2` under `MALLOC_CHECK_=3` / ASan).
+
+  Trigger pattern (filed by avn during 0.157.0 rebuild, hits 27 call sites in their user code via `client.remote_free` and `repo_storage.rep_free`):
+
+  ```aether
+  // Common "no-op free shim" for libraries with refcount-backed
+  // string lifetimes — the call is preserved for ABI continuity
+  // after the C-side explicit-free API was replaced.
+  noop_free(p: string) {
+      p = p
+      return
+  }
+
+  main() {
+      s = string.copy("hello")
+      noop_free(s)
+      println(s)   // pre-fix: garbage or SIGABRT
+  }
+  ```
+
+  Fix: peephole at the top of the reassignment-wrapper-emission branch — if `stmt->value == stmt->children[0]->value` (same identifier name, i.e. `lhs == rhs`), skip emission entirely. The self-assignment is semantically a no-op; emitting nothing keeps the heap-tracker in its pre-assignment state, which is correct (nothing actually changed). Guard fires before any wrapper-emission branch, so it covers every code path downstream (string-tracked, escaped, non-string, etc.) uniformly. Six lines.
+
+  Considered and rejected: making parameters borrows-by-default (refuse to flip `_heap_<param>` to 1 unless annotated `@retain` / `@own`). Broader architectural change with category-of-bugs benefits but multi-PR scope; the peephole closes the surfaced regression cleanly and the architectural fix can land as a follow-up without conflicting.
+
+  ### Upgrade notes
+
+  No user code change required. Code using the `p = p` "no-op free shim" pattern (or any other `lhs = lhs` self-assignment, however unusual) was double-freeing pre-fix; post-fix the assignment is correctly a no-op. Behaviour change is strictly correctness recovery; no regression on any other shape.
+
 ## [0.157.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -2771,6 +2771,37 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
 
                 // Check if this is a reassignment (Python-style)
                 if (is_var_declared(gen, stmt->value)) {
+                    /* Self-assignment peephole. `p = p` is a no-op at
+                     * the semantic level; the heap-tracker wrapper
+                     * below would otherwise (a) consult
+                     * is_heap_string_expr on the RHS, which now
+                     * recognises bare-identifier-of-tracked-local as
+                     * heap=1, (b) emit `_heap_<p> = 1` at wrapper
+                     * exit, and (c) cause the function-exit defer-
+                     * free to free the buffer the caller still owns
+                     * (the parameter was a borrow, not an owned
+                     * value). avn's `noop_free(p: string) { p = p }`
+                     * shim hit this — every call double-freed the
+                     * caller's heap-allocated string. See
+                     * path-b-self-assign-param-doublefree.md filing.
+                     *
+                     * Skipping emission entirely is sound: `p = p`
+                     * has no observable effect. C doesn't even need
+                     * the statement (it'd compile to a no-op
+                     * anyway), and the heap-tracker stays in its
+                     * pre-assignment state — which is the truth
+                     * because the assignment didn't change anything.
+                     *
+                     * The guard fires before any other wrapper-
+                     * emission branch, so it covers every code path
+                     * downstream (string-tracked, escaped, non-
+                     * string, etc.) uniformly. */
+                    if (stmt->child_count > 0 && stmt->children[0] &&
+                        stmt->children[0]->type == AST_IDENTIFIER &&
+                        stmt->children[0]->value && stmt->value &&
+                        strcmp(stmt->children[0]->value, stmt->value) == 0) {
+                        break;
+                    }
                     // Already declared - generate assignment only.
                     //
                     // For string-tracked variables (issue #405) the

--- a/tests/regression/test_self_assign_param_doublefree.ae
+++ b/tests/regression/test_self_assign_param_doublefree.ae
@@ -1,0 +1,101 @@
+// Regression: `p = p` self-assignment on a string parameter must
+// NOT lift `_heap_p` to 1 (which would cause the function-exit
+// defer-free to free the caller's borrowed buffer → double-free).
+//
+// Trigger pattern — "no-op free shim" common in libraries with
+// refcount-backed string lifetimes:
+//
+//   noop_free(p: string) {
+//       p = p
+//       return
+//   }
+//
+// Pre-fix on 0.157.0 (and post the Path B classifier extension
+// that recognises bare-identifier-of-tracked-local as heap=1):
+//   1. `p = p` triggers the reassignment-wrapper.
+//   2. `is_heap_string_expr(RHS=p)` returns 1 (p is a heap-tracked
+//      local in the wrapper's view).
+//   3. Wrapper sets `_heap_p = 1`.
+//   4. Function exits; defer-free fires `free(p)` → frees caller's
+//      buffer.
+//   5. Caller continues using `s` (which is the same pointer) →
+//      use-after-free, double-free if caller also frees.
+//
+// avn's `client.remote_free` and `repo_storage.rep_free` (27 call
+// sites) hit this. Filed in path-b-self-assign-param-doublefree.md.
+//
+// Fix: peephole at the reassignment-wrapper-emission top — if
+// `stmt->value == stmt->children[0]->value` (same identifier, i.e.
+// `lhs == rhs`), skip emission entirely. The self-assignment is a
+// semantic no-op; emitting nothing keeps the heap-tracker in its
+// pre-assignment state, which is correct (nothing actually
+// changed).
+
+import std.string
+
+extern exit(code: int)
+
+// "No-op free" shim — caller still owns the buffer; this function
+// does nothing observable. Pre-fix this freed the caller's buffer.
+noop_free(p: string) {
+    p = p
+    return
+}
+
+main() {
+    println("=== test_self_assign_param_doublefree ===")
+
+    // Case 1: caller-allocated string, passed through the no-op
+    // shim, then read post-call. Pre-fix this read freed memory
+    // (garbage or SIGABRT).
+    s = string.copy("hello")
+    noop_free(s)
+    if string.length(s) != 5 {
+        println("FAIL 1: length(s) after noop_free = ${string.length(s)}, expected 5")
+        exit(1)
+    }
+    if string.char_at(s, 0) != 104 {  // 'h'
+        println("FAIL 1: s[0] = ${string.char_at(s, 0)}, expected 104 ('h')")
+        exit(1)
+    }
+    if string.char_at(s, 4) != 111 {  // 'o'
+        println("FAIL 1: s[4] = ${string.char_at(s, 4)}, expected 111 ('o')")
+        exit(1)
+    }
+    println("  PASS 1: heap-allocated string survives no-op-free shim")
+
+    // Case 2: loop of 1000 noop_free calls. Pre-fix this would
+    // double-free on each subsequent free (caller's reassignment
+    // of `s` after one noop_free, then noop_free again on the
+    // new value). Confirms the shim doesn't accumulate corruption.
+    i = 0
+    while i < 1000 {
+        local_s = string.copy("iteration-payload")
+        noop_free(local_s)
+        if string.length(local_s) != 17 {
+            println("FAIL 2 iter ${i}: length = ${string.length(local_s)}, expected 17")
+            exit(1)
+        }
+        i = i + 1
+    }
+    println("  PASS 2: 1000 no-op-free shim calls, no double-free / corruption")
+
+    // Case 3: confirm a normal (non-self-assign) reassignment in a
+    // parameter still goes through the wrapper. Regression guard
+    // against over-aggressive peephole.
+    reassign_param("input")
+    println("  PASS 3: normal parameter-reassign path still works")
+
+    println("=== all cases passed ===")
+}
+
+// A function that reassigns its parameter to a fresh heap value.
+// The wrapper SHOULD fire here (the peephole skip only applies to
+// `lhs == rhs` self-assignment).
+reassign_param(p: string) {
+    p = string.concat(p, "-suffix")
+    if string.length(p) < 7 {
+        println("FAIL 3: reassign_param's p = ${p}")
+        exit(1)
+    }
+}


### PR DESCRIPTION
…eter

Hard correctness regression introduced by the Path B is_heap_string_expr extension that recognises bare-identifier-of- tracked-local as heap=1. The reassignment-wrapper's emission for `p = p`:

  { const char* _tmp_old = p; p = p;
    if (_heap_p) free((void*)_tmp_old);
    _heap_p = 1; }

(a) RHS=p, AST_IDENTIFIER, in heap-tracked-vars → is_heap_string_expr returns 1. (b) Wrapper sets _heap_p = 1. (c) Function-exit defer- free fires `free((void*)p)` — but p is a borrowed parameter; the caller still holds the pointer. Use-after-free or double-free (`free(): double free detected in tcache 2` under MALLOC_CHECK_=3 or ASan).

Trigger pattern (filed by avn, hits 27 call sites in their user code — `client.remote_free` and `repo_storage.rep_free` shims):

  noop_free(p: string) {
      p = p
      return
  }

  main() {
      s = string.copy("hello")
      noop_free(s)
      println(s)   // pre-fix: garbage or SIGABRT
  }

Fix: peephole at the top of the reassignment-wrapper-emission branch — if stmt->value == stmt->children[0]->value (same identifier name, lhs == rhs), skip emission entirely. The self- assignment is semantically a no-op; emitting nothing keeps the heap-tracker in its pre-assignment state, which is correct (nothing actually changed). Guard fires before any wrapper emission branch, so it covers every code path uniformly (string- tracked, escaped, non-string, etc.).

Considered and rejected: making parameters borrows-by-default (refuse to flip _heap_<param> to 1 unless annotated @retain / @own). Broader architectural change with category-of-bugs benefits but multi-PR scope; the peephole closes the surfaced regression cleanly and the architectural fix can land as a follow-up without conflicting.

Regression test (tests/regression/test_self_assign_param_doublefree.ae):
- Case 1: heap-allocated string survives the no-op-free shim.
- Case 2: 1000-iter loop of fresh allocate + noop_free, no corruption / double-free accumulation.
- Case 3: regression guard — normal (non-self-assign) parameter reassignment still goes through the wrapper.

Full test-ae: 501/501 passed locally.