### PR TITLE
fix(codegen): closure-call return-type cast (non-int returns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Closure-call trampoline emitted `int`-return cast for any return
+  type → segfault on string-returning closures, GCC warning on
+  ptr/struct returns** — `compiler/codegen/codegen_expr.c`,
+  `tests/regression/test_fn_closure_call_return_types.ae`. Reported
+  in `aether/fn_return_float_cast.md` from the AeVG (CVG → Aether)
+  port (initially float-only, widened 2026-05-30 to "any non-int
+  return"). The trampoline that invokes a `fn`-typed parameter's
+  `_AeClosure.fn` defaulted the cast's return-type slot to `int`
+  when the call's `node_type` was UNKNOWN — which it always is for
+  a bare-`fn` parameter (no signature info to read). String-typed
+  closures **segfaulted** (int reinterpreted as `AetherString*` →
+  heap-tracker dereferenced a non-heap value); ptr/struct returns
+  worked by ABI luck on x86-64 SysV (both int and void* live in
+  rax) but GCC warned and Windows LLP64 would truncate.
+
+  Fix: extend the return-type fallback chain. The cast's return
+  type now resolves in order: (1) the call's `node_type` if known;
+  (2) the closure_arg's declared `return_type` (typed
+  `fn(args) -> ret` signature); (3) the **enclosing function's**
+  declared return type — handles the bare-`fn` shape
+  `f(cb: fn) -> R { return cb(...) }` that has no signature to
+  read. Argument types also resolve from the closure_arg's
+  declared `param_types[]` when available. Default-to-`int` only
+  fires when none resolve. The same fix surface that landed for
+  string/ptr returns also tightens int return cases by surfacing
+  the right type at the C boundary.
+
+  **Known follow-up (NOT in this PR):** float-returning bare-fn
+  calls remain broken under -O2. When a bare named function is
+  wrapped at the coercion site as `(_AeClosure){.fn=name,
+  .env=NULL}`, the wrapped fn's REAL C signature is `R(args)` (no
+  env), but the trampoline calls it as `R(void*, args)` — incompat-
+  ible-pointer-conversion UB that -O2 folds to undefined (typically
+  zero for non-int values via floating-point return registers). Real
+  fix needs a per-bare-fn adapter wrapper at the wrap site (a
+  codegen-emitted `_aether_bare_adapter_N(void* env, args) -> R`
+  that ignores env and forwards). Tracked separately; the
+  string-segfault and GCC-warning shapes are closed by this PR.
+
 ## [0.194.0]
 
 ### Added

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2680,25 +2680,88 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         }
                         fprintf(gen->output, ")");
                     } else {
-                        // Fallback: generic closure invocation via function pointer cast
-                        // Determine return type — if call() result is used, assume int
-                        const char* ret = (expr->node_type &&
-                            expr->node_type->kind != TYPE_VOID &&
-                            expr->node_type->kind != TYPE_UNKNOWN) ?
-                            get_c_type(expr->node_type) : "int";
+                        /* Fallback: generic closure invocation via
+                         * function-pointer cast.  Determine the
+                         * cast's return type from (in order):
+                         *
+                         *   1. the call expression's node_type (the
+                         *      typechecker fills this in when the
+                         *      `fn`-typed variable has a known
+                         *      return-type signature).
+                         *   2. the closure_arg's declared
+                         *      `return_type` (when `cb` has a typed
+                         *      `fn(args) -> ret` signature).
+                         *   3. the **enclosing function's** declared
+                         *      return type — handles the bare-`fn`
+                         *      shape `f(cb: fn) -> R { return cb(...) }`
+                         *      that has no signature info to read.
+                         *
+                         * Pre-fix: when all three were UNKNOWN the
+                         * cast defaulted to `int`.  For non-int
+                         * returns this was a silent miscompile —
+                         * float, string, ptr all wrong:
+                         *   - float: int return slot reads rax instead
+                         *     of xmm0 (x86-64 SysV) → silent zero.
+                         *   - string: int reinterpreted as
+                         *     AetherString* → segfault when the
+                         *     heap-tracker dereferences it.
+                         *   - ptr: UB but happens to survive on
+                         *     x86-64 SysV (int and ptr both in rax);
+                         *     gcc warns "returning 'int' from a
+                         *     function with return type 'const
+                         *     char *'", and on Windows LLP64 the
+                         *     upper 32 bits truncate.
+                         * Filed in aether/fn_return_float_cast.md
+                         * (widened to "any non-int return") from
+                         * the AeVG (CVG → Aether) port.
+                         *
+                         * The arg-type slots get the same
+                         * closure_arg-declared-signature path when
+                         * available, falling back to the supplied
+                         * arg's `node_type`. */
+                        Type* closure_sig = (closure_arg && closure_arg->node_type &&
+                                             closure_arg->node_type->kind == TYPE_FUNCTION)
+                                            ? closure_arg->node_type : NULL;
+                        Type* ret_t = NULL;
+                        if (expr->node_type && expr->node_type->kind != TYPE_VOID &&
+                            expr->node_type->kind != TYPE_UNKNOWN) {
+                            ret_t = expr->node_type;
+                        } else if (closure_sig && closure_sig->return_type &&
+                                   closure_sig->return_type->kind != TYPE_UNKNOWN) {
+                            ret_t = closure_sig->return_type;
+                        } else if (gen->current_func_return_type &&
+                                   gen->current_func_return_type->kind != TYPE_VOID &&
+                                   gen->current_func_return_type->kind != TYPE_UNKNOWN) {
+                            /* Last resort: the call is a `return
+                             * cb(...)` statement inside a typed
+                             * fn, and the enclosing fn's return
+                             * type dictates the cast's return slot.
+                             * Imperfect if the call result is
+                             * discarded or used in a non-return
+                             * position, but those cases already
+                             * have `expr->node_type` set correctly. */
+                            ret_t = gen->current_func_return_type;
+                        }
+                        const char* ret = ret_t ? get_c_type(ret_t) : "int";
                         fprintf(gen->output, "((%s(*)(void*", ret);
+                        int sig_pi = 0;
                         for (int i = 1; i < expr->child_count; i++) {
                             ASTNode* arg = expr->children[i];
                             if (arg && arg->type == AST_CLOSURE &&
                                 arg->value && strcmp(arg->value, "trailing") == 0) continue;
-                            // Infer arg type
                             const char* atype = "int";
-                            if (arg && arg->node_type) {
+                            if (closure_sig && sig_pi < closure_sig->param_count &&
+                                closure_sig->param_types &&
+                                closure_sig->param_types[sig_pi] &&
+                                closure_sig->param_types[sig_pi]->kind != TYPE_UNKNOWN) {
+                                atype = get_c_type(closure_sig->param_types[sig_pi]);
+                            } else if (arg && arg->node_type) {
                                 atype = get_c_type(arg->node_type);
                             } else if (arg && arg->type == AST_CLOSURE) {
                                 atype = "_AeClosure";
                             }
                             fprintf(gen->output, ", %s", atype);
+                            sig_pi++;
                         }
                         fprintf(gen->output, "))");
                         generate_expression(gen, closure_arg);

--- a/tests/regression/test_fn_closure_call_return_types.ae
+++ b/tests/regression/test_fn_closure_call_return_types.ae
@@ -1,0 +1,112 @@
+// Regression: closure-call trampoline emits a return-type-correct
+// cast for non-int returns.
+//
+// Filed in aether/fn_return_float_cast.md (widened 2026-05-30 from
+// float-only to "any non-int return"). The trampoline historically
+// emitted `((int(*)(void*, args))cb.fn)` regardless of the actual
+// return type. The bug had two layers:
+//
+// LAYER 1 (this commit fixes): the cast's return-type slot was
+// hard-coded to `int` when the call expression's `node_type` was
+// UNKNOWN. For a bare-`fn` parameter (no signature in the type
+// system), the typechecker leaves the call's node_type unknown, so
+// the cast defaulted to `int`. Non-int return values were
+// reinterpreted:
+//   - string: int reinterpreted as AetherString* — segfault when
+//     the heap-tracker dereferences it.
+//   - ptr: UB but survives on x86-64 SysV by ABI luck (both int and
+//     void* live in rax); GCC warns "returning 'int' from a
+//     function with return type 'const char *'".
+//   - float: the closure-adapter path returns via the integer return
+//     register (rax) but a float-returning bare fn writes to xmm0 —
+//     silent zero. (See LAYER 2 below for why float still fails
+//     after this fix.)
+//
+// Fix: extend the return-type fallback chain to consult, in order:
+//   1. the call's `node_type` (the typechecker fills this when the
+//      `fn`-typed variable has a known return-type signature);
+//   2. the closure_arg's declared `return_type` (typed
+//      `fn(args) -> ret`);
+//   3. the **enclosing function's** declared return type — handles
+//      the bare-`fn` shape `f(cb: fn) -> R { return cb(...) }` that
+//      has no signature info to read.
+// Argument types also resolve from the closure_arg's declared
+// `param_types[]` when available. Default-to-`int` only fires when
+// none of the above resolve.
+//
+// LAYER 2 (NOT yet fixed; tracked as a follow-up to this PR): when
+// a bare named function is wrapped in `(_AeClosure){.fn=name,
+// .env=NULL}`, the wrapped function's REAL C signature is `R(args)`
+// (no env), but the trampoline calls it as `R(void*, args)` — a
+// cast that's incompatible with the declared function type. Under
+// -O2 gcc sees both declarations (same TU), detects the
+// incompatible-pointer-conversion UB, and folds the call result to
+// undefined. For non-int returns going through float / pointer
+// registers on x86-64 SysV, that surfaces as a silent zero / wrong
+// value. Fixing it cleanly needs a per-bare-fn adapter wrapper at
+// the wrap site (the codegen generates a `_aether_bare_adapter_N`
+// of signature `(void* env, args) -> R` that ignores env and
+// forwards to the bare fn). Out of scope for this commit — the
+// fix here closes the more common shapes (closures with captured
+// state, string/ptr returns).
+//
+// This test exercises the string and ptr return-type cases that
+// LAYER 1 fixes. Float-returning bare-fn calls remain known-broken
+// under -O2 and are NOT covered here.
+
+import std.string
+
+extern exit(code: int)
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+
+// String-returning closure.
+my_greeting() -> string { return "hello" }
+
+call_string(cb: fn) -> string {
+    return cb()
+}
+
+// Ptr-returning closure.
+my_buf() -> ptr { return malloc(16) }
+
+call_ptr(cb: fn) -> ptr {
+    return cb()
+}
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    print("=== closure-call return types (string, ptr) ===\n\n")
+
+    // ---- string ----
+    //
+    // Pre-fix: int reinterpreted as AetherString* → segfault on
+    // string-cleanup dereference. Post-fix: cast resolves through
+    // the enclosing fn's return type (`-> string`), the trampoline
+    // returns AetherString* through the pointer return register,
+    // the caller assigns into a string-typed local cleanly.
+
+    s = call_string(my_greeting)
+    if string.equals(s, "hello") != 1 {
+        fail("my_greeting() → '${s}', want 'hello'")
+    }
+    print("  PASS: string (no segfault, value correct)\n")
+
+    // ---- ptr ----
+    //
+    // Pre-fix: int return slot reads the ptr register on x86-64
+    // SysV (both in rax), so the value survives — but GCC warns,
+    // and on Windows LLP64 the upper 32 bits would truncate.
+    // Post-fix: cast says ptr, no warning, no truncation hazard.
+
+    p = call_ptr(my_buf)
+    if p == null { fail("my_buf() returned null") }
+    free(p)
+    print("  PASS: ptr (non-null, freeable)\n")
+
+    print("\n=== closure-call return-type tests passed ===\n")
+}


### PR DESCRIPTION
## Description

Reported in \`aether/fn_return_float_cast.md\` from the AeVG (CVG →
Aether) port (initially float-only, **widened 2026-05-30** to "any
non-int return"). The closure-invocation trampoline that calls a
\`fn\`-typed parameter's \`_AeClosure.fn\` historically emitted
\`((int(*)(void*, args))cb.fn)\` regardless of the actual return type.

For non-int return types this was a silent or noisy miscompile:

- **string**: SEGFAULT — the int return slot was reinterpreted as
  \`AetherString*\`; the string-cleanup machinery dereferenced what
  was actually an integer and crashed.
- **ptr / *Struct**: GCC warned "returning 'int' from a function
  with return type 'const char *'"; value survived on x86-64 SysV
  by ABI luck (int and void* both live in rax) but Windows LLP64
  would truncate the upper 32 bits.
- **float**: returned through the integer register (rax) instead
  of the floating-point register (xmm0) → silent zero. (See "Known
  follow-up" below for why float remains broken under -O2 after
  this fix.)

## Type of Change

- [x] Bug fix

## Fix

Extend the return-type fallback chain in the closure-call fallback
emit site (\`compiler/codegen/codegen_expr.c\`, the generic
\`call(closure_var, args)\` dispatch path). The cast's return type
now resolves in order:

1. The call expression's \`node_type\` if known (typechecker fills
   this when the \`fn\`-typed variable has a known return-type
   signature).
2. The closure_arg's declared \`return_type\` (typed \`fn(args) -> ret\`).
3. The **enclosing function's** declared return type — handles the
   bare-\`fn\` shape \`f(cb: fn) -> R { return cb(...) }\` that has no
   signature info in the type system.

Argument types also resolve from the closure_arg's declared
\`param_types[]\` when available, falling back to the supplied arg's
\`node_type\`. Default-to-\`int\` only fires when none of the above
resolve — a strictly narrower set than before.

## Known follow-up (NOT in this PR)

Float-returning **bare-fn calls** remain broken under -O2. When a
bare named function is wrapped at the coercion site as
\`(_AeClosure){.fn=name, .env=NULL}\`, the wrapped fn's REAL C
signature is \`R(args)\` (no env), but the trampoline calls it as
\`R(void*, args)\` — incompatible-pointer-conversion UB that -O2
folds to undefined (typically zero for non-int values through
floating-point return registers).

Real fix needs a per-bare-fn adapter wrapper at the wrap site (a
codegen-emitted \`_aether_bare_adapter_N(void* env, args) -> R\` that
ignores env and forwards). Tracked separately. The string-segfault
and GCC-warning shapes are closed by this PR.

## Testing

- [x] Added \`tests/regression/test_fn_closure_call_return_types.ae\`
      (string + ptr cases under \`ae build\` -O2; the pre-fix builds
      segfaulted on the string case)
- [x] \`make ci\`: 226/226 C unit tests pass; 554/556 \`.ae\` tests
      pass; 2 failures are the flaky HTTP2-framing / proxy-pool-
      bind tests from prior PRs, unrelated.
- [x] \`HARDEN=1 make ci\`: same counts (226/226 + 554/556)
- [x] Existing closure tests (\`test_closure_calculator_shape\`,
      \`test_closure_var_reassignment\`, etc.) still pass — the fix
      only expands the return-type resolution chain, doesn't change
      the trampoline shape or arg-passing.

## Performance Impact

- [x] No performance impact (the fallback chain is consulted at
      compile time; codegen emits the same shape with a corrected
      cast).

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (the new fallback chain has
      an inline paragraph explaining each level and the pre-fix
      failure mode)
- [x] Documentation updated (\`CHANGELOG.md\` \`[current]\` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)