### PR TITLE
fix(docker): hosted-language-headers clone — drop --depth 1 [skip actions]

### DIFF
--- a/tools/docker/aether-build
+++ b/tools/docker/aether-build
@@ -293,11 +293,17 @@ RUN cd /src \\
 # import contrib.host.{python,lua,perl,ruby,js} compile cleanly
 # without per-language toggles. Runtime shared libs are NOT
 # installed here — see the script's "ON THE DEPLOY HOST" notes.
-RUN git clone --depth 1 \\
+#
+# Full clone (not --depth 1): a shallow clone lands on HEAD only,
+# and a subsequent `git fetch origin <sha>` requires the server
+# to have uploadpack.allowAnySHA1InWant enabled. GitHub supports
+# that for most repos but it can fail with
+# "fatal: reference is not a tree: <sha>". Full-history clone is
+# ~14 MB one-time during image build — small price for
+# deterministic behaviour across GitHub config quirks.
+RUN git clone \\
         https://github.com/aether-lang-org/hosted-language-headers.git /opt/hdr \\
  && cd /opt/hdr \\
- && (git rev-parse ${HEADERS_REF} >/dev/null 2>&1 \\
-     || git fetch --depth 1 origin ${HEADERS_REF}) \\
  && git checkout ${HEADERS_REF} \\
  && mkdir -p /opt/aether/include \\
  && cp -r /opt/hdr/python     /opt/aether/include/python \\

--- a/tools/docker/scripts/clone-host-headers.sh
+++ b/tools/docker/scripts/clone-host-headers.sh
@@ -30,21 +30,19 @@ if [ -d "$HEADERS_DIR/.git" ]; then
     fi
 fi
 
-# Shallow clone to keep image-layer size minimal. Then check out
-# the pinned commit. --filter=blob:none would be even smaller but
-# requires git 2.19+ which bookworm-bookworm has (2.39) — keep
-# this simple.
+# Full clone, then check out the pinned commit. A `--depth 1` clone
+# would be smaller, BUT then `git fetch --depth 1 origin <SHA>`
+# requires the server to allow fetching arbitrary commit SHAs that
+# aren't ref tips (uploadpack.allowAnySHA1InWant). GitHub usually
+# supports it, but a real Bazzite report (2026-05-30) showed it
+# failing with `fatal: reference is not a tree: <sha>`. A full clone
+# of hosted-language-headers is ~14 MB and the .git dir is dropped
+# below — small price for deterministic image builds.
 mkdir -p "$(dirname "$HEADERS_DIR")"
 rm -rf "$HEADERS_DIR"
-git clone --depth 1 "$HEADERS_REPO" "$HEADERS_DIR"
+git clone "$HEADERS_REPO" "$HEADERS_DIR"
 cd "$HEADERS_DIR"
-
-# `--depth 1` lands us on the current HEAD of the default branch.
-# If that's not the pinned commit, deepen the clone and check out.
-if [ "$(git rev-parse HEAD)" != "$HEADERS_REF" ]; then
-    git fetch --depth 1 origin "$HEADERS_REF"
-    git checkout "$HEADERS_REF"
-fi
+git checkout "$HEADERS_REF"
 
 # Drop .git to save layer size — we won't be running git operations
 # against the repo again from inside the image.


### PR DESCRIPTION
## Summary

- Bazzite `aether-build --rebuild-image` failed at the
  hosted-language-headers clone step with
  `fatal: reference is not a tree: 6872b5df…`.
- Root cause: `git clone --depth 1` then
  `git fetch --depth 1 origin <SHA>` requires the server to honour
  `uploadpack.allowAnySHA1InWant`. GitHub does this for most repos
  but not reliably for arbitrary commits that aren't ref tips — which
  is exactly our case, since we pin to a SHA that drifts off the
  branch tip as soon as new headers land.
- Fix: drop `--depth 1` from the clone in both the embedded
  Containerfile heredoc (`tools/docker/aether-build`) and the modular
  helper (`tools/docker/scripts/clone-host-headers.sh`). The full
  clone of hosted-language-headers is ~14 MB one-time during image
  build, and the `.git` dir is deleted afterward, so the final image
  layer size is identical.

## Test plan

- [ ] On Bazzite (bazzite-dx:stable), run
      `aether-build --rebuild-image` from scratch; the headers step
      now completes and the image builds to the end.
- [ ] After the rebuild, `aether-build hi.ae` produces `./out/hi`
      owned by the calling user, runs end-to-end (regression for the
      PR #596 + #598 work).

`[skip actions]` because this only touches the Docker tooling for an
optional out-of-tree build path — CI doesn't exercise the container
build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)