### PR TITLE
fix: 5 follow-ups from tinygo bake + sibling-claude reports (#623, #625, ctr_notes findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,72 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **`ae build` auto-links the tinygo bridge's transitive `-lffi`**
+  (`tools/ae.c`, `tests/integration/host_tinygo/test_host_tinygo.sh`).
+  Closes ctr_notes.md Finding 2. The six interpreter bridges
+  (python/ruby/lua/perl/tcl/duktape) dlopen their host language at
+  runtime and have no link-time deps of their own. `tinygo` is the
+  first bridge whose `.a` carries undefined symbols — `ffi_*` from
+  `tinygo_call_dynamic`, compiled in under `AETHER_HAS_LIBFFI`.
+  The import auto-link previously stopped at the `.a` and required
+  every consumer to add `link_flags = "-lffi"` to their
+  `aether.toml`, defeating the "import is the trigger" promise in
+  contrib/host/python/README.md §8. `prepare_host_bridge_imports`
+  now probes the resolved `.a` with `nm -u | grep ffi_prep_cif`
+  and only appends `-lffi` when the symbol is actually undefined.
+  By-symbol (not by-language) so an end-host that received a
+  bridge `.a` built without libffi never tries to link a missing
+  `-lffi`. One `popen` per `ae build`; no measurable cost. The
+  workaround `aether.toml` in this test is removed — the test now
+  exercises the auto-link path it was previously masking.
+
+- **`http.get_query_param` returns the requested key's value, not
+  the last param's value** (`std/net/aether_http_server.c`,
+  `std/net/aether_http_server.h`,
+  `tests/integration/http_query_param_multi/`,
+  `tests/integration/http_external_ptr/shim.c`). Closes #625.
+  The previous implementation parsed `req->query_string` with
+  `strstr` on every call and returned a pointer into a
+  function-local **static** buffer; two sequential
+  `get_query_param` calls overwrote the same buffer, so both
+  returned pointers aliased the second call's value (e.g.
+  `?alpha=AAA&beta=BBB` made `get_query_param("alpha")` and
+  `get_query_param("beta")` both return `"BBB"`). Now lazily parses
+  the query string once into per-key `query_keys`/`query_values`
+  arrays on the request (mirroring how `header_keys`/`param_keys`
+  already work) and looks up via `strcmp`. Each call returns a
+  stable per-request pointer. Substring-of-another-key safety is
+  now structural (exact `strcmp`) instead of leaning on the
+  `&`-boundary check. The lazy-parse arrays are freed in
+  `http_request_free`. Downstream impact: this broke S3 multipart
+  routing in the fbs-core port (`?uploadId=…&partNumber=1` made
+  `get_query_param("uploadId")` return `"1"`).
+
+- **Build cache invalidates on edits to symlinked lib-dir entries**
+  (`tools/ae.c`,
+  `tests/integration/cache_symlinked_lib_edit/`). Closes #623.
+  `compute_cache_key` previously only `stat`ed each `tc.lib_dirs[i]`
+  directory itself — and a directory's mtime only bumps on
+  create/delete/rename, NOT on an in-place edit of an existing
+  entry. When the entry was a symlink to a file *outside* the lib
+  dir (the natural shape when a test harness builds a flat
+  `.ae_test_lib/` of symlinks to vendored modules), `sed -i` of
+  the link target left BOTH the symlink's and the lib dir's mtime
+  unchanged. The cache key stayed stable, `ae run` served a stale
+  binary, and edits looked like no-ops until
+  `rm -rf ~/.aether/cache`. The fix walks each lib dir's top-level
+  `.ae` / `.c` / `.h` entries, `stat`s each (which follows
+  symlinks), and folds the resolved target's mtime + size into a
+  rolling FNV hash that joins the cache key. Per-dir entry count
+  is also capped at 256 — well above any realistic stdlib/vendored
+  count, but bounded so a runaway can't blow the key buffer. `ae`
+  now also seeds `tc.lib_dirs[]` from `AETHER_LIB_DIR` at the top
+  of `compute_cache_key` (matching the documented priority in
+  `ae lib-path`); without that seed the entry walk wouldn't run
+  when only the env var was set. Downstream impact: in the
+  fbs-core port a correct fix to a module read as "did nothing"
+  for ~30 minutes until the cache was cleared.
+
 - **`contrib.host.tinygo` docs and integration test now use
   `go build`, not `tinygo build`, for native c-shared**
   (`contrib/host/tinygo/README.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ next version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **`string.split` / `string.array_get` — lifetime warning added to
+  module.ae and C source** (`std/string/module.ae`,
+  `std/string/aether_string.c`). `string_array_get` returns a
+  pointer that *borrows* from the array's storage; the natural
+  pattern `v = string.array_get(parts, idx); string.array_free(parts);
+  return v` silently use-after-frees. The externs in `std/string/
+  module.ae` previously had zero lifetime documentation (the
+  sibling `*StringSeq` API right below got a generous docblock).
+  Added an explicit warning at the extern declarations, listed two
+  safe escape patterns (`string.concat(v, "")` to make an owned
+  copy, or `string_split_to_seq` for refcounted cells), and
+  mirrored the warning at the C definition. No behaviour change —
+  the existing pattern is still cheap when access is "build, walk
+  once, free" within one scope; the doc clarifies when that's
+  unsafe. Caught downstream by the aeb-side validator parsing
+  tab-joined rule rows (ctr_notes.md OPEN #3).
+
 ### Fixed
 
 - **`contrib.host.tinygo` docs and integration test now use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`contrib.host.tinygo` docs and integration test now use
+  `go build`, not `tinygo build`, for native c-shared**
+  (`contrib/host/tinygo/README.md`,
+  `contrib/host/tinygo/module.ae`,
+  `contrib/host/tinygo/examples/greet.go`,
+  `examples/host-tinygo-demo.ae`,
+  `tests/integration/host_tinygo/test_host_tinygo.sh`,
+  `tests/scripts/contrib_build.sh`). TinyGo 0.34.0's
+  `-buildmode=c-shared` is wasm-only ("buildmode c-shared is only
+  supported on wasm at the moment"); the README, module header,
+  example header, demo and integration test all documented
+  `tinygo build -buildmode=c-shared` for native linux/macOS/Windows,
+  which has never worked. The integration test silently `[SKIP]`ed
+  on the failed `tinygo build` (line 34 — "tinygo c-shared build
+  failed (likely target/version mismatch)"), so the end-to-end
+  smoke test had been a no-op since v0.215.0 landed. Docs now show
+  standard `CGO_ENABLED=1 go build -buildmode=c-shared` for native
+  and reserve TinyGo for the wasm target. The bridge itself is
+  unchanged — it's a runtime `dlopen` of whatever c-shared `.so`
+  the toolchain produced. The integration test now hard-fails on
+  build error instead of skipping (skip is now reserved for "no Go
+  toolchain installed at all"). The `--with=tinygo` builder image
+  already ships both `go` and `tinygo`, so no capability change is
+  needed. The bridge module name `contrib.host.tinygo` is retained
+  as the brand. Caught downstream by the aeb-side validator on the
+  NUC after v0.216.0 image bake (ctr_notes.md "Finding 1").
+
 ## [0.216.0]
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,6 +388,38 @@ The general rule: if a cast names a typedef, check whether MinGW's
 explicit-width type from `<stdint.h>` or the plain integer type the
 struct field declares it as.
 
+**5c. In shell tests, BSD `sed -i` needs an explicit backup suffix;
+GNU `sed -i` does not.** Linux ships GNU sed, macOS ships BSD sed.
+`sed -i 's/a/b/' file.txt` works fine on Linux and **fails on
+macOS** with `sed: 1: "…": invalid command code f` — BSD sed reads
+the next argument as the backup-suffix and parses the s-expression
+as the file path. The portable shapes:
+
+```bash
+# BAD — Linux-only
+sed -i 's/v1/v2/' "$file"
+
+# GOOD — works on both BSD and GNU sed (the '' is the empty
+# backup-suffix BSD sed wants; GNU sed treats it as a no-op file)
+sed -i '' 's/v1/v2/' "$file"   # NB: only correct on BSD!
+
+# BETTER — works everywhere because both seds accept -i<suffix>
+sed -i.bak 's/v1/v2/' "$file" && rm "$file.bak"
+
+# BEST when you don't actually need a regex — just rewrite the file
+cat > "$file" <<'EOF'
+new content
+EOF
+```
+
+`sed -i ''` is BSD-only; GNU sed treats the empty string as a file
+argument and errors. There is no single `sed -i` invocation that
+parses identically under both. When the test only needs to swap a
+literal value (the common shape in regression tests), prefer
+rewriting the file with `cat > file <<EOF` — fewer moving parts,
+no backup file to clean up, and identical behaviour on every
+platform.
+
 **6. Prefer existing portable helpers over re-rolling your own path
 handling.** `std/fs/aether_fs.c` provides `path_join`, `path_dirname`,
 `path_basename`, `path_normalize`, `path_is_absolute`. These already

--- a/contrib/host/tinygo/README.md
+++ b/contrib/host/tinygo/README.md
@@ -1,9 +1,21 @@
-# contrib.host.tinygo — In-Process Go via TinyGo c-shared
+# contrib.host.tinygo — In-Process Go via c-shared
 
-Run TinyGo-compiled Go code inside the Aether process — no
-subprocess, no IPC, no marshalling. Just `dlopen` the `.so` /
-`.dll` that `tinygo build -buildmode=c-shared` produces and call
-its exported functions directly.
+Run Go code inside the Aether process — no subprocess, no IPC, no
+marshalling. Just `dlopen` the `.so` / `.dll` that
+`go build -buildmode=c-shared` produces and call its exported
+functions directly.
+
+> **Toolchain note.** The bridge is named `tinygo` (and the
+> `--with=tinygo` capability layer ships TinyGo) for the
+> small-footprint, embedded-friendly story, but
+> `tinygo build -buildmode=c-shared` currently only supports
+> `wasm` targets ("buildmode c-shared is only supported on wasm
+> at the moment"). For **native** linux/darwin/windows c-shared
+> libraries — what this bridge dlopens — use standard
+> `go build -buildmode=c-shared`. The bridge dlopens by symbol;
+> it doesn't care which compiler produced the `.so`. The
+> `--with=tinygo` image ships both `go` and `tinygo` so either
+> path is one command away.
 
 This is the in-process counterpart of [`contrib/host/go`](../go/),
 which spawns the standard `go` toolchain as a sandboxed
@@ -20,16 +32,16 @@ subprocess. Pick the host that matches your containment story:
 
 ## Prerequisites
 
-```bash
-# macOS
-brew install tinygo
+You need a Go toolchain that can build `-buildmode=c-shared`.
+On native linux/darwin/windows that's standard `go` (≥1.21);
+TinyGo is fine for the wasm target only.
 
-# Debian/Ubuntu — see https://tinygo.org/getting-started/install/linux/
-wget https://github.com/tinygo-org/tinygo/releases/download/v0.34.0/tinygo_0.34.0_amd64.deb
-sudo dpkg -i tinygo_0.34.0_amd64.deb
+```bash
+# macOS / Linux / Windows — standard Go
+# https://go.dev/dl/
 
 # Verify
-tinygo version
+go version
 ```
 
 ## Build the Go side
@@ -59,13 +71,17 @@ func Greet(name *C.char) *C.char {
 func main() {}  // c-shared still requires a main() — empty body is fine
 ```
 
-Build:
+Build (native — use standard `go`, not `tinygo`; see toolchain
+note at the top):
 
 ```bash
-tinygo build -buildmode=c-shared -o libgreet.so greet.go     # Linux
-tinygo build -buildmode=c-shared -o libgreet.dylib greet.go  # macOS
-tinygo build -buildmode=c-shared -o libgreet.dll greet.go    # Windows
+CGO_ENABLED=1 go build -buildmode=c-shared -o libgreet.so    greet.go  # Linux
+CGO_ENABLED=1 go build -buildmode=c-shared -o libgreet.dylib greet.go  # macOS
+CGO_ENABLED=1 go build -buildmode=c-shared -o libgreet.dll   greet.go  # Windows
 ```
+
+For the wasm target — and only then — substitute
+`tinygo build -buildmode=c-shared -target=wasm …`.
 
 ## Call from Aether
 
@@ -130,18 +146,20 @@ window.
 ## Limitations
 
 - **Single Go runtime per process.** `dlopen` of two distinct
-  TinyGo c-shared libraries in the same process can collide on
+  c-shared Go libraries in the same process can collide on
   runtime state. Stick to one library per Aether process.
-- **No goroutines that outlive the Aether call.** TinyGo's
-  scheduler runs cooperatively inside the call; spawning a
-  goroutine that blocks on I/O and returns to the Aether caller
-  before the goroutine completes is undefined behaviour.
-- **Standard `go` toolchain produces a different ABI.** Building
-  with `go build -buildmode=c-shared` (not `tinygo`) embeds the
-  full Go runtime, which conflicts with Aether's actor scheduler.
-  Use `contrib/host/go` (subprocess) for full Go.
-- **Symbol export is `//export Name`.** TinyGo does not export
-  package-level `Name` automatically — you must annotate.
+- **No goroutines that outlive the Aether call.** The Go
+  scheduler runs inside the call; spawning a goroutine that
+  blocks on I/O and returns to the Aether caller before the
+  goroutine completes is undefined behaviour.
+- **`tinygo build -buildmode=c-shared` is wasm-only today.**
+  Native linux/darwin/windows c-shared `.so`s come from standard
+  `go build` (see the toolchain note at the top of this file).
+  The Aether-side bridge is purely a `dlopen` + symbol lookup —
+  it loads whatever c-shared the toolchain produced.
+- **Symbol export is `//export Name`.** Neither standard Go nor
+  TinyGo exports package-level `Name` automatically — you must
+  annotate each function you want callable from C / Aether.
 
 ## See also
 

--- a/contrib/host/tinygo/examples/greet.go
+++ b/contrib/host/tinygo/examples/greet.go
@@ -1,5 +1,7 @@
-// Build with:
-//   tinygo build -buildmode=c-shared -o libgreet.so contrib/host/tinygo/examples/greet.go
+// Build with standard `go` (TinyGo's -buildmode=c-shared is wasm-only
+// on current releases; see ../README.md "Toolchain note"):
+//
+//   CGO_ENABLED=1 go build -buildmode=c-shared -o libgreet.so contrib/host/tinygo/examples/greet.go
 //
 // Then load from Aether via contrib.host.tinygo (see ../README.md).
 package main

--- a/contrib/host/tinygo/module.ae
+++ b/contrib/host/tinygo/module.ae
@@ -1,13 +1,18 @@
-// contrib.host.tinygo — In-process Go via TinyGo c-shared.
+// contrib.host.tinygo — In-process Go via c-shared.
 //
 // Unlike contrib/host/go (subprocess + LD_PRELOAD), this host loads a
-// TinyGo-built .so/.dll into the Aether process via std.dl and calls
+// c-shared Go .so/.dll into the Aether process via std.dl and calls
 // the exported functions directly. No JSON marshalling, no IPC, no
 // fork/exec — same address space, same scheduler.
 //
-// Build the Go side first:
+// Build the Go side first. On native linux/darwin/windows use
+// standard `go build` — TinyGo's -buildmode=c-shared currently only
+// supports the wasm target ("buildmode c-shared is only supported on
+// wasm at the moment" on TinyGo 0.34.0). The bridge dlopens by symbol
+// and doesn't care which compiler produced the .so:
 //
-//   tinygo build -buildmode=c-shared -o libgreet.so contrib/host/tinygo/examples/greet.go
+//   CGO_ENABLED=1 go build -buildmode=c-shared \
+//       -o libgreet.so contrib/host/tinygo/examples/greet.go
 //
 // Then from Aether:
 //

--- a/examples/host-tinygo-demo.ae
+++ b/examples/host-tinygo-demo.ae
@@ -1,13 +1,17 @@
-// examples/host-tinygo-demo.ae - in-process Go from Aether via TinyGo
+// examples/host-tinygo-demo.ae - in-process Go from Aether via c-shared
 //
-// Prerequisite: tinygo on PATH, then build the demo lib:
+// Prerequisite: a Go toolchain on PATH, then build the demo lib.
+// Use standard `go` — TinyGo's -buildmode=c-shared is wasm-only on
+// current releases. See contrib/host/tinygo/README.md "Toolchain
+// note" for the full story.
 //
-//   tinygo build -buildmode=c-shared \
+//   CGO_ENABLED=1 go build -buildmode=c-shared \
 //       -o /tmp/libgreet.so contrib/host/tinygo/examples/greet.go
 //
 // Then run:
 //
-//   AETHER_HOME=$(pwd) ./build/ae run examples/host-tinygo-demo.ae
+//   AETHER_HOME=$(pwd) TINYGO_LIB=/tmp/libgreet.so \
+//       ./build/ae run examples/host-tinygo-demo.ae
 //
 // On macOS use libgreet.dylib; on Windows libgreet.dll. See
 // contrib/host/tinygo/README.md for the full cookbook.

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -1430,31 +1430,68 @@ const char* http_get_header(HttpRequest* req, const char* key) {
     return NULL;
 }
 
+// Parse req->query_string into req->query_keys / query_values once and
+// cache on the request. Called lazily from http_get_query_param so any
+// request that never asks for a query param pays nothing.
+//
+// The previous implementation walked the raw query_string on every call
+// with strstr and returned a pointer into a function-local static buffer
+// (#625): two sequential calls overwrote the buffer, so the first call's
+// returned pointer aliased the second call's value. With a real per-key
+// array each call returns a stable per-request pointer.
+static void http_parse_query_locked(HttpRequest* req) {
+    req->query_parsed = 1;
+    if (!req->query_string || !*req->query_string) return;
+
+    // First pass: count pairs (one per '&' boundary, plus the tail).
+    int cap = 1;
+    for (const char* p = req->query_string; *p; p++) {
+        if (*p == '&') cap++;
+    }
+    req->query_keys   = (char**)calloc((size_t)cap, sizeof(char*));
+    req->query_values = (char**)calloc((size_t)cap, sizeof(char*));
+    if (!req->query_keys || !req->query_values) {
+        free(req->query_keys);   req->query_keys = NULL;
+        free(req->query_values); req->query_values = NULL;
+        return;
+    }
+
+    const char* cur = req->query_string;
+    while (*cur) {
+        const char* amp = strchr(cur, '&');
+        size_t pair_len = amp ? (size_t)(amp - cur) : strlen(cur);
+        const char* eq = (const char*)memchr(cur, '=', pair_len);
+        if (pair_len > 0 && eq && eq > cur) {
+            size_t klen = (size_t)(eq - cur);
+            size_t vlen = pair_len - klen - 1;
+            char* k = (char*)malloc(klen + 1);
+            char* v = (char*)malloc(vlen + 1);
+            if (k && v) {
+                memcpy(k, cur, klen); k[klen] = '\0';
+                memcpy(v, eq + 1, vlen); v[vlen] = '\0';
+                req->query_keys[req->query_count]   = k;
+                req->query_values[req->query_count] = v;
+                req->query_count++;
+            } else {
+                free(k); free(v);
+            }
+        }
+        // Bare-key form (`?foo&bar=1`) is silently skipped — matches the
+        // previous behaviour where strchr('=') would return NULL on it.
+        if (!amp) break;
+        cur = amp + 1;
+    }
+}
+
 const char* http_get_query_param(HttpRequest* req, const char* key) {
     if (!req || !key) return NULL;
-    if (!req->query_string) return NULL;
-    
-    // Parse query params on demand
-    char* found = strstr(req->query_string, key);
-    if (!found) return NULL;
-    
-    // Check if it's actually the key (not part of another key)
-    if (found != req->query_string && *(found - 1) != '&') {
-        return NULL;
+    if (!req->query_parsed) http_parse_query_locked(req);
+    for (int i = 0; i < req->query_count; i++) {
+        if (strcmp(req->query_keys[i], key) == 0) {
+            return req->query_values[i];
+        }
     }
-    
-    char* equals = strchr(found, '=');
-    if (!equals) return NULL;
-    
-    char* value_start = equals + 1;
-    char* value_end = strchr(value_start, '&');
-    
-    static char value_buf[256];
-    size_t value_len = value_end ? (size_t)(value_end - value_start) : strlen(value_start);
-    strncpy(value_buf, value_start, value_len);
-    value_buf[value_len] = '\0';
-    
-    return value_buf;
+    return NULL;
 }
 
 const char* http_get_path_param(HttpRequest* req, const char* key) {
@@ -1488,7 +1525,14 @@ void http_request_free(HttpRequest* req) {
     }
     free(req->param_keys);
     free(req->param_values);
-    
+
+    for (int i = 0; i < req->query_count; i++) {
+        free(req->query_keys[i]);
+        free(req->query_values[i]);
+    }
+    free(req->query_keys);
+    free(req->query_values);
+
     free(req);
 }
 

--- a/std/net/aether_http_server.h
+++ b/std/net/aether_http_server.h
@@ -21,6 +21,16 @@ typedef struct {
     char** param_keys;      // From /users/:id
     char** param_values;
     int param_count;
+
+    // Lazily parsed from query_string on first http_get_query_param() call.
+    // query_parsed=0 means "not yet attempted"; ?0 is also the sentinel for
+    // a NULL query_string (then count stays 0). Each value is its own
+    // strdup so http_get_query_param can hand out a stable borrowed pointer
+    // across the request's lifetime without a static-buffer collision.
+    char** query_keys;
+    char** query_values;
+    int query_count;
+    int query_parsed;
 } HttpRequest;
 
 // HTTP Response

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -519,6 +519,12 @@ int string_array_size(AetherStringArray* arr) {
 // Returns the raw C string data (const char*) for the element at index.
 // Aether treats strings as const char* — returning AetherString* would cause
 // printf("%s", ...) to print garbage (struct pointer instead of char data).
+//
+// LIFETIME: returned pointer is BORROWED — it aliases arr->strings[index]->data
+// and is invalidated by string_array_free(arr). Aether-side callers that need
+// the value to outlive the array must copy first (e.g. string.concat(v, ""))
+// or use string_split_to_seq which returns refcounted cells. The module.ae
+// extern carries the same warning for the Aether-side reader.
 const char* string_array_get(AetherStringArray* arr, int index) {
     if (!arr || index < 0 || (size_t)index >= arr->count) return NULL;
     AetherString* s = arr->strings[index];

--- a/std/string/module.ae
+++ b/std/string/module.ae
@@ -130,7 +130,34 @@ extern string_to_upper(str: string) -> string
 extern string_to_lower(str: string) -> string
 extern string_trim(str: string) -> string
 
-// String array operations
+// String array operations.
+//
+// LIFETIME WARNING — `string_array_get` returns a *borrowed* pointer
+// into the array's internal storage, NOT an owned copy. After
+// `string_array_free(arr)` every pointer previously handed out by
+// `string_array_get(arr, ...)` is dangling. The natural-looking
+// pattern below silently use-after-frees:
+//
+//     v = string.array_get(parts, idx)
+//     string.array_free(parts)
+//     return v                 // <- v dangles
+//
+// Symptom is garbage bytes / random crashes downstream — the array's
+// backing storage is gone but the pointer still reads.
+//
+// Safe options when you need a value to outlive the array:
+//   1. Copy first:  v = string.concat(string.array_get(parts, idx), "")
+//                   then string.array_free(parts) — the concat made
+//                   an owned, refcounted copy.
+//   2. Use `string_split_to_seq` (declared further down) — returns a
+//      refcounted `*StringSeq` whose cells own their data
+//      independently of any backing array, so there's no
+//      array-wide free to worry about.
+//
+// If your access pattern is "build, walk once, free" within a single
+// scope, the borrowed-pointer form is fine and the cheapest. Reach
+// for option 1/2 only when a piece needs to escape the array's
+// lifetime.
 extern string_split(str: string, delimiter: string) -> ptr
 extern string_array_size(arr: ptr) -> int
 extern string_array_get(arr: ptr, index: int) -> ptr

--- a/tests/integration/cache_symlinked_lib_edit/test_cache_symlinked_lib_edit.sh
+++ b/tests/integration/cache_symlinked_lib_edit/test_cache_symlinked_lib_edit.sh
@@ -5,7 +5,7 @@
 # Pre-fix bug: compute_cache_key only mtime'd the lib dir itself.
 # A dir's mtime only bumps on create/delete/rename of an entry, NOT
 # on an in-place edit of a file behind a symlink that points outside
-# the dir. So `sed -i` of the symlink target left the dir mtime
+# the dir. So editing the symlink target left the dir mtime
 # unchanged, the cache key stayed stable, `ae run` served the
 # previously-compiled binary, and edits looked like no-ops until
 # `rm -rf ~/.aether/cache`.
@@ -82,7 +82,14 @@ sleep 1.1
 # Edit the REAL file behind the symlink. Pre-fix bug: this didn't
 # invalidate the cache because the symlink's mtime, the lib dir's
 # mtime, and the cache key stayed unchanged.
-sed -i 's/v1/v2/' "$TMP/mod_real.ae"
+# (Rewrite instead of `sed -i` — BSD `sed -i` requires an explicit
+# empty backup-suffix `sed -i ''`, GNU sed doesn't take one. No
+# portable single form. See CONTRIBUTING.md "Coding for
+# portability" §5c.)
+cat > "$TMP/mod_real.ae" <<'AE'
+exports (greet)
+greet() -> string { return "v2" }
+AE
 
 OUT2=$(AETHER_LIB_DIR="$TMP/lib" "$AE" run main.ae 2>&1 | tail -1)
 if [ "$OUT2" != "got=v2" ]; then
@@ -108,7 +115,10 @@ OUT3=$(AETHER_LIB_DIR="$TMP/lib" "$AE" run main2.ae 2>&1 | tail -1)
     exit 1
 }
 sleep 1.1
-sed -i 's/direct-v1/direct-v2/' "$TMP/lib/direct_mod.ae"
+cat > "$TMP/lib/direct_mod.ae" <<'AE'
+exports (val)
+val() -> string { return "direct-v2" }
+AE
 OUT4=$(AETHER_LIB_DIR="$TMP/lib" "$AE" run main2.ae 2>&1 | tail -1)
 [ "$OUT4" = "d=direct-v2" ] || {
     echo "  [FAIL] direct-mod edit: expected 'd=direct-v2', got '$OUT4'"

--- a/tests/integration/cache_symlinked_lib_edit/test_cache_symlinked_lib_edit.sh
+++ b/tests/integration/cache_symlinked_lib_edit/test_cache_symlinked_lib_edit.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+# #623 regression: editing a module behind a SYMLINK on the
+# `AETHER_LIB_DIR` search path must invalidate the build cache.
+#
+# Pre-fix bug: compute_cache_key only mtime'd the lib dir itself.
+# A dir's mtime only bumps on create/delete/rename of an entry, NOT
+# on an in-place edit of a file behind a symlink that points outside
+# the dir. So `sed -i` of the symlink target left the dir mtime
+# unchanged, the cache key stayed stable, `ae run` served the
+# previously-compiled binary, and edits looked like no-ops until
+# `rm -rf ~/.aether/cache`.
+#
+# Fix: compute_cache_key now walks each lib_dir's top-level entries
+# and folds each entry's resolved-target (`stat`, follows symlinks)
+# mtime + size into the key. ae also now seeds tc.lib_dirs[] from
+# AETHER_LIB_DIR up front so the walk runs even when only the env
+# var (no --lib flag) is set.
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP-WIN] symlinks + bash heredoc — POSIX-only test"
+        exit 0
+        ;;
+esac
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if ! command -v ln >/dev/null 2>&1; then
+    echo "  [SKIP] no ln(1)"; exit 0
+fi
+
+TMP="$(mktemp -d)"
+CACHE_BACKUP=""
+cleanup() {
+    rm -rf "$TMP"
+    if [ -n "$CACHE_BACKUP" ] && [ -d "$CACHE_BACKUP" ]; then
+        rm -rf "$HOME/.aether/cache"
+        mv "$CACHE_BACKUP" "$HOME/.aether/cache" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# Move any existing cache aside so the test doesn't trample real builds.
+if [ -d "$HOME/.aether/cache" ]; then
+    CACHE_BACKUP="$HOME/.aether/cache.t623bk.$$"
+    mv "$HOME/.aether/cache" "$CACHE_BACKUP"
+fi
+mkdir -p "$HOME/.aether/cache"
+
+mkdir -p "$TMP/lib"
+cat > "$TMP/mod_real.ae" <<'AE'
+exports (greet)
+greet() -> string { return "v1" }
+AE
+ln -s "$TMP/mod_real.ae" "$TMP/lib/mod.ae"
+
+cat > "$TMP/main.ae" <<'AE'
+import mod
+main() { r = mod.greet()  println("got=${r}") }
+AE
+
+cd "$TMP"
+
+# First run — establish baseline.
+OUT1=$(AETHER_LIB_DIR="$TMP/lib" "$AE" run main.ae 2>&1 | tail -1)
+if [ "$OUT1" != "got=v1" ]; then
+    echo "  [FAIL] first run: expected 'got=v1', got '$OUT1'"
+    exit 1
+fi
+
+# Bump mtime so a same-second edit isn't masked by 1-second mtime
+# granularity on some filesystems. The fix folds in st_size too so
+# size-changing edits invalidate even at the same second, but this
+# test edits replace v1 → v2 (same size), so we need a real second
+# of separation to be sure we're not relying on the size fallback.
+sleep 1.1
+
+# Edit the REAL file behind the symlink. Pre-fix bug: this didn't
+# invalidate the cache because the symlink's mtime, the lib dir's
+# mtime, and the cache key stayed unchanged.
+sed -i 's/v1/v2/' "$TMP/mod_real.ae"
+
+OUT2=$(AETHER_LIB_DIR="$TMP/lib" "$AE" run main.ae 2>&1 | tail -1)
+if [ "$OUT2" != "got=v2" ]; then
+    echo "  [FAIL] post-edit run: expected 'got=v2', got '$OUT2'"
+    echo "  (pre-fix bug: edits behind a symlinked lib entry are missed)"
+    exit 1
+fi
+
+# Bonus — also verify that an edit to a NON-symlinked module on the
+# lib path invalidates (the original #413 promise; same code path
+# now exercises real lstat-follows behaviour for both).
+cat > "$TMP/lib/direct_mod.ae" <<'AE'
+exports (val)
+val() -> string { return "direct-v1" }
+AE
+cat > "$TMP/main2.ae" <<'AE'
+import direct_mod
+main() { r = direct_mod.val()  println("d=${r}") }
+AE
+OUT3=$(AETHER_LIB_DIR="$TMP/lib" "$AE" run main2.ae 2>&1 | tail -1)
+[ "$OUT3" = "d=direct-v1" ] || {
+    echo "  [FAIL] direct-mod baseline: expected 'd=direct-v1', got '$OUT3'"
+    exit 1
+}
+sleep 1.1
+sed -i 's/direct-v1/direct-v2/' "$TMP/lib/direct_mod.ae"
+OUT4=$(AETHER_LIB_DIR="$TMP/lib" "$AE" run main2.ae 2>&1 | tail -1)
+[ "$OUT4" = "d=direct-v2" ] || {
+    echo "  [FAIL] direct-mod edit: expected 'd=direct-v2', got '$OUT4'"
+    exit 1
+}
+
+echo "  [PASS] cache_symlinked_lib_edit: edits behind symlinked lib entries invalidate (#623)"

--- a/tests/integration/host_tinygo/test_host_tinygo.sh
+++ b/tests/integration/host_tinygo/test_host_tinygo.sh
@@ -1,11 +1,21 @@
 #!/bin/sh
 # Issue #261: contrib/host/tinygo end-to-end smoke test.
 #
-# Skips cleanly when tinygo is not on PATH (matches contrib/host/go's
-# pattern — host bridges should never break CI on machines that don't
-# have the toolchain installed). When tinygo IS available, the test
-# builds a c-shared .so, loads it via contrib.host.tinygo, and exercises
-# every wrapper signature.
+# Skips cleanly when the Go toolchain is not on PATH (matches
+# contrib/host/go's pattern — host bridges should never break CI on
+# machines that don't have the toolchain installed). When `go` IS
+# available, the test builds a c-shared .so, loads it via
+# contrib.host.tinygo, and exercises every wrapper signature.
+#
+# NOTE on the build command: this used `tinygo build -buildmode=c-shared`
+# historically, but TinyGo 0.34.0 restricts that buildmode to wasm
+# targets ("buildmode c-shared is only supported on wasm at the moment").
+# The bridge is a runtime dlopen — it doesn't care which compiler
+# produced the .so, only that it's a valid c-shared with the exported
+# symbols. We use standard `go build -buildmode=c-shared`, which works
+# natively on linux/darwin and produces a binary-compatible .so. The
+# "tinygo" name on the bridge is retained as the brand; the toolchain
+# choice is a build-time detail.
 
 set -e
 
@@ -13,8 +23,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 AE="$ROOT/build/ae"
 
-if ! command -v tinygo >/dev/null 2>&1; then
-    echo "  [SKIP] tinygo not on PATH — install via https://tinygo.org/getting-started/install/"
+if ! command -v go >/dev/null 2>&1; then
+    echo "  [SKIP] go not on PATH — install via https://go.dev/dl/"
     exit 0
 fi
 
@@ -31,16 +41,48 @@ esac
 LIB_PATH="$TMPDIR/libgreet.$LIB_EXT"
 GO_SRC="$ROOT/contrib/host/tinygo/examples/greet.go"
 
-if ! tinygo build -buildmode=c-shared -o "$LIB_PATH" "$GO_SRC" 2>"$TMPDIR/tinygo.err"; then
-    echo "  [SKIP] tinygo c-shared build failed (likely target/version mismatch):"
-    head -5 "$TMPDIR/tinygo.err"
-    exit 0
+# `go build -buildmode=c-shared` requires CGO (the source uses `import "C"`)
+# and writes the source's directory into the binary, so build from a
+# fresh tmpdir copy to keep the source tree clean.
+cp "$GO_SRC" "$TMPDIR/greet.go"
+if ! (cd "$TMPDIR" && CGO_ENABLED=1 go build -buildmode=c-shared -o "$LIB_PATH" greet.go) 2>"$TMPDIR/go.err"; then
+    echo "  [FAIL] go build -buildmode=c-shared failed:"
+    head -10 "$TMPDIR/go.err"
+    exit 1
 fi
 
+# Stage a workspace with its own aether.toml so the -lffi link flag flows
+# into the gcc invocation. libaether_host_tinygo.a has an unresolved
+# ffi_* set when built with AETHER_HAS_LIBFFI (for the call_dynamic
+# escape hatch); the import-driven auto-link adds the bridge .a but
+# not its transitive -lffi yet (ctr_notes.md Finding 2 — separate PR).
+# Workspace also symlinks contrib/ so `import contrib.host.tinygo`
+# resolves the same way `aeb`'s in-container workspace does.
+WORK="$TMPDIR/work"
+mkdir -p "$WORK"
+ln -s "$ROOT/contrib" "$WORK/contrib"
+cp "$SCRIPT_DIR/uses_tinygo.ae" "$WORK/uses_tinygo.ae"
+
+cat > "$WORK/aether.toml" <<EOF
+[project]
+name = "host_tinygo_probe"
+version = "0.0.0"
+
+[[bin]]
+name = "uses_tinygo"
+path = "uses_tinygo.ae"
+
+[build]
+link_flags = "-lffi"
+EOF
+
 ACTUAL="$TMPDIR/actual.txt"
-if ! AETHER_HOME="$ROOT" TINYGO_LIB="$LIB_PATH" "$AE" run "$SCRIPT_DIR/uses_tinygo.ae" >"$ACTUAL" 2>"$TMPDIR/err.log"; then
+if ! (
+    cd "$WORK" && AETHER_HOME="$ROOT" TINYGO_LIB="$LIB_PATH" \
+        "$AE" run uses_tinygo.ae >"$ACTUAL" 2>"$TMPDIR/err.log"
+); then
     echo "  [FAIL] ae run exited non-zero"
-    cat "$TMPDIR/err.log" | head -10
+    cat "$TMPDIR/err.log" | head -20
     cat "$ACTUAL" | head -10
     exit 1
 fi

--- a/tests/integration/host_tinygo/test_host_tinygo.sh
+++ b/tests/integration/host_tinygo/test_host_tinygo.sh
@@ -51,36 +51,14 @@ if ! (cd "$TMPDIR" && CGO_ENABLED=1 go build -buildmode=c-shared -o "$LIB_PATH" 
     exit 1
 fi
 
-# Stage a workspace with its own aether.toml so the -lffi link flag flows
-# into the gcc invocation. libaether_host_tinygo.a has an unresolved
-# ffi_* set when built with AETHER_HAS_LIBFFI (for the call_dynamic
-# escape hatch); the import-driven auto-link adds the bridge .a but
-# not its transitive -lffi yet (ctr_notes.md Finding 2 — separate PR).
-# Workspace also symlinks contrib/ so `import contrib.host.tinygo`
-# resolves the same way `aeb`'s in-container workspace does.
-WORK="$TMPDIR/work"
-mkdir -p "$WORK"
-ln -s "$ROOT/contrib" "$WORK/contrib"
-cp "$SCRIPT_DIR/uses_tinygo.ae" "$WORK/uses_tinygo.ae"
-
-cat > "$WORK/aether.toml" <<EOF
-[project]
-name = "host_tinygo_probe"
-version = "0.0.0"
-
-[[bin]]
-name = "uses_tinygo"
-path = "uses_tinygo.ae"
-
-[build]
-link_flags = "-lffi"
-EOF
-
+# The `import contrib.host.tinygo` triggers `ae build`'s auto-link
+# of libaether_host_tinygo.a — AND, as of this PR, its transitive
+# `-lffi` when the bridge .a was compiled with AETHER_HAS_LIBFFI
+# (the call_dynamic escape hatch). No aether.toml workaround
+# required here any more (previously needed link_flags = "-lffi").
 ACTUAL="$TMPDIR/actual.txt"
-if ! (
-    cd "$WORK" && AETHER_HOME="$ROOT" TINYGO_LIB="$LIB_PATH" \
-        "$AE" run uses_tinygo.ae >"$ACTUAL" 2>"$TMPDIR/err.log"
-); then
+if ! AETHER_HOME="$ROOT" TINYGO_LIB="$LIB_PATH" \
+        "$AE" run "$SCRIPT_DIR/uses_tinygo.ae" >"$ACTUAL" 2>"$TMPDIR/err.log"; then
     echo "  [FAIL] ae run exited non-zero"
     cat "$TMPDIR/err.log" | head -20
     cat "$ACTUAL" | head -10

--- a/tests/integration/http_external_ptr/shim.c
+++ b/tests/integration/http_external_ptr/shim.c
@@ -23,6 +23,15 @@ typedef struct {
     char** param_keys;
     char** param_values;
     int param_count;
+    /* #625: lazily-parsed query-param cache. Tracked at the end of
+     * the struct so existing C consumers stay binary-compatible if
+     * they fail to update — but the calloc below sets everything to
+     * zero (query_parsed=0 = "not yet attempted"), which is what
+     * http_get_query_param's lazy-parse path expects. */
+    char** query_keys;
+    char** query_values;
+    int query_count;
+    int query_parsed;
 } HttpRequest;
 
 typedef struct {
@@ -78,6 +87,13 @@ void probe_free_request(void* p) {
     }
     free(r->header_keys); free(r->header_values);
     free(r->body);
+    /* Mirror http_request_free's query-cache cleanup — set by the
+     * lazy parse path inside http_get_query_param the first time
+     * the test calls it. */
+    for (int i = 0; i < r->query_count; i++) {
+        free(r->query_keys[i]); free(r->query_values[i]);
+    }
+    free(r->query_keys); free(r->query_values);
     free(r);
 }
 

--- a/tests/integration/http_query_param_multi/server.ae
+++ b/tests/integration/http_query_param_multi/server.ae
@@ -1,0 +1,78 @@
+// #625 regression: http.get_query_param must return the value for the
+// requested key, not whatever the LAST key's value was. The previous
+// implementation used a function-local static buffer that two sequential
+// calls overwrote, so both returned pointers aliased the second call's
+// value (`?alpha=AAA&beta=BBB` → `a=[BBB] b=[BBB]`).
+
+import std.http
+import std.os
+
+extern exit(code: int)
+extern http_server_start_raw(server: ptr) -> int
+
+const PORT = 18283
+
+handle(req: ptr, res: ptr, ud: ptr) {
+    // Read each key BEFORE building the body so the bug, if reintroduced,
+    // shows up as both reads aliasing the last-written value.
+    a = http.get_query_param(req, "alpha")
+    b = http.get_query_param(req, "beta")
+    c = http.get_query_param(req, "gamma")
+    if a == null { a = "<null>" }
+    if b == null { b = "<null>" }
+    if c == null { c = "<null>" }
+
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "a=[${a}] b=[${b}] c=[${c}]")
+}
+
+handle_single(req: ptr, res: ptr, ud: ptr) {
+    only = http.get_query_param(req, "only")
+    if only == null { only = "<null>" }
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "only=[${only}]")
+}
+
+handle_missing(req: ptr, res: ptr, ud: ptr) {
+    missing = http.get_query_param(req, "nope")
+    if missing == null { missing = "<null>" }
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "nope=[${missing}]")
+}
+
+message StartSrv { raw: ptr }
+message Noop {}
+
+actor SrvActor {
+    state s = 0
+    receive { StartSrv(raw) -> { s = raw; http_server_start_raw(raw) } }
+}
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+main() {
+    raw = http.server_create(PORT)
+    http.server_set_host(raw, "127.0.0.1")
+    if raw == 0 {
+        println("FAIL: server_create returned null")
+        exit(1)
+    }
+
+    http.server_get(raw, "/multi",   handle,         0)
+    http.server_get(raw, "/single",  handle_single,  0)
+    http.server_get(raw, "/missing", handle_missing, 0)
+
+    println("READY")
+
+    spawn(SchedHelper())
+    a = spawn(SrvActor())
+    a ! StartSrv { raw: raw }
+
+    sleep(60000)
+    exit(0)
+}

--- a/tests/integration/http_query_param_multi/test_http_query_param_multi.sh
+++ b/tests/integration/http_query_param_multi/test_http_query_param_multi.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# #625 regression: http.get_query_param returns the value for the
+# REQUESTED key, not the last key's value, when the query has 2+
+# parameters. The previous implementation parsed with strstr on every
+# call and returned a pointer into a function-local static buffer —
+# two sequential calls aliased to the second's value.
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP-WIN] http_query_param_multi — HTTP server is platform-independent; covered by POSIX matrix"
+        exit 0
+        ;;
+esac
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "  [SKIP] curl not on PATH"; exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+SRV_PID=""
+cleanup() {
+    if [ -n "$SRV_PID" ]; then
+        kill "$SRV_PID" 2>/dev/null || true
+        wait "$SRV_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+SRV_PID=$!
+
+deadline=$(($(date +%s) + 15))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    if grep -q READY "$TMPDIR/srv.log" 2>/dev/null; then break; fi
+    if ! kill -0 "$SRV_PID" 2>/dev/null; then
+        echo "  [FAIL] server died:"; head -20 "$TMPDIR/srv.log"; exit 1
+    fi
+    sleep 0.1
+done
+sleep 0.3
+
+BASE="http://127.0.0.1:18283"
+
+# Test 1 — the regression. Three params; each must come back distinct.
+RESP=$(curl --silent --show-error --max-time 5 "$BASE/multi?alpha=AAA&beta=BBB&gamma=CCC") || {
+    echo "  [FAIL] curl multi failed"; exit 1
+}
+EXPECT="a=[AAA] b=[BBB] c=[CCC]"
+if [ "$RESP" != "$EXPECT" ]; then
+    echo "  [FAIL] multi-param query: expected '$EXPECT', got '$RESP'"
+    echo "  (pre-fix bug returned a=[CCC] b=[CCC] c=[CCC] due to static-buffer aliasing)"
+    exit 1
+fi
+
+# Test 2 — single-param query still works (sanity that we didn't break the easy case).
+RESP=$(curl --silent --show-error --max-time 5 "$BASE/single?only=ONE") || {
+    echo "  [FAIL] curl single failed"; exit 1
+}
+[ "$RESP" = "only=[ONE]" ] || {
+    echo "  [FAIL] single-param query: expected 'only=[ONE]', got '$RESP'"; exit 1
+}
+
+# Test 3 — asking for a key that isn't present returns null/absent.
+RESP=$(curl --silent --show-error --max-time 5 "$BASE/missing?something=else") || {
+    echo "  [FAIL] curl missing failed"; exit 1
+}
+[ "$RESP" = "nope=[<null>]" ] || {
+    echo "  [FAIL] missing-key query: expected 'nope=[<null>]', got '$RESP'"; exit 1
+}
+
+# Test 4 — key whose name is a substring of another key (the original
+# strstr() boundary check was the only thing keeping this from
+# misfiring; the new parser uses exact strcmp so the issue can't
+# come back). `?aa=1&aaa=2` asking for "aa" must return 1, not 2.
+RESP=$(curl --silent --show-error --max-time 5 "$BASE/multi?aa=1&aaa=2&beta=B") || {
+    echo "  [FAIL] curl substring failed"; exit 1
+}
+# alpha/beta/gamma handler: only beta is present here, alpha and gamma null.
+EXPECT="a=[<null>] b=[B] c=[<null>]"
+[ "$RESP" = "$EXPECT" ] || {
+    echo "  [FAIL] substring-key query: expected '$EXPECT', got '$RESP'"; exit 1
+}
+
+echo "  [PASS] http_query_param_multi: per-key values stable across calls (#625)"

--- a/tests/scripts/contrib_build.sh
+++ b/tests/scripts/contrib_build.sh
@@ -139,11 +139,12 @@ probe_duktape() {
 
 probe_tinygo() {
     # The bridge .c is pure dlopen via std.dl (aether_dl_*) — it does NOT
-    # need the tinygo toolchain at COMPILE time. libffi is the only
+    # need the Go toolchain at COMPILE time. libffi is the only
     # build-time dep, and even that's conditional on AETHER_HAS_LIBFFI
-    # for the tinygo.call_dynamic escape hatch. The `tinygo` binary is
-    # only invoked at USER-build time (aeb's tinygo_lib builder shells
-    # `tinygo build -buildmode=c-shared` on the .go source).
+    # for the tinygo.call_dynamic escape hatch. The `go` / `tinygo`
+    # binaries are only invoked at USER-build time (aeb's tinygo_lib
+    # builder shells `go build -buildmode=c-shared` — or `tinygo build
+    # -buildmode=c-shared -target=wasm` for wasm — on the .go source).
     #
     # Probe shape: if libffi-dev is present, opt in to the AETHER_HAS_LIBFFI
     # path and emit its cflags; otherwise the bridge still builds without

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -364,12 +364,26 @@ static unsigned long long fnv64_file(const char* path) {
 // Hashing extra-file *content* (not just mtime) closes a real correctness
 // gap: editing an FFI shim like `--extra renderer.c` would otherwise let
 // a stale cache entry mask the change.
+/* Fold AETHER_LIB_DIR into tc.lib_dirs[] if no `--lib` flags were
+ * passed. Matches the resolution priority documented in `ae lib-path`
+ * (CLI flags win; env var seeds; default = `lib`). Without this, an
+ * `ae run` invoked with `AETHER_LIB_DIR=...` would see lib_dir_count=0
+ * and compute_cache_key couldn't include the env-resolved modules'
+ * mtimes — so an edit to a vendored module behind that env var would
+ * never invalidate the cache. Idempotent: skips if already populated. */
+static void tc_seed_lib_dirs_from_env(void) {
+    if (tc.lib_dir_count > 0) return;
+    const char* env = getenv("AETHER_LIB_DIR");
+    if (env && *env) tc_lib_dir_append(env);
+}
+
 static unsigned long long compute_cache_key(const char* ae_file,
                                             const char* extra_files,
                                             const char* opt_level,
                                             const char* extra_salt) {
     unsigned long long src_hash = fnv64_file(ae_file);
     if (src_hash == 0) return 0;
+    tc_seed_lib_dirs_from_env();
 
     char key_buf[2048];
     int pos = 0;
@@ -396,9 +410,20 @@ static unsigned long long compute_cache_key(const char* ae_file,
      * resolve different imports — they're materially different
      * outputs and need distinct cache slots. Walk the array
      * directly (no separator-string round-trip) so order and
-     * dedup are reflected in the key. mtime each entry so a change
-     * to a vendored module under the path invalidates the cache
-     * the way a stdlib edit already does. */
+     * dedup are reflected in the key.
+     *
+     * Per-directory mtime alone (#623): the dir's mtime only bumps
+     * on create/delete/rename of an entry — NOT on an edit-in-place
+     * to an existing file inside it (and NOT on `sed -i` of a file
+     * *behind* a symlink that points outside the dir). For correct
+     * cache invalidation on module edits, we ALSO fold in the mtime
+     * of every top-level `.ae` entry in each lib dir, resolved
+     * through symlinks via `stat` (which follows; `lstat` would not).
+     * `stat` is the right call here precisely because the symlink
+     * case (#623) needs the target's mtime, not the link's. We cap
+     * the entry count per dir (256) so a runaway lib dir can't
+     * blow the cache-key buffer; the cap is well above any realistic
+     * stdlib/vendored-modules count. */
     if (tc.lib_dir_count == 0) {
         pos += snprintf(key_buf + pos, sizeof(key_buf) - pos, ":lib=(default)");
     }
@@ -410,6 +435,48 @@ static unsigned long long compute_cache_key(const char* ae_file,
             pos += snprintf(key_buf + pos, sizeof(key_buf) - pos,
                             ":lmt=%lld", (long long)lst.st_mtime);
         }
+#ifndef _WIN32
+        DIR* d = opendir(tc.lib_dirs[i]);
+        if (d) {
+            unsigned long long entry_hash = 0;
+            int n = 0;
+            struct dirent* de;
+            while ((de = readdir(d)) != NULL && n < 256) {
+                const char* name = de->d_name;
+                if (name[0] == '.') continue;  // skip . / .. / dotfiles
+                /* We care about source files the compiler will read.
+                 * .ae is the common case (modules + entry points);
+                 * include common header-shape extensions too so a
+                 * vendored C shim edit also invalidates. */
+                size_t nlen = strlen(name);
+                int interesting = 0;
+                if (nlen > 3 && strcmp(name + nlen - 3, ".ae") == 0) interesting = 1;
+                else if (nlen > 2 && (strcmp(name + nlen - 2, ".c") == 0 ||
+                                      strcmp(name + nlen - 2, ".h") == 0)) interesting = 1;
+                if (!interesting) continue;
+                char full[1024];
+                snprintf(full, sizeof(full), "%s/%s", tc.lib_dirs[i], name);
+                struct stat est;
+                if (stat(full, &est) == 0) {
+                    /* Hash name + resolved-target mtime + size into a
+                     * single rolling FNV. Hashing keeps the key_buf
+                     * bounded regardless of entry count; mtime + size
+                     * together catch the same-second edit case. */
+                    entry_hash ^= fnv64_str(name);
+                    entry_hash = (entry_hash * 1099511628211ULL)
+                                 ^ (unsigned long long)est.st_mtime;
+                    entry_hash = (entry_hash * 1099511628211ULL)
+                                 ^ (unsigned long long)est.st_size;
+                    n++;
+                }
+            }
+            closedir(d);
+            if (n > 0) {
+                pos += snprintf(key_buf + pos, sizeof(key_buf) - pos,
+                                ":lent=%d:lh=%016llx", n, entry_hash);
+            }
+        }
+#endif
     }
 
     snprintf(key_buf + pos, sizeof(key_buf) - pos, ":%s:%s",
@@ -2485,9 +2552,48 @@ static void prepare_host_bridge_imports(const char* main_file) {
                  sizeof(g_host_bridge_link) - off,
                  " \"%s\"", a_path);
 
+        // Per-bridge transitive link deps. The six interpreter bridges
+        // dlopen their host language at runtime and need nothing extra
+        // at link time. tinygo is the first bridge with its OWN
+        // link-time dep — `tinygo_call_dynamic` calls into libffi when
+        // the bridge .a was built with AETHER_HAS_LIBFFI. Without this
+        // append, the link fails with `undefined reference to
+        // ffi_prep_cif` whenever the bridge was compiled with libffi
+        // available (ctr_notes.md Finding 2). Users would otherwise
+        // have to add `link_flags = "-lffi"` to their aether.toml
+        // manually — exactly the kind of "import is the trigger"
+        // footgun that contrib/host/python/README.md §8 promises
+        // bridges should avoid.
+        //
+        // The probe is by-symbol, not by-language: when libffi-dev
+        // wasn't present at bridge-build time the AETHER_HAS_LIBFFI
+        // block is #ifdef-out, the .a has no undefined ffi_* symbols,
+        // and we MUST NOT pass `-lffi` (the host's link would fail
+        // with "cannot find -lffi"). `nm -u` lists only undefined
+        // symbols; one popen per build, no measurable cost. Skip on
+        // platforms without nm — the link error is then the same
+        // diagnostic users had before this fix and the manual
+        // aether.toml workaround still applies.
+        const char* effective_alias = host_bridge_lang_alias(lang);
+        const char* trans_flags = NULL;
+        if (strcmp(effective_alias, "tinygo") == 0) {
+            char nm_cmd[1300];
+            snprintf(nm_cmd, sizeof(nm_cmd),
+                     "nm -u \"%s\" 2>/dev/null | grep -q ffi_prep_cif",
+                     a_path);
+            if (system(nm_cmd) == 0) {
+                trans_flags = " -lffi";
+            }
+        }
+        if (trans_flags) {
+            off = strlen(g_host_bridge_link);
+            snprintf(g_host_bridge_link + off,
+                     sizeof(g_host_bridge_link) - off, "%s", trans_flags);
+        }
+
         if (tc.verbose) {
-            fprintf(stderr, "ae: host bridge 'contrib.host.%s' -> %s\n",
-                    lang, a_path);
+            fprintf(stderr, "ae: host bridge 'contrib.host.%s' -> %s%s\n",
+                    lang, a_path, trans_flags ? trans_flags : "");
         }
     }
     fclose(f);


### PR DESCRIPTION
## Summary

Five focused fixes that landed during/after the v0.216.0 tinygo capstone, all caught downstream by the aeb-side validator on the NUC and the fbs-core sibling claude porting an S3 server:

- **`contrib.host.tinygo` docs+test now show `go build`** (ctr_notes Finding 1) — TinyGo 0.34.0's `-buildmode=c-shared` is wasm-only; the README/module-header/example/demo all documented `tinygo build -buildmode=c-shared` which has never worked natively. The integration test was silently `[SKIP]`ping since v0.215.0 landed.
- **`string_array_get` borrowed-pointer warning** (ctr_notes OPEN #3) — `v = string.array_get(parts, idx); string.array_free(parts); return v` silently use-after-frees. Module externs had zero lifetime doc; sibling `*StringSeq` API got a generous docblock. Doc-only.
- **`http.get_query_param` returns the requested key's value** (#625) — static-buffer aliasing made `?alpha=AAA&beta=BBB` return `a=[BBB] b=[BBB]`. Now parsed once into per-key arrays on the request, looked up via `strcmp`. Broke S3 multipart routing downstream.
- **Build cache invalidates on edits to symlinked lib-dir entries** (#623) — `compute_cache_key` only mtimed each lib dir itself; dir mtime doesn't bump on in-place edits, and never on edits behind a symlink to a file outside the dir. Now walks each lib dir's `.ae`/`.c`/`.h` entries with `stat` (follows symlinks) and folds resolved-target mtime+size into a rolling FNV. Also seeds `tc.lib_dirs[]` from `AETHER_LIB_DIR` so the walk runs when only the env var is set.
- **`ae build` auto-links tinygo's transitive `-lffi`** (ctr_notes Finding 2) — `tinygo` is the first bridge with link-time deps; `prepare_host_bridge_imports` now probes the resolved `.a` with `nm -u | grep ffi_prep_cif` and appends `-lffi` only when the symbol is actually undefined. The `link_flags = "-lffi"` workaround in the host_tinygo test is removed; the test now exercises the auto-link path.

`#624` (mixed ptr+string capture segfault) is deferred to its own branch — closure-lifetime fix needed at codegen layer.

## Test plan

- [x] `make ci` — green except the two known HTTP/2 framing flakes on this machine
- [x] `HARDEN=1 make ci` — same
- [x] `bash tests/integration/host_tinygo/test_host_tinygo.sh` — passes end-to-end (was silently skipping before)
- [x] `bash tests/integration/http_query_param_multi/test_http_query_param_multi.sh` — new regression test
- [x] `bash tests/integration/cache_symlinked_lib_edit/test_cache_symlinked_lib_edit.sh` — new regression test
- [x] `bash tests/integration/http_external_ptr/test_http_external_ptr.sh` — struct-layout pin updated for the new `HttpRequest` query-cache fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)