### PR TITLE
feat(contrib.host.tinygo): wire --with=tinygo capability layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`aether-build --with=tinygo` — TinyGo c-shared sidecar capability**
+  (`tools/docker/aether-build`, `tests/scripts/contrib_build.sh`,
+  `Makefile`). New `--with=tinygo` token builds an
+  `aether-builder-tinygo:slim` image with `libaether_host_tinygo.a` +
+  TinyGo (pinned to 0.34.0 via `--build-arg TINYGO_VERSION=…`) +
+  `golang-go` (cgo host Go) + `libffi-dev`. The bridge `.c` is pure
+  dlopen via `std.dl` — TinyGo isn't needed to build the `.a`; it's
+  needed at user-program build time when `aeb`'s `aether.tinygo_lib`
+  builder shells `tinygo build -buildmode=c-shared` to produce a
+  sidecar `.so`. The capability ships the toolchain in the builder
+  image so the aeb-toolchain layer stays language-agnostic (same
+  property the six interpreter bridges rely on). Closes the
+  capability-set across all host-language bridges (python, ruby, lua,
+  perl, tcl, duktape, tinygo).
+
+### Changed
+
+- **`install-contrib` ships `contrib/host/tinygo/`** (`Makefile`).
+  Was previously stripped under the v1 "out of scope" comment that
+  also nukes `host/java` + `host/go`. tinygo IS in scope — it's
+  the first c-shared sidecar capability and its `module.ae` must be
+  installable so `import contrib.host.tinygo` resolves in
+  `aether-builder-tinygo:slim`.
+
 ## [0.214.0]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1331,10 +1331,9 @@ install: release ae stdlib
 #
 # Modules covered (v1):
 #   - sqlite                    (-lsqlite3)
-#   - host/{python,lua,perl,ruby,js,tcl}
-# Out of scope for v1: host/{java,go,tinygo} (separate-process or
-# JNI-style bridges, different build shape), tinyweb,
-# climate_http_tests. The widget toolkit (formerly contrib/aether_ui)
+#   - host/{python,lua,perl,ruby,duktape,tcl,tinygo}
+# Out of scope for v1: host/{java,go} (separate-process or JNI-style
+# bridges, different build shape), tinyweb, climate_http_tests. The widget toolkit (formerly contrib/aether_ui)
 # spun out to https://github.com/aether-lang-org/aether-ui and is no
 # longer in this repo.
 # -----------------------------------------------------------------
@@ -1372,14 +1371,13 @@ install-contrib: contrib
 	@# Mirror the contrib source tree for module.ae + headers.
 	@# Trim noise: tests, benchmarks, example .ae, build scripts,
 	@# CI scripts, and the modules we don't ship in v1
-	@# (climate_http_tests, host/{java,go,tinygo}, tinyweb — see
-	@# contrib: target comment).
+	@# (climate_http_tests, host/{java,go}, tinyweb — see
+	@# contrib: target comment). host/tinygo IS shipped (--with=tinygo).
 	@cp -R contrib $(PREFIX)/share/aether/
 	@rm -rf $(PREFIX)/share/aether/contrib/climate_http_tests
 	@rm -rf $(PREFIX)/share/aether/contrib/tinyweb
 	@rm -rf $(PREFIX)/share/aether/contrib/host/java
 	@rm -rf $(PREFIX)/share/aether/contrib/host/go
-	@rm -rf $(PREFIX)/share/aether/contrib/host/tinygo
 	@rm -rf $(PREFIX)/share/aether/contrib/host/aether
 	@find $(PREFIX)/share/aether/contrib -type d -name tests       -exec rm -rf {} + 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type d -name benchmarks  -exec rm -rf {} + 2>/dev/null || true

--- a/tests/scripts/contrib_build.sh
+++ b/tests/scripts/contrib_build.sh
@@ -137,6 +137,27 @@ probe_duktape() {
     return 1
 }
 
+probe_tinygo() {
+    # The bridge .c is pure dlopen via std.dl (aether_dl_*) — it does NOT
+    # need the tinygo toolchain at COMPILE time. libffi is the only
+    # build-time dep, and even that's conditional on AETHER_HAS_LIBFFI
+    # for the tinygo.call_dynamic escape hatch. The `tinygo` binary is
+    # only invoked at USER-build time (aeb's tinygo_lib builder shells
+    # `tinygo build -buildmode=c-shared` on the .go source).
+    #
+    # Probe shape: if libffi-dev is present, opt in to the AETHER_HAS_LIBFFI
+    # path and emit its cflags; otherwise the bridge still builds without
+    # the escape hatch.
+    if pkg-config --exists libffi 2>/dev/null; then
+        echo "-DAETHER_HAS_LIBFFI $(pkg-config --cflags libffi 2>/dev/null)"
+        return 0
+    fi
+    # No libffi: the bridge still compiles (the call_dynamic block is
+    # behind #ifdef AETHER_HAS_LIBFFI).
+    echo ""
+    return 0
+}
+
 # build_module <module_name> <relative_src_path> <AETHER_HAS_FLAG> <probe_fn>
 # Returns: 0 OK, 1 SKIP (probe failed), 2 FAIL (compile/archive failed)
 # Caller decides whether SKIP or FAIL is fatal (depends on MODULES mode).
@@ -185,6 +206,7 @@ CATALOGUE=(
     "ruby|host_ruby      contrib/host/ruby/aether_host_ruby.c     AETHER_HAS_RUBY    probe_ruby"
     "duktape|host_duktape  contrib/host/duktape/aether_host_duktape.c  AETHER_HAS_DUKTAPE  probe_duktape"
     "tcl|host_tcl        contrib/host/tcl/aether_host_tcl.c       AETHER_HAS_TCL     probe_tcl"
+    "tinygo|host_tinygo  contrib/host/tinygo/aether_host_tinygo.c AETHER_HAS_TINYGO  probe_tinygo"
 )
 
 # Find a catalogue line by short name. Echoes the build_module arg list

--- a/tools/docker/aether-build
+++ b/tools/docker/aether-build
@@ -26,7 +26,12 @@
 #
 #   Each --with=<lang> adds an apt -dev-kit layer + a `make contrib
 #   MODULES=<lang>` layer to the generated image. Known langs:
-#     python | lua | perl | ruby | java | duktape (alias: js) | tcl
+#     python | lua | perl | ruby | java | duktape (alias: js) | tcl | tinygo
+#
+#   `tinygo` is the odd one out — it's a c-shared sidecar builder, not
+#   a host-interpreter dlopen. Its layer installs the TinyGo .deb from
+#   the upstream GitHub release (+ golang-go for cgo + libffi-dev for
+#   the bridge's call_dynamic path) instead of an apt -dev kit.
 #
 #   The bare image (no --with) contains NO hosted-language bridges.
 #   --with= entries are alpha-sorted before deriving the image name,
@@ -166,6 +171,13 @@ with_dev_pkg() {
         duktape) echo "duktape-dev" ;;
         js)      echo "duktape-dev" ;;  # alias: --with=js maps to duktape
         tcl)     echo "tcl-dev" ;;
+        # tinygo is structurally different from the apt-installed -dev
+        # kits: TinyGo isn't in Debian repos, so the layer fetches the
+        # upstream .deb from the GitHub release. The "apt portion"
+        # below covers golang-go (the cgo host Go), libffi-dev (used by
+        # the bridge's tinygo.call_dynamic path AND by TinyGo's runtime
+        # for c-shared mode), and curl (to fetch the .deb).
+        tinygo)  echo "golang-go libffi-dev curl" ;;
         *)       return 1 ;;
     esac
 }
@@ -179,7 +191,7 @@ while [ $# -gt 0 ]; do
         --with=*)
             lang="${1#--with=}"
             if ! with_dev_pkg "$lang" >/dev/null; then
-                echo "aether-build: --with=$lang: unknown language (known: python lua perl ruby java duktape (alias: js) tcl)" >&2
+                echo "aether-build: --with=$lang: unknown language (known: python lua perl ruby java duktape (alias: js) tcl tinygo)" >&2
                 exit 1
             fi
             # Canonicalise aliases BEFORE the sort/dedupe pass so
@@ -399,7 +411,35 @@ bootstrap_image() {
     WITH_LAYERS=""
     for lang in $WITH_LANGS; do
         pkg=$(with_dev_pkg "$lang")
-        WITH_LAYERS="$WITH_LAYERS
+        if [ "$lang" = "tinygo" ]; then
+            # TinyGo isn't apt-packaged in Debian; fetch the upstream
+            # .deb from the GitHub release. The .deb arch names
+            # (amd64/arm64/armhf) match \`dpkg --print-architecture\`
+            # exactly — no remap. Override the version via
+            # \`--build-arg TINYGO_VERSION=0.X.Y\` on \`podman build\`.
+            WITH_LAYERS="$WITH_LAYERS
+# --- Hosted-language layer: tinygo (custom .deb + apt $pkg) ---
+# Added because aether-build was invoked with --with=tinygo. Unlike
+# the interpreter bridges, tinygo isn't a host-dlopen target — it's
+# a c-shared sidecar builder. The apt portion gives us golang-go
+# (cgo host Go), libffi-dev (bridge call_dynamic + tinygo runtime),
+# and curl (.deb fetch). The .deb step installs TinyGo itself.
+RUN apt-get update \\
+ && apt-get install -y --no-install-recommends $pkg \\
+ && rm -rf /var/lib/apt/lists/*
+ARG TINYGO_VERSION=0.34.0
+RUN ARCH=\$(dpkg --print-architecture) \\
+ && curl -fsSL -o /tmp/tinygo.deb \\
+      \"https://github.com/tinygo-org/tinygo/releases/download/v\${TINYGO_VERSION}/tinygo_\${TINYGO_VERSION}_\${ARCH}.deb\" \\
+ && apt-get update \\
+ && apt-get install -y --no-install-recommends /tmp/tinygo.deb \\
+ && rm -rf /var/lib/apt/lists/* /tmp/tinygo.deb
+RUN cd /src \\
+ && make contrib MODULES=tinygo \\
+ && make install-contrib
+"
+        else
+            WITH_LAYERS="$WITH_LAYERS
 # --- Hosted-language layer: $lang (via apt $pkg) ---
 # Added because aether-build was invoked with --with=$lang.
 # The -dev kit lays down REAL platform-specific headers
@@ -412,6 +452,7 @@ RUN cd /src \\
  && make contrib MODULES=$lang \\
  && make install-contrib
 "
+        fi
     done
 
     cat > "$BUILDCTX/Containerfile" <<CONTAINERFILE


### PR DESCRIPTION
## Summary

Closes the host-language bridge set: tinygo joins python, ruby, lua, perl, tcl, and duktape as a first-class `--with=` capability. Unlike the six interpreter bridges (which dlopen a host-installed `libfoo` at runtime), tinygo is a c-shared **sidecar** capability — the user writes `.go` source, aeb's `aether.tinygo_lib` builder shells `tinygo build -buildmode=c-shared`, and the resulting `libfoo.so` travels alongside the binary.

The bridge `.c` itself is pure dlopen via `std.dl` (no TinyGo or Go needed to build the `.a`). The TinyGo toolchain is needed at **user-program build time**, not at bridge-`.a`-build time — so the layer ships TinyGo in the builder image (mirrors how `aether-builder-python:slim` ships `python3-dev`, keeping the aeb-toolchain layer language-agnostic).

### Why TinyGo via .deb (not tarball)

- arch names (`amd64`/`arm64`/`armhf`) match `dpkg --print-architecture` exactly — no remap
- apt resolves declared deps
- aligns with the rest of the `--with=` layers being apt-driven

Pinned to TinyGo `0.34.0`; override via `--build-arg TINYGO_VERSION=0.X.Y`.

### Three coordinated changes

1. **`Makefile install-contrib`** no longer strips `contrib/host/tinygo` (was in v1 "out of scope" list with `host/java` and `host/go`; tinygo is now first-class, those two stay out).
2. **`tests/scripts/contrib_build.sh`** gains a `tinygo` catalogue entry + `probe_tinygo` (libffi-cflags-or-empty; the bridge `.c` compiles with or without libffi).
3. **`tools/docker/aether-build`** — `with_dev_pkg` adds `tinygo) golang-go libffi-dev curl`; `WITH_LAYERS` emit special-cases tinygo to apt + curl-fetch + apt-install .deb + bridge `.a` build.

## Test plan

- [x] `make contrib MODULES=tinygo` → `build/contrib/libaether_host_tinygo.a`
- [x] `make ci` — 570 passed, 2 failed (forgiven HTTP/2 framing flakes)
- [x] Containerfile fragment dry-rendered locally; escapes (`\$`, `\${}`, `\"`) survive the heredoc round-trip
- [ ] NUC re-bake by aeb-sib: `AETHER_REF=v0.215.0 aether-build --with=tinygo --rebuild-image` → `aeb-ctr hosttinygo/.build.ae` → `hello from tinygo, hosted by aether` + `Add(2,40)=42 Answer()=42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)