### PR TITLE
fix: tolerate trailing comma in exports() and selective import lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **Trailing commas are now tolerated in `exports (…)` and selective
+  import lists** (`compiler/parser/parser.c`,
+  `tests/integration/trailing_comma_lists/`). `exports (a, b, c,)` and
+  `import mod (a, b,)` previously emitted a spurious
+  `error[E0100]: Expected IDENTIFIER, got RIGHT_PAREN` — the
+  `do { expect IDENTIFIER } while (match COMMA)` loop re-entered after
+  the trailing comma and hit `)`. Because the parser recovered and
+  exited 0, the failure was intermittent: any program importing
+  `std.http.proxy` (whose export list ends with a trailing comma)
+  printed the error, mis-located onto the *importer's* file path with
+  the proxy module's line number, and downstream build chains saw it as
+  a "nondeterministic E0100 on rebuild." Reported by the avnproxy port
+  (closures-with-context-builder-blockers.md, Blocker 1).
 - **The series-collapse loop optimizer no longer folds a loop whose body
   consumes varargs** (`compiler/codegen/codegen_stmt.c`). `va_arg` /
   `va_start` / `va_end` are now treated as side-effecting in

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -2445,6 +2445,11 @@ ASTNode* parse_import_statement(Parser* parser) {
             expect_token(parser, TOKEN_RIGHT_PAREN);
         } else {
             do {
+                // Tolerate a trailing comma before the closing paren —
+                // `import mod (a, b,)`. Without this guard the comma's
+                // next loop iteration hits `)` and errors spuriously.
+                if (peek_token(parser) &&
+                    peek_token(parser)->type == TOKEN_RIGHT_PAREN) break;
                 Token* symbol = expect_token(parser, TOKEN_IDENTIFIER);
                 if (!symbol) break;
 
@@ -2500,6 +2505,15 @@ ASTNode* parse_exports_list(Parser* parser) {
     // it pins "this module exports nothing public" explicitly.
     if (peek_token(parser) && peek_token(parser)->type != TOKEN_RIGHT_PAREN) {
         do {
+            // Tolerate a trailing comma before the closing paren —
+            // `exports (a, b,)`. The multi-line, comma-per-line export
+            // list style (one name per line, trailing comma on the last)
+            // is common in stdlib modules (e.g. std.http.proxy). Without
+            // this guard the trailing comma's next loop iteration hits
+            // `)` and emits a spurious "Expected IDENTIFIER, got
+            // RIGHT_PAREN" parse error.
+            if (peek_token(parser) &&
+                peek_token(parser)->type == TOKEN_RIGHT_PAREN) break;
             Token* name = expect_token(parser, TOKEN_IDENTIFIER);
             if (!name) break;
             ASTNode* id = create_ast_node(AST_IDENTIFIER, name->value,

--- a/tests/integration/trailing_comma_lists/lib/listmod/module.ae
+++ b/tests/integration/trailing_comma_lists/lib/listmod/module.ae
@@ -1,0 +1,33 @@
+// Regression fixture for the trailing-comma parse bug.
+//
+// The `exports (…)` list below ends with a trailing comma on the last
+// name — the multi-line, one-name-per-line style used by stdlib
+// modules such as std.http.proxy. Before the fix, parse_exports_list's
+// `do { expect IDENTIFIER } while (match COMMA)` loop re-entered after
+// the trailing comma, hit `)`, and emitted a spurious
+//   error[E0100]: Expected IDENTIFIER, got RIGHT_PAREN
+// The error was mis-located onto the *importing* file's path with this
+// module's line number, and surfaced as the "nondeterministic E0100 on
+// rebuild" the avnproxy port reported.
+exports (
+    alpha,
+    beta,
+    gamma,
+)
+
+alpha(x) {
+    return x + 1
+}
+
+beta(x) {
+    return x + 2
+}
+
+gamma(x) {
+    return x + 3
+}
+
+// Private — not exported.
+internal_helper(x) {
+    return x * 100
+}

--- a/tests/integration/trailing_comma_lists/test_no_spurious_e0100.sh
+++ b/tests/integration/trailing_comma_lists/test_no_spurious_e0100.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Regression guard for Blocker 1 of closures-with-context-builder-blockers.md:
+# a trailing comma in an `exports (…)` list (or a selective import list)
+# must NOT produce a spurious `error[E0100]: Expected IDENTIFIER, got
+# RIGHT_PAREN`.
+#
+# This needs a dedicated shell test rather than a plain .ae test because
+# the buggy compiler still *exited 0* — it recovered from the parse error
+# and emitted a usable program — so an exit-code-only check passed even
+# when broken. The deterministic signal is the E0100 line printed to
+# stderr. The pre-fix compiler printed it on every run; the fixed
+# compiler prints nothing.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+pass=0
+fail=0
+
+cd "$SCRIPT_DIR"
+err=$("$ROOT/build/ae" build test_trailing_comma_lists.ae -o /tmp/ae_tcl_guard 2>&1)
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    echo "  [FAIL] build of trailing-comma program failed (exit $rc)"
+    echo "$err" | head -5
+    fail=$((fail + 1))
+else
+    echo "  [PASS] build succeeded"
+    pass=$((pass + 1))
+fi
+
+if echo "$err" | grep -q "E0100"; then
+    echo "  [FAIL] spurious E0100 emitted on a trailing comma:"
+    echo "$err" | grep "E0100"
+    fail=$((fail + 1))
+else
+    echo "  [PASS] no spurious E0100"
+    pass=$((pass + 1))
+fi
+
+rm -f /tmp/ae_tcl_guard
+
+echo ""
+echo "Trailing-comma E0100 guard: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then exit 1; fi

--- a/tests/integration/trailing_comma_lists/test_trailing_comma_lists.ae
+++ b/tests/integration/trailing_comma_lists/test_trailing_comma_lists.ae
@@ -1,0 +1,24 @@
+// Regression test: trailing commas in parenthesised identifier lists.
+//
+// Two parser paths are covered:
+//   1. `exports (a, b, c,)`            — see lib/listmod/module.ae
+//   2. `import mod (a, b,)` selective  — the import line below
+//
+// Both used the same `do { expect IDENTIFIER } while (match COMMA)`
+// shape, which did not tolerate a trailing comma. The proxy stdlib
+// module's export list ends with one, so any program importing
+// std.http.proxy printed a spurious E0100 (mis-located onto the
+// importer's path). aetherc recovered and exited 0, so the failure
+// was intermittent under downstream build chains. See
+// closures-with-context-builder-blockers.md (Blocker 1).
+//
+// This test must compile cleanly (no E0100) and exit 0.
+
+import listmod (alpha, beta, gamma,)
+
+main() {
+    if listmod.alpha(10) != 11 { println("FAIL alpha"); exit(1) }
+    if listmod.beta(10) != 12 { println("FAIL beta"); exit(1) }
+    if listmod.gamma(10) != 13 { println("FAIL gamma"); exit(1) }
+    println("PASS trailing-comma exports + selective import")
+}


### PR DESCRIPTION
`parse_exports_list` and the selective-import list parser used a `do { expect IDENTIFIER } while (match COMMA)` loop that did not tolerate a trailing comma. `exports (a, b, c,)` and `import mod (a, b,)` therefore re-entered the loop after the trailing comma, hit `)`, and emitted a spurious
`error[E0100]: Expected IDENTIFIER, got RIGHT_PAREN`.

std.http.proxy's `exports(...)` list ends with a trailing comma, so every program importing it tripped the error. Because the parser recovered (the `)` was consumed afterward) and aetherc still exited 0, the failure was intermittent under downstream build chains (aeb), and the diagnostic was mis-located onto the *importing* file's path with the proxy module's line number — surfacing as the "nondeterministic E0100 on rebuild" the avnproxy port reported in
closures-with-context-builder-blockers.md (Blocker 1).

Fix: in both loops, break when the next token is the closing paren, so a trailing comma is accepted.

Tests: tests/integration/trailing_comma_lists/ exercises both paths (an exports list and a selective import that each end with a trailing comma). A companion shell guard asserts no E0100 is printed — needed because the buggy compiler still exited 0, so an exit-code-only check passed even when broken.