### PR TITLE
feat(ae): auto-link libaether_host_<lang>.a when imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`ae build` links `libaether_host_<lang>.a` automatically when a
+  program `import contrib.host.<lang>`**
+  (`tools/ae.c`,
+  `tests/integration/host_bridge_import_link/`,
+  `contrib/host/python/README.md`).
+  Previously the import resolved the bridge headers (so the program
+  compiled), but the bridge static archive was NEVER linked — so the
+  produced binary failed at runtime with `undefined symbol: python_run`
+  (the BRIDGE's own function, not a CPython symbol). Users had to
+  repeat the import as `link_flags = "-laether_host_python"` in
+  `aether.toml` — busywork easily forgotten (ctr_notes.md Bug 4 trace,
+  2026-06-03).
+
+  Now: import-driven. `import contrib.host.python` in the entry .ae
+  queues `libaether_host_python.a` onto the link line in the correct
+  position (before `-laether` / `tc.runtime_srcs` so the bridge's
+  runtime references resolve). A pure-Aether program with NO
+  `contrib.host.*` import does NOT link any bridge — critical, since
+  blanket-linking would force a hello-world to dlopen libpython at
+  runtime even when it doesn't use Python.
+
+  **Scope:** entry-file-only. Only the .ae passed to `ae build` /
+  `ae run` is scanned for `import contrib.host.<lang>`. If your
+  imported module in turn imports a host bridge, you must still write
+  the import in your entry file. Widening to transitive imports later
+  is purely additive.
+
+  **Hard error if `.a` is missing:** `ae: cannot find
+  libaether_host_<lang>.a — required by ` `import contrib.host.<lang>` `…`
+  points at `make contrib` (dev) or `make install-contrib` (installed).
+  Silent fallback was what created Bug 4 in the first place.
+
+  **POSIX-only:** the host bridges aren't compiled on the Windows
+  matrix.
+
 ## [0.207.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,6 +422,21 @@ language bridge, name its env contract `AETHER_<LANG>_LDFLAGS` /
 `AETHER_<LANG>_CFLAGS` so the existing allowlist accepts it without
 code changes here.
 
+**9. New `contrib/host/<lang>` bridges are auto-linked by `ae build`
+when imported — do NOT ask users to repeat themselves.** `ae build`
+scans the entry .ae for `import contrib.host.<lang>` and queues
+`libaether_host_<lang>.a` onto the link line automatically (the .a
+is built by `tests/scripts/contrib_build.sh`; install paths handled
+by `make install-contrib`). Users only need to supply the HOST
+LANGUAGE'S OWN runtime link flags (the `${AETHER_<LANG>_LDFLAGS}`
+for `libpython`, `libruby`, etc.) — never the bridge .a itself.
+
+When adding a new bridge: the only step on the `ae` side is to
+verify the .a name matches `libaether_host_<lang>.a` and lives next
+to `libaether.a` (install) or in `build/contrib/` (dev). The scan
+loop in `tools/ae.c` keys on the `<lang>` token after
+`import contrib.host.` and needs no per-language code.
+
 ### Additional Checks
 
 1. **No memory leaks**

--- a/contrib/host/python/README.md
+++ b/contrib/host/python/README.md
@@ -7,6 +7,21 @@ inside the calling process, with permission-checked access controls.
 The build needs CPython's headers at compile time and `libpython` at
 link time. Two recipes — pick whichever matches how you're building.
 
+## What `ae build` does for you automatically
+
+When your program has `import contrib.host.python`, `ae build` links
+`libaether_host_python.a` (the in-tree bridge that connects Aether to
+CPython) onto the resulting binary automatically. You do NOT need to
+add `-laether_host_python` to `link_flags` — the import is the trigger.
+
+What you DO still need to supply yourself is the path to `libpython`
+itself (CPython's own runtime). That's `${AETHER_PYTHON_LDFLAGS}` in
+the recipes below.
+
+`ae build` errors with a clear actionable message if you import
+`contrib.host.python` but `libaether_host_python.a` hasn't been built:
+run `make contrib` (dev tree) or `make install-contrib` (installed).
+
 ## Recipe A — single-box dev (Linux with `python3-dev` installed)
 
 ```bash

--- a/tests/integration/host_bridge_import_link/test_host_bridge_import_link.sh
+++ b/tests/integration/host_bridge_import_link/test_host_bridge_import_link.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# Regression: `import contrib.host.<lang>` queues libaether_host_<lang>.a
+# onto the gcc link line; a pure-Aether program does NOT.
+#
+# This is the import-driven linking from ctr_notes.md Bug 4: without it,
+# `import contrib.host.python` resolved the headers (so the program
+# compiled) but never linked the bridge .a, so the binary failed at
+# runtime with `undefined symbol: python_run` — the bridge's OWN
+# function, not a CPython symbol.
+#
+# We verify by capturing `ae build -v` output and grepping for the .a
+# (positive) or its absence (negative). We do NOT attempt to RUN the
+# produced positive binary — that needs libpython at runtime, which
+# the CI box may not have. The link-line check is portable and
+# sufficient to prove the wiring.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+fail=0
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# --- Setup: ensure contrib bridges are built so the positive case has
+# a .a to find. Skip the test gracefully when host_python wasn't built
+# (e.g. because python3-dev is unavailable on this host).
+PY_A="$ROOT/build/contrib/libaether_host_python.a"
+INST_PY_A="$ROOT/lib/aether/libaether_host_python.a"
+if [ ! -f "$PY_A" ] && [ ! -f "$INST_PY_A" ]; then
+    # Try to build it once.
+    (cd "$ROOT" && bash tests/scripts/contrib_build.sh) >/dev/null 2>&1 || true
+fi
+if [ ! -f "$PY_A" ] && [ ! -f "$INST_PY_A" ]; then
+    echo "  [SKIP] host_bridge_import_link: libaether_host_python.a not built (python3-dev not installed?)"
+    exit 0
+fi
+
+# --- Test A (positive): import contrib.host.python → .a in link line.
+# We don't need the source to compile/link successfully — the link line
+# is logged before the linker actually runs, so even a failing link
+# proves what flags reached gcc. To avoid spurious "build failed" noise
+# we redirect everything; we read the verbose log for the .a path.
+cat > "$tmpdir/a.ae" <<'EOF'
+import contrib.host.python
+
+main() {
+    python.run_sandboxed(0, "print('unreached')")
+}
+EOF
+"$AE" build "$tmpdir/a.ae" -o "$tmpdir/a_out" -v >"$tmpdir/a.log" 2>&1 || true
+
+if grep -q 'libaether_host_python\.a' "$tmpdir/a.log"; then
+    echo "  [PASS] host_bridge_import_link A: contrib.host.python import queues libaether_host_python.a"
+else
+    echo "  [FAIL] host_bridge_import_link A: bridge .a missing from link line despite the import"
+    grep -E 'host bridge|libaether_host|\[cmd\]' "$tmpdir/a.log" | sed 's/^/    /' | head -5
+    fail=1
+fi
+
+# --- Test B (negative): pure-Aether program → NO bridge .a on link
+# line, AND the build must succeed + run. This guards the critical
+# "do not blanket-link" constraint: a hello-world must not pick up
+# libpython runtime deps it doesn't need.
+cat > "$tmpdir/b.ae" <<'EOF'
+main() { println("hi") }
+EOF
+if ! "$AE" build "$tmpdir/b.ae" -o "$tmpdir/b_out" -v >"$tmpdir/b.log" 2>&1; then
+    echo "  [FAIL] host_bridge_import_link B: pure-Aether build failed (unexpected)"
+    sed 's/^/    /' "$tmpdir/b.log" | tail -5
+    fail=1
+elif grep -qE 'libaether_host_[a-z]+\.a' "$tmpdir/b.log"; then
+    echo "  [FAIL] host_bridge_import_link B: pure-Aether build pulled in a bridge .a (blanket-link bug)"
+    grep -E 'libaether_host_[a-z]+\.a' "$tmpdir/b.log" | sed 's/^/    /' | head -3
+    fail=1
+elif ! "$tmpdir/b_out" 2>&1 | grep -q '^hi$'; then
+    echo "  [FAIL] host_bridge_import_link B: pure-Aether binary did not print 'hi'"
+    "$tmpdir/b_out" 2>&1 | sed 's/^/    /' | head -3
+    fail=1
+else
+    echo "  [PASS] host_bridge_import_link B: pure-Aether build has no bridge .a, runs cleanly"
+fi
+
+# --- Test C (hard error): `import contrib.host.nonexistent` → ae
+# rejects the build with a clear actionable message.
+cat > "$tmpdir/c.ae" <<'EOF'
+import contrib.host.definitelynothere
+
+main() { println("never") }
+EOF
+"$AE" build "$tmpdir/c.ae" -o "$tmpdir/c_out" >"$tmpdir/c.log" 2>&1
+c_rc=$?
+if [ "$c_rc" -eq 0 ]; then
+    echo "  [FAIL] host_bridge_import_link C: missing bridge .a did not trigger hard error"
+    fail=1
+elif ! grep -q "libaether_host_definitelynothere.a" "$tmpdir/c.log"; then
+    echo "  [FAIL] host_bridge_import_link C: error did not name the missing .a"
+    sed 's/^/    /' "$tmpdir/c.log" | head -5
+    fail=1
+elif ! grep -q "make contrib\|install-contrib" "$tmpdir/c.log"; then
+    echo "  [FAIL] host_bridge_import_link C: error did not point at remediation"
+    sed 's/^/    /' "$tmpdir/c.log" | head -5
+    fail=1
+else
+    echo "  [PASS] host_bridge_import_link C: missing bridge .a → actionable hard error"
+fi
+
+exit $fail

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -213,6 +213,20 @@ static bool g_emit_lib = false;
 // gated on dlopen availability); stays empty on Windows.
 static char g_binimport_link[4096] = "";
 
+// Extra link flags accumulated by the host-bridge import prepass: when
+// a program `import`s `contrib.host.<lang>`, the bridge's static lib
+// (libaether_host_<lang>.a) must be on the link line or the produced
+// binary fails at runtime with `undefined symbol: <lang>_run` (the
+// BRIDGE symbol, not the host language's). The user previously had to
+// repeat themselves with `link_flags = "-laether_host_python"` in
+// aether.toml — same information twice. Driven entirely by the import,
+// so a pure-Aether program with no `contrib.host.*` imports does NOT
+// link any bridge .a (critical: blanket-linking would force a
+// hello-world binary to dlopen libpython at runtime). Empty unless
+// `prepare_host_bridge_imports` found a match. POSIX-only (the host
+// bridges aren't built / linked on Windows).
+static char g_host_bridge_link[2048] = "";
+
 // Mirror of runtime/aether_lib_meta.h's catalog structs, kept
 // layout-compatible so `ae` can dlopen a `--emit=lib` artifact and walk
 // its `aether_lib_meta()` without including the runtime header. Used by
@@ -1964,9 +1978,13 @@ static void build_gcc_cmd(char* cmd, size_t size,
          * would dlopen a script.so with RTLD_NOW and the resolver
          * would fail to find any libaether symbol — silently on
          * macOS via dynamic_lookup, hard-failing on Linux. */
+        // Order matters: host-bridge .a files reference symbols in
+        // libaether.a (aether_shared_map_*, etc.), so they must appear
+        // BEFORE -laether on the link line — gcc resolves undefined
+        // references left-to-right through static archives.
         int w = snprintf(cmd, size,
-            "gcc %s %s \"%s\"%s %s -rdynamic -L%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s",
-            opt, tc.include_flags, c_file, config_c, extra, lib_dir, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, link_flags, g_binimport_link);
+            "gcc %s %s \"%s\"%s %s -rdynamic -L%s %s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s",
+            opt, tc.include_flags, c_file, config_c, extra, lib_dir, g_host_bridge_link, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu) — "
@@ -1975,9 +1993,12 @@ static void build_gcc_cmd(char* cmd, size_t size,
                 w, size);
         }
     } else {
+        // Order matters: host-bridge .a files reference runtime
+        // symbols defined in tc.runtime_srcs (aether_shared_map_*,
+        // etc.), so they appear BEFORE the runtime source list.
         int w = snprintf(cmd, size,
-            "gcc %s %s \"%s\"%s %s %s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s",
-            opt, tc.include_flags, c_file, config_c, extra, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, link_flags, g_binimport_link);
+            "gcc %s %s \"%s\"%s %s %s %s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s",
+            opt, tc.include_flags, c_file, config_c, extra, g_host_bridge_link, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu) — "
@@ -2343,6 +2364,126 @@ static void prepare_binary_imports(const char* main_file) {
 static void prepare_binary_imports(const char* main_file) { (void)main_file; }
 #endif
 
+// Scan `main_file` for `import contrib.host.<lang>` statements and
+// queue the matching bridge static archive onto the link line.
+//
+// The bridge .c (contrib/host/<lang>/aether_host_<lang>.c) compiles
+// to libaether_host_<lang>.a (see Makefile:1324). Linking the .a is
+// what supplies symbols like `python_run` — the BRIDGE's own ABI,
+// distinct from the host language's runtime symbols (Py_Initialize
+// et al.) that the bridge in turn calls. Without this scan, an
+// import like `import contrib.host.python` compiled because the
+// headers resolved, but at runtime failed with `undefined symbol:
+// python_run` because the .a was never linked. Users had to repeat
+// the import as `link_flags = "-laether_host_python"` in
+// aether.toml — busywork easily forgotten (the ctr_notes.md Bug 4
+// trace from 2026-06-03).
+//
+// Entry-file-only: only the top-level .ae passed to `ae build` /
+// `ae run` is scanned. If a library you import in turn imports
+// `contrib.host.python`, you must still write the import yourself
+// in your top-level file. Widening to transitive imports later is
+// purely additive — same predicate, more files to scan.
+//
+// Hard error if the .a is missing (the user opted in via the
+// import; silently dropping it just defers the failure to a more
+// confusing runtime error). The two search paths mirror the two
+// install layouts in tools/ae.c:1013-1017:
+//   - install layout: <lib_dir>/libaether_host_<lang>.a
+//     (Makefile install-contrib target installs here)
+//   - dev layout:     <lib_dir>/contrib/libaether_host_<lang>.a
+//     (`make contrib` builds here, without installing)
+// where `lib_dir` is the directory containing libaether.a, same as
+// build_gcc_cmd derives it from `tc.lib`.
+//
+// POSIX-only — host bridges aren't compiled on the Windows matrix.
+#ifndef _WIN32
+static bool host_bridge_a_path(const char* lang, char* out, size_t outsz) {
+    if (!tc.has_lib) return false;
+    char lib_dir[1024];
+    strncpy(lib_dir, tc.lib, sizeof(lib_dir) - 1);
+    lib_dir[sizeof(lib_dir) - 1] = '\0';
+    char* slash = strrchr(lib_dir, '/');
+    if (slash) *slash = '\0';
+
+    // Install layout: <lib_dir>/libaether_host_<lang>.a
+    snprintf(out, outsz, "%s/libaether_host_%s.a", lib_dir, lang);
+    if (path_exists(out)) return true;
+    // Dev layout: <lib_dir>/contrib/libaether_host_<lang>.a (build/contrib/)
+    snprintf(out, outsz, "%s/contrib/libaether_host_%s.a", lib_dir, lang);
+    if (path_exists(out)) return true;
+    return false;
+}
+
+static void prepare_host_bridge_imports(const char* main_file) {
+    FILE* f = fopen(main_file, "r");
+    if (!f) return;
+
+    // Track which languages we've already queued so the same import
+    // appearing twice doesn't double-link the .a (gcc would tolerate
+    // it but the noise hides real problems).
+    char seen[256] = "";
+
+    char line[1024];
+    while (fgets(line, sizeof(line), f)) {
+        const char* p = line;
+        while (*p == ' ' || *p == '\t') p++;
+        if (strncmp(p, "import", 6) != 0 || (p[6] != ' ' && p[6] != '\t')) continue;
+        p += 6;
+        while (*p == ' ' || *p == '\t') p++;
+        if (strncmp(p, "contrib.host.", 13) != 0) continue;
+        p += 13;
+        // Extract <lang> — identifier chars only.
+        char lang[64];
+        size_t li = 0;
+        while (*p && (isalnum((unsigned char)*p) || *p == '_') && li < sizeof(lang) - 1) {
+            lang[li++] = *p++;
+        }
+        lang[li] = '\0';
+        if (li == 0) continue;
+
+        // Dedup against `seen` (space-delimited, surrounded by spaces
+        // so "py" doesn't match "python").
+        char needle[80];
+        snprintf(needle, sizeof(needle), " %s ", lang);
+        if (strstr(seen, needle)) continue;
+        size_t soff = strlen(seen);
+        snprintf(seen + soff, sizeof(seen) - soff, "%s%s ",
+                 soff == 0 ? " " : "", lang);
+
+        char a_path[1200];
+        if (!host_bridge_a_path(lang, a_path, sizeof(a_path))) {
+            fclose(f);
+            fprintf(stderr,
+                "ae: cannot find libaether_host_%s.a — required by "
+                "`import contrib.host.%s` in %s.\n"
+                "  Build the contrib bridges with `make contrib` (dev tree)\n"
+                "  or `make install-contrib` (installed layout); the .a is\n"
+                "  expected next to libaether.a or in a sibling contrib/ dir.\n",
+                lang, lang, main_file);
+            exit(1);
+        }
+
+        // Append the .a as a direct file path (more deterministic than
+        // -L+-l in the build-tree case where multiple lib dirs might
+        // shadow each other). gcc treats a bare .a on the command line
+        // as an input archive, the way -laether_host_<lang> would.
+        size_t off = strlen(g_host_bridge_link);
+        snprintf(g_host_bridge_link + off,
+                 sizeof(g_host_bridge_link) - off,
+                 " \"%s\"", a_path);
+
+        if (tc.verbose) {
+            fprintf(stderr, "ae: host bridge 'contrib.host.%s' -> %s\n",
+                    lang, a_path);
+        }
+    }
+    fclose(f);
+}
+#else
+static void prepare_host_bridge_imports(const char* main_file) { (void)main_file; }
+#endif
+
 // --------------------------------------------------------------------------
 // Commands
 // --------------------------------------------------------------------------
@@ -2477,6 +2618,12 @@ static int cmd_run(int argc, char** argv) {
     // `import foo` that resolves to a precompiled libfoo.so, and record
     // it on the link line. No-op for all-source programs.
     prepare_binary_imports(file);
+
+    // Host-bridge prepass: `import contrib.host.<lang>` queues
+    // libaether_host_<lang>.a onto the link line. Import-driven so a
+    // pure-Aether program doesn't gain libpython et al. as runtime
+    // dependencies it doesn't use.
+    prepare_host_bridge_imports(file);
 
     // Step 1: Compile .ae to .c
     if (tc.verbose) printf("Compiling %s...\n", file);
@@ -4556,6 +4703,10 @@ static int cmd_build(int argc, char** argv) {
     // Binary-import prepass: synthesize interface stubs for any
     // `import foo` resolving to a precompiled libfoo.so, link it in.
     prepare_binary_imports(file);
+
+    // Host-bridge prepass: queue libaether_host_<lang>.a for any
+    // `import contrib.host.<lang>` in the entry file. See cmd_run.
+    prepare_host_bridge_imports(file);
 
     // Step 1: .ae to .c
     build_aetherc_cmd(cmd, sizeof(cmd), file, c_file);


### PR DESCRIPTION
## Summary

Closes `ctr_notes.md` **Bug 4** (2026-06-03) from the aeb sibling's
Aether-hosts-Python work on Bazzite:

`import contrib.host.python` resolved the bridge headers (so the
program compiled), but `libaether_host_python.a` was never linked,
so the binary failed at runtime with `undefined symbol: python_run`
— the **bridge's own** function, not a CPython symbol. Users had
to repeat the import as `link_flags = "-laether_host_python"` in
`aether.toml`, busywork easily forgotten.

This PR makes `ae build` (and `ae run`) scan the entry `.ae` for
`import contrib.host.<lang>`, find the matching
`libaether_host_<lang>.a`, and queue it onto the gcc link line in
the correct position (BEFORE `-laether` / `tc.runtime_srcs`, so the
bridge's references to Aether runtime symbols like
`aether_shared_map_*` resolve).

## The critical "do NOT blanket-link" property

A pure-Aether program with no `import contrib.host.*` gets **zero**
bridge .a on its link line. Otherwise hello-world would gain
libpython et al. as runtime deps it doesn't need. The integration
test's negative cell guards this.

## Behaviour summary

| Program | Link line | Outcome |
|---|---|---|
| `import contrib.host.python` + `.a` present | `libaether_host_python.a` queued before `-laether` | Links cleanly; user supplies `${AETHER_PYTHON_LDFLAGS}` for libpython itself |
| Pure Aether (no `contrib.host.*`) | No bridge .a | Hello-world runs without any host runtime |
| `import contrib.host.<lang>` + `.a` missing | Hard error | `ae: cannot find libaether_host_<lang>.a — required by …` + pointer to `make contrib` / `make install-contrib` |

## Scope (deliberate v1)

- **Entry-file-only scan.** If your imported module in turn imports
  a host bridge, you must also import it from your top-level `.ae`.
  Widening to transitive imports later is purely additive (same
  predicate, more files to scan) so this can be loosened without
  breaking anyone.
- **POSIX-only.** The host bridges aren't compiled on the Windows
  matrix.
- **Hard error if .a missing** (silent fallback was the original
  Bug 4 hazard).

## Test plan

`tests/integration/host_bridge_import_link/` exercises three cells:

- **A** (positive): `import contrib.host.python` → grep `ae build -v`
  output for `libaether_host_python.a` on the link line.
- **B** (negative): pure-Aether `main() { println("hi") }` →
  grep proves NO `libaether_host_*.a` is linked; binary runs.
- **C** (hard error): `import contrib.host.definitelynothere` →
  build fails with the actionable message naming the missing .a
  and pointing at `make contrib`.

- [x] `make ci` (green modulo HTTP/2 framing flakes — forgiven)
- [x] `HARDEN=1 make ci` (green modulo same flakes)
- [ ] CI matrix on Linux gcc/clang
- [ ] CI matrix on macOS Apple Clang
- [ ] CI matrix on Windows (helper is `#ifdef _WIN32` no-op)
- [ ] Smoke-test the contrib.host.python integration on the Bazzite
      box (orchestrator side); aeb-ctr can then DROP the
      `--unresolved-symbols=ignore-all` workaround once this lands

## Docs

- `CHANGELOG.md [current]` entry.
- `CONTRIBUTING.md §9`: import-driven link contract; future bridges
  need no per-language code on the `ae` side (the loop keys on the
  `<lang>` token).
- `contrib/host/python/README.md`: new "What `ae build` does for you"
  section explaining the user no longer writes
  `-laether_host_python`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)