### PR TITLE
feat(std.regex): Perl-compatible regular expressions via libpcre2-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.regex` — Perl-compatible regex via libpcre2-8**
+  (`std/regex/{module.ae,aether_regex.c}`, `Makefile`, `tools/ae.c`,
+  `docs/bootstrap-from-source.md`). Full PCRE2 surface: captures
+  (numbered + named), `$1`/`$2`/`${name}` substitutions, Unicode,
+  look-around, alternation, non-greedy, character classes, flags
+  (`FLAG_CASELESS`/`MULTILINE`/`DOTALL`/`EXTENDED`/`UNGREEDY`). Go-style
+  wrapper API (`regex.compile`, `compile_flags`, `matches`, `find`,
+  `captures` + accessors, `find_all` + accessors, `replace`,
+  `replace_all`, one-shot `matches_lit` / `find_lit`, `last_error`).
+  PCRE2 is auto-detected via `pkg-config libpcre2-8` (mirroring the
+  existing OpenSSL/zlib/nghttp2 pattern); without `libpcre2-dev` the
+  build still succeeds and every entry point returns a clean
+  "built without libpcre2-8" via `regex.last_error()`. Test:
+  `tests/regression/test_regex.ae`.
+
 ## [0.190.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,27 @@ ifneq ($(NGHTTP2_LDFLAGS),)
   NGHTTP2_CFLAGS += -DAETHER_HAS_NGHTTP2
 endif
 
+# PCRE2 auto-detection: enables std.regex (full Perl-compatible regex via
+# libpcre2-8 — captures, $-substitutions, Unicode, look-around, etc.).
+# Same pkg-config probe shape as OpenSSL/zlib/nghttp2; when absent,
+# std.regex compiles in a stub mode where every call returns a clean
+# "regex: built without libpcre2-8" diagnostic via regex.last_error(),
+# so the build never fails for lack of the dependency.
+PCRE2 ?= auto
+ifeq ($(PCRE2),auto)
+  PCRE2_CFLAGS := $(shell pkg-config --cflags libpcre2-8 2>/dev/null)
+  PCRE2_LDFLAGS := $(shell pkg-config --libs libpcre2-8 2>/dev/null)
+else ifeq ($(PCRE2),1)
+  PCRE2_CFLAGS := $(shell pkg-config --cflags libpcre2-8 2>/dev/null)
+  PCRE2_LDFLAGS := $(shell pkg-config --libs libpcre2-8 2>/dev/null)
+else
+  PCRE2_CFLAGS :=
+  PCRE2_LDFLAGS :=
+endif
+ifneq ($(PCRE2_LDFLAGS),)
+  PCRE2_CFLAGS += -DAETHER_HAS_PCRE2
+endif
+
 # -fPIC on every runtime/stdlib object so the precompiled `build/libaether.a`
 # can be linked into a shared object by `ae build --emit=lib`. Without it,
 # any `--emit=lib` build that pulls in a TLS-using runtime object (e.g.
@@ -159,8 +180,8 @@ endif
 # (vcr_embed_abi_wish.md Part A). Negligible codegen cost on x86-64/arm64
 # (most distros already default to PIE); one archive serves both the exe
 # link and the shared-object link.
-CFLAGS = -O2 -fPIC -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(EXTRA_CFLAGS)
-LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS)
+CFLAGS = -O2 -fPIC -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(EXTRA_CFLAGS)
+LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS)
 
 # Hardening flags (issue #396). Opt-in via `HARDEN=1`. The CI matrix
 # pins a Linux/gcc + HARDEN=1 entry so a hardened-build regression
@@ -221,7 +242,7 @@ endif
 COMPILER_SRC = compiler/aetherc.c compiler/parser/lexer.c compiler/parser/parser.c compiler/ast.c compiler/analysis/typechecker.c compiler/analysis/derive.c compiler/codegen/codegen.c compiler/codegen/codegen_expr.c compiler/codegen/codegen_stmt.c compiler/codegen/codegen_actor.c compiler/codegen/codegen_func.c compiler/aether_error.c compiler/aether_module.c compiler/analysis/type_inference.c compiler/codegen/optimizer.c compiler/aether_diagnostics.c runtime/actors/aether_message_registry.c lsp/aether_lsp.c
 COMPILER_LIB_SRC = compiler/parser/lexer.c compiler/parser/parser.c compiler/ast.c compiler/analysis/typechecker.c compiler/analysis/derive.c compiler/codegen/codegen.c compiler/codegen/codegen_expr.c compiler/codegen/codegen_stmt.c compiler/codegen/codegen_actor.c compiler/codegen/codegen_func.c compiler/aether_error.c compiler/aether_module.c compiler/analysis/type_inference.c compiler/codegen/optimizer.c compiler/aether_diagnostics.c runtime/actors/aether_message_registry.c lsp/aether_lsp.c
 RUNTIME_SRC = $(SCHEDULER_SRC) runtime/scheduler/scheduler_optimizations.c runtime/scheduler/aether_io_poller_epoll.c runtime/scheduler/aether_io_poller_kqueue.c runtime/scheduler/aether_io_poller_poll.c runtime/config/aether_optimization_config.c runtime/memory/aether_arena.c runtime/memory/aether_pool.c runtime/memory/aether_memory_stats.c runtime/utils/aether_tracing.c runtime/utils/aether_bounds_check.c runtime/utils/aether_test.c runtime/memory/aether_arena_optimized.c runtime/aether_runtime_types.c runtime/utils/aether_cpu_detect.c runtime/memory/aether_batch.c runtime/utils/aether_simd_vectorized.c runtime/aether_runtime.c runtime/aether_numa.c runtime/aether_sandbox.c runtime/aether_spawn_sandboxed.c runtime/aether_shared_map.c runtime/aether_host.c runtime/aether_resource_caps.c runtime/libaether_caps.c runtime/actors/aether_send_buffer.c runtime/actors/aether_send_message.c runtime/actors/aether_actor_thread.c runtime/actors/aether_panic.c
-STD_SRC = std/string/aether_string.c std/math/aether_math.c std/net/aether_http.c std/net/aether_http_server.c std/net/aether_net.c std/collections/aether_collections.c std/json/aether_json.c std/fs/aether_fs.c std/log/aether_log.c std/io/aether_io.c std/os/aether_os.c std/ipc/aether_ipc.c std/mem/aether_mem.c std/cryptography/aether_cryptography.c std/zlib/aether_zlib.c std/lzf/lzf_c.c std/lzf/lzf_d.c std/lzf/aether_lzf.c std/dl/aether_dl.c std/http/middleware/aether_middleware.c std/http/server/h2/aether_h2.c std/http/proxy/aether_proxy_pool.c std/http/proxy/aether_proxy_lb.c std/http/proxy/aether_proxy_breaker.c std/http/proxy/aether_proxy_health.c std/http/proxy/aether_proxy_cache.c std/http/proxy/aether_proxy_opts.c std/http/proxy/aether_proxy_metrics.c std/http/proxy/aether_proxy_middleware.c std/http/script_gateway/aether_script_gateway.c std/bytes/aether_bytes.c std/strbuilder/aether_strbuilder.c std/config/aether_config.c std/actors/aether_actor_registry.c
+STD_SRC = std/string/aether_string.c std/math/aether_math.c std/net/aether_http.c std/net/aether_http_server.c std/net/aether_net.c std/collections/aether_collections.c std/json/aether_json.c std/fs/aether_fs.c std/log/aether_log.c std/io/aether_io.c std/os/aether_os.c std/ipc/aether_ipc.c std/mem/aether_mem.c std/cryptography/aether_cryptography.c std/zlib/aether_zlib.c std/lzf/lzf_c.c std/lzf/lzf_d.c std/lzf/aether_lzf.c std/dl/aether_dl.c std/http/middleware/aether_middleware.c std/http/server/h2/aether_h2.c std/http/proxy/aether_proxy_pool.c std/http/proxy/aether_proxy_lb.c std/http/proxy/aether_proxy_breaker.c std/http/proxy/aether_proxy_health.c std/http/proxy/aether_proxy_cache.c std/http/proxy/aether_proxy_opts.c std/http/proxy/aether_proxy_metrics.c std/http/proxy/aether_proxy_middleware.c std/http/script_gateway/aether_script_gateway.c std/bytes/aether_bytes.c std/strbuilder/aether_strbuilder.c std/config/aether_config.c std/actors/aether_actor_registry.c std/regex/aether_regex.c
 # Stdlib sources that reference scheduler internals (scheduler_io_register,
 # g_sync_step_actor, current_core_id). Excluded from the compiler binary
 # because aetherc does not link the runtime scheduler, but included in
@@ -284,7 +305,7 @@ STANDALONE_TESTS = tests/runtime/test_runtime_manual.c \
 all: compiler ae stdlib
 
 # Create object directories
-$(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime:
+$(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime:
 ifdef WINDOWS_NATIVE
 	@if not exist "$(subst /,\,$@)" mkdir "$(subst /,\,$@)"
 else
@@ -292,7 +313,7 @@ else
 endif
 
 # Pattern rule for object files
-$(OBJ_DIR)/%.o: %.c | $(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime
+$(OBJ_DIR)/%.o: %.c | $(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime
 	@echo "Compiling $<..."
 	@$(CC) $(CFLAGS) -c $< -o $@
 
@@ -895,7 +916,7 @@ ae: compiler
 	@echo "==================================="
 	@echo "Building ae command-line tool ($(DETECTED_OS)) v$(VERSION)"
 	@echo "==================================="
-	$(CC) -O2 -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_OPENSSL_LIBS='"$(OPENSSL_LDFLAGS)"' -DAETHER_ZLIB_LIBS='"$(ZLIB_LDFLAGS)"' -DAETHER_NGHTTP2_LIBS='"$(NGHTTP2_LDFLAGS)"' $(if $(AETHER_ENABLE_LLM),-DAETHER_ENABLE_LLM=1) -Itools tools/ae.c tools/ae_help.c tools/apkg/toml_parser.c $(if $(AETHER_ENABLE_LLM),tools/llm_shim.c $(LLM_LDFLAGS)) -o build/ae$(EXE_EXT) $(LDFLAGS)
+	$(CC) -O2 -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_OPENSSL_LIBS='"$(OPENSSL_LDFLAGS)"' -DAETHER_ZLIB_LIBS='"$(ZLIB_LDFLAGS)"' -DAETHER_NGHTTP2_LIBS='"$(NGHTTP2_LDFLAGS)"' -DAETHER_PCRE2_LIBS='"$(PCRE2_LDFLAGS)"' $(if $(AETHER_ENABLE_LLM),-DAETHER_ENABLE_LLM=1) -Itools tools/ae.c tools/ae_help.c tools/apkg/toml_parser.c $(if $(AETHER_ENABLE_LLM),tools/llm_shim.c $(LLM_LDFLAGS)) -o build/ae$(EXE_EXT) $(LDFLAGS)
 	@echo "✓ Built successfully: build/ae$(EXE_EXT)"
 	@echo ""
 	@echo "Usage:"

--- a/Makefile
+++ b/Makefile
@@ -2094,8 +2094,8 @@ ci-embedded: clean compiler
 #   libc6-dev-riscv64-cross   — riscv64 libc/headers
 #   qemu-user-static          — qemu-riscv64-static binary
 #
-# Optional libs (OpenSSL, zlib, nghttp2, GTK4) are disabled for the
-# riscv64 build — pkg-config on the host runner returns x86_64 lib
+# Optional libs (OpenSSL, zlib, nghttp2, PCRE2, GTK4) are disabled for
+# the riscv64 build — pkg-config on the host runner returns x86_64 lib
 # paths that wouldn't link against riscv64 objects. Disabling them
 # matches the std.* feature-detection pattern: the wrappers fall
 # into their "unavailable" stubs cleanly. The portability check is
@@ -2116,7 +2116,7 @@ ci-riscv64: clean
 	@$(MAKE) compiler ae stdlib \
 	    CC=riscv64-linux-gnu-gcc \
 	    EXTRA_CFLAGS="-march=rv64gc -mabi=lp64d" \
-	    OPENSSL=0 ZLIB=0 NGHTTP2=0
+	    OPENSSL=0 ZLIB=0 NGHTTP2=0 PCRE2=0
 	@echo ""
 	@echo "[2/3] Verifying cross-built binaries are riscv64 ELF..."
 	@file build/aetherc | grep -q "RISC-V" || { echo "  FAIL: aetherc not riscv64 ELF"; file build/aetherc; exit 1; }

--- a/docs/bootstrap-from-source.md
+++ b/docs/bootstrap-from-source.md
@@ -49,6 +49,18 @@ and you link Aether-as-a-library with **`$(ae cflags)`** (never hand-rolled
 | **git** | version stamping reads `git tag` (a non-git tree falls back to the `VERSION` file) |
 | **pthreads + libm** | linked by default on POSIX (already present on Linux/macOS) |
 
+Optional **system libraries** that enable specific stdlib features
+(each is auto-detected via `pkg-config`; without it, the related stdlib
+calls return a clean "built without ..." diagnostic rather than failing
+the build):
+
+| Lib | Enables |
+|---|---|
+| `libssl-dev` / `libcrypto-dev` (OpenSSL) | TLS in `std.http.client` (HTTPS) and the `std.http` server |
+| `zlib1g-dev` (zlib) | `std.zlib.deflate`/`inflate`; HTTP gzip |
+| `libnghttp2-dev` | HTTP/2 server (`std.http` h2/h2c + HPACK) |
+| `libpcre2-dev` | `std.regex` (Perl-compatible regex via libpcre2-8) |
+
 Optional, only if you want the corresponding **contrib** module built
 natively (each is independently probed and **skipped if its dev library
 is absent** — a skip is normal, not an error):

--- a/std/regex/aether_regex.c
+++ b/std/regex/aether_regex.c
@@ -1,0 +1,349 @@
+/*
+ * std.regex — Perl-compatible regular expressions via libpcre2-8.
+ *
+ * Detection: AETHER_HAS_PCRE2 is defined by the Makefile when
+ * `pkg-config libpcre2-8` succeeds. Without it, every entry point
+ * compiles to a safe stub and `regex.last_error()` returns
+ * "regex: built without libpcre2-8 (install libpcre2-dev and rebuild)" —
+ * so consumers of std.regex never break the build; they just see a
+ * clean diagnostic at runtime.
+ *
+ * Handles:
+ *   - RegexHandle   — opaque, holds the compiled pcre2_code*.
+ *   - RegexCaptures — opaque, holds match_data + a copy of the subject
+ *                     (so capture(i) is safe even after the caller frees
+ *                     the original Aether string).
+ *   - RegexFindAll  — opaque, holds an owned span array + subject copy.
+ *
+ * Strings returned from `capture` and `replace*` are AetherString refcounts
+ * (marked @heap on the Aether side) — the auto-cleanup releases them.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../string/aether_string.h"
+
+/* Mirror the file-static helpers in aether_string.c so we accept both
+ * AetherString* and plain const char* at the FFI boundary, identically
+ * to every other std C wrapper. */
+static inline const char* str_data_local(const void* s) {
+    if (!s) return "";
+    if (is_aether_string(s)) return ((const AetherString*)s)->data;
+    return (const char*)s;
+}
+static inline size_t str_len_local(const void* s) {
+    if (!s) return 0;
+    if (is_aether_string(s)) return ((const AetherString*)s)->length;
+    return strlen((const char*)s);
+}
+
+/* Thread-local last-error slot. Set on any compile/match/replace error
+ * path; cleared on the next successful entry. Aether reads it via
+ * `regex.last_error()`. */
+#if defined(_MSC_VER)
+#  define TLS __declspec(thread)
+#else
+#  define TLS __thread
+#endif
+static TLS char g_last_error[256] = "";
+
+static void set_last_error(const char* msg) {
+    snprintf(g_last_error, sizeof(g_last_error), "%s", msg ? msg : "");
+}
+static void clear_last_error(void) { g_last_error[0] = '\0'; }
+
+const char* aether_regex_last_error(void) { return g_last_error; }
+void aether_regex_clear_last_error(void) { clear_last_error(); }
+
+#ifdef AETHER_HAS_PCRE2
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+typedef struct {
+    pcre2_code* code;
+    int ngroups;   /* captures + 1 (group 0 = whole match) */
+} RegexHandle;
+
+typedef struct {
+    pcre2_match_data* md;
+    char* subject;       /* owned copy, NUL-terminated */
+    size_t subject_len;
+    int ngroups;          /* matched groups returned by pcre2_match */
+} RegexCaptures;
+
+typedef struct {
+    int count;
+    PCRE2_SIZE* spans;   /* 2*count entries: [s0,e0, s1,e1, ...] */
+    char* subject;        /* owned copy */
+    size_t subject_len;
+} RegexFindAll;
+
+static void set_pcre2_error(int errnum, PCRE2_SIZE offset) {
+    PCRE2_UCHAR buf[200];
+    int n = pcre2_get_error_message(errnum, buf, sizeof(buf));
+    if (n < 0) snprintf((char*)buf, sizeof(buf), "pcre2 error %d", errnum);
+    if (offset != (PCRE2_SIZE)-1) {
+        snprintf(g_last_error, sizeof(g_last_error),
+                 "regex: %s (at offset %zu)", (char*)buf, (size_t)offset);
+    } else {
+        snprintf(g_last_error, sizeof(g_last_error), "regex: %s", (char*)buf);
+    }
+}
+
+void* aether_regex_compile(const void* pattern_s, int flags) {
+    clear_last_error();
+    if (!pattern_s) { set_last_error("regex: null pattern"); return NULL; }
+    const char* pattern = str_data_local(pattern_s);
+    size_t plen = str_len_local(pattern_s);
+    int errnum;
+    PCRE2_SIZE offset;
+    pcre2_code* code = pcre2_compile((PCRE2_SPTR)pattern, plen,
+                                      (uint32_t)flags,
+                                      &errnum, &offset, NULL);
+    if (!code) { set_pcre2_error(errnum, offset); return NULL; }
+    uint32_t ngroups = 0;
+    pcre2_pattern_info(code, PCRE2_INFO_CAPTURECOUNT, &ngroups);
+    RegexHandle* h = (RegexHandle*)calloc(1, sizeof(RegexHandle));
+    if (!h) { pcre2_code_free(code); set_last_error("regex: out of memory"); return NULL; }
+    h->code = code;
+    h->ngroups = (int)ngroups + 1;
+    return h;
+}
+
+void aether_regex_free(void* h_) {
+    if (!h_) return;
+    RegexHandle* h = (RegexHandle*)h_;
+    if (h->code) pcre2_code_free(h->code);
+    free(h);
+}
+
+int aether_regex_matches(void* h_, const void* s_) {
+    if (!h_ || !s_) return 0;
+    RegexHandle* h = (RegexHandle*)h_;
+    const char* s = str_data_local(s_);
+    size_t slen = str_len_local(s_);
+    pcre2_match_data* md = pcre2_match_data_create_from_pattern(h->code, NULL);
+    if (!md) return 0;
+    int rc = pcre2_match(h->code, (PCRE2_SPTR)s, slen, 0, 0, md, NULL);
+    pcre2_match_data_free(md);
+    return rc > 0 ? 1 : 0;
+}
+
+void* aether_regex_captures(void* h_, const void* s_) {
+    clear_last_error();
+    if (!h_ || !s_) return NULL;
+    RegexHandle* h = (RegexHandle*)h_;
+    const char* s = str_data_local(s_);
+    size_t slen = str_len_local(s_);
+    pcre2_match_data* md = pcre2_match_data_create_from_pattern(h->code, NULL);
+    if (!md) { set_last_error("regex: match data alloc failed"); return NULL; }
+    int rc = pcre2_match(h->code, (PCRE2_SPTR)s, slen, 0, 0, md, NULL);
+    if (rc < 0) {
+        if (rc != PCRE2_ERROR_NOMATCH) set_pcre2_error(rc, (PCRE2_SIZE)-1);
+        pcre2_match_data_free(md);
+        return NULL;  /* null + empty last_error = no match */
+    }
+    char* copy = (char*)malloc(slen + 1);
+    if (!copy) { pcre2_match_data_free(md); set_last_error("regex: out of memory"); return NULL; }
+    memcpy(copy, s, slen); copy[slen] = '\0';
+    RegexCaptures* c = (RegexCaptures*)calloc(1, sizeof(RegexCaptures));
+    if (!c) { free(copy); pcre2_match_data_free(md); set_last_error("regex: out of memory"); return NULL; }
+    c->md = md;
+    c->subject = copy;
+    c->subject_len = slen;
+    c->ngroups = rc;
+    return c;
+}
+
+int aether_regex_captures_count(void* c_) {
+    return c_ ? ((RegexCaptures*)c_)->ngroups : 0;
+}
+
+/* Returns 1 + writes span if valid; 0 if OOB or PCRE2_UNSET. */
+static int caps_span(RegexCaptures* c, int index, PCRE2_SIZE* os, PCRE2_SIZE* oe) {
+    if (!c || index < 0 || index >= c->ngroups) return 0;
+    PCRE2_SIZE* ov = pcre2_get_ovector_pointer(c->md);
+    PCRE2_SIZE s = ov[2*index], e = ov[2*index + 1];
+    if (s == PCRE2_UNSET || e == PCRE2_UNSET) return 0;
+    *os = s; *oe = e;
+    return 1;
+}
+
+const char* aether_regex_captures_get(void* c_, int index) {
+    PCRE2_SIZE s, e;
+    if (!caps_span((RegexCaptures*)c_, index, &s, &e))
+        return (const char*)string_new_with_length("", 0);
+    RegexCaptures* c = (RegexCaptures*)c_;
+    return (const char*)string_new_with_length(c->subject + s, (size_t)(e - s));
+}
+
+int aether_regex_captures_start(void* c_, int index) {
+    PCRE2_SIZE s, e;
+    if (!caps_span((RegexCaptures*)c_, index, &s, &e)) return -1;
+    return (int)s;
+}
+int aether_regex_captures_end(void* c_, int index) {
+    PCRE2_SIZE s, e;
+    if (!caps_span((RegexCaptures*)c_, index, &s, &e)) return -1;
+    return (int)e;
+}
+
+void aether_regex_captures_free(void* c_) {
+    if (!c_) return;
+    RegexCaptures* c = (RegexCaptures*)c_;
+    if (c->md) pcre2_match_data_free(c->md);
+    if (c->subject) free(c->subject);
+    free(c);
+}
+
+void* aether_regex_find_all(void* h_, const void* s_) {
+    clear_last_error();
+    if (!h_ || !s_) return NULL;
+    RegexHandle* h = (RegexHandle*)h_;
+    const char* s = str_data_local(s_);
+    size_t slen = str_len_local(s_);
+    pcre2_match_data* md = pcre2_match_data_create_from_pattern(h->code, NULL);
+    if (!md) { set_last_error("regex: match data alloc failed"); return NULL; }
+
+    int cap = 16, count = 0;
+    PCRE2_SIZE* spans = (PCRE2_SIZE*)malloc(sizeof(PCRE2_SIZE) * 2 * cap);
+    if (!spans) { pcre2_match_data_free(md); set_last_error("regex: out of memory"); return NULL; }
+
+    PCRE2_SIZE pos = 0;
+    while (pos <= slen) {
+        int rc = pcre2_match(h->code, (PCRE2_SPTR)s, slen, pos, 0, md, NULL);
+        if (rc < 0) {
+            if (rc != PCRE2_ERROR_NOMATCH) set_pcre2_error(rc, (PCRE2_SIZE)-1);
+            break;
+        }
+        PCRE2_SIZE* ov = pcre2_get_ovector_pointer(md);
+        PCRE2_SIZE ms = ov[0], me = ov[1];
+        if (count == cap) {
+            cap *= 2;
+            PCRE2_SIZE* ns = (PCRE2_SIZE*)realloc(spans, sizeof(PCRE2_SIZE) * 2 * cap);
+            if (!ns) { free(spans); pcre2_match_data_free(md); set_last_error("regex: out of memory"); return NULL; }
+            spans = ns;
+        }
+        spans[2*count] = ms;
+        spans[2*count + 1] = me;
+        count++;
+        /* Empty match? advance one byte to avoid an infinite loop. */
+        pos = (me == ms) ? me + 1 : me;
+    }
+    pcre2_match_data_free(md);
+
+    char* copy = (char*)malloc(slen + 1);
+    if (!copy) { free(spans); set_last_error("regex: out of memory"); return NULL; }
+    memcpy(copy, s, slen); copy[slen] = '\0';
+
+    RegexFindAll* fa = (RegexFindAll*)calloc(1, sizeof(RegexFindAll));
+    if (!fa) { free(copy); free(spans); set_last_error("regex: out of memory"); return NULL; }
+    fa->count = count;
+    fa->spans = spans;
+    fa->subject = copy;
+    fa->subject_len = slen;
+    return fa;
+}
+
+int aether_regex_find_all_count(void* fa_) {
+    return fa_ ? ((RegexFindAll*)fa_)->count : 0;
+}
+int aether_regex_find_all_start(void* fa_, int i) {
+    RegexFindAll* fa = (RegexFindAll*)fa_;
+    if (!fa || i < 0 || i >= fa->count) return -1;
+    return (int)fa->spans[2*i];
+}
+int aether_regex_find_all_end(void* fa_, int i) {
+    RegexFindAll* fa = (RegexFindAll*)fa_;
+    if (!fa || i < 0 || i >= fa->count) return -1;
+    return (int)fa->spans[2*i + 1];
+}
+void aether_regex_find_all_free(void* fa_) {
+    if (!fa_) return;
+    RegexFindAll* fa = (RegexFindAll*)fa_;
+    if (fa->spans) free(fa->spans);
+    if (fa->subject) free(fa->subject);
+    free(fa);
+}
+
+/* Internal substitute: shared by replace and replace_all (option toggles
+ * PCRE2_SUBSTITUTE_GLOBAL). PCRE2_SUBSTITUTE_EXTENDED enables the
+ * familiar $1, $2, ${name} replacement syntax. */
+static const char* regex_substitute(void* h_, const void* s_, const void* repl_,
+                                    uint32_t extra_options) {
+    clear_last_error();
+    if (!h_ || !s_) return (const char*)string_new_with_length("", 0);
+    RegexHandle* h = (RegexHandle*)h_;
+    const char* s = str_data_local(s_);
+    size_t slen = str_len_local(s_);
+    const char* repl = repl_ ? str_data_local(repl_) : "";
+    size_t rlen = repl_ ? str_len_local(repl_) : 0;
+
+    PCRE2_SIZE outlen = slen + rlen + 64;
+    PCRE2_UCHAR* out = (PCRE2_UCHAR*)malloc(outlen);
+    if (!out) { set_last_error("regex: out of memory"); return (const char*)string_new_with_length("", 0); }
+    uint32_t opts = PCRE2_SUBSTITUTE_EXTENDED | extra_options;
+    int rc = pcre2_substitute(h->code, (PCRE2_SPTR)s, slen, 0, opts,
+                               NULL, NULL,
+                               (PCRE2_SPTR)repl, rlen, out, &outlen);
+    if (rc == PCRE2_ERROR_NOMEMORY) {
+        /* PCRE2 wrote the required size into outlen — grow + retry. */
+        PCRE2_UCHAR* grown = (PCRE2_UCHAR*)realloc(out, outlen);
+        if (!grown) { free(out); set_last_error("regex: out of memory"); return (const char*)string_new_with_length("", 0); }
+        out = grown;
+        rc = pcre2_substitute(h->code, (PCRE2_SPTR)s, slen, 0, opts,
+                               NULL, NULL,
+                               (PCRE2_SPTR)repl, rlen, out, &outlen);
+    }
+    if (rc < 0) {
+        set_pcre2_error(rc, (PCRE2_SIZE)-1);
+        free(out);
+        return (const char*)string_new_with_length("", 0);
+    }
+    const char* result = (const char*)string_new_with_length((char*)out, (size_t)outlen);
+    free(out);
+    return result;
+}
+
+const char* aether_regex_replace(void* h_, const void* s_, const void* repl_) {
+    return regex_substitute(h_, s_, repl_, 0);
+}
+const char* aether_regex_replace_all(void* h_, const void* s_, const void* repl_) {
+    return regex_substitute(h_, s_, repl_, PCRE2_SUBSTITUTE_GLOBAL);
+}
+
+#else /* !AETHER_HAS_PCRE2 — stub mode: every call returns a safe sentinel. */
+
+static void set_unavailable(void) {
+    set_last_error("regex: built without libpcre2-8 (install libpcre2-dev and rebuild)");
+}
+
+void* aether_regex_compile(const void* p, int f) { (void)p; (void)f; set_unavailable(); return NULL; }
+void  aether_regex_free(void* h) { (void)h; }
+int   aether_regex_matches(void* h, const void* s) { (void)h; (void)s; return 0; }
+
+void* aether_regex_captures(void* h, const void* s) { (void)h; (void)s; set_unavailable(); return NULL; }
+int   aether_regex_captures_count(void* c) { (void)c; return 0; }
+const char* aether_regex_captures_get(void* c, int i) { (void)c; (void)i; return (const char*)string_new_with_length("", 0); }
+int   aether_regex_captures_start(void* c, int i) { (void)c; (void)i; return -1; }
+int   aether_regex_captures_end(void* c, int i) { (void)c; (void)i; return -1; }
+void  aether_regex_captures_free(void* c) { (void)c; }
+
+void* aether_regex_find_all(void* h, const void* s) { (void)h; (void)s; set_unavailable(); return NULL; }
+int   aether_regex_find_all_count(void* fa) { (void)fa; return 0; }
+int   aether_regex_find_all_start(void* fa, int i) { (void)fa; (void)i; return -1; }
+int   aether_regex_find_all_end(void* fa, int i) { (void)fa; (void)i; return -1; }
+void  aether_regex_find_all_free(void* fa) { (void)fa; }
+
+const char* aether_regex_replace(void* h, const void* s, const void* r) {
+    (void)h; (void)s; (void)r; set_unavailable();
+    return (const char*)string_new_with_length("", 0);
+}
+const char* aether_regex_replace_all(void* h, const void* s, const void* r) {
+    (void)h; (void)s; (void)r; set_unavailable();
+    return (const char*)string_new_with_length("", 0);
+}
+
+#endif /* AETHER_HAS_PCRE2 */

--- a/std/regex/module.ae
+++ b/std/regex/module.ae
@@ -1,0 +1,233 @@
+// std.regex — Perl-compatible regular expressions (PCRE2-backed).
+// Import with: import std.regex
+//
+// Captures, $1/$2 substitutions, Unicode, look-around, alternation,
+// non-greedy, etc. — anything libpcre2-8 supports. When the build
+// didn't detect libpcre2-8 (Makefile probes pkg-config libpcre2-8),
+// every entry point still compiles but returns a clean diagnostic via
+// regex.last_error() — the build never fails for lack of the dependency.
+//
+// Quick example:
+//
+//   import std.regex
+//
+//   main() {
+//       re, err = regex.compile("(\\d{4})-(\\d{2})-(\\d{2})")
+//       if err != "" { println("bad pattern: ${err}"); return }
+//
+//       caps, _ = regex.captures(re, "release 2026-05-28 shipped")
+//       if caps != null {
+//           // group 0 = whole match; 1..3 = captured groups
+//           println("year=${regex.capture(caps, 1)}")
+//           println("month=${regex.capture(caps, 2)}")
+//           regex.captures_free(caps)
+//       }
+//       regex.free(re)
+//   }
+//
+// Ownership: handles (re, caps, fa) are caller-owned; free them with
+// regex.free / regex.captures_free / regex.find_all_free. Strings
+// returned from regex.capture / regex.replace* are heap-tracked
+// AetherString refcounts — Aether's auto-cleanup reclaims them.
+
+exports (
+    // raw externs (callable, but the wrappers below are the Go-style API)
+    aether_regex_compile, aether_regex_free, aether_regex_matches,
+    aether_regex_captures, aether_regex_captures_count, aether_regex_captures_get,
+    aether_regex_captures_start, aether_regex_captures_end, aether_regex_captures_free,
+    aether_regex_find_all, aether_regex_find_all_count,
+    aether_regex_find_all_start, aether_regex_find_all_end, aether_regex_find_all_free,
+    aether_regex_replace, aether_regex_replace_all,
+    aether_regex_last_error, aether_regex_clear_last_error,
+
+    // Aether-side wrappers
+    compile, compile_flags, free, last_error, clear_last_error,
+    matches, find,
+    captures, capture_count, capture, capture_start, capture_end, captures_free,
+    find_all, find_all_count, find_all_start, find_all_end, find_all_free,
+    replace, replace_all,
+    matches_lit, find_lit,
+
+    // flag constants (PCRE2 option bits — pass to compile_flags)
+    FLAG_CASELESS, FLAG_MULTILINE, FLAG_DOTALL, FLAG_EXTENDED, FLAG_UNGREEDY
+)
+
+// PCRE2 option bits — kept in sync with <pcre2.h>.
+const FLAG_CASELESS   = 0x00000008   // case-insensitive match
+const FLAG_MULTILINE  = 0x00000400   // ^ and $ match per-line
+const FLAG_DOTALL     = 0x00000020   // . matches newline
+const FLAG_EXTENDED   = 0x00000080   // ignore whitespace + #comments in pattern
+const FLAG_UNGREEDY   = 0x00040000   // greedy quantifiers become lazy and vice versa
+
+// ---- Raw externs (resolved by std/regex/aether_regex.c).
+
+extern aether_regex_compile(pattern: string, flags: int) -> ptr
+extern aether_regex_free(re: ptr)
+extern aether_regex_matches(re: ptr, s: string) -> int
+
+extern aether_regex_captures(re: ptr, s: string) -> ptr
+extern aether_regex_captures_count(caps: ptr) -> int
+extern aether_regex_captures_get(caps: ptr, index: int) -> string @heap
+extern aether_regex_captures_start(caps: ptr, index: int) -> int
+extern aether_regex_captures_end(caps: ptr, index: int) -> int
+extern aether_regex_captures_free(caps: ptr)
+
+extern aether_regex_find_all(re: ptr, s: string) -> ptr
+extern aether_regex_find_all_count(fa: ptr) -> int
+extern aether_regex_find_all_start(fa: ptr, index: int) -> int
+extern aether_regex_find_all_end(fa: ptr, index: int) -> int
+extern aether_regex_find_all_free(fa: ptr)
+
+extern aether_regex_replace(re: ptr, s: string, repl: string) -> string @heap
+extern aether_regex_replace_all(re: ptr, s: string, repl: string) -> string @heap
+
+extern aether_regex_last_error() -> string
+extern aether_regex_clear_last_error()
+
+// ---- Lifecycle ------------------------------------------------------
+
+// Compile a pattern. Returns (re, "") on success; (null, error) on a
+// pattern-syntax error or when the build lacks libpcre2-8.
+compile(pattern: string) -> (ptr, string) {
+    re = aether_regex_compile(pattern, 0)
+    if re == null { return null, aether_regex_last_error() }
+    return re, ""
+}
+
+// As compile, with PCRE2 option bits (FLAG_CASELESS | FLAG_MULTILINE …).
+compile_flags(pattern: string, flags: int) -> (ptr, string) {
+    re = aether_regex_compile(pattern, flags)
+    if re == null { return null, aether_regex_last_error() }
+    return re, ""
+}
+
+// Free a compiled regex. Safe to call with null.
+free(re: ptr) {
+    aether_regex_free(re)
+}
+
+// The last error message set by compile / captures / find_all / replace*.
+// "" if none. Diagnostics for the no-match case are NOT errors — captures
+// returns null with last_error == "" when the pattern simply didn't match.
+last_error() -> string {
+    return aether_regex_last_error()
+}
+
+clear_last_error() {
+    aether_regex_clear_last_error()
+}
+
+// ---- Match queries --------------------------------------------------
+
+// Does the pattern match anywhere in s? 1 if yes, 0 if no.
+matches(re: ptr, s: string) -> int {
+    return aether_regex_matches(re, s)
+}
+
+// First match span: returns (start_byte, end_byte, err). start = -1
+// when there's no match (err == "") OR a real error (err != "").
+find(re: ptr, s: string) -> (int, int, string) {
+    caps = aether_regex_captures(re, s)
+    if caps == null {
+        e = aether_regex_last_error()
+        return -1, -1, e
+    }
+    st = aether_regex_captures_start(caps, 0)
+    en = aether_regex_captures_end(caps, 0)
+    aether_regex_captures_free(caps)
+    return st, en, ""
+}
+
+// ---- Captures -------------------------------------------------------
+//
+// captures(re, s) returns (caps, err). On a match, caps is a handle the
+// caller frees via captures_free; on no match, caps == null and err == "".
+// On a real error (corrupt pattern, OOM), caps == null and err != "".
+//
+// Group 0 = whole match; groups 1..capture_count-1 = the parenthesized
+// captures, in left-to-right order. capture(caps, i) returns "" for
+// out-of-range or unset (optional, didn't participate) groups.
+
+captures(re: ptr, s: string) -> (ptr, string) {
+    caps = aether_regex_captures(re, s)
+    if caps == null {
+        e = aether_regex_last_error()
+        return null, e
+    }
+    return caps, ""
+}
+
+capture_count(caps: ptr) -> int { return aether_regex_captures_count(caps) }
+
+capture(caps: ptr, index: int) -> string {
+    return aether_regex_captures_get(caps, index)
+}
+
+capture_start(caps: ptr, index: int) -> int {
+    return aether_regex_captures_start(caps, index)
+}
+
+capture_end(caps: ptr, index: int) -> int {
+    return aether_regex_captures_end(caps, index)
+}
+
+captures_free(caps: ptr) { aether_regex_captures_free(caps) }
+
+// ---- find_all -------------------------------------------------------
+//
+// All non-overlapping matches in s, in subject order. Returns (fa, err)
+// where fa is a handle holding N spans; iterate via find_all_count +
+// find_all_start(i) / find_all_end(i). Free with find_all_free.
+
+find_all(re: ptr, s: string) -> (ptr, string) {
+    fa = aether_regex_find_all(re, s)
+    if fa == null {
+        e = aether_regex_last_error()
+        return null, e
+    }
+    return fa, ""
+}
+
+find_all_count(fa: ptr) -> int { return aether_regex_find_all_count(fa) }
+find_all_start(fa: ptr, index: int) -> int { return aether_regex_find_all_start(fa, index) }
+find_all_end(fa: ptr, index: int) -> int { return aether_regex_find_all_end(fa, index) }
+find_all_free(fa: ptr) { aether_regex_find_all_free(fa) }
+
+// ---- Replace --------------------------------------------------------
+//
+// PCRE2 substitution syntax: $0..$9 / ${name} / $$ for literal $.
+// replace replaces only the first match; replace_all replaces every
+// non-overlapping match. Returns (out, err); err == "" on success.
+
+replace(re: ptr, s: string, repl: string) -> (string, string) {
+    out = aether_regex_replace(re, s, repl)
+    e = aether_regex_last_error()
+    return out, e
+}
+
+replace_all(re: ptr, s: string, repl: string) -> (string, string) {
+    out = aether_regex_replace_all(re, s, repl)
+    e = aether_regex_last_error()
+    return out, e
+}
+
+// ---- One-shot convenience -------------------------------------------
+//
+// Compile + match/find + free, for callers that don't need to reuse the
+// pattern. For hot loops, compile() once and reuse the handle.
+
+matches_lit(pattern: string, s: string) -> (int, string) {
+    re, err = compile(pattern)
+    if err != "" { return 0, err }
+    ok = aether_regex_matches(re, s)
+    aether_regex_free(re)
+    return ok, ""
+}
+
+find_lit(pattern: string, s: string) -> (int, int, string) {
+    re, err = compile(pattern)
+    if err != "" { return -1, -1, err }
+    st, en, ferr = find(re, s)
+    aether_regex_free(re)
+    return st, en, ferr
+}

--- a/tests/regression/test_regex.ae
+++ b/tests/regression/test_regex.ae
@@ -1,0 +1,124 @@
+// std.regex regression test — exercises the PCRE2-backed surface.
+//
+// Note: skipped (PASS without checks) if the build didn't link
+// libpcre2-8 — compile() returns null with last_error reporting
+// "built without libpcre2-8". The wrapper is correct either way; this
+// test is only meaningful when PCRE2 is actually wired in.
+
+import std.regex
+import std.string
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    println("=== std.regex regression ===")
+
+    // Probe: is PCRE2 actually present?
+    probe, perr = regex.compile("a")
+    if probe == null {
+        println("  [SKIP] regex built without libpcre2-8: ${perr}")
+        exit(0)
+    }
+    regex.free(probe)
+
+    // ---- compile: success + syntax error path ----
+    bad, berr = regex.compile("(")
+    if bad != null { fail("expected unbalanced '(' to fail compile") }
+    if berr == "" { fail("invalid pattern should set last_error") }
+    println("  PASS: invalid pattern rejected (${berr})")
+
+    // ---- matches: yes / no ----
+    re, _ = regex.compile("hello")
+    if regex.matches(re, "well hello there") != 1 { fail("matches: positive miss") }
+    if regex.matches(re, "nothing") != 0 { fail("matches: false positive") }
+    regex.free(re)
+    println("  PASS: matches (positive + negative)")
+
+    // ---- find: span of first match; -1/-1 on no match (err "") ----
+    re2, _ = regex.compile("[0-9]+")
+    st, en, ferr = regex.find(re2, "abc 42 xyz")
+    if ferr != "" { fail("find err: ${ferr}") }
+    if st != 4 { fail("find start = ${st}, want 4") }
+    if en != 6 { fail("find end = ${en}, want 6") }
+    nst, nen, nerr = regex.find(re2, "no digits here")
+    if nerr != "" { fail("no-match should not set err, got: ${nerr}") }
+    if nst != -1 { fail("no match should give start=-1, got ${nst}") }
+    if nen != -1 { fail("no match should give end=-1, got ${nen}") }
+    regex.free(re2)
+    println("  PASS: find (span + no-match returns -1/-1, no err)")
+
+    // ---- captures: groups + count + start/end + OOB ----
+    re3, _ = regex.compile("(\\d{4})-(\\d{2})-(\\d{2})")
+    caps, _ = regex.captures(re3, "released on 2026-05-28 today")
+    if caps == null { fail("expected match for date pattern") }
+    if regex.capture_count(caps) != 4 { fail("capture_count = ${regex.capture_count(caps)}, want 4") }
+    g0 = regex.capture(caps, 0)
+    if g0 != "2026-05-28" { fail("group 0 = '${g0}'") }
+    if regex.capture(caps, 1) != "2026" { fail("group 1 wrong") }
+    if regex.capture(caps, 2) != "05" { fail("group 2 wrong") }
+    if regex.capture(caps, 3) != "28" { fail("group 3 wrong") }
+    if regex.capture_start(caps, 0) != 12 { fail("group-0 start") }
+    if regex.capture_end(caps, 0) != 22 { fail("group-0 end") }
+    // OOB returns ""
+    oob = regex.capture(caps, 99)
+    if oob != "" { fail("OOB capture should be empty, got '${oob}'") }
+    if regex.capture_start(caps, 99) != -1 { fail("OOB start should be -1") }
+    regex.captures_free(caps)
+    regex.free(re3)
+    println("  PASS: captures (groups, count, span, OOB)")
+
+    // ---- captures: no match returns null + no error ----
+    re4, _ = regex.compile("xyz123")
+    nocap, nerr2 = regex.captures(re4, "abc")
+    if nocap != null { fail("expected null on no match") }
+    if nerr2 != "" { fail("no match should not set err, got: ${nerr2}") }
+    regex.free(re4)
+    println("  PASS: captures returns null+no-err on no match")
+
+    // ---- find_all + accessors ----
+    re5, _ = regex.compile("[a-z]+")
+    fa, _ = regex.find_all(re5, "hello world foo")
+    if regex.find_all_count(fa) != 3 { fail("find_all_count = ${regex.find_all_count(fa)}, want 3") }
+    if regex.find_all_start(fa, 0) != 0 { fail("fa[0] start") }
+    if regex.find_all_end(fa, 0) != 5 { fail("fa[0] end") }
+    if regex.find_all_start(fa, 2) != 12 { fail("fa[2] start") }
+    if regex.find_all_end(fa, 2) != 15 { fail("fa[2] end") }
+    if regex.find_all_start(fa, 99) != -1 { fail("OOB span should be -1") }
+    regex.find_all_free(fa)
+    regex.free(re5)
+    println("  PASS: find_all (count + spans + OOB)")
+
+    // ---- replace + replace_all with $-substitution ----
+    re6, _ = regex.compile("(\\w+)@(\\w+)")
+    one, _ = regex.replace(re6, "foo@bar and baz@qux", "[$1 at $2]")
+    if one != "[foo at bar] and baz@qux" { fail("replace (first only) = '${one}'") }
+    all, _ = regex.replace_all(re6, "foo@bar and baz@qux", "[$1 at $2]")
+    if all != "[foo at bar] and [baz at qux]" { fail("replace_all = '${all}'") }
+    regex.free(re6)
+    println("  PASS: replace + replace_all (with \\$1/\\$2 substitution)")
+
+    // ---- case-insensitive flag ----
+    rei, _ = regex.compile_flags("hello", regex.FLAG_CASELESS)
+    if regex.matches(rei, "HELLO WORLD") != 1 { fail("FLAG_CASELESS: case-insensitive miss") }
+    regex.free(rei)
+    println("  PASS: FLAG_CASELESS")
+
+    // ---- one-shot convenience ----
+    ok, lerr = regex.matches_lit("[0-9]+", "abc 42 xyz")
+    if lerr != "" { fail("matches_lit err: ${lerr}") }
+    if ok != 1 { fail("matches_lit miss") }
+    lst, len2, lerr2 = regex.find_lit("[0-9]+", "abc 42 xyz")
+    if lerr2 != "" { fail("find_lit err: ${lerr2}") }
+    if lst != 4 || len2 != 6 { fail("find_lit span") }
+    _, blerr = regex.matches_lit("(", "anything")
+    if blerr == "" { fail("matches_lit should surface compile err") }
+    println("  PASS: matches_lit + find_lit (incl. compile-err propagation)")
+
+    println("PASS")
+    exit(0)
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1729,6 +1729,14 @@ static void build_gcc_cmd(char* cmd, size_t size,
 #else
     const char* nghttp2_libs = "";
 #endif
+#ifdef AETHER_PCRE2_LIBS
+    /* libpcre2-8 powers std.regex. Empty when not detected; the
+     * std.regex surface stays valid and every entry point returns
+     * a clean "built without libpcre2-8" via regex.last_error(). */
+    const char* pcre2_libs = AETHER_PCRE2_LIBS;
+#else
+    const char* pcre2_libs = "";
+#endif
     char opt[600];
     if (user_cflags[0])
         snprintf(opt, sizeof(opt), "-static %s %s", opt_flags(optimize), user_cflags);
@@ -1747,8 +1755,8 @@ static void build_gcc_cmd(char* cmd, size_t size,
         char* slash = (!bs) ? fs : (!fs) ? bs : (bs > fs ? bs : fs);
         if (slash) *slash = '\0';
         int w = snprintf(cmd, size,
-            "\"%s\" %s %s \"%s\" %s -L\"%s\" -laether -o \"%s\" %s %s %s %s %s",
-            s_gcc_bin, opt, tc.include_flags, c_file, extra, lib_dir, out_file, openssl_libs, zlib_libs, nghttp2_libs, win_link_libs, link_flags);
+            "\"%s\" %s %s \"%s\" %s -L\"%s\" -laether -o \"%s\" %s %s %s %s %s %s",
+            s_gcc_bin, opt, tc.include_flags, c_file, extra, lib_dir, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, win_link_libs, link_flags);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu).\n",
@@ -1756,8 +1764,8 @@ static void build_gcc_cmd(char* cmd, size_t size,
         }
     } else {
         int w = snprintf(cmd, size,
-            "\"%s\" %s %s \"%s\" %s %s -o \"%s\" %s %s %s %s %s",
-            s_gcc_bin, opt, tc.include_flags, c_file, extra, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, win_link_libs, link_flags);
+            "\"%s\" %s %s \"%s\" %s %s -o \"%s\" %s %s %s %s %s %s",
+            s_gcc_bin, opt, tc.include_flags, c_file, extra, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, win_link_libs, link_flags);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu).\n",
@@ -1838,6 +1846,15 @@ static void build_gcc_cmd(char* cmd, size_t size,
     const char* nghttp2_libs = "";
 #endif
 
+    // libpcre2-8 — std.regex (Perl-compatible regex with captures,
+    // $-substitutions, Unicode). Empty when not detected; std.regex
+    // surfaces a clean "built without libpcre2-8" via last_error().
+#ifdef AETHER_PCRE2_LIBS
+    const char* pcre2_libs = AETHER_PCRE2_LIBS;
+#else
+    const char* pcre2_libs = "";
+#endif
+
     if (tc.has_lib) {
         char lib_dir[1024];
         strncpy(lib_dir, tc.lib, sizeof(lib_dir) - 1);
@@ -1857,8 +1874,8 @@ static void build_gcc_cmd(char* cmd, size_t size,
          * would fail to find any libaether symbol — silently on
          * macOS via dynamic_lookup, hard-failing on Linux. */
         int w = snprintf(cmd, size,
-            "gcc %s %s \"%s\"%s %s -rdynamic -L%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s",
-            opt, tc.include_flags, c_file, config_c, extra, lib_dir, out_file, openssl_libs, zlib_libs, nghttp2_libs, link_flags, g_binimport_link);
+            "gcc %s %s \"%s\"%s %s -rdynamic -L%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s",
+            opt, tc.include_flags, c_file, config_c, extra, lib_dir, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu) — "
@@ -1868,8 +1885,8 @@ static void build_gcc_cmd(char* cmd, size_t size,
         }
     } else {
         int w = snprintf(cmd, size,
-            "gcc %s %s \"%s\"%s %s %s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s",
-            opt, tc.include_flags, c_file, config_c, extra, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, link_flags, g_binimport_link);
+            "gcc %s %s \"%s\"%s %s %s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s",
+            opt, tc.include_flags, c_file, config_c, extra, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu) — "


### PR DESCRIPTION
A new std.regex module — full PCRE2 surface (captures, $1/$2/${name} substitutions, Unicode, look-around, alternation, non-greedy, character classes) plus the standard option flags (CASELESS / MULTILINE / DOTALL / EXTENDED / UNGREEDY). Go-style Aether wrappers throughout:

  regex.compile(pattern) -> (re, err)
  regex.compile_flags(pattern, flags) -> (re, err)
  regex.matches(re, s) -> int
  regex.find(re, s) -> (start, end, err)         // start=-1 on no match
  regex.captures(re, s) -> (caps, err)           // null on no match
  regex.capture(caps, i) -> string               // OOB/unset -> ""
  regex.capture_count / capture_start / capture_end / captures_free
  regex.find_all(re, s) -> (fa, err)             // N non-overlapping spans
  regex.find_all_count / _start / _end / _free
  regex.replace(re, s, repl) -> (out, err)       // first match
  regex.replace_all(re, s, repl) -> (out, err)   // every match
  regex.matches_lit / find_lit                   // one-shot compile+match
  regex.last_error()

Wiring follows the existing OpenSSL/zlib/nghttp2 pattern: pkg-config libpcre2-8 is probed in the Makefile, setting AETHER_HAS_PCRE2 + PCRE2_CFLAGS
+ PCRE2_LDFLAGS. tools/ae.c forwards -lpcre2-8 to downstream user-program links (both POSIX and Windows snprintf sites). Without libpcre2-dev the build still succeeds and every regex entry point returns a clean "built without libpcre2-8 (install libpcre2-dev and rebuild)" via regex.last_error() — never breaks a build.

Implementation notes:
- C handles (RegexHandle / RegexCaptures / RegexFindAll) own their resources; captures copies the subject so capture(i) is safe across the caller freeing the source string.
- Returned strings (capture, replace*) are AetherString refcounts marked @heap on the extern declarations — Aether's auto-cleanup reclaims them.
- PCRE2_SUBSTITUTE_EXTENDED enables the familiar $-substitution syntax; replace_all adds PCRE2_SUBSTITUTE_GLOBAL.
- TLS last_error slot, set on any error path; cleared on success entries.

Test: tests/regression/test_regex.ae — 9 assertion blocks covering compile error, matches +/-, find with no-match (-1/-1, no err), captures (groups + count + spans + OOB), find_all, replace + replace_all with $-substitution, FLAG_CASELESS, and matches_lit/find_lit incl. compile-err propagation. Skips cleanly if PCRE2 wasn't linked at build time.

Docs: docs/bootstrap-from-source.md grows an "optional system libraries" table that documents the silent openssl/zlib/nghttp2 trio plus the new libpcre2-dev.

Verified: clean build; 226 C unit tests; new test + http_server_ops + http_client_dechunk + test_string_to_number_widths all pass.