### PR TITLE
feat: CVG-port round 3 — stdlib + tooling + closure-coercion fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.string.from_int_radix(value, radix) -> string`** —
+  inverse of `to_int_radix` (which landed in v0.193). Renders
+  `value` in base `radix` (`[2, 36]`); empty string on invalid
+  radix; `'-'` prefix for negatives. C runtime is a hand-rolled
+  digit loop because libc snprintf only covers `%x` / `%o` / `%d`.
+  `long long` parameter, not C `long`, for LLP64 safety (the same
+  invariant `string_to_long_raw` documents — PR #562). Headline
+  use case: hex color emit for animation interpolation
+  (`r.toString(16).padStart(2, '0')` patterns). Pair with the new
+  `pad_start` below for fixed-width hex bytes.
+- **`std.string.pad_start(s, total_width, pad_char)` and
+  `string.pad_end(...)`** — pad to a fixed width with a single-byte
+  char code (`48` for `'0'`, `32` for `' '`). If `s` is already
+  `>= total_width` chars, returns a fresh copy (no truncation;
+  same allocation behaviour as the pad path so callers release
+  uniformly). `pad_char` is a char code (not a multi-char string)
+  to match `string_char_at`'s convention and avoid string-alloc
+  overhead in tight loops.
+
+### Fixed
+
+- **`fn`-typed value at struct-field assignment rejected by
+  typechecker** — `compiler/analysis/typechecker.c`,
+  `compiler/codegen/codegen_expr.c`,
+  `tests/regression/test_fn_struct_field_assignment.ae`. The
+  Option B1 fn↔ptr boxing already in `[current]` covered call-
+  site argument positions, but `h.cb = c` (where `cb: ptr` and
+  `c: fn`) was rejected at typecheck with E0200. The CVG port hit
+  this for 17 callback fields in `grammar_element.ae`
+  (`onClick`, `bindFill`, `whenPredicate`, etc.). Fix: add
+  `fn ↔ ptr` to `is_type_compatible`, and at the
+  AST_BINARY_EXPRESSION assign-emit (`=`) box a `fn`-shaped RHS
+  (or bare named function) with `_aether_box_closure(...)` when
+  the LHS is `ptr`. Mirror of the call-site coercion path. Now
+  the boxing/unboxing surface is uniform across call-site args,
+  struct-field assignments, and (already supported) `as fn` casts.
+
+- **`fn`-typed parameter / `ptr` slot coercion silently miscompiled
+  to bad C** — `compiler/codegen/codegen_expr.c`,
+  `tests/regression/test_fn_ptr_coercion.ae`. The type-checker
+  accepted three coercion shapes at call sites — bare named
+  function → `fn` param, `fn` local → `ptr` param, `ptr` (boxed
+  closure) → `fn` param — but C codegen emitted incompatible types
+  (e.g. `int (*)(void)` into a slot expecting `_AeClosure`, or
+  `_AeClosure` into a slot expecting `void*`) and gcc rejected the
+  program. Downstream (the aether-ui CVG port's `whenStack` pattern)
+  worked around it by declaring callback params as `ptr`, losing
+  captured-state closures through forwarding.
+
+  Fix (Option B1 from the filing — make `fn ↔ ptr` actually work):
+  the existing `_aether_box_closure` / `_aether_unbox_closure`
+  runtime primitives are now wired at the coercion site. `fn → ptr`
+  heap-allocates an `_AeClosure` struct and passes the pointer; bare
+  named function → `fn` param emits a struct literal
+  `(_AeClosure){ .fn=..., .env=NULL }`; `ptr → fn` unboxes back to
+  the struct. Captured-state closures now survive forwarding through
+  `ptr`-typed slots (lists, maps, struct fields, opaque externs).
+  The pre-existing direct `bare-fn → ptr` direct-arg path remains
+  backwards-compatible (existing call sites unchanged).
+- **`ae cflags --libs` did not emit transitive dep flags
+  (`-lpcre2-8`, `-lssl -lcrypto`, `-lz`, `-lnghttp2`)** —
+  `tools/ae.c`, `tests/integration/ae_cflags/test_ae_cflags.sh`.
+  `cmd_build` already passed `AETHER_OPENSSL_LIBS` / `_ZLIB_LIBS`
+  / `_NGHTTP2_LIBS` / `_PCRE2_LIBS` to gcc, but `cmd_cflags` (the
+  documented entry point for external builds via `gcc your.c
+  $(ae cflags)`) silently omitted them. So downstream consumers
+  of `std.regex` got `undefined reference to pcre2_*` at link
+  time, and consumers of `std.cryptography` / `std.http` TLS got
+  `SSL_*` failures, even though `libaether.a` was compiled with
+  those deps — the archive's symbol table held unresolved
+  references the consuming link had to satisfy. Now matched.
+  Empty-string guard preserves the no-pkg-config case (a build
+  without `libpcre2-dev` sets `PCRE2_LDFLAGS :=` empty; the
+  macro expands to `""`; emit nothing). Test extended to nm
+  the local `libaether.a` and assert each detected symbol
+  family has its matching `-l` flag.
+
 ## [0.193.0]
 
 ### Added

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -886,6 +886,24 @@ int is_type_compatible(Type* from, Type* to) {
     if (from->kind == TYPE_INT && to->kind == TYPE_PTR) return 1;
     if (from->kind == TYPE_PTR && to->kind == TYPE_INT) return 1;
 
+    /* fn ↔ ptr compatibility (the Option B1 boxing shape). A closure
+     * stored as ptr (struct field, list/map element) and recovered
+     * back to a `fn` slot — codegen wraps the cross-direction
+     * transitions in _aether_box_closure / _aether_unbox_closure
+     * (compiler/codegen/codegen_expr.c at the AST_FUNCTION_CALL
+     * arg-emit loop and at struct-field assignment).
+     *
+     * Without this rule, `h.cb = c` where `h.cb: ptr` and `c: fn`
+     * fails at typecheck with E0200 — exactly the gap the aether-ui
+     * CVG port hit in `grammar_element.ae` for 17 callback fields
+     * (`onClick`, `bindFill`, `whenPredicate`, etc.).  Raw-C-fn-
+     * pointer form (TYPE_FUNCTION with is_fnptr=1, storage = void*)
+     * has always been ptr-compatible by virtue of the `as fn`
+     * cast contract; this extends the same compatibility to the
+     * `_AeClosure`-shaped form (is_fnptr=0). */
+    if (from->kind == TYPE_FUNCTION && to->kind == TYPE_PTR) return 1;
+    if (from->kind == TYPE_PTR && to->kind == TYPE_FUNCTION) return 1;
+
     // byte → int / int64 / float: safe widenings.
     // Reverse direction (int → byte) is intentionally NOT here — it's
     // gated at the assignment site so out-of-range integer literals

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2030,7 +2030,46 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
 
                     fprintf(gen->output, " %s ", get_c_operator(expr->value));
                     if (ptr_int_cmp && rhs_is_ptr) fprintf(gen->output, "(intptr_t)");
-                    generate_expression(gen, expr->children[1]);
+                    /* fn ↔ ptr coercion at struct-field assignment.
+                     * Mirror of the call-site coercion path. The
+                     * parser lands `h.cb = c` as
+                     * AST_BINARY_EXPRESSION (op="="). When the LHS
+                     * is a `ptr`-typed value and the RHS is a `fn`-
+                     * shaped value (is_fnptr=0) or a bare named
+                     * function, wrap the RHS in
+                     * _aether_box_closure(...) so the closure
+                     * round-trips through the field with the env
+                     * slot intact. */
+                    int assign_box_struct = 0;
+                    int assign_box_bare_fn = 0;
+                    if (is_assignment && lhs_is_ptr) {
+                        if (rtype && rtype->kind == TYPE_FUNCTION && !rtype->is_fnptr) {
+                            assign_box_struct = 1;
+                        } else if (expr->children[1] &&
+                                   expr->children[1]->type == AST_IDENTIFIER &&
+                                   expr->children[1]->value && gen->program) {
+                            for (int pi = 0; pi < gen->program->child_count; pi++) {
+                                ASTNode* pc = gen->program->children[pi];
+                                if (pc && (pc->type == AST_FUNCTION_DEFINITION ||
+                                           pc->type == AST_BUILDER_FUNCTION) &&
+                                    pc->value && strcmp(pc->value, expr->children[1]->value) == 0) {
+                                    assign_box_bare_fn = 1;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (assign_box_struct) {
+                        fprintf(gen->output, "_aether_box_closure(");
+                        generate_expression(gen, expr->children[1]);
+                        fprintf(gen->output, ")");
+                    } else if (assign_box_bare_fn) {
+                        fprintf(gen->output, "_aether_box_closure((_AeClosure){ .fn = (void(*)(void))(");
+                        generate_expression(gen, expr->children[1]);
+                        fprintf(gen->output, "), .env = NULL })");
+                    } else {
+                        generate_expression(gen, expr->children[1]);
+                    }
                     if (!skip_parens) fprintf(gen->output, ")");
                 }
             }
@@ -3063,6 +3102,16 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         // Cast int→void* when param expects void* (TYPE_PTR).
                         // Check extern registry first, then user-defined function params.
                         TypeKind expected = lookup_extern_param_kind(gen, c_func_name, arg_printed);
+                        /* For TYPE_FUNCTION params we also need the full
+                         * Type* so we can read `is_fnptr` — the boxing
+                         * coercions below only apply to the closure
+                         * shape (is_fnptr=0), NOT to raw C fn pointers
+                         * declared as `fn(T1, T2, ...) -> R` (is_fnptr=1,
+                         * storage = void*). Without this gate, passing
+                         * a bare named function to a `fn(args)->ret`
+                         * param would emit an _AeClosure struct literal
+                         * where the receiver expects void*. */
+                        Type* expected_type = NULL;
                         if (expected == TYPE_UNKNOWN) {
                             // Look up user-defined function's param type.
                             // Try both the original call-site name and the
@@ -3081,6 +3130,7 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                         if (fp->type == AST_GUARD_CLAUSE || fp->type == AST_BLOCK) continue;
                                         if (pi == arg_printed && fp->node_type) {
                                             expected = fp->node_type->kind;
+                                            expected_type = fp->node_type;
                                         }
                                         pi++;
                                     }
@@ -3088,7 +3138,89 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                 }
                             }
                         }
+                        int expected_is_fnptr_form = (expected == TYPE_FUNCTION &&
+                            expected_type && expected_type->is_fnptr);
                         if (expected == TYPE_PTR && arg->node_type &&
+                            arg->node_type->kind == TYPE_FUNCTION &&
+                            !arg->node_type->is_fnptr) {
+                            /* Closure (`_AeClosure` struct) → ptr slot.
+                             * Heap-box the struct so the receiver can
+                             * stash it in a list/map/struct ptr field
+                             * with the env slot intact, and the
+                             * inverse coercion (TYPE_FUNCTION expected,
+                             * TYPE_PTR arg, below) can recover it.
+                             *
+                             * `is_fnptr=1` means the source is a raw C
+                             * function pointer (produced by `expr as
+                             * fn(...)` casts — storage is `void*`, not
+                             * `_AeClosure`); that path falls through
+                             * to the default identity emit, which is
+                             * the established working behaviour from
+                             * tests/regression/test_fn_address_via_as_fn.ae
+                             * (Aether-fn address handed to qsort, etc.).
+                             * The filing's repro (fn_ptr_coercion.md)
+                             * was on the is_fnptr=0 closure path —
+                             * a `fn`-typed local that's a real
+                             * _AeClosure struct value.
+                             *
+                             * Pre-fix: `fn`-typed local arg into a
+                             * `ptr` slot caused gcc "expected void* but
+                             * argument is of type _AeClosure" — silent
+                             * type-check accept, hard fail at C compile. */
+                            fprintf(gen->output, "_aether_box_closure(");
+                            generate_expression(gen, arg);
+                            fprintf(gen->output, ")");
+                        } else if (expected == TYPE_FUNCTION &&
+                                   !expected_is_fnptr_form &&
+                                   !(arg->node_type && arg->node_type->is_fnptr)) {
+                            /* The receiver slot is `fn` (an _AeClosure
+                             * struct — bare `fn` with no signature).
+                             * The raw-fnptr form `fn(T1, ...) -> R`
+                             * (expected_is_fnptr_form) is `void*`-shaped
+                             * and falls through to the default emit:
+                             * a bare named function decays to its
+                             * address, which the C side reads as
+                             * `void*`. The argument shape can be:
+                             *
+                             *   (a) a bare named function — emit a
+                             *       struct literal with env=NULL so
+                             *       the receiver gets a real
+                             *       _AeClosure value.
+                             *   (b) a `fn`-typed local — already an
+                             *       _AeClosure; pass through.
+                             *   (c) a `ptr` value (boxed closure
+                             *       recovered from list/map/struct
+                             *       field) — unbox.
+                             *
+                             * Pre-fix: (a) caused gcc "expected
+                             * _AeClosure but argument is of type int
+                             * (*)(void)" — the silent type-check pass
+                             * that the fn_ptr_coercion.md filing
+                             * surfaced. */
+                            int arg_is_bare_fn = 0;
+                            if (arg->type == AST_IDENTIFIER && arg->value && gen->program) {
+                                for (int pi = 0; pi < gen->program->child_count; pi++) {
+                                    ASTNode* pc = gen->program->children[pi];
+                                    if (pc && (pc->type == AST_FUNCTION_DEFINITION ||
+                                               pc->type == AST_BUILDER_FUNCTION) &&
+                                        pc->value && strcmp(pc->value, arg->value) == 0) {
+                                        arg_is_bare_fn = 1;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (arg_is_bare_fn) {
+                                fprintf(gen->output, "(_AeClosure){ .fn = (void(*)(void))(");
+                                generate_expression(gen, arg);
+                                fprintf(gen->output, "), .env = NULL }");
+                            } else if (arg->node_type && arg->node_type->kind == TYPE_PTR) {
+                                fprintf(gen->output, "_aether_unbox_closure(");
+                                generate_expression(gen, arg);
+                                fprintf(gen->output, ")");
+                            } else {
+                                generate_expression(gen, arg);
+                            }
+                        } else if (expected == TYPE_PTR && arg->node_type &&
                             (arg->node_type->kind == TYPE_INT || arg->node_type->kind == TYPE_BOOL)) {
                             fprintf(gen->output, "(void*)(intptr_t)(");
                             generate_expression(gen, arg);

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -487,6 +487,9 @@ For a `split_once`-style operation (find the first `sep` in `s`, return the halv
 - `string.to_int(s)` → `(int, string)` - Parse base-10 integer
 - `string.to_long(s)` → `(long, string)` - Parse 64-bit integer
 - `string.to_int_radix(s, radix)` → `(long, string)` - Parse base-N integer; `radix` in `[2, 36]`. No `"0x"`/`"0b"` prefix recognition. Returns `long` so 32-bit-wide hex (ARGB colors, file offsets) survives. Errors on invalid radix, invalid digit, empty input, overflow, or trailing garbage.
+- `string.from_int_radix(value, radix)` → `string` - Inverse of `to_int_radix`. Render `value` in base `radix` (`[2, 36]`); empty string on invalid radix; `'-'` prefix for negatives. Pair with `pad_start` for fixed-width hex bytes.
+- `string.pad_start(s, total_width, pad_char)` → `string` - Prepend `pad_char` (single-byte char code, e.g. `48` for `'0'`, `32` for `' '`) until `s` reaches `total_width`. Returns a fresh copy if `s` is already long enough (no truncation).
+- `string.pad_end(s, total_width, pad_char)` → `string` - Append-side variant of `pad_start`. Useful for columnar text output.
 - `string.to_float(s)` → `(float, string)` - Parse float
 - `string.to_double(s)` → `(float, string)` - Parse double
 

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -632,6 +632,97 @@ AetherString* string_from_float(double value) {
     return string_new(buffer);
 }
 
+// Inverse of string_to_int_radix: render `value` as a base-N digit
+// string. radix in [2, 36]; out-of-range radix yields the empty
+// string (caller-detectable, matches the existing string_empty()
+// failure convention for stdlib emit-side functions). Negative
+// values get a leading '-'.
+//
+// Hand-rolled digit loop because libc only offers %x / %o / %d in
+// snprintf, not arbitrary base-N. Buffer size: 64-bit binary needs
+// 64 digits + sign + NUL = 66 bytes; we allocate 80 for headroom.
+//
+// `long long` parameter (NOT C `long`): Aether's `long` lowers to
+// int64_t on every platform; C `long` is 32-bit on Windows LLP64
+// — same lesson PR #562 pinned for string_to_long_raw, applied
+// preemptively.
+AetherString* string_from_int_radix(long long value, int radix) {
+    if (radix < 2 || radix > 36) return string_empty();
+
+    char buf[80];
+    int neg = (value < 0);
+    /* Negate via unsigned to avoid UB on LLONG_MIN (which can't be
+     * represented as a positive long long). */
+    unsigned long long v = neg
+        ? (unsigned long long)(-(value + 1)) + 1ULL
+        : (unsigned long long)value;
+
+    int n = 0;
+    if (v == 0) {
+        buf[n++] = '0';
+    } else {
+        while (v > 0) {
+            int d = (int)(v % (unsigned long long)radix);
+            buf[n++] = (d < 10) ? (char)('0' + d) : (char)('a' + d - 10);
+            v /= (unsigned long long)radix;
+        }
+    }
+    if (neg) buf[n++] = '-';
+
+    /* Reverse in place. */
+    for (int i = 0, j = n - 1; i < j; i++, j--) {
+        char t = buf[i]; buf[i] = buf[j]; buf[j] = t;
+    }
+    buf[n] = '\0';
+    return string_new_with_length(buf, (size_t)n);
+}
+
+/* Pad-start / pad-end helpers — mirror JS String.prototype.padStart
+ * / padEnd. If `s` is already >= total_width chars, returns a fresh
+ * copy (no truncation; same allocation behaviour as the pad path so
+ * callers can always release the result uniformly). total_width <= 0
+ * also returns a fresh copy.
+ *
+ * `pad_char` is a single-byte char code (int), NOT a multi-char fill
+ * string. This matches string_char_at's convention (returns int char
+ * code), avoids string-alloc overhead in tight loops, and keeps the
+ * C side a clean memset+memcpy. The aether-ui CVG port wants `48`
+ * ('0') for zero-padded hex bytes; columnar-output use cases want
+ * `32` (' '). Multi-char fill is deferred until someone needs it. */
+AetherString* string_pad_start(const void* s, int total_width, int pad_char) {
+    const char* data = str_data(s);
+    size_t len = str_len(s);
+    if (!s || total_width <= 0 || (size_t)total_width <= len) {
+        return string_new_with_length(data ? data : "", data ? len : 0);
+    }
+    size_t pad_n = (size_t)total_width - len;
+    char* tmp = (char*)malloc((size_t)total_width + 1);
+    if (!tmp) return string_empty();
+    memset(tmp, (char)pad_char, pad_n);
+    if (data && len > 0) memcpy(tmp + pad_n, data, len);
+    tmp[total_width] = '\0';
+    AetherString* out = string_new_with_length(tmp, (size_t)total_width);
+    free(tmp);
+    return out;
+}
+
+AetherString* string_pad_end(const void* s, int total_width, int pad_char) {
+    const char* data = str_data(s);
+    size_t len = str_len(s);
+    if (!s || total_width <= 0 || (size_t)total_width <= len) {
+        return string_new_with_length(data ? data : "", data ? len : 0);
+    }
+    size_t pad_n = (size_t)total_width - len;
+    char* tmp = (char*)malloc((size_t)total_width + 1);
+    if (!tmp) return string_empty();
+    if (data && len > 0) memcpy(tmp, data, len);
+    memset(tmp + len, (char)pad_char, pad_n);
+    tmp[total_width] = '\0';
+    AetherString* out = string_new_with_length(tmp, (size_t)total_width);
+    free(tmp);
+    return out;
+}
+
 // Parsing functions - convert string to numbers.
 // The `_raw` variants take an out-parameter and return 1/0 for ok/fail.
 // The Aether-native Go-style wrappers `string.to_int` etc. in module.ae

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -186,6 +186,20 @@ AetherString* string_from_long(long long value);
 // — see the .c-side comment for the full diagnosis.
 AetherString* string_from_float(double value);
 
+// Inverse of string_to_int_radix: render `value` in base `radix`
+// (2..36). Empty string on out-of-range radix; '-' prefix for
+// negatives. long long for LLP64 safety (matches the to_int_radix
+// shape).
+AetherString* string_from_int_radix(long long value, int radix);
+
+// Pad to a fixed width with `pad_char` (single-byte char code).
+// If s is already >= total_width chars, returns a fresh copy (no
+// truncation). pad_start prepends; pad_end appends. Allocation
+// behaviour is uniform across both branches so callers always
+// release the result the same way.
+AetherString* string_pad_start(const void* s, int total_width, int pad_char);
+AetherString* string_pad_end(const void* s, int total_width, int pad_char);
+
 // Parsing (string -> number) — raw form with out-parameter.
 // Returns 1 on success, 0 on failure. Result stored in out_value.
 // Aether code should prefer the Go-style wrappers in std.string

--- a/std/string/module.ae
+++ b/std/string/module.ae
@@ -19,6 +19,7 @@ exports (
     string_seq_from_array, string_seq_to_array,
     string_seq_reverse, string_seq_concat, string_seq_take, string_seq_drop,
     string_to_cstr, string_from_int, string_from_long, string_from_float,
+    string_from_int_radix, string_pad_start, string_pad_end,
     string_to_int_raw, string_to_long_raw, string_to_float_raw, string_to_double_raw,
     string_try_int, string_get_int, string_try_long, string_get_long,
     string_try_float, string_get_float, string_try_double, string_get_double,
@@ -216,6 +217,23 @@ extern string_to_cstr(str: string) -> string
 extern string_from_int(value: int) -> ptr
 extern string_from_long(value: long) -> ptr
 extern string_from_float(value: float) -> ptr
+
+// Inverse of to_int_radix. Render `value` in base `radix` (2..36).
+// Returns an empty string for radix outside [2, 36]; otherwise the
+// digit string (lowercase a-z for radix 11..36), with a leading '-'
+// for negatives. No "0x" / "0b" prefix.
+//
+// Headline use: hex emit for color round-trips (RGB → #rrggbb). Pair
+// with `string.pad_start(s, 2, 48)` to get the JS
+// `r.toString(16).padStart(2, '0')` shape.
+extern string_from_int_radix(value: long, radix: int) -> ptr
+
+// Pad to a fixed width with `pad_char` (single-byte char code —
+// `48` for '0', `32` for ' '). If `s` is already >= total_width
+// chars, returns a fresh copy (no truncation). total_width <= 0
+// also returns a fresh copy. pad_start prepends; pad_end appends.
+extern string_pad_start(s: string, total_width: int, pad_char: int) -> ptr
+extern string_pad_end(s: string, total_width: int, pad_char: int) -> ptr
 
 // Parsing — raw externs (escape hatch)
 extern string_to_int_raw(str: string, out_value: ptr) -> int

--- a/tests/integration/ae_cflags/test_ae_cflags.sh
+++ b/tests/integration/ae_cflags/test_ae_cflags.sh
@@ -68,6 +68,36 @@ if printf %s "$libs_only" | grep -q -- "-I"; then
     exit 1
 fi
 
+# Transitive deps: if libaether.a was compiled with PCRE2 / OpenSSL /
+# zlib / nghttp2 (detectable via the unresolved-symbol set in its
+# archive), `ae cflags --libs` MUST emit the corresponding -l flags
+# — otherwise downstream `gcc app.c $(ae cflags)` fails to link with
+# `undefined reference to pcre2_*` and similar. This pattern shipped
+# v0.193.0 broken; fix here in tools/ae.c cmd_cflags. The check uses
+# nm on the local libaether.a so it only fails when there's a real
+# symbol-to-flag mismatch (it self-skips on a no-pcre2 build).
+LIBAETHER="$ROOT/build/libaether.a"
+if [ -f "$LIBAETHER" ] && command -v nm >/dev/null 2>&1; then
+    # For each (symbol-prefix, expected-flag-pattern) pair: if the
+    # archive references the symbol family, the link flags must
+    # mention the corresponding library.
+    check_dep() {
+        sym_pat="$1"; flag_pat="$2"; name="$3"
+        if nm "$LIBAETHER" 2>/dev/null | grep -q "U $sym_pat"; then
+            if ! printf %s "$libs_only" | grep -qE -- "$flag_pat"; then
+                echo "  [FAIL] ae_cflags --libs: libaether.a references $name ($sym_pat) but no $flag_pat in cflags"
+                echo "  ---- libs ----"
+                echo "$libs_only"
+                exit 1
+            fi
+        fi
+    }
+    check_dep 'pcre2_'    '-lpcre2-8'           'PCRE2'
+    check_dep 'SSL_'      '-l(ssl|crypto)'      'OpenSSL'
+    check_dep 'deflate'   '-lz'                 'zlib'
+    check_dep 'nghttp2_'  '-lnghttp2'           'nghttp2'
+fi
+
 # Functional check: `gcc trivial.c $(ae cflags) -o out` runs end-to-end.
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
@@ -88,5 +118,5 @@ if [ "$actual" != "ae_cflags ok" ]; then
     exit 1
 fi
 
-echo "  [PASS] ae_cflags: full / --cflags / --libs subsets correct, gcc \$(ae cflags) builds"
+echo "  [PASS] ae_cflags: full / --cflags / --libs subsets correct, transitive deps present, gcc \$(ae cflags) builds"
 exit 0

--- a/tests/regression/test_fn_ptr_coercion.ae
+++ b/tests/regression/test_fn_ptr_coercion.ae
@@ -1,0 +1,95 @@
+// Regression: fn ↔ ptr coercion at call sites.
+//
+// Pre-fix (filed as aether/fn_ptr_coercion.md from the aether-ui CVG
+// port): the type-checker accepted a fn-typed value being passed into
+// a ptr slot AND a bare named function being passed into a fn-typed
+// slot, but C codegen emitted incompatible types and gcc rejected
+// the program. The workaround was to declare callback-carrying params
+// as `ptr` (loses captured-state closures through forwarding) and live
+// with the silent type-stripping.
+//
+// Post-fix (Option B1 from the filing): closure boxing is now wired
+// at the call site:
+//
+//   - fn → ptr  emits _aether_box_closure(...) (heap-alloc the
+//     _AeClosure struct, hand back its pointer)
+//   - bare-fn → fn  emits an _AeClosure struct literal with env=NULL
+//     (so the receiver gets a real closure value even when the
+//     source was a plain function reference)
+//   - ptr → fn  emits _aether_unbox_closure(...) (read back the
+//     boxed struct)
+//
+// This test exercises all three coercion directions plus the
+// previously-working bare-fn → ptr path, which must remain
+// backwards-compatible.
+
+import std.list
+
+// Forwarder: takes a callback through fn, stores it via the ptr
+// slot of list.add. Pre-fix this failed at gcc with
+// "expected void* but argument is of type _AeClosure".
+add_callback(l: ptr, cb: fn) {
+    _ = list.add(l, cb)
+}
+
+my_pred() -> int { return 42 }
+another_pred() -> int { return 99 }
+
+main() {
+    print("=== fn ↔ ptr coercion ===\n\n")
+
+    // ---- 1. Bare-fn → ptr (backwards-compat) ----
+    //
+    // This worked before the fix and must still work — the existing
+    // (void*)(intptr_t)(my_pred) coercion still fires for direct
+    // bare-fn → ptr arg passing. Used by every Aether call site that
+    // stores a function pointer in a list/map/struct ptr slot.
+
+    l1 = list.new()
+    _ = list.add(l1, my_pred)
+    if list.size(l1) != 1 {
+        println("  FAIL: bare-fn → ptr direct: size != 1")
+        exit(1)
+    }
+    print("  PASS: bare-fn → ptr direct (backwards-compat)\n")
+
+    // ---- 2. Bare-fn → fn param ----
+    //
+    // Pre-fix this errored with gcc "expected _AeClosure but
+    // argument is of type int (*)(void)". Post-fix the codegen emits
+    // a struct literal `(_AeClosure){ .fn=..., .env=NULL }`.
+
+    l2 = list.new()
+    add_callback(l2, my_pred)
+    if list.size(l2) != 1 {
+        println("  FAIL: bare-fn → fn-param forwarder: size != 1")
+        exit(1)
+    }
+    print("  PASS: bare-fn → fn-param forwarder\n")
+
+    // ---- 3. fn local → ptr arg (forwarder inside add_callback) ----
+    //
+    // The forwarder's body has `_ = list.add(l, cb)` where cb is
+    // declared `fn` (an _AeClosure value) and list.add wants `ptr`.
+    // Pre-fix this errored at gcc with "expected void* but
+    // argument is of type _AeClosure". Post-fix emits
+    // `_aether_box_closure(cb)`. Already exercised by step 2 (which
+    // can only succeed if BOTH the entry coercion AND the forwarder's
+    // internal fn → ptr coercion work).
+
+    // ---- 4. Multiple forwarder calls — distinct boxes ----
+    //
+    // Each call to add_callback heap-allocates a separate _AeClosure;
+    // adding two callbacks must give two distinct list entries.
+
+    l3 = list.new()
+    add_callback(l3, my_pred)
+    add_callback(l3, another_pred)
+    if list.size(l3) != 2 {
+        println("  FAIL: two distinct callback boxes: size != 2")
+        exit(1)
+    }
+    print("  PASS: two distinct callback boxes via forwarder\n")
+
+    print("\n=== All fn ↔ ptr coercion tests passed ===\n")
+}

--- a/tests/regression/test_fn_struct_field_assignment.ae
+++ b/tests/regression/test_fn_struct_field_assignment.ae
@@ -1,0 +1,99 @@
+// Regression: fn ↔ ptr coercion at struct-field assignment.
+//
+// Filed in aether/fn_ptr_coercion.md (follow-up): the fn_ptr_coercion
+// fix already in [current] wired Option B1 boxing at call-site
+// argument positions, but the SAME coercion shape was rejected at
+// struct-field assignment:
+//
+//   struct Holder { cb: ptr }
+//   set(h: *Holder, c: fn) {
+//       h.cb = c        // error[E0200]: Type mismatch in assignment
+//   }
+//
+// The CVG port hit this in `grammar_element.ae` for 17 callback fields
+// (onClick, bindFill, whenPredicate, etc.). Workaround was to declare
+// setter params as `ptr` everywhere, losing captured-state closures
+// through forwarding — the very thing the [current] fix unblocked
+// at call sites.
+//
+// Post-fix (this commit): the typechecker treats `fn` and `ptr` as
+// mutually compatible (via is_type_compatible), and codegen at the
+// AST_BINARY_EXPRESSION assign-emit boxes the RHS with
+// _aether_box_closure when LHS is ptr and RHS is fn-shaped (or a
+// bare named function). Mirror of the call-site coercion in
+// codegen_expr.c.
+
+import std.list
+
+extern malloc(n: long) -> ptr
+extern free(p: ptr)
+
+struct Holder {
+    cb: ptr
+}
+
+set_cb(h: *Holder, c: fn) {
+    h.cb = c
+}
+
+set_cb_bare(h: *Holder) {
+    h.cb = my_pred
+}
+
+my_pred() -> int { return 42 }
+
+main() {
+    print("=== fn → ptr at struct-field assignment ===\n\n")
+
+    // ---- 1. fn-typed param → ptr struct field ----
+    //
+    // The headline failure case. set_cb's `c: fn` argument gets
+    // assigned to `h.cb: ptr`. Pre-fix: E0200 at typecheck.
+    // Post-fix: typecheck accepts; codegen boxes the closure.
+
+    h = malloc(8) as *Holder
+    set_cb(h, my_pred)
+    if h.cb == null {
+        println("  FAIL: set_cb(my_pred): h.cb is null")
+        exit(1)
+    }
+    print("  PASS: fn-typed param → ptr struct field (boxed)\n")
+
+    // ---- 2. bare named function → ptr struct field direct ----
+    //
+    // h.cb = my_pred at a direct assignment site. Same shape as
+    // the call-site bare-fn → fn coercion: codegen emits a struct
+    // literal then boxes it.
+
+    h2 = malloc(8) as *Holder
+    set_cb_bare(h2)
+    if h2.cb == null {
+        println("  FAIL: set_cb_bare: h2.cb is null")
+        exit(1)
+    }
+    print("  PASS: bare-fn → ptr struct field direct (boxed literal)\n")
+
+    // ---- 3. multiple boxed closures are distinct ----
+    //
+    // Each assignment heap-allocates a fresh _AeClosure box; two
+    // holders pointing at the same Aether function must have
+    // different .cb pointers (sanity check that we're actually
+    // boxing, not just stashing one shared address).
+
+    h3a = malloc(8) as *Holder
+    h3b = malloc(8) as *Holder
+    set_cb(h3a, my_pred)
+    set_cb(h3b, my_pred)
+    if h3a.cb == h3b.cb {
+        println("  FAIL: two assignments produced the same box")
+        exit(1)
+    }
+    print("  PASS: distinct allocations per assignment\n")
+
+    free(h)
+    free(h2)
+    free(h3a)
+    free(h3b)
+
+    print("\n=== All struct-field fn-coercion tests passed ===\n")
+}

--- a/tests/regression/test_string_from_int_radix_and_pad.ae
+++ b/tests/regression/test_string_from_int_radix_and_pad.ae
@@ -1,0 +1,150 @@
+// Regression: std.string.from_int_radix (inverse of v0.193's
+// to_int_radix) + string.pad_start / string.pad_end.
+//
+// Headline use case: hex color emit for the CVG port's lerp_color
+// — JS-side `r.toString(16).padStart(2, '0')` round-trip into a
+// `#rrggbb` string. Both functions together so the round-trip works
+// for any color channel value 0..255 (and any other JS-style
+// padStart-of-radix-N use beyond CVG).
+
+import std.string
+
+extern exit(code: int)
+
+eq(a: string, b: string) -> int {
+    return string.equals(a, b)
+}
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    println("=== std.string.from_int_radix + pad_start/end ===")
+
+    // ---- from_int_radix: basic hex emit -----------------------
+
+    if eq(string.from_int_radix(255, 16), "ff") != 1 {
+        fail("hex 255: got '${string.from_int_radix(255, 16)}'")
+    }
+    if eq(string.from_int_radix(0, 16), "0") != 1 { fail("hex 0") }
+    if eq(string.from_int_radix(16, 16), "10") != 1 { fail("hex 16") }
+    if eq(string.from_int_radix(160, 16), "a0") != 1 {
+        fail("hex 160: got '${string.from_int_radix(160, 16)}'")
+    }
+    if eq(string.from_int_radix(3735928559, 16), "deadbeef") != 1 {
+        fail("hex DEADBEEF: got '${string.from_int_radix(3735928559, 16)}'")
+    }
+    println("  PASS: hex 0 / 16 / a0 / ff / deadbeef")
+
+    // ---- from_int_radix: binary / octal / decimal -------------
+
+    if eq(string.from_int_radix(11, 2), "1011") != 1 { fail("binary 11") }
+    if eq(string.from_int_radix(255, 2), "11111111") != 1 { fail("binary 255") }
+    if eq(string.from_int_radix(493, 8), "755") != 1 { fail("octal 493") }
+    if eq(string.from_int_radix(42, 10), "42") != 1 { fail("decimal 42") }
+    println("  PASS: binary 11/255, octal 493, decimal 42")
+
+    // ---- from_int_radix: radix 36 (max strtoll range) ---------
+
+    if eq(string.from_int_radix(35, 36), "z") != 1 { fail("radix-36 35") }
+    if eq(string.from_int_radix(1295, 36), "zz") != 1 { fail("radix-36 1295") }
+    println("  PASS: radix 36 (35→'z', 1295→'zz')")
+
+    // ---- from_int_radix: negatives ---------------------------
+
+    if eq(string.from_int_radix(0 - 255, 16), "-ff") != 1 {
+        fail("hex -255: got '${string.from_int_radix(0 - 255, 16)}'")
+    }
+    if eq(string.from_int_radix(0 - 1, 10), "-1") != 1 { fail("decimal -1") }
+    println("  PASS: negative hex / decimal")
+
+    // ---- from_int_radix: 64-bit width survives ---------------
+    //
+    // Same LLP64-safety concern as to_int_radix: a 2^32 value
+    // pretends to be a long (int64) end-to-end. C `long` Windows
+    // truncation would surface here as a wrong digit count.
+
+    if eq(string.from_int_radix(4294967296, 16), "100000000") != 1 {
+        fail("hex 2^32: got '${string.from_int_radix(4294967296, 16)}'")
+    }
+    if eq(string.from_int_radix(1099511627776, 16), "10000000000") != 1 {
+        fail("hex 2^40: got '${string.from_int_radix(1099511627776, 16)}'")
+    }
+    println("  PASS: 64-bit hex (2^32, 2^40)")
+
+    // ---- from_int_radix: invalid radix -----------------------
+
+    if eq(string.from_int_radix(123, 1), "") != 1 { fail("radix 1 → empty") }
+    if eq(string.from_int_radix(123, 37), "") != 1 { fail("radix 37 → empty") }
+    if eq(string.from_int_radix(123, 0), "") != 1 { fail("radix 0 → empty") }
+    println("  PASS: radix 1/37/0 → empty string")
+
+    // ---- pad_start: zero-pad short ---------------------------
+
+    if eq(string.pad_start("5", 2, 48), "05") != 1 {
+        fail("pad '5' to 2 with '0': got '${string.pad_start(\"5\", 2, 48)}'")
+    }
+    if eq(string.pad_start("", 3, 48), "000") != 1 {
+        fail("pad '' to 3 with '0'")
+    }
+    if eq(string.pad_start("ff", 4, 48), "00ff") != 1 {
+        fail("pad 'ff' to 4 with '0'")
+    }
+    println("  PASS: pad_start zero-pad")
+
+    // ---- pad_start: already-long → unchanged ----------------
+
+    if eq(string.pad_start("hello", 2, 32), "hello") != 1 {
+        fail("'hello' wider than 2: must not truncate")
+    }
+    if eq(string.pad_start("ff", 2, 48), "ff") != 1 {
+        fail("'ff' equal to 2: must not pad")
+    }
+    println("  PASS: pad_start no truncation, no extra padding when long enough")
+
+    // ---- pad_start: total_width <= 0 -------------------------
+
+    if eq(string.pad_start("x", 0, 48), "x") != 1 { fail("pad_start total=0") }
+    if eq(string.pad_start("x", 0 - 5, 48), "x") != 1 { fail("pad_start total<0") }
+    println("  PASS: pad_start total_width <= 0 returns s unchanged")
+
+    // ---- pad_end: space-pad / zero-pad ----------------------
+
+    if eq(string.pad_end("hi", 5, 32), "hi   ") != 1 {
+        fail("pad_end 'hi' to 5 with space: got '${string.pad_end(\"hi\", 5, 32)}'")
+    }
+    if eq(string.pad_end("5", 3, 48), "500") != 1 {
+        fail("pad_end '5' to 3 with '0'")
+    }
+    println("  PASS: pad_end")
+
+    // ---- The headline: hex byte emit (CVG lerp_color shape) --
+    //
+    // The JS `r.toString(16).padStart(2, '0')` round-trip. 5
+    // becomes "05"; 255 stays "ff"; 16 becomes "10".
+
+    rh = string.pad_start(string.from_int_radix(5, 16), 2, 48)
+    if eq(rh, "05") != 1 { fail("CVG hex byte 5: got '${rh}'") }
+
+    rh = string.pad_start(string.from_int_radix(255, 16), 2, 48)
+    if eq(rh, "ff") != 1 { fail("CVG hex byte 255: got '${rh}'") }
+
+    rh = string.pad_start(string.from_int_radix(16, 16), 2, 48)
+    if eq(rh, "10") != 1 { fail("CVG hex byte 16: got '${rh}'") }
+
+    rh = string.pad_start(string.from_int_radix(0, 16), 2, 48)
+    if eq(rh, "00") != 1 { fail("CVG hex byte 0: got '${rh}'") }
+    println("  PASS: CVG hex-byte round-trip (5→'05', 255→'ff', 16→'10', 0→'00')")
+
+    // ---- to_int_radix / from_int_radix round-trip -----------
+
+    s = string.from_int_radix(0xDEAD, 16)
+    v, err = string.to_int_radix(s, 16)
+    if eq(err, "") != 1 { fail("round-trip to_int_radix err=${err}") }
+    if v != 0xDEAD { fail("round-trip got ${v}") }
+    println("  PASS: from_int_radix → to_int_radix round-trip")
+
+    println("\n=== All from_int_radix + pad tests passed ===")
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -6316,6 +6316,33 @@ static int cmd_cflags(int argc, char** argv) {
         if (wrote_anything) fputc(' ', stdout);
         fputs("-pthread -lm", stdout);
         wrote_anything = 1;
+
+        // Transitive deps. libaether.a was compiled with whatever optional
+        // libraries pkg-config detected at Aether-build time (PCRE2 for
+        // std.regex; OpenSSL for std.cryptography and std.http TLS; zlib
+        // for std.zlib and HTTP gzip; nghttp2 for h2). Downstream binaries
+        // that use those modules need the SAME libs on their link line, or
+        // they get `undefined reference to pcre2_*` and similar at link
+        // time. `ae build` (cmd_build, ae.c:~1877) already appends these
+        // strings; `ae cflags` did not — the docs promise "use $(ae cflags)
+        // in your gcc line" but that promise was broken for any binary
+        // touching the four optional modules above. Now matched.
+        //
+        // Empty-string guard: pkg-config-failed builds set the macro to
+        // ""; we skip the empty case so downstream doesn't see stray
+        // whitespace.
+#ifdef AETHER_OPENSSL_LIBS
+        if (AETHER_OPENSSL_LIBS[0]) { fputc(' ', stdout); fputs(AETHER_OPENSSL_LIBS, stdout); }
+#endif
+#ifdef AETHER_ZLIB_LIBS
+        if (AETHER_ZLIB_LIBS[0])    { fputc(' ', stdout); fputs(AETHER_ZLIB_LIBS, stdout); }
+#endif
+#ifdef AETHER_NGHTTP2_LIBS
+        if (AETHER_NGHTTP2_LIBS[0]) { fputc(' ', stdout); fputs(AETHER_NGHTTP2_LIBS, stdout); }
+#endif
+#ifdef AETHER_PCRE2_LIBS
+        if (AETHER_PCRE2_LIBS[0])   { fputc(' ', stdout); fputs(AETHER_PCRE2_LIBS, stdout); }
+#endif
     }
 
     if (wrote_anything) fputc('\n', stdout);


### PR DESCRIPTION
## Description

Round-3 batch of fixes surfaced by the aether-ui CVG (SVG → renderer)
→ Aether port. Bundled into one squashed commit on `cvg_work` to
conserve GH-Action minutes.

## Type of Change

- [x] Bug fix (3 separate bugs — `ae cflags`, fn↔ptr call-site,
      fn↔ptr struct-field)
- [x] New feature (`string.from_int_radix`, `string.pad_start`,
      `string.pad_end`)

## What's in this PR

1. **fix(tools/ae): emit transitive lib flags from `ae cflags --libs`** —
   `cmd_cflags` now appends \`AETHER_{OPENSSL,ZLIB,NGHTTP2,PCRE2}_LIBS\`
   (the same strings `cmd_build` uses), so \`gcc app.c \$(ae cflags)\`
   actually links binaries that import \`std.regex\` /
   \`std.cryptography\` / \`std.http\` TLS / \`std.zlib\`. Empty-string
   guard preserves the no-pkg-config case.

2. **feat(std.string): from_int_radix + pad_start / pad_end** —
   inverse of v0.193's \`to_int_radix\`, plus the canonical
   pad-to-fixed-width helpers. Headline use case: the JS
   \`r.toString(16).padStart(2, '0')\` shape for hex byte emit in
   color round-trips, which unblocks CVG's \`lerp_color\` animation
   primitive. \`long long\` parameter for LLP64 safety (same lesson
   as PR #562's \`string_to_long_raw\`).

3. **fix(codegen): box closures at fn↔ptr coercion sites (Option B1)** —
   type-checker accepted three coercion shapes that codegen
   mis-emitted (bare-fn → \`fn\` param, \`fn\` local → \`ptr\` param,
   \`ptr\` → \`fn\` param). Wire \`_aether_box_closure\` /
   \`_aether_unbox_closure\` at the AST_FUNCTION_CALL arg-emit. The
   is_fnptr=1 case (raw C fn pointer from \`expr as fn(...)\` casts)
   is gated out so the existing qsort-style path still works.

4. **fix(codegen,typecheck): fn↔ptr coercion at struct-field assignment** —
   follow-up to (3). The CVG port hit this for 17 callback fields in
   \`grammar_element.ae\` (\`onClick\`, \`bindFill\`, \`whenPredicate\`,
   etc.). Two-side fix: typechecker adds \`fn↔ptr\` to
   \`is_type_compatible\`; codegen wraps RHS with \`_aether_box_closure\`
   at AST_BINARY_EXPRESSION (op=\"=\") when LHS is ptr-typed and RHS is
   fn-shaped or a bare named function.

Combined, the boxing/unboxing surface is now uniform across **call-
site arg positions**, **struct-field assignments**, and the
pre-existing **\`as fn\` casts**.

### Known follow-up (filed but not in this PR)

\`aether/fn_return_float_cast.md\` — the trampoline that invokes a
\`fn\`-typed parameter's \`_AeClosure.fn\` assumes a \`(env, args)\` ABI
shape, but bare named functions wrapped as closures don't have the
env arg in their actual signature. -O0 accidentally works (unused
rdi slot ignored); -O2 picks up on the mismatch and the result is
silently zero. Real fix needs a generated per-signature adapter or a
runtime trampoline-with-cif primitive (libffi-style) — bigger than
this round.

## Testing

- [x] Added tests for new functionality
  - \`tests/integration/ae_cflags/test_ae_cflags.sh\` (extended)
  - \`tests/regression/test_string_from_int_radix_and_pad.ae\` (new)
  - \`tests/regression/test_fn_ptr_coercion.ae\` (new)
  - \`tests/regression/test_fn_struct_field_assignment.ae\` (new)
- [x] All tests pass (\`make test\`) — **226/226 C unit tests**
- [x] \`make ci\`: 552/555 \`.ae\` tests pass; the 3 failures are the
      flaky HTTP2-framing / proxy-pool-bind tests from prior PRs,
      unrelated to this change.
- [x] \`HARDEN=1 make ci\` (required for any C change in compiler /
      runtime / std — which we did): 553/555; 2 of the same HTTP
      flakes.
- [ ] Windows CI must pass (LLP64 invariant matters for the
      \`long long\`-typed \`from_int_radix\`; the codegen changes are
      ABI-symmetric)

## Performance Impact

- [x] No performance impact (the new boxing path only fires at
      fn↔ptr coercion sites where the previous behaviour was a hard
      C compile error; no existing call paths regress)

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (each new branch carries a
      paragraph explaining the coercion shape it handles and the
      pre-fix failure mode)
- [x] Documentation updated (\`CHANGELOG.md\` \`[current]\` block;
      \`docs/stdlib-reference.md\` rows for from_int_radix /
      pad_start / pad_end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)