### PR TITLE
fix(codegen): heap value stored via a string-param wrapper is no long…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **A heap string passed to a wrapper that stores it (`f(v: string) {
+  map.put(m, k, v) }`) is no longer freed out from under the container**
+  (`compiler/codegen/codegen_stmt.c`, `compiler/codegen/codegen_expr.c`,
+  `compiler/codegen/codegen_internal.h`,
+  `tests/regression/test_map_value_storing_wrapper.ae`). The escape
+  analysis judged a callee parameter purely by its declared type:
+  `ptr`/unknown params escape (the callee may stash the pointer),
+  `string` params are read-only (`string.length`, `print`, …). But a
+  user wrapper with a `string`-typed value parameter that puts it into a
+  `std.map`/`std.list` *does* let it escape — so a heap local passed in
+  was never marked escaped, the caller's function-exit defer-free
+  reclaimed it, and the map slot dangled: a later `map.get` returned
+  freed (often overwritten) memory. Silent data corruption, no
+  diagnostic, liveness-sensitive (a `println` that kept the value live
+  hid it). Reported by aeb, whose `build.fail(ctx, reason)` stored the
+  reason into a nested status map and read garbage back later
+  (`heap-string-map-value-use-after-free-multi-tu.md`; reproduces
+  single-TU too, not only across cloned-import TUs as first thought).
+  Fix: `callee_param_escapes_via_body` looks through the callee's body —
+  if the parameter reaches an escaping sink (a `ptr`/`@retain` argument,
+  a container put, transitively another storing wrapper, or a return),
+  the argument escapes even when typed `string`, so the caller keeps the
+  buffer alive. Read-only wrappers are unaffected (the walk bottoms out
+  at externs like `string.length`, which don't escape). Recursion-guarded
+  and conservative on overflow (over-marking is a leak, never a UAF).
+
+### Upgrade notes
+
+This release marks *more* heap-string values as escaping: a value handed
+to a wrapper whose body stores it (into a map/list, a `@retain` sink, or
+a return) is no longer freed at the caller's scope exit. The previous
+compiler freed it there while the container still held the pointer — a
+use-after-free returning garbage on a later read.
+
+The change only ever *keeps a value alive longer*; it cannot turn
+working code into a crash. If your project worked around this by storing
+container values as literals only, or by routing reason/label text
+through disk markers (as aeb did), you can revisit those workarounds —
+the in-memory heap-value-into-container path is now read-safe. Note the
+value is kept alive by *not freeing it at the caller*: when the container
+doesn't own the value (a non-`@retain` `map_put_raw`/`list_add_raw`
+path), it now leaks rather than dangles — the safe direction, tracked
+separately in `heap-temp-into-owned-map-leak.md`. No pre-upgrade action
+is required.
+
 ## [0.183.0]
 
 ### Added

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2911,6 +2911,12 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                              * tradeoff that gate exists to manage. */
                             TypeKind param_kind = lookup_callee_param_kind(gen, func_name, ai);
                             if (call_arg_escapes(param_kind)) continue;
+                            /* A `string`-typed param of a storing
+                             * wrapper still escapes (it reaches a
+                             * container put / @retain sink in the
+                             * callee body) — don't drain the arg-temp,
+                             * or the map slot dangles. */
+                            if (callee_param_escapes_via_body(gen, func_name, ai, 0)) continue;
                             ad_arg_idx[ad_arg_count++] = ai;
                         }
                     }

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -65,6 +65,15 @@ int call_arg_escapes(TypeKind param_kind);
  * resolved or the index is out of range. Defined in codegen_stmt.c. */
 TypeKind lookup_callee_param_kind(CodeGenerator* gen, const char* func_name, int param_idx);
 
+/* Interprocedural escape: does parameter `param_idx` of user function
+ * `func_name` flow into an escaping sink within its body (a container
+ * put / `@retain` / `ptr` callee param, transitively, or a return)?
+ * Catches storing wrappers with `string`-typed value params that
+ * `call_arg_escapes` alone would misjudge as read-only — the map-value
+ * use-after-free. `depth` is the recursion guard (start at 0). Defined
+ * in codegen_stmt.c. */
+int callee_param_escapes_via_body(CodeGenerator* gen, const char* func_name, int param_idx, int depth);
+
 /* Normalise a callee name's dots to underscores, writing into `out`
    and returning `out`. The AST stores source-level callees in dotted
    form (`"string.concat"`) but stdlib externs, the generated C call

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1745,6 +1745,85 @@ int call_arg_escapes(TypeKind param_kind) {
     }
 }
 
+/* Interprocedural escape: does parameter `param_idx` of user function
+ * `func_name` flow into an escaping sink within that function's body —
+ * i.e. is it passed (as a bare identifier) to a call-argument position
+ * that itself escapes (a `ptr`/unknown param, a `@retain` extern param,
+ * or, recursively, another user wrapper whose param escapes), or
+ * returned?
+ *
+ * This is the missing edge behind the map-value use-after-free
+ * (heap-string-map-value-use-after-free-multi-tu.md): a storing wrapper
+ * `store(m, v: string) { map.put(m, k, v) }` has a `string`-typed value
+ * parameter, which `call_arg_escapes` treats as read-only. Without this
+ * check the caller's heap local — passed as `v` — is never marked
+ * escaped, so it's freed at the caller's scope exit while the map still
+ * holds the pointer. Looking through the callee's body sees `v` reach
+ * `map.put`'s `ptr` value parameter and reports the escape, so the
+ * caller keeps the buffer alive.
+ *
+ * Conservative on recursion overflow (returns escape — over-marking is
+ * a leak, under-marking is a UAF). Handles only direct param→sink flow
+ * and param-return; aliasing the param through an intermediate local is
+ * not tracked (rare, and the safe direction would only be a leak). */
+static int param_escapes_in_subtree(CodeGenerator* gen, ASTNode* node,
+                                     const char* pname, int depth);
+
+int callee_param_escapes_via_body(CodeGenerator* gen, const char* func_name,
+                                  int param_idx, int depth) {
+    if (!gen || !gen->program || !func_name || param_idx < 0) return 0;
+    if (depth > 8) return 1;  /* recursion / mutual-recursion guard */
+    char fn_norm[256];
+    const char* fn = codegen_normalise_callee(func_name, fn_norm, sizeof(fn_norm));
+    ASTNode* fn_def = find_function_definition_by_name(gen->program, fn);
+    if (!fn_def || param_idx >= fn_def->child_count) return 0;
+    ASTNode* param = fn_def->children[param_idx];
+    if (!param || !param->value ||
+        (param->type != AST_VARIABLE_DECLARATION &&
+         param->type != AST_PATTERN_VARIABLE)) {
+        return 0;
+    }
+    const char* pname = param->value;
+    ASTNode* body = NULL;
+    for (int i = fn_def->child_count - 1; i >= 0; i--) {
+        if (fn_def->children[i] && fn_def->children[i]->type == AST_BLOCK) {
+            body = fn_def->children[i];
+            break;
+        }
+    }
+    if (!body) return 0;
+    return param_escapes_in_subtree(gen, body, pname, depth);
+}
+
+static int param_escapes_in_subtree(CodeGenerator* gen, ASTNode* node,
+                                    const char* pname, int depth) {
+    if (!node) return 0;
+    if (node->type == AST_RETURN_STATEMENT) {
+        for (int i = 0; i < node->child_count; i++) {
+            ASTNode* r = node->children[i];
+            if (r && r->type == AST_IDENTIFIER && r->value &&
+                strcmp(r->value, pname) == 0) return 1;
+        }
+    }
+    if (node->type == AST_FUNCTION_CALL && node->value) {
+        for (int i = 0; i < node->child_count; i++) {
+            ASTNode* a = node->children[i];
+            if (a && a->type == AST_IDENTIFIER && a->value &&
+                strcmp(a->value, pname) == 0) {
+                char fn_norm[256];
+                const char* fn = codegen_normalise_callee(node->value, fn_norm, sizeof(fn_norm));
+                if (is_retain_extern_param(gen, fn, i)) return 1;
+                if (call_arg_escapes(lookup_callee_param_kind(gen, node->value, i))) return 1;
+                if (callee_param_escapes_via_body(gen, node->value, i, depth + 1)) return 1;
+            }
+        }
+    }
+    for (int i = 0; i < node->child_count; i++) {
+        if (param_escapes_in_subtree(gen, node->children[i], pname, depth)) return 1;
+    }
+    return 0;
+}
+
 static void escape_inspect_call_args(CodeGenerator* gen, ASTNode* call,
                                       const char* consumed_lhs) {
     if (!call) return;
@@ -1783,7 +1862,15 @@ static void escape_inspect_call_args(CodeGenerator* gen, ASTNode* call,
                     mark_escaped_string_var(gen, arg->value);
                 } else {
                     TypeKind k = lookup_callee_param_kind(gen, call->value, i);
-                    if (call_arg_escapes(k)) {
+                    /* A `string`-typed param looks read-only to
+                     * call_arg_escapes, but a storing wrapper
+                     * (`f(v: string) { map.put(m, k, v) }`) lets it
+                     * escape — look through the callee's body so the
+                     * heap local isn't freed at this scope's exit while
+                     * the callee has stashed its pointer (the map-value
+                     * UAF). */
+                    if (call_arg_escapes(k) ||
+                        callee_param_escapes_via_body(gen, call->value, i, 0)) {
                         mark_escaped_string_var(gen, arg->value);
                     }
                 }

--- a/tests/regression/test_map_value_storing_wrapper.ae
+++ b/tests/regression/test_map_value_storing_wrapper.ae
@@ -1,0 +1,65 @@
+// Regression: a heap string passed to a wrapper whose value parameter is
+// typed `string` and which stores it into a map must NOT be freed at the
+// caller's scope exit — the map slot would dangle and read back garbage.
+//
+// (heap-string-map-value-use-after-free-multi-tu.md — surfaced by aeb's
+// build session, where `build.fail(ctx, reason)` stored the reason into a
+// nested status map and a later `reason_of` read it as garbage.)
+//
+// Root cause: `call_arg_escapes` judged a `string`-typed callee parameter
+// read-only, so the caller's heap local was never marked escaped and the
+// function-exit defer-free reclaimed it while `pr`'s `map.put` had already
+// stashed the pointer. Fix: interprocedural escape — look through the
+// callee body and see the param reach `map.put`'s `ptr` value parameter.
+// (Reported as multi-TU-only; in fact it reproduces single-TU with this
+// exact named-local-through-string-param-wrapper shape, which is what this
+// test pins.)
+
+import std.map
+import std.string
+
+extern exit(code: int)
+
+// Storing wrapper: value parameter typed `string`, stored into the map.
+pr(m: ptr, k: string, v: string) {
+    _e = map.put(m, k, v)
+}
+
+reason_of(m: ptr, k: string) -> ptr {
+    v, _ = map.get(m, k)
+    return v
+}
+
+// Caller mints a NAMED heap local and hands it to the string-param wrapper.
+record_fail(m: ptr, label: string, code: int) {
+    reason = string.concat("exit ", string.from_int(code))
+    pr(m, label, reason)
+}
+
+main() {
+    println("=== test_map_value_storing_wrapper ===")
+    m = map.new()
+    record_fail(m, "java", 2)
+    record_fail(m, "rust", 7)
+
+    // Heavy intervening heap churn — reuses any prematurely-freed buffer,
+    // turning a latent UAF into observable corruption.
+    j = 0
+    while j < 500 {
+        _t = string.concat("churn-", string.from_int(j))
+        j = j + 1
+    }
+
+    r1 = reason_of(m, "java")
+    if string.equals(r1, "exit 2") == 0 {
+        println("FAIL: java reason corrupted (got length ${string.length(r1)})")
+        exit(1)
+    }
+    r2 = reason_of(m, "rust")
+    if string.equals(r2, "exit 7") == 0 {
+        println("FAIL: rust reason corrupted (got length ${string.length(r2)})")
+        exit(1)
+    }
+    println("  PASS: stored heap reasons survived the storing wrapper")
+    println("=== all cases passed ===")
+}


### PR DESCRIPTION
…er freed early

A heap string passed to a wrapper whose value parameter is typed `string` and which stores it into a container — `f(v: string) { map.put(m, k, v) }` — was freed at the CALLER's scope exit while the container still held the pointer, so a later read returned freed/overwritten memory. Silent corruption, liveness-sensitive. Reported by aeb (build.fail -> nested status map -> reason_of read garbage;
heap-string-map-value-use-after-free-multi-tu.md). Framed as multi-TU (cloned-import) only, but it reproduces single-TU with the same named-local-through-string-param-wrapper shape.

Root cause: escape analysis judged a callee param by declared type alone (`call_arg_escapes`): `ptr`/unknown escape, `string` is read-only. A storing wrapper with a `string` value param therefore looked read-only, so the caller's heap local was never marked escaped and its function-exit defer-free reclaimed it.

Fix: `callee_param_escapes_via_body` (codegen_stmt.c, declared in codegen_internal.h) looks through the callee's body — if the parameter reaches an escaping sink (a `ptr`/`@retain` arg position, a container put, transitively another storing wrapper, or a return) the argument escapes even when typed `string`. Wired into both the escape walker (escape_inspect_call_args) and the argument-temp drain (codegen_expr.c). Read-only wrappers are unaffected (the walk bottoms out at externs like string.length). Recursion-guarded; conservative on overflow (over-mark = leak, never UAF). Converts the UAF to the safe leak direction (heap-temp-into-owned-map-leak.md) when the container is non-owning.

New regression test reproduces (garbage pre-fix) and passes post-fix. HARDEN=1 make ci green (560 .ae tests + integration/ASan/leak guards), no regression and no new leaks in the leak-gated suites.