### PR TITLE
feat: AeVG round-4 — three CVG-port asks (builder/with, qualified struct lit, bare-fn adapter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`builder name(...) with <factory>` did not module-resolve the
+  factory across an import boundary** —
+  `compiler/aether_module.c`,
+  `tests/integration/builder_with_factory_cross_module/`. The
+  builder lowering emits `_bcfg = <factory>()` at every call site,
+  but the import resolver renamed the builder's name to
+  `<ns>_<builder>` and left the `with`-factory annotation as the
+  bare unprefixed name. Consumer translation units then emitted
+  `_bcfg = mkfac()` (unresolved bare symbol) and gcc/ld failed
+  with "undefined reference to mkfac" even though `mkfac` was
+  exported from the builder's module. Filed in
+  `aether/new_aevg_asks.md` ASK 1 as the **blocker** for the AeVG
+  surface DSL (`window` / `render_to` / `record` live in the
+  `aether_ui` library and are called from example/transpiler-
+  output files).
+
+  Fix in two layers:
+  1. `rename_intra_module_refs` now rewrites the
+     `AST_BUILDER_FUNCTION` annotation alongside the body's
+     `AST_FUNCTION_CALL` / `AST_IDENTIFIER` values, so the cloned
+     builder carries `annotation = <ns>_<factory>`.
+  2. `collect_intra_module_callees` + `prune_collect_calls` now
+     treat the builder's annotation as a real call-dependency, so
+     the factory's body gets pulled into the program AST and
+     survives the mark-and-sweep dead-code prune. Without this,
+     the factory's symbol stayed declared but undefined.
+
+- **Closure-call trampoline arg-slot shift miscompiled bare
+  named functions wrapped in `_AeClosure`** —
+  `compiler/codegen/codegen.{c,h}`, `compiler/codegen/codegen_func.c`,
+  `compiler/codegen/codegen_internal.h`,
+  `compiler/codegen/codegen_expr.c`,
+  `tests/regression/test_fn_bare_adapter.ae`. Reported in
+  `aether/new_aevg_asks.md` ASK 3 (and the LAYER 2 follow-up
+  in `fn_return_float_cast.md`).
+
+  Pre-fix: at every coercion site where a bare named function got
+  wrapped as `(_AeClosure){.fn=name, .env=NULL}`, the wrapped
+  fn's REAL C signature was `R(args)` but the closure-invocation
+  trampoline called `.fn` as `R(void* env, args)` — incompatible-
+  pointer-conversion UB that shifted every argument by one
+  register/stack slot:
+    - `call(my_fn, 3, 7)` (where `my_fn(w, h) -> int`) returned
+      `3` — NULL shifted into `w`, `3` into `h`, `7` dropped.
+    - `call_it(my_double, 3.0) -> float` returned `0` (xmm0 holds
+      the real arg but the env shift puts NULL in front).
+    - string returns segfaulted; ptr returns read garbage.
+
+  Fix: codegen synthesises a per-bare-fn env-ignoring adapter
+  `_aether_bare_adapter_<name>(void* env, args) -> R` at file
+  scope. The wrap site stuffs the **adapter's** address into `.fn`
+  (not the bare fn's). The trampoline calls `adapter(env, args)`;
+  the adapter ignores `env` and forwards `args` to the real fn —
+  ABI shapes match on both sides. Adapters are registered via a
+  pre-walk that mirrors the lazy coercion-site registration and
+  emitted alongside closure definitions before main, so calls
+  through them work regardless of where in the program the wrap
+  site appears. Adapter forward decls and bodies live together
+  in the same emission block — no chicken-and-egg ordering. Closes
+  the LAYER 2 follow-up to PR #574 (the bare-fn arg/return-slot
+  hazard that PR documented but couldn't close without per-
+  signature adapter generation).
+
+### Added
+
+- **Qualified struct-literal syntax: `module.Type { field: value, ... }`** —
+  `compiler/parser/parser.c`,
+  `tests/integration/qualified_struct_literal/`. Pre-fix the parser
+  only accepted the bare-name `Type{...}` form, so a struct
+  imported with `import shapes` (vs `import shapes (Circle)`) had
+  no way to be literal-constructed cross-module without the
+  selective-import companion line. Filed in
+  `aether/new_aevg_asks.md` ASK 2 from the AeVG port.
+
+  Fix: parser detects the `IDENT . IDENT { IDENT :` (or
+  `IDENT . IDENT { }`) lookahead pattern at the primary-expression
+  dispatch and lowers it the same way as the bare-name form, just
+  with the module prefix dropped from the type name. Module struct
+  definitions land in the program AST by their bare struct name
+  (matches how the import resolver clones them), so the lowered
+  literal references the same C type either way.
+
 ## [0.195.0]
 
 ### Fixed

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -1340,6 +1340,28 @@ static void rename_intra_module_refs(ASTNode* node, const char* prefix,
         }
     }
 
+    /* `builder name(...) with <factory>` carries the factory name in
+     * the AST_BUILDER_FUNCTION node's `annotation` field (see
+     * parser.c:3626 and codegen_func.c:get_builder_factory which
+     * reads it back). When the builder is cloned across an import
+     * boundary, the factory needs the same intra-module rename — the
+     * codegen later emits `_bcfg = <annotation>()` verbatim, so
+     * without this the consumer TU emits a bare `mkfac()` and gets
+     * "undefined reference to mkfac" at link time even though the
+     * builder itself was renamed to `<ns>_<builder>` correctly.
+     * Filed in aether/new_aevg_asks.md ASK 1 from the AeVG port. */
+    if (node->type == AST_BUILDER_FUNCTION && node->annotation) {
+        for (int i = 0; i < func_count; i++) {
+            if (strcmp(node->annotation, func_names[i]) == 0) {
+                char prefixed[256];
+                snprintf(prefixed, sizeof(prefixed), "%s_%s", prefix, node->annotation);
+                free(node->annotation);
+                node->annotation = strdup(prefixed);
+                break;
+            }
+        }
+    }
+
     if (node->type == AST_IDENTIFIER && node->value) {
         // Only rename if this identifier matches a module constant AND is not
         // shadowed by a local variable or parameter in the enclosing function
@@ -1528,6 +1550,30 @@ static void collect_intra_module_callees(ASTNode* node, const char* ns,
         size_t ns_len = strlen(ns);
         if (strncmp(node->value, ns, ns_len) == 0 && node->value[ns_len] == '_') {
             const char* bare = node->value + ns_len + 1;
+            for (int i = 0; i < mod_func_count; i++) {
+                if (strcmp(bare, mod_func_names[i]) == 0) {
+                    if (!name_in_list(bare, out, *out_count) && *out_count < max) {
+                        out[(*out_count)++] = mod_func_names[i];
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    /* `builder name(...) with <factory>` carries the factory function
+     * name in the builder's `annotation` field. After
+     * rename_intra_module_refs has run, it's the already-prefixed
+     * `<ns>_<factory>` form. Treat it as a callee dependency of the
+     * builder so the transitive-pull-in loop above clones the
+     * factory's body into the consumer TU. Without this, a
+     * selectively-imported `builder win(...) with mkfac` from module
+     * `smod` resolves `smod_win` correctly but leaves `smod_mkfac`
+     * unresolved — bare `mkfac()` in the emitted C with no
+     * declaration. Filed in aether/new_aevg_asks.md ASK 1. */
+    if (node->type == AST_BUILDER_FUNCTION && node->annotation) {
+        size_t ns_len = strlen(ns);
+        if (strncmp(node->annotation, ns, ns_len) == 0 && node->annotation[ns_len] == '_') {
+            const char* bare = node->annotation + ns_len + 1;
             for (int i = 0; i < mod_func_count; i++) {
                 if (strcmp(bare, mod_func_names[i]) == 0) {
                     if (!name_in_list(bare, out, *out_count) && *out_count < max) {
@@ -2185,6 +2231,19 @@ static void prune_collect_calls(ASTNode* node, NameSet* seen, NameSet* worklist)
                  node->children[0]->value, node->value);
         if (nameset_add(seen, qualified)) {
             nameset_add(worklist, qualified);
+        }
+    }
+    /* `builder name(...) with <factory>` carries the factory name in
+     * the AST_BUILDER_FUNCTION's `annotation` field. Codegen lowers
+     * the call site as `_bcfg = <annotation>()`, so the factory is
+     * a real (call-site) dependency of the builder even though it
+     * doesn't appear in the body. Without seeding it here, the
+     * mark-and-sweep dead-code prune drops the cross-module-cloned
+     * factory body and the consumer TU emits an unresolved bare
+     * call. Filed in aether/new_aevg_asks.md ASK 1. */
+    if (node->type == AST_BUILDER_FUNCTION && node->annotation) {
+        if (nameset_add(seen, node->annotation)) {
+            nameset_add(worklist, node->annotation);
         }
     }
     for (int i = 0; i < node->child_count; i++) {

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -194,6 +194,10 @@ CodeGenerator* create_code_generator(FILE* output) {
     gen->builder_funcs_reg = NULL;
     gen->builder_func_reg_count = 0;
     gen->builder_func_reg_capacity = 0;
+    // Bare-fn adapter registry
+    gen->bare_fn_adapter_names = NULL;
+    gen->bare_fn_adapter_count = 0;
+    gen->bare_fn_adapter_capacity = 0;
     // Closure support
     gen->closure_counter = 0;
     gen->closures = NULL;
@@ -3254,6 +3258,15 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
         print_line(gen, "// Closure definitions");
         emit_closure_definitions(gen);
     }
+
+    /* Bare-fn → fn-typed-slot adapter discovery + emit. Pre-walk the
+     * program to register every bare-fn that gets wrapped at a
+     * coercion site (mirrors the lazy registration in the wrap
+     * codegen path). Then emit forward declarations + bodies here so
+     * the user code that calls through them (main, etc.) sees the
+     * adapter symbol in scope. ASK 3 from aether/new_aevg_asks.md. */
+    discover_bare_fn_adapters(gen);
+    emit_bare_fn_adapters(gen);
 
     // Pre-pass: build request->reply type map from actor receive handlers.
     // This lets the ? operator know the reply message type at codegen time.

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -228,6 +228,22 @@ typedef struct {
     int builder_func_reg_count;
     int builder_func_reg_capacity;
 
+    /* Bare-fn → fn-typed-slot adapter registry. When a bare named
+     * function is wrapped into an _AeClosure at a coercion site
+     * (`(_AeClosure){.fn=name, .env=NULL}`), the real C signature of
+     * `name` is `R(args)` but the closure-invocation trampoline calls
+     * .fn as `R(void* env, args)`. Under -O2 (and silently on the
+     * arg-shift path even at -O0) this UB-via-incompatible-pointer-
+     * cast surfaces as wrong values. Fix: synthesise a per-bare-fn
+     * adapter `_aether_bare_adapter_<name>(void* env, args) -> R` at
+     * file scope that ignores env and forwards to the bare fn; the
+     * wrap site stuffs the adapter's address into .fn instead. Filed
+     * in aether/new_aevg_asks.md ASK 3 (and the LAYER 2 follow-up
+     * in fn_return_float_cast.md). */
+    char** bare_fn_adapter_names;
+    int    bare_fn_adapter_count;
+    int    bare_fn_adapter_capacity;
+
     // Closure support: track closures for hoisted C function generation
     int closure_counter;    // unique ID for closure env structs and functions
     // Map variable names to closure IDs (set during variable declaration codegen)

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2064,9 +2064,16 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         generate_expression(gen, expr->children[1]);
                         fprintf(gen->output, ")");
                     } else if (assign_box_bare_fn) {
-                        fprintf(gen->output, "_aether_box_closure((_AeClosure){ .fn = (void(*)(void))(");
-                        generate_expression(gen, expr->children[1]);
-                        fprintf(gen->output, "), .env = NULL })");
+                        /* Register an env-ignoring adapter for this
+                         * bare fn so the wrap embeds the adapter
+                         * address (not the bare fn's address) into
+                         * .fn. See ASK 3 in aether/new_aevg_asks.md. */
+                        const char* bn = expr->children[1] && expr->children[1]->value
+                                         ? expr->children[1]->value : NULL;
+                        if (bn) register_bare_fn_adapter(gen, bn);
+                        fprintf(gen->output,
+                                "_aether_box_closure((_AeClosure){ .fn = (void(*)(void))_aether_bare_adapter_%s, .env = NULL })",
+                                bn ? bn : "unknown");
                     } else {
                         generate_expression(gen, expr->children[1]);
                     }
@@ -3273,9 +3280,11 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                 }
                             }
                             if (arg_is_bare_fn) {
-                                fprintf(gen->output, "(_AeClosure){ .fn = (void(*)(void))(");
-                                generate_expression(gen, arg);
-                                fprintf(gen->output, "), .env = NULL }");
+                                const char* bn = arg && arg->value ? arg->value : NULL;
+                                if (bn) register_bare_fn_adapter(gen, bn);
+                                fprintf(gen->output,
+                                        "(_AeClosure){ .fn = (void(*)(void))_aether_bare_adapter_%s, .env = NULL }",
+                                        bn ? bn : "unknown");
                             } else if (arg->node_type && arg->node_type->kind == TYPE_PTR) {
                                 fprintf(gen->output, "_aether_unbox_closure(");
                                 generate_expression(gen, arg);

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -177,6 +177,169 @@ int is_builder_func_reg(CodeGenerator* gen, const char* func_name) {
     return 0;
 }
 
+/* Find a user-fn definition by name in the program AST. Helper for
+ * the bare-fn-adapter discovery pre-pass. */
+static ASTNode* find_user_function_by_name(CodeGenerator* gen, const char* name) {
+    if (!gen || !gen->program || !name) return NULL;
+    for (int i = 0; i < gen->program->child_count; i++) {
+        ASTNode* c = gen->program->children[i];
+        if (c && (c->type == AST_FUNCTION_DEFINITION ||
+                  c->type == AST_BUILDER_FUNCTION) &&
+            c->value && strcmp(c->value, name) == 0) {
+            return c;
+        }
+    }
+    return NULL;
+}
+
+/* Pre-walk the AST registering bare-fn adapters for every coercion site
+ * where a bare named function is wrapped as `(_AeClosure){.fn=name,
+ * .env=NULL}`. This mirrors the registration that happens lazily at
+ * the wrap-site codegen — doing it eagerly lets emit_bare_fn_adapters
+ * run before main is emitted, so adapter forward declarations are
+ * visible to user code that calls through them.
+ *
+ * The mirror is conservative: we register any bare-fn identifier
+ * appearing as a call argument where the callee has a `fn`-typed
+ * param, as the RHS of an `=` assignment to a `ptr`-typed
+ * struct field, or in an `_aether_box_closure(...)` wrap position
+ * (which the call-site arg coercion also handles). False positives
+ * are harmless — they just emit an unused adapter the C compiler
+ * inlines / discards. */
+static void discover_bare_fn_adapters_walk(CodeGenerator* gen, ASTNode* node) {
+    if (!gen || !node) return;
+    /* AST_FUNCTION_CALL: register any bare-fn arg whose callee param
+     * is `fn`-typed. */
+    if (node->type == AST_FUNCTION_CALL && node->value && gen->program) {
+        ASTNode* callee = find_user_function_by_name(gen, node->value);
+        if (callee) {
+            int pi = 0;
+            for (int j = 0; j < callee->child_count; j++) {
+                ASTNode* p = callee->children[j];
+                if (!p || p->type == AST_GUARD_CLAUSE || p->type == AST_BLOCK) continue;
+                /* Map param index to call-arg index. Skip _ctx
+                 * auto-injection — the user's child index 0 maps to
+                 * the callee's first non-_ctx param. */
+                if (p->node_type && p->node_type->kind == TYPE_FUNCTION &&
+                    !p->node_type->is_fnptr &&
+                    pi < node->child_count) {
+                    ASTNode* arg = node->children[pi];
+                    if (arg && arg->type == AST_IDENTIFIER && arg->value) {
+                        if (find_user_function_by_name(gen, arg->value)) {
+                            register_bare_fn_adapter(gen, arg->value);
+                        }
+                    }
+                }
+                pi++;
+            }
+        }
+    }
+    /* AST_BINARY_EXPRESSION with op="=": register bare-fn RHS into a
+     * ptr-typed LHS struct field. Conservative: also register for any
+     * RHS that's a bare named function regardless of LHS — false
+     * positives just emit unused adapters. */
+    if (node->type == AST_BINARY_EXPRESSION && node->value &&
+        strcmp(node->value, "=") == 0 && node->child_count == 2) {
+        ASTNode* lhs = node->children[0];
+        ASTNode* rhs = node->children[1];
+        if (lhs && rhs && rhs->type == AST_IDENTIFIER && rhs->value &&
+            lhs->node_type && lhs->node_type->kind == TYPE_PTR) {
+            if (find_user_function_by_name(gen, rhs->value)) {
+                register_bare_fn_adapter(gen, rhs->value);
+            }
+        }
+    }
+    for (int i = 0; i < node->child_count; i++) {
+        discover_bare_fn_adapters_walk(gen, node->children[i]);
+    }
+}
+
+void discover_bare_fn_adapters(CodeGenerator* gen) {
+    if (!gen || !gen->program) return;
+    discover_bare_fn_adapters_walk(gen, gen->program);
+}
+
+/* Register `bare_fn_name` as needing an env-ignoring adapter emitted at
+ * file finalisation. Returns 1 if newly added, 0 if it was already
+ * registered. Idempotent / deduping — multiple wrap sites for the same
+ * bare fn share one adapter. */
+int register_bare_fn_adapter(CodeGenerator* gen, const char* bare_fn_name) {
+    if (!gen || !bare_fn_name) return 0;
+    for (int i = 0; i < gen->bare_fn_adapter_count; i++) {
+        if (strcmp(gen->bare_fn_adapter_names[i], bare_fn_name) == 0) return 0;
+    }
+    if (gen->bare_fn_adapter_count >= gen->bare_fn_adapter_capacity) {
+        int new_cap = gen->bare_fn_adapter_capacity ? gen->bare_fn_adapter_capacity * 2 : 8;
+        char** nn = realloc(gen->bare_fn_adapter_names, sizeof(char*) * new_cap);
+        if (!nn) return 0;
+        gen->bare_fn_adapter_names = nn;
+        gen->bare_fn_adapter_capacity = new_cap;
+    }
+    gen->bare_fn_adapter_names[gen->bare_fn_adapter_count++] = strdup(bare_fn_name);
+    return 1;
+}
+
+/* Emit `_aether_bare_adapter_<name>(void* env, args) -> R` for every
+ * registered bare-fn name. The adapter ignores env and forwards to the
+ * bare fn with its real C signature. Looks up each bare fn in the
+ * program AST to derive its param + return type list; for fns that
+ * can't be resolved (shouldn't happen — registration only fires from
+ * the bare-fn coercion path which already confirms the def exists),
+ * a no-op stub is emitted so the codegen isn't blocked. Must be called
+ * AFTER all user fn forward decls and bodies — the adapter calls into
+ * the bare fn by its real C name. */
+void emit_bare_fn_adapters(CodeGenerator* gen) {
+    if (!gen || gen->bare_fn_adapter_count == 0) return;
+    if (!gen->program) return;
+    print_line(gen, "// Bare-fn → fn-typed-slot env-ignoring adapters (ASK 3)");
+    for (int i = 0; i < gen->bare_fn_adapter_count; i++) {
+        const char* fname = gen->bare_fn_adapter_names[i];
+        ASTNode* fdef = NULL;
+        for (int j = 0; j < gen->program->child_count; j++) {
+            ASTNode* c = gen->program->children[j];
+            if (c && (c->type == AST_FUNCTION_DEFINITION ||
+                      c->type == AST_BUILDER_FUNCTION) &&
+                c->value && strcmp(c->value, fname) == 0) {
+                fdef = c;
+                break;
+            }
+        }
+        if (!fdef) continue;  /* Shouldn't happen; registration gate
+                               * already confirmed existence. */
+        /* Walk the def's children to find params and return type.
+         * Skip AST_GUARD_CLAUSE and AST_BLOCK; the remaining typed
+         * nodes are the params, in order. */
+        ASTNode* params[16];
+        int param_count = 0;
+        for (int k = 0; k < fdef->child_count && param_count < 16; k++) {
+            ASTNode* p = fdef->children[k];
+            if (!p) continue;
+            if (p->type == AST_GUARD_CLAUSE || p->type == AST_BLOCK) continue;
+            params[param_count++] = p;
+        }
+        Type* rt = fdef->node_type;
+        const char* ret_c = (rt && rt->kind != TYPE_UNKNOWN)
+                            ? get_c_type(rt) : "void";
+        fprintf(gen->output, "static %s _aether_bare_adapter_%s(void* _env",
+                ret_c, fname);
+        for (int k = 0; k < param_count; k++) {
+            ASTNode* p = params[k];
+            const char* pt = p->node_type ? get_c_type(p->node_type) : "int";
+            fprintf(gen->output, ", %s _a%d", pt, k);
+        }
+        fprintf(gen->output, ") {\n    (void)_env;\n    ");
+        if (rt && rt->kind != TYPE_VOID && rt->kind != TYPE_UNKNOWN) {
+            fprintf(gen->output, "return ");
+        }
+        fprintf(gen->output, "%s(", fname);
+        for (int k = 0; k < param_count; k++) {
+            if (k > 0) fprintf(gen->output, ", ");
+            fprintf(gen->output, "_a%d", k);
+        }
+        fprintf(gen->output, ");\n}\n");
+    }
+}
+
 // Get the factory function for a builder function (default: "map_new").
 const char* get_builder_factory(CodeGenerator* gen, const char* func_name) {
     if (!gen || !func_name) return "map_new";

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -188,6 +188,15 @@ const char* lookup_extern_c_name(CodeGenerator* gen, const char* func_name);
 int is_builder_func_reg(CodeGenerator* gen, const char* func_name);
 const char* get_builder_factory(CodeGenerator* gen, const char* func_name);
 
+/* Bare-fn → fn-typed-slot adapter registry (ASK 3). At every bare-fn
+ * wrap site we call register_bare_fn_adapter(name); at file
+ * finalisation we call emit_bare_fn_adapters() to dump the resulting
+ * env-ignoring forwarder functions. See codegen.h field comment for
+ * the bug-shape rationale. */
+int  register_bare_fn_adapter(CodeGenerator* gen, const char* bare_fn_name);
+void emit_bare_fn_adapters(CodeGenerator* gen);
+void discover_bare_fn_adapters(CodeGenerator* gen);
+
 /* Function/struct generation (codegen_func.c) */
 int has_return_value(ASTNode* node);
 

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -875,6 +875,61 @@ ASTNode* parse_primary_expression(Parser* parser) {
             }
             // Could be identifier or struct literal
             Token* next = peek_ahead(parser, 1);
+
+            /* Qualified struct literal: `module.Type { field: value }`.
+             * Pattern: IDENTIFIER `.` IDENTIFIER `{` IDENTIFIER `:`
+             * (with the empty-struct variant `module.Type{}`). Parse
+             * the dotted name into the struct_name so the rest of the
+             * struct-literal lowering uses `Type` as the struct (which
+             * is what the rename pass produces — modules' struct
+             * definitions go into the program AST by their bare name,
+             * not module-prefixed). Filed in aether/new_aevg_asks.md
+             * ASK 2 from the AeVG port. */
+            if (next && next->type == TOKEN_DOT && !parser->in_condition) {
+                Token* t_type = peek_ahead(parser, 2);
+                Token* t_brace = peek_ahead(parser, 3);
+                if (t_type && t_type->type == TOKEN_IDENTIFIER &&
+                    t_brace && t_brace->type == TOKEN_LEFT_BRACE) {
+                    Token* t_after = peek_ahead(parser, 4);
+                    int looks_qualified_struct = 0;
+                    if (t_after && t_after->type == TOKEN_RIGHT_BRACE) {
+                        looks_qualified_struct = 1;
+                    } else if (t_after && t_after->type == TOKEN_IDENTIFIER) {
+                        Token* t_colon = peek_ahead(parser, 5);
+                        if (t_colon && t_colon->type == TOKEN_COLON) {
+                            looks_qualified_struct = 1;
+                        }
+                    }
+                    if (looks_qualified_struct) {
+                        /* Drop the module prefix — module structs land
+                         * in the program AST by their bare name. */
+                        char* struct_name = strdup(t_type->value);
+                        int s_line = token->line;
+                        int s_col = token->column;
+                        advance_token(parser);  /* module ident */
+                        advance_token(parser);  /* . */
+                        advance_token(parser);  /* Type ident */
+                        advance_token(parser);  /* { */
+
+                        ASTNode* struct_lit = create_ast_node(AST_STRUCT_LITERAL, struct_name, s_line, s_col);
+                        if (!match_token(parser, TOKEN_RIGHT_BRACE)) {
+                            do {
+                                Token* field_name = expect_token(parser, TOKEN_IDENTIFIER);
+                                if (!field_name) { free_ast_node(struct_lit); return NULL; }
+                                if (!expect_token(parser, TOKEN_COLON)) { free_ast_node(struct_lit); return NULL; }
+                                ASTNode* value_expr = parse_expression(parser);
+                                if (!value_expr) { free_ast_node(struct_lit); return NULL; }
+                                ASTNode* field_init = create_ast_node(AST_ASSIGNMENT, field_name->value,
+                                                                       field_name->line, field_name->column);
+                                add_child(field_init, value_expr);
+                                add_child(struct_lit, field_init);
+                            } while (match_token(parser, TOKEN_COMMA));
+                            if (!expect_token(parser, TOKEN_RIGHT_BRACE)) { free_ast_node(struct_lit); return NULL; }
+                        }
+                        return struct_lit;
+                    }
+                }
+            }
             // Disambiguate: IDENTIFIER { could be a struct literal OR an identifier
             // followed by a block (e.g., while i < n { ... }).
             // A struct literal has the pattern: TypeName { field: value } or TypeName {}

--- a/tests/integration/builder_with_factory_cross_module/lib/smod.ae
+++ b/tests/integration/builder_with_factory_cross_module/lib/smod.ae
@@ -1,0 +1,10 @@
+// Module side: a builder whose `with` factory is a same-module helper.
+// Factory returns a ptr (a real context handle that children attach to).
+
+exports ( win, mkfac )
+
+mkfac() -> ptr { return null }
+
+builder win(title: string) with mkfac {
+    println("win ${title}")
+}

--- a/tests/integration/builder_with_factory_cross_module/test_builder_with_factory_cross_module.ae
+++ b/tests/integration/builder_with_factory_cross_module/test_builder_with_factory_cross_module.ae
@@ -1,0 +1,36 @@
+// Regression: `builder name(...) with <factory>` whose factory is a
+// helper function in the SAME module must resolve correctly when the
+// builder is selectively imported by a different module.
+//
+// Pre-fix (filed in aether/new_aevg_asks.md ASK 1 from the AeVG port):
+// the import resolver renamed the builder's name to <ns>_<builder>
+// but left the `with`-factory annotation as the bare unprefixed name.
+// The consumer TU then emitted `_bcfg = mkfac()` (unresolved bare
+// symbol) and gcc/ld failed with "undefined reference to mkfac"
+// even though mkfac was exported from the builder's module.
+//
+// Two layers fixed:
+//   1. rename_intra_module_refs now rewrites the AST_BUILDER_FUNCTION
+//      annotation alongside the body's AST_FUNCTION_CALL / AST_IDENTIFIER
+//      values, so the cloned builder carries `annotation = <ns>_<factory>`.
+//   2. collect_intra_module_callees + prune_collect_calls now treat the
+//      builder's annotation as a real call-dependency, so the factory's
+//      body gets pulled into the program AST and survives the mark-and-
+//      sweep dead-code prune.
+//
+// What this test guards: a builder in lib/smod with `with mkfac` is
+// selectively imported here, called with a trailing block, and the
+// program both links and runs to completion. Pre-fix it failed at
+// gcc link time.
+
+import smod ( win )
+
+extern exit(code: int)
+
+child(_ctx: ptr, n: int) { }
+
+main() {
+    println("=== builder...with factory cross-module ===")
+    win("Calc") { child(1) }
+    println("=== all tests passed ===")
+}

--- a/tests/integration/qualified_struct_literal/lib/shapes.ae
+++ b/tests/integration/qualified_struct_literal/lib/shapes.ae
@@ -1,0 +1,3 @@
+exports ( Circle, Rect )
+struct Circle { cx: float, cy: float, r: float }
+struct Rect { x: int, y: int, w: int, h: int }

--- a/tests/integration/qualified_struct_literal/test_qualified_struct_literal.ae
+++ b/tests/integration/qualified_struct_literal/test_qualified_struct_literal.ae
@@ -1,0 +1,27 @@
+// Regression: `module.Type { field: value }` qualified struct-literal
+// syntax. Pre-fix the parser only accepted bare-name `Type{...}`;
+// the qualified form errored at parse with "Expected statement in
+// block". Filed in aether/new_aevg_asks.md ASK 2 from the AeVG port.
+//
+// Post-fix: parser detects the IDENT `.` IDENT `{` IDENT `:` (with
+// the empty-struct `{}` variant) pattern at the primary-expression
+// dispatch and lowers it the same way as the bare form, dropping
+// the module prefix since module struct definitions are merged
+// into the program AST by their bare struct name.
+
+import shapes
+
+extern exit(code: int)
+
+main() {
+    println("=== qualified struct literal ===")
+
+    c = shapes.Circle{cx: 1.0, cy: 2.0, r: 3.0}
+    if c.r != 3.0 { println("FAIL: c.r = ${c.r}"); exit(1) }
+
+    r = shapes.Rect{x: 10, y: 20, w: 100, h: 50}
+    if r.w != 100 { println("FAIL: r.w = ${r.w}"); exit(1) }
+    if r.h != 50 { println("FAIL: r.h = ${r.h}"); exit(1) }
+
+    println("=== all tests passed ===")
+}

--- a/tests/regression/test_fn_bare_adapter.ae
+++ b/tests/regression/test_fn_bare_adapter.ae
@@ -1,0 +1,98 @@
+// Regression: bare named function wrapped in a `_AeClosure` for a
+// `fn`-typed slot must invoke with the correct ABI shape.
+//
+// Filed in aether/new_aevg_asks.md ASK 3 (and the LAYER 2 follow-up
+// in fn_return_float_cast.md). Pre-fix: at every coercion site
+// where a bare named function was wrapped as
+// `(_AeClosure){.fn=name, .env=NULL}`, the wrapped fn's REAL C
+// signature was `R(args)` but the closure-invocation trampoline
+// called .fn as `R(void* env, args)`. The argument-passing
+// machinery shifted everything by one register/stack slot:
+//   - call(my_fn, 3, 7) where my_fn(w, h) -> int returned 3 (env=NULL
+//     shifts into w, 3 shifts into h, 7 dropped).
+//   - call_it(my_double, 3.0) -> float returned 0 (xmm0 holds the
+//     real arg but rdi/integer ABI shift puts NULL where the float
+//     should have been read).
+//   - any string- or ptr-returning bare-fn through the trampoline
+//     either segfaulted (string) or read garbage (ptr/struct).
+//
+// Post-fix: codegen synthesises a per-bare-fn env-ignoring adapter
+// `_aether_bare_adapter_<name>(void* env, args) -> R` at file scope.
+// The wrap site stuffs the ADAPTER's address into .fn (not the bare
+// fn's). The trampoline calls adapter(env, args), the adapter
+// ignores env and forwards args to the real fn — ABI shapes match
+// on both sides.
+//
+// The adapters are registered at emission time and emitted alongside
+// closure definitions before main, so calls through them work
+// regardless of where in the program the wrap site appears.
+
+import std.math
+import std.string
+
+extern exit(code: int)
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+
+// ---- Integer args + return (the ASK 3 headline) ----
+my_fn(w: int, h: int) -> int { return w * 100 + h }
+my_sum(a: int, b: int) -> int { return a + b }
+
+call_int(cb: fn, w: int, h: int) -> int { return cb(w, h) }
+
+// ---- Float arg + float return (LAYER 2 from fn_return_float_cast.md) ----
+my_double(x: float) -> float { return x * 2.0 }
+
+call_float(cb: fn, x: float) -> float { return cb(x) }
+
+// ---- String return ----
+my_hello() -> string { return "hello" }
+
+call_string(cb: fn) -> string { return cb() }
+
+// ---- Ptr return ----
+my_buf() -> ptr { return malloc(16) }
+
+call_ptr(cb: fn) -> ptr { return cb() }
+
+eps_ok(a: float, b: float) -> int {
+    diff = a - b
+    if diff < 0.0 { diff = 0.0 - diff }
+    if diff > 0.001 { return 0 }
+    return 1
+}
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    print("=== bare-fn → fn-slot adapter (ASK 3 + LAYER 2) ===\n\n")
+
+    // ---- 1. int args, int return ----
+    r = call_int(my_fn, 3, 7)
+    if r != 307 { fail("my_fn(3,7) → ${r}, want 307") }
+
+    r2 = call_int(my_sum, 10, 32)
+    if r2 != 42 { fail("my_sum(10,32) → ${r2}, want 42") }
+    print("  PASS: int (my_fn 307, my_sum 42)\n")
+
+    // ---- 2. float arg, float return (LAYER 2) ----
+    a = call_float(my_double, 3.0)
+    if eps_ok(a, 6.0) == 0 { fail("my_double(3.0) → ${a}, want 6.0") }
+    print("  PASS: float (my_double 3.0 → 6.0)\n")
+
+    // ---- 3. string return ----
+    s = call_string(my_hello)
+    if string.equals(s, "hello") != 1 { fail("my_hello → '${s}', want 'hello'") }
+    print("  PASS: string (my_hello → 'hello')\n")
+
+    // ---- 4. ptr return ----
+    p = call_ptr(my_buf)
+    if p == null { fail("my_buf → null") }
+    free(p)
+    print("  PASS: ptr (my_buf returns non-null)\n")
+
+    print("\n=== All bare-fn adapter tests passed ===\n")
+}


### PR DESCRIPTION
## Description

All three asks from \`aether/new_aevg_asks.md\` filed by the
aether-ui CVG → AeVG port. Bundled into one PR per the
\"conserve GH-Action minutes\" pattern from prior CVG rounds.

## Type of Change

- [x] Bug fix (3 separate bugs — builder/with module resolution,
      bare-fn arg-slot shift)
- [x] New feature (qualified \`module.Type{...}\` struct literal)

## What's in this PR

### 1. fix(aether_module): \`builder ... with <factory>\` module-resolution (ASK 1 — BLOCKER)

The builder lowering emits \`_bcfg = <factory>()\` verbatim, but
the import resolver renamed the builder's name to
\`<ns>_<builder>\` and left the \`with\`-factory annotation
unprefixed. Consumer translation units got
\`undefined reference to mkfac\` at link time even though the
factory was exported from the builder's module. This blocked the
entire AeVG surface DSL (\`window\` / \`render_to\` / \`record\`
live in the \`aether_ui\` library and are called from
example/transpiler-output files).

Two-layer fix:
1. \`rename_intra_module_refs\` rewrites the
   \`AST_BUILDER_FUNCTION\` annotation alongside the body's
   \`AST_FUNCTION_CALL\` / \`AST_IDENTIFIER\` values.
2. \`collect_intra_module_callees\` + \`prune_collect_calls\`
   treat the builder's annotation as a real call-dependency so
   the factory's body survives both the transitive-pull-in clone
   and the dead-code prune.

### 2. feat(parser): qualified struct literal \`module.Type { ... }\` (ASK 2)

Pre-fix the parser only accepted bare \`Type{...}\`; qualified
form errored at parse with \"Expected statement in block\". Now
detected via the \`IDENT . IDENT { IDENT :\` (and empty-struct
\`IDENT . IDENT { }\`) lookahead at the primary-expression
dispatch, lowered the same way as the bare form with the module
prefix dropped from the type name. Lets a DSL keep its structs
namespaced (\`vg.Circle{...}\`) without forcing every consumer to
add a bare-import companion line.

### 3. fix(codegen): per-bare-fn env-ignoring adapter (ASK 3 + LAYER 2)

The closure-invocation trampoline calls \`.fn\` as
\`R(void* env, args)\`, but a bare named fn wrapped as
\`(_AeClosure){.fn=name, .env=NULL}\` has real signature
\`R(args)\`. Incompatible-pointer-conversion UB shifted every
argument by one register/stack slot:

- \`call(my_fn, 3, 7)\` → \`3\` (env shifts in, 7 dropped)
- \`call_it(my_double, 3.0)\` → \`0\` (NULL into FP slot)
- string returns segfaulted; ptr returns read garbage

Fix: codegen synthesises a per-bare-fn adapter
\`_aether_bare_adapter_<name>(void* env, args) -> R\` at file
scope. The wrap site stuffs the **adapter's** address into
\`.fn\` (not the bare fn's). The trampoline calls
\`adapter(env, args)\`; adapter ignores \`env\` and forwards
\`args\` to the real fn — ABI shapes match on both sides.

Adapters are registered via a pre-walk that mirrors the lazy
coercion-site registration, then emitted alongside closure
definitions **before main** so calls through them work
regardless of where in the program the wrap site appears.
Forward decls and bodies live together in the same emission
block — no chicken-and-egg ordering.

**This also closes the LAYER 2 follow-up from PR #574** — the
bare-fn arg/return-slot hazard that PR's regression test
intentionally left out because the fix needed per-signature
adapter generation. Float-, string- and ptr-returning bare-fn
closures all now work under -O2.

## What's NOT in this PR

- **ASK 4** (closure-capture int inference) — explicitly a
  recap-only item in the filing; workaround in place downstream.

## Testing

- [x] Added regression tests for each ask:
  - \`tests/integration/builder_with_factory_cross_module/\`
  - \`tests/integration/qualified_struct_literal/\`
  - \`tests/regression/test_fn_bare_adapter.ae\` (covers ASK 3 +
    LAYER 2 from \`fn_return_float_cast.md\` — float, int,
    string, ptr returns under \`ae build\` -O2)
- [x] \`make ci\`: 226/226 C unit tests pass; 556/559 \`.ae\`
      tests pass; 3 failures are the flaky HTTP2-framing /
      proxy-pool-bind tests from prior PRs, unrelated.
- [x] \`HARDEN=1 make ci\`: 226/226 C; 557/559 \`.ae\` (2 of the
      same flakes)
- [x] Existing PR #574 regression test
      (\`test_fn_closure_call_return_types.ae\`) still passes —
      the return-type-cast fix from that PR is still load-bearing
      for the captured-state closure path (env != NULL); the new
      adapter handles the bare-fn (env = NULL) path.

## Performance Impact

- [x] No performance impact for code that doesn't use the new
      features. The bare-fn adapter is one extra function call on
      the dispatch path for bare-fn-as-closure usage — but
      compared to the pre-fix behaviour (silent wrong values), a
      one-call cost is trivially worth the correctness.

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (each fix carries a
      paragraph explaining the bug shape and the chosen approach)
- [x] Documentation updated (\`CHANGELOG.md\` \`[current]\` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)