### PR TITLE
Compiler: sizeof/offsetof builtins, fn address-of test, builder/function collision diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,18 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **A `builder` and a plain function sharing a name are now rejected at
+  typecheck time** (`compiler/analysis/typechecker.c`,
+  `tests/integration/builder_function_collision_reject/`). Both mangle
+  to the same C symbol (`<module>_<name>`); previously one silently won
+  and every call dispatched to it — clean compile, clean link, wrong
+  function body, exit 0 (cost ~1h debugging an aeb `lib/ruby` build).
+  Now emits `duplicate definition of '<name>': a builder and a function
+  cannot share a name (both emit the same C symbol)` with the prior
+  definition's line. Narrowed to builder-vs-function: two plain
+  functions sharing a name remain legal (the multi-clause
+  pattern-matching form).
+
 - **`@c_import` struct pointers now emit `struct Name*` for typedef-less C
   headers** (`compiler/codegen/codegen.c`, `compiler/codegen/codegen_expr.c`,
   `compiler/codegen/codegen_func.c`, `tests/integration/c_import_struct/`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
-## [0.177.0]
+## [current]
 
 ### Added
+
+- **`sizeof(T)` / `offsetof(T, field)` compile-time layout builtins**
+  (`compiler/ast.h`, `compiler/parser/parser.c`,
+  `compiler/analysis/typechecker.c`, `compiler/codegen/codegen_expr.c`,
+  `tests/regression/test_sizeof_offsetof.ae`). `sizeof(StructName)` and
+  `offsetof(StructName, field)` lower to C's own
+  `((int)sizeof(struct StructName))` / `((int)offsetof(struct StructName,
+  field))`, so the value can never disagree with the layout the C
+  compiler actually produces. Motivating case: ports that mirror a C
+  struct as an `extern struct` overlay previously hand-maintained byte
+  offsets, which silently drifted from the real layout (the mquickjs
+  port shipped a stale `344` where the field had moved to `138`,
+  corrupting the heap). Spelled as call syntax over an identifier — not
+  reserved words — so only the `sizeof(` / `offsetof(` shape triggers
+  them.
 
 - **`std.mem.get_byte_sz` / `std.mem.set_byte_sz` provide size_t-indexed byte
   access** (`std/mem/module.ae`, `std/mem/aether_mem.c`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ next version number before tagging the release.
 
 ### Added
 
+- **Taking the address of an Aether function** is confirmed supported
+  via the existing `funcname as fn(T1, ...) -> R` cast — applying it to
+  a bare function name yields a real C-ABI function pointer (`ptr`),
+  passable to `qsort`, callback tables, etc.
+  (`tests/regression/test_fn_address_via_as_fn.ae`). No compiler change;
+  this locks in the capability with a regression test so C ports can
+  drop their `*_addr()` shim helpers.
+
 - **`sizeof(T)` / `offsetof(T, field)` compile-time layout builtins**
   (`compiler/ast.h`, `compiler/parser/parser.c`,
   `compiler/analysis/typechecker.c`, `compiler/codegen/codegen_expr.c`,

--- a/builder-function-name-collision-silent-dispatch.md
+++ b/builder-function-name-collision-silent-dispatch.md
@@ -1,5 +1,13 @@
 # `builder` and plain function sharing a name silently collide (wrong dispatch, no diagnostic)
 
+**Status**: FIXED 2026-05-22 — `compiler/analysis/typechecker.c` now
+rejects a builder-vs-function name clash at definition time with a
+`duplicate definition of '<name>'` diagnostic naming both sites. The
+check is narrowed to *different* declaration kinds (builder vs plain
+function), so the legal multi-clause pattern-matching form (two plain
+functions sharing a name) is unaffected. Covered by
+`tests/integration/builder_function_collision_reject/`.
+
 **Reporter**: aeb session (Claude, 2026-05-22)
 **Toolchain**: ae 0.177.0 (aetherc 0.177.0)
 **Severity**: medium — compiles clean, runs the wrong function, no

--- a/builder-function-name-collision-silent-dispatch.md
+++ b/builder-function-name-collision-silent-dispatch.md
@@ -1,0 +1,121 @@
+# `builder` and plain function sharing a name silently collide (wrong dispatch, no diagnostic)
+
+**Reporter**: aeb session (Claude, 2026-05-22)
+**Toolchain**: ae 0.177.0 (aetherc 0.177.0)
+**Severity**: medium — compiles clean, runs the wrong function, no
+warning. Cost ~1h of debugging in aeb's `lib/ruby`.
+
+## What's wrong
+
+When a module declares a plain function and a `builder` with the
+**same name**, both mangle to the same C symbol (`<module>_<name>`).
+aetherc does not reject the duplicate. The two declarations coexist
+at the Aether level (distinct declaration kinds), but at C-emit time
+one definition silently wins and **every call site dispatches to the
+winner** — including call sites that meant the other one.
+
+Across an `import` boundary there is no diagnostic at all: the
+consumer compiles clean, links clean, and runs the wrong function
+body with exit 0.
+
+In aeb this bit `lib/ruby`: a `gem(_ctx, line)` setter (appends a
+line to the in-memory Gemfile) and a `builder gem(ctx)` (runs
+`gem build`) both mangled to `ruby_gem`. `ruby.gem(b) { ... }` in a
+`.build.ae` silently invoked the *setter* and skipped the gem build
+entirely — no error, the build just reported success without
+producing a `.gem`. Worked around by renaming the builder to
+`package` (matching `python.package`), but the compiler should have
+caught it.
+
+## Minimal reproduction
+
+`mylib/module.ae`:
+
+```aether
+import std.string
+import std.map
+
+extern println(s: string)
+
+// Setter: plain function named `gem`.
+gem(_ctx: ptr, line: string) {
+    _e = map.put(_ctx, "gems", line)
+    println("SETTER ran")
+}
+
+// Builder: same name. Mangles to mylib_gem, same as the setter.
+builder gem(ctx: ptr) {
+    println("BUILDER ran")
+}
+```
+
+`consumer.ae`:
+
+```aether
+import std.map
+import mylib
+import mylib (gem)
+
+extern println(s: string)
+
+main() {
+    m = map.new()
+    mylib.gem(m)   // intent: call the builder
+}
+```
+
+```
+$ ae build --lib . consumer.ae
+Building consumer.ae...
+Built: consumer
+$ ./consumer
+SETTER ran            # <-- builder body never ran; no warning; exit 0
+```
+
+## Same-file variant (different, slightly better)
+
+Compiling both declarations in a single file *does* surface an
+error, but a confusing one — the builder (1 arg) shadows the setter
+(2 args), so a 2-arg call fails with an arity error rather than a
+"duplicate definition":
+
+```
+error[E0200]: Function 'gem' expects 1 argument(s), got 2
+  --> collide.ae:19:9
+   |     gem(m, "rspec")
+```
+
+So the single-file path treats the two as one symbol (builder wins);
+the cross-module path silently dispatches to whichever the linker
+resolves first.
+
+## Expected behavior
+
+Reject the collision at definition time, in both the single-file and
+cross-module cases:
+
+```
+error: duplicate definition of 'gem' in module 'mylib'
+  a builder and a function cannot share a name (both emit C symbol 'mylib_gem')
+  --> mylib/module.ae:13:9   (builder)
+  note: previous definition here
+  --> mylib/module.ae:7:1    (function)
+```
+
+A definition-site error is far better than either the misleading
+arity error (same-file) or the silent wrong-dispatch (cross-module).
+
+## Notes / context
+
+- aeb already documents the *constraint* informally ("a builder must
+  not share a name with a function in its module", LLM.md), precisely
+  because the compiler doesn't enforce it. Enforcing it in aetherc
+  would let that note be deleted.
+- The general case is broader than builder-vs-function: any two
+  top-level definitions that mangle to the same C symbol should error.
+  The `builder` + function pair is just the case that occurs naturally
+  in the SDK idiom (a setter named `x` plus a builder verb `x`).
+- Related but distinct from
+  `emit-lib-export-filter-drops-prefix-shadowed-symbols.md` (that one
+  is about `--emit=lib` type-info dropping by name-prefix; this one is
+  about exact-name C-symbol collision and runtime dispatch).

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -937,6 +937,11 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
         case AST_NULL_LITERAL:
             return create_type(TYPE_PTR);
 
+        case AST_SIZEOF:
+        case AST_OFFSETOF:
+            // Compile-time layout builtins; both lower to a C int.
+            return create_type(TYPE_INT);
+
         case AST_PTR_AS_STRUCT_CAST: {
             /* `expr as *StructName` — view the operand as a pointer to
              * StructName. Operand must be ptr-typed. Result is
@@ -3115,6 +3120,17 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
 
         case AST_LITERAL:
             // Literals are already typed
+            return 1;
+
+        case AST_SIZEOF:
+        case AST_OFFSETOF:
+            // Layout builtins. The child of OFFSETOF is the field name,
+            // which is NOT an expression to resolve — do not recurse
+            // (the default case would treat it as an undefined variable).
+            // Field/type validity is the C compiler's job (offsetof on a
+            // bad field is a hard C error), matching the trust-the-author
+            // posture of the `as *Struct` cast.
+            expr->node_type = create_type(TYPE_INT);
             return 1;
 
         case AST_IF_EXPRESSION:

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -1777,6 +1777,40 @@ int typecheck_program(ASTNode* program) {
             }
             case AST_BUILDER_FUNCTION:
             case AST_FUNCTION_DEFINITION: {
+                // Reject two top-level definitions that mangle to the
+                // same C symbol (<module>_<name>). A `builder` and a
+                // plain function sharing a name both emit that symbol;
+                // without this check one silently wins and every call
+                // site dispatches to the winner — clean compile, clean
+                // link, wrong function body (no diagnostic). The check
+                // runs on the post-merge program, so it catches the
+                // cross-module case too. See
+                // builder-function-name-collision-silent-dispatch.md.
+                // Only a builder-vs-plain-function clash is a true
+                // collision. Two plain functions sharing a name is the
+                // legal multi-clause / pattern-matching form (Erlang-
+                // style: several `fib(...)` clauses merged into one
+                // dispatcher), so function-vs-function must NOT fire.
+                if (child->value) {
+                    Symbol* prior = lookup_symbol(global_table, child->value);
+                    if (prior && prior->node &&
+                        (prior->node->type == AST_FUNCTION_DEFINITION ||
+                         prior->node->type == AST_BUILDER_FUNCTION) &&
+                        prior->node->type != child->type) {
+                        const char* this_kind =
+                            (child->type == AST_BUILDER_FUNCTION) ? "builder" : "function";
+                        const char* prior_kind =
+                            (prior->node->type == AST_BUILDER_FUNCTION) ? "builder" : "function";
+                        char msg[320];
+                        snprintf(msg, sizeof(msg),
+                            "duplicate definition of '%s': a %s and a %s "
+                            "cannot share a name (both emit the same C symbol); "
+                            "previous definition at line %d",
+                            child->value, prior_kind, this_kind,
+                            prior->node->line);
+                        type_error(msg, child->line, child->column);
+                    }
+                }
                 add_symbol(global_table, child->value, clone_type(child->node_type), 0, 1, 0);
                 // Store AST node so arity can be verified at call sites
                 Symbol* func_sym = lookup_symbol(global_table, child->value);

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -432,6 +432,8 @@ const char* ast_node_type_to_string(ASTNodeType type) {
         case AST_PRINT_STATEMENT: return "PRINT_STATEMENT";
         case AST_NULL_LITERAL: return "NULL_LITERAL";
         case AST_IF_EXPRESSION: return "IF_EXPRESSION";
+        case AST_SIZEOF: return "SIZEOF";
+        case AST_OFFSETOF: return "OFFSETOF";
         case AST_CONST_DECLARATION: return "CONST_DECLARATION";
         case AST_STRING_INTERP: return "STRING_INTERP";
         case AST_EXTERN_FUNCTION: return "EXTERN_FUNCTION";

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -132,6 +132,14 @@ typedef enum {
                             // arity/types of the call's arguments.
     AST_IF_EXPRESSION,      // if cond { expr } else { expr } — value-producing
 
+    // Compile-time layout builtins over extern/struct types. Both
+    // yield an int. `value` holds the struct type name; for OFFSETOF
+    // children[0] is an AST_IDENTIFIER naming the field. Codegen emits
+    // C's sizeof(T) / offsetof(T, field) so the value always matches
+    // the real C struct layout (no hand-maintained offset constants).
+    AST_SIZEOF,             // sizeof(TypeName)
+    AST_OFFSETOF,           // offsetof(TypeName, fieldName)
+
     // Closures
     AST_CLOSURE,            // |params| -> expr  OR  |params| { block }
     AST_CLOSURE_PARAM,      // parameter in a closure: name [: type]

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1686,6 +1686,24 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             }
             break;
 
+        case AST_SIZEOF:
+            // sizeof(TypeName) → C sizeof(struct TypeName). Extern/struct
+            // types emit as `struct <Name>` (same convention as
+            // `as *StructName`), so the value always tracks the real C
+            // layout.
+            fprintf(gen->output, "((int)sizeof(struct %s))", expr->value);
+            break;
+
+        case AST_OFFSETOF:
+            // offsetof(TypeName, field) → C offsetof(struct TypeName, field).
+            if (expr->child_count >= 1 && expr->children[0]->value) {
+                fprintf(gen->output, "((int)offsetof(struct %s, %s))",
+                        expr->value, expr->children[0]->value);
+            } else {
+                fprintf(gen->output, "/* malformed offsetof */0");
+            }
+            break;
+
         case AST_IDENTIFIER:
             if (!expr->value) { fprintf(gen->output, "/* NULL identifier */0"); break; }
             // Source-location intrinsics (#265) — `__LINE__` / `__FILE__` /

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -776,6 +776,47 @@ ASTNode* parse_primary_expression(Parser* parser) {
         }
 
         case TOKEN_IDENTIFIER: {
+            // Layout builtins: sizeof(TypeName) / offsetof(TypeName, field).
+            // Lexed as plain identifiers (not reserved keywords) so user
+            // code may still name things `sizeof`/`offsetof` elsewhere;
+            // only the `sizeof(` / `offsetof(` call shape triggers these.
+            {
+                Token* after = peek_ahead(parser, 1);
+                if (after && after->type == TOKEN_LEFT_PAREN &&
+                    (strcmp(token->value, "sizeof") == 0 ||
+                     strcmp(token->value, "offsetof") == 0)) {
+                    bool is_offsetof = (strcmp(token->value, "offsetof") == 0);
+                    int line = token->line;
+                    int column = token->column;
+                    advance_token(parser);                       // consume sizeof/offsetof
+                    if (!expect_token(parser, TOKEN_LEFT_PAREN)) return NULL;
+                    Token* tyname = expect_token(parser, TOKEN_IDENTIFIER);
+                    if (!tyname) return NULL;
+                    ASTNode* node = create_ast_node(
+                        is_offsetof ? AST_OFFSETOF : AST_SIZEOF,
+                        tyname->value, line, column);
+                    node->node_type = create_type(TYPE_INT);
+                    if (is_offsetof) {
+                        if (!expect_token(parser, TOKEN_COMMA)) {
+                            free_ast_node(node);
+                            return NULL;
+                        }
+                        Token* field = expect_token(parser, TOKEN_IDENTIFIER);
+                        if (!field) {
+                            free_ast_node(node);
+                            return NULL;
+                        }
+                        ASTNode* field_node = create_ast_node(
+                            AST_IDENTIFIER, field->value, field->line, field->column);
+                        add_child(node, field_node);
+                    }
+                    if (!expect_token(parser, TOKEN_RIGHT_PAREN)) {
+                        free_ast_node(node);
+                        return NULL;
+                    }
+                    return node;
+                }
+            }
             // Could be identifier or struct literal
             Token* next = peek_ahead(parser, 1);
             // Disambiguate: IDENTIFIER { could be a struct literal OR an identifier

--- a/docs/ticket-mquickjs-port-core-needs.md
+++ b/docs/ticket-mquickjs-port-core-needs.md
@@ -28,7 +28,11 @@ This means the `*_addr()` C shims in the mquickjs port are unnecessary:
 can all be deleted in favour of `<fn> as fn(...) -> R` at the call site.
 (Original ticket text wrongly believed this was missing.)
 
-## 2. `va_list` consumers cannot be authored in Aether
+## 2. `va_list` consumers cannot be authored in Aether — DEFERRED
+
+Status (2026-05-22): not started; deferred to a later session. Items 1
+and 3 of this ticket plus the builder/function collision fix shipped
+together; this one is the largest and least-used, so it was held back.
 
 Aether can *call* C variadics (the `extern foo(..., ...)` feature is
 used heavily and works well), but cannot *define* a function that

--- a/docs/ticket-mquickjs-port-core-needs.md
+++ b/docs/ticket-mquickjs-port-core-needs.md
@@ -1,0 +1,72 @@
+# Ticket: Aether-core ergonomics gaps surfaced by the mquickjs C→Aether port
+
+Status: open
+Filed: 2026-05-22
+Source: the mquickjs C→Aether migration (mquickjs/ in this tree)
+
+Migrating mquickjs's engine to Aether keeps hitting the same
+boundary-ergonomics walls. Each forces a hand-written C shim to
+survive in mquickjs.c, blocking the "pristine Aether-calling-Aether"
+end state. None are blockers (workarounds exist), but each leaves a
+residue of C that the migration cannot otherwise eliminate.
+
+## 1. Take the address of an Aether function — ALREADY SUPPORTED
+
+RESOLVED (2026-05-22): no compiler change needed. The existing
+`funcname as fn(T1, T2, ...) -> R` cast, when applied to a bare
+*function name* (not a ptr value), evaluates the function name — which
+decays to its address in C — and lowers to `((void*)(funcname))`. The
+result is a real C-ABI function pointer storable in a `ptr` and
+passable to `qsort`, callback tables, etc. Verified end-to-end against
+libc `qsort` with an Aether comparator
+(`tests/regression/test_fn_address_via_as_fn.ae`).
+
+This means the `*_addr()` C shims in the mquickjs port are unnecessary:
+- `mquickjs.c` `mqjs_js_array_sort_cmp_addr` / `_swap_addr`,
+  `mqjs_range_sort_cmp_addr` / `_swap_addr`
+- `mquickjs_build.c` `atom_cmp` + `mqjs_build_atom_cmp_addr`
+can all be deleted in favour of `<fn> as fn(...) -> R` at the call site.
+(Original ticket text wrongly believed this was missing.)
+
+## 2. `va_list` consumers cannot be authored in Aether
+
+Aether can *call* C variadics (the `extern foo(..., ...)` feature is
+used heavily and works well), but cannot *define* a function that
+consumes a `va_list`. Every printf-family function therefore stays in
+C, and any Aether code that wants formatted output must route through
+a fixed-arity C shim per format string.
+
+Concrete cases:
+- `js_printf` / `js_vprintf` / `js_vsnprintf` / `term_printf` — remain
+  in C.
+- This session folded ~30 `mqjs_js_printf_*` / `mqjs_dbc_*` /
+  `mqjs_dump_mem_*` fixed-string shims into two surviving generic
+  shims (`mqjs_js_printf_str`, `mqjs_js_printf_str_int`) — but those
+  two must stay C because they hold the `va_list` boundary.
+
+Ask: either Aether-side `va_list` consumption, or a blessed
+`format(fmt, args...)` builtin so the printf boundary need not be C.
+
+## 3. No portable `sizeof`/`INTPTR_MAX` / compile-time platform width
+
+Aether code that must zero or stack-allocate a C struct needs the
+struct's byte size, and there is no portable Aether-side `sizeof`.
+Hardcoding (e.g. `mem.set(s, 0, 408)` for `sizeof(JSParseState)`)
+is brittle and DID break this session (wrong guessed size → segfault),
+so the C `memset(s, 0, sizeof(T))` shim had to stay.
+
+Likewise `mquickjs_build.c`'s `build_atoms` trampoline survives only
+to resolve `host_default_jsw` via the C preprocessor
+(`#if INTPTR_MAX >= INT64_MAX`), which Aether cannot read.
+
+Ask: a compile-time `sizeof(extern struct T)` usable from Aether, and
+a portable pointer-width / platform constant.
+
+## Notes / non-asks
+
+- The `as fn(...) -> R` cast for *calling through* a C function
+  pointer works well and eliminated several shims this session
+  (interrupt-handler dispatch, JSWriteFunc dispatch). Item 1 above is
+  the *inverse* (producing a pointer), which is still missing.
+- libc-macro bridges (`stderr`, `stdout`) legitimately need a C
+  symbol; those are not part of this ask.

--- a/docs/ticket-mquickjs-port-core-needs.md
+++ b/docs/ticket-mquickjs-port-core-needs.md
@@ -28,11 +28,12 @@ This means the `*_addr()` C shims in the mquickjs port are unnecessary:
 can all be deleted in favour of `<fn> as fn(...) -> R` at the call site.
 (Original ticket text wrongly believed this was missing.)
 
-## 2. `va_list` consumers cannot be authored in Aether — DEFERRED
+## 2. `va_list` consumers cannot be authored in Aether — TRACKED IN #536
 
-Status (2026-05-22): not started; deferred to a later session. Items 1
-and 3 of this ticket plus the builder/function collision fix shipped
-together; this one is the largest and least-used, so it was held back.
+Status (2026-05-22): not started; tracked as GitHub issue
+aether-lang-org/aether#536. Items 1 and 3 of this ticket plus the
+builder/function collision fix shipped together; this one is the
+largest and least-used, so it was held back.
 
 Aether can *call* C variadics (the `extern foo(..., ...)` feature is
 used heavily and works well), but cannot *define* a function that

--- a/tests/integration/builder_function_collision_reject/test_builder_function_collision_reject.sh
+++ b/tests/integration/builder_function_collision_reject/test_builder_function_collision_reject.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Tests that a `builder` and a plain function sharing a name are
+# rejected at typecheck time with a clear "duplicate definition"
+# diagnostic — rather than silently emitting one C symbol and
+# dispatching every call to whichever definition the linker resolves
+# first (clean compile, clean link, wrong function body, exit 0).
+#
+# See builder-function-name-collision-silent-dispatch.md.
+#
+# Also asserts the two NON-collisions still compile:
+#   - a plain multi-clause function (same name, pattern-matching form)
+#   - a builder and function with DISTINCT names
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+pass=0
+fail=0
+
+# --- Case 1: builder + function same name → rejected ---------------
+cat > /tmp/ae_bfc_bad.ae << 'EOF'
+extern println(s: string)
+
+gem(ctx: ptr, line: string) {
+    println("SETTER")
+}
+
+builder gem(ctx: ptr) {
+    println("BUILDER")
+}
+
+main() {
+    println("x")
+}
+EOF
+output=$(AETHER_HOME="" "$ROOT/build/ae" build /tmp/ae_bfc_bad.ae -o /tmp/ae_bfc_bad_out 2>&1)
+if echo "$output" | grep -q "duplicate definition of 'gem'"; then
+    echo "  [PASS] builder+function name collision rejected with diagnostic"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] expected duplicate-definition diagnostic; got:"
+    echo "$output" | head -10 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+# --- Case 2: multi-clause plain function (same name) → OK ----------
+# Two clauses of the same plain function is the legal pattern-matching
+# form and must NOT be flagged as a collision.
+cat > /tmp/ae_bfc_multiclause.ae << 'EOF'
+extern exit(code: int)
+
+classify(0) -> int { return 100 }
+classify(n: int) -> int { return n }
+
+main() {
+    if classify(0) != 100 { exit(1) }
+    if classify(7) != 7 { exit(2) }
+    exit(0)
+}
+EOF
+if AETHER_HOME="" "$ROOT/build/ae" build /tmp/ae_bfc_multiclause.ae -o /tmp/ae_bfc_mc_out 2>/dev/null; then
+    if /tmp/ae_bfc_mc_out; then
+        echo "  [PASS] multi-clause plain function not flagged as collision"
+        pass=$((pass + 1))
+    else
+        echo "  [FAIL] multi-clause function compiled but ran wrong"
+        fail=$((fail + 1))
+    fi
+else
+    echo "  [FAIL] multi-clause plain function should still compile"
+    fail=$((fail + 1))
+fi
+
+# --- Case 3: builder + function with DISTINCT names → OK -----------
+cat > /tmp/ae_bfc_distinct.ae << 'EOF'
+extern exit(code: int)
+extern println(s: string)
+
+gem_set(ctx: ptr, line: string) {
+    println("SETTER")
+}
+
+builder gem(ctx: ptr) {
+    println("BUILDER")
+}
+
+main() {
+    exit(0)
+}
+EOF
+if AETHER_HOME="" "$ROOT/build/ae" build /tmp/ae_bfc_distinct.ae -o /tmp/ae_bfc_d_out 2>/dev/null; then
+    echo "  [PASS] builder + function with distinct names compiles"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] distinct-named builder + function should compile"
+    fail=$((fail + 1))
+fi
+
+# Cleanup
+rm -f /tmp/ae_bfc_bad.ae /tmp/ae_bfc_multiclause.ae /tmp/ae_bfc_distinct.ae \
+      /tmp/ae_bfc_bad_out /tmp/ae_bfc_mc_out /tmp/ae_bfc_d_out
+
+echo ""
+echo "builder_function_collision_reject: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/regression/test_fn_address_via_as_fn.ae
+++ b/tests/regression/test_fn_address_via_as_fn.ae
@@ -1,0 +1,54 @@
+// Regression: taking the address of an Aether-defined function so it
+// can be handed to a C API expecting a function pointer (qsort's
+// comparator, a callback table, etc.).
+//
+// `funcname as fn(T1, T2, ...) -> R` evaluates the bare function name
+// as a value; in C the function name decays to its address, and the
+// `as fn` cast lowers to `((void*)(funcname))`. The resulting `ptr`
+// is a real C-ABI function pointer.
+//
+// Pre-fix belief: the mquickjs port kept C `*_addr()` shims (e.g.
+// `mqjs_build_atom_cmp_addr`, the sort-callback `_addr` helpers)
+// because "Aether can't take the address of its own function." This
+// test proves the `as fn` cast already covers that need — no shim
+// required — so those C helpers can be deleted.
+//
+// Exercises: pass an Aether comparator's address to libc qsort and
+// confirm it actually sorts.
+
+import std.mem
+
+extern exit(code: int)
+extern qsort(base: ptr, nmemb: long, size: long, compar: ptr)
+extern malloc(n: long) -> ptr
+extern free(p: ptr)
+
+int_cmp(a: ptr, b: ptr) -> int {
+    int x = mem.get_int(a, 0)
+    int y = mem.get_int(b, 0)
+    return x - y
+}
+
+main() {
+    buf = malloc(5 * 4)
+    mem.set_int(buf, 0, 30)
+    mem.set_int(buf, 4, 10)
+    mem.set_int(buf, 8, 50)
+    mem.set_int(buf, 12, 20)
+    mem.set_int(buf, 16, 40)
+
+    // Take the address of int_cmp and hand it to qsort.
+    cmp_addr = int_cmp as fn(ptr, ptr) -> int
+    if cmp_addr == null { exit(10) }
+    qsort(buf, 5, 4, cmp_addr)
+
+    // Ascending: 10, 20, 30, 40, 50
+    if mem.get_int(buf, 0) != 10 { exit(1) }
+    if mem.get_int(buf, 4) != 20 { exit(2) }
+    if mem.get_int(buf, 8) != 30 { exit(3) }
+    if mem.get_int(buf, 12) != 40 { exit(4) }
+    if mem.get_int(buf, 16) != 50 { exit(5) }
+
+    free(buf)
+    exit(0)
+}

--- a/tests/regression/test_sizeof_offsetof.ae
+++ b/tests/regression/test_sizeof_offsetof.ae
@@ -1,0 +1,51 @@
+// Regression test for the `sizeof(T)` / `offsetof(T, field)` builtins.
+//
+// Bug shape: Aether code mirroring a C struct as an `extern struct`
+// overlay had no way to ask the C compiler for the struct's size or a
+// field's byte offset. Hand-maintained offset constants drifted from
+// the real C layout (the mquickjs port shipped a stale 344 where the
+// real offset was 138, corrupting the heap). These builtins emit C's
+// own `sizeof`/`offsetof` so the value can never disagree with the
+// struct the C compiler actually lays out.
+//
+// Pre-fix: `sizeof(Foo)` / `offsetof(Foo, b)` were parse/codegen
+// errors (no such construct). Post-fix they lower to
+// `((int)sizeof(struct Foo))` / `((int)offsetof(struct Foo, b))`.
+//
+// This exercises: (1) sizeof of an extern struct, (2) offsetof of
+// each field, (3) use of the results in arithmetic / comparisons.
+
+extern exit(code: int)
+
+// An extern struct: layout owned by the C side. Fields chosen so the
+// offsets are unambiguous on LP64 (8-byte ptr/long, 4-byte int):
+//   a @ 0   (long, 8 bytes)
+//   b @ 8   (int,  4 bytes)
+//   c @ 12  (int,  4 bytes)
+// sizeof == 16.
+extern struct Layout {
+    a: long
+    b: int
+    c: int
+}
+
+main() {
+    int sz = sizeof(Layout)
+    int off_a = offsetof(Layout, a)
+    int off_b = offsetof(Layout, b)
+    int off_c = offsetof(Layout, c)
+
+    if sz != 16 { exit(1) }
+    if off_a != 0 { exit(2) }
+    if off_b != 8 { exit(3) }
+    if off_c != 12 { exit(4) }
+
+    // Usable in arithmetic: stride to the 3rd Layout in an array.
+    int third = sz * 2
+    if third != 32 { exit(5) }
+
+    // Usable in a comparison guard.
+    if offsetof(Layout, c) <= offsetof(Layout, b) { exit(6) }
+
+    exit(0)
+}


### PR DESCRIPTION
## Description

Three compiler-side improvements surfaced by the mquickjs C→Aether port,
plus tracking docs. Batched into one PR to conserve CI minutes.

1. **`sizeof(T)` / `offsetof(T, field)` compile-time layout builtins.**
   Lower to C's own `((int)sizeof(struct T))` / `((int)offsetof(struct
   T, field))`, so the value can never disagree with the layout the C
   compiler actually produces. Motivating bug: extern-struct overlays in
   C ports hand-maintained byte offsets that silently drifted (the
   mquickjs port shipped a stale `344` where a field had moved to `138`,
   corrupting the heap). Spelled as call syntax over plain identifiers —
   not reserved words — so only the `sizeof(` / `offsetof(` shape
   triggers them.

2. **Function address-of via the existing `<fn> as fn(...) -> R` cast.**
   Turned out already supported (the function name decays to its address,
   lowering to `((void*)(fn))`); no compiler change. Added a regression
   test proving it hands a real address to libc `qsort`, so C ports can
   drop their `*_addr()` shim helpers. Corrected the tracking ticket
   which wrongly believed this was missing.

3. **Reject a `builder` / plain-function name collision at typecheck
   time.** Both mangle to the same C symbol (`<module>_<name>`);
   previously one silently won and every call dispatched to it (clean
   compile, clean link, wrong body, exit 0 — cost ~1h debugging an aeb
   `lib/ruby` build). Now emits a duplicate-definition diagnostic naming
   both sites. Narrowed to builder-vs-function so the legal multi-clause
   pattern-matching form (two plain functions sharing a name) is
   unaffected.

The fourth ticket item (Aether-side `va_list` consumers) is deferred and
tracked as #536.

## Type of Change
- [x] New feature (sizeof/offsetof builtins)
- [x] Bug fix (builder/function collision diagnostic)
- [x] Documentation update (port-needs ticket + collision report)

## Testing
- [x] Added tests: `tests/regression/test_sizeof_offsetof.ae`,
  `tests/regression/test_fn_address_via_as_fn.ae`,
  `tests/integration/builder_function_collision_reject/`.
- [x] `make ci` run locally. Compiler builds clean under `-Werror`.
  341-file syntax+regression sweep green; **zero** duplicate-definition
  false positives (verified the multi-clause forms in
  `test_erlang_variable_pattern` / `test_pattern_guards` still compile).
- [x] All three new features verified passing independently.

### Note on CI status

The local `make ci` reports 4 failures — **all in HTTP/HTTP2
integration tests** (`http_server_h2`, `http_h2_concurrent_dispatch`,
`http_reverse_proxy_pool` ×2), and **none in the compiler**. These are
the known-flaky port-bind / `READY`-timeout / HTTP2-framing races
(`Failed to bind socket to 127.0.0.1:18260`, `no READY within timeout`,
`curl: (16) Error in the HTTP2 framing layer`); the reverse-proxy-pool
pair passes on retry. This PR touches only `compiler/` (parser,
typechecker, codegen) and cannot affect HTTP/2 socket binding. Deferring
to GitHub's CI matrix as the arbiter.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for the non-obvious logic (multi-clause carve-out)
- [x] CHANGELOG.md updated under `[current]`