### PR TITLE
test(contrib.xml.expat): 8 more probe sub-cases covering XML features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`contrib.xml.expat` probe — 8 XML-feature coverage cases**
+  (`tests/integration/contrib_xml_expat/probe.ae`). Expands the
+  integration probe from 8 → 16 sub-cases: nesting depth tracking
+  (6-deep with siblings, balanced to 0), mixed content (text and
+  child elements interleaved in document order), whitespace-only
+  text events (pretty-printed XML produces text events for the
+  inter-element whitespace), entity decoding (`&amp;` / `&lt;` /
+  `&#65;` / `&#x42;` all resolved by libexpat before reaching the
+  text handler), UTF-8 in element names + attribute values + text
+  (`<café leño="árbol">日本語 🎉</café>` round-trips multibyte
+  byte-for-byte), CDATA payload delivery (markup chars inside
+  `<![CDATA[ ... ]]>` pass through raw via the regular text
+  handler), real-world RSS fragment (extract title/link/description
+  with the `current_field` pattern), and real-world SVG fragment
+  (count `<rect>` elements and sum their `width` attributes).
+
+  Implementation note: variables captured by `parse_with`'s handler
+  closures are hoisted to function scope rather than declared inside
+  per-case `{ ... }` blocks, sidestepping a known Aether codegen
+  issue where heap-promoted strings / strbuilder ptrs captured from
+  a nested block crash on the next event when the block exits.
+
 ## [0.199.0]
 
 ### Added

--- a/tests/integration/contrib_xml_expat/probe.ae
+++ b/tests/integration/contrib_xml_expat/probe.ae
@@ -19,6 +19,7 @@
 import contrib.xml.expat
 import std.mem
 import std.string
+import std.strbuilder
 
 extern malloc(n: int) -> ptr
 extern free(p: ptr)
@@ -81,6 +82,24 @@ new_counters() -> *ParseCounters {
 
 main() {
     println("=== contrib.xml.expat integration test ===")
+
+    // Function-scope captures for the closure-based cases 9-16.
+    // Heap-promoted strings and strbuilder ptrs captured inside a
+    // nested `{ ... }` block by closures crash on the next event
+    // (Aether codegen bug — env pointer dangles at block exit).
+    // Hoisting to function scope sidesteps it; lifetime is all of
+    // main() so nothing dangles. Each case prefixes its names to
+    // avoid collisions.
+    sb_entity = strbuilder.new(16)
+    sb_cdata  = strbuilder.new(16)
+    sb_title  = strbuilder.new(32)
+    sb_link   = strbuilder.new(32)
+    sb_desc   = strbuilder.new(32)
+    c10_event_log = ""
+    c13_attr_val  = ""
+    c13_elem_name_bytes = 0
+    c13_text_total = 0
+    c15_current_field = ""
 
     // ---- Case 1: simple well-formed doc, count events ----
 
@@ -295,6 +314,257 @@ main() {
         if ok != 1 { fail("parse_with start-only failed") }
         if only_starts != 3 { fail("parse_with only_starts = ${only_starts}, want 3 (root,a,b)") }
         println("  PASS: parse_with with only bind_start works (3 starts)")
+    }
+
+    // ============================================================
+    // XML-feature coverage cases (9-16) — using the closure builder
+    // surface. These exercise libexpat-side behaviour we previously
+    // didn't have probes for: deep nesting, mixed content, whitespace
+    // handling, entity decoding, UTF-8, CDATA-as-text delivery, and
+    // small fragments from two real-world XML dialects (RSS + SVG).
+    // ============================================================
+
+    // ---- Case 9: nesting depth tracking ----
+    //
+    // Track maximum nesting depth via start/end events. Six-deep
+    // structure with siblings to verify the depth counter goes up on
+    // every start and down on every end, not just down at EOF.
+
+    {
+        depth = 0
+        max_depth = 0
+        doc = "<a><b><c><d><e><f/></e></d></c><c2/></b></a>"
+        ok = expat.parse_with(doc) {
+            bind_start(|name: string, atts: ptr| {
+                depth = depth + 1
+                if depth > max_depth { max_depth = depth }
+            })
+            bind_end(|name: string| {
+                depth = depth - 1
+            })
+        }
+        if ok != 1 { fail("nesting parse failed") }
+        if max_depth != 6 { fail("max_depth = ${max_depth}, want 6 (a/b/c/d/e/f)") }
+        if depth != 0 { fail("final depth = ${depth}, want 0 (every start matched)") }
+        println("  PASS: nesting depth — max 6, balanced to 0 on close")
+    }
+
+    // ---- Case 10: mixed content (text and child elements interleaved) ----
+    //
+    // libexpat fires start/end/text events in document order. Verify
+    // a span like <p>Hello <b>bold</b> world.</p> delivers text +
+    // start + text + end + text in the right interleaving.
+
+    {
+        ok = expat.parse_with("<p>Hello <b>bold</b> world.</p>") {
+            bind_start(|name: string, atts: ptr| {
+                c10_event_log = "${c10_event_log}S(${name})"
+            })
+            bind_end(|name: string| {
+                c10_event_log = "${c10_event_log}E(${name})"
+            })
+            bind_text(|text: string, len: int| {
+                c10_event_log = "${c10_event_log}T(${len})"
+            })
+        }
+        if ok != 1 { fail("mixed-content parse failed") }
+        // Expected: S(p) T(6 'Hello ') S(b) T(4 'bold') E(b) T(7 ' world.') E(p)
+        // libexpat may chunk text; we just verify the start/end order
+        // and that text events occur between elements.
+        expected = "S(p)T(6)S(b)T(4)E(b)T(7)E(p)"
+        if c10_event_log != expected {
+            fail("mixed-content event log = '${c10_event_log}', want '${expected}'")
+        }
+        println("  PASS: mixed content — text interleaved with child elements in order")
+    }
+
+    // ---- Case 11: whitespace-only text events ----
+    //
+    // libexpat fires the text handler for whitespace runs between
+    // elements too (it does NOT distinguish "ignorable whitespace"
+    // by default — that requires a DTD). Verify that pretty-printed
+    // XML produces text events with whitespace payloads.
+
+    {
+        ws_bytes = 0
+        ws_text_events = 0
+        // Three whitespace runs: "\n  ", "\n  ", "\n" between sibling tags.
+        doc = "<r>\n  <a/>\n  <b/>\n</r>"
+        ok = expat.parse_with(doc) {
+            bind_text(|text: string, len: int| {
+                ws_text_events = ws_text_events + 1
+                ws_bytes = ws_bytes + len
+            })
+        }
+        if ok != 1 { fail("whitespace-only parse failed") }
+        if ws_text_events == 0 {
+            fail("whitespace-only ws_text_events = 0, expected at least one")
+        }
+        // Total whitespace: "\n  " + "\n  " + "\n" = 7 bytes
+        if ws_bytes != 7 {
+            fail("whitespace-only ws_bytes = ${ws_bytes}, want 7")
+        }
+        println("  PASS: whitespace-only text — ${ws_text_events} event(s), 7 bytes total")
+    }
+
+    // ---- Case 12: entity decoding ----
+    //
+    // Built-in XML entities (&amp; &lt; &gt; &quot; &apos;) and
+    // numeric character references (&#65; &#x41;) must be decoded
+    // by libexpat before reaching the text handler. The handler sees
+    // the resolved characters, not the entity reference.
+
+    {
+        ok = expat.parse_with("<r>&amp;&lt;&gt;&quot;&apos;&#65;&#x42;</r>") {
+            bind_text(|text: string, len: int| {
+                strbuilder.append_n(sb_entity, text, len)
+            })
+        }
+        if ok != 1 { fail("entity parse failed") }
+        result = strbuilder.finish(sb_entity)
+        // Expected: & < > " ' A B  (7 characters total)
+        expected = "&<>\"'AB"
+        if result != expected {
+            fail("entity-decode result = '${result}', want '${expected}'")
+        }
+        println("  PASS: entity decoding — &amp;&lt;&gt;&quot;&apos;&#65;&#x42; → '${result}'")
+    }
+
+    // ---- Case 13: UTF-8 in element names, attributes, and text ----
+    //
+    // libexpat reads UTF-8 input natively (we link the byte-oriented
+    // -lexpat, not the wide variant). Element names with non-ASCII
+    // codepoints, attribute values with emoji, and text with
+    // multibyte sequences must all round-trip byte-for-byte.
+
+    {
+        // <café leño="árbol">日本語 🎉</café> — element name with é,
+        // attr name with ñ, attr value with á+r+b+o+l, text mixing
+        // CJK and emoji. All captured vars hoisted to function scope
+        // (c13_*) — see the comment block at top of main().
+        ok = expat.parse_with("<café leño=\"árbol\">日本語 🎉</café>") {
+            bind_start(|name: string, atts: ptr| {
+                c13_elem_name_bytes = string.length(name)
+                if expat.attr_count(atts) > 0 {
+                    c13_attr_val = expat.attr_value(atts, 0)
+                }
+            })
+            bind_text(|text: string, len: int| {
+                c13_text_total = c13_text_total + len
+            })
+        }
+        if ok != 1 { fail("UTF-8 parse failed") }
+        // "café" in UTF-8 is c(1) + a(1) + f(1) + é(2) = 5 bytes
+        if c13_elem_name_bytes != 5 {
+            fail("UTF-8 element name bytes = ${c13_elem_name_bytes}, want 5 ('café')")
+        }
+        // "árbol" in UTF-8: á(2) + r(1) + b(1) + o(1) + l(1) = 6 bytes
+        if string.length(c13_attr_val) != 6 {
+            fail("UTF-8 attr value bytes = ${string.length(c13_attr_val)}, want 6 ('árbol')")
+        }
+        // "日本語 🎉" = 日(3) + 本(3) + 語(3) + space(1) + 🎉(4) = 14 bytes
+        if c13_text_total != 14 {
+            fail("UTF-8 text bytes = ${c13_text_total}, want 14 ('日本語 🎉')")
+        }
+        println("  PASS: UTF-8 — element name=5B, attr value=6B, text=14B (multibyte preserved)")
+    }
+
+    // ---- Case 14: CDATA payload delivered to text handler ----
+    //
+    // libexpat's default behaviour is to deliver CDATA section
+    // contents through the regular character-data handler, with the
+    // section markers (`<![CDATA[` / `]]>`) stripped. Special chars
+    // inside CDATA are NOT entity-decoded — they pass through raw.
+    // (Explicit XML_SetCdataSectionHandler is not in v1; we just
+    // verify the implicit text-handler delivery.)
+
+    {
+        // Inside CDATA: literal "<x>" + "&amp;" + "</x>" — should pass
+        // through without parsing as markup or entity expansion.
+        doc = "<r><![CDATA[<x>&amp;</x>]]></r>"
+        ok = expat.parse_with(doc) {
+            bind_text(|text: string, len: int| {
+                strbuilder.append_n(sb_cdata, text, len)
+            })
+        }
+        if ok != 1 { fail("CDATA parse failed") }
+        result = strbuilder.finish(sb_cdata)
+        // CDATA contents preserved verbatim — markup chars NOT decoded.
+        expected = "<x>&amp;</x>"
+        if result != expected {
+            fail("CDATA text = '${result}', want '${expected}'")
+        }
+        println("  PASS: CDATA payload — '${result}' delivered raw (markup/entity not decoded)")
+    }
+
+    // ---- Case 15: real-world fragment — RSS item ----
+    //
+    // Trim a minimal RSS 2.0 item to its bones: <item><title>...</title>
+    // <link>...</link><description>...</description></item>. Confirm
+    // we can extract the three fields the way an RSS consumer would.
+
+    {
+        // Three strbuilders (sb_title/sb_link/sb_desc) plus the
+        // current-element tracker (c15_current_field) are all hoisted
+        // to function scope. The text handler picks the right one
+        // based on the currently-open element, copying bytes through
+        // append_n at the moment of delivery (the libexpat-supplied
+        // text slice is borrowed and unterminated).
+        rss = "<rss version=\"2.0\"><channel><item><title>Hello World</title><link>https://example.com/post/1</link><description>A short post.</description></item></channel></rss>"
+        ok = expat.parse_with(rss) {
+            bind_start(|name: string, atts: ptr| {
+                c15_current_field = name
+            })
+            bind_text(|text: string, len: int| {
+                if c15_current_field == "title" { strbuilder.append_n(sb_title, text, len) }
+                if c15_current_field == "link"  { strbuilder.append_n(sb_link,  text, len) }
+                if c15_current_field == "description" { strbuilder.append_n(sb_desc, text, len) }
+            })
+            bind_end(|name: string| {
+                c15_current_field = ""
+            })
+        }
+        if ok != 1 { fail("RSS parse failed") }
+        title = strbuilder.finish(sb_title)
+        link  = strbuilder.finish(sb_link)
+        desc  = strbuilder.finish(sb_desc)
+        if title != "Hello World" { fail("RSS title = '${title}', want 'Hello World'") }
+        if link  != "https://example.com/post/1" { fail("RSS link = '${link}'") }
+        if desc  != "A short post." { fail("RSS desc = '${desc}'") }
+        println("  PASS: RSS fragment — title/link/description all extracted")
+    }
+
+    // ---- Case 16: real-world fragment — SVG ----
+    //
+    // Small SVG: count <rect> elements, sum their width attributes.
+    // Exercises attribute parsing on multiple sibling elements with
+    // numeric values that need parsing on the consumer side.
+
+    {
+        rect_count = 0
+        width_sum = 0
+        svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"50\"><rect x=\"0\" y=\"0\" width=\"10\" height=\"10\"/><rect x=\"20\" y=\"0\" width=\"30\" height=\"10\"/><rect x=\"60\" y=\"0\" width=\"40\" height=\"10\"/></svg>"
+        ok = expat.parse_with(svg) {
+            bind_start(|name: string, atts: ptr| {
+                if name == "rect" {
+                    rect_count = rect_count + 1
+                    n = expat.attr_count(atts)
+                    i = 0
+                    while i < n {
+                        if expat.attr_name(atts, i) == "width" {
+                            w, _ = string.to_int(expat.attr_value(atts, i))
+                            width_sum = width_sum + w
+                        }
+                        i = i + 1
+                    }
+                }
+            })
+        }
+        if ok != 1 { fail("SVG parse failed") }
+        if rect_count != 3 { fail("SVG rect_count = ${rect_count}, want 3") }
+        // Widths: 10 + 30 + 40 = 80
+        if width_sum != 80 { fail("SVG width_sum = ${width_sum}, want 80 (10+30+40)") }
+        println("  PASS: SVG fragment — 3 rects counted, width sum = 80")
     }
 
     println("=== All contrib.xml.expat tests passed ===")

--- a/tests/integration/contrib_xml_expat/probe.ae
+++ b/tests/integration/contrib_xml_expat/probe.ae
@@ -95,11 +95,16 @@ main() {
     sb_title  = strbuilder.new(32)
     sb_link   = strbuilder.new(32)
     sb_desc   = strbuilder.new(32)
+    sb_c13_attr = strbuilder.new(16)
     c10_event_log = ""
-    c13_attr_val  = ""
     c13_elem_name_bytes = 0
     c13_text_total = 0
-    c15_current_field = ""
+    // Case 15 tracks which RSS field is currently open with an int
+    // code rather than storing the borrowed element-name string from
+    // libexpat (the pointer goes stale by the next callback — fine
+    // on Linux's allocator, but macOS reuses the slot). 0 = none,
+    // 1 = title, 2 = link, 3 = description.
+    c15_current_field = 0
 
     // ---- Case 1: simple well-formed doc, count events ----
 
@@ -441,12 +446,18 @@ main() {
         // <café leño="árbol">日本語 🎉</café> — element name with é,
         // attr name with ñ, attr value with á+r+b+o+l, text mixing
         // CJK and emoji. All captured vars hoisted to function scope
-        // (c13_*) — see the comment block at top of main().
+        // (c13_*, sb_c13_attr) — see the comment block at top of
+        // main(). The attribute value is COPIED into a strbuilder at
+        // callback time rather than stored as a borrowed string —
+        // libexpat's attr_value pointer is only valid for the
+        // duration of the start callback; storing it directly worked
+        // on Linux but the bytes were freed under us on macOS.
         ok = expat.parse_with("<café leño=\"árbol\">日本語 🎉</café>") {
             bind_start(|name: string, atts: ptr| {
                 c13_elem_name_bytes = string.length(name)
                 if expat.attr_count(atts) > 0 {
-                    c13_attr_val = expat.attr_value(atts, 0)
+                    v = expat.attr_value(atts, 0)
+                    strbuilder.append_n(sb_c13_attr, v, string.length(v))
                 }
             })
             bind_text(|text: string, len: int| {
@@ -454,6 +465,7 @@ main() {
             })
         }
         if ok != 1 { fail("UTF-8 parse failed") }
+        c13_attr_val = strbuilder.finish(sb_c13_attr)
         // "café" in UTF-8 is c(1) + a(1) + f(1) + é(2) = 5 bytes
         if c13_elem_name_bytes != 5 {
             fail("UTF-8 element name bytes = ${c13_elem_name_bytes}, want 5 ('café')")
@@ -504,24 +516,29 @@ main() {
     // we can extract the three fields the way an RSS consumer would.
 
     {
-        // Three strbuilders (sb_title/sb_link/sb_desc) plus the
-        // current-element tracker (c15_current_field) are all hoisted
-        // to function scope. The text handler picks the right one
-        // based on the currently-open element, copying bytes through
-        // append_n at the moment of delivery (the libexpat-supplied
-        // text slice is borrowed and unterminated).
+        // Three strbuilders (sb_title/sb_link/sb_desc) plus an int
+        // tracker (c15_current_field — 1/2/3 for title/link/desc)
+        // are all hoisted to function scope. The text handler picks
+        // the right one based on the currently-open element, copying
+        // bytes through append_n at the moment of delivery (the
+        // libexpat-supplied text slice is borrowed and unterminated).
+        // The start handler matches the element NAME against known
+        // RSS field names at callback time (not storing the borrowed
+        // string ptr — that goes stale by the time bind_text fires).
         rss = "<rss version=\"2.0\"><channel><item><title>Hello World</title><link>https://example.com/post/1</link><description>A short post.</description></item></channel></rss>"
         ok = expat.parse_with(rss) {
             bind_start(|name: string, atts: ptr| {
-                c15_current_field = name
+                if name == "title"       { c15_current_field = 1 }
+                if name == "link"        { c15_current_field = 2 }
+                if name == "description" { c15_current_field = 3 }
             })
             bind_text(|text: string, len: int| {
-                if c15_current_field == "title" { strbuilder.append_n(sb_title, text, len) }
-                if c15_current_field == "link"  { strbuilder.append_n(sb_link,  text, len) }
-                if c15_current_field == "description" { strbuilder.append_n(sb_desc, text, len) }
+                if c15_current_field == 1 { strbuilder.append_n(sb_title, text, len) }
+                if c15_current_field == 2 { strbuilder.append_n(sb_link,  text, len) }
+                if c15_current_field == 3 { strbuilder.append_n(sb_desc, text, len) }
             })
             bind_end(|name: string| {
-                c15_current_field = ""
+                c15_current_field = 0
             })
         }
         if ok != 1 { fail("RSS parse failed") }

--- a/tests/integration/contrib_xml_expat/test_contrib_xml_expat.sh
+++ b/tests/integration/contrib_xml_expat/test_contrib_xml_expat.sh
@@ -83,4 +83,4 @@ if ! grep -q "All contrib.xml.expat tests passed" "$TMPDIR/run.log"; then
     exit 1
 fi
 
-echo "  [PASS] contrib_xml_expat: 8 cases"
+echo "  [PASS] contrib_xml_expat: 16 cases"


### PR DESCRIPTION
## Summary

Expands the `contrib.xml.expat` integration probe from 8 → 16 sub-cases (the second tranche from the user's earlier ask). The new cases cover XML-feature behaviour the original probe didn't touch:

| # | Case |
|---|------|
| 9 | Nesting depth tracking (6-deep with siblings, balanced to 0) |
| 10 | Mixed content (text and child elements interleaved in document order) |
| 11 | Whitespace-only text events between pretty-printed elements |
| 12 | Entity decoding (`&amp;` `&lt;` `&gt;` `&quot;` `&apos;` `&#65;` `&#x42;`) |
| 13 | UTF-8 in element names + attribute values + text (`café`, `árbol`, `日本語 🎉`) |
| 14 | CDATA payload delivered raw via the regular text handler |
| 15 | Real-world RSS fragment (extract title/link/description) |
| 16 | Real-world SVG fragment (count `<rect>` elements, sum `width` attributes) |

## Implementation gotcha (worth knowing)

Closures inside a nested `{ ... }` block that capture heap-promoted values (strings, strbuilder ptrs) crash on the next event because the env pointer dangles when the block exits. Closure-captured-int inference also loses writes from a closure inside a block in some configurations.

Workaround applied: hoisted all closure-captured vars (`sb_entity`, `c10_event_log`, `c13_*`, `c15_current_field`, etc.) to function scope. The cases retain their `{ ... }` block structure for readability; only the variables that get captured live at function scope.

Worth filing as its own compiler issue if it hasn't already been captured.

## Test plan

- [x] `bash tests/integration/contrib_xml_expat/test_contrib_xml_expat.sh` → `[PASS] contrib_xml_expat: 16 cases`
- [x] All 16 sub-cases print their individual PASS line
- [x] No regressions in the original 8 cases
- [x] `tests/` and CHANGELOG.md only — no C or compiler changes, no skip-actions needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)