### PR TITLE
feat(contrib.templating.liquid): README + filter polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,39 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.223.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **`contrib.templating.liquid` — filter polish + README + LLM.md
+  pointer** (`contrib/templating/liquid/module.ae`,
+  `contrib/templating/liquid/README.md`,
+  `tests/integration/liquid_filter_polish/`, `LLM.md`). Three small
+  slices:
+  (a) **`truncate: N, "ellipsis"`** — second arg overrides the
+  default `"..."` ellipsis (`truncate:"10","…"` → 7 body bytes + the
+  3-byte UTF-8 ellipsis). 1-arg form keeps its existing behaviour;
+  empty-string ellipsis is accepted (= hard cut). When `N <=
+  length(ellipsis)` the ellipsis itself is cut to fit.
+  (b) **`default: VAL, allow_false:"true"`** — Shopify-compat
+  widening of the fallback set. Without `allow_false`, fires only
+  on the empty string (existing). With it, fires on `""`,
+  `"false"`, `"nil"`, `"null"` (the string-encoded Liquid falsy
+  set). Recognises both the bare `default:"alt","true"` 2-arg form
+  and the keyword-prefixed `default:"alt",allow_false:"true"` form.
+  (c) **`contrib/templating/liquid/README.md`** — first user-facing
+  doc. Covers install, supported tags / filters / typed bindings /
+  layouts, public surface, sandbox story, what's NOT supported,
+  performance notes. Closes the "is this ready for downstream"
+  documentation gap.
+  (d) **`LLM.md`** gets a one-line idiom: "Operator-supplied Liquid
+  templates → `contrib.templating.liquid`. Don't hand-roll
+  Mustache." 15 new integration tests in `liquid_filter_polish/`
+  bring the Liquid suite to **312 across 22 directories**.
 
 ## [0.223.0]
 

--- a/LLM.md
+++ b/LLM.md
@@ -201,6 +201,17 @@ plays that role), no interfaces.
   an `index_of`-based parser — that exact mistake landed in
   fbs-core's S3 port (#627) because the porter didn't realise
   `contrib.xml.expat` existed.
+- **Operator-supplied Liquid templates → `contrib.templating.liquid`.**
+  Pure-Aether Shopify-Liquid port. Use it for email bodies, dashboards,
+  generated reports — anywhere a trusted-human operator writes a
+  template but you don't want their template to execute arbitrary
+  code. `{% include %}` / `{% render %}` need an explicit
+  `context_set_include_root(ctx, root)` (path traversal blocked via
+  `fs.is_within_base`). Phase 1 ships scalar typed bindings
+  (`context_put_int`/`_float`/`_bool`/`_nil`); array / object / dotted
+  path access is Phase 2. Don't hand-roll a Mustache or own-syntax
+  templater unless you have a specific reason — this is the supported
+  path.
 - **HTTP client lives in two tiers, server in one.** `import
   std.http` gives v1 client one-liners (`http.get(url) -> (body,
   err)`, `http.post`, `http.put`, `http.delete`) plus the entire

--- a/TODO.md
+++ b/TODO.md
@@ -316,14 +316,13 @@ World-touching (gated):
 
 **8. Documentation:**
 
-- [ ] `contrib/templating/liquid/README.md` — install, usage,
-      sandbox-with-`--with=fs` story, mapping from Shopify-Liquid
-      reference docs to what's supported here (clear list of
-      OUT-of-scope features), the struct-binding `to_value` adapter
-      pattern with a worked example
-- [ ] `CHANGELOG.md` entry under `[current]`
-- [ ] `LLM.md` idiom (probably one line: "operator-supplied Liquid
-      templates → `contrib.templating.liquid`")
+- [x] `contrib/templating/liquid/README.md` — landed; install, usage,
+      tags + filters + typed-bindings + layouts, public surface,
+      sandbox story, what's NOT supported, performance notes.
+      Struct-binding `to_value` adapter pattern is Phase-2 (depends
+      on `context_put_object`).
+- [x] `CHANGELOG.md` entry under `[current]`
+- [x] `LLM.md` idiom — one-liner pointer landed.
 
 ### Test plan — cases to cover as each layer lands
 
@@ -396,8 +395,9 @@ minimum:
       false: 0 (Liquid treats 0 as truthy — confirm vs Shopify)
 - [ ] `replace` — multi-occurrence
 - [ ] `append` / `prepend`
-- [ ] `truncate` — boundary at exact length (no ellipsis), boundary at
-      length+1, custom ellipsis arg
+- [x] `truncate` — custom ellipsis arg + boundary cases (cap == ellipsis
+      length, cap == ellipsis length + 1, empty ellipsis as hard cut)
+      landed in `liquid_filter_polish/`
 - [ ] `plus` / `minus` / `times` / `divided_by` / `modulo` — integer
       math; check Shopify's "divide-by-zero returns null" behaviour
 - [ ] Unknown filter passes through (matches Shopify)

--- a/contrib/templating/liquid/README.md
+++ b/contrib/templating/liquid/README.md
@@ -1,0 +1,245 @@
+# `contrib.templating.liquid` — Shopify Liquid for Aether
+
+A pure-Aether port of the [Liquid template language](https://shopify.github.io/liquid/).
+Sandbox-friendly: no reflection, no eval, the filter and tag set is
+explicit and finite. Intended for rendering operator-supplied templates
+(email bodies, dashboards, generated reports) where the surrounding
+program needs the rendering to be deterministic and free of arbitrary
+code execution.
+
+```aether
+import contrib.templating.liquid
+
+t, _ = liquid.parse_string("Hello {{ name }}!")
+
+ctx = liquid.context_new()
+liquid.context_put_string(ctx, "name", "alice")
+
+out, _ = liquid.render(t, ctx)
+// out == "Hello alice!"
+```
+
+This module lives in `contrib/`, **not** in `libaether.a`. To use it
+you import `contrib.templating.liquid` from your Aether program; the
+build system links it in automatically.
+
+## When to use this
+
+- **Operator-supplied templates.** Marketing emails, admin dashboards,
+  generated PDFs / HTML reports where the template author is a trusted
+  human but not a code author, and the template should not be able to
+  read arbitrary files, fork processes, or call out to the network.
+- **Static-site generation.** Render Liquid against a JSON-like
+  context, write the output. The renderer is single-pass and the
+  output is deterministic.
+- **Server-side rendering of Shopify-shaped data.** Existing
+  `.liquid` files port over directly for the supported subset (see
+  below).
+
+If you control the template author and want them to write Aether
+directly (escape-correct via the host language's type system rather
+than the renderer's escape rules), see the
+[native DSL sketch in TODO.md](../../../TODO.md) instead.
+
+## What's supported
+
+All of the following have integration tests in
+`tests/integration/liquid_*/`. The Liquid suite is 312 tests across
+22 directories.
+
+### Output and lookup
+
+- `{{ name }}` — single-segment variable lookup against a string-keyed
+  context.
+- `{{ "literal string" }}` — string literals (single or double quotes).
+- `{{ 42 }}` — integer literals.
+- `{{ x | filter | filter2:arg | filter3:'a','b' }}` — filter chains
+  with positional args.
+
+### Tags
+
+- `{% if cond %}` / `{% elsif cond %}` / `{% else %}` / `{% endif %}` —
+  with `==` `!=` `<` `>` `<=` `>=`, `and` `or`, and `contains`
+  (substring-in-string / item-in-string-list).
+- `{% unless cond %}` / `{% endunless %}` — inverted `if`.
+- `{% case x %}{% when v %}…{% else %}…{% endcase %}` — pattern match.
+- `{% for i in (LO..HI) %}…{% endfor %}` — range iteration. `forloop.index` /
+  `index0` / `first` / `last` / `length` / `rindex` / `rindex0` are
+  bound inside the loop. `limit` / `offset` / `reversed` modifiers.
+- `{% break %}` / `{% continue %}` — for-body control flow.
+- `{% assign name = expr %}` — bind a name in the context (full filter
+  chain on RHS).
+- `{% capture name %}…{% endcapture %}` — render the block to a
+  string and assign it.
+- `{% increment x %}` / `{% decrement x %}` — Shopify counters,
+  namespace independent from `assign`.
+- `{% cycle 'a', 'b', 'c' %}` — anonymous and named-group lockstep.
+- `{% tablerow %}` — HTML-table iterator with `cols` / `limit` /
+  `offset` / `reversed`.
+- `{% comment %}` / `{% endcomment %}` — body suppressed.
+- `{% raw %}` / `{% endraw %}` — body emitted verbatim (no
+  interpolation).
+- `{%# inline comment %}` — Shopify's single-tag comment form.
+- `{% liquid %}` — line-per-tag block form.
+- `{{- … -}}` / `{%- … -%}` whitespace control on adjacent text
+  tokens, symmetric on comment/raw open and close edges.
+
+### Includes & layouts
+
+- `{% include 'partial' %}` and `{% render 'partial' %}` — read a
+  partial from a configurable root, parse it, render it inline.
+  `context_set_include_root(ctx, "path/to/partials")` is required
+  before render or an error is raised. Path traversal escapes are
+  rejected via `std.fs.is_within_base`. Depth-limited at 100 to
+  prevent infinite-include recursion.
+- `{% layout 'parent' %}` + `{% block name %}…{% endblock %}` —
+  Jekyll-style template inheritance (single level).
+- `{% extends 'parent' %}` — Django/Jinja alias for `{% layout %}`.
+- `{{ block.super }}` — inside a child block override, emits the
+  parent's default block content.
+
+### Filters
+
+String, math, html, encoding — over 30 filters. The complete list:
+
+```
+upcase  downcase  capitalize  strip  lstrip  rstrip  reverse  size
+append  prepend  default  truncate  truncatewords  replace
+replace_first  remove  remove_first  newline_to_br  strip_html
+strip_newlines  escape  escape_once  url_encode  url_decode  slice
+plus  minus  times  divided_by  modulo  at_least  at_most
+md5  sha1  sha256  base64_encode  base64_decode
+escape_xml  json_escape
+```
+
+Unknown filter names pass the input through unchanged (Shopify
+behaviour, not an error). `divided_by:"0"` and `modulo:"0"` raise
+render-time errors rather than crashing. `default: VAL,
+allow_false:"true"` widens the fallback set to include `"false"`,
+`"nil"`, `"null"` (string-encoded falsy set).
+
+### Typed bindings (Phase 1)
+
+Alongside `context_put_string`, four scalar typed setters:
+
+```aether
+liquid.context_put_int(ctx,   "n",  42)
+liquid.context_put_float(ctx, "pi", 3.14)
+liquid.context_put_bool(ctx,  "ok", 1)        // 1 = true, 0 = false
+liquid.context_put_nil(ctx,   "x")
+```
+
+Typed bindings are stored under an internal `v:<key>` namespace and
+stringified for `{{ x }}` interpolation via the canonical
+`value_to_string`. A typed binding shadows a same-name legacy
+`context_put_string` regardless of bind order.
+
+**Array and object setters (`context_put_array` / `_object`) plus
+dotted-and-bracketed path access (`items[0]`, `user.name`,
+`.size`/`.first`/`.last`) are deferred to Phase 2** — they need a
+heap-retention story for the std.list / std.map backing storage that
+survives the encoding round-trip. See `TODO.md` for the punch list.
+
+### Lexer / parse errors
+
+Unterminated `{{` / `{%` / `{% comment %}` / `{% raw %}` errors carry
+an `at line N` suffix (1-based, counts `\n`).
+
+## Public surface
+
+```aether
+parse_string(src: string) -> (ptr, string)        // (template, error)
+parse_file(path: string)  -> (ptr, string)        // fs.read + parse_string
+
+context_new()                                        -> ptr
+context_put_string(ctx: ptr, key: string, v: string)
+context_put_int(ctx: ptr, key: string, v: int)
+context_put_float(ctx: ptr, key: string, v: float)
+context_put_bool(ctx: ptr, key: string, v: int)       // 1=true, 0=false
+context_put_nil(ctx: ptr, key: string)
+context_set_include_root(ctx: ptr, root: string)
+context_free(ctx: ptr)
+
+render(t: ptr, ctx: ptr)                       -> (string, string)
+render_to_strbuilder(t: ptr, ctx: ptr, sb: ptr) -> string  // (error)
+```
+
+Value constructors / inspectors (mostly for downstream code that
+builds packed values directly):
+
+```aether
+value_nil()             -> string
+value_bool(b: int)      -> string
+value_int(i: int)       -> string
+value_float(f: float)   -> string
+value_str(s: string)    -> string
+
+value_kind(v: string)        -> int           // LV_NIL .. LV_OBJ
+value_payload(v: string)     -> string        // strip "X:" prefix
+value_to_string(v: string)   -> string        // canonical stringify
+value_get_int(v: string)     -> int
+value_get_float(v: string)   -> float
+```
+
+## Sandbox story
+
+The Liquid renderer itself does **not** call `fs.read`. Only
+`{% include %}` / `{% render %}` and `parse_file` do. When the
+include tags are used, `context_set_include_root` must be called with
+an explicit root directory; partials resolved against that root are
+checked with `std.fs.is_within_base` so an attacker-supplied filename
+like `'../../etc/passwd'` is rejected.
+
+The `--with=fs` capability gate for `--emit=lib` is not yet wired up
+(see `TODO.md`). For now, treat the renderer as "safe-by-default for
+`{{ … }}` and `{% if %}` / `{% for %}` etc., but `{% include %}`
+requires explicit caller opt-in via the include root."
+
+## What's NOT supported
+
+- `for x in array_var` over a non-range iterable (Phase 2; ranges
+  `(0..9)` work today).
+- Dotted attribute access `{{ user.name }}` (Phase 2).
+- Bracket index `{{ items[0] }}` (Phase 2).
+- `.size` / `.first` / `.last` on bindings (Phase 2 — only on the
+  Phase-1 typed surface via direct `value_*` calls).
+- Array filters: `sort`, `uniq`, `map:"prop"`, `where`,
+  `compact`, `concat:array2`, `split:":"` (→ array). All require
+  the Phase-2 typed-array surface.
+- `round` / `ceil` / `floor` / `abs` — need float-aware value model
+  (Phase 2).
+- `date` — currently identity. Real strftime needs a clock + format
+  parser; out of scope until a real downstream user asks.
+- Multi-level `{% layout %}` chain (child → middle → base). We have
+  single-level.
+- Partial caching: each `{% include %}` re-reads from disk.
+
+See `TODO.md` "`contrib.templating.liquid`" section for the full
+deferred list.
+
+## Performance notes
+
+- Parsing is single-pass over a token stream; render walks the tokens
+  with no AST allocation per render.
+- Strings are `std.string` (refcounted heap strings); the renderer
+  uses `std.strbuilder` for output accumulation so output assembly
+  is O(N).
+- Includes are uncached — partials are re-read and re-parsed per
+  render. For a static-site generator that uses 100 partials, this
+  is the long-pole cost. (Caching is a Phase-2 follow-up.)
+
+## Testing
+
+```
+bash tests/integration/liquid_*/test_*.sh
+```
+
+Or as part of the full Aether CI:
+
+```
+make ci
+```
+
+## License
+
+Same as Aether.

--- a/contrib/templating/liquid/module.ae
+++ b/contrib/templating/liquid/module.ae
@@ -1070,18 +1070,19 @@ parse_int_arg(s: string, name: string) -> (int, string) {
     return v, ""
 }
 
-// Truncate `s` to `cap` bytes, appending `...` if the string was cut.
+// Truncate `s` to `cap` bytes, appending `ell` if the string was cut.
 // Matches Liquid's default: total length (including the ellipsis) is
-// `cap`. If `cap <= 3` the ellipsis itself is truncated.
-filter_truncate(s: string, cap: int) -> string {
+// `cap`. If `cap <= length(ell)` the ellipsis itself is truncated.
+filter_truncate(s: string, cap: int, ell: string) -> string {
     n = string_length(s)
     if cap < 0 { return "" }
     if n <= cap { return s }
-    if cap <= 3 {
+    eln = string_length(ell)
+    if cap <= eln {
         return string.substring_n(s, n, 0, cap)
     }
-    body = string.substring_n(s, n, 0, cap - 3)
-    return string.concat(body, "...")
+    body = string.substring_n(s, n, 0, cap - eln)
+    return string.concat(body, ell)
 }
 
 // Apply one filter stage to the current value. Returns (new_value, "")
@@ -1135,20 +1136,73 @@ apply_filter(val: string, name: string, args: string) -> (string, string) {
         return string.concat(s, val), ""
     }
     if string.equals(name, "default") == 1 {
-        if argc != 1 { return "", "default needs exactly 1 arg" }
+        // Shopify signature: default: VAL [, allow_false: BOOL]
+        // Aether's filter-arg parser is positional and string-keyed, so
+        // the second arg is whatever the user wrote — typically
+        // `allow_false:"true"` (a quoted "true") or just `"true"`.
+        // Without the typed value model in resolve_atom's filter
+        // pipeline (Phase 2), the fallback set on a legacy string is
+        // {"", "false", "nil", "null"} when allow_false fires, and just
+        // {""} otherwise. With a typed binding the legacy `lookup`
+        // already stringifies via value_to_string, so a typed LV_NIL
+        // lands here as "" and an LV_BOOL(false) as "false".
+        if argc != 1 && argc != 2 { return "", "default needs 1 or 2 args" }
         s, err = unquote_arg(string_list_get(arg_list, 0))
         if err != "" { return "", err }
-        // Liquid's `default` falsy set for strings: empty string.
-        if string_length(val) == 0 { return s, "" }
+        allow_false = 0
+        if argc == 2 {
+            // The second arg may carry a `key:value` shape
+            // (`allow_false:true`) or just a bare value
+            // (`"true"`). We accept either.
+            raw2 = string_list_get(arg_list, 1)
+            // Strip optional `allow_false:` prefix.
+            n2 = string_length(raw2)
+            af_pref = "allow_false:"
+            afn = string_length(af_pref)
+            payload2 = raw2
+            if n2 >= afn {
+                head2 = string.substring_n(raw2, n2, 0, afn)
+                if string.equals(head2, af_pref) == 1 {
+                    payload2 = trim(string.substring_n(raw2, n2, afn, n2))
+                }
+            }
+            // Now payload2 is either a quoted "true"/"false" or a bare
+            // true/false. unquote_arg handles the quoted form; we
+            // accept bare true/false too.
+            unq, uerr = unquote_arg(payload2)
+            if uerr != "" {
+                unq = payload2
+            }
+            if string.equals(unq, "true") == 1 { allow_false = 1 }
+        }
+        // Compute falsy verdict on `val`. With allow_false the
+        // string-only falsy set widens to {"", "false", "nil", "null"};
+        // otherwise just {""}.
+        falsy = 0
+        if string_length(val) == 0 { falsy = 1 }
+        if allow_false == 1 {
+            if string.equals(val, "false") == 1 { falsy = 1 }
+            if string.equals(val, "nil")   == 1 { falsy = 1 }
+            if string.equals(val, "null")  == 1 { falsy = 1 }
+        }
+        if falsy == 1 { return s, "" }
         return val, ""
     }
     if string.equals(name, "truncate") == 1 {
-        if argc != 1 { return "", "truncate needs exactly 1 arg" }
+        // Shopify Liquid signature: truncate: N [, ellipsis]
+        // Both 1-arg (default "...") and 2-arg (custom ellipsis) forms.
+        if argc != 1 && argc != 2 { return "", "truncate needs 1 or 2 args" }
         s, err = unquote_arg(string_list_get(arg_list, 0))
         if err != "" { return "", err }
         cap, ierr = string.to_int(s)
         if ierr != "" { return "", string.concat("truncate arg not an integer: ", s) }
-        return filter_truncate(val, cap), ""
+        ell = "..."
+        if argc == 2 {
+            e2, eerr = unquote_arg(string_list_get(arg_list, 1))
+            if eerr != "" { return "", eerr }
+            ell = e2
+        }
+        return filter_truncate(val, cap, ell), ""
     }
     if string.equals(name, "replace") == 1 {
         if argc != 2 { return "", "replace needs exactly 2 args" }

--- a/tests/integration/liquid_filter_polish/probe.ae
+++ b/tests/integration/liquid_filter_polish/probe.ae
@@ -1,0 +1,122 @@
+// contrib.templating.liquid — filter polish slice.
+//
+// Two Shopify-compat polishes:
+//
+//   1. `truncate: N, "…"` — second arg overrides the default "..."
+//      ellipsis. 1-arg `truncate:"N"` keeps its existing behaviour.
+//
+//   2. `default: VAL, allow_false: BOOL` — when allow_false is true,
+//      the fallback fires on `""`, `"false"`, `"nil"`, `"null"` (the
+//      Liquid falsy set for string-encoded values). Without
+//      allow_false it fires only on `""`.
+//
+// Cases:
+//   1.  truncate:"10" with default ellipsis (existing behaviour)
+//   2.  truncate:"10","…" with custom unicode ellipsis
+//   3.  truncate:"5","-" — short string, custom 1-char ellipsis
+//   4.  truncate:"3","..." — cap equal to ellipsis length: ellipsis
+//       itself is cut (no body)
+//   5.  truncate:"4","..." — cap one larger than ellipsis: one body
+//       char then ellipsis
+//   6.  truncate:"10","" — empty ellipsis = plain hard cut
+//   7.  default:"alt" with empty value — fallback fires (existing)
+//   8.  default:"alt" with "false" — fallback does NOT fire (no
+//       allow_false; "false" is a non-empty string)
+//   9.  default:"alt", allow_false:"true" with "false" — fallback fires
+//   10. default:"alt", allow_false:"true" with "nil" — fallback fires
+//   11. default:"alt", allow_false:"true" with "null" — fallback fires
+//   12. default:"alt", allow_false:"true" with "real" — fallback does
+//       NOT fire (real value)
+//   13. default:"alt", allow_false:"false" with "false" — fallback
+//       does NOT fire (allow_false explicitly off)
+//   14. default:"alt" with bare `allow_false:"true"` syntax (the
+//       `allow_false:` prefix is recognised, not required to be a
+//       separate quoted arg)
+
+import contrib.templating.liquid
+import std.string
+
+extern exit(code: int)
+
+expect_eq(actual: string, want: string, label: string) {
+    if string.equals(actual, want) != 1 {
+        println("FAIL ${label}: got '${actual}' want '${want}'")
+        exit(1)
+    }
+    println("PASS ${label}: '${actual}'")
+}
+
+render_with_name(src: string, key: string, val: string) -> string {
+    t, _ = liquid.parse_string(src)
+    ctx = liquid.context_new()
+    liquid.context_put_string(ctx, key, val)
+    out, _ = liquid.render(t, ctx)
+    return out
+}
+
+main() {
+    // (1) truncate default ellipsis.
+    expect_eq(render_with_name("{{ s | truncate:\"10\" }}", "s", "abcdefghijklmnop"),
+              "abcdefg...", "1 truncate default ellipsis")
+
+    // (2) Custom unicode ellipsis (3-byte UTF-8 char "…").
+    // cap=10 bytes, ellipsis="…" (3 bytes) → 7 body bytes + "…" = 10 bytes.
+    expect_eq(render_with_name("{{ s | truncate:\"10\",\"…\" }}", "s", "abcdefghijklmnop"),
+              "abcdefg…", "2 truncate unicode ellipsis")
+
+    // (3) Short string, custom 1-char ellipsis.
+    // "abcdefghij" length 10 > cap 5; ellipsis 1 byte → 4 body + "-" = 5.
+    expect_eq(render_with_name("{{ s | truncate:\"5\",\"-\" }}", "s", "abcdefghij"),
+              "abcd-", "3 truncate custom 1-char ellipsis")
+
+    // (4) cap equals ellipsis length → ellipsis cut.
+    // cap=3, ellipsis="...", so cap <= eln → substring(s, 0, 3).
+    expect_eq(render_with_name("{{ s | truncate:\"3\",\"...\" }}", "s", "abcdefghij"),
+              "abc", "4 cap equals ellipsis length")
+
+    // (5) cap one larger than ellipsis length.
+    // cap=4, ellipsis="...", so body=cap-eln=1, returns "a..."
+    expect_eq(render_with_name("{{ s | truncate:\"4\",\"...\" }}", "s", "abcdefghij"),
+              "a...", "5 cap one bigger than ellipsis")
+
+    // (6) Empty ellipsis = plain hard cut.
+    expect_eq(render_with_name("{{ s | truncate:\"7\",\"\" }}", "s", "abcdefghij"),
+              "abcdefg", "6 empty ellipsis hard cut")
+
+    // (7) default:"alt" with empty value.
+    expect_eq(render_with_name("{{ s | default:\"alt\" }}", "s", ""),
+              "alt", "7 default fires on empty")
+
+    // (8) default:"alt" with "false" string — does NOT fire (no allow_false).
+    expect_eq(render_with_name("{{ s | default:\"alt\" }}", "s", "false"),
+              "false", "8 default skips false without allow_false")
+
+    // (9) default:"alt", allow_false:"true" with "false" — fires.
+    expect_eq(render_with_name("{{ s | default:\"alt\",\"true\" }}", "s", "false"),
+              "alt", "9a default fires on false with allow_false")
+    // Same with explicit allow_false: prefix.
+    expect_eq(render_with_name("{{ s | default:\"alt\",allow_false:\"true\" }}", "s", "false"),
+              "alt", "9b default fires on false with allow_false: prefix")
+
+    // (10) allow_false with "nil".
+    expect_eq(render_with_name("{{ s | default:\"alt\",\"true\" }}", "s", "nil"),
+              "alt", "10 default fires on nil with allow_false")
+
+    // (11) allow_false with "null".
+    expect_eq(render_with_name("{{ s | default:\"alt\",\"true\" }}", "s", "null"),
+              "alt", "11 default fires on null with allow_false")
+
+    // (12) allow_false with real value — does NOT fire.
+    expect_eq(render_with_name("{{ s | default:\"alt\",\"true\" }}", "s", "real"),
+              "real", "12 default skips real value with allow_false")
+
+    // (13) allow_false explicitly off — "false" passes through.
+    expect_eq(render_with_name("{{ s | default:\"alt\",\"false\" }}", "s", "false"),
+              "false", "13 default skips false with allow_false=false")
+
+    // (14) `allow_false:"true"` long-form recognised (same as case 9b).
+    expect_eq(render_with_name("{{ s | default:\"alt\",allow_false:\"true\" }}", "s", "nil"),
+              "alt", "14 allow_false: prefix recognised")
+
+    println("All PASS")
+}

--- a/tests/integration/liquid_filter_polish/test_liquid_filter_polish.sh
+++ b/tests/integration/liquid_filter_polish/test_liquid_filter_polish.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# contrib.templating.liquid — filter polish: truncate custom ellipsis
+# + default with allow_false.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+OUT="$(AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/probe.ae" 2>&1)"
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "  [FAIL] liquid_filter_polish (exit $RC):"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+if ! echo "$OUT" | grep -q "All PASS"; then
+    echo "  [FAIL] liquid_filter_polish — no 'All PASS' line:"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+
+echo "  [PASS] liquid_filter_polish: 15/15"


### PR DESCRIPTION
## Summary

Tight polish tranche — three small slices that round out the docs +
filter set without needing the Phase 2 value-model work:

1. **`truncate: N, "ellipsis"`** — second arg overrides the default
   `"..."` ellipsis. Shopify-compat. Empty-string ellipsis = hard cut.
2. **`default: VAL, allow_false:"true"`** — widens the fallback set
   to `{"", "false", "nil", "null"}` per Shopify. Without
   `allow_false`, fires only on the empty string (existing).
3. **`contrib/templating/liquid/README.md`** — first user-facing doc.
   Install, supported tags / filters / typed bindings / layouts,
   public surface, sandbox story, what's NOT supported, performance
   notes. Closes the "is this ready for downstream" gap.
4. **`LLM.md`** — one-liner: "Operator-supplied Liquid templates →
   `contrib.templating.liquid`. Don't hand-roll Mustache."

15 new integration tests in `tests/integration/liquid_filter_polish/`
cover the truncate and default polishes including boundary cases
(cap == ellipsis length, cap == ellipsis length + 1, empty ellipsis
as hard cut, allow_false explicitly off, keyword-prefix form).

## What changed

- `contrib/templating/liquid/module.ae`:
  - `filter_truncate(s, cap, ell)` — signature widened to take the
    ellipsis string (was hard-coded `"..."`)
  - `truncate` filter dispatcher accepts 1- or 2-arg invocation
  - `default` filter dispatcher accepts 1- or 2-arg invocation;
    recognises both `default:"alt","true"` and
    `default:"alt",allow_false:"true"` forms; applies the widened
    falsy set `{"", "false", "nil", "null"}` only when allow_false
    is explicitly true
- `contrib/templating/liquid/README.md` — new (245 lines)
- `tests/integration/liquid_filter_polish/` — new (15 tests)
- `CHANGELOG.md`, `TODO.md`, `LLM.md` — updated

## Test plan

- [x] Local: `liquid_filter_polish`: 15/15
- [x] Full Liquid suite: 312/312 across 22 directories
- [x] `make ci`: 622 passed, 3 failed — all HTTP/2 networking flakes
      (`http_h2_concurrent_dispatch`, `http_reverse_proxy_pool`,
      `http_server_h2`); zero Liquid failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)