### PR TITLE
feat: get.sh remote one-liner installer (curl | sh), like aeb's [skip…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`get.sh` — remote one-liner installer** (`get.sh`, `README.md`).
+  `curl -sSL https://raw.githubusercontent.com/aether-lang-org/aether/main/get.sh | sh`
+  fetches a pinned source tarball, builds the toolchain, and `make
+  install`s it — no clone, no tests. Mirrors aeb's installer: env knobs
+  `AETHER_REF` (tag/branch/SHA; default = latest `vX.Y.Z` tag, falls back
+  to `main`), `PREFIX` (default `~/.local`, sudo-free), `CC`. Prereqs are
+  just a C compiler + GNU make + curl/tar (Aether compiles to C, so no
+  toolchain bootstrap dependency). Complements the existing clone-time
+  `install.sh` (editor extension, `ae version` management, `~/.aether`
+  layout) and `docs/bootstrap-from-source.md` (from-HEAD developer flow).
+
 ## [0.185.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -100,10 +100,18 @@ See [Performance Benchmarks](docs/performance-benchmarks.md) for methodology and
 
 ### Install
 
-**Linux / macOS — one-line install:**
+**Linux / macOS — remote one-liner (no clone):**
 
 ```bash
-git clone https://github.com/nicolasmd87/aether.git
+curl -sSL https://raw.githubusercontent.com/aether-lang-org/aether/main/get.sh | sh
+```
+
+Fetches a pinned source tarball, builds the toolchain (Aether compiles to C, so the only prerequisites are a C compiler + GNU make — no tests run), and installs to `~/.local` (sudo-free). Pin a version with `AETHER_REF=v0.185.0`, or change the prefix with `PREFIX=/usr/local` (system-wide; needs sudo). Add `~/.local/bin` to your `PATH` if it isn't already.
+
+**Linux / macOS — full clone install** (editor extension, `ae version` management, shell-PATH setup, `~/.aether` layout):
+
+```bash
+git clone https://github.com/aether-lang-org/aether.git
 cd aether
 ./install.sh
 ```

--- a/get.sh
+++ b/get.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+# Aether remote installer — fetch a pinned source tarball and `make install`.
+#
+# The one-command, no-clone path (mirrors aeb's install.sh). For the full
+# clone-time installer (editor extension, `ae version` management, shell-rc
+# setup, `~/.aether` layout) use ./install.sh after `git clone`; for the
+# from-HEAD developer flow see docs/bootstrap-from-source.md.
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/aether-lang-org/aether/main/get.sh | sh
+#   AETHER_REF=v0.184.0 sh get.sh
+#   AETHER_REF=v0.184.0 PREFIX=/usr/local sh get.sh   # system-wide (needs sudo)
+#
+# Env knobs:
+#   AETHER_REF  tag (vX.Y.Z), branch, or commit SHA to install.
+#               Default: the latest vX.Y.Z tag (falls back to `main`).
+#   PREFIX      install prefix. Default: $HOME/.local  (no sudo).
+#   CC          C compiler to build with. Default: cc (gcc/clang).
+#
+# Aether compiles to C, so the only build prerequisites are a C compiler
+# and GNU make — there is no chicken-and-egg toolchain dependency. Tests
+# are NOT run (building + installing is enough to use Aether).
+set -eu
+
+REPO="aether-lang-org/aether"
+PREFIX="${PREFIX:-$HOME/.local}"
+CC="${CC:-cc}"
+
+say()  { printf 'aether-install: %s\n' "$*"; }
+die()  { printf 'aether-install: %s\n' "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+have curl || die "curl is required."
+have tar  || die "tar is required."
+have make || die "GNU make is required."
+have "$CC" || die "a C compiler ('$CC') is required — install gcc or clang, or set CC."
+
+# Resolve the ref to install. Default: highest vX.Y.Z tag on the remote.
+REF="${AETHER_REF:-}"
+if [ -z "$REF" ]; then
+    latest=$(curl -fsSL "https://api.github.com/repos/$REPO/tags?per_page=100" 2>/dev/null \
+        | grep -o '"name"[[:space:]]*:[[:space:]]*"v[0-9][0-9.]*"' \
+        | sed -n 's/.*"\(v[0-9][0-9.]*\)".*/\1/p' \
+        | sort -t. -k1.2,1n -k2,2n -k3,3n | tail -1)
+    if [ -n "$latest" ]; then
+        REF="$latest"
+    else
+        REF="main"
+        say "no vX.Y.Z tag found; falling back to 'main' (not pinned)."
+    fi
+fi
+
+say "installing aether @ $REF  ->  PREFIX=$PREFIX  (CC=$CC)"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# GitHub serves a source tarball for any ref (tag/branch/sha) at this URL.
+url="https://github.com/$REPO/archive/$REF.tar.gz"
+say "fetching $url"
+curl -fSL "$url" -o "$tmp/aether.tar.gz" || die "download failed for ref '$REF'."
+tar -xzf "$tmp/aether.tar.gz" -C "$tmp" || die "extract failed."
+
+# GitHub names the top dir <repo>-<ref> (leading 'v' stripped for tags).
+src=$(find "$tmp" -mindepth 1 -maxdepth 1 -type d -name 'aether-*' | head -1)
+[ -n "$src" ] && [ -d "$src" ] || die "could not locate extracted source dir."
+
+say "building + installing (no tests run) — this compiles the toolchain, ~1-2 min"
+make -C "$src" install PREFIX="$PREFIX" CC="$CC"
+
+bin="$PREFIX/bin/ae"
+[ -x "$bin" ] || die "install finished but $bin is missing."
+say "installed: $bin"
+"$bin" version || true
+
+case ":$PATH:" in
+    *":$PREFIX/bin:"*) ;;
+    *) say "note: $PREFIX/bin is not on your PATH — add it to use 'ae' directly." ;;
+esac
+
+say "optional: native contrib modules (sqlite, host_python, …) — from a"
+say "          checkout run 'make contrib && make install-contrib PREFIX=$PREFIX'"
+say "          (built only where the dev libraries are present)."
+say "done. Pin this in CI with: AETHER_REF=$REF"


### PR DESCRIPTION
… actions]

Adds a no-clone remote installer mirroring aeb's install.sh: `curl -sSL .../get.sh | sh` resolves the latest vX.Y.Z tag (or AETHER_REF tag/branch/SHA), fetches the GitHub source tarball, and `make install`s the toolchain into PREFIX (default ~/.local, sudo-free; CC overridable). No tests are run. Prereqs are just a C compiler + GNU make + curl/tar — Aether compiles to C, so unlike aeb (which needs `ae`) there is no toolchain bootstrap dependency.

Complements the existing clone-time install.sh (editor extension, `ae version` management, ~/.aether layout) and docs/bootstrap-from-source.md (from-HEAD dev flow). README gains the one-liner alongside the clone install. Smoke-tested end to end: resolves v0.185.0, fetches, builds, installs, and the installed `ae` compiles+runs a hello program.

Script/docs only; [skip actions] (the CI matrix neither builds nor runs get.sh, and a remote installer can't be validated without network + a published release tarball).