### PR TITLE
fix(--with=tinygo): use upstream Go 1.23.4, not bookworm golang-go (1.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`--with=tinygo` layer — install upstream Go 1.23.4, not bookworm's
+  Go 1.19** (`tools/docker/aether-build`). The original v0.215.0
+  layer used `apt install golang-go`, which on debian:bookworm-slim
+  installs Go 1.19. TinyGo 0.34.0's build-time Go-version gate
+  requires ≥1.22; the image built green but `tinygo build` in
+  user-program Phase 1 would fail with a version-rejection error.
+  Layer now fetches a pinned Go tarball from go.dev
+  (`--build-arg GO_VERSION=1.23.4`) and includes a `tinygo version`
+  sanity-check RUN step so a broken Go/TinyGo pairing fails at
+  IMAGE build time rather than at first user `tinygo build`.
+
 ## [0.215.0]
 
 ### Added
@@ -27,6 +42,10 @@ next version number before tagging the release.
   property the six interpreter bridges rely on). Closes the
   capability-set across all host-language bridges (python, ruby, lua,
   perl, tcl, duktape, tinygo).
+
+  **Note**: the `golang-go` choice here was wrong (Go 1.19, rejected
+  by TinyGo 0.34); see the `[current]` section above for the followup
+  fix that switched to a pinned go.dev tarball.
 
 ### Changed
 

--- a/tools/docker/aether-build
+++ b/tools/docker/aether-build
@@ -172,12 +172,15 @@ with_dev_pkg() {
         js)      echo "duktape-dev" ;;  # alias: --with=js maps to duktape
         tcl)     echo "tcl-dev" ;;
         # tinygo is structurally different from the apt-installed -dev
-        # kits: TinyGo isn't in Debian repos, so the layer fetches the
-        # upstream .deb from the GitHub release. The "apt portion"
-        # below covers golang-go (the cgo host Go), libffi-dev (used by
+        # kits: neither TinyGo nor a new-enough Go is in bookworm. The
+        # tinygo layer below fetches BOTH from upstream — Go from
+        # go.dev (tarball, pinnable) and TinyGo from the GitHub release
+        # (.deb). The "apt portion" here is just libffi-dev (used by
         # the bridge's tinygo.call_dynamic path AND by TinyGo's runtime
-        # for c-shared mode), and curl (to fetch the .deb).
-        tinygo)  echo "golang-go libffi-dev curl" ;;
+        # for c-shared mode) + curl + ca-certificates for the fetches.
+        # bookworm's `golang-go` is Go 1.19 — TinyGo 0.34 rejects it
+        # (its build-time Go-version gate wants ≥1.22).
+        tinygo)  echo "libffi-dev curl ca-certificates" ;;
         *)       return 1 ;;
     esac
 }
@@ -412,21 +415,32 @@ bootstrap_image() {
     for lang in $WITH_LANGS; do
         pkg=$(with_dev_pkg "$lang")
         if [ "$lang" = "tinygo" ]; then
-            # TinyGo isn't apt-packaged in Debian; fetch the upstream
-            # .deb from the GitHub release. The .deb arch names
-            # (amd64/arm64/armhf) match \`dpkg --print-architecture\`
-            # exactly — no remap. Override the version via
-            # \`--build-arg TINYGO_VERSION=0.X.Y\` on \`podman build\`.
+            # Neither TinyGo nor a new-enough Go is in bookworm — fetch
+            # both from upstream. Go from go.dev (tarball, version
+            # pinned via --build-arg GO_VERSION). TinyGo from the
+            # GitHub release .deb (version pinned via --build-arg
+            # TINYGO_VERSION). Both arch maps use \`dpkg
+            # --print-architecture\` directly (amd64/arm64).
+            #
+            # bookworm's \`golang-go\` is Go 1.19; TinyGo 0.34.0 rejects
+            # it via its build-time Go-version gate. So we ignore the
+            # apt-packaged Go entirely and install a current one.
             WITH_LAYERS="$WITH_LAYERS
-# --- Hosted-language layer: tinygo (custom .deb + apt $pkg) ---
+# --- Hosted-language layer: tinygo (Go + TinyGo from upstream + apt $pkg) ---
 # Added because aether-build was invoked with --with=tinygo. Unlike
 # the interpreter bridges, tinygo isn't a host-dlopen target — it's
-# a c-shared sidecar builder. The apt portion gives us golang-go
-# (cgo host Go), libffi-dev (bridge call_dynamic + tinygo runtime),
-# and curl (.deb fetch). The .deb step installs TinyGo itself.
+# a c-shared sidecar builder. The apt portion gives us libffi-dev
+# (bridge call_dynamic + tinygo runtime), curl + ca-certificates
+# (upstream fetches). The two RUN steps below install the cgo host
+# Go and TinyGo itself.
 RUN apt-get update \\
  && apt-get install -y --no-install-recommends $pkg \\
  && rm -rf /var/lib/apt/lists/*
+ARG GO_VERSION=1.23.4
+RUN ARCH=\$(dpkg --print-architecture) \\
+ && curl -fsSL \"https://go.dev/dl/go\${GO_VERSION}.linux-\${ARCH}.tar.gz\" \\
+      | tar -C /usr/local -xz
+ENV PATH=\"/usr/local/go/bin:\${PATH}\"
 ARG TINYGO_VERSION=0.34.0
 RUN ARCH=\$(dpkg --print-architecture) \\
  && curl -fsSL -o /tmp/tinygo.deb \\
@@ -434,6 +448,10 @@ RUN ARCH=\$(dpkg --print-architecture) \\
  && apt-get update \\
  && apt-get install -y --no-install-recommends /tmp/tinygo.deb \\
  && rm -rf /var/lib/apt/lists/* /tmp/tinygo.deb
+# Sanity-check at IMAGE build time: \`tinygo version\` must succeed.
+# If either Go or TinyGo were installed wrong, fail HERE (loud) rather
+# than at first \`tinygo build\` in aeb-ctr Phase 1 (silent until then).
+RUN tinygo version
 RUN cd /src \\
  && make contrib MODULES=tinygo \\
  && make install-contrib


### PR DESCRIPTION
## Summary

v0.215.0 shipped `--with=tinygo` with `apt install golang-go`, which on debian:bookworm-slim is **Go 1.19**. TinyGo 0.34.0's build-time Go-version gate requires **≥1.22** — the image builds green, but `tinygo build` in user-program Phase 1 would fail with a version-rejection error.

Caught by aeb-sib on paper before NUC bake (saved ~20 minutes of red-herring iteration).

Switching to a pinned Go tarball from go.dev:
- reproducible (no backports apt source, no "latest" drift)
- arch names already match `dpkg --print-architecture` (amd64/arm64)
- symmetric with the TinyGo .deb fetch right below it

Also adds a `RUN tinygo version` sanity-check inside the layer so a broken Go/TinyGo pairing fails at **image** build time rather than at first user `tinygo build` — same "fail at build, not at use" property as the other bridges.

## Test plan

- [x] Dry-render Containerfile fragment locally; escapes (`\$`, `\${}`, `\"`) survive
- [ ] NUC re-bake by aeb-sib: `AETHER_REF=v0.216.0 aether-build --with=tinygo --rebuild-image` → `aeb-ctr hosttinygo/.build.ae` → `hello from tinygo, hosted by aether`

🤖 Generated with [Claude Code](https://claude.com/claude-code)