### PR TITLE
feat(vcr): embed-ABI surface parity, strict-ignore helper, quiet mode…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **VCR embed ABI: two missing wraps + strict-ignore ergonomics**
+  (`std/http/server/vcr/embed.ae`, `docs/http-vcr.md`,
+  `vcr_embed_surface_and_strict_ignore_wish.md`). The
+  `aether_vcr_embed_*` C ABI now exposes
+  `start_playback_url` (replay a tape fetched over HTTP) and
+  `stop_and_flush_or_check` (the non-destructive `.actual`-sibling drift
+  variant), reaching parity with the `vcr` module surface the four
+  Servirtium bindings wrap. New `aether_vcr_embed_strict_ignore_common_headers()`
+  drops the volatile request headers stock HTTP clients send
+  (`User-Agent`, `Accept`, `Accept-Encoding`, `Connection`) from strict
+  matching in one call — the underlying lever,
+  `vcr.remove_header(FIELD_REQUEST_HEADERS, name)`, is now documented as
+  the "ignore this header when matching" mechanism.
+
+### Fixed
+
+- **`vcr.load_url` use-after-free** (`std/http/server/vcr/module.ae`).
+  It freed the HTTP response before parsing the body string borrowed from
+  it, so an HTTP-sourced tape parsed as empty ("no '## Interaction '
+  headers"). The body is now copied before the response is freed. Caught
+  by `load_url`'s first test coverage (the embed `start_playback_url`
+  round-trip).
+
+### Changed
+
+- **Embedded VCR runs quiet** (`std/http/server/vcr/{aether_vcr.c,module.ae,embed.ae}`).
+  The embed ABI enables a quiet mode (`vcr.set_quiet`) so an embedded
+  library never writes `vcr.load*` diagnostics to the host's stdout; the
+  failure reason stays retrievable via `vcr_embed_last_error()` (now
+  falling back to the new `vcr.load_error()`). Foreground `import
+  std.http.server.vcr` callers are unchanged (quiet defaults off). The
+  interactive "Press Ctrl+C" banner was already silenced for background
+  servers in 0.185.0.
+
 ## [0.186.0]
 
 ### Added

--- a/docs/http-vcr.md
+++ b/docs/http-vcr.md
@@ -128,7 +128,7 @@ they're part of the format, not markdown escaping.
 
 | Feature                           | Functions                                   |
 |-----------------------------------|---------------------------------------------|
-| **Replay** (load + serve)         | `vcr.load`, `vcr.eject`, `vcr.tape_length`  |
+| **Replay** (load + serve)         | `vcr.load`, `vcr.load_url` (tape fetched over HTTP), `vcr.eject`, `vcr.tape_length`  |
 | **Record server**                 | `vcr.load_record`, `vcr.eject_record`       |
 | **Direct capture + flush**        | `vcr.record`, `vcr.record_full`, `vcr.record_full_response`, `vcr.clear_recording`, `vcr.flush` |
 | **Re-record checks**              | `vcr.flush_or_check`, `vcr.flush_and_fail_if_changed` |
@@ -142,6 +142,32 @@ they're part of the format, not markdown escaping.
 Field selectors for mutations: `vcr.FIELD_PATH`,
 `vcr.FIELD_REQUEST_HEADERS`, `vcr.FIELD_REQUEST_BODY`,
 `vcr.FIELD_RESPONSE_HEADERS`, `vcr.FIELD_RESPONSE_BODY`.
+
+### Ignoring a header under strict matching
+
+Strict matching (`vcr.set_strict_headers(1)`, or any tape with a
+non-empty recorded request-headers block) compares the live request's
+headers against the tape and rejects anything **unexpected** with a 599.
+Real HTTP clients defeat this by attaching headers the tape never
+recorded — Go `net/http`, `java.net.http`, Rust `ureq`, and .NET
+`HttpClient` each send their own `User-Agent`, and some add `Accept`,
+`Accept-Encoding`, or `Connection`.
+
+The lever is `vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, name)`: a
+request-header removal is applied to **both** the recorded expectation
+and the live request before they are compared, so naming a header there
+tells strict matching to *ignore* it:
+
+```aether
+vcr.set_strict_headers(1)
+vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "User-Agent")  // ignore it
+raw = vcr.load("api.tape", 8080)
+```
+
+`Host` is already stripped during normalization, so it never needs this.
+Embedding via the C ABI? `aether_vcr_embed_strict_ignore_common_headers()`
+does the whole volatile set (`User-Agent`, `Accept`, `Accept-Encoding`,
+`Connection`) in one call.
 
 Gzip policy: record mode treats `Content-Encoding: gzip` as a
 transport encoding. The caller receives the upstream gzip response,
@@ -242,6 +268,8 @@ where this implementation drifted from the spec).
 | `tests/integration/test_vcr_notes.ae`                  | Step 9 — per-interaction `[Note]` blocks |
 | `tests/integration/test_vcr_strict_match.ae`           | Step 10 — header mismatch surfaces via `last_error` |
 | `tests/integration/test_vcr_strict_match_body.ae`      | Step 10 — body mismatch surfaces via `last_error` |
+| `tests/integration/test_vcr_strict_ignore_headers.ae`  | Step 10 — `remove_header(REQUEST_HEADERS, …)` makes strict matching ignore a stock client's `User-Agent` |
+| `tests/integration/vcr_embed_abi/`                     | Embed C-ABI — disk + HTTP-sourced (`start_playback_url`) playback via `dlopen` |
 | `tests/integration/test_vcr_static_content.ae`         | Step 11 — `/api/*` from tape, `/assets/*` from disk |
 | `tests/integration/test_vcr_format_options.ae`         | Step 12 — `*GET*` + indented code blocks round-trip |
 | `contrib/climate_http_tests/test_climate_real.ae`      | Live network — real WorldBank climate API |

--- a/std/http/server/vcr/TODO.md
+++ b/std/http/server/vcr/TODO.md
@@ -139,27 +139,25 @@ Remaining gap:
 
 - The first cut assumes decoded gzip bodies are textual enough for the current tape string storage. Full arbitrary binary decoded bodies should go through the existing `base64 below` path once the record-side emitter carries explicit body lengths end to end.
 
-## HTTP-Sourced Markdown Tapes
+## HTTP-Sourced Markdown Tapes — DONE
 
 Servirtium step 16 mentions markdown recordings sourced over HTTP.
-
-Potential API:
 
 ```aether
 vcr.load_url(tape_url, port) -> ptr
 ```
 
-Implementation:
-
-- Use `std.http.client` to fetch markdown.
-- Parse the fetched string using the existing parser path, probably by extracting a `parse_tape_text(label, markdown)` helper from `parse_tape_file()`.
-- Preserve filesystem `load()` as the default.
-
-Tests:
-
-- Local test server serves a tape markdown file.
-- `vcr.load_url()` replays it.
-- Transport failure returns null and sets/prints a useful load error.
+- Uses `std.http.client` to fetch markdown, then the shared
+  `parse_tape_text(label, markdown)` path; filesystem `load()` stays the
+  default.
+- Exposed over the C ABI as `aether_vcr_embed_start_playback_url`
+  (`vcr_embed_surface_and_strict_ignore_wish.md` §1).
+- A use-after-free here (the response was freed before the borrowed body
+  string was parsed, so the fetched tape parsed as empty) was fixed when
+  the embed test gave `load_url` its first coverage — `load_url` now
+  `string.copy`s the body before freeing the response.
+- Test: `tests/integration/vcr_embed_abi/` serves `smoke.tape` from a
+  local `python3 -m http.server` and replays it via the embed ABI.
 
 ## Compatibility Suite
 
@@ -187,6 +185,17 @@ Useful preparation:
 > de-chunks `Transfer-Encoding: chunked` responses, so record tapes
 > store (and replay serves) the decoded payload rather than chunk
 > framing. Same shape as the gzip-normalize path below.
+>
+> **Embed surface gaps + strict-ignore ergonomics:**
+> `vcr_embed_surface_and_strict_ignore_wish.md` is DONE — the embed ABI
+> now wraps `flush_or_check` (`aether_vcr_embed_stop_and_flush_or_check`,
+> the non-destructive `.actual`-sibling drift variant) and `load_url`
+> (`aether_vcr_embed_start_playback_url`); a one-call
+> `aether_vcr_embed_strict_ignore_common_headers()` drops the volatile
+> request headers (`User-Agent`/`Accept`/`Accept-Encoding`/`Connection`)
+> stock clients send; and embedded mode runs quiet (`vcr.set_quiet`) so
+> load diagnostics never hit the host's stdout — the reason stays on
+> `vcr_embed_last_error()` (falling back to `vcr.load_error()`).
 
 Long-horizon goal, probably many months out: make the Aether VCR usable as an embedded Servirtium server behind test-framework wrappers for higher-level languages. The primary product shape should stay server-first: the system under test talks HTTP to an Aether VCR server, and the language wrapper gives the test author a fixture object that exposes a base URL, lifecycle, tape configuration, mutations, and diagnostics.
 

--- a/std/http/server/vcr/aether_vcr.c
+++ b/std/http/server/vcr/aether_vcr.c
@@ -180,6 +180,13 @@ static int          g_tape_cap   = 0;
 static int          g_tape_cursor = 0;
 static char*        g_tape_err   = NULL;
 
+/* Quiet mode: when set, the Aether vcr surface suppresses its load /
+ * load_url / load_record diagnostic prints to stdout. The embed ABI
+ * turns this on (an embedded library should never write to the host's
+ * stdout); the reason is still retrievable via vcr_load_err(). Default
+ * 0 so the foreground `import std.http.server.vcr` surface is unchanged. */
+static int          g_vcr_quiet  = 0;
+
 /* Pending note staged via vcr_note() — attaches to the next
  * vcr_record_interaction() call, then clears. NULL when nothing
  * is staged. */
@@ -446,6 +453,11 @@ void vcr_aether_set_resp_headers(int index, const char* headers);
 const char* vcr_load_err(void) {
     return g_tape_err ? g_tape_err : "";
 }
+
+/* Quiet mode toggle — see g_vcr_quiet. Set by the embed ABI so an
+ * embedded VCR doesn't print load diagnostics to the host's stdout. */
+void vcr_set_quiet(int on) { g_vcr_quiet = on ? 1 : 0; }
+int  vcr_quiet(void)       { return g_vcr_quiet; }
 
 int vcr_tape_length(void) {
     return g_tape_n;

--- a/std/http/server/vcr/embed.ae
+++ b/std/http/server/vcr/embed.ae
@@ -49,7 +49,32 @@ extern vcr_embed_free(s: string)
 // `label` is human-facing (logs/diagnostics), never the state key.
 // Returns null on parse/bind failure.
 vcr_embed_start_playback(label: string, tape_path: string, host: string, port: int) -> ptr {
+    vcr.set_quiet(1)
     raw = vcr.load(tape_path, port)
+    if raw == 0 {
+        return null
+    }
+    http_server_set_host(raw, host)
+    rc = http_server_bind_raw(raw, host, port)
+    if rc < 0 {
+        vcr.eject(raw)
+        return null
+    }
+    sb = http_server_start_background_raw(raw)
+    if sb < 0 {
+        return null
+    }
+    return raw
+}
+
+// As vcr_embed_start_playback, but the tape is fetched over HTTP from
+// `tape_url` instead of read from disk — for centralized/shared tape
+// libraries (vcr_embed_surface_and_strict_ignore_wish.md §1). `label`
+// is human-facing only. Returns null on fetch/parse/bind failure; the
+// reason is retrievable via vcr_embed_last_error().
+vcr_embed_start_playback_url(label: string, tape_url: string, host: string, port: int) -> ptr {
+    vcr.set_quiet(1)
+    raw = vcr.load_url(tape_url, port)
     if raw == 0 {
         return null
     }
@@ -70,6 +95,7 @@ vcr_embed_start_playback(label: string, tape_path: string, host: string, port: i
 // return the live response to the caller, and capture the interaction.
 // Flush to the tape with vcr_embed_stop_and_flush. Returns null on failure.
 vcr_embed_start_record(label: string, tape_path: string, upstream_base: string, host: string, port: int) -> ptr {
+    vcr.set_quiet(1)
     raw = vcr.load_record(tape_path, upstream_base, port)
     if raw == 0 {
         return null
@@ -105,6 +131,17 @@ vcr_embed_stop_and_flush_fail_if_changed(s: ptr, tape_path: string) -> string {
     return vcr_embed_dup(vcr.flush_and_fail_if_changed(tape_path))
 }
 
+// Stop + the non-destructive drift variant: writes the freshly recorded
+// tape to a `<tape_path>.actual` sibling and byte-compares against the
+// committed tape WITHOUT overwriting it. Returns "" when they match (and
+// removes the .actual sibling), else a mismatch message (leaving .actual
+// on disk for inspection). For CI that prefers reviewing drift over
+// rewriting the checked-in tape (the wish §1 form). Caller frees.
+vcr_embed_stop_and_flush_or_check(s: ptr, tape_path: string) -> string {
+    vcr.eject(s)
+    return vcr_embed_dup(vcr.flush_or_check(tape_path))
+}
+
 // ---- introspection ----
 
 // Resolved listening port (the OS-assigned port when started with 0).
@@ -129,8 +166,16 @@ vcr_embed_reset_cursor() {
 
 // ---- diagnostics (drain after a request to assert outcomes) ----
 
+// The last match-failure detail, or — when no match failure is pending
+// — the last load failure reason (fetch/parse/bind). Since the embed
+// layer runs the server quietly (no stdout), this is how a host learns
+// *why* a start_playback[_url] returned null.
 vcr_embed_last_error() -> string {
-    return vcr_embed_dup(vcr.last_error())
+    e = vcr.last_error()
+    if e == "" {
+        e = vcr.load_error()
+    }
+    return vcr_embed_dup(e)
 }
 
 vcr_embed_last_kind() -> int {
@@ -157,6 +202,23 @@ vcr_embed_unredact(field: int, pattern: string, replacement: string) -> string {
 
 vcr_embed_remove_header(field: int, name: string) -> string {
     return vcr_embed_dup(vcr.remove_header(field, name))
+}
+
+// One-call opt-in for the headers stock HTTP clients attach but a tape
+// never recorded — User-Agent, Accept, Accept-Encoding, Connection. Each
+// is dropped from BOTH the recorded expectation and the live request
+// before strict matching (see vcr.remove_header), so a StrictHeaders
+// test against a real client (Go/Java/Rust/.NET) matches without the
+// test scrubbing each header by hand (the wish §2 ergonomics item). Host
+// is already stripped during normalization, so it's omitted here. Call
+// BEFORE start_playback[_url], like the other config. Returns "" on
+// success, else the first error (caller frees).
+vcr_embed_strict_ignore_common_headers() -> string {
+    e = vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "User-Agent")
+    if e == "" { e = vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "Accept") }
+    if e == "" { e = vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "Accept-Encoding") }
+    if e == "" { e = vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "Connection") }
+    return vcr_embed_dup(e)
 }
 
 vcr_embed_note(title: string, body: string) -> string {

--- a/std/http/server/vcr/module.ae
+++ b/std/http/server/vcr/module.ae
@@ -135,6 +135,7 @@ exports (
     FIELD_PATH, FIELD_RESPONSE_BODY, FIELD_REQUEST_HEADERS,
     FIELD_REQUEST_BODY, FIELD_RESPONSE_HEADERS,
     load, load_url, eject, tape_length,
+    set_quiet, load_error,
     load_record, eject_record,
     record, clear_recording, flush, flush_or_check, flush_and_fail_if_changed,
     redact, clear_redactions, unredact, clear_unredactions,
@@ -166,6 +167,8 @@ extern http_response_free(resp: ptr)
 // parse_tape_file now reads + parses, calling vcr_aether_*
 // setters to populate the C-side tape storage.
 extern vcr_load_err() -> string                       // populated by vcr_aether_set_load_err on parse failure
+extern vcr_set_quiet(on: int)                          // suppress load-path stdout diagnostics (embed ABI sets this)
+extern vcr_quiet() -> int                              // 1 when quiet mode is on
 extern vcr_tape_length() -> int
 extern vcr_dispatch(req: ptr, res: ptr, ud: ptr)     // server handler — matches next entry, emits response
 extern vcr_register_static_routes(server: ptr)         // registers configured static-content mounts
@@ -320,19 +323,48 @@ extern string_concat(a: string, b: string) -> string
 //
 // Returns null on tape parse failure or port-bind failure; the
 // reason is printed via println before the null return.
+// Load-path diagnostic. Suppressed under quiet mode (set by the embed
+// ABI) so an embedded VCR never writes to the host's stdout; the same
+// reason stays retrievable via load_error() / last_error(). Foreground
+// `import std.http.server.vcr` callers (quiet off) still see the line.
+diag(msg: string) {
+    // Record the reason so load_error() reflects every load failure
+    // (parse, fetch, and bind), not just parse errors — an embedded
+    // host needs it when stdout is suppressed.
+    vcr_aether_set_load_err(msg)
+    if vcr_quiet() == 0 {
+        println(msg)
+    }
+}
+
+// Suppress (1) or restore (0) the load-path stdout diagnostics above.
+// Embedded hosts (the embed ABI) turn this on so the library stays
+// silent; the failure reason is still available via load_error().
+set_quiet(on: int) {
+    vcr_set_quiet(on)
+}
+
+// The most recent load / load_url / load_record failure reason ("" if
+// none). Same text that the diagnostics print in non-quiet mode, so an
+// embedded host can surface *why* a start returned null without parsing
+// stdout. Populated by the parser via vcr_aether_set_load_err.
+load_error() -> string {
+    return vcr_load_err()
+}
+
 load(tape_path: string, port: int) -> ptr {
     // Aether-side parser. The pre-port C parser (still shipped as
     // vcr_load_tape) is unused by this surface but retained as a
     // fallback for the duration of the C→Aether migration.
     perr = parse_tape_file(tape_path)
     if perr != "" {
-        println("vcr.load: ${perr}")
+        diag("vcr.load: ${perr}")
         return null
     }
 
     raw = http.server_create(port)
     if raw == 0 {
-        println("vcr.load: server_create on port ${port} returned 0")
+        diag("vcr.load: server_create on port ${port} returned 0")
         return null
     }
 
@@ -357,31 +389,35 @@ load_url(tape_url: string, port: int) -> ptr {
     // Fetch the tape over HTTP using raw client (30s timeout)
     resp = http_get_with_timeout_raw(tape_url, 30000)
     if resp == null {
-        println("vcr.load_url: failed to fetch ${tape_url}")
+        diag("vcr.load_url: failed to fetch ${tape_url}")
         return null
     }
 
     err = http_response_error(resp)
     if err != "" && string.length(err) > 0 {
-        println("vcr.load_url: ${err}")
+        diag("vcr.load_url: ${err}")
         http_response_free(resp)
         return null
     }
 
-    tape_markdown = http_response_body(resp)
+    // http_response_body returns a pointer borrowed from resp; copy it
+    // out before freeing the response, or the parser below reads freed
+    // memory (the bug the embed-ABI start_playback_url test caught — the
+    // fetched tape would parse as empty: "no '## Interaction ' headers").
+    tape_markdown = string.copy(http_response_body(resp))
     http_response_free(resp)
 
     // Parse the fetched markdown using the same path as load()
     // The parser populates the C-side tape storage via vcr_aether_* calls
     perr = parse_tape_text("http-sourced", tape_markdown)
     if perr != "" {
-        println("vcr.load_url: ${perr}")
+        diag("vcr.load_url: ${perr}")
         return null
     }
 
     raw = http.server_create(port)
     if raw == 0 {
-        println("vcr.load_url: server_create on port ${port} returned 0")
+        diag("vcr.load_url: server_create on port ${port} returned 0")
         return null
     }
 
@@ -412,13 +448,13 @@ load_record(tape_path: string, upstream_base: string, port: int) -> ptr {
 
     raw = http.server_create(port)
     if raw == 0 {
-        println("vcr.load_record: server_create on port ${port} returned 0")
+        diag("vcr.load_record: server_create on port ${port} returned 0")
         return null
     }
 
     ok = vcr_register_record_routes(raw, upstream_base)
     if ok == 0 {
-        println("vcr.load_record: ${vcr_load_err()}")
+        diag("vcr.load_record: ${vcr_load_err()}")
         http.server_stop(raw)
         return null
     }
@@ -612,6 +648,20 @@ clear_unredactions() {
 // request-header removals to both the recorded expectation and the
 // live incoming request before strict matching. Header-name matching
 // is case-insensitive and exact.
+//
+// IGNORE-A-HEADER-WHEN-MATCHING: because the removal is applied to
+// *both* sides before comparison, this is also the lever for telling
+// strict matching to ignore a header. Real HTTP clients attach headers
+// the tape never recorded — Go/Java/Rust/.NET each add their own
+// `User-Agent`, `Accept`, `Accept-Encoding`, `Connection` — and strict
+// matching (correctly) rejects them as unexpected. Drop them from the
+// comparison with, e.g.:
+//
+//   vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "User-Agent")
+//
+// (Host is already stripped during normalization, so it never needs
+// this.) The embed ABI bundles the common volatile set into one call,
+// vcr_embed_strict_ignore_common_headers().
 remove_header(field: int, name: string) -> string {
     ok = vcr_add_header_removal(field, name)
     if ok == 0 { return vcr_load_err() }

--- a/tests/integration/tapes/strict_no_request_headers.tape
+++ b/tests/integration/tapes/strict_no_request_headers.tape
@@ -1,0 +1,23 @@
+## Interaction 0: GET /hello
+
+### Request headers recorded for playback:
+
+```
+```
+
+### Request body recorded for playback ():
+
+```
+```
+
+### Response headers recorded for playback:
+
+```
+Content-Type: text/plain
+```
+
+### Response body recorded for playback (200: text/plain):
+
+```
+hello-strict
+```

--- a/tests/integration/test_vcr_strict_ignore_headers.ae
+++ b/tests/integration/test_vcr_strict_ignore_headers.ae
@@ -1,0 +1,110 @@
+// vcr_embed_surface_and_strict_ignore_wish.md §2 — strict matching must
+// be able to IGNORE a request header the tape never recorded but that a
+// stock HTTP client always attaches (User-Agent, Accept, ...). The lever
+// is vcr.remove_header(FIELD_REQUEST_HEADERS, name): because it strips
+// the header from BOTH the recorded expectation and the live request
+// before comparing, strict matching stops seeing it as "unexpected".
+//
+// Two phases against the same tape (strict_no_request_headers.tape:
+// empty recorded request headers + set_strict_headers ON). Each phase
+// runs the VCR on a background thread (http_server_start_background_raw,
+// the same seam the embed ABI uses) so two server lifecycles can run
+// back-to-back in one process without an accept-loop actor blocking:
+//
+//   A (control): no removal. A request carrying User-Agent is rejected
+//                599 — strict matching reports an unexpected header.
+//   B (fix):     remove_header(REQUEST_HEADERS, "User-Agent") first. The
+//                same request now matches → 200 + recorded body.
+//
+// This mirrors the embed ABI's vcr_embed_strict_ignore_common_headers()
+// (one call for the whole volatile set); here we exercise the single
+// underlying lever the bindings discovered the hard way.
+
+import std.http.server.vcr
+import std.http
+import std.http.client
+import std.string
+
+extern exit(code: int)
+
+const PORT_A = 18120
+const PORT_B = 18121
+const TAPE   = "tests/integration/tapes/strict_no_request_headers.tape"
+
+// Bind + start a loaded VCR server on a background thread. Returns 0 on
+// failure. Mirrors vcr_embed_start_playback.
+serve_bg(raw: ptr, port: int) -> int {
+    http.server_set_host(raw, "127.0.0.1")
+    if http.server_bind_raw(raw, "127.0.0.1", port) < 0 { return 0 }
+    if http.server_start_background_raw(raw) < 0 { return 0 }
+    return 1
+}
+
+// GET /hello carrying a User-Agent — i.e. what a stock HTTP client
+// (Go net/http, java.net.http, ureq, HttpClient) sends automatically.
+// Returns (status, body); negative status means a transport error.
+get_with_user_agent(url: string) -> (int, string) {
+    creq = client.request("GET", url)
+    if creq == null { return -1, "" }
+    client.set_header(creq, "User-Agent", "stock-client/1.0")
+    cresp, cerr = client.send_request(creq)
+    client.request_free(creq)
+    if cerr != "" { return -2, "" }
+    st = client.response_status(cresp)
+    bd = string.copy(client.response_body(cresp))
+    client.response_free(cresp)
+    return st, bd
+}
+
+main() {
+    println("=== VCR strict-match: ignore a stock client's volatile header ===")
+    vcr.set_strict_headers(1)
+
+    // ---- Phase A: control — the auto-header is rejected as unexpected.
+    println("\nPhase A: strict on, no ignore — User-Agent must be rejected")
+    vcr.clear_last_error()
+    rawA = vcr.load(TAPE, PORT_A)
+    if rawA == null { println("  FAIL: load A: ${vcr.load_error()}"); exit(1) }
+    if serve_bg(rawA, PORT_A) == 0 { println("  FAIL: serve A"); vcr.eject(rawA); exit(1) }
+    sleep(300)
+
+    statusA, _ = get_with_user_agent("http://127.0.0.1:${PORT_A}/hello")
+    if statusA != 599 {
+        println("  FAIL: expected 599 (unexpected header), got ${statusA}")
+        vcr.eject(rawA); exit(1)
+    }
+    errA = vcr.last_error()
+    if string.contains(errA, "User-Agent") != 1 {
+        println("  FAIL: last_error should name User-Agent, got: ${errA}")
+        vcr.eject(rawA); exit(1)
+    }
+    println("  PASS: rejected 599, last_error='${errA}'")
+    vcr.eject(rawA)
+    sleep(200)
+
+    // ---- Phase B: ignore User-Agent, then the same request matches.
+    println("\nPhase B: remove_header(REQUEST_HEADERS, User-Agent) — must match")
+    vcr.clear_last_error()
+    rerr = vcr.remove_header(vcr.FIELD_REQUEST_HEADERS, "User-Agent")
+    if rerr != "" { println("  FAIL: remove_header: ${rerr}"); exit(1) }
+
+    rawB = vcr.load(TAPE, PORT_B)
+    if rawB == null { println("  FAIL: load B: ${vcr.load_error()}"); exit(1) }
+    if serve_bg(rawB, PORT_B) == 0 { println("  FAIL: serve B"); vcr.eject(rawB); exit(1) }
+    sleep(300)
+
+    statusB, bodyB = get_with_user_agent("http://127.0.0.1:${PORT_B}/hello")
+    if statusB != 200 {
+        println("  FAIL: expected 200 after ignoring User-Agent, got ${statusB} (last_error='${vcr.last_error()}')")
+        vcr.eject(rawB); exit(1)
+    }
+    if string.contains(bodyB, "hello-strict") != 1 {
+        println("  FAIL: body did not contain recorded 'hello-strict', got: ${bodyB}")
+        vcr.eject(rawB); exit(1)
+    }
+    println("  PASS: matched 200, body='${bodyB}'")
+    vcr.eject(rawB)
+
+    println("\n=== strict-ignore test passed ===")
+    exit(0)
+}

--- a/tests/integration/vcr_embed_abi/consume.c
+++ b/tests/integration/vcr_embed_abi/consume.c
@@ -25,10 +25,12 @@
 #include <sys/socket.h>
 
 typedef void* (*start_playback_fn)(const char*, const char*, const char*, int);
+typedef void* (*start_playback_url_fn)(const char*, const char*, const char*, int);
 typedef int   (*port_fn)(void*);
 typedef char* (*base_url_fn)(void*, const char*);
 typedef int   (*tape_length_fn)(void);
 typedef int   (*last_kind_fn)(void);
+typedef char* (*strict_ignore_fn)(void);
 typedef void  (*stop_fn)(void*);
 typedef void  (*free_string_fn)(char*);
 
@@ -113,6 +115,38 @@ int main(int argc, char** argv) {
     }
 
     stop(srv);
+
+    /* New surface (vcr_embed_surface_and_strict_ignore_wish.md): assert
+     * the added exports resolve under --emit=lib, and — when a tape URL
+     * is supplied (argv[3], a local http.server serving smoke.tape) —
+     * drive a real start_playback_url round-trip. */
+    strict_ignore_fn strict_ignore =
+        (strict_ignore_fn)sym(h, "aether_vcr_embed_strict_ignore_common_headers");
+    char* ig = strict_ignore();          /* no server needed; "" on success */
+    if (ig && ig[0] != '\0') {
+        fprintf(stderr, "FAIL: strict_ignore_common_headers() returned error: %s\n", ig);
+        return 1;
+    }
+    free_string(ig);
+    /* Presence under the C ABI is the contract servirtium bindings rely on. */
+    (void)sym(h, "aether_vcr_embed_stop_and_flush_or_check");
+    start_playback_url_fn start_playback_url =
+        (start_playback_url_fn)sym(h, "aether_vcr_embed_start_playback_url");
+
+    if (argc >= 4) {
+        void* usrv = start_playback_url("url-smoke", argv[3], "127.0.0.1", 0);
+        if (!usrv) { fprintf(stderr, "FAIL: start_playback_url(%s) returned NULL\n", argv[3]); return 1; }
+        int uport = get_port(usrv);
+        if (uport <= 0) { fprintf(stderr, "FAIL: url-mode port() = %d\n", uport); return 1; }
+        char uresp[8192];
+        if (http_get(uport, "/ok", uresp, sizeof(uresp)) <= 0 || !strstr(uresp, "ok-body")) {
+            fprintf(stderr, "FAIL: url-mode GET /ok did not return recorded body\n--- response:\n%s\n", uresp);
+            return 1;
+        }
+        stop(usrv);
+        printf("OK: VCR embed start_playback_url round-trip via dlopen (tape fetched over HTTP)\n");
+    }
+
     dlclose(h);
     printf("OK: VCR embed playback round-trip via dlopen (port, base_url, GET /ok, last_kind)\n");
     return 0;

--- a/tests/integration/vcr_embed_abi/test_vcr_embed_abi.sh
+++ b/tests/integration/vcr_embed_abi/test_vcr_embed_abi.sh
@@ -35,9 +35,34 @@ fi
 if ! gcc "$SCRIPT_DIR/consume.c" -ldl -o "$TMPDIR/consume" 2>"$TMPDIR/gcc.log"; then
     echo "--- gcc log:"; cat "$TMPDIR/gcc.log"; fail "could not compile consume.c"
 fi
-if ! OUT="$("$TMPDIR/consume" "$TMPDIR/libvcr$LIB_EXT" "$SCRIPT_DIR/smoke.tape" 2>&1)"; then
+# If python3 is available, also serve the tape over HTTP so the driver
+# can exercise aether_vcr_embed_start_playback_url (tape fetched over the
+# network, not from disk). Skipped gracefully where python3 is absent.
+TAPE_URL=""
+PY_PID=""
+if command -v python3 >/dev/null 2>&1; then
+    ( cd "$SCRIPT_DIR" && exec python3 -m http.server 18137 --bind 127.0.0.1 ) \
+        >/dev/null 2>&1 &
+    PY_PID=$!
+    trap 'rm -rf "$TMPDIR"; [ -n "$PY_PID" ] && kill "$PY_PID" 2>/dev/null' EXIT
+    # Wait for the static server to come up.
+    i=0
+    while [ $i -lt 30 ]; do
+        if curl -fsS "http://127.0.0.1:18137/smoke.tape" >/dev/null 2>&1; then break; fi
+        i=$((i + 1)); sleep 0.1
+    done
+    TAPE_URL="http://127.0.0.1:18137/smoke.tape"
+fi
+
+if ! OUT="$("$TMPDIR/consume" "$TMPDIR/libvcr$LIB_EXT" "$SCRIPT_DIR/smoke.tape" $TAPE_URL 2>&1)"; then
     echo "$OUT"; fail "VCR embed C driver reported an error"
 fi
 echo "$OUT" | grep -q "^OK:" || { echo "$OUT"; fail "unexpected driver output"; }
 
-echo "  [PASS] vcr_embed_abi: embed.ae --emit=lib playback round-trips via dlopen"
+if [ -n "$TAPE_URL" ]; then
+    echo "$OUT" | grep -q "start_playback_url round-trip" \
+        || { echo "$OUT"; fail "start_playback_url round-trip did not run"; }
+    echo "  [PASS] vcr_embed_abi: --emit=lib playback round-trips via dlopen (disk + HTTP tape)"
+else
+    echo "  [PASS] vcr_embed_abi: --emit=lib playback round-trips via dlopen (disk tape; python3 absent, URL mode skipped)"
+fi


### PR DESCRIPTION
…; fix load_url UAF

Implements vcr_embed_surface_and_strict_ignore_wish.md (surfaced by the four Servirtium FFI bindings over embed.ae).

§1 Two module features the embed ABI didn't wrap, now exposed:
  - aether_vcr_embed_start_playback_url  — replay a tape fetched over HTTP (vcr.load_url) instead of from disk.
  - aether_vcr_embed_stop_and_flush_or_check — the non-destructive drift variant (writes a <tape>.actual sibling + byte-compares, no overwrite).

§2 Strict-match volatile-header ergonomics:
  - Documented (module.ae + docs/http-vcr.md) that remove_header(FIELD_REQUEST_HEADERS, name) is the lever to make strict matching IGNORE a header — it strips it from both the recorded expectation and the live request before comparing. The bindings each discovered this the hard way.
  - New one-call aether_vcr_embed_strict_ignore_common_headers() drops the volatile set stock clients send (User-Agent, Accept, Accept-Encoding, Connection). Opt-in, so default strict-match semantics are unchanged.

§3 Embedded server stays off the host's stdout:
  - New quiet mode (vcr_set_quiet/vcr_quiet in aether_vcr.c; vcr.set_quiet wrapper). The embed start_* entry points enable it, so vcr.load* diagnostics no longer print when hosted as a library. The reason is retrievable via vcr_embed_last_error() (now falls back to the new vcr.load_error()). Foreground `import std.http.server.vcr` callers are unchanged (quiet defaults off). The "Press Ctrl+C" banner was already silenced for background servers in 0.185.0.

Fix: vcr.load_url use-after-free — it freed the HTTP response before parsing the body string borrowed from it, so an HTTP-sourced tape parsed as empty. Now copies the body before the free. This was load_url's first test coverage (via the embed start_playback_url round-trip), which is what exposed it.

Tests:
  - tests/integration/test_vcr_strict_ignore_headers.ae — control (599, last_error names User-Agent) then fix (200 + body) on background servers; proves the wish §2 acceptance.
  - vcr_embed_abi extended: a python3-served smoke.tape drives a real start_playback_url round-trip via dlopen, plus a strict_ignore_common_headers smoke (skip-tolerant if python3 absent).

Verified: full build; 226 C unit tests; 14 vcr .ae + 3 vcr shell tests; foreground load diagnostics still print.