### PR TITLE
Aether-authored C-variadic functions (va_start/va_arg/va_end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Aether functions can now be C-variadic and consume their own
+  varargs** (`compiler/parser/parser.c`, `compiler/analysis/typechecker.c`,
+  `compiler/codegen/codegen_func.c`, `compiler/codegen/codegen.c`,
+  `compiler/codegen/codegen_expr.c`,
+  `tests/regression/test_va_list_consumer.ae`). A function declared with
+  a trailing `...` (`f(fmt: string, ...)`) emits a C `...` signature; its
+  body reads varargs via three intrinsics: `va_start()` (yields an opaque
+  cookie; the prologue emits `va_list __ae_va; va_start(__ae_va, <last
+  named param>)`), `va_arg(vap, T)` (lowers to `va_arg(*(va_list*)vap,
+  ctype)`), and `va_end(vap)`. The call-site arity check accepts any
+  trailing args beyond the named params for such callees. Closes #536;
+  lets C ports (e.g. mquickjs's `js_vprintf` + its `mqjs_va_arg_*`
+  helpers) move their printf-family routines fully to Aether.
+
+### Fixed
+
+- **The series-collapse loop optimizer no longer folds a loop whose body
+  consumes varargs** (`compiler/codegen/codegen_stmt.c`). `va_arg` /
+  `va_start` / `va_end` are now treated as side-effecting in
+  `expr_has_side_effects`, so a `total = total + va_arg(vl, int)`
+  accumulator loop is emitted as a real loop instead of a closed-form
+  `addend * trip_count` (which read only one vararg). Surfaced while
+  landing #536.
+
 ## [0.178.0]
 
 ### Added

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -942,6 +942,18 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
             // Compile-time layout builtins; both lower to a C int.
             return create_type(TYPE_INT);
 
+        case AST_VA_START:
+            // Opaque va_list cookie, modelled as a ptr.
+            return create_type(TYPE_PTR);
+
+        case AST_VA_ARG:
+            // Yields whatever C type the call requested (parser set it).
+            return expr->node_type ? clone_type(expr->node_type)
+                                   : create_type(TYPE_PTR);
+
+        case AST_VA_END:
+            return create_type(TYPE_VOID);
+
         case AST_PTR_AS_STRUCT_CAST: {
             /* `expr as *StructName` — view the operand as a pointer to
              * StructName. Operand must be ptr-typed. Result is
@@ -3167,6 +3179,27 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             expr->node_type = create_type(TYPE_INT);
             return 1;
 
+        case AST_VA_START:
+            // No children; opaque va_list cookie (ptr).
+            expr->node_type = create_type(TYPE_PTR);
+            return 1;
+
+        case AST_VA_ARG:
+            // children[0] is the cookie expr — typecheck it; the result
+            // type was fixed by the parser from the requested C type.
+            if (expr->child_count > 0) {
+                typecheck_expression(expr->children[0], table);
+            }
+            if (!expr->node_type) expr->node_type = create_type(TYPE_PTR);
+            return 1;
+
+        case AST_VA_END:
+            if (expr->child_count > 0) {
+                typecheck_expression(expr->children[0], table);
+            }
+            expr->node_type = create_type(TYPE_VOID);
+            return 1;
+
         case AST_IF_EXPRESSION:
             // Typecheck all children (condition, then-expr, else-expr)
             for (int i = 0; i < expr->child_count; i++) {
@@ -3821,9 +3854,16 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
         // `required` and `expected` (inclusive) is also OK — the
         // missing trailing args get filled in below from the
         // declared defaults.
+        // A C-variadic callee (declared `f(fixed..., ...)`, marked with
+        // annotation "varargs") accepts any number of trailing args
+        // beyond its named parameters — so any count >= the named-param
+        // count is fine.
+        int is_variadic_callee = (symbol->node->annotation &&
+                                  strcmp(symbol->node->annotation, "varargs") == 0);
         int arity_ok = (got == expected) ||
                        (ctx_first && got == expected - 1) ||
-                       (got >= required && got < expected);
+                       (got >= required && got < expected) ||
+                       (is_variadic_callee && got >= expected);
         if (!arity_ok) {
             char error_msg[256];
             if (required < expected) {

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -434,6 +434,9 @@ const char* ast_node_type_to_string(ASTNodeType type) {
         case AST_IF_EXPRESSION: return "IF_EXPRESSION";
         case AST_SIZEOF: return "SIZEOF";
         case AST_OFFSETOF: return "OFFSETOF";
+        case AST_VA_START: return "VA_START";
+        case AST_VA_ARG: return "VA_ARG";
+        case AST_VA_END: return "VA_END";
         case AST_CONST_DECLARATION: return "CONST_DECLARATION";
         case AST_STRING_INTERP: return "STRING_INTERP";
         case AST_EXTERN_FUNCTION: return "EXTERN_FUNCTION";

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -140,6 +140,21 @@ typedef enum {
     AST_SIZEOF,             // sizeof(TypeName)
     AST_OFFSETOF,           // offsetof(TypeName, fieldName)
 
+    // C variadic-consumer intrinsics. Let an Aether function declared
+    // with a trailing `...` param read its varargs the way C does.
+    //   AST_VA_START — `va_start()`; yields an opaque ptr (va_list
+    //     cookie). The variadic function's prologue emits the hidden
+    //     `va_list` decl + `va_start(..., <last named param>)`; this
+    //     node just yields its address. No children.
+    //   AST_VA_ARG   — `va_arg(vap, TYPE)`; children[0] = the cookie
+    //     expr; node_type = the requested type. Emits
+    //     `va_arg(*(va_list*)vap, <ctype>)`.
+    //   AST_VA_END   — `va_end(vap)`; children[0] = the cookie expr.
+    //     Emits `va_end(*(va_list*)vap)`. Yields void.
+    AST_VA_START,
+    AST_VA_ARG,
+    AST_VA_END,
+
     // Closures
     AST_CLOSURE,            // |params| -> expr  OR  |params| { block }
     AST_CLOSURE_PARAM,      // parameter in a closure: name [: type]

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -2874,6 +2874,13 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
         if (child->type == AST_BUILDER_FUNCTION) {
             if (param_count > 0) fprintf(gen->output, ", ");
             fprintf(gen->output, "void*");
+            param_count++;
+        }
+        // C-variadic function: trailing `...` in the prototype, matching
+        // the definition (see generate_function_definition).
+        if (child->annotation && strcmp(child->annotation, "varargs") == 0
+            && param_count > 0) {
+            fprintf(gen->output, ", ...");
         } else if (param_count == 0) {
             fprintf(gen->output, "void");
         }

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1704,6 +1704,37 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             }
             break;
 
+        case AST_VA_START:
+            // The variadic function's prologue declared `va_list __ae_va`
+            // and called va_start. This expression just yields its
+            // address as the opaque cookie ptr the va_arg/va_end
+            // intrinsics consume.
+            fprintf(gen->output, "((void*)&__ae_va)");
+            break;
+
+        case AST_VA_ARG:
+            // va_arg(vap, T) → va_arg(*(va_list*)(vap), <ctype>).
+            if (expr->child_count >= 1) {
+                fprintf(gen->output, "va_arg(*(va_list*)(");
+                generate_expression(gen, expr->children[0]);
+                fprintf(gen->output, "), %s)",
+                        expr->node_type ? get_c_type(expr->node_type) : "void*");
+            } else {
+                fprintf(gen->output, "/* malformed va_arg */0");
+            }
+            break;
+
+        case AST_VA_END:
+            // va_end(vap) → va_end(*(va_list*)(vap)).
+            if (expr->child_count >= 1) {
+                fprintf(gen->output, "va_end(*(va_list*)(");
+                generate_expression(gen, expr->children[0]);
+                fprintf(gen->output, "))");
+            } else {
+                fprintf(gen->output, "/* malformed va_end */");
+            }
+            break;
+
         case AST_IDENTIFIER:
             if (!expr->value) { fprintf(gen->output, "/* NULL identifier */0"); break; }
             // Source-location intrinsics (#265) — `__LINE__` / `__FILE__` /

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -673,7 +673,11 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
     // Generate parameters - handle pattern matching
     int param_count = 0;
     ASTNode* body = NULL;
-    
+    // Track the C name of the last emitted named parameter — needed as
+    // the second argument to va_start() if this function is variadic.
+    char last_param_cname[256];
+    last_param_cname[0] = '\0';
+
     for (int i = 0; i < func->child_count; i++) {
         ASTNode* child = func->children[i];
         
@@ -709,8 +713,10 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             }
             if (is_promoted) {
                 fprintf(gen->output, " _param_%s", child->value);
+                snprintf(last_param_cname, sizeof(last_param_cname), "_param_%s", child->value);
             } else {
                 fprintf(gen->output, " %s", child->value);
+                snprintf(last_param_cname, sizeof(last_param_cname), "%s", child->value);
             }
             param_count++;
         } else if (child->type == AST_PATTERN_LITERAL) {
@@ -718,10 +724,12 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             if (param_count > 0) fprintf(gen->output, ", ");
             generate_type(gen, child->node_type);
             fprintf(gen->output, " _pattern_%d", param_count);
+            snprintf(last_param_cname, sizeof(last_param_cname), "_pattern_%d", param_count);
             param_count++;
         } else if (child->type == AST_PATTERN_STRUCT) {
             if (param_count > 0) fprintf(gen->output, ", ");
             fprintf(gen->output, "%s _pattern_%d", child->value, param_count);
+            snprintf(last_param_cname, sizeof(last_param_cname), "_pattern_%d", param_count);
             param_count++;
         } else if (child->type == AST_PATTERN_LIST || child->type == AST_PATTERN_CONS) {
             // List pattern becomes array pointer
@@ -744,12 +752,28 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
         fprintf(gen->output, "void* _builder");
         param_count++;
     }
+    // C-variadic function (Aether `f(..., ...)`): trailing `...`. C
+    // requires at least one named parameter before it.
+    int is_variadic = (func->annotation && strcmp(func->annotation, "varargs") == 0
+                       && last_param_cname[0] != '\0');
+    if (is_variadic) {
+        if (param_count > 0) fprintf(gen->output, ", ");
+        fprintf(gen->output, "...");
+        param_count++;
+    }
     if (param_count == 0) {
         fprintf(gen->output, "void");
     }
 
     fprintf(gen->output, ") {\n");
     indent(gen);
+    // Variadic prologue: declare the hidden va_list and prime it from
+    // the last named parameter. va_start()/va_arg()/va_end() in the
+    // body operate on `&__ae_va`.
+    if (is_variadic) {
+        fprintf(gen->output, "    va_list __ae_va; va_start(__ae_va, %s);\n",
+                last_param_cname);
+    }
     clear_declared_vars(gen);  // Reset for each function
     clear_heap_string_vars(gen);
     clear_escaped_string_vars(gen);

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -143,7 +143,14 @@ static int expr_has_side_effects(ASTNode* node) {
     if (!node) return 0;
     if (node->type == AST_FUNCTION_CALL ||
         node->type == AST_SEND_FIRE_FORGET ||
-        node->type == AST_SEND_ASK) return 1;
+        node->type == AST_SEND_ASK ||
+        // va_arg advances the va_list each evaluation; va_start/va_end
+        // mutate it too. Treating them as impure stops the series-
+        // collapse optimizer from hoisting/folding them (which would
+        // read the wrong number of varargs). Issue #536.
+        node->type == AST_VA_ARG ||
+        node->type == AST_VA_START ||
+        node->type == AST_VA_END) return 1;
     for (int i = 0; i < node->child_count; i++) {
         if (expr_has_side_effects(node->children[i])) return 1;
     }

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -817,6 +817,62 @@ ASTNode* parse_primary_expression(Parser* parser) {
                     return node;
                 }
             }
+            // C variadic-consumer intrinsics: va_start() / va_arg(vap, T)
+            // / va_end(vap). Same non-reserving treatment as sizeof —
+            // intercepted only on the `va_*(`  call shape. Usable only
+            // inside a function declared with a trailing `...` param.
+            {
+                Token* after = peek_ahead(parser, 1);
+                if (after && after->type == TOKEN_LEFT_PAREN && token->value &&
+                    (strcmp(token->value, "va_start") == 0 ||
+                     strcmp(token->value, "va_arg") == 0 ||
+                     strcmp(token->value, "va_end") == 0)) {
+                    int line = token->line;
+                    int column = token->column;
+                    if (strcmp(token->value, "va_start") == 0) {
+                        advance_token(parser);                       // va_start
+                        if (!expect_token(parser, TOKEN_LEFT_PAREN)) return NULL;
+                        if (!expect_token(parser, TOKEN_RIGHT_PAREN)) return NULL;
+                        ASTNode* node = create_ast_node(AST_VA_START, NULL, line, column);
+                        node->node_type = create_type(TYPE_PTR);  // opaque va_list cookie
+                        return node;
+                    }
+                    if (strcmp(token->value, "va_arg") == 0) {
+                        advance_token(parser);                       // va_arg
+                        if (!expect_token(parser, TOKEN_LEFT_PAREN)) return NULL;
+                        ASTNode* cookie = parse_expression(parser);  // the va_list ptr
+                        if (!cookie) return NULL;
+                        if (!expect_token(parser, TOKEN_COMMA)) {
+                            free_ast_node(cookie);
+                            return NULL;
+                        }
+                        Type* arg_type = parse_type(parser);         // requested C type
+                        if (!arg_type) { free_ast_node(cookie); return NULL; }
+                        if (!expect_token(parser, TOKEN_RIGHT_PAREN)) {
+                            free_ast_node(cookie);
+                            free_type(arg_type);
+                            return NULL;
+                        }
+                        ASTNode* node = create_ast_node(AST_VA_ARG, NULL, line, column);
+                        node->node_type = arg_type;
+                        add_child(node, cookie);
+                        return node;
+                    }
+                    // va_end(vap)
+                    advance_token(parser);                           // va_end
+                    if (!expect_token(parser, TOKEN_LEFT_PAREN)) return NULL;
+                    ASTNode* cookie = parse_expression(parser);
+                    if (!cookie) return NULL;
+                    if (!expect_token(parser, TOKEN_RIGHT_PAREN)) {
+                        free_ast_node(cookie);
+                        return NULL;
+                    }
+                    ASTNode* node = create_ast_node(AST_VA_END, NULL, line, column);
+                    node->node_type = create_type(TYPE_VOID);
+                    add_child(node, cookie);
+                    return node;
+                }
+            }
             // Could be identifier or struct literal
             Token* next = peek_ahead(parser, 1);
             // Disambiguate: IDENTIFIER { could be a struct literal OR an identifier
@@ -3507,13 +3563,24 @@ ASTNode* parse_function_definition(Parser* parser) {
     ASTNode* func = create_ast_node(AST_FUNCTION_DEFINITION, name->value, name->line, name->column);
     
     // Parse parameters - can be patterns!
+    // A trailing `...` after the last named param marks the function as
+    // C-variadic: codegen emits a trailing `...` in the C signature and
+    // the body reads its varargs via va_start()/va_arg()/va_end(). The
+    // marker is recorded as annotation "varargs" (same convention as
+    // variadic externs).
     if (!match_token(parser, TOKEN_RIGHT_PAREN)) {
         do {
+            if (peek_token(parser) && peek_token(parser)->type == TOKEN_DOTDOTDOT) {
+                advance_token(parser);  // consume '...'
+                if (func->annotation) free(func->annotation);
+                func->annotation = strdup("varargs");
+                break;
+            }
             ASTNode* param = parse_pattern(parser);
             if (!param) break;
             add_child(func, param);
         } while (match_token(parser, TOKEN_COMMA));
-        
+
         expect_token(parser, TOKEN_RIGHT_PAREN);
     }
     

--- a/docs/ticket-mquickjs-port-core-needs.md
+++ b/docs/ticket-mquickjs-port-core-needs.md
@@ -28,12 +28,15 @@ This means the `*_addr()` C shims in the mquickjs port are unnecessary:
 can all be deleted in favour of `<fn> as fn(...) -> R` at the call site.
 (Original ticket text wrongly believed this was missing.)
 
-## 2. `va_list` consumers cannot be authored in Aether — TRACKED IN #536
+## 2. `va_list` consumers cannot be authored in Aether — IMPLEMENTED
 
-Status (2026-05-22): not started; tracked as GitHub issue
-aether-lang-org/aether#536. Items 1 and 3 of this ticket plus the
-builder/function collision fix shipped together; this one is the
-largest and least-used, so it was held back.
+Status (2026-05-22): DONE (issue #536). A function declared with a
+trailing `...` is now C-variadic; its body reads varargs via
+`va_start()` / `va_arg(vap, T)` / `va_end(vap)` intrinsics, lowering to
+the standard C `va_list` machinery. Covered by
+`tests/regression/test_va_list_consumer.ae`. This lets the mquickjs
+port move `js_vprintf` and retire its `mqjs_va_arg_*` C helpers.
+(Original text below kept for context.)
 
 Aether can *call* C variadics (the `extern foo(..., ...)` feature is
 used heavily and works well), but cannot *define* a function that

--- a/tests/regression/test_va_list_consumer.ae
+++ b/tests/regression/test_va_list_consumer.ae
@@ -1,0 +1,57 @@
+// Regression: an Aether function can be C-variadic and read its own
+// varargs via va_start() / va_arg(vap, T) / va_end(vap).
+//
+// Before this landed (issue #536), the printf-family routines in C
+// ports had to keep a hand-written C shim: `va_list ap; va_start(ap,
+// fmt); ...; va_end(ap)` plus a pile of per-type `va_arg(*vap, T)`
+// helpers, because Aether could declare `extern f(fmt, ...)` (call
+// side) but could not *define* a function that consumes a va_list.
+//
+// Now `f(fixed..., ...)` marks the function variadic; the body pulls
+// args with the va_start/va_arg/va_end intrinsics, which lower to the
+// obvious C (`va_list __ae_va; va_start(__ae_va, <last named>)`,
+// `va_arg(*(va_list*)vap, ctype)`, `va_end(*(va_list*)vap)`).
+//
+// Exercises: (1) int varargs in a loop, (2) mixed int/ptr varargs,
+// (3) the call-site arity check accepting extra trailing args.
+
+import std.mem
+
+extern exit(code: int)
+extern strlen(s: ptr) -> int
+
+// Sum `count` int args.
+sum_ints(count: int, ...) -> int {
+    vl = va_start()
+    int total = 0
+    int i = 0
+    while i < count {
+        total = total + va_arg(vl, int)
+        i = i + 1
+    }
+    va_end(vl)
+    return total
+}
+
+// Mixed types: an int, a string (read its length), and a ptr (test null).
+mixed(tag: int, ...) -> int {
+    vl = va_start()
+    int n = va_arg(vl, int)
+    s = va_arg(vl, ptr)
+    p = va_arg(vl, ptr)
+    va_end(vl)
+    int pnull = 0
+    if p == null { pnull = 1 }
+    return tag + n + strlen(s) + pnull
+}
+
+main() {
+    if sum_ints(4, 10, 20, 30, 40) != 100 { exit(1) }
+    if sum_ints(3, 1, 2, 3) != 6 { exit(2) }
+    if sum_ints(0) != 0 { exit(3) }
+
+    // tag=1, n=10, "abc"(len 3), null(pnull 1) => 15
+    if mixed(1, 10, "abc", null) != 15 { exit(4) }
+
+    exit(0)
+}


### PR DESCRIPTION
## Description

Closes #536. Lets an Aether function be C-variadic and consume its own
varargs, so printf-family routines in C ports can move fully to Aether.

A function declared with a trailing `...` (`f(fmt: string, ...)`) is now
C-variadic:
- Codegen emits a `...` C signature **and** prototype, plus a prologue
  `va_list __ae_va; va_start(__ae_va, <last named param>);`.
- The body reads varargs via three intrinsics:
  - `va_start()` — yields an opaque cookie ptr (`&__ae_va`).
  - `va_arg(vap, T)` — lowers to `va_arg(*(va_list*)vap, <ctype>)`.
  - `va_end(vap)` — lowers to `va_end(*(va_list*)vap)`.
- The call-site arity check accepts any trailing args beyond the named
  params for a variadic callee.

The intrinsics are spelled as ordinary call syntax intercepted in the
parser (same non-reserving approach as `sizeof`/`offsetof`), so they
don't become reserved words.

### Also fixed

The series-collapse loop optimizer treated `va_arg` as pure and folded
`total = total + va_arg(vl, int)` into a closed-form `addend *
trip_count` — which read only one vararg. `va_arg`/`va_start`/`va_end`
are now side-effecting in `expr_has_side_effects`, so such loops emit as
real loops. (Surfaced because the optimizer only engaged once `std.mem`
was imported — a nasty silent miscompile.)

## Type of Change
- [x] New feature (Aether-authored variadic functions)
- [x] Bug fix (optimizer purity for va_arg)

## Testing
- [x] New regression test `tests/regression/test_va_list_consumer.ae`
  (int varargs in a loop, mixed int/string/ptr varargs, zero-vararg
  call, arity acceptance). Exits 0.
- [x] Full 341-file syntax+regression sweep compiles clean.
- [x] Series-collapse tests (`test_series_collapse`, `test_series_long`)
  and extern-variadic / printf / arity tests still pass — confirms the
  `expr_has_side_effects` change and arity-check change don't regress
  existing paths.
- [x] Verified the generated C: `int f(int, ...)` prototype + def,
  `va_list __ae_va; va_start(__ae_va, tag)`, `va_arg(*(va_list*)(vl),
  int)`, `va_end(*(va_list*)(vl))`.

### CI note

As with the prior compiler PR, the local HTTP/HTTP2 integration tests
are flaky on this box (port-bind / `READY`-timeout / HTTP2-framing
races) and unrelated to this change, which is compiler-only (parser,
typechecker, codegen, optimizer). Deferring to the GitHub CI matrix.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for the non-obvious logic (cookie/prologue, optimizer purity)
- [x] CHANGELOG.md updated under `[current]` (Added + Fixed)