### PR TITLE
feat(contrib.templating.liquid): Shopify Liquid engine v0 [skip actions]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,31 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.220.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **`contrib.templating.liquid` — Shopify Liquid templating engine v0**
+  (`contrib/templating/liquid/module.ae`,
+  `tests/integration/liquid_basics/`,
+  `tests/integration/liquid_tags_simple/`). A pure-Aether port of the
+  [Liquid template language](https://shopify.github.io/liquid/),
+  sandbox-friendly (no reflection, no eval, explicit filter set).
+  Opt-in `contrib/` module — not in `libaether.a`. Initial vertical
+  slice: text passthrough, `{{ name }}` single-segment variable lookup
+  against a string-keyed context, `{% comment %}...{% endcomment %}`
+  (body suppressed), `{% raw %}...{% endraw %}` (body emitted verbatim
+  with no interpolation), and a render-time error for any unsupported
+  `{% xxx %}` tag. Public surface: `parse_string`, `context_new`,
+  `context_put_string`, `context_free`, `render`. 15 integration tests
+  across two directories cover the implemented behaviour; future tags
+  (`if`/`for`/`assign`/...), filters, dotted attribute access,
+  includes, layouts, and the JSON value model are tracked in
+  `TODO.md` and will land with their own tests as each layer is built.
 
 ## [0.220.0]
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,476 @@
+# Aether — TODO
+
+Long-running list of things to build / decide later. Short-lived
+tasks live in PRs and the CHANGELOG; this file is for ideas with a
+hint of design but no committed scope.
+
+## `contrib.templating.dsl` — native, no-reflection templating
+
+**Why:** Aether already has the closure-DSL pattern
+(`docs/closures-and-builder-dsl.md`). A native templating engine
+fits naturally on top: the template *is* a `.ae` closure, the output
+format is chosen by which emitter the builder runs against.
+
+The `contrib.templating.liquid` port is shipping first because the
+ecosystem-interop case is more immediate (operators bring their own
+`.liquid` files). The native DSL is the inverse pitch: library
+authors expose a template-shaped surface where users write Aether,
+not template syntax.
+
+### Sketch
+
+```aether
+import contrib.templating.dsl
+
+t = template(html) {
+    h1   { text("Hello ${user}") }
+    each items |it| {
+        li { text(it.name) }
+    }
+}
+println(render(t))
+```
+
+Swap the first arg to switch output:
+- `template(html)` — escape-aware HTML
+- `template(xml)`  — XML (CDATA-aware, namespace-prefix-aware)
+- `template(json)` — JSON (commas, array/object dispatch)
+- `template(sql)`  — SQL with placeholder binding (never raw
+                     concatenation — `text(user_input)` produces
+                     `?` + a side-channel parameter list)
+
+The escape decision lives in the **emitter**, not the template. That
+is the whole reason this shape is valuable in a sandboxed language —
+the template author cannot accidentally produce raw user content in
+an HTML attribute.
+
+### Dispatch model — three options to pick between
+
+When the time comes to build this, decide first:
+
+1. **One namespace per emitter** — `import contrib.templating.dsl.html`
+   brings `h1/text/each` bound to HTML escape rules. SQL importers
+   get `select/where/text` bound to bind-parameter rules. Same
+   surface symbol (`text`) means different things based on which
+   module imported it. No runtime dispatch, sandbox-clean. Mixing
+   HTML + SQL in one file requires aliasing.
+2. **Single namespace, emitter chosen at `template()` call** —
+   runtime dispatch off the active emitter on the context stack.
+   More flexible, slightly more magical, risk of invisible
+   escape-mode changes if emitters nest.
+3. **Emitter-as-typed-receiver** — `html.h1 { html.text(x) }`.
+   Most explicit, most verbose. Dead-simple sandbox story.
+
+Leaning toward option 1 — it's the most Aether-shaped (matches how
+`std.fs` / `std.http` / etc. work).
+
+### Dependencies
+
+- The existing closures-and-builder-dsl machinery, no additions.
+- `std.strbuilder` for output accumulation.
+- No reflection, no runtime type dispatch — same constraints as the
+  Liquid port.
+
+### Out of scope (for v1 of this when it lands)
+
+- Partials / layouts (the `extends`/`block` pattern from Liquid).
+- Cross-emitter composition (an HTML fragment embedded in a SQL
+  string, say) — solve when there's a real use case.
+- Streaming output. v1 builds a string; if a server author needs
+  chunked output, that's a v2 ask.
+
+### When to pick this up
+
+After the Liquid port has been in `contrib/` long enough to validate
+the value-tree + filter-registry shapes, and after at least one
+downstream user has asked for the "templates that ARE Aether
+code" pitch explicitly.
+
+---
+
+## `contrib.templating.liquid` — v0 landed, more layers to come
+
+**Branch:** `feat/contrib-templating-liquid` (off main at `035e701`,
+not pushed)
+
+**File:** `contrib/templating/liquid/module.ae` — ~200 LoC, compiles,
+**tested** (`tests/integration/liquid_basics/`, 7 cases all green).
+
+### v0 scope (what works today)
+
+- Plain text passthrough
+- `{{ varname }}` single-segment variable lookup against a string→string
+  context
+- Whitespace trimming inside `{{ ... }}`
+- Unbound variables render as empty string (Shopify Liquid behaviour)
+- Unterminated `{{` returns a non-empty error
+
+That's it. Everything below is deferred and must arrive WITH its own
+tests in the same commit/PR (no skeleton tests, no stub directories;
+tests live alongside working code only).
+
+### History of this round
+
+The original ~1215-LoC speculative draft was discarded. It hit
+multiple structural issues (the `fn` keyword problem, then `as int` /
+`as ptr` coercion issues, then almost certainly more). A 1200-line
+parser written without smoke-testing as it grew is a sunk cost — the
+right move was to start over with the absolute minimum, prove it
+works end-to-end, and grow from there. The discarded draft was a
+useful exploration but not the right artifact to ship.
+
+The lesson encoded into next-session policy: **add one layer, write
+its tests, get them green, then add the next layer**. No more
+speculative parser-shaped drafts.
+
+### Adjacent compiler issue worth filing
+
+While doing this work I confirmed that `fn name(...) -> T { ... }` at
+top level errors with E0100 in user/contrib code, but stdlib modules
+(`std/uuid/module.ae:29`, `std/url/module.ae:38/46/56/66/127`) use this
+shape and compile. The compiler should make `fn`-prefixed declarations
+either work everywhere or nowhere; right now it depends on which build
+path the file goes through. Worth filing as a separate GH issue —
+NOT blocking templating work (contrib uses bare-name throughout).
+
+### Next layer to add — and its tests
+
+The next-up scope, with tests that must arrive in the same commit:
+
+**Filters chain over the lookup:** `{{ name | upcase }}`,
+`{{ name | downcase }}`, `{{ x | default:"y" }}`, chained
+`{{ name | upcase | reverse }}`. Test cases:
+
+- Single filter, then another single filter
+- Chained: 2-deep, 3-deep
+- Filter with one positional arg (`default`)
+- Filter with multiple positional args (`replace:"a","b"`)
+- Unknown filter passes through identity (Shopify behaviour)
+
+That layer requires:
+- An expression parser (atom + `|` chain)
+- A filter dispatch (`upcase` / `downcase` / `default` / `replace` /
+  `size` to start)
+- The renderer to call the filter chain instead of `lookup`
+
+The implementation will use `std.json` for the value type so a filter
+that returns a number (`size`) is distinguishable from one returning a
+string. The current string→string context grows into string→json-value.
+That migration is part of this layer and should NOT preserve the
+v0 string-only context — the v0 tests get rewritten to use the new
+context shape if the API changes.
+
+### Layers still to build, in dependency order
+
+Each layer below is to be implemented in its own commit with its own
+tests added to `tests/integration/liquid_*/` in the same commit.
+Don't write the next layer until the previous layer's tests pass.
+
+**1. Tag parser (`{% ... %}`)** — currently throws `"unsupported tag"`.
+Per-tag work:
+
+- [ ] `{% comment %}...{% endcomment %}` — simplest, just skip body
+- [ ] `{% assign x = expr %}` — bind a name in the current scope
+- [ ] `{% if cond %}` / `{% elsif cond %}` / `{% else %}` / `{% endif %}` —
+      conditional with else-if chain. Needs:
+      - condition evaluator (truthy/falsy, comparison ops `==` `!=` `>` `<` `>=` `<=` `contains`)
+      - `and` / `or` connectives
+      - Liquid's special falsy rules: `nil`, `false`, **empty string is truthy** in Liquid (different from many languages)
+- [ ] `{% unless %}` / `{% endunless %}` — `if` with inverted condition
+- [ ] `{% for x in coll %}...{% endfor %}` — iteration. Needs:
+      - iterable = array / range / object (Liquid iterates object values)
+      - `forloop.index` / `forloop.index0` / `forloop.first` / `forloop.last` /
+        `forloop.length` / `forloop.rindex` / `forloop.rindex0` exposed in
+        loop body
+      - `limit:N` / `offset:N` / `reversed` modifiers on the `for` tag
+      - range form: `{% for i in (1..10) %}`
+- [ ] `{% break %}` / `{% continue %}` — `for`-body control flow
+- [ ] `{% case x %}{% when v %}...{% else %}...{% endcase %}` — pattern match
+- [ ] `{% capture name %}...{% endcapture %}` — render-block-to-string assigment
+- [ ] `{% cycle 'a', 'b', 'c' %}` (optional in v1; common in tables)
+- [ ] `{% increment x %}` / `{% decrement x %}` (optional in v1)
+
+**Scope contract:** each tag adds an `AST_NODE_*` constant + a parser
+branch in `parse_tokens` + a renderer branch in `render_node`. All keep
+the same list-of-string-lists representation as the existing nodes; no
+new infrastructure needed.
+
+**2. Operator-bearing expressions for `if` conditions** — the current
+`parse_filtered` only handles `atom (| filter)*`. Conditions need:
+
+- [ ] `==` `!=` `>` `<` `>=` `<=` binary ops (Liquid's are left-associative,
+      no precedence — `a and b or c` is `((a and b) or c)`)
+- [ ] `and` `or` logical
+- [ ] `contains` (string-in-string, item-in-array, key-in-object)
+- [ ] Parenthesized grouping is NOT a Liquid thing (their grammar is
+      flat) — confirm before adding
+
+**3. Filter additions to reach Shopify parity** — drafted ~18, need ~12 more:
+
+Pure (default-on):
+- [ ] `replace_first` (only first occurrence)
+- [ ] `remove` / `remove_first` (replace with "")
+- [ ] `split:":"` → array
+- [ ] `truncatewords` (truncate by word count)
+- [ ] `newline_to_br` (`\n` → `<br />`)
+- [ ] `strip_html` / `strip_newlines`
+- [ ] `escape_once` (HTML-escape, but skip already-escaped entities)
+- [ ] `url_decode`
+- [ ] `slice` (substring or array slice)
+- [ ] `sort` / `sort_natural` (case-insensitive sort)
+- [ ] `uniq`
+- [ ] `map:"prop"` (extract a property from each array element)
+- [ ] `where:"prop","value"` (filter array)
+- [ ] `concat:array2` (array concat — distinct from string append)
+- [ ] `compact` (drop nils)
+- [ ] `round` / `ceil` / `floor` / `abs` / `at_least` / `at_most`
+
+World-touching (gated):
+- [ ] `date` — full strftime semantics (not just identity). Needs
+      `std.os.now_utc_iso8601` or a date-parsing primitive. Currently
+      returns `"[date filter disabled — call allow_world_filters]"`
+      when gated and an identity pass-through when allowed; needs real
+      formatting.
+- [ ] `asset_url` / `img_tag` (Shopify-specific; out of scope unless a
+      user asks)
+
+**4. Includes** (`{% include 'partial' %}`) — requires `std.fs`:
+
+- [ ] File resolution: relative to a configured template-search root
+- [ ] Engine config field: `template_root: string` (defaults to ".")
+- [ ] Variable scoping: include sees the parent context by default;
+      `{% include 'p' with name %}` and `{% include 'p', k: v %}` pass
+      specific bindings
+- [ ] Recursion limit (Liquid caps at depth 100 — match that)
+- [ ] Cache parsed partials by absolute path so a partial used N times
+      is parsed once
+- [ ] **Gate via `--with=fs` when --emit=lib** — sandbox story: the
+      contrib module imports `std.fs`, so a `--emit=lib` user without
+      `--with=fs` cannot use the include path. `parse_string` /
+      programmatic API stays available without `--with=fs`.
+
+**5. Layouts** (`{% extends 'parent' %}` + `{% block name %}...{% endblock %}`):
+
+- [ ] `extends` MUST be the first non-whitespace token in the template
+      (validation + clear error)
+- [ ] `block` declarations in the parent define overridable regions
+- [ ] `block` declarations in the child override; `{{ block.super }}`
+      inserts the parent's content (Liquid's spelling varies — confirm
+      Shopify's vs Django-inspired forks)
+- [ ] Recursive `extends` chain — child extends middle extends base
+- [ ] Same caching as `include`
+
+**6. Error reporting**:
+
+- [ ] Currently `lex` returns one of `"unterminated delimiter"` or `""`.
+      `parse_tokens` returns `"unsupported tag: <body>"`. Both should
+      include source line numbers (the lexer captures line numbers per
+      token; the parse path needs to thread them).
+- [ ] Filter errors: unknown filter → identity (Shopify behaviour,
+      matches the WIP). Filter raising an error (e.g. `divided_by:0`)
+      currently silently returns null; should propagate as a render
+      error tied to a source position.
+- [ ] Render-time error tuple: `(string, string)` already in place.
+      The "fail loudly on type errors" mode (Shopify's `strict` flag)
+      is out of scope per the design decisions.
+
+**7. Public surface gaps**:
+
+- [ ] `parse_file(path)` is currently a stub; needs `std.fs.read` +
+      include-search-root configuration
+- [ ] `render_file(t, ctx, path)` for streaming output to a file
+      (useful for static-site generators) — optional, may not ship in v1
+- [ ] `template_free(t)` — currently no explicit free; the underlying
+      lists own their string memory and the std.json values are
+      orphaned. Audit memory ownership before shipping.
+- [ ] `engine_set_template_root(eng, path)` for include search
+- [ ] `engine_set_max_include_depth(eng, n)` (default 100)
+
+**8. Documentation:**
+
+- [ ] `contrib/templating/liquid/README.md` — install, usage,
+      sandbox-with-`--with=fs` story, mapping from Shopify-Liquid
+      reference docs to what's supported here (clear list of
+      OUT-of-scope features), the struct-binding `to_value` adapter
+      pattern with a worked example
+- [ ] `CHANGELOG.md` entry under `[current]`
+- [ ] `LLM.md` idiom (probably one line: "operator-supplied Liquid
+      templates → `contrib.templating.liquid`")
+
+### Test plan — cases to cover as each layer lands
+
+Tests live in `tests/integration/liquid_*/` (each is a directory with
+one `.sh` driver + one or more `.ae` programs + `.liquid` fixture
+files where needed). Pattern follows existing tests like
+`tests/integration/http_serve_static_range/`.
+
+**Layer-by-layer cases below.** When a layer lands, its full case set
+goes in with it. `liquid_basics/probe.ae` already covers Layer 5 (the
+v0 render path) for the cases v0 supports. As filters / tags / etc.
+land, either extend `liquid_basics/probe.ae` or add a new sibling
+directory (`liquid_filters/`, `liquid_tags/`, etc.).
+
+**Layer 1 — lexer (`lex(src)` returns tokens):**
+
+A single Aether program that lexes representative sources and
+asserts token counts + kinds + contents. Cases:
+
+- [ ] Plain text → 1 TEXT token
+- [ ] `Hello {{ x }}!` → TEXT, OUTPUT, TEXT
+- [ ] `{% if x %}Y{% endif %}` → TAG, TEXT, TAG
+- [ ] `{{- x -}}` whitespace control: surrounding whitespace stripped
+- [ ] Unterminated `{{ x` returns the `unterminated delimiter` error
+- [ ] Empty source → 0 tokens
+- [ ] Source with only delimiters, no text → no TEXT tokens
+
+**Layer 2 — expression parser (`parse_expr(body)` returns expr ADT):**
+
+- [ ] String literal: `'foo'` and `"foo"` both parse as EXPR_LITERAL_STR
+- [ ] Integer literal: `42` and `-7`
+- [ ] Boolean literals: `true` / `false`
+- [ ] Nil literals: `nil` / `null`
+- [ ] Empty / blank: `empty` / `blank` (parse as empty string)
+- [ ] Bare variable: `name` → EXPR_VAR with one segment
+- [ ] Dotted: `user.address.city` → EXPR_VAR with three segments
+- [ ] Bracket: `items[0]` → EXPR_VAR with two segments (`items`, `0`)
+- [ ] String-bracket: `items['key']` → segments include the unquoted key
+- [ ] Mixed: `users[0].name`
+- [ ] Single filter: `x | upcase`
+- [ ] Filter with args: `x | replace:"a","b"`
+- [ ] Filter chain: `x | upcase | reverse | first`
+- [ ] Expression serialize → deserialize round-trip identity
+
+**Layer 3 — value resolution (`resolve_var` against std.json contexts):**
+
+- [ ] Top-level key: `user` against `{user: ...}` returns the inner value
+- [ ] Nested: `user.name` against `{user: {name: "alice"}}`
+- [ ] Array index: `items[0]` against `{items: ["a","b"]}`
+- [ ] String-keyed bracket: `items['x']` (object access via bracket)
+- [ ] Missing key → null
+- [ ] Out-of-bounds index → null
+- [ ] `.size` on array: returns length
+- [ ] `.size` on string: returns byte length
+- [ ] `.size` on object: returns key count
+- [ ] `.first` / `.last` on array
+- [ ] Type mismatch (`.x` on a number) → null
+
+**Layer 4 — filters (one test program per filter family):**
+
+For each filter, a small fixture template + expected output. Cover at
+minimum:
+
+- [ ] `upcase` / `downcase` / `capitalize` / `strip` / `lstrip` / `rstrip`
+- [ ] `escape` HTML-safety (`&` → `&amp;`, etc.)
+- [ ] `url_encode` (space → `+`, RFC 3986 unreserved kept)
+- [ ] `size` / `first` / `last` on array, string, object
+- [ ] `join` with and without explicit separator
+- [ ] `default` — true falsy cases: nil, false, "", `[]`, `{}`. NOT
+      false: 0 (Liquid treats 0 as truthy — confirm vs Shopify)
+- [ ] `replace` — multi-occurrence
+- [ ] `append` / `prepend`
+- [ ] `truncate` — boundary at exact length (no ellipsis), boundary at
+      length+1, custom ellipsis arg
+- [ ] `plus` / `minus` / `times` / `divided_by` / `modulo` — integer
+      math; check Shopify's "divide-by-zero returns null" behaviour
+- [ ] Unknown filter passes through (matches Shopify)
+- [ ] World-touching `date` returns the gated string when not allowed;
+      formats correctly when allowed (after the full impl lands)
+
+**Layer 5 — end-to-end rendering:**
+
+A handful of fixture `.liquid` files with expected `.txt` outputs, run
+via a single shell script:
+
+- [ ] Hello-world: `Hello {{ name }}!` + `name=alice` → `Hello alice!`
+- [ ] Filter chain: `{{ user.name | upcase }}`
+- [ ] Multiple outputs in one template
+- [ ] Output of a nested-access value
+- [ ] Output that produces an empty string (nil value)
+- [ ] Whitespace control: `{{- x -}}` strips surrounding whitespace
+
+**Layer 6 — tags (when they land):**
+
+One fixture per tag:
+- [ ] `{% if %}` true branch, false branch, else, elsif chain
+- [ ] `{% if a == b %}` / `{% if a != b %}` / `{% if a > b %}` etc.
+- [ ] `{% if a and b %}` / `{% if a or b %}` / `{% if s contains 'foo' %}`
+- [ ] `{% unless %}` inverse
+- [ ] `{% for %}` over array, object, range
+- [ ] `forloop.index/first/last/length` exposed correctly
+- [ ] `for ... limit:N offset:N reversed`
+- [ ] `{% break %}` / `{% continue %}`
+- [ ] `{% case %}` / `{% when %}` / `{% else %}`
+- [ ] `{% capture name %}...{% endcapture %}` + `{{ name }}` use
+- [ ] `{% assign x = ... %}` + use
+- [ ] `{% comment %}` body invisible
+- [ ] Nested tags (if-in-for, for-in-if, capture-of-if, etc.)
+
+**Layer 7 — includes + layouts (when they land):**
+
+These run only under `--with=fs`. Sandbox test verifies the negative
+case (no `--with=fs` → engine errors clearly):
+
+- [ ] Plain `{% include 'partial' %}` — partial sees parent context
+- [ ] `{% include 'p' with name %}` — scoped binding
+- [ ] `{% include 'p', k: v %}` — multiple bindings
+- [ ] Missing partial → render error with the path
+- [ ] Circular include → error (depth limit)
+- [ ] `{% extends 'base' %}` + `{% block %}` — child overrides parent
+- [ ] Chain: child → middle → base
+- [ ] Missing parent → error
+- [ ] No `--with=fs` under `--emit=lib` → import gate rejects the
+      contrib module (this falls out of Aether's existing
+      capability-gate machinery; add the test that asserts the error
+      message points at the right opt-in)
+
+**Layer 8 — error reporting:**
+
+- [ ] Lexer: unterminated `{{` → error includes line number
+- [ ] Parser: bad expression → error includes line + what was expected
+- [ ] Render: unknown tag → identity (matches Shopify), DOES NOT panic
+- [ ] Render: filter that errors (e.g. `divided_by:0`) returns null +
+      doesn't crash subsequent renders
+
+**Layer 9 — fuzz / robustness:**
+
+- [ ] Empty template → empty string output
+- [ ] Template that is only delimiters → empty string output
+- [ ] Very long template (10000+ lines) — make sure linear-time lex
+- [ ] Deeply-nested `for` (10+ levels) — make sure no stack overflow
+      in the renderer
+- [ ] Template with embedded NULs in TEXT — lexer should preserve
+      (`string.char_at_n` is binary-safe; verify)
+
+### Working policy for this module
+
+- One layer at a time. Add the code, add the tests, run the tests,
+  green, commit. Then start the next layer.
+- No speculative drafts. The big-bang 1215-LoC attempt was a sunk cost.
+- No placeholder tests. Tests live alongside working code.
+- Rewrite tests freely when the underlying API changes. v0's tests
+  will need rewriting when the context migrates from string→string to
+  string→json-value; that's expected.
+
+### Design decisions already locked in (don't re-litigate)
+
+- **Value model:** `std.json` value tree. `to_value(s: *MyStruct) ->
+  ptr` adapter pattern for struct binding, documented in README with a
+  worked example.
+- **Filters:** pure shipped enabled; world-touching (`date`,
+  `asset_url`, ...) off by default, opt-in via
+  `liquid.allow_world_filters(engine)`.
+- **Scope:** Tier A + includes/layouts. Multi-range, custom drops,
+  registers, strict mode, ifchanged, the Shopify e-commerce filters
+  (`money`, `payment_terms`, etc.) explicitly OUT.
+- **Approach:** vertical slice first (`{{ var | filter }}` end-to-end),
+  then expand tag-by-tag. After Layer 6 (tags), add Layer 7
+  (includes/layouts) in one go.
+- **Build path:** pure Aether, no C source. Contrib install pattern
+  follows `contrib/xml/expat/` — module.ae lives in
+  `contrib/templating/liquid/`, `import contrib.templating.liquid`
+  pulls it in; downstream user adds nothing to their aether.toml
+  (because the engine doesn't depend on any C libraries).
+
+## Other parked work
+
+(Add as it surfaces.)

--- a/contrib/templating/liquid/module.ae
+++ b/contrib/templating/liquid/module.ae
@@ -1,0 +1,336 @@
+// contrib.templating.liquid — Shopify Liquid templating engine for Aether.
+//
+// A faithful pure-Aether port of the Liquid template language
+// (https://shopify.github.io/liquid/). Sandbox-friendly: no reflection,
+// no eval, filter set is explicit.
+//
+// Current scope (incremental build):
+//
+//   - Text passthrough
+//   - `{{ varname }}` single-segment variable lookup against a string map
+//   - `{% comment %}...{% endcomment %}` (body suppressed)
+//   - `{% raw %}...{% endraw %}` (body emitted verbatim — no interpolation)
+//
+// Not yet implemented (see TODO.md): dotted attribute access, filters,
+// most other tags (`if`/`for`/`assign`/`case`/`capture`/...),
+// includes, layouts, JSON-tree value model.
+//
+// Surface:
+//
+//   import contrib.templating.liquid
+//
+//   t, err = liquid.parse_string("Hello {{ name }}!")
+//
+//   ctx = liquid.context_new()
+//   liquid.context_put_string(ctx, "name", "alice")
+//
+//   out, _ = liquid.render(t, ctx)
+//   // → "Hello alice!"
+
+import std.string
+import std.strbuilder
+import std.map
+import std.collections
+
+exports (
+    parse_string,
+    context_new, context_put_string, context_free,
+    render
+)
+
+// ---------------------------------------------------------------------------
+// Lexer — split source into TEXT / OUTPUT / TAG segments
+// ---------------------------------------------------------------------------
+//
+// We store the token stream as parallel string_lists wrapped in a list:
+//   index 0: token-kind strings ("TEXT" / "OUTPUT" / "TAG")
+//   index 1: token-content strings
+//
+// `{% comment %}...{% endcomment %}` and `{% raw %}...{% endraw %}` are
+// recognised at lex time and collapsed:
+//   - comment-body bytes are dropped (no token emitted for the body)
+//   - raw-body bytes are emitted as a single TEXT token verbatim, even
+//     if they contain `{{` or `{%`
+//
+// Any other `{% ... %}` body becomes a TAG token. The renderer treats
+// unknown tags as a render-time error, so the lexer can hand them
+// through without parsing — future tag support is purely renderer-side
+// growth.
+
+const TOK_TEXT   = "TEXT"
+const TOK_OUTPUT = "OUTPUT"
+const TOK_TAG    = "TAG"
+
+// Find the next `{{` OR `{%` starting at `p`. Returns (offset, kind)
+// where kind is "{{" or "{%". Returns (-1, "") if none found.
+find_next_delim(src: string, n: int, p: int) -> (int, string) {
+    i = p
+    while i < n - 1 {
+        if string.char_at_n(src, n, i) == 123 {       // '{'
+            nxt = string.char_at_n(src, n, i + 1)
+            if nxt == 123 { return i, "{{" }
+            if nxt == 37  { return i, "{%" }
+        }
+        i = i + 1
+    }
+    return -1, ""
+}
+
+// Find `}}` starting at `p`. Returns -1 if not found.
+find_output_close(src: string, n: int, p: int) -> int {
+    i = p
+    while i < n - 1 {
+        if string.char_at_n(src, n, i) == 125 {       // '}'
+            if string.char_at_n(src, n, i + 1) == 125 {  // '}'
+                return i
+            }
+        }
+        i = i + 1
+    }
+    return -1
+}
+
+// Find `%}` starting at `p`. Returns -1 if not found.
+find_tag_close(src: string, n: int, p: int) -> int {
+    i = p
+    while i < n - 1 {
+        if string.char_at_n(src, n, i) == 37 {        // '%'
+            if string.char_at_n(src, n, i + 1) == 125 {  // '}'
+                return i
+            }
+        }
+        i = i + 1
+    }
+    return -1
+}
+
+// Return 1 if the trimmed tag body is literally the keyword `kw`
+// (allowing for one or more trailing whitespace + extra chars to be
+// rejected — `comment` MUST match exactly so that `commented` doesn't
+// trip it). We currently use this only for the bare opener/closer
+// keywords (`comment`, `endcomment`, `raw`, `endraw`).
+tag_body_is(body: string, kw: string) -> int {
+    return string.equals(body, kw)
+}
+
+// Trim ASCII whitespace from both ends of `s`.
+trim(s: string) -> string {
+    n = string_length(s)
+    a = 0
+    while a < n {
+        c = string.char_at_n(s, n, a)
+        if c == 32 || c == 9 || c == 10 || c == 13 {
+            a = a + 1
+        } else {
+            break
+        }
+    }
+    b = n
+    while b > a {
+        c = string.char_at_n(s, n, b - 1)
+        if c == 32 || c == 9 || c == 10 || c == 13 {
+            b = b - 1
+        } else {
+            break
+        }
+    }
+    return string.substring_n(s, n, a, b)
+}
+
+// Lex `src` into the parallel-list token stream described above. Returns
+// (tokens, "") on success or (tokens, error_message) on a syntax problem.
+lex(src: string) -> (ptr, string) {
+    kinds    = string_list_new()
+    contents = string_list_new()
+    n = string_length(src)
+    pos = 0
+    while pos < n {
+        open_at, opener = find_next_delim(src, n, pos)
+        if open_at < 0 {
+            // Trailing text only.
+            tail = string.substring_n(src, n, pos, n)
+            string_list_add(kinds, TOK_TEXT)
+            string_list_add(contents, tail)
+            pos = n
+        } else {
+            if open_at > pos {
+                text = string.substring_n(src, n, pos, open_at)
+                string_list_add(kinds, TOK_TEXT)
+                string_list_add(contents, text)
+            }
+            if string.equals(opener, "{{") == 1 {
+                // Output tag.
+                close_at = find_output_close(src, n, open_at + 2)
+                if close_at < 0 {
+                    tail = string.substring_n(src, n, open_at, n)
+                    string_list_add(kinds, TOK_TEXT)
+                    string_list_add(contents, tail)
+                    toks = list_new()
+                    list_add_raw(toks, kinds)
+                    list_add_raw(toks, contents)
+                    return toks, "unterminated `{{`"
+                }
+                body = trim(string.substring_n(src, n, open_at + 2, close_at))
+                string_list_add(kinds, TOK_OUTPUT)
+                string_list_add(contents, body)
+                pos = close_at + 2
+            } else {
+                // Tag — `{% ... %}`.
+                close_at = find_tag_close(src, n, open_at + 2)
+                if close_at < 0 {
+                    tail = string.substring_n(src, n, open_at, n)
+                    string_list_add(kinds, TOK_TEXT)
+                    string_list_add(contents, tail)
+                    toks = list_new()
+                    list_add_raw(toks, kinds)
+                    list_add_raw(toks, contents)
+                    return toks, "unterminated `{%`"
+                }
+                body = trim(string.substring_n(src, n, open_at + 2, close_at))
+                pos_after = close_at + 2
+
+                // `comment` and `raw` are recognised at lex time: scan
+                // forward to the matching `endcomment`/`endraw` and
+                // either drop or preserve the body in one TEXT token.
+                if tag_body_is(body, "comment") == 1 {
+                    end_at, end_close = find_block_end(src, n, pos_after, "endcomment")
+                    if end_at < 0 {
+                        toks = list_new()
+                        list_add_raw(toks, kinds)
+                        list_add_raw(toks, contents)
+                        return toks, "unterminated `{% comment %}`"
+                    }
+                    pos = end_close
+                } else if tag_body_is(body, "raw") == 1 {
+                    end_at, end_close = find_block_end(src, n, pos_after, "endraw")
+                    if end_at < 0 {
+                        toks = list_new()
+                        list_add_raw(toks, kinds)
+                        list_add_raw(toks, contents)
+                        return toks, "unterminated `{% raw %}`"
+                    }
+                    raw_body = string.substring_n(src, n, pos_after, end_at)
+                    string_list_add(kinds, TOK_TEXT)
+                    string_list_add(contents, raw_body)
+                    pos = end_close
+                } else {
+                    // Future tag — pass through; renderer will error.
+                    string_list_add(kinds, TOK_TAG)
+                    string_list_add(contents, body)
+                    pos = pos_after
+                }
+            }
+        }
+    }
+    toks = list_new()
+    list_add_raw(toks, kinds)
+    list_add_raw(toks, contents)
+    return toks, ""
+}
+
+// Find a `{% endXX %}` block-end starting at `p`. Returns
+//   (body_end_offset, after_close_offset)
+// where `body_end_offset` is the byte just BEFORE the `{%` (i.e. the
+// last byte of the block body), and `after_close_offset` is the byte
+// AFTER the closing `%}`. On failure returns (-1, -1).
+find_block_end(src: string, n: int, p: int, endkw: string) -> (int, int) {
+    i = p
+    while i < n - 1 {
+        if string.char_at_n(src, n, i) == 123 &&
+           string.char_at_n(src, n, i + 1) == 37 {
+            // Found `{%`. Read its body and check for the matching endXX.
+            body_start = i + 2
+            close_at = find_tag_close(src, n, body_start)
+            if close_at < 0 {
+                return -1, -1
+            }
+            body = trim(string.substring_n(src, n, body_start, close_at))
+            if string.equals(body, endkw) == 1 {
+                return i, close_at + 2
+            }
+            // Not the matching close; skip past this inner tag and continue.
+            i = close_at + 2
+        } else {
+            i = i + 1
+        }
+    }
+    return -1, -1
+}
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+//
+// A parsed template is the token list itself — we walk it directly at
+// render time. This keeps v0 small. Once tags arrive, an AST sits between
+// the lexer and renderer.
+//
+// A context is a `std.map` of string → string. Once filters and dotted
+// access land, the value side becomes a std.json value tree (see TODO.md
+// "Value model").
+
+// Parse a Liquid source string. Returns (template_handle, "") on success
+// or (null, error) on a syntax problem.
+parse_string(src: string) -> (ptr, string) {
+    toks, err = lex(src)
+    if err != "" {
+        return 0, err
+    }
+    return toks, ""
+}
+
+// Build a fresh string→string context.
+context_new() -> ptr {
+    return map_new()
+}
+
+// Bind `key` to `value` in the context. Replaces any prior binding for `key`.
+context_put_string(ctx: ptr, key: string, value: string) {
+    map_put(ctx, key, value)
+}
+
+// Free the context's storage.
+context_free(ctx: ptr) {
+    map_free(ctx)
+}
+
+// Look up `name` in the context. Returns the empty string for an unbound
+// name — Shopify Liquid's documented behaviour for `{{ undefined }}`.
+lookup(ctx: ptr, name: string) -> string {
+    if map_has(ctx, name) == 0 {
+        return ""
+    }
+    return map_get_raw(ctx, name)
+}
+
+// Render `t` against `ctx`. Returns (output, "") on success or
+// (partial_output, error) on a render-time problem (currently: unknown
+// tag — anything that lexed as a TAG token but isn't yet supported).
+//
+// `comment` and `raw` were handled at lex time (their body is either
+// dropped or emitted as TEXT), so the renderer never sees a TAG token
+// for them — only the future tags we haven't implemented yet
+// (`if`/`for`/`assign`/...) reach the error path below.
+render(t: ptr, ctx: ptr) -> (string, string) {
+    kinds    = list_get_raw(t, 0)
+    contents = list_get_raw(t, 1)
+    n = string_list_size(kinds)
+    sb = strbuilder.new(64)
+    i = 0
+    while i < n {
+        kind = string_list_get(kinds, i)
+        body = string_list_get(contents, i)
+        if string.equals(kind, TOK_TEXT) == 1 {
+            strbuilder.append(sb, body)
+        } else if string.equals(kind, TOK_OUTPUT) == 1 {
+            // v0 OUTPUT: bare variable names only.
+            strbuilder.append(sb, lookup(ctx, body))
+        } else {
+            // TAG: unsupported in current scope. Return the partial
+            // output we have so the caller can see how far we got.
+            return strbuilder.finish(sb), string.concat("unsupported tag: ", body)
+        }
+        i = i + 1
+    }
+    return strbuilder.finish(sb), ""
+}

--- a/tests/integration/liquid_basics/probe.ae
+++ b/tests/integration/liquid_basics/probe.ae
@@ -1,0 +1,79 @@
+// contrib.templating.liquid v0 — tests for everything currently implemented:
+//
+//   1. Plain text passes through verbatim.
+//   2. `{{ name }}` substitutes a string from the context.
+//   3. An unbound `{{ undefined }}` renders as the empty string
+//      (Shopify Liquid's documented behaviour).
+//   4. Multiple `{{ }}` outputs in one template.
+//   5. Whitespace inside `{{   x   }}` is trimmed for the lookup key.
+//   6. An unterminated `{{` returns a non-empty error.
+//
+// As tags / filters / dotted access land, this file grows. If a future
+// reshape (JSON-tree value model, etc.) breaks the v0 surface, these
+// tests will need rewriting too — that's expected.
+
+import contrib.templating.liquid
+import std.string
+
+extern exit(code: int)
+
+expect_eq(actual: string, want: string, label: string) {
+    if string.equals(actual, want) != 1 {
+        println("FAIL ${label}: got '${actual}' want '${want}'")
+        exit(1)
+    }
+    println("PASS ${label}: '${actual}'")
+}
+
+main() {
+    // (1) Plain text passthrough.
+    t1, e1 = liquid.parse_string("just words")
+    if e1 != "" { println("FAIL 1 parse: ${e1}"); exit(1) }
+    out1, _ = liquid.render(t1, liquid.context_new())
+    expect_eq(out1, "just words", "1 plain text")
+
+    // (2) Variable substitution.
+    t2, _ = liquid.parse_string("Hello {{ name }}!")
+    ctx2 = liquid.context_new()
+    liquid.context_put_string(ctx2, "name", "alice")
+    out2, _ = liquid.render(t2, ctx2)
+    expect_eq(out2, "Hello alice!", "2 variable substitution")
+
+    // (3) Unbound variable → empty string.
+    t3, _ = liquid.parse_string("Hi {{ missing }}!")
+    out3, _ = liquid.render(t3, liquid.context_new())
+    expect_eq(out3, "Hi !", "3 unbound variable")
+
+    // (4) Multiple outputs in one template.
+    t4, _ = liquid.parse_string("{{ a }}-{{ b }}-{{ c }}")
+    ctx4 = liquid.context_new()
+    liquid.context_put_string(ctx4, "a", "1")
+    liquid.context_put_string(ctx4, "b", "2")
+    liquid.context_put_string(ctx4, "c", "3")
+    out4, _ = liquid.render(t4, ctx4)
+    expect_eq(out4, "1-2-3", "4 multiple outputs")
+
+    // (5) Whitespace inside {{ }} is trimmed.
+    t5, _ = liquid.parse_string("[{{   name   }}]")
+    ctx5 = liquid.context_new()
+    liquid.context_put_string(ctx5, "name", "bob")
+    out5, _ = liquid.render(t5, ctx5)
+    expect_eq(out5, "[bob]", "5 whitespace trim in output tag")
+
+    // (6) Unterminated `{{` is reported.
+    _, e6 = liquid.parse_string("oops {{ name")
+    if string.equals(e6, "") == 1 {
+        println("FAIL 6 unterminated: expected error, got ''")
+        exit(1)
+    }
+    println("PASS 6 unterminated: '${e6}'")
+
+    // (7) Output adjacent to text on both sides.
+    t7, _ = liquid.parse_string("pre{{x}}post")
+    ctx7 = liquid.context_new()
+    liquid.context_put_string(ctx7, "x", "MID")
+    out7, _ = liquid.render(t7, ctx7)
+    expect_eq(out7, "preMIDpost", "7 no-space adjacency")
+
+    println("All PASS")
+}

--- a/tests/integration/liquid_basics/test_liquid_basics.sh
+++ b/tests/integration/liquid_basics/test_liquid_basics.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# contrib.templating.liquid v0 — tests for the currently-implemented
+# vertical slice (text passthrough, `{{ name }}` substitution against a
+# string-only context). Grows as tags / filters / dotted access land.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+OUT="$(AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/probe.ae" 2>&1)"
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "  [FAIL] liquid_basics (exit $RC):"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+if ! echo "$OUT" | grep -q "All PASS"; then
+    echo "  [FAIL] liquid_basics — no 'All PASS' line:"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+
+echo "  [PASS] liquid_basics: 7/7"

--- a/tests/integration/liquid_tags_simple/probe.ae
+++ b/tests/integration/liquid_tags_simple/probe.ae
@@ -1,0 +1,91 @@
+// contrib.templating.liquid — `{% comment %}` and `{% raw %}` tags.
+//
+// Cases:
+//   1. `{% comment %}body{% endcomment %}` produces nothing
+//   2. Text + comment + text around it stays glued together
+//   3. `{% raw %}{{ x }}{% endraw %}` outputs literal `{{ x }}`
+//      (no interpolation inside raw)
+//   4. raw preserves multi-line content verbatim
+//   5. Unterminated `{% comment %}` returns an error
+//   6. Unterminated `{% raw %}` returns an error
+//   7. Any other `{% xxx %}` (future tags not yet supported) gives an
+//      "unsupported tag" render error
+//   8. comment + variable substitution interleaved keeps everything
+//      else working
+
+import contrib.templating.liquid
+import std.string
+
+extern exit(code: int)
+
+expect_eq(actual: string, want: string, label: string) {
+    if string.equals(actual, want) != 1 {
+        println("FAIL ${label}: got '${actual}' want '${want}'")
+        exit(1)
+    }
+    println("PASS ${label}: '${actual}'")
+}
+
+main() {
+    // (1) Bare comment renders to nothing.
+    t1, _ = liquid.parse_string("{% comment %}hidden{% endcomment %}")
+    out1, _ = liquid.render(t1, liquid.context_new())
+    expect_eq(out1, "", "1 bare comment")
+
+    // (2) Text around a comment.
+    t2, _ = liquid.parse_string("pre{% comment %}hidden{% endcomment %}post")
+    out2, _ = liquid.render(t2, liquid.context_new())
+    expect_eq(out2, "prepost", "2 text around comment")
+
+    // (3) Raw passes `{{ x }}` through verbatim.
+    t3, _ = liquid.parse_string("{% raw %}{{ x }}{% endraw %}")
+    ctx3 = liquid.context_new()
+    liquid.context_put_string(ctx3, "x", "WOULD_HAVE_BEEN_INTERPOLATED")
+    out3, _ = liquid.render(t3, ctx3)
+    expect_eq(out3, "{{ x }}", "3 raw preserves output tag")
+
+    // (4) Raw preserves multi-line + special chars verbatim.
+    t4, _ = liquid.parse_string("[{% raw %}line1\nline2 {% if %}{% endraw %}]")
+    out4, _ = liquid.render(t4, liquid.context_new())
+    expect_eq(out4, "[line1\nline2 {% if %}]", "4 raw multi-line + nested tags")
+
+    // (5) Unterminated comment is reported.
+    _, e5 = liquid.parse_string("oops {% comment %}never ends")
+    if string.equals(e5, "") == 1 {
+        println("FAIL 5 unterminated comment: expected error")
+        exit(1)
+    }
+    println("PASS 5 unterminated comment: '${e5}'")
+
+    // (6) Unterminated raw is reported.
+    _, e6 = liquid.parse_string("oops {% raw %}never ends")
+    if string.equals(e6, "") == 1 {
+        println("FAIL 6 unterminated raw: expected error")
+        exit(1)
+    }
+    println("PASS 6 unterminated raw: '${e6}'")
+
+    // (7) Unsupported future tag (e.g. {% if %}) gives a render error.
+    t7, e7 = liquid.parse_string("a {% if cond %}b{% endif %} c")
+    if e7 != "" {
+        // The lexer might also reject it — either failure mode is fine
+        // as long as it's reported clearly.
+        println("PASS 7 unsupported tag (lex-time): '${e7}'")
+    } else {
+        _, rerr = liquid.render(t7, liquid.context_new())
+        if string.equals(rerr, "") == 1 {
+            println("FAIL 7 unsupported tag: expected render error")
+            exit(1)
+        }
+        println("PASS 7 unsupported tag (render-time): '${rerr}'")
+    }
+
+    // (8) Comment interleaved with variable substitution.
+    t8, _ = liquid.parse_string("Hi {{ name }}{% comment %} silenced {% endcomment %}!")
+    ctx8 = liquid.context_new()
+    liquid.context_put_string(ctx8, "name", "alice")
+    out8, _ = liquid.render(t8, ctx8)
+    expect_eq(out8, "Hi alice!", "8 comment + substitution interleaved")
+
+    println("All PASS")
+}

--- a/tests/integration/liquid_tags_simple/test_liquid_tags_simple.sh
+++ b/tests/integration/liquid_tags_simple/test_liquid_tags_simple.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# contrib.templating.liquid — `{% comment %}` and `{% raw %}` tags.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+OUT="$(AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/probe.ae" 2>&1)"
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "  [FAIL] liquid_tags_simple (exit $RC):"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+if ! echo "$OUT" | grep -q "All PASS"; then
+    echo "  [FAIL] liquid_tags_simple — no 'All PASS' line:"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+
+echo "  [PASS] liquid_tags_simple: 8/8"


### PR DESCRIPTION
## Description

First slice of a pure-Aether Shopify [Liquid](https://shopify.github.io/liquid/)
templating engine, landed as an opt-in `contrib/` module
(`contrib/templating/liquid/`). Sandbox-friendly: no reflection, no
eval, explicit filter set when filters arrive. Not part of
`libaether.a`.

What ships in this slice:

- Text passthrough
- `{{ name }}` single-segment variable lookup against a string-keyed context
- `{% comment %}...{% endcomment %}` (body dropped at lex time)
- `{% raw %}...{% endraw %}` (body emitted verbatim, no interpolation)
- Render-time error for any other `{% xxx %}` (future tags — `if`/`for`/`assign`/...)

Public surface: `parse_string`, `context_new`, `context_put_string`, `context_free`, `render`.

Working policy + the next layers (filters, full tag parser, includes,
layouts, JSON value model) are tracked in `TODO.md`. Each layer will
land one at a time with its own tests — no speculative drafts.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] All existing tests still pass (only known-flaky HTTP/2 framing tests
      and a recurring `http_reverse_proxy_pool` port-bind flake on this
      machine; unrelated to this change)
- [x] Two new integration tests added covering the implemented behaviour:
  - `tests/integration/liquid_basics/` — 7/7 (text, single sub, unbound
    -> empty, multiple subs, whitespace trim, unterminated `{{`,
    no-space adjacency)
  - `tests/integration/liquid_tags_simple/` — 8/8 (bare comment, text
    around comment, raw preserves `{{ x }}`, raw multi-line,
    unterminated comment, unterminated raw, unsupported tag, comment +
    sub interleaved)
- [x] Tested manually on Linux x86_64 via `make test`

## Performance Impact

None. The module is opt-in and not linked into `libaether.a`. No
existing code paths changed.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the changes
- [x] Added tests covering every behaviour implemented in this slice
- [x] No new compiler warnings introduced
- [x] Updated `CHANGELOG.md` under `## [current]`
- [x] No `compiler/`, `runtime/`, `std/`, `tools/`, `Makefile`, or
      `.github/` changes — `[skip actions]` is appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)