### PR TITLE
fix(codegen/stdlib/ci): caps-aware collections + macOS leaks(1) gate + memory-ownership leak elimination (#463, #468)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,21 @@ jobs:
     - name: Run full CI suite
       run: HARDEN=${{ matrix.harden }} CC=${{ matrix.cc }} make ci
 
+    # macOS leaks(1) gate (#468). Runs only on the ARM64 macOS job —
+    # one macOS arch is enough leak coverage, and MallocStackLogging
+    # is ~10x slower so we don't want it on both. Linux gets leak
+    # coverage from test-valgrind + ASan-LSan; this is the only
+    # detector that works on Apple Silicon (Apple clang ships ASan
+    # without LSan; upstream LSan hangs here).
+    - name: macOS leaks gate
+      if: matrix.name == 'macOS / Clang (ARM64)'
+      # Hard step cap as a backstop to the per-test timeouts inside
+      # run_macos_leaks.sh: the gate can never hold a runner indefinitely.
+      # 20 min is generous for 16 instrumented programs (leaks +
+      # MallocStackLogging is ~10x slower than the bare run).
+      timeout-minutes: 20
+      run: make test-macos-leaks
+
   # ============================================================
   # contrib/host bridge check — syntax check of every host bridge
   # in stub mode (always-on), plus end-to-end build+link+run of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,108 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.153.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **Deterministic `*StringSeq` ownership** (`compiler/codegen/codegen.c`,
+  `codegen_stmt.c`, `codegen_func.c`). Cons-cell sequence locals are now
+  reclaimed automatically — freed on reassignment and at scope exit via
+  `string_seq_free` — mirroring the heap-string ownership system. Because
+  `string_seq_free` is a refcount *decrement*, this is safe even for
+  structurally-shared spines (the documented `cons(x,t)`/`cons(y,t)`
+  sharing contract is preserved; verified by `string_seq_shared_tail`).
+  An owning-producer classifier distinguishes `cons`/`reverse`/`concat`/
+  `take`/`drop`/`from_array`/`split_to_seq`/`retain`/`empty` (owned) from
+  `string_seq_tail` (borrowed). `test_string_seq`: 5003 leaks → 0.
+
+### Fixed
+
+- **aetherc double-free crash on the `*StringSeq` tracking fields**
+  (`compiler/codegen/codegen.c`). The `CodeGenerator` is field-initialised
+  (not `calloc`'d); the new seq registry fields were left uninitialised,
+  so the first `clear_seq_vars()` freed garbage pointers — a glibc abort
+  on Linux (`aetherc` SIGABRT/SIGSEGV; 335 programs "Compilation failed")
+  that macOS's allocator silently tolerated. Found with an
+  AddressSanitizer-instrumented `aetherc`; root-caused to a missing field
+  init.
+- **`defer string.release(X)` double-free / use-after-free on magic
+  AetherStrings** (`compiler/codegen/codegen_expr.c`). `string.from_int`/
+  `from_long`/`new` return a refcounted AetherString that the heap-string
+  tracker manages, so the value was freed twice — once by the explicit
+  `string_release`, once by the function-exit defer-free. `string.release(X)`
+  now lowers through the same flag-guarded form as the bare `release()`
+  builtin for any heap-tracked local, freeing once and clearing the
+  tracker. Verified leak-free under AddressSanitizer.
+- **Heap-string leaks from `release()`, `print`/`println` arguments, and
+  `==`/`!=` operands** (`compiler/codegen/codegen_expr.c`,
+  `codegen_stmt.c`). `release()` now reclaims plain malloc'd `char*`
+  results (string.concat/substring/to_upper/to_lower/trim) via a
+  flag-guarded free; the print family and `release`/`string_release` no
+  longer mark their argument escaped (they provably never retain it), so
+  loop accumulators printed/released each iteration are reclaimed; and a
+  heap-returning string expression used directly as a comparison operand
+  is drained after the compare (the binary-operator analogue of the
+  call-argument drain). `test_release_builtin` 102→0,
+  `test_string_leak_loop` 1000→0, `test_fs_realpath` 30→0.
+- **macOS `leaks(1)` gate could hang the CI job indefinitely**
+  (`tests/run_macos_leaks.sh`). Two compounding causes: (1) no per-step
+  timeout, and (2) the leaks output was captured with a `$(...)` pipe — a
+  `leaks --atExit` run whose target program didn't exit cleanly orphaned
+  that program still holding the pipe's write end, so the command
+  substitution blocked **even if `leaks` was killed**. Fixed by capturing
+  to a file (no orphan-reader dependency) and bounding every `ae build` +
+  `leaks` step with a perl `alarm` wrapper that kills the whole **process
+  group** (so `leaks` and its target die together), plus a `pkill` reap
+  of any straggler and a 20-minute step cap in CI. A timed-out step now
+  fails fast as `[FAIL] <test>: ... TIMED OUT`, and a per-test progress
+  line makes the in-flight test visible in the live log. The gate can no
+  longer hold a runner.
+- **Regression tests leaked the containers they allocated** — added the
+  missing explicit container frees (the codebase convention is explicit
+  container ownership; only heap-string and `*StringSeq` *locals*
+  auto-free). `test_json_object_iter` (`json.free` ×7, 16→0),
+  `test_list_add_heap_alias_escape` (`list.free` ×3, 16→0),
+  `test_destructure_reassign_over_heap_lhs` (`map.free` ×4, 23→0). Each
+  verified leak-free and double-free-free under AddressSanitizer.
+- **`std.url` working-buffer leak on the decode error paths**
+  (`std/url/module.ae`). `url.decode` allocated a `bytes` working buffer
+  and freed it only on the success path (via `bytes.finish`); the two
+  malformed-percent-encoding error returns leaked it. Both now
+  `bytes.free(buf)` before returning. `test_url` also gained the missing
+  `string_list_free` calls for the lists returned by `url.parse_query` /
+  `url.query_get_all` (caller-owned, per the explicit-container-ownership
+  convention) — together taking `test_url` from 21 leaks to 10. The
+  residual 10 are plain-`char*` query entries stored in a refcounted
+  `string_list` (a `@retain` API): `string.concat` / `string.substring_n`
+  return plain `malloc`'d `char*` that `string_retain` / `string_release`
+  no-op on, so the list can't reclaim them — the same string-ABI boundary
+  tracked for the dedicated magic-tagging follow-up, not closed here to
+  avoid an unverified refcount-contract change.
+- **`test_fs_positional_io` failed the Windows CI job** (`tests/
+  regression/test_fs_positional_io.ae`). The #640 positional-I/O test
+  hardcoded `path = "/tmp/aether_test_pio.bin"`; on Windows a bare
+  `/tmp` resolves through `fopen` to `C:\tmp` (not created), so
+  `fs.open(path, "w+")` failed and the whole CI run went red. Switched
+  to the portable scratch-dir idiom the other `std.fs` tests already use
+  (`io.getenv("TMPDIR")` → `"TEMP"` → `/tmp` fallback). The positional
+  ops themselves were already Windows-correct (`fseek`+`fwrite`/`fread`,
+  `_chsize_s`, `_commit`); only the path was wrong.
+
+### Documentation
+
+- **`string.array_get` borrow-warning now points at deterministic
+  `*StringSeq`** (`std/string/module.ae`, `std/string/aether_string.c`).
+  Following review feedback on the interaction with the #635 lifetime
+  warning: the "make an owned copy" guidance now names `string_split_to_seq`
+  / `*StringSeq` as the recommended shape, reclaimed *deterministically*
+  by the compiler (auto-freed at scope exit, sharing-safe) now that this
+  release lands that ownership — so escaping a split piece no longer risks
+  dangling into a freed backing array.
 
 ## [0.219.0]
 
@@ -2082,8 +2181,6 @@ The same hazard affects any user-defined wrapper whose body is `f(x) -> { return
 ### Tests
 
 - **`tests/regression/test_for_loop_c_style.ae`** pins the C-style `for (init; cond; step) body` form. The parser has accepted it for a long time (`compiler/parser/parser.c:parse_for_loop`) but it was never exercised end-to-end. Now covered: typed init / inferred init / pointer-stride step. The empty-step form `for (init; cond;) { body }` is known-bad — the parser greedily pulls the next body statement into the step slot — and is documented as out-of-scope for this test; tracked separately.
-
-
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -464,6 +464,16 @@ else
 	ASAN_OPTIONS=halt_on_error=1 ./build/test_runner_asan$(EXE_EXT)
 endif
 
+# macOS leaks(1) gate (#468). Builds a curated set of memory-
+# ownership regression programs and runs each under
+# `MallocStackLogging=1 leaks --atExit`. Skips cleanly on non-Darwin
+# (Linux gets leak coverage from test-valgrind + ASan-LSan). NOT
+# folded into `make ci` — MallocStackLogging is ~10x slower; runs as
+# its own macOS-CI step. See tests/run_macos_leaks.sh for the covered
+# set and rationale.
+test-macos-leaks: compiler ae stdlib
+	@sh tests/run_macos_leaks.sh
+
 test-memory: compiler stdlib-memory
 	@echo "==================================="
 	@echo "Running Memory Tracking Tests"
@@ -1848,7 +1858,7 @@ asan-check: clean
 	  fi
 	@echo "✓ ASan clean — no memory errors detected"
 
-.PHONY: all compiler lsp apkg ae profiler docgen docs-server docs docs-serve test test-build test-valgrind test-asan test-memory test-manual-runtime test-install test-release-archive benchmark benchmark-ui examples run compile repl clean help self-test install stats stdlib stdlib-asan stdlib-memory stdlib-dbg ci ci-windows docker-ci docker-ci-windows docker-build-ci valgrind-check asan-check ci-coop ci-wasm ci-embedded ci-portability docker-ci-wasm docker-ci-embedded contrib-host-check contrib install-contrib stdlib-cov ci-coverage ci-coverage-clean ci-coverage-html
+.PHONY: all compiler lsp apkg ae profiler docgen docs-server docs docs-serve test test-build test-valgrind test-asan test-macos-leaks test-memory test-manual-runtime test-install test-release-archive benchmark benchmark-ui examples run compile repl clean help self-test install stats stdlib stdlib-asan stdlib-memory stdlib-dbg ci ci-windows docker-ci docker-ci-windows docker-build-ci valgrind-check asan-check ci-coop ci-wasm ci-embedded ci-portability docker-ci-wasm docker-ci-embedded contrib-host-check contrib install-contrib stdlib-cov ci-coverage ci-coverage-clean ci-coverage-html
 
 # Cross-language benchmark UI (alias for benchmark)
 benchmark-ui: benchmark

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -213,6 +213,14 @@ CodeGenerator* create_code_generator(FILE* output) {
     gen->escaped_string_var_count = 0;
     gen->return_escaped_string_vars = NULL;
     gen->return_escaped_string_var_count = 0;
+    // *StringSeq ownership tracking — MUST be zero-initialised here:
+    // the CodeGenerator is field-initialised (not calloc'd), so leaving
+    // these uninitialised made the first clear_seq_vars() free garbage
+    // pointers (glibc abort / SEGV on Linux CI; tolerated on macOS).
+    gen->seq_vars = NULL;
+    gen->seq_var_count = 0;
+    gen->escaped_seq_vars = NULL;
+    gen->escaped_seq_var_count = 0;
     // Ask/reply type map
     gen->reply_type_map = NULL;
     gen->reply_type_count = 0;
@@ -285,6 +293,7 @@ void free_code_generator(CodeGenerator* gen) {
             free(gen->declared_vars);
         }
         clear_heap_string_vars(gen);
+    clear_seq_vars(gen);
         clear_escaped_string_vars(gen);
         clear_try_clobbered_vars(gen);  /* Issue #501 follow-up */
         if (gen->message_registry) {
@@ -429,6 +438,60 @@ void clear_escaped_string_vars(CodeGenerator* gen) {
     }
     gen->return_escaped_string_vars = NULL;
     gen->return_escaped_string_var_count = 0;
+}
+
+/* ---- *StringSeq local registry (parallel to heap_string_vars) ----
+ * A seq var owns a refcounted spine; string_seq_free is a decrement, so
+ * freeing on reassign / scope-exit is refcount-safe even when shared. */
+int is_seq_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return 0;
+    for (int i = 0; i < gen->seq_var_count; i++) {
+        if (strcmp(gen->seq_vars[i], var_name) == 0) return 1;
+    }
+    return 0;
+}
+
+void mark_seq_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return;
+    if (is_seq_var(gen, var_name)) return;
+    char** nv = realloc(gen->seq_vars, sizeof(char*) * (gen->seq_var_count + 1));
+    if (!nv) return;
+    gen->seq_vars = nv;
+    gen->seq_vars[gen->seq_var_count++] = strdup(var_name);
+}
+
+int is_escaped_seq_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return 0;
+    for (int i = 0; i < gen->escaped_seq_var_count; i++) {
+        if (strcmp(gen->escaped_seq_vars[i], var_name) == 0) return 1;
+    }
+    return 0;
+}
+
+void mark_escaped_seq_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return;
+    if (is_escaped_seq_var(gen, var_name)) return;
+    char** nv = realloc(gen->escaped_seq_vars,
+                        sizeof(char*) * (gen->escaped_seq_var_count + 1));
+    if (!nv) return;
+    gen->escaped_seq_vars = nv;
+    gen->escaped_seq_vars[gen->escaped_seq_var_count++] = strdup(var_name);
+}
+
+void clear_seq_vars(CodeGenerator* gen) {
+    if (!gen) return;
+    if (gen->seq_vars) {
+        for (int i = 0; i < gen->seq_var_count; i++) free(gen->seq_vars[i]);
+        free(gen->seq_vars);
+    }
+    gen->seq_vars = NULL;
+    gen->seq_var_count = 0;
+    if (gen->escaped_seq_vars) {
+        for (int i = 0; i < gen->escaped_seq_var_count; i++) free(gen->escaped_seq_vars[i]);
+        free(gen->escaped_seq_vars);
+    }
+    gen->escaped_seq_vars = NULL;
+    gen->escaped_seq_var_count = 0;
 }
 
 /* Return-escape sibling. See the header comment on
@@ -600,6 +663,24 @@ static int try_emit_heap_string_exit_free(CodeGenerator* gen, ASTNode* deferred)
     return 1;
 }
 
+/* *StringSeq scope-exit free carrier. Annotation: "seq_exit_free:<name>".
+ * string_seq_free is a refcount decrement, so this is safe even when the
+ * spine is shared; the flag guard + NULL keep it idempotent against an
+ * explicit string.seq_free that already ran. */
+static int try_emit_seq_exit_free(CodeGenerator* gen, ASTNode* deferred) {
+    if (!deferred || !deferred->annotation) return 0;
+    const char* prefix = "seq_exit_free:";
+    size_t plen = strlen(prefix);
+    if (strncmp(deferred->annotation, prefix, plen) != 0) return 0;
+    const char* name = deferred->annotation + plen;
+    if (!*name) return 0;
+    print_indent(gen);
+    fprintf(gen->output,
+            "/* deferred */ if (_seqheap_%s) { string_seq_free(%s); %s = NULL; _seqheap_%s = 0; }\n",
+            name, name, name, name);
+    return 1;
+}
+
 /* Struct-destructor defer carrier (#465). Annotation:
  *   "struct_destroy:<varname>:<StructName>"
  * Pushed by the struct-local-declaration site in codegen_stmt.c
@@ -642,6 +723,7 @@ void emit_defers_for_scope(CodeGenerator* gen) {
         ASTNode* deferred = gen->defer_stack[i];
         if (deferred) {
             if (try_emit_heap_string_exit_free(gen, deferred)) continue;
+            if (try_emit_seq_exit_free(gen, deferred)) continue;
             if (try_emit_struct_destroy(gen, deferred)) continue;
             print_indent(gen);
             fprintf(gen->output, "/* deferred */ ");
@@ -722,6 +804,7 @@ void emit_all_defers_protected(CodeGenerator* gen, char** protected_names, int p
             continue;
         }
         if (try_emit_heap_string_exit_free(gen, deferred)) continue;
+        if (try_emit_seq_exit_free(gen, deferred)) continue;
         if (try_emit_struct_destroy(gen, deferred)) continue;
         print_indent(gen);
         fprintf(gen->output, "/* deferred */ ");
@@ -2323,6 +2406,7 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
     indent(gen);
     clear_declared_vars(gen);  // Reset for main function
     clear_heap_string_vars(gen);
+    clear_seq_vars(gen);
     clear_escaped_string_vars(gen);
     clear_try_clobbered_vars(gen);  /* Issue #501 follow-up */
     // Reset defer state for main function and enter scope
@@ -2391,7 +2475,9 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
              * locals modified inside a try body. */
             mark_try_clobbered_vars(gen, main->children[0]);
             hoist_heap_string_trackers(gen, main->children[0]);
+            hoist_seq_trackers(gen, main->children[0]);
             mark_escaped_heap_string_vars(gen, main->children[0]);
+            mark_escaped_seq_vars(gen, main->children[0]);
             /* Mirror the regular-function path in
              * codegen_func.c::generate_function_definition: push a
              * function-exit defer-free for every non-escaped
@@ -2408,6 +2494,7 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
              * escaped, so the auto-free here cannot double-free
              * a buffer the user already released manually. */
             push_heap_string_exit_free_defers(gen, main->children[0]);
+            push_seq_exit_free_defers(gen, main->children[0]);
         }
         generate_statement(gen, main->children[0]);
         gen->current_promoted_captures = prev_promoted;

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -311,6 +311,25 @@ typedef struct {
     char** return_escaped_string_vars;
     int return_escaped_string_var_count;
 
+    // `*StringSeq` (cons-cell sequence) locals whose current value is a
+    // heap-allocated, refcounted seq returned by an OWNING producer
+    // (string_seq_cons / reverse / concat / take / drop / from_array /
+    // split_to_seq / retain / empty — NOT string_seq_tail, which borrows
+    // into an existing spine). Parallel to heap_string_vars: the codegen
+    // frees the prior value on reassignment and at scope exit via
+    // string_seq_free(), which is a refcount DECREMENT — so freeing a
+    // shared spine is safe (it survives while another owner holds a ref).
+    // Because every seq_* op retains or reads (never steals the caller's
+    // ref), the only escapes are `return <name>` and a raw store into a
+    // non-seq container; escaped_seq_vars records those so their
+    // scope-exit free is suppressed. A `_seqheap_<name>` flag tracks
+    // whether the slot currently owns a ref (set from an owning producer,
+    // cleared by an explicit seq_free / borrowed assignment).
+    char** seq_vars;
+    int seq_var_count;
+    char** escaped_seq_vars;
+    int escaped_seq_var_count;
+
     // Ask/reply type map: request message name -> reply message name.
     // Built by scanning actor receive handlers for reply statements.
     struct ReplyTypeEntry {

--- a/compiler/codegen/codegen_actor.c
+++ b/compiler/codegen/codegen_actor.c
@@ -239,6 +239,7 @@ void generate_actor_definition(CodeGenerator* gen, ASTNode* actor) {
                         // identifier errors in the generated C.
                         clear_declared_vars(gen);
                         clear_heap_string_vars(gen);
+    clear_seq_vars(gen);
                         print_line(gen, "%s* _pattern = (%s*)_msg_data;", pattern->value, pattern->value);
                         mark_var_declared(gen, "_pattern");
 

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1477,6 +1477,7 @@ void emit_closure_definitions(CodeGenerator* gen) {
             // Free this closure body's heap-string set and restore the
             // enclosing scope's (see the matching reset above).
             clear_heap_string_vars(gen);
+    clear_seq_vars(gen);
             gen->heap_string_vars = prev_heap;
             gen->heap_string_var_count = prev_heap_count;
             gen->current_function = prev_current_function;
@@ -2050,13 +2051,52 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 }
 
                 if (is_string_cmp) {
-                    if (!skip_parens) fprintf(gen->output, "(");
-                    fprintf(gen->output, "strcmp(_aether_safe_str(");
-                    generate_expression(gen, expr->children[0]);
-                    fprintf(gen->output, "), _aether_safe_str(");
-                    generate_expression(gen, expr->children[1]);
-                    fprintf(gen->output, ")) %s 0", get_c_operator(expr->value));
-                    if (!skip_parens) fprintf(gen->output, ")");
+                    /* Operand drain — the binary-operator analogue of the
+                     * call-argument drain (ArgDrainSub). A heap-returning
+                     * string expression used directly as a comparison
+                     * operand (`string.substring(s, i, j) == "lit"`,
+                     * `a.concat(b) != c`, an interpolation) is an anonymous
+                     * allocation with no owner: evaluated, read by
+                     * _aether_safe_str, then leaked. Inside a loop this is
+                     * one leak per iteration (observed in test_fs_realpath's
+                     * substring-scan). Capture each such operand in a temp,
+                     * run the compare, then free it. Gated exactly like the
+                     * arg-drain: only AST_FUNCTION_CALL / AST_STRING_INTERP
+                     * operands that is_heap_string_expr classifies as
+                     * fresh heap — never a tracked local (it owns its own
+                     * lifetime), a borrowed return (string.to_cstr), or a
+                     * literal. So no double-free is possible. */
+                    ASTNode* cl = expr->children[0];
+                    ASTNode* cr = expr->children[1];
+                    int drain_l = (cl->type == AST_FUNCTION_CALL ||
+                                   cl->type == AST_STRING_INTERP) &&
+                                  is_heap_string_expr(gen, cl);
+                    int drain_r = (cr->type == AST_FUNCTION_CALL ||
+                                   cr->type == AST_STRING_INTERP) &&
+                                  is_heap_string_expr(gen, cr);
+                    if (drain_l || drain_r) {
+                        if (!skip_parens) fprintf(gen->output, "(");
+                        fprintf(gen->output, "({ const char* _se_l = (const char*)(");
+                        generate_expression(gen, cl);
+                        fprintf(gen->output, "); const char* _se_r = (const char*)(");
+                        generate_expression(gen, cr);
+                        fprintf(gen->output,
+                                "); int _se_v = (strcmp(_aether_safe_str(_se_l), "
+                                "_aether_safe_str(_se_r)) %s 0); ",
+                                get_c_operator(expr->value));
+                        if (drain_l) fprintf(gen->output, "aether_heap_str_free(_se_l); ");
+                        if (drain_r) fprintf(gen->output, "aether_heap_str_free(_se_r); ");
+                        fprintf(gen->output, "_se_v; })");
+                        if (!skip_parens) fprintf(gen->output, ")");
+                    } else {
+                        if (!skip_parens) fprintf(gen->output, "(");
+                        fprintf(gen->output, "strcmp(_aether_safe_str(");
+                        generate_expression(gen, expr->children[0]);
+                        fprintf(gen->output, "), _aether_safe_str(");
+                        generate_expression(gen, expr->children[1]);
+                        fprintf(gen->output, ")) %s 0", get_c_operator(expr->value));
+                        if (!skip_parens) fprintf(gen->output, ")");
+                    }
                 } else {
                     if (!skip_parens) fprintf(gen->output, "(");
 
@@ -2479,21 +2519,56 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                     generate_expression(gen, expr->children[0]);
                     fprintf(gen->output, ")");
                 }
-                // release(X) — explicit release sugar for refcounted
-                // strings. Emits `string_release(X)` so users can write
-                // `defer release(body)` after `body, err = http.get(url)`
-                // without reaching for the std.string namespace.
-                // Restricted to `string` arguments today; other heap
-                // types use their typed release function (e.g.
-                // string.string_seq_free for *StringSeq, hashmap.free
-                // for *Map). Expanding the dispatch table requires a
-                // stable destructor-vtable convention; out of scope here.
+                // release(X) — explicit release sugar for heap strings,
+                // for `defer release(body)` after `body, err =
+                // http.get(url)` without reaching for std.string.
+                //
+                // Two lowerings, chosen by what the codegen knows about
+                // the argument:
+                //
+                //  1. A heap-tracked local (is_heap_string_var) is freed
+                //     through its runtime ownership flag:
+                //         ({ if (_heap_X) { aether_heap_str_free(X);
+                //              X = NULL; _heap_X = 0; } })
+                //     aether_heap_str_free reclaims BOTH a magic-tagged
+                //     AetherString* (string.from_int / concat_wrapped /
+                //     fs.read_binary) AND a plain malloc'd char*
+                //     (string.concat / substring / to_upper / to_lower /
+                //     trim) — the latter is exactly what string_release
+                //     alone cannot free, because a plain heap char* is
+                //     indistinguishable at runtime from a .rodata
+                //     literal. The `_heap_X` guard is what makes freeing
+                //     a plain char* safe here: a variable currently
+                //     holding a literal has _heap_X == 0, so nothing is
+                //     freed (this is what kept `release("literal")` from
+                //     crashing — the literal arm below — and equally
+                //     protects `s = "lit"` after a heap assignment).
+                //     Clearing the flag means the restored function-exit
+                //     defer-free (release no longer marks its arg
+                //     escaped — see is_nonstoring_builtin) sees _heap_X
+                //     == 0 and does not double-free. The reassignment
+                //     wrapper frees each prior value, so a `defer
+                //     release(s)` accumulator in a loop frees every
+                //     iteration's buffer exactly once.
+                //
+                //  2. A literal / borrowed param / non-tracked
+                //     expression falls back to string_release, which is
+                //     literal-safe (no-ops unless the value carries the
+                //     AetherString magic header).
                 else if (strcmp(func_name, "release") == 0 && expr->child_count == 1) {
                     ASTNode* arg = expr->children[0];
                     if (arg->node_type && arg->node_type->kind == TYPE_STRING) {
-                        fprintf(gen->output, "string_release(");
-                        generate_expression(gen, arg);
-                        fprintf(gen->output, ")");
+                        if (arg->type == AST_IDENTIFIER && arg->value &&
+                            is_heap_string_var(gen, arg->value)) {
+                            fprintf(gen->output,
+                                "({ if (_heap_%s) { aether_heap_str_free((void*)%s); "
+                                "%s = NULL; _heap_%s = 0; } })",
+                                arg->value, arg->value, arg->value, arg->value);
+                        } else {
+                            fprintf(gen->output, "string_release(");
+                            generate_expression(gen, arg);
+                            fprintf(gen->output, ")");
+                        }
                     } else {
                         fprintf(stderr,
                             "error: release() at line %d: only `string` is supported today.\n"
@@ -2502,6 +2577,57 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                             "    *Map       -> hashmap.free\n",
                             expr->line);
                         fprintf(gen->output, "0 /* release() type error — see stderr */");
+                    }
+                }
+                // string.release(X) — the namespaced sibling of the bare
+                // release() builtin (resolves to the string_release
+                // extern). When X is a heap-tracked string local, lower it
+                // through the SAME flag-guarded free so it frees once and
+                // clears _heap_X. This is required because string_release
+                // no longer marks its argument escaped (is_nonstoring_
+                // builtin), so X now also receives an automatic
+                // function-exit defer-free — without clearing the flag
+                // here, `defer string.release(s)` on a magic AetherString
+                // would be freed twice (explicit + auto): a double-free.
+                // Non-heap-var arguments (literals, borrowed params) fall
+                // through to the plain, literal-safe string_release call.
+                else if ((strcmp(func_name, "string_release") == 0 ||
+                          strcmp(func_name, "string.release") == 0) &&
+                         expr->child_count == 1 &&
+                         expr->children[0]->type == AST_IDENTIFIER &&
+                         expr->children[0]->value &&
+                         is_heap_string_var(gen, expr->children[0]->value)) {
+                    /* Any heap-tracked local — NOT only string-typed.
+                     * string.from_int / from_long / new return a magic
+                     * AetherString that the classifier tracks but types
+                     * `-> ptr`; those too get an auto defer-free now, so
+                     * `defer string.release(num)` must clear the flag here
+                     * or the magic string is string_release'd twice. The
+                     * _heap_X guard makes aether_heap_str_free safe for
+                     * both the magic and plain-char* representations. */
+                    ASTNode* arg = expr->children[0];
+                    fprintf(gen->output,
+                        "({ if (_heap_%s) { aether_heap_str_free((void*)%s); "
+                        "%s = NULL; _heap_%s = 0; } })",
+                        arg->value, arg->value, arg->value, arg->value);
+                }
+                // string.seq_free(seq) — explicit refcount-decrement on a
+                // *StringSeq. For a tracked seq local, clear the ownership
+                // flag and NULL the slot so the scope-exit defer-free does
+                // not decrement a spine this call already released.
+                // string_seq_free is itself NULL-safe.
+                else if (strcmp(func_name, "string_seq_free") == 0 &&
+                         expr->child_count == 1) {
+                    ASTNode* arg = expr->children[0];
+                    if (arg->type == AST_IDENTIFIER && arg->value &&
+                        is_seq_var(gen, arg->value)) {
+                        fprintf(gen->output,
+                            "({ string_seq_free(%s); %s = NULL; _seqheap_%s = 0; })",
+                            arg->value, arg->value, arg->value);
+                    } else {
+                        fprintf(gen->output, "string_seq_free(");
+                        generate_expression(gen, arg);
+                        fprintf(gen->output, ")");
                     }
                 }
                 // ref(value) — create a heap-allocated mutable cell

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -939,6 +939,7 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
     }
     clear_declared_vars(gen);  // Reset for each function
     clear_heap_string_vars(gen);
+    clear_seq_vars(gen);
     clear_escaped_string_vars(gen);
     clear_try_clobbered_vars(gen);  /* Issue #501 follow-up — per-fn set */
 
@@ -1139,6 +1140,11 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             // undeclared local. See codegen_stmt.c::
             // hoist_heap_string_trackers for the full rationale.
             hoist_heap_string_trackers(gen, body);
+            // *StringSeq locals: hoist their _seqheap flags + function-
+            // scope decl, mark return/raw-store escapes, and push the
+            // refcount-decrement scope-exit free (parallel to the
+            // heap-string passes immediately around this).
+            hoist_seq_trackers(gen, body);
             // Mark heap-string vars that escape via call argument or
             // closure capture. The wrapper at codegen_stmt.c:1611
             // skips its `free(_tmp_old)` for escaped vars to avoid
@@ -1146,6 +1152,7 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             // message fields/etc. Conservative — alias-safe at the
             // cost of leaking the value over the function's lifetime.
             mark_escaped_heap_string_vars(gen, body);
+            mark_escaped_seq_vars(gen, body);
             // Push a function-exit defer-free for every non-escaped
             // hoisted heap-string var (#420 follow-up). The
             // wrapper-on-reassignment frees the previous value on
@@ -1155,6 +1162,7 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             // by exit_scope at function end and emit_all_defers at
             // every explicit return.
             push_heap_string_exit_free_defers(gen, body);
+            push_seq_exit_free_defers(gen, body);
         }
         // If body is a block, it handles its own scope
         // If not a block, we still need to generate the statements
@@ -1556,6 +1564,7 @@ void generate_combined_function(CodeGenerator* gen, ASTNode** clauses, int claus
     indent(gen);
     clear_declared_vars(gen);
     clear_heap_string_vars(gen);
+    clear_seq_vars(gen);
     clear_try_clobbered_vars(gen);  /* Issue #501 follow-up — per-fn set */
 
     // Generate each clause as an if/else-if branch

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -34,6 +34,18 @@ void clear_escaped_string_vars(CodeGenerator* gen);
 int is_return_escaped_string_var(CodeGenerator* gen, const char* var_name);
 void mark_return_escaped_string_var(CodeGenerator* gen, const char* var_name);
 
+/* *StringSeq local registry (parallel to the heap-string set). A seq
+ * var owns a refcounted spine freed by string_seq_free (a decrement). */
+int is_seq_var(CodeGenerator* gen, const char* var_name);
+void mark_seq_var(CodeGenerator* gen, const char* var_name);
+void clear_seq_vars(CodeGenerator* gen);
+int is_escaped_seq_var(CodeGenerator* gen, const char* var_name);
+void mark_escaped_seq_var(CodeGenerator* gen, const char* var_name);
+/* Classifier: does the expression produce an OWNED *StringSeq (a fresh
+ * ref the caller must free), vs a borrowed spine pointer (seq_tail)?
+ * Defined in codegen_stmt.c. */
+int is_seq_owning_expr(CodeGenerator* gen, ASTNode* expr);
+
 /* Classifier: does the expression produce a heap-allocated string?
  * Defined in codegen_stmt.c. Used by the codegen_expr.c argument-
  * temp lifetime wrap (ArgDrainSub) to detect heap-returning
@@ -162,6 +174,11 @@ void mark_escaped_heap_string_vars(CodeGenerator* gen, ASTNode* body);
  * and before body codegen. See codegen_stmt.c for the
  * implementation rationale (issue #420 follow-up). */
 void push_heap_string_exit_free_defers(CodeGenerator* gen, ASTNode* body);
+
+/* *StringSeq local lifecycle (parallel to the heap-string passes). */
+void hoist_seq_trackers(CodeGenerator* gen, ASTNode* body);
+void mark_escaped_seq_vars(CodeGenerator* gen, ASTNode* body);
+void push_seq_exit_free_defers(CodeGenerator* gen, ASTNode* body);
 
 /* Actor generation (codegen_actor.c) */
 void generate_actor_definition(CodeGenerator* gen, ASTNode* actor);

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -704,6 +704,39 @@ static int extern_returns_heap_string(ASTNode* ext) {
 // hardcoded-stdlib + string-interp fast paths in isolation. When
 // non-NULL, gen->program is consulted for user-defined-fn lookup;
 // when NULL, we fall through to the conservative answer.
+/* Does `expr` produce an OWNED *StringSeq — a fresh refcount the caller
+ * must release — as opposed to a borrowed pointer into an existing
+ * spine? Owned: cons / reverse / concat / take / drop / from_array /
+ * split_to_seq / retain / empty, and any user fn returning *StringSeq
+ * (its return-escape contract hands the caller a ref). Borrowed:
+ * string_seq_tail (returns s->tail with no new ref) — must NOT be
+ * tracked as owned, or freeing it would decrement a cell the parent
+ * spine still owns. The empty producer yields NULL, which string_seq_free
+ * treats as a no-op, so tracking it as owned is harmless. */
+int is_seq_owning_expr(CodeGenerator* gen, ASTNode* expr) {
+    if (!expr || expr->type != AST_FUNCTION_CALL || !expr->value) return 0;
+    if (!expr->node_type || !is_string_seq_ptr_type(expr->node_type)) return 0;
+    char fn_norm[256];
+    const char* fn = codegen_normalise_callee(expr->value, fn_norm, sizeof(fn_norm));
+    if (!fn) return 0;
+    if (strcmp(fn, "string_seq_tail") == 0) return 0;  /* borrowed */
+    if (strcmp(fn, "string_seq_cons") == 0 ||
+        strcmp(fn, "string_seq_empty") == 0 ||
+        strcmp(fn, "string_seq_reverse") == 0 ||
+        strcmp(fn, "string_seq_concat") == 0 ||
+        strcmp(fn, "string_seq_take") == 0 ||
+        strcmp(fn, "string_seq_drop") == 0 ||
+        strcmp(fn, "string_seq_from_array") == 0 ||
+        strcmp(fn, "string_seq_retain") == 0 ||
+        strcmp(fn, "string_split_to_seq") == 0) {
+        return 1;
+    }
+    /* A user-defined function with a *StringSeq return type hands back an
+     * owned ref (its own return-escaped local). */
+    if (gen && find_function_definition_by_name(gen->program, fn)) return 1;
+    return 0;
+}
+
 int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
     if (!expr) return 0;
 
@@ -768,7 +801,24 @@ int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
             strcmp(fn, "string_from_int") == 0 ||
             strcmp(fn, "string_from_long") == 0 ||
             strcmp(fn, "string_from_float") == 0 ||
-            strcmp(fn, "string_from_char") == 0) {
+            strcmp(fn, "string_from_char") == 0 ||
+            /* Additional always-fresh-heap string producers (verified
+             * each returns owned heap, never a borrowed/literal pointer):
+             *   string_from_int_radix : string_new / string_empty
+             *   string_pad_start/_end : string_new_with_length / _empty
+             *   string_format_list    : fresh AetherString
+             *   json_stringify_raw    : fresh malloc'd char*
+             * aether_heap_str_free dispatches on the magic header, so
+             * AetherString producers string_release and the plain-char*
+             * json one free()s — both correct, neither ever a literal.
+             * NOT string_to_cstr: it returns a BORROWED pointer into its
+             * argument (the AetherString's ->data, or the input itself),
+             * so auto-freeing it would corrupt the source. */
+            strcmp(fn, "string_from_int_radix") == 0 ||
+            strcmp(fn, "string_pad_start") == 0 ||
+            strcmp(fn, "string_pad_end") == 0 ||
+            strcmp(fn, "string_format_list") == 0 ||
+            strcmp(fn, "json_stringify_raw") == 0) {
             return 1;
         }
         // User-defined function: only heap if its body provably
@@ -1628,6 +1678,70 @@ void hoist_heap_string_trackers(CodeGenerator* gen, ASTNode* body) {
     }
 }
 
+/* Collect `*StringSeq`-typed local declaration names (parallel to
+ * collect_heap_string_var_names). A declaration is seq-typed if its LHS
+ * or initializer carries a *StringSeq type. */
+static void collect_seq_var_names(CodeGenerator* gen, ASTNode* node,
+                                  const char** names, int* count, int cap) {
+    if (!node || *count >= cap) return;
+    if (node->type == AST_VARIABLE_DECLARATION && node->value &&
+        strcmp(node->value, "_") != 0) {
+        int is_seq = (node->node_type && is_string_seq_ptr_type(node->node_type));
+        if (!is_seq && node->child_count > 0 && node->children[0] &&
+            node->children[0]->node_type &&
+            is_string_seq_ptr_type(node->children[0]->node_type)) {
+            is_seq = 1;
+        }
+        if (is_seq) {
+            int already = 0;
+            for (int i = 0; i < *count; i++)
+                if (strcmp(names[i], node->value) == 0) { already = 1; break; }
+            if (!already && *count < cap) names[(*count)++] = node->value;
+        }
+    }
+    for (int i = 0; i < node->child_count; i++)
+        collect_seq_var_names(gen, node->children[i], names, count, cap);
+}
+
+/* Hoist `int _seqheap_<name> = 0;` + the function-scope `StringSeq*
+ * <name> = NULL;` declaration for every *StringSeq local, mirroring
+ * hoist_heap_string_trackers. Function-scope hoisting means the
+ * scope-exit defer-free can always reference the slot, and every
+ * assignment (including the first) routes through the reassignment
+ * wrapper that maintains the ownership flag. */
+void hoist_seq_trackers(CodeGenerator* gen, ASTNode* body) {
+    if (!body || !gen) return;
+    const char* names[256];
+    int count = 0;
+    collect_seq_var_names(gen, body, names, &count, 256);
+    for (int i = 0; i < count; i++) {
+        const char* name = names[i];
+        if (!is_seq_var(gen, name)) {
+            print_indent(gen);
+            fprintf(gen->output,
+                    "int _seqheap_%s = 0; (void)_seqheap_%s;\n", name, name);
+            mark_seq_var(gen, name);
+        }
+        if (is_var_declared(gen, name)) continue;
+        if (gen->current_actor) {
+            int is_state = 0;
+            for (int s = 0; s < gen->state_var_count; s++)
+                if (gen->actor_state_vars[s] &&
+                    strcmp(gen->actor_state_vars[s], name) == 0) { is_state = 1; break; }
+            if (is_state) continue;
+        }
+        int is_env_cap = 0;
+        for (int e = 0; e < gen->current_env_capture_count; e++)
+            if (gen->current_env_captures[e] &&
+                strcmp(gen->current_env_captures[e], name) == 0) { is_env_cap = 1; break; }
+        if (is_env_cap) continue;
+        if (is_promoted_capture(gen, name)) continue;
+        print_indent(gen);
+        fprintf(gen->output, "StringSeq* %s = NULL;\n", name);
+        mark_var_declared(gen, name);
+    }
+}
+
 // =====================================================================
 // Escape analysis for heap-string variables
 //
@@ -1825,6 +1939,33 @@ static int param_escapes_in_subtree(CodeGenerator* gen, ASTNode* node,
     return 0;
 }
 
+/* Built-in callees that take a string argument but provably never
+ * RETAIN the pointer beyond the call, so the argument does not escape:
+ *   - the print family (print / println / print_char) writes the bytes
+ *     to stdout/stderr and returns;
+ *   - `release` / `string_release` FREE the argument — the opposite of
+ *     stashing it for later — and hand ownership back, not onward.
+ * Their parameter has no registered type, so lookup_callee_param_kind
+ * returns TYPE_UNKNOWN and the conservative call_arg_escapes() would
+ * mark the argument escaped. That false escape suppresses the
+ * reassignment-free wrapper and the function-exit defer-free, leaking
+ * every prior value of a variable printed in a loop (string_leak_loop's
+ * `println(result)`) and — for `release` — withholding the `_heap_X`
+ * tracker the release lowering needs to actually free the value. This
+ * list is sound in the only direction that matters: we assert
+ * non-retention, so we never withhold a free a recipient still depends
+ * on (a UAF) — we only restore a free the heuristic wrongly withheld.
+ * The release lowering (codegen_expr.c) is itself flag-guarded, so the
+ * restored defer-free and the explicit release never double-free. */
+static int is_nonstoring_builtin(const char* fn) {
+    if (!fn) return 0;
+    return strcmp(fn, "print") == 0 ||
+           strcmp(fn, "println") == 0 ||
+           strcmp(fn, "print_char") == 0 ||
+           strcmp(fn, "release") == 0 ||
+           strcmp(fn, "string_release") == 0;
+}
+
 static void escape_inspect_call_args(CodeGenerator* gen, ASTNode* call,
                                       const char* consumed_lhs) {
     if (!call) return;
@@ -1859,7 +2000,11 @@ static void escape_inspect_call_args(CodeGenerator* gen, ASTNode* call,
                 const char* fn = call->value
                     ? codegen_normalise_callee(call->value, fn_norm, sizeof(fn_norm))
                     : NULL;
-                if (fn && is_retain_extern_param(gen, fn, i)) {
+                if (fn && is_nonstoring_builtin(fn)) {
+                    /* Provably non-storing (print family) — not an
+                     * escape; leave the variable freeable so its
+                     * reassignment-free wrapper fires. */
+                } else if (fn && is_retain_extern_param(gen, fn, i)) {
                     mark_escaped_string_var(gen, arg->value);
                 } else {
                     TypeKind k = lookup_callee_param_kind(gen, call->value, i);
@@ -2088,6 +2233,103 @@ void push_heap_string_exit_free_defers(CodeGenerator* gen, ASTNode* body) {
          * into the body. */
         char annot[300];
         snprintf(annot, sizeof(annot), "heap_string_exit_free:%s", name);
+        ASTNode* carrier = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
+                                            body->line, body->column);
+        if (carrier) {
+            if (carrier->annotation) free(carrier->annotation);
+            carrier->annotation = strdup(annot);
+            push_defer(gen, carrier);
+        }
+    }
+}
+
+/* Escape pre-pass for *StringSeq locals. A seq var escapes (and so its
+ * scope-exit free is suppressed) only when ownership leaves the
+ * function: it is `return`ed, captured by a closure, or passed to a
+ * NON-seq function that may store it raw (list.add, map.put, an actor
+ * message field, a struct constructor). Passing a seq to any
+ * `string_seq_*` op is NOT an escape — those retain (cons, concat,
+ * retain) or read (length, head, is_empty) or consume-and-clear
+ * (seq_free, handled by the explicit-free flag-clear), so the caller
+ * keeps its own ref. The RHS-of-own-assignment exception (`deep =
+ * cons(x, deep)`) keeps the accumulator pattern freeable. */
+static void seq_escape_walk(CodeGenerator* gen, ASTNode* node,
+                            const char* consumed_lhs) {
+    if (!node) return;
+    if (node->type == AST_RETURN_STATEMENT) {
+        for (int i = 0; i < node->child_count; i++) {
+            ASTNode* c = node->children[i];
+            if (c && c->type == AST_IDENTIFIER && c->value &&
+                is_seq_var(gen, c->value)) {
+                mark_escaped_seq_var(gen, c->value);
+            } else {
+                seq_escape_walk(gen, c, consumed_lhs);
+            }
+        }
+        return;
+    }
+    if (node->type == AST_VARIABLE_DECLARATION && node->value &&
+        node->child_count > 0) {
+        for (int i = 0; i < node->child_count; i++)
+            seq_escape_walk(gen, node->children[i], node->value);
+        return;
+    }
+    if (node->type == AST_CLOSURE) {
+        for (int i = 0; i < node->child_count; i++)
+            seq_escape_walk(gen, node->children[i], NULL);
+        return;
+    }
+    if (node->type == AST_FUNCTION_CALL && node->value) {
+        char fn_norm[256];
+        const char* fn = codegen_normalise_callee(node->value, fn_norm, sizeof(fn_norm));
+        int callee_is_seq_op = fn && strncmp(fn, "string_seq_", 11) == 0;
+        for (int i = 0; i < node->child_count; i++) {
+            ASTNode* a = node->children[i];
+            if (a && a->type == AST_IDENTIFIER && a->value &&
+                is_seq_var(gen, a->value)) {
+                if (consumed_lhs && strcmp(a->value, consumed_lhs) == 0) continue;
+                if (callee_is_seq_op) continue;
+                mark_escaped_seq_var(gen, a->value);
+            } else {
+                seq_escape_walk(gen, a, consumed_lhs);
+            }
+        }
+        return;
+    }
+    if (node->type == AST_FUNCTION_DEFINITION ||
+        node->type == AST_BUILDER_FUNCTION) {
+        return;
+    }
+    for (int i = 0; i < node->child_count; i++)
+        seq_escape_walk(gen, node->children[i], consumed_lhs);
+}
+
+void mark_escaped_seq_vars(CodeGenerator* gen, ASTNode* body) {
+    if (!gen || !body) return;
+    seq_escape_walk(gen, body, NULL);
+}
+
+/* Scope-exit defer-free for non-escaped *StringSeq locals (parallel to
+ * push_heap_string_exit_free_defers). The carrier annotation
+ * `seq_exit_free:<name>` is recognised by try_emit_seq_exit_free. */
+void push_seq_exit_free_defers(CodeGenerator* gen, ASTNode* body) {
+    if (!gen || !body) return;
+    if (gen->seq_var_count <= 0) return;
+    for (int i = 0; i < gen->seq_var_count; i++) {
+        const char* name = gen->seq_vars[i];
+        if (!name) continue;
+        if (is_escaped_seq_var(gen, name)) continue;
+        int is_env_cap = 0;
+        for (int e = 0; e < gen->current_env_capture_count; e++) {
+            if (gen->current_env_captures[e] &&
+                strcmp(gen->current_env_captures[e], name) == 0) {
+                is_env_cap = 1; break;
+            }
+        }
+        if (is_env_cap) continue;
+        if (is_promoted_capture(gen, name)) continue;
+        char annot[300];
+        snprintf(annot, sizeof(annot), "seq_exit_free:%s", name);
         ASTNode* carrier = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
                                             body->line, body->column);
         if (carrier) {
@@ -3214,7 +3456,45 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                      * mark_escaped_heap_string_vars in this file for
                      * the analysis. */
                     int var_escaped = is_escaped_string_var(gen, stmt->value);
-                    if (var_is_string && stmt->child_count > 0 && var_escaped) {
+                    /* *StringSeq reassignment. The slot owns a refcounted
+                     * spine; free the prior ref (string_seq_free is a
+                     * decrement, so this is safe even when the spine is
+                     * shared) before overwriting. A bare-identifier alias
+                     * of another owned seq takes an INDEPENDENT ref via
+                     * string_seq_retain so both slots free safely. The
+                     * `_seqheap_<name>` flag records whether the slot
+                     * currently owns a ref; it is suppressed (free skipped)
+                     * for escaped seqs (returned / raw-stored) exactly like
+                     * the heap-string escape gate. */
+                    int var_is_seq = is_seq_var(gen, stmt->value);
+                    if (var_is_seq && stmt->child_count > 0) {
+                        ASTNode* srhs = stmt->children[0];
+                        int srhs_owning = is_seq_owning_expr(gen, srhs);
+                        int srhs_alias = (srhs->type == AST_IDENTIFIER &&
+                                          srhs->value &&
+                                          is_seq_var(gen, srhs->value) &&
+                                          strcmp(srhs->value, stmt->value) != 0);
+                        int seq_escaped = is_escaped_seq_var(gen, stmt->value);
+                        fprintf(gen->output, "{ StringSeq* _tmp_seq = %s; %s = ",
+                                stmt->value, stmt->value);
+                        if (srhs_alias) {
+                            fprintf(gen->output, "string_seq_retain(");
+                            generate_expression(gen, srhs);
+                            fprintf(gen->output, ")");
+                        } else {
+                            generate_expression(gen, srhs);
+                        }
+                        if (!seq_escaped) {
+                            fprintf(gen->output,
+                                    "; if (_seqheap_%s) string_seq_free(_tmp_seq);",
+                                    stmt->value);
+                        } else {
+                            fprintf(gen->output, ";");
+                        }
+                        fprintf(gen->output, " _seqheap_%s = %d; }\n",
+                                stmt->value,
+                                (srhs_owning || srhs_alias) ? 1 : 0);
+                    } else if (var_is_string && stmt->child_count > 0 && var_escaped) {
                         /* Escaped-LHS bare assignment. Wrapper-free is
                          * suppressed because the var's old value is
                          * potentially stored by a recipient (list_add,

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -232,6 +232,24 @@ s = "literal end"               // free(prev concat): yes — _heap_s was 1; _he
 
 The wrapper handles all four transitions (heap→heap, heap→literal, literal→heap, literal→literal) uniformly, so heap memory used by string-returning expressions is reclaimed eagerly without any user-visible `defer`.
 
+The same tracker also covers two related cases automatically:
+
+- **`release(s)` / `string.release(s)`** on a heap-tracked local lowers to
+  a flag-guarded free (`if (_heap_s) { aether_heap_str_free(s); s = NULL;
+  _heap_s = 0; }`). It reclaims both a refcounted AetherString
+  (`string.from_int` / `new` / …) *and* a plain malloc'd `char*`
+  (`string.concat` / `substring` / `to_upper` / `to_lower` / `trim`), and
+  clears the tracker so the scope-exit free can't double-free. Safe on a
+  literal — the flag is 0.
+- A heap-returning string expression used directly as a `==`/`!=`
+  comparison operand (`string.substring(s, i, j) == "lit"`) is captured in
+  a temp and freed after the compare — the binary-operator analogue of
+  the call-argument drain.
+
+`*StringSeq` cons-cell locals get an analogous automatic lifecycle (freed
+on reassignment and at scope exit via the refcount-decrementing
+`string_seq_free`); see [sequences.md](sequences.md) § Automatic ownership.
+
 ### Heap-string sources
 
 The compiler treats these expressions as heap-allocated:

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -65,7 +65,7 @@ main() {
     println("first=${string.seq_head(s)}")      // a
 
     walk(s)                                     // pattern-match
-    string.seq_free(s)                          // iterative spine walk
+    string.seq_free(s)                          // optional — see below
 }
 
 walk(s: *StringSeq) {
@@ -78,6 +78,34 @@ walk(s: *StringSeq) {
     }
 }
 ```
+
+## Automatic ownership
+
+A `*StringSeq` local is reclaimed **automatically** — the compiler frees
+it on reassignment and at scope exit, so the explicit `string.seq_free(s)`
+above is optional. This mirrors the heap-string ownership model:
+
+```aether
+deep = string.seq_empty()
+i = 0
+while i < 1000 {
+    deep = string.seq_cons("x", deep)   // each prior spine freed on reassign
+    i = i + 1
+}
+// `deep` freed here at scope exit — no leak, no manual free needed
+```
+
+It is safe to *also* call `string.seq_free(s)` yourself: the explicit
+free clears the ownership tracker so the scope-exit free does not run
+twice. Freeing is a refcount **decrement** (`string_seq_free`), so a
+structurally-shared tail survives until its last owner is freed —
+`string.seq_cons(x, t)` and `string.seq_cons(y, t)` share `t` safely, and
+each rooted list can be freed independently.
+
+A sequence that **escapes** the function — returned, captured by a
+closure, or stored raw in a non-seq container (`list.add`, an actor
+message field) — is *not* auto-freed; ownership transfers to the
+recipient, which is responsible for the eventual `string.seq_free`.
 
 ## Pattern match
 

--- a/std/collections/aether_intarr.c
+++ b/std/collections/aether_intarr.c
@@ -10,6 +10,7 @@
  * resize on write use std.list. */
 
 #include "aether_collections.h"
+#include "../../runtime/aether_resource_caps.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -20,15 +21,18 @@ struct IntArray {
 
 IntArray* intarr_new_raw(int size) {
     if (size < 0) return NULL;
-    IntArray* arr = (IntArray*)malloc(sizeof(*arr));
+    /* #463: cap-aware. The struct is sizeof(IntArray); the data
+     * array is size×sizeof(int). Both byte counts are recoverable at
+     * free time from `arr->size`. */
+    IntArray* arr = (IntArray*)aether_caps_malloc(sizeof(*arr));
     if (!arr) return NULL;
     arr->size = size;
     if (size == 0) {
         arr->data = NULL;   // legal empty array; intarr_free still OK
         return arr;
     }
-    arr->data = (int*)calloc((size_t)size, sizeof(int));
-    if (!arr->data) { free(arr); return NULL; }
+    arr->data = (int*)aether_caps_calloc((size_t)size, sizeof(int));
+    if (!arr->data) { aether_caps_free(arr, sizeof(*arr)); return NULL; }
     return arr;
 }
 
@@ -68,6 +72,8 @@ void intarr_fill(IntArray* arr, int value) {
 
 void intarr_free(IntArray* arr) {
     if (!arr) return;
-    free(arr->data);
-    free(arr);
+    /* data was calloc'd size×sizeof(int) (NULL for the empty array,
+     * where caps_free is a no-op). */
+    aether_caps_free(arr->data, (size_t)arr->size * sizeof(int));
+    aether_caps_free(arr, sizeof(*arr));
 }

--- a/std/collections/aether_pqueue.c
+++ b/std/collections/aether_pqueue.c
@@ -1,4 +1,5 @@
 #include "aether_pqueue.h"
+#include "../../runtime/aether_resource_caps.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
@@ -18,16 +19,18 @@ PriorityQueue* aether_pqueue_create(size_t initial_capacity,
     
     if (!compare) return NULL;
     
-    PriorityQueue* pq = (PriorityQueue*)malloc(sizeof(PriorityQueue));
+    /* #463: cap-aware. The backing array's byte count is recoverable
+     * at free / realloc time from `pq->capacity * sizeof(void*)`. */
+    PriorityQueue* pq = (PriorityQueue*)aether_caps_malloc(sizeof(PriorityQueue));
     if (!pq) return NULL;
-    
+
     if (initial_capacity < DEFAULT_CAPACITY) {
         initial_capacity = DEFAULT_CAPACITY;
     }
-    
-    pq->data = (void**)malloc(initial_capacity * sizeof(void*));
+
+    pq->data = (void**)aether_caps_malloc(initial_capacity * sizeof(void*));
     if (!pq->data) {
-        free(pq);
+        aether_caps_free(pq, sizeof(PriorityQueue));
         return NULL;
     }
     
@@ -49,10 +52,10 @@ void aether_pqueue_free(PriorityQueue* pq) {
                 pq->element_free(pq->data[i]);
             }
         }
-        free(pq->data);
+        aether_caps_free(pq->data, pq->capacity * sizeof(void*));
     }
-    
-    free(pq);
+
+    aether_caps_free(pq, sizeof(PriorityQueue));
 }
 
 // Ensure capacity
@@ -66,11 +69,13 @@ static bool aether_pqueue_ensure_capacity(PriorityQueue* pq, size_t min_capacity
         new_capacity = min_capacity;
     }
     
-    void** new_data = (void**)realloc(pq->data, new_capacity * sizeof(void*));
+    void** new_data = (void**)aether_caps_realloc(pq->data,
+                                                  pq->capacity * sizeof(void*),
+                                                  new_capacity * sizeof(void*));
     if (!new_data) {
         return false;
     }
-    
+
     pq->data = new_data;
     pq->capacity = new_capacity;
     return true;

--- a/std/collections/aether_set.c
+++ b/std/collections/aether_set.c
@@ -1,4 +1,5 @@
 #include "aether_set.h"
+#include "../../runtime/aether_resource_caps.h"
 #include <stdlib.h>
 
 #define DUMMY_VALUE ((void*)1)
@@ -9,24 +10,27 @@ Set* set_create(size_t initial_capacity,
                void (*key_free)(void*),
                void* (*key_clone)(const void*)) {
     
-    Set* set = (Set*)malloc(sizeof(Set));
+    /* #463: cap-aware wrapper struct. The backing hashmap is already
+     * caps-aware (aether_hashmap.c, #469); only the Set shell
+     * converts here. */
+    Set* set = (Set*)aether_caps_malloc(sizeof(Set));
     if (!set) return NULL;
-    
+
     set->map = hashmap_create(initial_capacity, hash_func, key_equals,
                              key_free, NULL, key_clone, NULL);
-    
+
     if (!set->map) {
-        free(set);
+        aether_caps_free(set, sizeof(Set));
         return NULL;
     }
-    
+
     return set;
 }
 
 void set_free(Set* set) {
     if (!set) return;
     hashmap_free(set->map);
-    free(set);
+    aether_caps_free(set, sizeof(Set));
 }
 
 bool set_add(Set* set, void* element) {

--- a/std/collections/aether_stringlist.c
+++ b/std/collections/aether_stringlist.c
@@ -1,6 +1,7 @@
 #include "aether_stringlist.h"
 #include "aether_collections.h"
 #include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #include <stdlib.h>
 
@@ -15,11 +16,14 @@ struct StringList {
 };
 
 StringList* string_list_new(void) {
-    StringList* sl = (StringList*)malloc(sizeof(StringList));
+    /* #463: cap-aware wrapper struct. The backing ArrayList is
+     * already caps-aware (#471); only the StringList shell
+     * converts here. */
+    StringList* sl = (StringList*)aether_caps_malloc(sizeof(StringList));
     if (!sl) return NULL;
     sl->items = list_new();
     if (!sl->items) {
-        free(sl);
+        aether_caps_free(sl, sizeof(StringList));
         return NULL;
     }
     return sl;
@@ -94,5 +98,5 @@ void string_list_free(StringList* list) {
         }
         list_free(list->items);
     }
-    free(list);
+    aether_caps_free(list, sizeof(StringList));
 }

--- a/std/collections/aether_stringseq.c
+++ b/std/collections/aether_stringseq.c
@@ -1,5 +1,6 @@
 #include "aether_stringseq.h"
 #include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -21,7 +22,9 @@ StringSeq* string_seq_empty(void) {
 }
 
 StringSeq* string_seq_cons(const char* head, StringSeq* tail) {
-    StringSeq* cell = (StringSeq*)malloc(sizeof(StringSeq));
+    /* #463: cap-aware cons cell. Fixed sizeof(StringSeq); the
+     * matching free in string_seq_free passes the same size. */
+    StringSeq* cell = (StringSeq*)aether_caps_malloc(sizeof(StringSeq));
     if (!cell) return NULL;
     cell->ref_count = 1;
     cell->length = (tail ? tail->length : 0) + 1;
@@ -74,7 +77,7 @@ void string_seq_free(StringSeq* s) {
         }
         StringSeq* next = s->tail;
         string_release(s->head);
-        free(s);
+        aether_caps_free(s, sizeof(StringSeq));
         s = next;
     }
 }
@@ -214,12 +217,20 @@ StringSeq* string_seq_drop(StringSeq* s, int n) {
 void* string_seq_to_array(StringSeq* s) {
     if (!s) return NULL;
     int n = s->length;
-    AetherStringArrayLayout* arr = (AetherStringArrayLayout*)malloc(
+    /* #463 cross-file T1 pair: this AetherStringArrayLayout is
+     * layout-compatible with std/string's AetherStringArray
+     * {AetherString** strings; size_t count;} and is freed by
+     * string_array_free over there — which now uses aether_caps_free
+     * with `count * sizeof(AetherString*)` for the strings array and
+     * `sizeof(AetherStringArray)` for the struct. Allocate with the
+     * matching caps shapes so the cross-file free accounts correctly
+     * (this is why the two sides convert in the same commit). */
+    AetherStringArrayLayout* arr = (AetherStringArrayLayout*)aether_caps_malloc(
         sizeof(AetherStringArrayLayout));
     if (!arr) return NULL;
-    arr->strings = (AetherString**)malloc(sizeof(AetherString*) * (size_t)n);
+    arr->strings = (AetherString**)aether_caps_malloc(sizeof(AetherString*) * (size_t)n);
     if (!arr->strings) {
-        free(arr);
+        aether_caps_free(arr, sizeof(AetherStringArrayLayout));
         return NULL;
     }
     arr->count = (size_t)n;

--- a/std/collections/aether_vector.c
+++ b/std/collections/aether_vector.c
@@ -1,4 +1,5 @@
 #include "aether_vector.h"
+#include "../../runtime/aether_resource_caps.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -9,16 +10,18 @@ Vector* vector_create(size_t initial_capacity,
                      void (*element_free)(void*),
                      void* (*element_clone)(const void*)) {
     
-    Vector* vec = (Vector*)malloc(sizeof(Vector));
+    /* #463: cap-aware. Backing array byte count recoverable from
+     * `vec->capacity * sizeof(void*)` at free / realloc. */
+    Vector* vec = (Vector*)aether_caps_malloc(sizeof(Vector));
     if (!vec) return NULL;
-    
+
     if (initial_capacity < DEFAULT_CAPACITY) {
         initial_capacity = DEFAULT_CAPACITY;
     }
-    
-    vec->data = (void**)malloc(initial_capacity * sizeof(void*));
+
+    vec->data = (void**)aether_caps_malloc(initial_capacity * sizeof(void*));
     if (!vec->data) {
-        free(vec);
+        aether_caps_free(vec, sizeof(Vector));
         return NULL;
     }
     
@@ -39,10 +42,10 @@ void vector_free(Vector* vec) {
                 vec->element_free(vec->data[i]);
             }
         }
-        free(vec->data);
+        aether_caps_free(vec->data, vec->capacity * sizeof(void*));
     }
-    
-    free(vec);
+
+    aether_caps_free(vec, sizeof(Vector));
 }
 
 // Ensure capacity
@@ -56,11 +59,13 @@ static bool vector_ensure_capacity(Vector* vec, size_t min_capacity) {
         new_capacity = min_capacity;
     }
     
-    void** new_data = (void**)realloc(vec->data, new_capacity * sizeof(void*));
+    void** new_data = (void**)aether_caps_realloc(vec->data,
+                                                  vec->capacity * sizeof(void*),
+                                                  new_capacity * sizeof(void*));
     if (!new_data) {
         return false;
     }
-    
+
     vec->data = new_data;
     vec->capacity = new_capacity;
     return true;
@@ -164,7 +169,9 @@ void vector_shrink_to_fit(Vector* vec) {
     if (!vec || vec->size == 0) return;
     
     if (vec->size < vec->capacity) {
-        void** new_data = (void**)realloc(vec->data, vec->size * sizeof(void*));
+        void** new_data = (void**)aether_caps_realloc(vec->data,
+                                                      vec->capacity * sizeof(void*),
+                                                      vec->size * sizeof(void*));
         if (new_data) {
             vec->data = new_data;
             vec->capacity = vec->size;

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -431,15 +431,22 @@ char* string_trim(const void* str) {
 
 // Helper: free a partially-built array on OOM during split. Used on
 // every early-exit path so no cleanup branch leaks memory.
-static void string_array_partial_free(AetherStringArray* arr, size_t built) {
+//
+// #463: cap-aware. `built` is how many elements were constructed
+// (release each); `capacity` is how many the strings array was
+// ALLOCATED for — distinct from `built` and from `arr->count`
+// (which isn't finalized until split succeeds), so the matching
+// caps_free byte count is `capacity * sizeof(AetherString*)`.
+static void string_array_partial_free(AetherStringArray* arr,
+                                      size_t built, size_t capacity) {
     if (!arr) return;
     if (arr->strings) {
         for (size_t k = 0; k < built; k++) {
             if (arr->strings[k]) string_release(arr->strings[k]);
         }
-        free(arr->strings);
+        aether_caps_free(arr->strings, capacity * sizeof(AetherString*));
     }
-    free(arr);
+    aether_caps_free(arr, sizeof(AetherStringArray));
 }
 
 // String array operations
@@ -449,7 +456,16 @@ AetherStringArray* string_split(const void* str, const char* delimiter) {
     const char* sdata = str_data(str);
     size_t delim_len = strlen(delimiter);
 
-    AetherStringArray* arr = (AetherStringArray*)malloc(sizeof(AetherStringArray));
+    /* #463: cap-aware. AetherStringArray shape is
+     * {AetherString** strings; size_t count;}. The strings array's
+     * allocated element count equals `arr->count` in every success
+     * path, so string_array_free recovers the byte count from
+     * arr->count; the OOM cleanup uses string_array_partial_free
+     * which is passed the allocation capacity explicitly (count
+     * isn't finalized yet). Paired with the string_seq_to_array
+     * conversion in std/collections/aether_stringseq.c, which builds
+     * the same layout and is freed by this same string_array_free. */
+    AetherStringArray* arr = (AetherStringArray*)aether_caps_malloc(sizeof(AetherStringArray));
     if (!arr) return NULL;
     arr->count = 0;
     arr->strings = NULL;
@@ -457,11 +473,11 @@ AetherStringArray* string_split(const void* str, const char* delimiter) {
     // Empty delimiter → one entry per byte.
     if (delim_len == 0) {
         if (slen == 0) return arr;
-        arr->strings = (AetherString**)malloc(sizeof(AetherString*) * slen);
-        if (!arr->strings) { free(arr); return NULL; }
+        arr->strings = (AetherString**)aether_caps_malloc(sizeof(AetherString*) * slen);
+        if (!arr->strings) { aether_caps_free(arr, sizeof(AetherStringArray)); return NULL; }
         for (size_t i = 0; i < slen; i++) {
             AetherString* piece = string_new_with_length(sdata + i, 1);
-            if (!piece) { string_array_partial_free(arr, i); return NULL; }
+            if (!piece) { string_array_partial_free(arr, i, slen); return NULL; }
             arr->strings[i] = piece;
         }
         arr->count = slen;
@@ -470,10 +486,14 @@ AetherStringArray* string_split(const void* str, const char* delimiter) {
 
     // Input shorter than the delimiter → one piece, the whole input.
     if (slen < delim_len) {
-        arr->strings = (AetherString**)malloc(sizeof(AetherString*));
-        if (!arr->strings) { free(arr); return NULL; }
+        arr->strings = (AetherString**)aether_caps_malloc(sizeof(AetherString*));
+        if (!arr->strings) { aether_caps_free(arr, sizeof(AetherStringArray)); return NULL; }
         arr->strings[0] = string_new_with_length(sdata, slen);
-        if (!arr->strings[0]) { free(arr->strings); free(arr); return NULL; }
+        if (!arr->strings[0]) {
+            aether_caps_free(arr->strings, sizeof(AetherString*));
+            aether_caps_free(arr, sizeof(AetherStringArray));
+            return NULL;
+        }
         arr->count = 1;
         return arr;
     }
@@ -489,15 +509,15 @@ AetherStringArray* string_split(const void* str, const char* delimiter) {
         }
     }
 
-    arr->strings = (AetherString**)malloc(sizeof(AetherString*) * count);
-    if (!arr->strings) { free(arr); return NULL; }
+    arr->strings = (AetherString**)aether_caps_malloc(sizeof(AetherString*) * count);
+    if (!arr->strings) { aether_caps_free(arr, sizeof(AetherStringArray)); return NULL; }
 
     size_t start = 0;
     size_t idx = 0;
     for (size_t i = 0; i <= upper; i++) {
         if (memcmp(sdata + i, delimiter, delim_len) == 0) {
             AetherString* piece = string_new_with_length(sdata + start, i - start);
-            if (!piece) { string_array_partial_free(arr, idx); return NULL; }
+            if (!piece) { string_array_partial_free(arr, idx, count); return NULL; }
             arr->strings[idx++] = piece;
             start = i + delim_len;
             i += delim_len - 1;
@@ -505,7 +525,7 @@ AetherStringArray* string_split(const void* str, const char* delimiter) {
     }
     // Tail piece (may be empty if input ends with the delimiter).
     AetherString* tail = string_new_with_length(sdata + start, slen - start);
-    if (!tail) { string_array_partial_free(arr, idx); return NULL; }
+    if (!tail) { string_array_partial_free(arr, idx, count); return NULL; }
     arr->strings[idx] = tail;
     arr->count = count;
 
@@ -523,8 +543,10 @@ int string_array_size(AetherStringArray* arr) {
 // LIFETIME: returned pointer is BORROWED — it aliases arr->strings[index]->data
 // and is invalidated by string_array_free(arr). Aether-side callers that need
 // the value to outlive the array must copy first (e.g. string.concat(v, ""))
-// or use string_split_to_seq which returns refcounted cells. The module.ae
-// extern carries the same warning for the Aether-side reader.
+// or use string_split_to_seq, which returns refcounted cells that the
+// compiler reclaims deterministically at scope exit (the recommended shape;
+// see std/string/module.ae). The module.ae extern carries the same warning
+// for the Aether-side reader.
 const char* string_array_get(AetherStringArray* arr, int index) {
     if (!arr || index < 0 || (size_t)index >= arr->count) return NULL;
     AetherString* s = arr->strings[index];
@@ -536,8 +558,13 @@ void string_array_free(AetherStringArray* arr) {
     for (size_t i = 0; i < arr->count; i++) {
         string_release(arr->strings[i]);
     }
-    free(arr->strings);
-    free(arr);
+    /* #463: the strings array's allocated element count equals
+     * arr->count in every path that produces a fully-built array
+     * (string_split's three branches + string_seq_to_array all set
+     * count to the allocation size). caps_free(NULL, 0) is a no-op
+     * for the empty-delimiter zero-length case (strings == NULL). */
+    aether_caps_free(arr->strings, arr->count * sizeof(AetherString*));
+    aether_caps_free(arr, sizeof(AetherStringArray));
 }
 
 /* string_split_to_seq — sibling of string_split that materialises the

--- a/std/string/module.ae
+++ b/std/string/module.ae
@@ -152,7 +152,14 @@ extern string_trim(str: string) -> string
 //   2. Use `string_split_to_seq` (declared further down) — returns a
 //      refcounted `*StringSeq` whose cells own their data
 //      independently of any backing array, so there's no
-//      array-wide free to worry about.
+//      array-wide free to worry about. This is the RECOMMENDED shape:
+//      a `*StringSeq` local is reclaimed DETERMINISTICALLY by the
+//      compiler — freed automatically at scope exit via the
+//      refcount-decrementing `string_seq_free`, the same way heap
+//      strings are. No manual free, and (because the free is a
+//      decrement) structurally-shared tails stay safe. A piece you
+//      pull from a sequence and let escape transfers ownership
+//      cleanly, with no dangling-into-a-backing-array hazard.
 //
 // If your access pattern is "build, walk once, free" within a single
 // scope, the borrowed-pointer form is fine and the cheapest. Reach

--- a/std/url/module.ae
+++ b/std/url/module.ae
@@ -150,11 +150,13 @@ decode(s: string) -> {
         if c == 37 {
             // %XX
             if i + 2 >= n {
+                bytes.free(buf)
                 return "", "malformed encoding"
             }
             h1 = hex_value(string.char_at_n(s, n, i + 1) & 255)
             h2 = hex_value(string.char_at_n(s, n, i + 2) & 255)
             if h1 < 0 || h2 < 0 {
+                bytes.free(buf)
                 return "", "malformed encoding"
             }
             bytes.set(buf, out, (h1 << 4) | h2)

--- a/tests/integration/heap_leak_cross_fn_recursion/shim.c
+++ b/tests/integration/heap_leak_cross_fn_recursion/shim.c
@@ -1,10 +1,46 @@
+/* getrusage_max_rss_kb — current resident-set size in KB, after
+ * forcing the allocator to release cached free pages.
+ *
+ * Despite the historical name, this returns CURRENT RSS, not the
+ * peak. The probes compare RSS before/after a long loop to assert a
+ * leak doesn't grow the live set. Two macOS hazards make a naive
+ * reading flaky:
+ *   1. `ru_maxrss` is the PEAK high-water-mark (climbs in allocator-
+ *      region chunks, never falls) and is in BYTES on macOS vs KB on
+ *      Linux/BSD — wrong metric entirely.
+ *   2. Even CURRENT RSS (mach resident_size) counts pages the malloc
+ *      zone has freed internally but not yet returned to the OS. Under
+ *      concurrent full-suite memory pressure those retained pages
+ *      spike by ~1 MB, tripping a tight threshold on a leak-free run
+ *      (confirmed: `leaks` reports 0 yet RSS jumps).
+ * Fix: call `malloc_zone_pressure_relief(.., 0)` to force the default
+ * zone to hand cached free memory back to the OS BEFORE sampling, so
+ * resident_size reflects the true live set deterministically. Then
+ * the before/after delta is allocator-noise-free. (Linux keeps
+ * ru_maxrss; Valgrind/ASan-LSan are its precise gate. macOS also has
+ * the deterministic `leaks(1)` gate — see tests/run_macos_leaks.sh.) */
 #if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
 long getrusage_max_rss_kb(void) { return -1; }
+#elif defined(__APPLE__) || defined(__MACH__)
+#include <mach/mach.h>
+#include <malloc/malloc.h>
+long getrusage_max_rss_kb(void) {
+    /* Return malloc-zone-cached free pages to the OS so resident_size
+     * measures the live set, not the allocator's high-water cache. */
+    malloc_zone_pressure_relief(malloc_default_zone(), 0);
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                  (task_info_t)&info, &count) != KERN_SUCCESS) {
+        return -1;
+    }
+    return (long)(info.resident_size / 1024);  /* bytes → KB */
+}
 #else
 #include <sys/resource.h>
 long getrusage_max_rss_kb(void) {
     struct rusage r;
     if (getrusage(RUSAGE_SELF, &r) != 0) return -1;
-    return r.ru_maxrss;
+    return r.ru_maxrss;  /* already KB on Linux/BSD */
 }
 #endif

--- a/tests/integration/heap_leak_interp_as_arg/shim.c
+++ b/tests/integration/heap_leak_interp_as_arg/shim.c
@@ -1,10 +1,46 @@
+/* getrusage_max_rss_kb — current resident-set size in KB, after
+ * forcing the allocator to release cached free pages.
+ *
+ * Despite the historical name, this returns CURRENT RSS, not the
+ * peak. The probes compare RSS before/after a long loop to assert a
+ * leak doesn't grow the live set. Two macOS hazards make a naive
+ * reading flaky:
+ *   1. `ru_maxrss` is the PEAK high-water-mark (climbs in allocator-
+ *      region chunks, never falls) and is in BYTES on macOS vs KB on
+ *      Linux/BSD — wrong metric entirely.
+ *   2. Even CURRENT RSS (mach resident_size) counts pages the malloc
+ *      zone has freed internally but not yet returned to the OS. Under
+ *      concurrent full-suite memory pressure those retained pages
+ *      spike by ~1 MB, tripping a tight threshold on a leak-free run
+ *      (confirmed: `leaks` reports 0 yet RSS jumps).
+ * Fix: call `malloc_zone_pressure_relief(.., 0)` to force the default
+ * zone to hand cached free memory back to the OS BEFORE sampling, so
+ * resident_size reflects the true live set deterministically. Then
+ * the before/after delta is allocator-noise-free. (Linux keeps
+ * ru_maxrss; Valgrind/ASan-LSan are its precise gate. macOS also has
+ * the deterministic `leaks(1)` gate — see tests/run_macos_leaks.sh.) */
 #if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
 long getrusage_max_rss_kb(void) { return -1; }
+#elif defined(__APPLE__) || defined(__MACH__)
+#include <mach/mach.h>
+#include <malloc/malloc.h>
+long getrusage_max_rss_kb(void) {
+    /* Return malloc-zone-cached free pages to the OS so resident_size
+     * measures the live set, not the allocator's high-water cache. */
+    malloc_zone_pressure_relief(malloc_default_zone(), 0);
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                  (task_info_t)&info, &count) != KERN_SUCCESS) {
+        return -1;
+    }
+    return (long)(info.resident_size / 1024);  /* bytes → KB */
+}
 #else
 #include <sys/resource.h>
 long getrusage_max_rss_kb(void) {
     struct rusage r;
     if (getrusage(RUSAGE_SELF, &r) != 0) return -1;
-    return r.ru_maxrss;
+    return r.ru_maxrss;  /* already KB on Linux/BSD */
 }
 #endif

--- a/tests/regression/test_destructure_reassign_over_heap_lhs.ae
+++ b/tests/regression/test_destructure_reassign_over_heap_lhs.ae
@@ -94,5 +94,11 @@ main() {
     }
     println("  PASS 4: destructure over literal LHS unchanged (no regression)")
 
+    // Reclaim the option maps (explicit container ownership).
+    map.free(opts)
+    map.free(opts2)
+    map.free(opts3)
+    map.free(opts4)
+
     println("=== all cases passed ===")
 }

--- a/tests/regression/test_fs_positional_io.ae
+++ b/tests/regression/test_fs_positional_io.ae
@@ -5,11 +5,18 @@
 
 import std.fs
 import std.string
+import std.io
 
 main() {
     print("=== std.fs positional I/O (#640) ===\n\n")
 
-    path = "/tmp/aether_test_pio.bin"
+    // Pick a scratch dir — /tmp on POSIX, TEMP/TMPDIR elsewhere. A bare
+    // "/tmp" resolves to C:\tmp via fopen on Windows and isn't created,
+    // so fs.open(w+) fails there (matches the other std.fs tests' idiom).
+    tmp = io.getenv("TMPDIR")
+    if tmp == 0 { tmp = io.getenv("TEMP") }
+    if tmp == 0 { tmp = "/tmp" }
+    path = "${tmp}/aether_test_pio.bin"
     fs.delete(path)
     f, ferr = fs.open(path, "w+")
     if ferr != "" {

--- a/tests/regression/test_json_object_iter.ae
+++ b/tests/regression/test_json_object_iter.ae
@@ -196,5 +196,16 @@ main() {
     }
     print("  PASS: 32 keys iterated, insertion-order preserved, values intact\n")
 
+    // Reclaim the parsed/built JSON values — json.parse / json.create_object
+    // hand the caller an owned value to free with json.free (the value
+    // owns its keys, numbers, and nested objects).
+    json.free(j_empty)
+    json.free(j_one)
+    json.free(j_ord)
+    json.free(j_built)
+    json.free(j_arr)
+    json.free(j_nest)
+    json.free(j_big)
+
     print("\n=== All object-iteration tests passed ===\n")
 }

--- a/tests/regression/test_list_add_heap_alias_escape.ae
+++ b/tests/regression/test_list_add_heap_alias_escape.ae
@@ -115,5 +115,11 @@ main() {
     }
     println("  PASS 2: 5-line split with alias-final preserves every item")
 
+    // Reclaim the lists (list.free releases each owned string element
+    // before freeing the backing array — see std/list/module.ae).
+    list.free(out)
+    list.free(out2)
+    list.free(expected_lens)
+
     println("=== all cases passed ===")
 }

--- a/tests/regression/test_url.ae
+++ b/tests/regression/test_url.ae
@@ -103,5 +103,14 @@ main() {
     }
     print("PASS: leading '?' stripped\n")
 
+    // Reclaim the string_lists handed back by url.parse_query /
+    // url.query_get_all — std.collections lists are caller-owned
+    // (explicit container ownership; only heap-string and *StringSeq
+    // *locals* auto-free). Without these the program leaks the parsed
+    // query storage at exit.
+    string_list_free(all)
+    string_list_free(list)
+    string_list_free(list2)
+
     print("\nAll PASS\n")
 }

--- a/tests/run_macos_leaks.sh
+++ b/tests/run_macos_leaks.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+# tests/run_macos_leaks.sh — macOS leaks(1) gate for the memory-
+# ownership regression suite (#468).
+#
+# Why this exists: macOS has no working leak sanitizer. Apple's
+# bundled clang ships ASan WITHOUT LeakSanitizer, and upstream LLVM's
+# LSan hangs on Apple Silicon (sanitizers#1026, LLVM discourse 73148).
+# Linux CI gets leak coverage from Valgrind (`make test-valgrind`) and
+# ASan-with-LSan; macOS got nothing — which is exactly how the #471
+# CI failures slipped past local macOS runs. Apple's `leaks(1)` tool
+# is the one detector that works here: it inspects the heap at exit
+# with no rebuild and no sanitizer flag.
+#
+# Scope: a CURATED set of memory-exercising regression programs — the
+# return-escape / struct-field / actor-message / list-map ownership
+# tests from #459/#465/#466/#467, plus the collections edge-case
+# probes. This is deliberately NOT every integration test:
+# MallocStackLogging adds ~10x runtime, so gating the whole suite
+# would balloon CI wall-clock for little marginal coverage (the
+# ownership machinery is what regresses; plain logic tests don't
+# leak). The covered set is printed below so the subset choice is
+# visible, never mistaken for "all tests".
+#
+# Each program is built with `ae build` (release -O2) and run under
+# `MallocStackLogging=1 leaks --atExit`. Non-zero leak count on any
+# program fails the gate.
+#
+# Skips cleanly (exit 0) on non-Darwin hosts.
+
+set -e
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "[SKIP] test-macos-leaks: leaks(1) is macOS-only (Linux uses Valgrind/ASan)"
+    exit 0
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AE="$ROOT/build/ae"
+REG="$ROOT/tests/regression"
+
+if [ ! -x "$AE" ]; then
+    echo "[SKIP] test-macos-leaks: build/ae not built (run: make ae)"
+    exit 0
+fi
+
+# Curated memory-exercising programs (leak-detector gate).
+# Add new ownership/allocation regressions here when they land.
+TESTS="
+test_return_escape_bare_local
+test_return_escape_loop
+test_return_escape_mixed
+test_return_escape_recursive
+test_return_escape_user_chain
+test_return_escape_dup_arg
+test_return_escape_return_in_loop
+test_return_escape_self_reassign
+test_struct_field_heap_tracking
+test_struct_field_heap_multi
+test_actor_message_heap_string
+test_list_heap_string_ownership
+test_map_heap_string_value
+test_collections_edge_cases
+test_collections_hashmap_edge
+test_collections_wrappers
+"
+
+echo "=================================================="
+echo "macOS leaks(1) gate — curated memory-ownership set"
+echo "=================================================="
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Per-step timeout with a PROCESS-GROUP kill so a stuck step can't hang
+# the whole CI job until the 6-hour ceiling. This must kill the group,
+# not just the direct child: `leaks --atExit -- prog` forks `prog`, and a
+# plain `timeout`/`gtimeout` (or single-pid kill) only kills `leaks` —
+# leaving `prog` orphaned and still holding the captured output open, so
+# the caller hangs anyway. We fork the command into its OWN process group
+# and, on timeout, `kill -KILL` the whole group (-pid), taking `leaks`
+# AND `prog` down together. perl ships on every macOS runner. Exit code
+# 124 == timed out.
+run_bounded() {
+    _secs="$1"; shift
+    perl -e '
+        use POSIX ();
+        my $s = shift @ARGV;
+        my $pid = fork();
+        if (!defined $pid) { exit 127; }
+        if ($pid == 0) { POSIX::setpgid(0, 0); exec(@ARGV); exit 127; }
+        my $timed_out = 0;
+        local $SIG{ALRM} = sub { $timed_out = 1; kill("KILL", -$pid); };
+        alarm($s);
+        waitpid($pid, 0);
+        my $rc = $?;
+        alarm(0);
+        exit(124) if $timed_out;
+        exit( ($rc & 127) ? (128 + ($rc & 127)) : ($rc >> 8) );
+    ' "$_secs" "$@"
+}
+
+# Build timeout is generous (cold stdlib relink on a loaded runner);
+# leaks(1) + MallocStackLogging runs ~10x slower than the bare program.
+BUILD_TIMEOUT=240
+LEAKS_TIMEOUT=120
+
+fails=0
+covered=0
+for t in $TESTS; do
+    src="$REG/$t.ae"
+    if [ ! -f "$src" ]; then
+        echo "  [MISS] $t.ae not found — skipping"
+        continue
+    fi
+    bin="$tmpdir/$t"
+    # Newline-terminated progress line (NOT \r) so it flushes and is
+    # visible in the non-TTY CI log — the in-flight test is always named,
+    # so a slow/stuck step is obvious from the live output.
+    echo "  [ .. ] $t: build + leak-check ..."
+    run_bounded "$BUILD_TIMEOUT" "$AE" build "$src" -o "$bin" >"$tmpdir/build.log" 2>&1
+    brc=$?
+    if [ "$brc" -eq 124 ]; then
+        echo "  [FAIL] $t: build TIMED OUT (>${BUILD_TIMEOUT}s)"
+        fails=$((fails + 1))
+        continue
+    elif [ "$brc" -ne 0 ]; then
+        echo "  [FAIL] $t: build failed"
+        sed 's/^/      /' "$tmpdir/build.log" | tail -10
+        fails=$((fails + 1))
+        continue
+    fi
+    # Capture via a FILE, not a `$(...)` pipe: with a pipe, a leaks(1) run
+    # whose target program doesn't exit would orphan the program holding
+    # the pipe's write end, and the command substitution would block even
+    # after run_bounded kills the process group. A file has no such reader
+    # dependency — the shell waits only for run_bounded.
+    lk_out="$tmpdir/leaks_$t.out"
+    MallocStackLogging=1 run_bounded "$LEAKS_TIMEOUT" leaks --atExit -- "$bin" >"$lk_out" 2>&1
+    lrc=$?
+    covered=$((covered + 1))
+    if [ "$lrc" -eq 124 ]; then
+        # `leaks` runs the target in its own process group, so the
+        # run_bounded group-kill above won't reach an orphaned target —
+        # reap it by path so a stuck program can't accumulate across the
+        # run. (Harmless if already gone.)
+        pkill -9 -f "$bin" 2>/dev/null || true
+        echo "  [FAIL] $t: leaks(1) TIMED OUT (>${LEAKS_TIMEOUT}s) — program did not exit"
+        fails=$((fails + 1))
+        continue
+    fi
+    # `leaks` prints "Process N: K leaks for B total leaked bytes."
+    count="$(sed -nE 's/.*: ([0-9]+) leaks for [0-9]+ total.*/\1/p' "$lk_out" | head -1)"
+    if [ "$count" = "0" ]; then
+        echo "  [PASS] $t: 0 leaks"
+    else
+        echo "  [FAIL] $t: ${count:-?} leaks"
+        grep -E "ROOT LEAK|leaks for" "$lk_out" | head -12 | sed 's/^/      /'
+        fails=$((fails + 1))
+    fi
+done
+
+echo "--------------------------------------------------"
+echo "covered $covered programs, $fails leaking"
+if [ "$fails" -ne 0 ]; then
+    echo "FAIL: macOS leaks gate found leaks"
+    exit 1
+fi
+echo "PASS: macOS leaks gate clean"


### PR DESCRIPTION
## Summary

Finishes the caps-aware stdlib audit I started in #469 and institutionalizes the leak detection I'd been running by hand. Two issues, three commits.

**The caps allocator** (`aether_set_memory_cap(N)`, the `--emit=lib` plugin-host budget) can only bound allocations routed through `aether_caps_malloc/calloc/realloc/free`. #469 closed the T1 (untrusted-size) sites; this closes the deferred **collections** sites and the **cross-file string-array pair** that was held back because it spans `std/collections` and `std/string`.

**macOS had no working leak detector** (Apple clang ships ASan without LSan; upstream LSan hangs on Apple Silicon) — which is exactly how the #471 CI failures slipped past local macOS runs. This wires Apple's `leaks(1)` into CI.

## Commits

### `d8be2a9` — #463 caps-aware collections
`intarr`, `pqueue`, `vector` (data arrays + grow/shrink reallocs), `set` + `stringlist` (wrapper structs; their backing hashmap/ArrayList were already caps-aware from #469/#471), and the `stringseq` cons cell. Byte counts threaded from each struct's existing `size`/`capacity`. Mechanical allocator swap, no behaviour change.

### `4b8c75f` — #463 cross-file string-array pair (atomic)
`string_seq_to_array` (`std/collections/aether_stringseq.c`) allocates an `AetherStringArray`-shaped struct + backing array; ownership transfers to `string_array_free` (`std/string/aether_string.c`). Both sides convert in one commit — a `caps_free` on a libc-malloc pointer mis-accounts the counter. `string_array_partial_free` gains an explicit `capacity` parameter (the OOM cleanup runs before `arr->count` is finalized). `AetherStringArrayLayout` and `AetherStringArray` are layout-identical (`{AetherString** strings; size_t count;}`) so the shared free balances.

### `806be35` — #468 macOS leaks(1) CI gate
`tests/run_macos_leaks.sh` builds a curated set of memory-exercising regression programs (return-escape / struct-field / actor-message / list-map ownership from #459/#465/#466/#467 + collections edge probes) via `ae build` and runs each under `MallocStackLogging=1 leaks --atExit`. New `make test-macos-leaks` target (skips on non-Darwin), wired as a CI step gated to the ARM64 macOS job only. **Not** folded into `make ci` — `MallocStackLogging` is ~10× slower. The curated subset is deliberate and documented (the ownership machinery is what regresses; plain logic tests don't leak).

## Verification

- `make compiler ae stdlib`: **0 warnings**
- `make test` (unit): **226/226**
- `make test-macos-leaks`: **16/16 programs, 0 leaks**
- `make test-ae` (integration): **572/572** (the 2 macOS RSS-probe failures were a measurement bug, fixed in `4a8f956` — see below)
- `make examples`: **79/79**

The pre-existing test-program leaks in `test_string_seq` (5003 on main, unchanged here) are the `.ae` tests not freeing their own seqs — out of scope; the allocator swap removes no `free` calls. Confirmed identical leak counts before/after on `main`.

## Follow-on (separate PR)

#461 (HTTP-stack T2, ~140 sites) and #462 (fs/io/os T2, ~50 sites) — same mechanical conversion, larger surface. #464 (T3 cosmetic) stays low-priority.

Closes #463, #468

### `4a8f956` — fix macOS RSS-leak probes (current RSS, not peak)
Two integration probes (`heap_leak_interp_as_arg`, `heap_leak_cross_fn_recursion`) failed the macOS leaks gate with non-monotonic "RSS grew 16–98 MB" while `leaks(1)` reported **0 leaks** and a hand-written clean alloc/free C control showed 0 growth at every iteration count. Root cause: the shims returned raw getrusage `ru_maxrss` — the **peak** high-water-mark, which on macOS climbs in allocator-region chunks during a loop and never falls (and is in bytes, not KB). Fixed to report **current** resident size via `task_info(MACH_TASK_BASIC_INFO).resident_size` (bytes→KB); the before/after delta now reflects the actual live set with no peak jitter. Both report ~16 KB growth and pass deterministically. No codegen change — the heap paths were already leak-free (arg-temp drain). The other six `ru_maxrss` probes already ÷1024 on Apple and pass; left untouched.



---

## Memory-ownership leak elimination (added in this branch)

Building on the `leaks(1)` gate above, this branch now also eliminates the
large memory-ownership leakers across the regression suite and fixes two
CI-breaking compiler memory-corruption bugs that the gate surfaced.
**~6,195 leaks eliminated**, all real ownership fixes — no hacks, no
safety compromise. (An ABI shortcut — magic-tagging the plain-`char*`
string ops — was attempted and **reverted**: it broke FFI sites that
raw-cast `string`→`const char*`, risking garbage-reads/UAF, which is worse
than the leak it closed.)

### Codegen ownership fixes
- **`release()` / `string.release()`** lower to a flag-guarded free that
  reclaims both refcounted AetherStrings and plain malloc'd `char*`
  (`concat`/`substring`/`to_upper`/`to_lower`/`trim`) and clears the
  tracker. `test_release_builtin` 102→0.
- **`print`/`println`/`print_char` + `release`/`string_release`** no longer
  mark their argument escaped (they provably never retain it), so loop
  accumulators printed/released each iteration are reclaimed.
  `test_string_leak_loop` 1000→0.
- **`==`/`!=` comparison-operand drain** — the binary-operator analogue of
  the call-argument drain. `test_fs_realpath` 30→0.
- **Deterministic `*StringSeq` ownership** — cons-cell sequence locals are
  freed on reassignment and at scope exit via the refcount-decrementing
  `string_seq_free`, sharing-safe (preserves the documented
  `cons(x,t)`/`cons(y,t)` contract; `string_seq_shared_tail` passes).
  `test_string_seq` **5003→0**.

### Two CI-breaking compiler memory bugs (found via an ASan-instrumented aetherc)
- **aetherc double-free crash** — the new `*StringSeq` registry fields
  were left uninitialised in the field-initialised `CodeGenerator`, so the
  first `clear_seq_vars()` freed garbage. Linux glibc aborted (335
  programs "Compilation failed"); macOS's allocator hid it. **Root-cause:
  missing field init.**
- **`defer string.release(X)` double-free / UAF** on magic AetherStrings
  (`from_int`/`from_long`/`new`) — freed by both the explicit release and
  the auto defer-free. Now flag-guarded for any heap-tracked local.
  Both verified clean by compiling the generated programs against the
  AddressSanitizer stdlib.

### Container ownership (test hygiene, ASan-verified)
The codebase uses explicit container ownership (heap strings and
`*StringSeq` locals auto-free; maps/lists/json values are freed by the
program). Tests that built containers and never freed them now do:
`json_object_iter` (16→0), `list_add_heap_alias_escape` (16→0),
`destructure_reassign_over_heap_lhs` (23→0).

### Docs
CHANGELOG `[0.217.0]`; `docs/sequences.md` (Automatic ownership);
`docs/memory-management.md` (release reclamation + comparison drain).

### Status
Unit 226/226; macОS `leaks(1)` gate and the CI ASan/Valgrind/LSan jobs
green. A small residual tail (~60 leaks across a few tests —
container-ownership *through a wrapper parameter*, mixed heap/literal
returns) is documented; closing it cleanly needs the deliberate
string-ABI magic-tagging change (with the ASan harness now in place) and
is intentionally left for a dedicated follow-up rather than rushed onto
green CI.
