### PR TITLE
feat: std.strbuilder vappend_format — C-side va_list bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.strbuilder` — `aether_strbuilder_vappend_format`, a C-only `va_list`-accepting companion to `append_format`** (`std/strbuilder/aether_strbuilder.{c,h}`, `tests/runtime/test_runtime_strbuilder.c`). v1/v2 of `std.strbuilder` cover Aether-side call sites with literal arguments; the inverse direction — a variadic *defining* function written in C that wants to delegate its formatting to strbuilder and route the result through Aether — had no bridge, forcing handwritten `va_start`/`vsnprintf`/`va_end` C to stay in the in-tree mquickjs port. Aether deliberately has no defining-varargs (`foo(fmt: string, ...) { ... }` is intentionally not a language feature — platform-specific `va_list`, ABI-fragile); `vappend_format` is the C→Aether bridge that lets that exclusion not block the port. A handwritten variadic C shim that already holds a `va_list` can now do `aether_strbuilder_vappend_format(b, fmt, ap)` and move all the surrounding logic (message building, error routing, throw semantics) to Aether. This is a pure C-FFI primitive — there is **no Aether-side wrapper**, because a `va_list` cannot cross the Aether boundary, so the `module.ae` `exports` list does not grow. `aether_strbuilder_append_format` is refactored to a thin wrapper that delegates to it, with the byte-output-identical guarantee covered by a regression test. The header documents the `va_list` consumption contract: the call consumes the caller's `ap` (matching the `vsnprintf` contract), the caller must `va_end` it, and a caller needing to format the same arguments twice (e.g. a retry with a fallback format) must take its own `va_copy` before the call. C-side regression harness covers five cases — byte-identity with `append_format`, the >256-byte slow path, the caller-owns-`va_end` contract, the `va_copy` retry pattern (the shape mquickjs's `js_vsnprintf` retry needs), and NULL/empty inputs. Named downstream: the mquickjs port, where eight variadic C functions (`js_printf`, `js_vprintf`, `js_vsnprintf`/`js_snprintf`, `js_parse_error`, `cprintf`, `JS_Throw{Syntax,Type,Range,Reference}Error`) migrate from full handwritten C bodies to ~3-line C shims delegating to Aether, retiring ~200 lines of handwritten C.
+
 ## [0.163.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,7 @@ TEST_SRC = tests/runtime/test_harness.c \
            tests/runtime/test_64bit.c \
            tests/runtime/test_runtime_collections.c \
            tests/runtime/test_runtime_strings.c \
+           tests/runtime/test_runtime_strbuilder.c \
            tests/runtime/test_runtime_math.c \
            tests/runtime/test_runtime_json.c \
            tests/runtime/test_runtime_http.c \

--- a/std/strbuilder/aether_strbuilder.c
+++ b/std/strbuilder/aether_strbuilder.c
@@ -150,34 +150,47 @@ int aether_strbuilder_append_codepoint(AetherStrBuilder* b, int cp) {
     return aether_strbuilder_append_n(b, (const char*)enc, n);
 }
 
-int aether_strbuilder_append_format(AetherStrBuilder* b, const char* fmt, ...) {
+int aether_strbuilder_vappend_format(AetherStrBuilder* b, const char* fmt,
+                                     va_list ap) {
     if (!b || !fmt) return 0;
     /* Fast path: format into a stack scratch buffer. vsnprintf always
      * reports the length it WOULD have written, so a single probe
-     * tells us whether the scratch was large enough. */
+     * tells us whether the scratch was large enough.
+     *
+     * The probe runs against a va_copy of `ap`, not `ap` itself: a
+     * va_list is single-pass on most ABIs, and the slow path below
+     * needs a fresh traversal to re-format. The caller's `ap` is
+     * still consumed by the time this returns (see the slow path);
+     * that is the documented vsnprintf-style contract. */
     char scratch[256];
-    va_list ap;
-    va_start(ap, fmt);
-    int needed = vsnprintf(scratch, sizeof(scratch), fmt, ap);
-    va_end(ap);
+    va_list ap_probe;
+    va_copy(ap_probe, ap);
+    int needed = vsnprintf(scratch, sizeof(scratch), fmt, ap_probe);
+    va_end(ap_probe);
     if (needed < 0) return 0;  /* encoding error */
     if (needed < (int)sizeof(scratch)) {
         return aether_strbuilder_append_n(b, scratch, needed);
     }
     /* Slow path: output exceeded the scratch. Reserve room in the
      * builder for `needed` bytes plus a NUL (vsnprintf always writes
-     * a terminator), format directly into the tail, then bump the
-     * logical length by `needed` only — the NUL is not part of the
-     * content. */
+     * a terminator), format directly into the tail using the
+     * caller's `ap`, then bump the logical length by `needed` only —
+     * the NUL is not part of the content. */
     size_t end = b->length + (size_t)needed;
     if (end < b->length) return 0;  /* overflow */
     if (!strbuilder_reserve(b, end + 1)) return 0;
-    va_start(ap, fmt);
     int wrote = vsnprintf(b->data + b->length, (size_t)needed + 1, fmt, ap);
-    va_end(ap);
     if (wrote != needed) return 0;
     b->length = end;
     return 1;
+}
+
+int aether_strbuilder_append_format(AetherStrBuilder* b, const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int rc = aether_strbuilder_vappend_format(b, fmt, ap);
+    va_end(ap);
+    return rc;
 }
 
 int aether_strbuilder_length(AetherStrBuilder* b) {

--- a/std/strbuilder/aether_strbuilder.h
+++ b/std/strbuilder/aether_strbuilder.h
@@ -2,6 +2,7 @@
 #define AETHER_STRBUILDER_H
 
 #include <stddef.h>
+#include <stdarg.h>
 
 /* std.strbuilder — amortised-O(1) string append primitive.
  *
@@ -84,8 +85,39 @@ int aether_strbuilder_append_codepoint(AetherStrBuilder* b, int cp);
  * with vsnprintf and appends the result. A 256-byte stack scratch
  * covers the common case in one pass; longer output reserves builder
  * space and formats directly into the tail. Returns 1 on success, 0
- * on failure (NULL args, encoding error, OOM). */
+ * on failure (NULL args, encoding error, OOM). Thin wrapper over
+ * `aether_strbuilder_vappend_format` — byte-output identical. */
 int aether_strbuilder_append_format(AetherStrBuilder* b, const char* fmt, ...);
+
+/* va_list-accepting companion to `append_format`. C-FFI ONLY — there
+ * is no Aether-side wrapper because a va_list cannot cross the Aether
+ * boundary. It exists so that a handwritten variadic C shim (which
+ * already holds a va_list from its own va_start) can delegate its
+ * formatting to a strbuilder, then route the finished bytes back to
+ * Aether — the C->Aether bridge for the *defining* side of the
+ * variadic story (Aether deliberately has no defining-varargs).
+ *
+ * va_list consumption contract: this call CONSUMES the caller's `ap`
+ * (matching the vsnprintf contract). The caller must `va_end(ap)`
+ * afterwards, and must NOT pass `ap` to a second consumer. A caller
+ * that needs to format the same arguments twice (e.g. a retry with a
+ * fallback format) must take its own `va_copy` *before* calling:
+ *
+ *     va_list ap, saved;
+ *     va_start(ap, fmt);
+ *     va_copy(saved, ap);
+ *     aether_strbuilder_vappend_format(b1, fmt, ap);     // consumes ap
+ *     va_end(ap);
+ *     aether_strbuilder_vappend_format(b2, fmt, saved);  // consumes saved
+ *     va_end(saved);
+ *
+ * Internally a va_copy is taken for the fast-path scratch probe so a
+ * 256-byte-overflowing format still has a fresh va_list to re-format
+ * from; that is an implementation detail and does not relax the
+ * "caller's ap is consumed" contract above. Returns 1 on success, 0
+ * on failure (NULL builder, NULL fmt, encoding error, OOM). */
+int aether_strbuilder_vappend_format(AetherStrBuilder* b, const char* fmt,
+                                     va_list ap);
 
 /* Current accumulated length in bytes, or -1 if `b` is NULL. */
 int aether_strbuilder_length(AetherStrBuilder* b);

--- a/tests/runtime/test_runtime_strbuilder.c
+++ b/tests/runtime/test_runtime_strbuilder.c
@@ -1,0 +1,195 @@
+/* C-side regression harness for aether_strbuilder_vappend_format —
+ * the va_list-accepting companion to append_format. This is a pure
+ * C-FFI primitive (no Aether-side wrapper, since va_list does not
+ * cross the Aether boundary), so it can only be exercised from C:
+ * the Aether-side strbuilder surface is covered separately in
+ * tests/regression/test_std_strbuilder.ae.
+ *
+ * Five cases, mirroring the ask in new_stringbuilder_ask.md:
+ *   1. byte-identical to append_format across the conversion set
+ *   2. slow path — output exceeds the 256-byte scratch
+ *   3. caller owns va_end (the documented consumption contract)
+ *   4. caller-side va_copy retry stays clean
+ *   5. NULL / empty inputs
+ */
+
+#include "test_harness.h"
+#include "../../std/strbuilder/aether_strbuilder.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Minimal variadic shim: exactly the shape a downstream C function
+ * (js_parse_error, cprintf, ...) uses to bridge into Aether. */
+static int shim_vappend(AetherStrBuilder* b, const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int rc = aether_strbuilder_vappend_format(b, fmt, ap);
+    va_end(ap);
+    return rc;
+}
+
+/* ---- Case 1 — byte-identical to append_format -------------------- */
+TEST_CATEGORY(strbuilder_vappend_format_byte_identical, TEST_CATEGORY_STDLIB) {
+    AetherStrBuilder* b1 = aether_strbuilder_new(64);
+    AetherStrBuilder* b2 = aether_strbuilder_new(64);
+    ASSERT_NOT_NULL(b1);
+    ASSERT_NOT_NULL(b2);
+
+    /* Exercises %s / %d / %lld / %x / %c / %.Nf / literal %%. */
+    int rc1 = aether_strbuilder_append_format(b1,
+        "id=%d name=%s hex=%x ch=%c pct=%.2f%% big=%lld",
+        42, "alpha", 0xCAFE, '!', 3.14159, (long long)1LL << 40);
+    int rc2 = shim_vappend(b2,
+        "id=%d name=%s hex=%x ch=%c pct=%.2f%% big=%lld",
+        42, "alpha", 0xCAFE, '!', 3.14159, (long long)1LL << 40);
+    ASSERT_EQ(rc1, 1);
+    ASSERT_EQ(rc2, 1);
+
+    ASSERT_EQ(aether_strbuilder_length(b1), aether_strbuilder_length(b2));
+
+    _tuple_ptr_int t1 = aether_strbuilder_finish_with_length(b1);
+    _tuple_ptr_int t2 = aether_strbuilder_finish_with_length(b2);
+    ASSERT_EQ(t1._1, t2._1);
+    ASSERT_EQ(memcmp(t1._0, t2._0, (size_t)t1._1), 0);
+    free(t1._0);
+    free(t2._0);
+}
+
+/* ---- Case 2 — slow path: output exceeds the 256-byte scratch ----- */
+TEST_CATEGORY(strbuilder_vappend_format_slow_path, TEST_CATEGORY_STDLIB) {
+    char filler[400];
+    memset(filler, 'X', sizeof(filler) - 1);
+    filler[sizeof(filler) - 1] = '\0';   /* 399 X's */
+
+    AetherStrBuilder* b = aether_strbuilder_new(0);
+    ASSERT_NOT_NULL(b);
+    int rc = shim_vappend(b, "prefix:%s:suffix", filler);
+    ASSERT_EQ(rc, 1);
+    /* "prefix:" (7) + 399 X + ":suffix" (7) = 413, well past 256. */
+    ASSERT_EQ(aether_strbuilder_length(b), 7 + 399 + 7);
+
+    /* Reference output via plain vsnprintf into a malloc'd buffer. */
+    int n = snprintf(NULL, 0, "prefix:%s:suffix", filler);
+    char* ref = (char*)malloc((size_t)n + 1);
+    ASSERT_NOT_NULL(ref);
+    snprintf(ref, (size_t)n + 1, "prefix:%s:suffix", filler);
+
+    _tuple_ptr_int got = aether_strbuilder_finish_with_length(b);
+    ASSERT_EQ(got._1, n);
+    ASSERT_EQ(memcmp(got._0, ref, (size_t)n), 0);
+    free(got._0);
+    free(ref);
+}
+
+/* ---- Case 3 — caller owns va_end (consumption contract) ---------- */
+static int once(AetherStrBuilder* b, const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int rc = aether_strbuilder_vappend_format(b, fmt, ap);
+    /* vappend does NOT va_end on the caller's behalf — caller owns it. */
+    va_end(ap);
+    return rc;
+}
+
+TEST_CATEGORY(strbuilder_vappend_format_caller_owns_va_end, TEST_CATEGORY_STDLIB) {
+    AetherStrBuilder* b = aether_strbuilder_new(32);
+    ASSERT_NOT_NULL(b);
+    ASSERT_EQ(once(b, "%d %s", 7, "ok"), 1);
+
+    _tuple_ptr_int got = aether_strbuilder_finish_with_length(b);
+    ASSERT_EQ(got._1, 4);
+    ASSERT_EQ(memcmp(got._0, "7 ok", 4), 0);
+    free(got._0);
+}
+
+/* ---- Case 4 — caller-side va_copy retry stays clean -------------- */
+static void two_builders_via_va_copy(AetherStrBuilder* b1, AetherStrBuilder* b2,
+                                     const char* fmt, ...) {
+    va_list ap, saved;
+    va_start(ap, fmt);
+    va_copy(saved, ap);
+    aether_strbuilder_vappend_format(b1, fmt, ap);
+    va_end(ap);
+    aether_strbuilder_vappend_format(b2, fmt, saved);
+    va_end(saved);
+}
+
+TEST_CATEGORY(strbuilder_vappend_format_va_copy_retry, TEST_CATEGORY_STDLIB) {
+    AetherStrBuilder* b1 = aether_strbuilder_new(32);
+    AetherStrBuilder* b2 = aether_strbuilder_new(32);
+    ASSERT_NOT_NULL(b1);
+    ASSERT_NOT_NULL(b2);
+
+    two_builders_via_va_copy(b1, b2, "v=%d msg=%s", 99, "retry");
+
+    _tuple_ptr_int t1 = aether_strbuilder_finish_with_length(b1);
+    _tuple_ptr_int t2 = aether_strbuilder_finish_with_length(b2);
+    ASSERT_EQ(t1._1, t2._1);
+    ASSERT_EQ(memcmp(t1._0, t2._0, (size_t)t1._1), 0);
+    free(t1._0);
+    free(t2._0);
+}
+
+/* A va_copy retry that also crosses the slow path (>256 bytes) on
+ * both legs — confirms the internal probe va_copy in vappend_format
+ * does not corrupt the caller's surviving copy. */
+TEST_CATEGORY(strbuilder_vappend_format_va_copy_retry_slow, TEST_CATEGORY_STDLIB) {
+    char filler[400];
+    memset(filler, 'Z', sizeof(filler) - 1);
+    filler[sizeof(filler) - 1] = '\0';
+
+    AetherStrBuilder* b1 = aether_strbuilder_new(0);
+    AetherStrBuilder* b2 = aether_strbuilder_new(0);
+    two_builders_via_va_copy(b1, b2, "[%s]", filler);
+
+    _tuple_ptr_int t1 = aether_strbuilder_finish_with_length(b1);
+    _tuple_ptr_int t2 = aether_strbuilder_finish_with_length(b2);
+    ASSERT_EQ(t1._1, 401);   /* '[' + 399 Z + ']' */
+    ASSERT_EQ(t1._1, t2._1);
+    ASSERT_EQ(memcmp(t1._0, t2._0, (size_t)t1._1), 0);
+    free(t1._0);
+    free(t2._0);
+}
+
+/* ---- Case 5 — NULL / empty inputs -------------------------------- */
+static int call_with_null_b(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int rc = aether_strbuilder_vappend_format(NULL, fmt, ap);
+    va_end(ap);
+    return rc;
+}
+
+static int call_with_null_fmt(AetherStrBuilder* b, ...) {
+    va_list ap;
+    va_start(ap, b);   /* last named arg */
+    int rc = aether_strbuilder_vappend_format(b, NULL, ap);
+    va_end(ap);
+    return rc;
+}
+
+static int call_with_empty_fmt(AetherStrBuilder* b, ...) {
+    va_list ap;
+    va_start(ap, b);
+    int rc = aether_strbuilder_vappend_format(b, "", ap);
+    va_end(ap);
+    return rc;
+}
+
+TEST_CATEGORY(strbuilder_vappend_format_null_and_empty, TEST_CATEGORY_STDLIB) {
+    AetherStrBuilder* b = aether_strbuilder_new(8);
+    ASSERT_NOT_NULL(b);
+
+    /* NULL builder / NULL fmt return 0 without crashing. */
+    ASSERT_EQ(call_with_null_b("x"), 0);
+    ASSERT_EQ(call_with_null_fmt(b), 0);
+    ASSERT_EQ(aether_strbuilder_length(b), 0);
+
+    /* Empty format string appends zero bytes, returns 1. */
+    ASSERT_EQ(call_with_empty_fmt(b), 1);
+    ASSERT_EQ(aether_strbuilder_length(b), 0);
+
+    aether_strbuilder_free(b);
+}


### PR DESCRIPTION
## Description

Adds `aether_strbuilder_vappend_format`, the `va_list`-accepting companion to `append_format`.

v1/v2 of `std.strbuilder` cover Aether-side call sites with literal arguments. The remaining gap is the inverse direction: a variadic *defining* function written in C that wants to delegate its formatting to strbuilder, then route the result through Aether. With no bridge, handwritten `va_start`/`vsnprintf`/`va_end` C is forced to stay in the in-tree mquickjs port (8 such functions: `js_printf`, `js_vprintf`, `js_vsnprintf`/`js_snprintf`, `js_parse_error`, `cprintf`, `JS_Throw{Syntax,Type,Range,Reference}Error`).

Aether deliberately has no defining-varargs (`foo(fmt: string, ...) { ... }` — platform-specific `va_list`, ABI-fragile). `vappend_format` is the C→Aether bridge so that exclusion doesn't block the port:

```c
JSValue js_parse_error(JSParseState *s, const char *fmt, ...) {
    void *b = aether_strbuilder_new(128);
    va_list ap; va_start(ap, fmt);
    aether_strbuilder_vappend_format(b, fmt, ap);
    va_end(ap);
    char *msg = aether_strbuilder_finish(b);
    return aether_js_throw_syntax(s->ctx, msg);
}
```

Pure C-FFI primitive — **no Aether-side wrapper** (a `va_list` cannot cross the Aether boundary), so `module.ae` `exports` does not grow. `append_format` is refactored to a thin wrapper delegating to `vappend_format`; the byte-output-identical guarantee is covered by the existing `test_std_strbuilder_v2.ae` regression. The header documents the `va_list` consumption contract and the `va_copy`-before-call retry pattern.

## Type of Change
- [x] New feature

## Testing
- [x] Added tests — new C-side harness `tests/runtime/test_runtime_strbuilder.c`, 6 cases: byte-identity with `append_format`, the >256-byte slow path, caller-owns-`va_end` contract, `va_copy` retry pattern (incl. a slow-path retry variant), and NULL/empty inputs
- [x] `make test` — 221/221 pass
- [x] `make test-asan` — 221/221, 0 leaks (ASan + LeakSanitizer)
- [x] `HARDEN=1 make test` — clean, no `printf`-format-injection / unchecked-`memcpy` warnings
- [x] `make ci` / `test-ae` — all strbuilder suites pass (v1, v2, csv, no-leak). 3 unrelated failures are pre-existing local HTTP2-framing / socket-bind issues, not touched by this change

## Performance Impact
- [x] No performance impact — `append_format`'s fast/slow path is unchanged; it now delegates through one extra function call

## Checklist
- [x] Code follows style guidelines (matches the file's existing 4-space style)
- [x] Self-review completed
- [x] Comments added (header documents the `va_list` contract + `va_copy` retry)
- [x] Documentation updated (CHANGELOG under `[current]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)