### PR TITLE
chore: make install warns when a stale `current` symlink shadows it […

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Changed
+
+- **`make install` warns when a stale `$PREFIX/current` symlink would shadow the install** (`Makefile`). `make install` writes the flat layout (`$PREFIX/{bin,lib,include,share}/aether`), but `ae` resolves its toolchain through `$PREFIX/current/` whenever that symlink points at a tree containing `lib/aether` or `share/aether` — the `ae version use` version-manager hook (`tools/ae.c`). A `current` left over from an older install scheme or a past `ae version use` therefore *silently* shadows a fresh `make install`: the maintainer rebuilds, installs, and `ae` keeps linking the stale toolchain with no diagnostic — `ae` only warns on a *half*-populated `current`, never on a complete-but-stale one. The `install` recipe now ends with a check: if `$PREFIX/current` resolves to a real directory other than `$PREFIX` itself, it prints a loud warning naming the shadowing target and the two fixes (`rm` the symlink, or `ae version use`). Diagnostic only — no change to `ae`'s resolution order, so `ae version use` workflows are unaffected. Surfaced while reinstalling the toolchain for the strbuilder-v2 consumer (aeb): a stale `current -> v0.158.0` made `import std.strbuilder` fail at link despite a correct fresh 0.161.0 build.
+
 ## [0.161.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1244,6 +1244,32 @@ install: release ae stdlib
 	@echo "✓ Installed successfully"
 	@echo ""
 	@echo "Run: ae version"
+	@# Stale-`current`-symlink shadow check. `make install` writes the
+	@# flat layout ($(PREFIX)/{bin,lib,include,share}/aether), but `ae`
+	@# prefers $(PREFIX)/current/ whenever that symlink resolves to a
+	@# tree with lib/aether or share/aether (tools/ae.c — the
+	@# `ae version use` version-manager hook). A `current` left over
+	@# from an older install or a past `ae version use` therefore
+	@# silently shadows this fresh install: the dev rebuilds, installs,
+	@# and `ae` keeps linking the stale toolchain. `ae` only warns when
+	@# `current` is half-populated — a complete-but-stale tree looks
+	@# valid and draws no diagnostic. Surface it loudly here so the
+	@# `make && sudo make install` loop can't silently no-op. Warn
+	@# only when `current` resolves to a real directory other than
+	@# $(PREFIX) itself (a `current` -> $(PREFIX) symlink is harmless;
+	@# a broken symlink doesn't shadow because `ae` stat-checks it).
+	@cur=$$(cd "$(PREFIX)/current" 2>/dev/null && pwd -P); \
+	pfx=$$(cd "$(PREFIX)" 2>/dev/null && pwd -P); \
+	if [ -n "$$cur" ] && [ "$$cur" != "$$pfx" ]; then \
+		echo ""; \
+		echo "⚠  WARNING: $(PREFIX)/current shadows this install."; \
+		echo "   $(PREFIX)/current -> $$(readlink "$(PREFIX)/current" 2>/dev/null || echo '?')"; \
+		echo "   'ae' prefers current/ over the freshly-installed flat tree,"; \
+		echo "   so it will keep using the stale toolchain above — not this build."; \
+		echo "   Fix:  sudo rm $(PREFIX)/current      (use this flat install), or"; \
+		echo "         ae version use <version>       (re-point the symlink)"; \
+		echo ""; \
+	fi
 
 # -----------------------------------------------------------------
 # contrib — build per-module static libs (libaether_<x>.a) for every


### PR DESCRIPTION
…skip actions]

`make install` writes the flat layout ($PREFIX/{bin,lib,include, share}/aether), but `ae` resolves its toolchain through $PREFIX/current/ whenever that symlink points at a tree with lib/aether or share/aether — the `ae version use` version-manager hook (tools/ae.c). A `current` left over from an older install scheme or a past `ae version use` silently shadows a fresh `make install`: the maintainer rebuilds, installs, and `ae` keeps linking the stale toolchain. `ae` only warns on a half-populated `current`, never on a complete-but-stale one — so the failure is silent.

The `install` recipe now ends with a check: if $PREFIX/current resolves to a real directory other than $PREFIX itself, it prints a loud warning naming the shadowing target and the two fixes (`rm` the symlink, or `ae version use`). A `current` -> $PREFIX symlink is harmless and draws no warning; a broken symlink doesn't shadow (ae stat-checks it) so it's left alone too.

Diagnostic only — no change to `ae`'s resolution order, so `ae version use` workflows are unaffected.

Surfaced while reinstalling the toolchain for the strbuilder-v2 consumer (aeb): a stale `current -> v0.158.0` made `import std.strbuilder` fail at link despite a correct fresh 0.161.0 build. Verified by installing to a temp prefix with no `current` (no warning), a stale `current` (warning fires, names the target), and a `current` -> prefix self-symlink (no warning).

[skip actions]: Makefile-only change isolated to the `install:` recipe — `make ci` does not build or run that recipe, so CI would exercise nothing here; verification was the temp-prefix install runs above. CI deliberately skipped to conserve GitHub Actions minutes.