### PR TITLE
feat: std.mem size_t byte access and proxy method routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.mem.get_byte_sz` / `std.mem.set_byte_sz` provide size_t-indexed byte
+  access** (`std/mem/module.ae`, `std/mem/aether_mem.c`,
+  `tests/integration/std_mem_byte_access/`). These mirror `get_byte` /
+  `set_byte` but take a `size_t` offset, avoiding one-off C shims in ports
+  whose natural byte index is already `size_t`.
+
+- **`std.http.proxy` can route by HTTP method and route pattern**
+  (`std/http/proxy/module.ae`, `std/http/proxy/aether_proxy_middleware.c`,
+  `tests/integration/http_reverse_proxy_pool/`). New `proxy.mount_methods`
+  filters a proxy mount by a comma-separated method list, and
+  `proxy.mount_match` combines a method list with std.http route-pattern
+  syntax such as `/repos/:repo/info`. Non-matches pass through to later
+  middleware, so first matching mount wins.
+
+### Fixed
+
+- **`@c_import` struct pointers now emit `struct Name*` for typedef-less C
+  headers** (`compiler/codegen/codegen.c`, `compiler/codegen/codegen_expr.c`,
+  `compiler/codegen/codegen_func.c`, `tests/integration/c_import_struct/`).
+  Header-owned structs still emit no Aether typedef, but pointer casts,
+  extern returns and extern parameters no longer assume the header also
+  declares `typedef struct Name Name;`.
+
 ## [0.176.0]
 
 ### Fixed

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -7,6 +7,46 @@
 #include "../aether_module.h"
 #include "../aether_error.h"
 
+/* Set of struct names declared `extern struct Name @c_import`.
+ * aetherc does not emit typedefs for these because the C header owns the
+ * layout. Some headers, such as <time.h> for `struct tm`, also do not ship
+ * `typedef struct Name Name;`, so bare `Name*` is not portable. */
+static char** g_c_import_struct_names = NULL;
+static int g_c_import_struct_count = 0;
+static int g_c_import_struct_capacity = 0;
+
+void aether_register_c_import_struct(const char* name) {
+    if (!name) return;
+    for (int i = 0; i < g_c_import_struct_count; i++) {
+        if (strcmp(g_c_import_struct_names[i], name) == 0) return;
+    }
+    if (g_c_import_struct_count >= g_c_import_struct_capacity) {
+        int new_capacity = g_c_import_struct_capacity ? g_c_import_struct_capacity * 2 : 8;
+        char** grown = (char**)realloc(g_c_import_struct_names,
+            (size_t)new_capacity * sizeof(char*));
+        if (!grown) {
+            fprintf(stderr, "aetherc: out of memory registering @c_import struct\n");
+            exit(1);
+        }
+        g_c_import_struct_names = grown;
+        g_c_import_struct_capacity = new_capacity;
+    }
+    char* copy = strdup(name);
+    if (!copy) {
+        fprintf(stderr, "aetherc: out of memory registering @c_import struct\n");
+        exit(1);
+    }
+    g_c_import_struct_names[g_c_import_struct_count++] = copy;
+}
+
+int aether_is_c_import_struct(const char* name) {
+    if (!name) return 0;
+    for (int i = 0; i < g_c_import_struct_count; i++) {
+        if (strcmp(g_c_import_struct_names[i], name) == 0) return 1;
+    }
+    return 0;
+}
+
 // Map Aether type to C typename for array element declarations.
 // For arrays, the size goes after the name in C, so we need just the
 // element type, not the full "T[N]" form that get_c_type produces.
@@ -1258,13 +1298,25 @@ const char* get_c_type(Type* type) {
              * as `StructName*` so the C type carries the struct identity
              * across declarations / parameters / returns. Bare `ptr` (no
              * element type) stays `void*`. Mirrors the TYPE_ACTOR_REF
-             * shape just below. */
+             * shape just below.
+             *
+             * For `@c_import` structs we emit `struct Name*` instead:
+             * aetherc doesn't synthesise a `typedef struct Name Name;`
+             * for those (the header is supposed to), but some POSIX
+             * headers (notably <time.h> with `struct tm`) don't ship
+             * the convenience typedef.  `struct Name*` is universally
+             * portable. */
             if (type->element_type && type->element_type->kind == TYPE_STRUCT &&
                 type->element_type->struct_name) {
                 static char buffers[4][256];
                 static int buf_idx = 0;
                 char* buffer = buffers[buf_idx++ & 3];
-                snprintf(buffer, 256, "%s*", type->element_type->struct_name);
+                const char* sname = type->element_type->struct_name;
+                if (aether_is_c_import_struct(sname)) {
+                    snprintf(buffer, 256, "struct %s*", sname);
+                } else {
+                    snprintf(buffer, 256, "%s*", sname);
+                }
                 return buffer;
             }
             return "void*";
@@ -1273,8 +1325,12 @@ const char* get_c_type(Type* type) {
             static char buffers[4][256];
             static int buf_idx = 0;
             char* buffer = buffers[buf_idx++ & 3];
-            snprintf(buffer, 256, "%s",
-                    type->struct_name ? type->struct_name : "unnamed");
+            const char* sname = type->struct_name ? type->struct_name : "unnamed";
+            if (type->struct_name && aether_is_c_import_struct(type->struct_name)) {
+                snprintf(buffer, 256, "struct %s", sname);
+            } else {
+                snprintf(buffer, 256, "%s", sname);
+            }
             return buffer;
         }
         case TYPE_ARRAY: {
@@ -2683,6 +2739,9 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
              * Header-Defined C Struct Interop". */
             if (sd->annotation &&
                 strcmp(sd->annotation, "extern_c_import") == 0) {
+                /* Record this name so later emit sites can produce
+                 * `struct Name*` instead of `Name*` when needed. */
+                aether_register_c_import_struct(sd->value);
                 continue;
             }
             fprintf(gen->output, "typedef struct %s %s;\n", sd->value, sd->value);

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1839,9 +1839,17 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             /* `expr as *StructName` — emit `((StructName*)(expr))`.
              * The result is consumed by member-access codegen above,
              * which dispatches on TYPE_PTR{element=TYPE_STRUCT} and
-             * emits `->field`. */
+             * emits `->field`.
+             *
+             * For `@c_import` structs (no aetherc-emitted typedef),
+             * use `struct StructName*` instead — bare `StructName*`
+             * fails for headers that don't ship `typedef struct N N;`. */
             if (expr->child_count > 0 && expr->value) {
-                fprintf(gen->output, "((%s*)(", expr->value);
+                if (aether_is_c_import_struct(expr->value)) {
+                    fprintf(gen->output, "((struct %s*)(", expr->value);
+                } else {
+                    fprintf(gen->output, "((%s*)(", expr->value);
+                }
                 generate_expression(gen, expr->children[0]);
                 fprintf(gen->output, "))");
             }

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -437,8 +437,16 @@ void generate_extern_declaration(CodeGenerator* gen, ASTNode* ext) {
                 if (ext->node_type->element_type &&
                     ext->node_type->element_type->kind == TYPE_STRUCT &&
                     ext->node_type->element_type->struct_name) {
-                    fprintf(gen->output, "%s*",
-                        ext->node_type->element_type->struct_name);
+                    const char* sname = ext->node_type->element_type->struct_name;
+                    if (aether_is_c_import_struct(sname)) {
+                        /* `@c_import` structs have no aetherc-emitted
+                         * typedef; some headers (<time.h> `struct tm`)
+                         * don't ship one either.  `struct Name*` is the
+                         * portable form. */
+                        fprintf(gen->output, "struct %s*", sname);
+                    } else {
+                        fprintf(gen->output, "%s*", sname);
+                    }
                 } else {
                     fprintf(gen->output, "void*");
                 }
@@ -491,8 +499,12 @@ void generate_extern_declaration(CodeGenerator* gen, ASTNode* ext) {
                         if (param->node_type->element_type &&
                             param->node_type->element_type->kind == TYPE_STRUCT &&
                             param->node_type->element_type->struct_name) {
-                            fprintf(gen->output, "%s*",
-                                param->node_type->element_type->struct_name);
+                            const char* sname = param->node_type->element_type->struct_name;
+                            if (aether_is_c_import_struct(sname)) {
+                                fprintf(gen->output, "struct %s*", sname);
+                            } else {
+                                fprintf(gen->output, "%s*", sname);
+                            }
                         } else {
                             fprintf(gen->output, "void*");
                         }

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -207,6 +207,16 @@ const char* c_callback_symbol(ASTNode* func);
    AST_IDENTIFIER emission so a function name passed as a function
    pointer resolves to the linked symbol, not the Aether-side name. */
 const char* lookup_c_callback_symbol(CodeGenerator* gen, const char* name);
+
+/* @c_import struct registry (codegen.c).  Populated in the pre-scan
+ * of the program so every later `*StructName` emit site can ask "do I
+ * need to write `struct N*` instead of `N*`?".  Bare `N*` requires a
+ * `typedef struct N N;` somewhere in scope; with `@c_import` aetherc
+ * emits no typedef, and headers like <time.h> for `struct tm` don't
+ * ship one either, so `N*` doesn't compile.  `struct N*` is the
+ * universally-portable form. */
+void aether_register_c_import_struct(const char* name);
+int aether_is_c_import_struct(const char* name);
 void generate_extern_declaration(CodeGenerator* gen, ASTNode* ext);
 void generate_function_definition(CodeGenerator* gen, ASTNode* func);
 void generate_struct_definition(CodeGenerator* gen, ASTNode* struct_def);

--- a/docs/http-reverse-proxy.md
+++ b/docs/http-reverse-proxy.md
@@ -81,6 +81,24 @@ main() {
 }
 ```
 
+## Method-Aware Routing
+
+Multiple proxy mounts can share one listener. Registration order is
+execution order; a mount whose method or path pattern does not match
+passes through to the next middleware, so narrower carve-outs should
+be registered first.
+
+```aether
+proxy.mount_match(server, "/repos/:repo/info", primary_pool, primary_opts, "GET,HEAD")
+proxy.mount_methods(server, "/repos", primary_pool, write_opts, "POST,PUT,DELETE")
+proxy.mount_methods(server, "/repos", replica_pool, read_opts, "GET,HEAD")
+```
+
+`mount_methods` keeps the normal path-prefix match. `mount_match`
+uses std.http route-pattern syntax (`:param`, `*`) against the whole
+request path, which covers cases like `GET /repos/:repo/info` going
+to a primary while other reads fan out to replicas.
+
 ## Load-balancing algorithms
 
 | Algorithm | Selection rule | When to pick |

--- a/std/http/proxy/aether_proxy.h
+++ b/std/http/proxy/aether_proxy.h
@@ -234,6 +234,27 @@ const char* aether_proxy_use_reverse_proxy(HttpServer* server,
                                            AetherProxyPool* pool,
                                            AetherProxyOpts* opts);
 
+/* Method-filtered mount. `methods_csv` is a comma/space-separated
+ * allow-list such as "GET,HEAD" or "POST, PUT, DELETE". Requests
+ * whose method is not listed pass through to later middleware/routes.
+ * Middleware registration order is preserved, so first matching
+ * proxy mount wins. */
+const char* aether_proxy_use_reverse_proxy_methods(HttpServer* server,
+                                                   const char* path_prefix,
+                                                   AetherProxyPool* pool,
+                                                   AetherProxyOpts* opts,
+                                                   const char* methods_csv);
+
+/* Method + route-pattern mount. `path_pattern` uses the same shape
+ * as std.http routes (`/repos/:repo/info`, `/assets/<wildcard>`). Unlike
+ * `path_prefix`, it matches the whole request path before forwarding.
+ * Useful for carve-outs before broader method mounts. */
+const char* aether_proxy_use_reverse_proxy_match(HttpServer* server,
+                                                 const char* path_pattern,
+                                                 AetherProxyPool* pool,
+                                                 AetherProxyOpts* opts,
+                                                 const char* methods_csv);
+
 /* One-upstream convenience. Builds a pool with one upstream + RR +
  * default opts, mounts the middleware, and returns "". The pool
  * is owned by the middleware and freed alongside the server. */

--- a/std/http/proxy/aether_proxy_internal.h
+++ b/std/http/proxy/aether_proxy_internal.h
@@ -197,6 +197,8 @@ struct AetherProxyCache {
 
 struct AetherProxyOpts {
     char* path_prefix;                /* set by proxy.mount */
+    char* route_pattern;              /* optional full-path pattern */
+    char* methods;                    /* optional CSV allow-list */
     char* strip_path_prefix;
     int   preserve_host;
     int   add_xff;

--- a/std/http/proxy/aether_proxy_middleware.c
+++ b/std/http/proxy/aether_proxy_middleware.c
@@ -78,6 +78,48 @@ static int is_hop_by_hop(const char* name) {
     return 0;
 }
 
+static int token_list_contains(const char* csv, const char* needle) {
+    if (!csv || !*csv) return 1;
+    if (!needle || !*needle) return 0;
+    const char* p = csv;
+    size_t nl = strlen(needle);
+    while (*p) {
+        while (*p == ' ' || *p == '\t' || *p == ',') p++;
+        const char* start = p;
+        while (*p && *p != ',') p++;
+        const char* end = p;
+        while (end > start && (end[-1] == ' ' || end[-1] == '\t')) end--;
+        if ((size_t)(end - start) == nl && strncasecmp(start, needle, nl) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int route_pattern_matches(const char* pattern, const char* path) {
+    if (!pattern || !*pattern) return 1;
+    if (!path) path = "/";
+    if (strcmp(pattern, path) == 0) return 1;
+
+    const char* p = pattern;
+    const char* u = path;
+    while (*p && *u) {
+        if (*p == ':') {
+            p++;
+            while (*p && *p != '/') p++;
+            while (*u && *u != '/') u++;
+        } else if (*p == '*') {
+            return 1;
+        } else if (*p == *u) {
+            p++;
+            u++;
+        } else {
+            return 0;
+        }
+    }
+    return *p == '\0' && *u == '\0';
+}
+
 /* ----- helpers ----- */
 
 static const char* client_ip_for_xff(HttpRequest* req) {
@@ -268,9 +310,18 @@ int aether_middleware_reverse_proxy(HttpRequest* req,
     if (!opts || !opts->pool) return 1;  /* misconfigured — pass through */
     if (!req || !res) return 1;
 
+    if (!token_list_contains(opts->methods, req->method)) {
+        return 1;
+    }
+
+    if (opts->route_pattern &&
+        !route_pattern_matches(opts->route_pattern, req->path)) {
+        return 1;
+    }
+
     /* Path-prefix gate. Empty prefix or "/" matches everything. */
     const char* prefix = opts->path_prefix ? opts->path_prefix : "/";
-    if (*prefix && strcmp(prefix, "/") != 0) {
+    if (!opts->route_pattern && *prefix && strcmp(prefix, "/") != 0) {
         size_t pl = strlen(prefix);
         if (!req->path || strncmp(req->path, prefix, pl) != 0) {
             return 1;
@@ -670,6 +721,15 @@ const char* aether_proxy_use_reverse_proxy(HttpServer* server,
                                            const char* path_prefix,
                                            AetherProxyPool* pool,
                                            AetherProxyOpts* opts) {
+    return aether_proxy_use_reverse_proxy_methods(server, path_prefix, pool,
+                                                  opts, NULL);
+}
+
+const char* aether_proxy_use_reverse_proxy_methods(HttpServer* server,
+                                                   const char* path_prefix,
+                                                   AetherProxyPool* pool,
+                                                   AetherProxyOpts* opts,
+                                                   const char* methods_csv) {
     if (!server) return "server is null";
     if (!pool)   return "pool is null";
     if (!opts)   return "opts is null";
@@ -685,10 +745,57 @@ const char* aether_proxy_use_reverse_proxy(HttpServer* server,
     opts->pool = pool;
 
     free(opts->path_prefix);
+    free(opts->route_pattern);
+    free(opts->methods);
+    opts->route_pattern = NULL;
+    opts->methods = (methods_csv && *methods_csv) ? strdup(methods_csv) : NULL;
     opts->path_prefix = strdup(path_prefix);
-    if (!opts->path_prefix) {
+    if (!opts->path_prefix || ((methods_csv && *methods_csv) && !opts->methods)) {
         aether_proxy_pool_free(pool);  /* roll back retain */
         opts->pool = NULL;
+        free(opts->path_prefix);
+        opts->path_prefix = NULL;
+        free(opts->methods);
+        opts->methods = NULL;
+        return "out of memory";
+    }
+
+    http_server_use_middleware(server, aether_middleware_reverse_proxy, opts);
+    return "";
+}
+
+const char* aether_proxy_use_reverse_proxy_match(HttpServer* server,
+                                                 const char* path_pattern,
+                                                 AetherProxyPool* pool,
+                                                 AetherProxyOpts* opts,
+                                                 const char* methods_csv) {
+    if (!server) return "server is null";
+    if (!pool)   return "pool is null";
+    if (!opts)   return "opts is null";
+    if (!path_pattern || *path_pattern != '/') return "path_pattern must start with /";
+
+    aether_proxy_pool_retain(pool);
+    if (opts->pool && opts->pool != pool) {
+        aether_proxy_pool_free(opts->pool);
+    }
+    opts->pool = pool;
+
+    free(opts->path_prefix);
+    free(opts->route_pattern);
+    free(opts->methods);
+    opts->path_prefix = strdup("/");
+    opts->route_pattern = strdup(path_pattern);
+    opts->methods = (methods_csv && *methods_csv) ? strdup(methods_csv) : NULL;
+    if (!opts->path_prefix || !opts->route_pattern ||
+        ((methods_csv && *methods_csv) && !opts->methods)) {
+        aether_proxy_pool_free(pool);
+        opts->pool = NULL;
+        free(opts->path_prefix);
+        free(opts->route_pattern);
+        free(opts->methods);
+        opts->path_prefix = NULL;
+        opts->route_pattern = NULL;
+        opts->methods = NULL;
         return "out of memory";
     }
 

--- a/std/http/proxy/aether_proxy_opts.c
+++ b/std/http/proxy/aether_proxy_opts.c
@@ -29,6 +29,8 @@ void aether_proxy_opts_free(AetherProxyOpts* opts) {
     if (opts->pool) aether_proxy_pool_free(opts->pool);
     /* cache is owned by the caller; we never own it here */
     free(opts->path_prefix);
+    free(opts->route_pattern);
+    free(opts->methods);
     free(opts->strip_path_prefix);
     free(opts);
 }

--- a/std/http/proxy/module.ae
+++ b/std/http/proxy/module.ae
@@ -46,7 +46,7 @@ exports (
     opts_set_strip_prefix, opts_set_preserve_host, opts_set_xforwarded,
     opts_bind_cache, opts_set_body_cap,
     opts_set_retry_policy, opts_set_trace_inject,
-    mount, mount_simple,
+    mount, mount_methods, mount_match, mount_simple,
     pool_metrics_text,
 )
 
@@ -100,6 +100,16 @@ extern aether_proxy_use_reverse_proxy(server: ptr,
                                       path_prefix: string,
                                       pool: ptr,
                                       opts: ptr) -> string
+extern aether_proxy_use_reverse_proxy_methods(server: ptr,
+                                              path_prefix: string,
+                                              pool: ptr,
+                                              opts: ptr,
+                                              methods_csv: string) -> string
+extern aether_proxy_use_reverse_proxy_match(server: ptr,
+                                            path_pattern: string,
+                                            pool: ptr,
+                                            opts: ptr,
+                                            methods_csv: string) -> string
 extern aether_proxy_use_simple_proxy(server: ptr,
                                      path_prefix: string,
                                      upstream_url: string,
@@ -330,6 +340,30 @@ mount(server: ptr,
       pool: ptr,
       opts: ptr) -> string {
     return aether_proxy_use_reverse_proxy(server, path_prefix, pool, opts)
+}
+
+// Mount the proxy only for specific HTTP methods. `methods_csv` is
+// comma/space-separated, e.g. "GET,HEAD" or "POST, PUT, DELETE".
+// Non-matching methods pass through to later middleware/routes.
+mount_methods(server: ptr,
+              path_prefix: string,
+              pool: ptr,
+              opts: ptr,
+              methods_csv: string) -> string {
+    return aether_proxy_use_reverse_proxy_methods(server, path_prefix, pool,
+                                                  opts, methods_csv)
+}
+
+// Mount the proxy for a route pattern + method set. `path_pattern`
+// uses std.http route syntax (`/repos/:repo/info`, `/assets/*`).
+// Register narrower carve-outs first; middleware order is first-match-wins.
+mount_match(server: ptr,
+            path_pattern: string,
+            pool: ptr,
+            opts: ptr,
+            methods_csv: string) -> string {
+    return aether_proxy_use_reverse_proxy_match(server, path_pattern, pool,
+                                                opts, methods_csv)
 }
 
 // One-upstream convenience: builds a pool with one upstream + RR +

--- a/std/mem/aether_mem.c
+++ b/std/mem/aether_mem.c
@@ -52,6 +52,26 @@ int aether_mem_set_byte(void* p, int i, int value) {
     return 1;
 }
 
+/* size_t-indexed companions to get_byte / set_byte. The `int` index
+ * tops out at 2 GiB; codebases whose natural index width is size_t
+ * (Redis SDS, lzf, siphash, syncio, anything walking large mmap'd
+ * regions) need the wider form to avoid a per-port `_get_byte`
+ * shim that exists only to declare a size_t parameter. Aether has
+ * no primitive narrowing via `as`, so the caller cannot convert
+ * size_t to int at the call site — the only fix is to take the
+ * wider index here. Same NULL defence; out-of-range `i` still the
+ * caller's problem. */
+int aether_mem_get_byte_sz(void* p, size_t i) {
+    if (!p) return -1;
+    return (int)((uint8_t*)p)[i];
+}
+
+int aether_mem_set_byte_sz(void* p, size_t i, int value) {
+    if (!p) return 0;
+    ((uint8_t*)p)[i] = (uint8_t)(value & 0xff);
+    return 1;
+}
+
 /* Read a void*-sized pointer value at byte offset `offset` of `p`.
  * Returns NULL if `p` is NULL or the loaded value is itself NULL.
  * Note: returning NULL conflates "p was null" with "the loaded value

--- a/std/mem/module.ae
+++ b/std/mem/module.ae
@@ -30,6 +30,7 @@
 
 exports (
     aether_mem_get_byte, aether_mem_set_byte,
+    aether_mem_get_byte_sz, aether_mem_set_byte_sz,
     aether_mem_get_ptr, aether_mem_set_ptr,
     aether_mem_get_int, aether_mem_set_int,
     aether_mem_get_long, aether_mem_set_long,
@@ -51,7 +52,7 @@ exports (
     aether_mem_set_u32_le, aether_mem_set_u32_be,
     aether_mem_get_u64_le, aether_mem_get_u64_be,
     aether_mem_set_u64_le, aether_mem_set_u64_be,
-    get_byte, set_byte, get_ptr, set_ptr,
+    get_byte, set_byte, get_byte_sz, set_byte_sz, get_ptr, set_ptr,
     get_int, set_int,
     get_long, set_long,
     get_int8, set_int8, get_uint8, set_uint8,
@@ -78,6 +79,15 @@ extern aether_mem_get_byte(p: ptr, i: int) -> int
 // 1 on success, 0 if `p` is null. As with get_byte, out-of-range
 // `i` is undefined behaviour.
 extern aether_mem_set_byte(p: ptr, i: int, value: int) -> int
+
+// size_t-indexed companions. The int variants top out at 2 GiB;
+// codebases whose natural index width is size_t (Redis SDS, lzf,
+// siphash, syncio, large mmap walkers) need the wider form. Aether
+// has no primitive narrowing via `as` so callers cannot convert
+// size_t to int at the call site — that's the gap these fill.
+// Same null defence; same out-of-range UB contract.
+extern aether_mem_get_byte_sz(p: ptr, i: size_t) -> int
+extern aether_mem_set_byte_sz(p: ptr, i: size_t, value: int) -> int
 
 // Read a pointer-sized value at byte offset `offset` from `p`.
 // Returns null if `p` is null OR the loaded value is null —
@@ -269,6 +279,8 @@ extern aether_mem_set_u64_be(p: ptr, offset: int, value: long) -> int
 // std.* (`mem.get_byte(p, 0)`, `mem.set_byte(p, 0, 0xff)`).
 get_byte(p: ptr, i: int) -> int { return aether_mem_get_byte(p, i) }
 set_byte(p: ptr, i: int, value: int) -> int { return aether_mem_set_byte(p, i, value) }
+get_byte_sz(p: ptr, i: size_t) -> int { return aether_mem_get_byte_sz(p, i) }
+set_byte_sz(p: ptr, i: size_t, value: int) -> int { return aether_mem_set_byte_sz(p, i, value) }
 get_ptr(p: ptr, offset: int) -> ptr { return aether_mem_get_ptr(p, offset) }
 set_ptr(p: ptr, offset: int, value: ptr) -> int { return aether_mem_set_ptr(p, offset, value) }
 get_int(p: ptr, offset: int) -> int { return aether_mem_get_int(p, offset) }

--- a/tests/integration/c_import_struct/aether.toml
+++ b/tests/integration/c_import_struct/aether.toml
@@ -3,9 +3,7 @@ name = "probe"
 path = "probe.ae"
 
 [build]
-# Force-include the C header that owns `client` into every TU,
-# including the Aether-generated .gen.c.  The .gen.c references
-# `client*` and `c->argc` but — because `client` is declared
-# `@c_import` — emits no typedef of its own, so it relies on this
-# header for the definition.
+# Force-include the C header that owns `client` into every TU, including the
+# Aether-generated .gen.c. It references `struct client*` and `c->argc` but
+# emits no typedef of its own, so it relies on this header for the definition.
 cflags = "-include client.h -I."

--- a/tests/integration/c_import_struct/cdefs.ae
+++ b/tests/integration/c_import_struct/cdefs.ae
@@ -2,9 +2,8 @@
 // `@c_import` declaration carries across an Aether module import the
 // same way a regular `extern struct` does.
 //
-// `@c_import` means: the C header (client.h) owns the layout and the
-// typedef.  Aether typechecks `*client` field access against these
-// declared fields but emits no struct body and no typedef.
+// `@c_import` means: the C header (client.h) owns the layout. It deliberately
+// does not provide a `client` typedef, so generated C must use `struct client*`.
 extern struct client @c_import {
     argc: int
     argv: ptr

--- a/tests/integration/c_import_struct/client.h
+++ b/tests/integration/c_import_struct/client.h
@@ -1,18 +1,17 @@
-/* The C header that owns the `client` struct.  Stands in for a Redis
- * header (`server.h`) that already defines `client`, `robj`, `dict`,
- * etc.  The Aether side declares `client` with `@c_import` so it
- * typechecks field access against this layout WITHOUT emitting a
- * competing `typedef struct client { ... } client;` of its own.
+/* The C header that owns the `client` struct. Stands in for POSIX headers
+ * such as <time.h> that expose `struct tm` without a matching `tm` typedef.
+ * The Aether side declares `client` with `@c_import`, so generated C must
+ * refer to pointers as `struct client*`, not bare `client*`.
  *
  * Force-included into every translation unit (including the Aether
  * .gen.c) via `cflags = "-include client.h"` in aether.toml. */
 #ifndef C_IMPORT_STRUCT_CLIENT_H
 #define C_IMPORT_STRUCT_CLIENT_H
 
-typedef struct client {
+struct client {
     int   argc;
     void *argv;
     int   fd;
-} client;
+};
 
 #endif

--- a/tests/integration/c_import_struct/probe.ae
+++ b/tests/integration/c_import_struct/probe.ae
@@ -2,7 +2,7 @@
 // docs/redis-porting-language-gaps.md.
 //
 // `extern struct Name @c_import { ... }` declares a struct whose
-// layout lives in a C header — not one Aether emits.  Aether
+// layout lives in a C header, not one Aether emits. Aether
 // typechecks field access and `*Name` overlays against the declared
 // fields, but the generated C emits NO `typedef struct Name { ... }
 // Name;` and NO forward typedef, so it never collides with the
@@ -15,7 +15,7 @@
 //   - casts a raw `ptr` to `*client`,
 //   - writes and reads fields (emitting plain `c->field` C),
 //   - links against client.h (force-included via aether.toml cflags)
-//     with no duplicate-typedef error.
+//     with no duplicate-typedef error and no dependency on a `client` typedef.
 
 import std.mem
 import cdefs (*)

--- a/tests/integration/c_import_struct/test_c_import_struct.sh
+++ b/tests/integration/c_import_struct/test_c_import_struct.sh
@@ -3,17 +3,15 @@
 # (docs/redis-porting-language-gaps.md).
 #
 # Asserts that `extern struct Name @c_import { ... }`:
-#   1. builds and runs — fields read/write correctly through a raw
+#   1. builds and runs - fields read/write correctly through a raw
 #      `ptr` cast to `*client`;
-#   2. emits NO `typedef struct client` of its own (the C header
-#      client.h owns it; a competing typedef would be a C error);
+#   2. emits NO `typedef struct client` of its own and uses
+#      `struct client*`, because client.h deliberately has no typedef;
 #   3. survives an Aether module import (`cdefs` declares it, `probe`
 #      imports it).
 #
 # client.h is force-included into the generated C via the
-# `cflags = "-include client.h"` in aether.toml. If Aether emitted
-# its own `typedef struct client`, the build would fail with a
-# duplicate-typedef error.
+# `cflags = "-include client.h"` in aether.toml.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -41,6 +39,11 @@ fi
 if [ -n "$genc" ] && grep -Eq 'typedef struct client' "$genc"; then
     echo "  [FAIL] c_import_struct: generated C emitted a typedef for 'client'"
     echo "         (the C header owns the type; Aether must suppress it)"
+    exit 1
+fi
+if [ -n "$genc" ] && ! grep -Eq 'struct client\*' "$genc"; then
+    echo "  [FAIL] c_import_struct: generated C did not use 'struct client*'"
+    echo "         (client.h intentionally provides no bare 'client' typedef)"
     exit 1
 fi
 

--- a/tests/integration/http_reverse_proxy_pool/server.ae
+++ b/tests/integration/http_reverse_proxy_pool/server.ae
@@ -20,6 +20,7 @@
 //   proxy_rate_limit    1 rps per upstream (burst 1)
 //   proxy_trace         injects W3C traceparent when absent
 //   proxy_metrics       same as proxy_rr but exposes /proxy-metrics
+//   proxy_methods       method + route-pattern aware routing
 
 import std.http
 import std.http.proxy
@@ -189,6 +190,9 @@ build_upstream_a() {
     http.server_set_host(s, "127.0.0.1")
     http.server_set_keepalive(s, 1, 0, 5000)
     http.server_get(s, "/echo",            handle_echo_a,         0)
+    http.server_post(s, "/echo",           handle_echo_a,         0)
+    http.server_get(s, "/repos/:repo/info", handle_echo_a,        0)
+    http.server_post(s, "/repos/:repo/commit", handle_echo_a,     0)
     http.server_get(s, "/echo_vary",       handle_echo_vary,      0)
     http.server_get(s, "/echo_cacheable",  handle_echo_cacheable, 0)
     http.server_get(s, "/echo_cacheable_ttl",  handle_echo_cacheable_ttl, 0)
@@ -204,6 +208,9 @@ build_upstream_b() {
     http.server_set_host(s, "127.0.0.1")
     http.server_set_keepalive(s, 1, 0, 5000)
     http.server_get(s,  "/echo",            handle_echo_b,         0)
+    http.server_post(s, "/echo",            handle_echo_b,         0)
+    http.server_get(s,  "/repos/:repo/info", handle_echo_b,        0)
+    http.server_get(s,  "/repos/:repo/log",  handle_echo_b,        0)
     // The cache + vary routes live on every upstream so cache
     // tests don't 404 when a TTL-expired refetch hits a different
     // upstream under round-robin.
@@ -224,6 +231,9 @@ build_upstream_c() {
     http.server_set_host(s, "127.0.0.1")
     http.server_set_keepalive(s, 1, 0, 5000)
     http.server_get(s, "/echo",           handle_echo_c,         0)
+    http.server_post(s, "/echo",          handle_echo_c,         0)
+    http.server_get(s, "/repos/:repo/info", handle_echo_c,       0)
+    http.server_get(s, "/repos/:repo/log",  handle_echo_c,       0)
     http.server_get(s, "/echo_vary",      handle_echo_vary,      0)
     http.server_get(s, "/echo_cacheable", handle_echo_cacheable, 0)
     http.server_get(s, "/echo_cacheable_ttl", handle_echo_cacheable_ttl, 0)
@@ -357,6 +367,37 @@ build_proxy_drain() {
     run_server(s)
 }
 
+build_proxy_methods() {
+    primary = proxy.upstream_pool_new("round_robin", 30, 0, 0)
+    proxy.upstream_add(primary, "http://localhost:19101", 1)
+
+    replicas = proxy.upstream_pool_new("round_robin", 30, 0, 0)
+    proxy.upstream_add(replicas, "http://localhost:19102", 1)
+    proxy.upstream_add(replicas, "http://localhost:19103", 1)
+
+    s = http.server_create(PROXY_PORT)
+    if s == 0 { println("FAIL: methods server_create"); exit(1) }
+    http.server_set_host(s, "127.0.0.1")
+    http.server_set_keepalive(s, 1, 0, 5000)
+    http.server_get(s, "/proxy-metrics-primary", handle_proxy_metrics, primary)
+    http.server_get(s, "/proxy-metrics-replicas", handle_proxy_metrics, replicas)
+
+    opts_info = proxy.opts_new()
+    err = proxy.mount_match(s, "/repos/:repo/info", primary, opts_info, "GET,HEAD")
+    if err != "" { println("FAIL: methods info mount: ${err}"); exit(1) }
+
+    opts_writes = proxy.opts_new()
+    err = proxy.mount_methods(s, "/repos", primary, opts_writes, "POST,PUT,DELETE")
+    if err != "" { println("FAIL: methods write mount: ${err}"); exit(1) }
+
+    opts_reads = proxy.opts_new()
+    err = proxy.mount_methods(s, "/repos", replicas, opts_reads, "GET,HEAD")
+    if err != "" { println("FAIL: methods read mount: ${err}"); exit(1) }
+
+    println("READY")
+    run_server(s)
+}
+
 main() {
     n = aether_args_count()
     if n < 2 { println("FAIL: usage: server <role>"); exit(1) }
@@ -377,6 +418,7 @@ main() {
     if role == "proxy_rate_limit"  { build_proxy_rate_limit();  return }
     if role == "proxy_trace"       { build_proxy_trace();       return }
     if role == "proxy_drain"       { build_proxy_drain();       return }
+    if role == "proxy_methods"     { build_proxy_methods();     return }
 
     println("FAIL: unknown role: ${role}")
     exit(1)

--- a/tests/integration/http_reverse_proxy_pool/test_http_reverse_proxy_pool.sh
+++ b/tests/integration/http_reverse_proxy_pool/test_http_reverse_proxy_pool.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # std.http.proxy pool/LB/health/breaker integration tests, part 1 of 2.
 #
-# Tests 1-8 live here: round-robin / weighted-RR / ip-hash / cookie-
-# hash / drain / health (× 2) / breaker-open. The remaining tests
+# Tests 1-9 live here: round-robin / weighted-RR / ip-hash / cookie-
+# hash / drain / method routing / health (x2) / breaker-open. The remaining tests
 # (breaker-recovery, cache × 3, retry, rate-limit, trace, metrics)
 # live in test_http_reverse_proxy_pool_extra.sh.
 #
@@ -330,7 +330,26 @@ C=$(metric_2xx "http://localhost:19103")
 [ $((B + C)) -eq $HEALTH_BATCH ] || fail "drain: B+C=$((B + C)) expected $HEALTH_BATCH"
 stop_proxy
 
-# ---- Test 6: health checks kill an unhealthy upstream -----
+# ---- Test 6: method + route-pattern aware routing ----------
+start_proxy proxy_methods
+info_body=$(curl -s --max-time 3 "$PROXY/repos/proj/info" 2>/dev/null)
+case "$info_body" in
+    tag=A:*) ;;
+    *) fail "method routing: GET /repos/proj/info went to '$info_body', expected A" ;;
+esac
+log_body=$(curl -s --max-time 3 "$PROXY/repos/proj/log" 2>/dev/null)
+case "$log_body" in
+    tag=B:*|tag=C:*) ;;
+    *) fail "method routing: GET /repos/proj/log went to '$log_body', expected B/C" ;;
+esac
+commit_body=$(curl -s --max-time 3 -X POST "$PROXY/repos/proj/commit" 2>/dev/null)
+case "$commit_body" in
+    tag=A:*) ;;
+    *) fail "method routing: POST /repos/proj/commit went to '$commit_body', expected A" ;;
+esac
+stop_proxy
+
+# ---- Test 7: health checks kill an unhealthy upstream -----
 start_proxy proxy_health
 curl -s -o /dev/null --max-time 3 -X POST "http://127.0.0.1:19102/admin/503" 2>/dev/null || true
 wait_for_upstream_health "http://localhost:19102" 0 || exit 1
@@ -342,12 +361,12 @@ B=$(metric_2xx "http://localhost:19102")
 clear_upstream_b_503
 stop_proxy
 
-# ---- Test 7: health recovery — flip B back, it rejoins -----
-# Skipped on Windows: pairs with Test 6 to exercise the same health-
-# check state machine. Test 6 alone proves the unhealthy→healthy
+# ---- Test 8: health recovery — flip B back, it rejoins -----
+# Skipped on Windows: pairs with Test 7 to exercise the same health-
+# check state machine. Test 7 alone proves the unhealthy->healthy
 # transition gate; the recovery direction is symmetric.
 if [ "$IS_WIN" = "1" ]; then
-    echo "  [SKIP-WIN] Test 7 (health-recovery) — same state machine as Test 6"
+    echo "  [SKIP-WIN] Test 8 (health-recovery) - same state machine as Test 7"
 else
     start_proxy proxy_health
     curl -s -o /dev/null --max-time 3 -X POST "http://127.0.0.1:19102/admin/503" 2>/dev/null || true
@@ -363,7 +382,7 @@ else
     stop_proxy
 fi
 
-# ---- Test 8: circuit breaker opens after consecutive failures ----
+# ---- Test 9: circuit breaker opens after consecutive failures ----
 start_proxy proxy_breaker
 curl -s -o /dev/null --max-time 3 -X POST "http://127.0.0.1:19102/admin/503" 2>/dev/null || true
 parallel_echo $HEALTH_BATCH
@@ -378,7 +397,7 @@ clear_upstream_b_503
 stop_proxy
 
 if [ "$IS_WIN" = "1" ]; then
-    echo "  [PASS] http_reverse_proxy_pool: 5/8 win-reduced — RR/drain/health/breaker-open"
+    echo "  [PASS] http_reverse_proxy_pool: 6/9 win-reduced - RR/drain/methods/health/breaker-open"
 else
-    echo "  [PASS] http_reverse_proxy_pool: 8/8 — RR/WRR/ip_hash/cookie_hash/drain/health(2)/breaker-open"
+    echo "  [PASS] http_reverse_proxy_pool: 9/9 - RR/WRR/ip_hash/cookie_hash/drain/methods/health(2)/breaker-open"
 fi

--- a/tests/integration/std_mem_byte_access/probe.ae
+++ b/tests/integration/std_mem_byte_access/probe.ae
@@ -19,6 +19,7 @@
 //   5. Round-trip through values that exceed byte range (caller
 //      passes 256, 0x1ff, -1) — the C side masks to low 8 bits;
 //      verify the read matches the masked value.
+//   6. size_t-indexed get_byte_sz / set_byte_sz companions.
 
 import std.mem
 
@@ -650,8 +651,29 @@ main() {
         }
     }
 
+    // Case 26: size_t-indexed byte get/set companions.
+    {
+        p = malloc(8)
+        if p == null {
+            println("  [26] FAIL: malloc(8) returned null")
+            failed = failed + 1
+        } else {
+            size_t idx = 5
+            rc = mem.set_byte_sz(p, idx, 0x1ab)
+            v = mem.get_byte_sz(p, idx)
+            if rc != 1 || v != 0xab {
+                println("  [26] FAIL: get/set_byte_sz rc=${rc}, value=${v}, expected 171")
+                failed = failed + 1
+            } else {
+                println("  [26] PASS size_t-indexed byte round-trip")
+                passed = passed + 1
+            }
+            free(p)
+        }
+    }
+
     println("")
-    println("std_mem_byte_access: ${passed} passing, ${failed} failing (of 25)")
+    println("std_mem_byte_access: ${passed} passing, ${failed} failing (of 26)")
     if failed > 0 {
         exit(1)
     }

--- a/tests/integration/std_mem_byte_access/test_std_mem_byte_access.sh
+++ b/tests/integration/std_mem_byte_access/test_std_mem_byte_access.sh
@@ -7,8 +7,9 @@
 # (mquickjs) that fundamentally operate on raw pointers — every
 # UTF-8 decoder and bytecode interpreter does `((uint8_t*)p)[i]`.
 #
-# Exercises 25 cases across:
+# Exercises 26 cases across:
 #   * byte get/set: round-trip, NULL defence, low-8-bit masking
+#   * size_t-indexed byte get/set companions
 #   * pointer / int / long / float-bits accessors
 #   * clz32 / clz64 / udiv64_32
 #   * sized typed-array accessors (int8/uint8/int16/uint16/uint32/
@@ -37,8 +38,8 @@ if ! AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/probe.ae" >"$TMPDIR/out.log" 2>&
     exit 1
 fi
 
-if ! grep -q "std_mem_byte_access: 25 passing, 0 failing" "$TMPDIR/out.log"; then
-    echo "  [FAIL] std_mem_byte_access — not all 25 cases passed"
+if ! grep -q "std_mem_byte_access: 26 passing, 0 failing" "$TMPDIR/out.log"; then
+    echo "  [FAIL] std_mem_byte_access - not all 26 cases passed"
     tail -40 "$TMPDIR/out.log" | sed 's/^/    /'
     exit 1
 fi


### PR DESCRIPTION
## Summary
- add size_t-indexed std.mem byte helpers: get_byte_sz / set_byte_sz
- emit `struct Name*` for typedef-less `@c_import` structs such as POSIX `struct tm`
- add std.http.proxy method-aware routing via `mount_methods` and route-pattern-aware `mount_match`

## Tests
- `make all`
- `git diff --check`
- `tests/integration/c_import_struct/test_c_import_struct.sh`
- `tests/integration/std_mem_byte_access/test_std_mem_byte_access.sh` (rerun with cache write permission)
- `tests/integration/http_reverse_proxy_pool/test_http_reverse_proxy_pool.sh` (rerun with localhost binding allowed)
- `make ci`: compiler/C unit stages passed; integration run hit known local HTTP/2 flakes on this machine
- `HARDEN=1 make ci`: -Werror compiler/stdlib and C unit stages passed; later integration failures were local sandbox/cache/localhost-binding failures (for example /home/paul/.aether/cache read-only and Failed to create socket)