### PR TITLE
Windows CI speedup + memory-leak tail (post-#622)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,18 +171,17 @@ jobs:
         Write-Host "Windows Defender exclusions applied (best-effort)."
 
     - name: Run CI suite
-      # 30-min backstop. With the per-test build fanned out across NPROC
-      # jobs and Defender exclusions in place the suite finishes well under
-      # this; the cap guarantees a hung step can never hold the runner to
-      # GitHub's 6-hour ceiling (mirrors the macOS leaks-gate cap).
-      timeout-minutes: 30
-      env:
-        # Oversubscribe the 4-vCPU runner. Each .ae test build spends a lot
-        # of its wall time in process spawn / link / I/O rather than pure
-        # CPU, so running more jobs than cores keeps all CPUs busy instead
-        # of idling on those waits. NPROC drives both the `-j` toolchain
-        # build and the `-P` .ae-test fan-out (Makefile defaults to nproc).
-        NPROC: "8"
+      # 45-min backstop — a true safety net, not a tuning knob. The suite
+      # runs ~32-36 min on this runner (a handful of HTTP tests that
+      # statically link openssl/nghttp2/zlib/pcre2 dominate the .ae phase),
+      # so the cap sits above the natural runtime and only fires on a real
+      # hang, never on a slow-but-progressing run. (An earlier 30-min cap
+      # killed a healthy ~32-min run.) NPROC is left at the runner default
+      # (nproc=4): oversubscribing to 8 made it WORSE, because 8 of those
+      # heavy static links running at once thrash the 4-vCPU runner's RAM
+      # (one link ballooned to 11 min). Meaningfully cutting this needs a
+      # faster linker / fewer per-test relinks, tracked separately.
+      timeout-minutes: 45
       # The hardcoded `C:\msys64\...` probe in aether_http.c::load_windows_ca_bundle
       # doesn't match the GitHub runner's MSYS2 path (it's installed under a
       # temp dir, not C:\msys64). Export SSL_CERT_FILE explicitly using

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,40 @@ jobs:
         # cert verification fails for lack of a trust anchor on Windows).
         install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib mingw-w64-x86_64-openssl mingw-w64-x86_64-ca-certificates pkg-config make bc
 
+    # Windows Defender real-time scanning of every compiler-produced
+    # file is the dominant Windows-CI tax: `make ci` builds ~585 separate
+    # test executables, and AV-scanning each .c/.o/.exe as it is written
+    # made the .ae test phase ~33 min (vs ~5 min for the same suite on
+    # Linux/macOS, which have no such scanner). Excluding the runner work
+    # tree + temp dirs (and the toolchain processes) from real-time
+    # scanning removes that per-file tax. Best-effort: the job must never
+    # fail because Defender wasn't adjustable on a given runner image.
+    - name: Speed up build — exclude work tree from Windows Defender
+      shell: pwsh
+      continue-on-error: true
+      run: |
+        Add-MpPreference -ExclusionPath "D:\a" -ErrorAction SilentlyContinue
+        Add-MpPreference -ExclusionPath "$env:RUNNER_TEMP" -ErrorAction SilentlyContinue
+        Add-MpPreference -ExclusionPath "$env:TEMP" -ErrorAction SilentlyContinue
+        Add-MpPreference -ExclusionPath "$env:TMP" -ErrorAction SilentlyContinue
+        foreach ($p in 'gcc.exe','cc1.exe','collect2.exe','ld.exe','as.exe','aetherc.exe','ae.exe','bash.exe','sh.exe','make.exe') {
+          Add-MpPreference -ExclusionProcess $p -ErrorAction SilentlyContinue
+        }
+        Write-Host "Windows Defender exclusions applied (best-effort)."
+
     - name: Run CI suite
+      # 30-min backstop. With the per-test build fanned out across NPROC
+      # jobs and Defender exclusions in place the suite finishes well under
+      # this; the cap guarantees a hung step can never hold the runner to
+      # GitHub's 6-hour ceiling (mirrors the macOS leaks-gate cap).
+      timeout-minutes: 30
+      env:
+        # Oversubscribe the 4-vCPU runner. Each .ae test build spends a lot
+        # of its wall time in process spawn / link / I/O rather than pure
+        # CPU, so running more jobs than cores keeps all CPUs busy instead
+        # of idling on those waits. NPROC drives both the `-j` toolchain
+        # build and the `-P` .ae-test fan-out (Makefile defaults to nproc).
+        NPROC: "8"
       # The hardcoded `C:\msys64\...` probe in aether_http.c::load_windows_ca_bundle
       # doesn't match the GitHub runner's MSYS2 path (it's installed under a
       # temp dir, not C:\msys64). Export SSL_CERT_FILE explicitly using

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -838,7 +838,15 @@ int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
              * propagates ownership out to their callers too. */
             strcmp(fn, "file_read_all_raw") == 0 ||
             strcmp(fn, "os_exec_raw") == 0 ||
-            strcmp(fn, "os_run_capture_raw") == 0) {
+            strcmp(fn, "os_run_capture_raw") == 0 ||
+            /* StringBuilder finalise: hands the caller a plain libc-
+             * freeable char* and frees the wrapper (std/strbuilder/
+             * aether_strbuilder.c:235). Declared `-> string @heap`, but
+             * classify by name here too so the ownership propagates
+             * through .ae wrapper chains (strbuilder.finish, and any
+             * user fn that returns it) regardless of single-value
+             * @heap-annotation handling. */
+            strcmp(fn, "aether_strbuilder_finish") == 0) {
             return 1;
         }
         // User-defined function: only heap if its body provably

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -818,7 +818,27 @@ int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
             strcmp(fn, "string_pad_start") == 0 ||
             strcmp(fn, "string_pad_end") == 0 ||
             strcmp(fn, "string_format_list") == 0 ||
-            strcmp(fn, "json_stringify_raw") == 0) {
+            strcmp(fn, "json_stringify_raw") == 0 ||
+            /* std.fs lexical path ops (#632) and std.io whole-file read:
+             * each returns a FRESH malloc'd / caps-allocated string the
+             * caller owns (path_clean / path_rel build a new normalised
+             * path; io_read_file_raw returns the file contents). They are
+             * single-value `-> string` externs, so they can't carry the
+             * tuple-only `@heap` annotation — classify them here. Verified
+             * owned (never a borrowed/literal pointer): the leak each
+             * produced was exactly the caller never freeing this result. */
+            strcmp(fn, "path_clean") == 0 ||
+            strcmp(fn, "path_rel") == 0 ||
+            strcmp(fn, "io_read_file_raw") == 0 ||
+            /* Whole-file / command-capture reads: each call returns a
+             * FRESH malloc'd buffer of the file contents / process output
+             * (NULL on error, which aether_heap_str_free tolerates). Never
+             * a borrowed/static pointer. file_read_all_raw also drives the
+             * std.fs `read` / `read_or_empty` wrappers, so classifying it
+             * propagates ownership out to their callers too. */
+            strcmp(fn, "file_read_all_raw") == 0 ||
+            strcmp(fn, "os_exec_raw") == 0 ||
+            strcmp(fn, "os_run_capture_raw") == 0) {
             return 1;
         }
         // User-defined function: only heap if its body provably

--- a/std/collections/aether_stringlist.c
+++ b/std/collections/aether_stringlist.c
@@ -4,6 +4,31 @@
 #include "../../runtime/aether_resource_caps.h"
 
 #include <stdlib.h>
+#include <string.h>
+
+/* Own an independent NUL-terminated copy of `s`'s bytes, allocated
+ * through the caps accounting so the list's allocations balance.
+ * `aether_string_data` is magic-aware: it unwraps an AetherString to
+ * its .data or passes a plain `char*` straight through, NULL-safe.
+ * The list stores these copies and frees them with sl_free_item; the
+ * caller keeps ownership of its argument. Returns NULL on OOM. */
+static char* sl_dup_item(const void* s) {
+    const char* data = s ? aether_string_data(s) : NULL;
+    if (!data) data = "";
+    size_t n = strlen(data) + 1;
+    char* copy = (char*)aether_caps_malloc(n);
+    if (!copy) return NULL;
+    memcpy(copy, data, n);
+    return copy;
+}
+
+/* Free a copy produced by sl_dup_item. The copy is always a caps-
+ * allocated, NUL-terminated `char*`, so its allocation size is
+ * strlen+1 (it is never mutated after creation). NULL-safe. */
+static void sl_free_item(const void* item) {
+    if (!item) return;
+    aether_caps_free((void*)item, strlen((const char*)item) + 1);
+}
 
 /* StringList is a thin layer over the existing ArrayList. We could
  * have reused ArrayList directly with retain/release sprinkled on
@@ -31,14 +56,18 @@ StringList* string_list_new(void) {
 
 int string_list_add(StringList* list, const void* s) {
     if (!list || !list->items) return 0;
-    /* Take a strong reference before storing. string_retain is
-     * NULL-safe and a no-op on plain `char*` (the magic check
-     * fails), so literals pass through unchanged. */
-    string_retain(s);
-    if (!list_add_raw(list->items, (void*)s)) {
-        /* The list grew but realloc failed — release the ref we
-         * just took so the caller's accounting stays balanced. */
-        string_release(s);
+    /* Store an independent copy the list owns. The caller keeps
+     * ownership of its argument (the `string` param is copied, not
+     * retained) — this is what lets a heap `char*` element
+     * (string.concat / split result) be reclaimed: the caller frees
+     * its value at scope exit, and the list frees its copy in
+     * free/clear/remove. Storing the caller's raw pointer instead
+     * leaked every such element, because string_release is a no-op on
+     * a non-magic `char*`. */
+    char* copy = sl_dup_item(s);
+    if (!copy) return 0;
+    if (!list_add_raw(list->items, copy)) {
+        sl_free_item(copy);
         return 0;
     }
     return 1;
@@ -52,17 +81,16 @@ const void* string_list_get(StringList* list, int index) {
 void string_list_set(StringList* list, int index, const void* s) {
     if (!list || !list->items) return;
     if (index < 0 || index >= list_size(list->items)) return;
-    /* Release the previous occupant, then retain and store the new
-     * one. Releasing first means a self-set
-     * (`string_list_set(L, i, string_list_get(L, i))`) doesn't
-     * accidentally drop the only reference between the release and
-     * retain — string_retain bumps the refcount before string_release
-     * decrements it. Wait, no: that ordering is wrong. We need to
-     * retain first, *then* release the old. */
+    /* Copy the new value FIRST, then swap it in and free the old copy.
+     * Copying first makes a self-set
+     * (`string_list_set(L, i, string_list_get(L, i))`) safe: the
+     * source bytes are duplicated before the old element is freed, so
+     * there is no read-after-free even when `s` aliases the slot. */
+    char* copy = sl_dup_item(s);
+    if (!copy) return;
     const void* old = list_get_raw(list->items, index);
-    string_retain(s);
-    list_set(list->items, index, (void*)s);
-    string_release(old);
+    list_set(list->items, index, copy);
+    sl_free_item(old);
 }
 
 int string_list_size(StringList* list) {
@@ -75,7 +103,7 @@ void string_list_remove(StringList* list, int index) {
     if (index < 0 || index >= list_size(list->items)) return;
     const void* old = list_get_raw(list->items, index);
     list_remove(list->items, index);
-    string_release(old);
+    sl_free_item(old);
 }
 
 void string_list_clear(StringList* list) {
@@ -83,7 +111,7 @@ void string_list_clear(StringList* list) {
     int n = list_size(list->items);
     for (int i = 0; i < n; i++) {
         const void* item = list_get_raw(list->items, i);
-        string_release(item);
+        sl_free_item(item);
     }
     list_clear(list->items);
 }
@@ -94,7 +122,7 @@ void string_list_free(StringList* list) {
         int n = list_size(list->items);
         for (int i = 0; i < n; i++) {
             const void* item = list_get_raw(list->items, i);
-            string_release(item);
+            sl_free_item(item);
         }
         list_free(list->items);
     }

--- a/std/collections/module.ae
+++ b/std/collections/module.ae
@@ -91,16 +91,22 @@ extern intarr_free(arr: ptr)
 // is a no-op on values that don't bear the AetherString magic
 // header. Issue #274.
 extern string_list_new() -> ptr
-// `s` retains: the list stores the AetherString reference so the
-// caller's heap allocation must outlive the call. Without `@retain`
-// the heap-string-tracker's escape walker treats a string-typed
-// param as read-only (correct for string.length etc.) and the
-// function-exit defer-free would free the bytes while the list
-// still holds the pointer — UAF. See #420 follow-up.
-extern string_list_add(list: ptr, s: @retain string) -> int
+// `s` is COPIED, not retained: the list owns an independent NUL-
+// terminated copy of the string's bytes and frees it itself (in
+// remove / clear / free / overwriting set). The caller therefore keeps
+// ownership of its argument — a `string`-typed param is read-only to
+// the escape walker, so the caller's heap value is reclaimed normally
+// at its own scope exit. This is why there is no `@retain` here: an
+// earlier version stored the caller's pointer (needing `@retain` to
+// suppress the caller's free and avoid a UAF), but that leaked every
+// plain `char*` element — `string_retain`/`string_release` are no-ops
+// on non-magic `char*`, so the list could never reclaim a
+// `string.concat`/`split` result. Copy-on-add owns the bytes outright,
+// fixing the leak with no UAF. (#420 / leak-tail follow-up.)
+extern string_list_add(list: ptr, s: string) -> int
 extern string_list_get(list: ptr, index: int) -> string
-// `s` retains: same shape as string_list_add.
-extern string_list_set(list: ptr, index: int, s: @retain string)
+// `s` is copied, same as string_list_add; the overwritten element is freed.
+extern string_list_set(list: ptr, index: int, s: string)
 extern string_list_size(list: ptr) -> int
 extern string_list_remove(list: ptr, index: int)
 extern string_list_clear(list: ptr)

--- a/std/ksuid/module.ae
+++ b/std/ksuid/module.ae
@@ -107,5 +107,10 @@ generate() -> {
         bytes.set(rev, k, bytes.get(out, 26 - k))
         k = k + 1
     }
+    // `buf` (the divided-down bignum) and `out` (pre-reversal digits)
+    // were scratch; only `rev` is consumed by bytes.finish. Reclaim the
+    // two intermediates so the generator nets zero allocations.
+    bytes.free(buf)
+    bytes.free(out)
     return bytes.finish(rev, 27), ""
 }

--- a/std/ulid/module.ae
+++ b/std/ulid/module.ae
@@ -92,5 +92,9 @@ generate() -> {
         k = k + 1
     }
 
+    // `buf` was only a read-source for the encoder (its bytes are now
+    // in `out`); `out` is consumed by bytes.finish. Reclaim the
+    // intermediate so the generator allocates nothing net.
+    bytes.free(buf)
     return bytes.finish(out, 26), ""
 }

--- a/tests/regression/test_string_format.ae
+++ b/tests/regression/test_string_format.ae
@@ -64,5 +64,14 @@ main() {
         exit(1)
     }
 
+    // Reclaim the arg lists. list_free releases each element (the
+    // .rodata literals no-op; a5's from_int heap value is freed) and
+    // then frees the list struct + backing array.
+    list_free(a1)
+    list_free(a2)
+    list_free(a3)
+    list_free(a4)
+    list_free(a5)
+
     println("OK")
 }

--- a/tests/regression/test_string_seq_combinators.ae
+++ b/tests/regression/test_string_seq_combinators.ae
@@ -9,25 +9,36 @@
 // PR. See docs/sequences.md § Combinators for the cut-line.
 
 import std.string
+import std.strbuilder
 
 extern exit(code: int)
 
 // Walk the seq and join with "," for assertions. Same shape as the
 // pattern_match test's walk_join helper.
 walk_join(s: *StringSeq, acc: string) -> string {
-    match s {
-        []      -> {
-            return acc
-        }
-        [h | t] -> {
-            sep = ""
-            if string.length(acc) > 0 {
-                sep = ","
-            }
-            return walk_join(t, string.concat(string.concat(acc, sep), h))
-        }
+    // Iterative join via std.strbuilder: amortised-O(1) append, a single
+    // heap-owned result. The earlier recursive `string.concat` form was
+    // O(n²) AND leaked every intermediate buffer — a plain-`char*` value
+    // passed as a parameter carries no ownership bit, so the callee can't
+    // tell an owned buffer from a borrowed/literal one and can't free it.
+    // A StringBuilder owns its buffer outright; this is the correct,
+    // leak-free, performant shape.
+    sb = strbuilder.new(0)
+    strbuilder.append(sb, acc)
+    first = 1
+    if string.length(acc) > 0 {
+        first = 0
     }
-    return acc
+    cur = s
+    while string.seq_is_empty(cur) == 0 {
+        if first == 0 {
+            strbuilder.append(sb, ",")
+        }
+        strbuilder.append(sb, string.seq_head(cur))
+        cur = string.seq_tail(cur)
+        first = 0
+    }
+    return strbuilder.finish(sb)
 }
 
 main() {

--- a/tests/regression/test_string_seq_combinators.ae
+++ b/tests/regression/test_string_seq_combinators.ae
@@ -74,6 +74,11 @@ main() {
 
     string.seq_free(r)
     string.seq_free(r2)
+    // `e` (reverse of empty) and `s` (the split source that `r` was the
+    // reverse of) were created but not yet reclaimed — free them too, in
+    // keeping with this test's explicit-ownership convention.
+    string.seq_free(e)
+    string.seq_free(s)
     println("  PASS 1: reverse round-trip + empty edge case")
 
     // ---- concat -----------------------------------------------------
@@ -106,20 +111,26 @@ main() {
     string.seq_free(a)
     string.seq_free(b)
 
-    // Empty edges
-    empty_a = string.seq_concat(string.seq_empty(), string.split_to_seq("p,q", ","))
+    // Empty edges. Capture the split_to_seq operands in locals so their
+    // owning refs are reclaimed — an inline `split_to_seq(...)` argument
+    // is a fresh owned seq with no consumer otherwise.
+    pq = string.split_to_seq("p,q", ",")
+    empty_a = string.seq_concat(string.seq_empty(), pq)
     if string.seq_length(empty_a) != 2 {
         println("FAIL 2e: concat(empty, [p,q]).length=${string.seq_length(empty_a)}")
         exit(1)
     }
     string.seq_free(empty_a)
+    string.seq_free(pq)
 
-    empty_b = string.seq_concat(string.split_to_seq("r,s", ","), string.seq_empty())
+    rs = string.split_to_seq("r,s", ",")
+    empty_b = string.seq_concat(rs, string.seq_empty())
     if string.seq_length(empty_b) != 2 {
         println("FAIL 2f: concat([r,s], empty).length=${string.seq_length(empty_b)}")
         exit(1)
     }
     string.seq_free(empty_b)
+    string.seq_free(rs)
 
     println("  PASS 2: concat with shared tail + empty edges")
 


### PR DESCRIPTION
Two follow-ups after #622: cut the Windows GCC CI time, and drive down the
memory-leak tail. **In progress** — this tracks exactly what's done vs. left.

## Windows GCC CI time
Profiling the job log: phase [5/9] (.ae tests) was 33m39s of ~36 min; the
same suite is ~5 min on Linux/macOS. Root cause: `ae build` links the full
openssl/nghttp2/zlib/pcre2 stack into **every one of the ~585 test exes
unconditionally** (tools/ae.c build_gcc_cmd) — cheap on Linux/macOS, slow
under Windows GNU ld.
- Added a Windows Defender real-time-scan exclusion for the work tree +
  toolchain processes (best-effort; never fails the job).
- `timeout-minutes: 45` backstop (above the natural runtime).
- A first attempt with `NPROC=8` + a 30-min cap **regressed to a failure**
  (the cap killed a healthy run; 8 concurrent heavy static links thrashed
  the runner — one took 11 min) and was reverted to the runner default.
- A meaningful speedup needs **conditional linking** (only link libs a test
  imports) or a **faster linker (lld)** — real changes that need iterative
  Windows-CI validation; not landed blind.

## Memory leaks — fixed so far (real ownership fixes, ASan-safe)
A leaks(1) sweep of regression+integration found 31 leaking programs.
Fixed and verified to 0:
- **`string_list` owns copies of its elements** — `@retain` removed; the
  caller keeps ownership, the list frees its own copies. `test_url` 10→0,
  `test_string_list` 10→1→0.
- **Owned-heap stdlib string returns classified** (`path_clean`, `path_rel`,
  `io_read_file_raw`, `file_read_all_raw`, `os_exec_raw`,
  `os_run_capture_raw`): `test_fs_lexical_paths` 10→0, `test_file_io_char_return`
  5→0, `test_fs_move`/`fs_copy` 4→0, `test_fs_atomic_rename_stat_binary` 3→0,
  `test_os_module` 4→2.
Unit suite 226/226 throughout; no double-free (flag-guarded frees).

## Memory leaks — remaining (categorised, honest)
- **Library globals, not our bug**: `crypto` 122 (OpenSSL process-lifetime
  globals, `ROOT CYCLE`), `regex` 12 (PCRE2). Freed by the OS at exit; not
  in the leaks gate. Documenting rather than chasing.
- **Deep `*StringSeq` codegen** (biggest real chunk): `seq_combinators` 67,
  `seq_pattern_match` 11, `string_seq` 2 — cons-spines leak through
  combinator/`split_to_seq` paths.
- **Void-call arg drain** (codegen): `from_long` 12, `print_stdlib_returns`
  4, etc. — a heap result passed inline to a void helper.
- **Container / stdlib ownership** (each distinct): `string_format` (arg
  list), `map_value_storing_wrapper`, `ids` (generator-internal bytes),
  `json_error_tuples` (error-path values), `struct_field_string_escape`,
  `self_ref_struct`, and a small misc tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)