### PR TITLE
feat(ae): ${VAR} expansion in aether.toml link_flags / cflags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`aether.toml` `[build]` `cflags` / `link_flags` support `${VAR}`
+  expansion against the process environment**
+  (`tools/ae.c`,
+  `tests/integration/aether_toml_env_var_expansion/`,
+  `contrib/host/python/README.md`).
+  Values like `link_flags = "${AETHER_PYTHON_LDFLAGS}"` now substitute
+  the named env var at build time. Use case: container-built / host-
+  deployed flows (aeb-ctr on Bazzite, etc.) where the deploy host's
+  linker flags are known only to the orchestrator, not to the
+  toolchain image. The orchestrator probes the host once, passes the
+  string in via `-e VAR=…`, and the in-container `ae build` consumes
+  it through this expansion.
+
+  **Security:** name allowlist — only `${AETHER_*}` is honoured (e.g.
+  `${AETHER_PYTHON_LDFLAGS}`, `${AETHER_RUBY_LDFLAGS}`). Anything
+  else warns to stderr and expands to the empty string, so an
+  attacker who can write arbitrary env vars cannot hijack the link
+  line via `${PATH}`, `${LD_PRELOAD}`, etc. The allowlist is
+  conservative for v1; widening can come under review.
+
+  **Other rules:** unset `${AETHER_*}` warns + expands empty (clarity
+  failure mode); `\$` is a literal `$`; bare `$VAR` (no braces) is
+  NOT expanded; shell `$(...)` command substitution is NOT supported
+  (would let any `aether.toml` exec arbitrary commands at build time).
+
 ## [0.203.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -404,6 +404,24 @@ skip guards you wrote, which is where most per-test PR breakage lives:
 OS=Windows_NT build/test_syntax_test_my_new_test
 ```
 
+**8. `aether.toml` `[build] cflags` / `link_flags` support `${VAR}`
+expansion, NOT `$(shell substitution)`.** The values are copied
+verbatim into the gcc argv via `posix_spawnp` — no shell runs over
+them. `link_flags = "$(python3-config --ldflags --embed)"` reaches
+gcc as literal text and fails. `link_flags = "${AETHER_X}"` is
+expanded against the process environment by `ae` itself.
+
+The env-var name is restricted to the `AETHER_*` allowlist for
+security (so an attacker who can write env vars on CI can't hijack
+the link line via `${LD_PRELOAD}` etc.). Unset names and
+non-allowlisted names both warn to stderr and expand to empty.
+`\$` is a literal `$`. Bare `$VAR` without braces is NOT expanded.
+
+Practical contributor implication: when you add a new `contrib/host/*`
+language bridge, name its env contract `AETHER_<LANG>_LDFLAGS` /
+`AETHER_<LANG>_CFLAGS` so the existing allowlist accepts it without
+code changes here.
+
 ### Additional Checks
 
 1. **No memory leaks**

--- a/contrib/host/python/README.md
+++ b/contrib/host/python/README.md
@@ -1,23 +1,91 @@
 # contrib.host.python — Embedded CPython
 
-## Prerequisites
+`import contrib.host.python` lets an Aether program embed CPython
+in-process: `python.run_sandboxed(perms, "<source>")` evaluates Python
+inside the calling process, with permission-checked access controls.
+
+The build needs CPython's headers at compile time and `libpython` at
+link time. Two recipes — pick whichever matches how you're building.
+
+## Recipe A — single-box dev (Linux with `python3-dev` installed)
 
 ```bash
 # Debian/Ubuntu
 sudo apt install python3-dev
 
+# Fedora/Rocky
+sudo dnf install python3-devel
+
 # Verify
 python3-config --includes
 ```
 
-## Build flags
+Then in `aether.toml`, set the env vars **before** invoking `ae`:
+
+```sh
+export AETHER_PYTHON_CFLAGS="$(python3-config --includes) -DAETHER_HAS_PYTHON"
+export AETHER_PYTHON_LDFLAGS="$(python3-config --ldflags --embed)"
+ae build app.ae
+```
 
 ```toml
 # aether.toml
 [build]
-cflags = "-DAETHER_HAS_PYTHON $(python3-config --includes)"
-link_flags = "$(python3-config --ldflags --embed)"
+cflags     = "${AETHER_PYTHON_CFLAGS}"
+link_flags = "${AETHER_PYTHON_LDFLAGS}"
 ```
+
+`aether.toml` values support `${VAR}` substitution for the
+`AETHER_*` env-var allowlist (other names warn + expand empty).
+Shell `$(...)` is **not** expanded by `ae`; run it in your own
+shell when populating the env var as above.
+
+## Recipe B — split build/deploy (container compile, deploy on host)
+
+This is the aeb-ctr / Bazzite-style flow where the toolchain runs in
+a container that has the vendored headers but no `python3-config`
+or `libpython`, while the produced binary runs on a deploy host that
+has both.
+
+The orchestrator probes the **deploy host** once, then passes the
+flags into the container as env vars. The container's `ae build`
+expands them via `${VAR}` substitution in `aether.toml`.
+
+Host-side probe (works on hosts with `python3` but **without**
+`python3-config`, e.g. Fedora-derived immutable distros):
+
+```sh
+# On the deploy host:
+python3 -c '
+import sysconfig as s
+v = s.get_config_var
+print("-L"+v("LIBDIR"), "-lpython"+v("LDVERSION"),
+      v("LIBS") or "", v("SYSLIBS") or "")
+'
+# → e.g.  -L/usr/lib64 -lpython3.14 -ldl -lm
+```
+
+Capture that and pass it into the container build:
+
+```sh
+AETHER_PYTHON_LDFLAGS="$(python3 -c '...probe above...')" \
+podman run -e AETHER_PYTHON_LDFLAGS ... aether-builder app.ae
+```
+
+The container's `aether.toml`:
+
+```toml
+[build]
+# Headers are vendored in the image at /opt/aether/include/python/,
+# already on the container's include path — no -I needed.
+cflags     = "-DAETHER_HAS_PYTHON"
+link_flags = "${AETHER_PYTHON_LDFLAGS}"
+```
+
+The produced binary `dlopen`s `libpython` lazily, so the deploy
+host needs the python3 runtime package (not python3-dev). On
+Bazzite-derived hosts `libpython3.X.so.1.0` ships in the base
+image already.
 
 ## Usage
 

--- a/tests/integration/aether_toml_env_var_expansion/test_aether_toml_env_var_expansion.sh
+++ b/tests/integration/aether_toml_env_var_expansion/test_aether_toml_env_var_expansion.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Regression: ${VAR} expansion in aether.toml [build] cflags / link_flags.
+#
+# Honoured for the AETHER_*-prefixed allowlist only; unset names warn
+# and expand to empty; non-allowlisted names warn and expand to empty.
+#
+# Each subtest runs from its own tmpdir so the ae build-cache (which is
+# keyed by source hash, not by environment) doesn't return a stale
+# success from a previous test cell.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+fail=0
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Generate a fresh project dir under $tmpdir with the given toml + a
+# probe whose marker name is unique per test cell (defeats the build
+# cache so each cell exercises a real compile).
+make_proj() {
+    proj_dir="$1"; toml_body="$2"; marker_name="$3"
+    mkdir -p "$proj_dir"
+    cat > "$proj_dir/aether.toml" <<EOF
+[build]
+$toml_body
+
+[[bin]]
+name = "probe"
+path = "probe.ae"
+extra_sources = ["shim.c"]
+EOF
+    cat > "$proj_dir/probe.ae" <<EOF
+extern ae_env_exp_probe_value() -> int
+
+main() {
+    v = ae_env_exp_probe_value()
+    if v != 42 {
+        println("FAIL")
+        exit(1)
+    }
+    println("OK")
+}
+EOF
+    cat > "$proj_dir/shim.c" <<EOF
+#ifndef $marker_name
+#error "$marker_name not defined — \${VAR} expansion did not reach gcc"
+#endif
+
+int ae_env_exp_probe_value(void) { return $marker_name; }
+EOF
+}
+
+# --- Test 1: allowlisted env var expands; build succeeds, probe prints OK
+make_proj "$tmpdir/t1" 'cflags = "${AETHER_TEST_T1_CFLAGS}"' "AE_ENV_EXP_T1"
+( cd "$tmpdir/t1" && \
+  AETHER_TEST_T1_CFLAGS="-DAE_ENV_EXP_T1=42" "$AE" run probe.ae ) >"$tmpdir/t1.log" 2>&1
+t1_rc=$?
+if [ "$t1_rc" -ne 0 ]; then
+    echo "  [FAIL] aether_toml_env_var_expansion T1: ae run rejected the project (env expansion did not reach gcc)"
+    sed 's/^/    /' "$tmpdir/t1.log" | head -15
+    fail=1
+elif ! grep -q "^OK$" "$tmpdir/t1.log"; then
+    echo "  [FAIL] aether_toml_env_var_expansion T1: probe did not print OK"
+    sed 's/^/    /' "$tmpdir/t1.log" | head -10
+    fail=1
+else
+    echo "  [PASS] aether_toml_env_var_expansion T1: \${AETHER_*} env var expanded into cflags"
+fi
+
+# --- Test 2: unset allowlisted var warns + expands empty; shim.c #error fires
+make_proj "$tmpdir/t2" 'cflags = "${AETHER_TEST_T2_CFLAGS}"' "AE_ENV_EXP_T2"
+( cd "$tmpdir/t2" && unset AETHER_TEST_T2_CFLAGS && "$AE" run probe.ae ) >"$tmpdir/t2.log" 2>&1
+t2_rc=$?
+if [ "$t2_rc" -eq 0 ]; then
+    echo "  [FAIL] aether_toml_env_var_expansion T2: build succeeded with unset env var (should have failed at shim.c #error)"
+    sed 's/^/    /' "$tmpdir/t2.log" | head -10
+    fail=1
+elif ! grep -q "AETHER_TEST_T2_CFLAGS" "$tmpdir/t2.log"; then
+    echo "  [FAIL] aether_toml_env_var_expansion T2: build failed but warning naming the unset var was not emitted"
+    sed 's/^/    /' "$tmpdir/t2.log" | head -10
+    fail=1
+elif ! grep -q "unset" "$tmpdir/t2.log"; then
+    echo "  [FAIL] aether_toml_env_var_expansion T2: build failed but warning did not say 'unset'"
+    sed 's/^/    /' "$tmpdir/t2.log" | head -10
+    fail=1
+else
+    echo "  [PASS] aether_toml_env_var_expansion T2: unset \${AETHER_*} warns + expands empty"
+fi
+
+# --- Test 3: non-allowlisted name (no AETHER_ prefix) is REJECTED with a
+#     warning that documents the allowlist; build fails (#error in shim).
+make_proj "$tmpdir/t3" 'cflags = "${PATH}"' "AE_ENV_EXP_T3"
+( cd "$tmpdir/t3" && "$AE" run probe.ae ) >"$tmpdir/t3.log" 2>&1
+t3_rc=$?
+if [ "$t3_rc" -eq 0 ]; then
+    echo "  [FAIL] aether_toml_env_var_expansion T3: non-allowlisted \${PATH} was honoured (allowlist bypass)"
+    fail=1
+elif ! grep -q '${PATH}' "$tmpdir/t3.log" && ! grep -q 'PATH' "$tmpdir/t3.log"; then
+    echo "  [FAIL] aether_toml_env_var_expansion T3: build failed but no warning mentioned PATH"
+    sed 's/^/    /' "$tmpdir/t3.log" | head -10
+    fail=1
+elif ! grep -q "AETHER_\*" "$tmpdir/t3.log"; then
+    echo "  [FAIL] aether_toml_env_var_expansion T3: build failed but warning did not document the allowlist"
+    sed 's/^/    /' "$tmpdir/t3.log" | head -10
+    fail=1
+else
+    echo "  [PASS] aether_toml_env_var_expansion T3: non-allowlisted \${X} blocked + warned"
+fi
+
+# Escape (\$) is intentionally not covered as integration — it's a
+# helper-internal grammar concern (no real user-visible cflags shape
+# needs literal $). The unit-test surface in the helper would be the
+# better home for it.
+
+exit $fail

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1216,8 +1216,101 @@ found_root:
 #  pragma GCC diagnostic pop
 #endif
 
+// Expand ${VAR} occurrences in `src` against the process environment,
+// writing into dst (NUL-terminated, truncated if needed). Unset vars
+// expand to the empty string and emit a one-time stderr warning
+// (clarity, not security — silent expansion to "" is the most
+// surprising failure mode of this feature). `\$` is a literal `$`;
+// bare `$VAR` (without braces) is NOT expanded — keeps the grammar
+// tight and avoids ambiguity with `-L$LIB-foo`-style values. Shell
+// `$(...)` command substitution is intentionally NOT supported
+// (would let any aether.toml exec arbitrary commands at build time).
+//
+// SECURITY: name allowlist — only `AETHER_*` (uppercase letters,
+// digits, underscore) is honoured. Anything else expands to empty
+// + warning. The threat model: `aether.toml` is project-trusted,
+// and the env var contribution is a side channel from whoever runs
+// the build. By restricting names to a documented prefix, an
+// attacker who can write arbitrary env (e.g. via a CI permission
+// gap) can only hijack the contract this codebase declares — not
+// e.g. ${PATH}, ${HOME}, or ${LD_PRELOAD}. The allowlist is
+// deliberately conservative for v1; widening to a richer namespace
+// can come later under review. Removing it entirely would not
+// introduce a new RCE primitive (a hostile aether.toml can already
+// put `-Wl,...` literally in link_flags), but the allowlist makes
+// the *implicit* environment surface narrower and easier to audit.
+//
+// Why this is needed: aether.toml `[build] link_flags` / `cflags`
+// values are copied verbatim into the gcc argv via posix_spawnp.
+// No shell sees them, so `$(python3-config --ldflags --embed)` and
+// raw `${VAR}` would reach gcc as literal text and fail. Containerised
+// builds (aeb-ctr) probe the deploy host for host-specific runtime
+// link flags and pass them in via env (-e VAR=…), so the toml needs
+// a way to consume that. `${VAR}` is that way.
+static bool env_var_name_allowed(const char* name, size_t n) {
+    if (n < 8) return false;                       // "AETHER_" + ≥1
+    if (memcmp(name, "AETHER_", 7) != 0) return false;
+    for (size_t i = 0; i < n; i++) {
+        char c = name[i];
+        if (!((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'))
+            return false;
+    }
+    return true;
+}
+
+static void expand_env_vars(const char* src, char* dst, size_t dst_size) {
+    if (dst_size == 0) return;
+    size_t di = 0;
+    for (size_t si = 0; src[si] != '\0' && di + 1 < dst_size; ) {
+        if (src[si] == '\\' && src[si + 1] == '$') {
+            dst[di++] = '$';
+            si += 2;
+            continue;
+        }
+        if (src[si] == '$' && src[si + 1] == '{') {
+            const char* end = strchr(src + si + 2, '}');
+            if (end) {
+                char name[128];
+                size_t n = (size_t)(end - (src + si + 2));
+                if (n < sizeof(name)) {
+                    memcpy(name, src + si + 2, n);
+                    name[n] = '\0';
+                    if (!env_var_name_allowed(name, n)) {
+                        fprintf(stderr,
+                            "ae: warning: aether.toml ${%s} not expanded "
+                            "(only ${AETHER_*} env vars are honoured); "
+                            "substituting empty string\n", name);
+                    } else {
+                        const char* v = getenv(name);
+                        if (v) {
+                            size_t vl = strlen(v);
+                            size_t room = dst_size - 1 - di;
+                            size_t cp = vl < room ? vl : room;
+                            memcpy(dst + di, v, cp);
+                            di += cp;
+                        } else {
+                            fprintf(stderr,
+                                "ae: warning: aether.toml references "
+                                "${%s} which is unset; substituting "
+                                "empty string\n", name);
+                        }
+                    }
+                    si = (size_t)(end - src) + 1;
+                    continue;
+                }
+                // Name too long: fall through and copy the literal '$'.
+            }
+            // Unterminated ${: fall through and copy the literal '$'.
+        }
+        dst[di++] = src[si++];
+    }
+    dst[di] = '\0';
+}
+
 // Get link_flags from aether.toml [build] section
-// Returns empty string if not found or no aether.toml
+// Returns empty string if not found or no aether.toml.
+// `${VAR}` occurrences are expanded against the process environment
+// (see expand_env_vars()).
 static const char* get_link_flags(void) {
     static char flags[1024] = "";
     static bool checked = false;
@@ -1232,8 +1325,7 @@ static const char* get_link_flags(void) {
 
     const char* val = toml_get_value(doc, "build", "link_flags");
     if (val) {
-        strncpy(flags, val, sizeof(flags) - 1);
-        flags[sizeof(flags) - 1] = '\0';
+        expand_env_vars(val, flags, sizeof(flags));
     }
 
     toml_free_document(doc);
@@ -1352,8 +1444,7 @@ static const char* get_cflags(void) {
 
     const char* val = toml_get_value(doc, "build", "cflags");
     if (val) {
-        strncpy(flags, val, sizeof(flags) - 1);
-        flags[sizeof(flags) - 1] = '\0';
+        expand_env_vars(val, flags, sizeof(flags));
     }
 
     toml_free_document(doc);


### PR DESCRIPTION
## Summary

`aether.toml` `[build]` `link_flags` / `cflags` values are copied verbatim
into the gcc argv via `posix_spawnp` — no shell sees them — so
`link_flags = "${AETHER_X}"` previously reached gcc as literal text and
failed. This change adds a `${VAR}` expansion pass in `tools/ae.c`
between TOML parse and snprintf so the named env var substitutes at
build time.

**Motivating use case:** container-built / host-deployed flows
(aeb-ctr on Bazzite, etc.) where the deploy host's linker flags are
known only to the orchestrator, not to the toolchain image. The
orchestrator probes the host once for `libpython` linker flags etc.,
passes the string in via `podman run -e VAR=…`, and the in-container
`ae build` consumes it through `${AETHER_PYTHON_LDFLAGS}` in
`aether.toml`. The discovery thread is the Bazzite `--rebuild-image`
work in PR #600 / `ctr_notes.md` — `python3-config` isn't installed
there but `python3 -c 'import sysconfig…'` extracts the equivalent
flags, and this PR is what lets that string reach gcc.

## Security posture (belt + braces)

- **Name allowlist:** only `${AETHER_*}` is honoured. Non-allowlisted
  names warn to stderr and expand to empty, so an attacker who can
  write arbitrary env vars on CI cannot hijack the link line via
  `${PATH}`, `${LD_PRELOAD}`, etc. Conservative for v1; widening under
  review later.
- **Unset `${AETHER_*}`** also warns + expands empty (clarity, not
  security — silent expansion was the most surprising failure mode).
- `\$` is a literal `$`.
- Bare `$VAR` (no braces) is NOT expanded — keeps the grammar tight
  and avoids ambiguity with `-L$LIB-foo`-style values.
- Shell `$(...)` command substitution is NOT supported (would let
  any `aether.toml` exec arbitrary commands at build time).

Removing the allowlist would not introduce a new RCE primitive (a
hostile `aether.toml` can already put `-Wl,...` literally in
`link_flags`), but it makes the IMPLICIT environment surface narrower
and easier to audit. See the helper comment in `tools/ae.c` for the
full threat-model write-up.

## Tests

`tests/integration/aether_toml_env_var_expansion/` exercises three
cells in isolated tmpdirs (defeats the build cache, which is keyed by
source hash rather than environment):

| # | Cell | Expectation |
|---|---|---|
| 1 | `${AETHER_TEST_T1_CFLAGS}` set | expand succeeds, probe prints OK |
| 2 | `${AETHER_TEST_T2_CFLAGS}` unset | warn + expand empty + shim.c #error fires |
| 3 | `${PATH}` (non-allowlisted) | warn + expand empty + build fails |

Both `make ci` and `HARDEN=1 make ci` run them; both green except for
pre-existing HTTP/2 framing flakes (`http_h2_concurrent_dispatch`,
`http_server_h2`, `http_reverse_proxy_pool` — forgiven per maintainer
direction).

## Docs

- **`CHANGELOG.md` `[current]`** entry summarising the contract.
- **`CONTRIBUTING.md` §8**: portability list now documents that
  `aether.toml` flag values support `${VAR}` (not `$(shell)`), with
  the `AETHER_<LANG>_*` naming convention for new contrib bridges.
- **`contrib/host/python/README.md`** rewritten with two recipes:
  - **Recipe A — single-box dev:** `apt install python3-dev` and
    pre-expand via `$(python3-config ...)` in your shell before
    invoking `ae`.
  - **Recipe B — split build/deploy:** orchestrator probes the host
    with `python3 -c 'import sysconfig...'`, passes the result into
    the container as `AETHER_PYTHON_LDFLAGS`, and the container's
    `aether.toml` consumes it via `${AETHER_PYTHON_LDFLAGS}`.

## Test plan

- [x] `make ci` (green modulo HTTP/2 flakes)
- [x] `HARDEN=1 make ci` (green modulo HTTP/2 flakes)
- [ ] CI matrix on Linux gcc/clang
- [ ] CI matrix on macOS Apple Clang
- [ ] CI matrix on Windows MSYS2 / mingw-w64 (no platform-specific
      code in this change — same `getenv` path on all platforms)
- [ ] Smoke-test the contrib.host.python integration on a Bazzite box
      (orchestrator side; PR #600 needs to merge first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)