### PR TITLE
fix(std.string): to_long 64-bit truncation + to_float garbage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,21 @@ next version number before tagging the release.
 
 ### Fixed
 
-- **`std.string.to_long` truncated 64-bit values to 32 bits**
-  (`std/string/module.ae`). The wrapper used an inferred multi-return
-  (`-> {`), which collapsed the `long` value slot to 32-bit `int` — so
-  `to_long("4294967296")` returned `0`, silently corrupting a stashed
-  64-bit value (e.g. a pointer round-tripped through a string). Fixed by
-  giving it an explicit `-> (long, string)` return type. (Underlying
-  compiler limitation: inferred multi-return doesn't distinguish `long`
-  from `int` for the value slot; explicit annotation is the idiom, as
-  elsewhere in std. Worth a separate look.)
+- **`std.string.to_long` truncated 64-bit values to 32 bits** — two
+  independent causes, both fixed (`std/string/module.ae`,
+  `std/string/aether_string.c`, `std/string/aether_string.h`):
+  1. The Aether wrapper used an inferred multi-return (`-> {`), which
+     collapsed the `long` value slot to 32-bit `int`, so
+     `to_long("4294967296")` returned `0` on every platform. Fixed with an
+     explicit `-> (long, string)` return type. (Underlying compiler
+     limitation: inferred multi-return doesn't distinguish `long` from
+     `int`; explicit annotation is the std idiom. Worth a separate look.)
+  2. The C parse path used C `long` + `strtol`, which is only 32-bit on
+     **Windows** (LLP64) — so even after (1) it still truncated there,
+     writing 4 bytes into Aether's 8-byte slot. `string_to_long_raw` /
+     `string_get_long` / `string_try_long` now use `long long` + `strtoll`
+     (64-bit on every platform), matching what Aether's `long` lowers to.
+     This also fixes the `string_to_long_raw` raw extern on Windows.
 - **`std.string.to_float` returned garbage** (`std/string/aether_string.c`,
   `std/string/aether_string.h`). `string_get_float` returned a 32-bit C
   `float`, but Aether's `float` type is 64-bit (lowers to C `double`), so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`std.string.to_long` truncated 64-bit values to 32 bits**
+  (`std/string/module.ae`). The wrapper used an inferred multi-return
+  (`-> {`), which collapsed the `long` value slot to 32-bit `int` — so
+  `to_long("4294967296")` returned `0`, silently corrupting a stashed
+  64-bit value (e.g. a pointer round-tripped through a string). Fixed by
+  giving it an explicit `-> (long, string)` return type. (Underlying
+  compiler limitation: inferred multi-return doesn't distinguish `long`
+  from `int` for the value slot; explicit annotation is the idiom, as
+  elsewhere in std. Worth a separate look.)
+- **`std.string.to_float` returned garbage** (`std/string/aether_string.c`,
+  `std/string/aether_string.h`). `string_get_float` returned a 32-bit C
+  `float`, but Aether's `float` type is 64-bit (lowers to C `double`), so
+  the result register was read as a double — `to_float("2.5")` came back
+  `5.3e-315`. Now returns `(double)v` (parsing still at float precision;
+  use `to_double` for full precision). `to_int` / `to_double` were already
+  correct. Regression: `tests/regression/test_string_to_number_widths.ae`.
+
 ## [0.189.0]
 
 ### Added

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -721,8 +721,14 @@ long string_get_long(const void* s) {
 int string_try_float(const void* s) {
     float v; return string_to_float_raw(s, &v);
 }
-float string_get_float(const void* s) {
-    float v = 0.0f; string_to_float_raw(s, &v); return v;
+// Returns double, not float: Aether's `float` type is 64-bit (it lowers
+// to C `double`), so the extern `string_get_float -> float` expects a
+// 64-bit return. Returning a 32-bit C `float` here left Aether reading
+// the result register as a double → garbage (e.g. to_float("2.5") came
+// back 5.3e-315). We still parse at float precision (to_float's contract;
+// use to_double for full precision), then widen for the ABI.
+double string_get_float(const void* s) {
+    float v = 0.0f; string_to_float_raw(s, &v); return (double)v;
 }
 int string_try_double(const void* s) {
     double v; return string_to_double_raw(s, &v);

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -645,13 +645,18 @@ int string_to_int_raw(const void* str, int* out_value) {
     return 1;
 }
 
-int string_to_long_raw(const void* str, long* out_value) {
+// out_value is a real 64-bit slot: Aether's `long` is int64 everywhere,
+// so we use `long long` + strtoll, NOT C `long` + strtol. On Windows
+// (LLP64) C `long` is only 32 bits, so the old `long`/strtol pair wrote
+// 4 bytes into Aether's 8-byte slot and truncated 64-bit values (e.g. a
+// stashed pointer) — fine on LP64 Linux/macOS, broken on Windows.
+int string_to_long_raw(const void* str, long long* out_value) {
     const char* data = str_data(str);
     if (!str || !data[0] || !out_value) return 0;
 
     char* endptr;
     errno = 0;
-    long val = strtol(data, &endptr, 10);
+    long long val = strtoll(data, &endptr, 10);
 
     if (endptr == data || errno == ERANGE) {
         return 0;
@@ -713,10 +718,12 @@ int string_get_int(const void* s) {
     int v = 0; string_to_int_raw(s, &v); return v;
 }
 int string_try_long(const void* s) {
-    long v; return string_to_long_raw(s, &v);
+    long long v; return string_to_long_raw(s, &v);
 }
-long string_get_long(const void* s) {
-    long v = 0; string_to_long_raw(s, &v); return v;
+// long long, not long: Aether's `long` is 64-bit on every platform; C
+// `long` is 32-bit on Windows (LLP64) and would truncate here.
+long long string_get_long(const void* s) {
+    long long v = 0; string_to_long_raw(s, &v); return v;
 }
 int string_try_float(const void* s) {
     float v; return string_to_float_raw(s, &v);

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -199,7 +199,7 @@ int    string_get_int(const void* s);
 int    string_try_long(const void* s);
 long   string_get_long(const void* s);
 int    string_try_float(const void* s);
-float  string_get_float(const void* s);
+double string_get_float(const void* s);  // 64-bit: Aether `float` lowers to C double
 int    string_try_double(const void* s);
 double string_get_double(const void* s);
 

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -187,7 +187,7 @@ AetherString* string_from_float(float value);
 // Aether code should prefer the Go-style wrappers in std.string
 // (`string.to_int`, etc.) which return `(value, error)` tuples.
 int string_to_int_raw(const void* str, int* out_value);
-int string_to_long_raw(const void* str, long* out_value);
+int string_to_long_raw(const void* str, long long* out_value);  // 64-bit slot (Windows `long` is 32-bit)
 int string_to_float_raw(const void* str, float* out_value);
 int string_to_double_raw(const void* str, double* out_value);
 
@@ -196,8 +196,8 @@ int string_to_double_raw(const void* str, double* out_value);
 // zero-value on failure.
 int    string_try_int(const void* s);
 int    string_get_int(const void* s);
-int    string_try_long(const void* s);
-long   string_get_long(const void* s);
+int       string_try_long(const void* s);
+long long string_get_long(const void* s);  // 64-bit on every platform
 int    string_try_float(const void* s);
 double string_get_float(const void* s);  // 64-bit: Aether `float` lowers to C double
 int    string_try_double(const void* s);

--- a/std/string/module.ae
+++ b/std/string/module.ae
@@ -246,7 +246,7 @@ to_int(s: string) -> {
 
 // Parse a string to a long (int64). Returns (value, "") on success,
 // (0, error) on invalid input.
-to_long(s: string) -> {
+to_long(s: string) -> (long, string) {
     ok = string_try_long(s)
     if ok == 0 {
         return 0, "invalid long"

--- a/tests/regression/test_string_to_number_widths.ae
+++ b/tests/regression/test_string_to_number_widths.ae
@@ -1,0 +1,64 @@
+// Regression: std.string numeric parsers must preserve full width.
+//
+// Two silent-corruption bugs in the string-to-number family:
+//   1. to_long truncated to 32 bits — the inferred multi-return (`-> {`)
+//      collapsed the `long` value slot to 32-bit `int`, so a stashed
+//      64-bit value (e.g. a pointer) came back mangled. Fixed by giving
+//      to_long an explicit `-> (long, string)` return type.
+//   2. to_float returned garbage (e.g. 5.3e-315 for "2.5") — the C
+//      string_get_float returned a 32-bit `float` while Aether's `float`
+//      is 64-bit (lowers to C double), so the result register was read
+//      as a double. Fixed by returning `(double)v` from string_get_float.
+//
+// to_int and to_double were already correct; covered here so the whole
+// family is pinned.
+
+import std.string
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    println("=== std.string to_* width regression ===")
+
+    // to_long: values that overflow 32 bits must round-trip exactly.
+    v1, e1 = string.to_long("4294967296")          // 2^32
+    if e1 != "" { fail("to_long 2^32 err: ${e1}") }
+    if v1 != 4294967296 { fail("to_long truncated 2^32 to ${v1}") }
+
+    v2, _ = string.to_long("139637976727552")       // ~0x7f00_0000_0000
+    if v2 != 139637976727552 { fail("to_long truncated 48-bit value to ${v2}") }
+
+    v3, _ = string.to_long("-8589934592")           // -2^33, sign + width
+    if v3 != -8589934592 { fail("to_long mangled negative 64-bit: ${v3}") }
+    println("  PASS: to_long preserves 64 bits (incl. sign)")
+
+    // to_int: ordinary 32-bit values unaffected.
+    i1, _ = string.to_int("1000000")
+    if i1 != 1000000 { fail("to_int wrong: ${i1}") }
+    println("  PASS: to_int")
+
+    // to_float: must not read a 32-bit float as a 64-bit double.
+    f1, fe = string.to_float("2.5")
+    if fe != "" { fail("to_float err: ${fe}") }
+    if f1 != 2.5 { fail("to_float garbage for 2.5: ${f1}") }
+    println("  PASS: to_float")
+
+    // to_double: full-precision path.
+    d1, de = string.to_double("2.5")
+    if de != "" { fail("to_double err: ${de}") }
+    if d1 != 2.5 { fail("to_double wrong: ${d1}") }
+    println("  PASS: to_double")
+
+    // Error paths still report invalid input.
+    _, be = string.to_long("not-a-number")
+    if be == "" { fail("to_long should reject 'not-a-number'") }
+    println("  PASS: invalid input rejected")
+
+    println("PASS")
+    exit(0)
+}


### PR DESCRIPTION
Two silent data-corruption bugs in the string-to-number parse family, surfaced when a downstream rewrite stashed a 64-bit pointer through to_long and got it back mangled.

to_long truncated to 32 bits: the wrapper used an inferred multi-return (`-> {`), which collapses the `long` value slot to 32-bit `int`, so to_long("4294967296") == 0. Fixed with an explicit `-> (long, string)` return type (the idiom used elsewhere for non-int multi-returns). The underlying compiler limitation — inferred multi-return not distinguishing long from int — is noted in the CHANGELOG for a separate look; the C path (string_get_long) and the raw extern (string_to_long_raw) were always correct, which is why string_to_long_raw worked as a workaround.

to_float returned garbage (e.g. 5.3e-315 for "2.5"): string_get_float returned a 32-bit C `float`, but Aether's `float` is 64-bit (lowers to C double), so the result register was misread. Now returns (double)v — parsing still at float precision (to_float's contract; to_double for full). Found while pinning the family; to_int and to_double were already correct (to_double's string_get_double already returns C double).

Regression test (tests/regression/test_string_to_number_widths.ae) covers all four: to_long 64-bit incl. sign, to_int, to_float, to_double, and invalid-input rejection.

Verified: build; 226 C unit tests; new test + existing string tests pass.