### PR TITLE
fix(docker): aether-build SELinux + crun keep-id on Bazzite

### DIFF
--- a/tools/docker/aether-build
+++ b/tools/docker/aether-build
@@ -315,7 +315,18 @@ case "${1:-}" in
             exit 1
         fi
         if ! command -v aeb >/dev/null 2>&1; then
-            echo "aether-build (container): aeb not installed in this image" >&2
+            # --aeb is a guarded extension seam: this base image
+            # ships ae/aetherc but NOT aeb. aeb's own Docker layer
+            # is expected to FROM this base, install aeb, and
+            # inherit this entrypoint so the --aeb branch goes
+            # live. Point the user at how to get there rather than
+            # dead-ending them.
+            echo "aether-build (container): --aeb needs an aeb-bearing image."  >&2
+            echo "  The base aether-builder image ships ae/aetherc but NOT aeb."  >&2
+            echo "  Layer aeb on top: see aeb's tools/container/Containerfile.aeb-toolchain" >&2
+            echo "  ( https://github.com/aether-lang-org/aeb )"                   >&2
+            echo "  Then re-run with the aeb image:"                              >&2
+            echo "    AETHER_BUILDER_IMAGE=aeb-toolchain:slim aether-build --aeb <target>"  >&2
             exit 1
         fi
         aeb "$@"

--- a/tools/docker/aether-build
+++ b/tools/docker/aether-build
@@ -27,6 +27,14 @@
 #   AETHER_REF=v0.203.0                          # Aether release to bake in
 #   AETHER_TARBALL=/path/to/aether-0.203.0.tgz   # skip download, use this
 #   HEADERS_REF=6872b5d...                       # hosted-language-headers pin
+#   AETHER_USERNS=""                             # drop --userns flag entirely
+#                                                #   (some rootless setups don't
+#                                                #   need it; useful if your
+#                                                #   crun rejects the default)
+#   AETHER_SELINUX_LABEL=Z                       # bind-mount SELinux label;
+#                                                #   set to "" on non-SELinux
+#                                                #   hosts if it causes issues,
+#                                                #   or to "z" for shared label
 #
 #
 # ── SOURCE ACQUISITION ─────────────────────────────────────────────
@@ -115,10 +123,23 @@ ENGINE="$(detect_engine)"
 
 if [ "$ENGINE" = "podman" ]; then
     # Rootless podman maps the container's UID 0 into a subuid range
-    # on the host, not the calling user. --userns=keep-id flips that
-    # to 1:1 mapping so the calling user sees writable bind mounts
-    # they own on the host.
-    USERNS_FLAGS="--userns=keep-id"
+    # on the host, not the calling user. We want bind-mounted host
+    # dirs to be writable by the calling user — three paths to that:
+    #
+    #   1. (default) Explicit `--userns=keep-id:uid=$(id -u),gid=…`.
+    #      Some crun versions (notably Bazzite-shipped) reject the
+    #      bare `--userns=keep-id` form with an
+    #      "crun: readlink ``: No such file or directory" error.
+    #      The explicit uid/gid form works on those AND on every
+    #      older podman/crun that accepts the bare form.
+    #   2. (override) Set `AETHER_USERNS=` (empty) to drop the flag
+    #      entirely — works on some rootless setups where the
+    #      default user-namespace mapping already gives correct
+    #      ownership (true on Bazzite under SELinux Z-relabeled
+    #      mounts).
+    #   3. (override) Set `AETHER_USERNS=--userns=<whatever>` to
+    #      pass an arbitrary flag through.
+    USERNS_FLAGS="${AETHER_USERNS---userns=keep-id:uid=$(id -u),gid=$(id -g)}"
 else
     # docker (rootful by default): just run as the calling user.
     USERNS_FLAGS="-u $(id -u):$(id -g)"
@@ -352,15 +373,41 @@ fi
 
 mkdir -p "$OUT"
 
+# Refuse to bind-mount $HOME directly — SELinux-enforcing hosts
+# (Bazzite, Fedora Silverblue, etc.) refuse `:Z` relabeling of $HOME
+# itself, and even without :Z the surface area of mounting the
+# whole home dir into a build container is undesirable. Force the
+# user to point at a subdir.
+if [ "$WORK" = "$HOME" ] || [ "$OUT" = "$HOME" ]; then
+    echo "aether-build: refusing to bind-mount \$HOME directly (\$WORK or \$OUT == \$HOME)" >&2
+    echo "aether-build: use a subdirectory — e.g. mkdir ~/aebuild && cd ~/aebuild" >&2
+    echo "aether-build: (SELinux-enforcing hosts reject :Z relabeling of \$HOME; safer to scope the mount anyway)" >&2
+    exit 1
+fi
+
+# SELinux label option on bind mounts.
+# `:Z` relabels the host dir with a private container-shared label;
+# necessary on SELinux-enforcing hosts (Bazzite, Fedora Silverblue,
+# RHEL/CentOS Stream) — without it, the container can't read the
+# source dir and the entrypoint reports "/work/<src> not found"
+# (misleading: SELinux denied the read).
+# `:z` is the shared-label variant — fine if multiple containers
+# share the mount, slightly less isolation.
+# On non-SELinux hosts (Debian/Ubuntu/Arch desktop) the option is
+# a no-op, so defaulting to `:Z` is safe.
+# Override via AETHER_SELINUX_LABEL=z, or =""(empty) to disable.
+SELABEL="${AETHER_SELINUX_LABEL-Z}"
+if [ -n "$SELABEL" ]; then SELABEL_SUFFIX=",$SELABEL"; else SELABEL_SUFFIX=""; fi
+
 # aeb mode needs /work writable (target/ lands next to sources).
 # Direct ae build mode uses /work read-only as a defensive default.
 case "${1:-}" in
-    --aeb) MODE_MOUNT="-v $WORK:/work" ;;
-    *)     MODE_MOUNT="-v $WORK:/work:ro" ;;
+    --aeb) MODE_MOUNT="-v $WORK:/work$SELABEL_SUFFIX" ;;
+    *)     MODE_MOUNT="-v $WORK:/work:ro$SELABEL_SUFFIX" ;;
 esac
 
 exec "$ENGINE" run --rm $USERNS_FLAGS \
     $MODE_MOUNT \
-    -v "$OUT:/out" \
+    -v "$OUT:/out$SELABEL_SUFFIX" \
     "$IMAGE" \
     "$@"

--- a/tools/docker/build-entry.sh
+++ b/tools/docker/build-entry.sh
@@ -63,7 +63,16 @@ case "$1" in
             exit 1
         fi
         if ! command -v aeb >/dev/null 2>&1; then
-            echo "build-entry: aeb not on PATH inside the container. Was AEB installed?" >&2
+            # --aeb is a guarded extension seam: the aether-builder
+            # base ships ae/aetherc but not aeb. aeb's own Docker
+            # layer is expected to FROM this base, install aeb, and
+            # inherit this entrypoint so the --aeb branch goes live.
+            echo "build-entry: --aeb needs an aeb-bearing image."                    >&2
+            echo "  The aether-builder base ships ae/aetherc but NOT aeb."           >&2
+            echo "  Layer aeb on top: see aeb's tools/container/Containerfile.aeb-toolchain" >&2
+            echo "  ( https://github.com/aether-lang-org/aeb )"                      >&2
+            echo "  Then re-run with the aeb image:"                                 >&2
+            echo "    podman run ... aeb-toolchain:slim --aeb <target>"              >&2
             exit 1
         fi
         aeb "$@"


### PR DESCRIPTION
Three issues in `tools/docker/aether-build` discovered by a downstream session running the script end-to-end on a real Bazzite box (`bazzite-dx:stable`, rootless podman + SELinux enforcing). Field report at `ctr_notes.md`. Bugs 1 + 2 are run-path crashes; Bug 3 is a UX dead-end that the field report reframes as a guarded extension-seam design.

## Bug 1 — bare `--userns=keep-id` rejected by Bazzite's crun

The crun shipped with Bazzite errors at podman-run time:

```
Error: crun: readlink ``: No such file or directory
```

on bare `--userns=keep-id`. The fix is to use the explicit form `--userns=keep-id:uid=$(id -u),gid=$(id -g)` — accepted by every crun version we've encountered including this one. Plus a new `AETHER_USERNS` env-var override lets callers drop the flag entirely.

## Bug 2 — bind mounts need `:Z` on SELinux-enforcing hosts

Without the SELinux label option, the container can't read the source dir; the entrypoint reports `/work/<src> not found` (misleading — the file exists, SELinux denies the read). Default to `:Z` (private container-shared label). New `AETHER_SELINUX_LABEL` env-var overrides this with `=z` (shared) or `=""` (disabled). On non-SELinux hosts the option is a no-op so `:Z` is safe-default.

Companion guard: refuse `$WORK == $HOME` or `$OUT == $HOME` — Bazzite and other SELinux hosts refuse `:Z` relabeling of `$HOME` itself, and mounting an entire home dir into a build container is undesirable surface anyway. The script now exits with a message suggesting a subdir.

## Bug 3 — `--aeb` dead-end becomes a signpost

`aether-build --aeb` was aborting with `"aeb not installed in this image"` — accurate (the base image ships ae/aetherc but NOT aeb) but a dead end. The field report includes a design call: **keep `--aeb` in the base as a guarded extension seam**. aeb's own Docker layer (`aeb/tools/container/Containerfile.aeb-toolchain`) does `FROM aether-builder:slim`, installs aeb, and inherits this entrypoint — so the `--aeb` branch goes live automatically when an aeb-bearing image is used. The base declares the hook; the higher layer fills it. The dispatch logic stays; only the warning changes from a wall to a signpost pointing at:

1. The aeb-toolchain Containerfile in aeb's own repo
2. The `AETHER_BUILDER_IMAGE` env-var override that swaps in the aeb-bearing image

Two sites updated: the embedded heredoc in `aether-build` (single-file bootstrap users curl onto Bazzite), and `build-entry.sh` (modular Dockerfile path).

## New env-vars

- `AETHER_USERNS=""` — drop the `--userns` flag entirely
- `AETHER_SELINUX_LABEL=Z` — bind-mount SELinux label (override to `z` / empty)

Both documented in the script header.

## Test plan

- [x] Shell syntax check (`sh -n`)
- [x] Env-var override semantics: unset / empty / explicit value all produce expected behaviour
- [x] Field report says the workarounds (explicit keep-id form + `:Z`) work end-to-end on the real Bazzite box. This PR codifies those workarounds as defaults.
- [ ] On-box re-run with this branch's script — left to the downstream session that hit the bugs; CI doesn't exercise SELinux hosts.

`[skip actions]` on both commits — shell-script-only behaviour the GHA matrix doesn't reproduce (no SELinux hosts in the matrix, no aeb in any image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
