### PR TITLE
docs(changelog): backfill 0.196.0, 0.200.0, 0.204.0–0.207.0 [skip actions]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,23 @@ next version number before tagging the release.
   issue where heap-promoted strings / strbuilder ptrs captured from
   a nested block crash on the next event when the block exits.
 
+## [0.200.0]
+
+### Documentation
+
+- **CONTRIBUTING.md — POSIX typedef portability + stdlib param-type
+  grep recipe** (PR #585, `CONTRIBUTING.md`).
+  - **§5b**: documents the MinGW gap for POSIX-only typedefs
+    (`suseconds_t`, `ssize_t`, `off_t`); recommends casting through
+    the underlying integer type (`long`, `intptr_t`, `int64_t`)
+    rather than the typedef name, which silently breaks on the
+    Windows matrix.
+  - **"Changing a stdlib parameter's TYPE"**: when a PR widens or
+    replaces a stdlib parameter's type (canonical case
+    `int → Duration`), the typechecker doesn't always reject the
+    old call shape — grep all callers in `tests/`, `examples/`,
+    `std/` before merging. Codifies the rule we hit on PR #583.
+
 ## [0.199.0]
 
 ### Added
@@ -512,6 +529,21 @@ next version number before tagging the release.
   definitions land in the program AST by their bare struct name
   (matches how the import resolver clones them), so the lowered
   literal references the same C type either way.
+
+## [0.196.0]
+
+### Documentation
+
+- **`docs/closures-and-builder-dsl.md` — LLM quick-reckoner +
+  DSL-with-scope attribution** (PR #576,
+  `docs/closures-and-builder-dsl.md`).
+  Pins down the trailing-block / `_ctx` / `builder…with` semantics
+  in a form an LLM (or human reader) can use as a single-page
+  reference. Captures the rules that the existing builder-DSL code
+  enforces but had nowhere documented: when `()` is required for a
+  trailing block, how `_ctx` injection scopes through nested
+  builder calls, how `builder...with` differs from a plain factory
+  call. Companion to the `[builder DSL]` memory notes.
 
 ## [0.195.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,76 @@ next version number before tagging the release.
   NOT expanded; shell `$(...)` command substitution is NOT supported
   (would let any `aether.toml` exec arbitrary commands at build time).
 
+### Fixed
+
+- **`tools/docker/aether-build` headers-clone failure on Bazzite** (PR
+  #600): the `hosted-language-headers` clone used `git clone --depth 1`
+  then `git fetch --depth 1 origin <SHA>`, which requires the remote
+  to honour `uploadpack.allowAnySHA1InWant`. GitHub usually does but
+  not reliably for arbitrary commits that aren't ref tips. Symptom on
+  Bazzite: `fatal: reference is not a tree: <sha>` during
+  `--rebuild-image`. Fix: drop `--depth 1` from the clone; full-history
+  clone (~14 MB) then `git checkout <SHA>`. Applied to both the
+  embedded Containerfile heredoc in `tools/docker/aether-build` and
+  the modular helper `tools/docker/scripts/clone-host-headers.sh`.
+
+## [0.206.0]
+
+### Fixed
+
+- **`tools/docker/aether-build` Bazzite follow-up — SELinux+crun
+  auto-detect, mount-option separator** (PR #598).
+  - The `--userns=keep-id` flag (in any form, bare or explicit
+    uid/gid) crashes Bazzite's crun with `readlink ``: No such file
+    or directory`. Both forms fail identically. v0.205.0 added an
+    `AETHER_USERNS=` escape hatch but defaulted to keep-id, so the
+    headline Bazzite target was still broken out of the box. This
+    release auto-detects SELinux+crun hosts and drops the userns
+    flag by default; explicit override still works.
+  - The `:Z` SELinux mount label was built with a leading comma
+    (`SELABEL_SUFFIX=",$SELABEL"`), producing `-v "$OUT:/out,Z"`
+    which podman parsed as container path `/out,Z` rather than
+    `/out` with label `Z`. Build wrote into the image's ephemeral
+    `/out` and `~/aebuild/out/` stayed empty. Fix: `mount_opts()`
+    helper that emits colon-first then comma-subsequent
+    (`:ro,Z` / `:Z` correctly per case).
+
+## [0.205.0]
+
+### Fixed
+
+- **`tools/docker/aether-build` Bazzite SELinux + crun keep-id, plus
+  `--aeb` signpost** (PR #596).
+  - On Bazzite (rootless podman + SELinux enforcing + crun), bare
+    bind mounts hit `SELinux denies the read` (surface: misleading
+    `not found`); add `:Z` to relabel. Refuses to relabel `$HOME`
+    so `$WORK == $HOME` now emits a clear "use a subdir" message.
+  - `--userns=keep-id` crashes Bazzite's crun; introduced
+    `AETHER_USERNS=` env var to opt out (defaulted to keep-id; the
+    follow-up in v0.206.0 flipped the default for Bazzite).
+  - `--aeb` mode now emits a signpost message instead of dead-ending
+    when aeb isn't installed: points at aeb's own
+    `Containerfile.aeb-toolchain` layer, where the seam gets filled.
+
+## [0.204.0]
+
+### Added
+
+- **`tools/docker/aether-build` — single-file bootstrap script for
+  immutable-host development** (PR #594,
+  `tools/docker/aether-build`).
+  Curl-installable shell script that bootstraps a slim
+  `aether-builder` container image (Containerfile is heredoc'd
+  inline), then dispatches `aether-build app.ae` /
+  `aether-build --aeb <target>` into it. Target use case: Bazzite
+  and other immutable-by-design Linux hosts where you can't `apt
+  install gcc` but can run rootless podman. Image carries
+  vendored `contrib/host/{python,lua,perl,ruby,js}` headers from
+  the pinned `hosted-language-headers` repo, so end-user programs
+  using `import contrib.host.<lang>` compile without per-language
+  install toggles. Runtime libraries (libpython, libruby, etc.)
+  stay on the deploy host (the binary `dlopen`s them lazily).
+
 ## [0.203.0]
 
 ### Added


### PR DESCRIPTION
## Summary

Six PRs landed in releases that auto-tagged WITHOUT a CHANGELOG
entry, so the published CHANGELOG file had four gaps (0.196.0,
0.200.0, 0.204.0–0.206.0, plus a missing fix in the 0.207.0
block).

Causes:

- **#576, #596, #598, #600** were pushed with `[skip actions]` to
  conserve CI minutes on docker / docs-only changes. Skipped the
  pre-merge CI run, so any `[current]` nudge a contributor might
  have noticed was bypassed too. Each PR forgot to add a
  `[current]` entry.
- **#585, #594** had no `[skip actions]` but the author just
  forgot the CHANGELOG entry. CI ran; release pipeline tagged the
  version with an empty block.

The release pipeline promotes whatever sits under `## [current]` to
`## [X.Y.Z]`. If nothing's there, nothing gets promoted, and the
version block doesn't appear.

## What this PR does

Backfills six entries — historical only, no behaviour change.

| Version | PR | What landed |
|---|---|---|
| 0.196.0 | #576 | docs/closures-and-builder-dsl.md quick-reckoner |
| 0.200.0 | #585 | CONTRIBUTING.md §5b POSIX typedef portability + grep recipe |
| 0.204.0 | #594 | tools/docker/aether-build single-file bootstrap + parameterised image |
| 0.205.0 | #596 | Bazzite SELinux + crun keep-id workarounds (first cut), --aeb signpost |
| 0.206.0 | #598 | Bazzite follow-up: SELinux+crun auto-detect + :Z colon-vs-comma fix |
| 0.207.0 | #600 (+ #601 already present) | hosted-language-headers shallow-clone fix |

CHANGELOG version sequence now contiguous from 0.195.0 → 0.208.0.

## [skip actions] because

Pure docs change to a release-history file.

## Process note

Maintainers writing [skip actions] PRs MUST still include a
`## [current]` entry. The release pipeline only promotes what's
in the file, not what's in the commit messages.
