### PR TITLE
fix(codegen): don't tag a literal-holding variable as an owned map/li…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Putting a non-heap string value into a `std.collections` / `std.map` map (or `std.list`) no longer crashes at container teardown** (`compiler/codegen/codegen_expr.c`, `compiler/codegen/codegen.c`, `compiler/codegen/codegen_stmt.c`, `tests/regression/test_map_put_raw_literal_value.ae`). The codegen auto-routes a string value into the owning variant (`map_put_string_owned` / `list_add_string_owned`) so a heap value is released at `map.free` — issue #467. The routing was gated on `is_heap_string_expr`, which for a bare identifier answers "is this name heap-*tracked*" — true for *every* assigned string variable, including one that only ever holds a literal (`sentinel = "1"`). Such a variable was tagged owned, and `map.free` then `free()`d a `.rodata` literal: `free(): invalid pointer` / `double free or corruption`. It hit both the raw API (`map_put_raw`) and the `map.put` wrapper, and the runtime `_heap_<name>` flag could not rescue it — a map/list value has escaped into the container call, so the reassignment wrapper that maintains the flag is suppressed and it reads stale. Filed by the avn project (`map-put-raw-rewritten-to-owned.md`); avn's `working_copy.wc_status` builds a tracked-path set with a dummy literal value and aborted every `avn status`. The owned-routing now resolves a bare identifier *structurally* — via `body_assigns_var_from_heap`, which is reliable for escaped variables — and only routes it to the owning variant when some assignment in the enclosing function body sets it from a heap source. A literal-only variable stays on the non-owning path; a genuinely heap variable still routes to owned, so #467's leak fix is preserved. Direct heap expressions (`string.concat(...)`, interpolation) are unaffected — they were always exact.
+
 ## [0.168.0]
 
 ### Fixed

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1901,6 +1901,15 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
     // entry point explicitly.
     if (!gen->emit_exe) return;
 
+    /* Track `main` as the current function so body-structural queries
+     * (e.g. body_assigns_var_from_heap, used by the map/list owned-
+     * value routing) can reach `main`'s body. Restored at function end.
+     * All other `gen->current_function` consumers gate on
+     * `!gen->in_main_function` first, so a main node here is inert
+     * for them. */
+    ASTNode* prev_current_function = gen->current_function;
+    gen->current_function = main;
+
     print_line(gen, "int main(int argc, char** argv) {");
     indent(gen);
     clear_declared_vars(gen);  // Reset for main function
@@ -2043,6 +2052,7 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
     }
     unindent(gen);
     print_line(gen, "}");
+    gen->current_function = prev_current_function;
 }
 
 void generate_program(CodeGenerator* gen, ASTNode* program) {

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1379,6 +1379,13 @@ void emit_closure_definitions(CodeGenerator* gen) {
             int prev_heap_count = gen->heap_string_var_count;
             gen->heap_string_vars = NULL;
             gen->heap_string_var_count = 0;
+            /* Track the closure as the current function so
+             * body-structural queries (current_fn_body_block /
+             * body_assigns_var_from_heap) resolve a value identifier
+             * against the closure's own body, not the enclosing
+             * function's. */
+            ASTNode* prev_current_function = gen->current_function;
+            gen->current_function = closure;
             // Publish env-backed captures so generate_statement routes writes
             // through _env-> instead of a local alias.
             char** prev_env = gen->current_env_captures;
@@ -1431,6 +1438,7 @@ void emit_closure_definitions(CodeGenerator* gen) {
             clear_heap_string_vars(gen);
             gen->heap_string_vars = prev_heap;
             gen->heap_string_var_count = prev_heap_count;
+            gen->current_function = prev_current_function;
             gen->in_trailing_block--;
             gen->indent_level = 0;
         }
@@ -1592,6 +1600,22 @@ static void emit_send_target(CodeGenerator* gen, ASTNode* target, const char* ca
     if (needs_intptr) fprintf(gen->output, "(intptr_t)");
     generate_expression(gen, target);
     fprintf(gen->output, ")");
+}
+
+/* The AST_BLOCK body of the function / `main` / closure currently
+ * being generated, or NULL. `gen->current_function` is the enclosing
+ * AST_FUNCTION_DEFINITION / AST_MAIN_FUNCTION / AST_CLOSURE; the body
+ * is its AST_BLOCK child. Used by the map/list owned-value routing to
+ * resolve a bare identifier's heap-ness structurally. */
+static ASTNode* current_fn_body_block(CodeGenerator* gen) {
+    if (!gen || !gen->current_function) return NULL;
+    ASTNode* fn = gen->current_function;
+    for (int i = fn->child_count - 1; i >= 0; i--) {
+        if (fn->children[i] && fn->children[i]->type == AST_BLOCK) {
+            return fn->children[i];
+        }
+    }
+    return NULL;
 }
 
 void generate_expression(CodeGenerator* gen, ASTNode* expr) {
@@ -2682,7 +2706,46 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         int expected_arg_count = is_list_shape ? 2 : 3;
                         if (expr->child_count == expected_arg_count) {
                             ASTNode* val = expr->children[val_idx];
-                            if (val && is_heap_string_expr(gen, val)) {
+                            /* Route the value into the container's
+                             * owning variant only when it is genuinely
+                             * a heap allocation the container should
+                             * free.
+                             *
+                             * For a NON-identifier expression
+                             * (`string.concat(...)`, interpolation, a
+                             * heap-returning call) `is_heap_string_expr`
+                             * is exact — it is statically a fresh
+                             * allocation.
+                             *
+                             * For a bare IDENTIFIER `is_heap_string_expr`
+                             * is too coarse: it answers "is this name
+                             * heap-TRACKED" (every assigned string
+                             * variable is), which is true even for a
+                             * variable that only ever holds a literal
+                             * (`s = "1"`). Routing such a variable into
+                             * `_string_owned` tagged a `.rodata` literal
+                             * as owned and `free()`d it at container
+                             * teardown — a crash (map-put-raw-rewritten-
+                             * to-owned.md). The runtime `_heap_<name>`
+                             * flag can't rescue this either: the value
+                             * has escaped into the container call, so
+                             * the reassignment wrapper that maintains
+                             * the flag is suppressed and it reads stale.
+                             * Resolve the identifier structurally
+                             * instead — it is genuinely heap only if
+                             * some assignment in the enclosing function
+                             * body sets it from a heap source. A
+                             * variable that is only ever literal-
+                             * assigned is left un-rewritten (the
+                             * container does not own it). */
+                            int val_is_heap;
+                            if (val && val->type == AST_IDENTIFIER && val->value) {
+                                val_is_heap = body_assigns_var_from_heap(
+                                    gen, current_fn_body_block(gen), val->value);
+                            } else {
+                                val_is_heap = val && is_heap_string_expr(gen, val);
+                            }
+                            if (val_is_heap) {
                                 if (is_wrapper) {
                                     fprintf(gen->output, "(");
                                 }

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -39,6 +39,17 @@ void mark_return_escaped_string_var(CodeGenerator* gen, const char* var_name);
  * function calls in argument position. */
 int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr);
 
+/* Returns 1 if some `AST_VARIABLE_DECLARATION` for `var_name` inside
+ * `node` assigns it from a heap-string source (`is_heap_string_expr`
+ * of the RHS). A structural "is this variable ever heap-valued"
+ * query — coarser than the runtime `_heap_<name>` flag but reliable
+ * for escaped variables, whose flag the reassignment wrapper stops
+ * maintaining. Skips nested function / closure scopes. Defined in
+ * codegen_stmt.c; used by the map/list owned-value routing in
+ * codegen_expr.c. */
+int body_assigns_var_from_heap(CodeGenerator* gen, ASTNode* node,
+                               const char* var_name);
+
 /* Escape gate for heap-string arguments: returns 1 if a callee's
  * parameter slot of the given type-kind is treated as storage (the
  * recipient may stash the pointer beyond the call). Used by the

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -799,8 +799,8 @@ int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
  * Skips nested function / closure scopes (their assignments are in
  * a different lexical frame). Stops at the first heap-source
  * assignment to `var_name`. */
-static int body_assigns_var_from_heap(CodeGenerator* gen, ASTNode* node,
-                                       const char* var_name) {
+int body_assigns_var_from_heap(CodeGenerator* gen, ASTNode* node,
+                               const char* var_name) {
     if (!node || !var_name) return 0;
     if (node->type == AST_FUNCTION_DEFINITION ||
         node->type == AST_BUILDER_FUNCTION ||

--- a/tests/regression/test_map_put_raw_literal_value.ae
+++ b/tests/regression/test_map_put_raw_literal_value.ae
@@ -1,0 +1,78 @@
+// Regression: putting a non-heap string value into a `std.collections`
+// / `std.map` map — via the raw API or the wrapper — and then freeing
+// the map must not abort.
+//
+// The codegen auto-routes a string-typed map/list value into the
+// owning variant (`map_put_string_owned`) so heap values are released
+// at `map.free`. Pre-fix the routing was gated on the value being
+// string-*typed*, not heap-*owned*: a string-typed variable holding a
+// literal (`sentinel = "1"`) was tagged owned, and `map.free` then
+// called `free()` on a `.rodata` literal — `free(): invalid pointer`.
+// Filed by the avn project (map-put-raw-rewritten-to-owned.md); avn's
+// `working_copy.wc_status` builds a tracked-path set with a dummy
+// literal value and aborted every `avn status`.
+//
+// A bare heap-tracked identifier is only *maybe* heap — its ownership
+// is the runtime `_heap_<name>` flag — so it now routes through the
+// `*_maybe_owned` dispatcher. A literal-holding variable (`_heap == 0`)
+// stays unowned; a genuinely heap variable (`_heap == 1`) is owned and
+// released once. This test exercises both, on the raw API and the
+// wrapper, and frees the maps — the run completing IS the assertion
+// (pre-fix it aborted), with value checks guarding correctness.
+
+import std.map
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== test_map_put_raw_literal_value ===")
+
+    // --- raw API, literal value (the filed crash) ---
+    m1 = map.new()
+    sentinel = "1"                       // string-typed, _heap == 0
+    map.put_raw(m1, "k", sentinel)
+    map.put_raw(m1, "k2", sentinel)      // same literal, second key
+    got1, _ = map.get(m1, "k")
+    if got1 != "1" {
+        println("  FAIL: raw+literal readback got '${got1}'")
+        exit(1)
+    }
+    map.free(m1)                         // pre-fix: free() on "1" → abort
+
+    // --- raw API, heap value ---
+    m2 = map.new()
+    heap_val = string.concat("pre", "fix")   // _heap == 1
+    map.put_raw(m2, "k", heap_val)
+    got2, _ = map.get(m2, "k")
+    if got2 != "prefix" {
+        println("  FAIL: raw+heap readback got '${got2}'")
+        exit(1)
+    }
+    map.free(m2)                         // map owns heap_val, releases once
+
+    // --- wrapper, literal value (the latent wrapper case) ---
+    m3 = map.new()
+    flag = "y"                           // string-typed, _heap == 0
+    map.put(m3, "k", flag)
+    got3, _ = map.get(m3, "k")
+    if got3 != "y" {
+        println("  FAIL: wrapper+literal readback got '${got3}'")
+        exit(1)
+    }
+    map.free(m3)
+
+    // --- wrapper, heap value ---
+    m4 = map.new()
+    heap_val2 = string.concat("on", "e")     // _heap == 1
+    map.put(m4, "k", heap_val2)
+    got4, _ = map.get(m4, "k")
+    if got4 != "one" {
+        println("  FAIL: wrapper+heap readback got '${got4}'")
+        exit(1)
+    }
+    map.free(m4)
+
+    println("  PASS: literal and heap map values, raw API and wrapper")
+    println("=== test_map_put_raw_literal_value passed ===")
+}


### PR DESCRIPTION
…st value

The codegen auto-routes a string value into a container's owning variant (`map_put_string_owned` / `list_add_string_owned`) so a heap value is released at `map.free` / `list.free` (#467). The routing gate was `is_heap_string_expr`, which for a bare identifier answers "is this name heap-TRACKED" — true for every assigned string variable, including one that only ever holds a literal (`sentinel = "1"`). Such a variable was tagged owned, and container teardown then `free()`d a `.rodata` literal: `free(): invalid pointer` / `double free`.

It hit `map_put_raw` and the `map.put` wrapper alike. The runtime `_heap_<name>` flag can't gate the routing either: a map/list value has escaped into the container call, so the reassignment wrapper that maintains the flag is suppressed and it reads stale (0 even for a genuinely heap variable).

Fix: resolve a bare-identifier value structurally. `body_assigns_var_ from_heap` (un-static'd, declared in codegen_internal.h) walks the enclosing function body and reports whether the variable is ever assigned from a heap source — reliable for escaped variables. The owned-routing fires only when that holds; a literal-only variable stays on the non-owning path, a genuinely heap variable still routes to owned so #467's leak fix is preserved. Direct heap expressions (`string.concat(...)`, interpolation) were always exact and are unchanged.

To reach the enclosing body, `gen->current_function` is now also set while generating `main` (all other consumers gate on `!in_main_function`, so a main node is inert for them) and each closure body; `current_fn_body_block` extracts the AST_BLOCK child.

Regression test covers the raw API and the wrapper, each with a literal-holding variable and a heap variable; valgrind-clean (no crash, no leak). Verified under `make ci` and `HARDEN=1 make ci` (530/0).

Reported by the avn project (map-put-raw-rewritten-to-owned.md).