### PR TITLE
feat(contrib.templating.liquid): sandbox gate verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,73 @@ next version number before tagging the release.
   Mustache." 15 new integration tests in `liquid_filter_polish/`
   bring the Liquid suite to **312 across 22 directories**.
 
+## [0.224.0]
+
+This entry is backfilled — the release pipeline tagged 0.224.0
+against an empty `[current]` section, so the substantive work
+landed via PR #648 had no CHANGELOG entry at the time. Reconstructed
+from the commit messages of `perf/windows-ci-and-leak-tail`.
+
+### Fixed
+
+- **`std.collections.string_list` owns copies of its elements** (#622
+  follow-up; `std/collections/aether_stringlist.c`,
+  `std/collections/module.ae`). Previously the list stored the caller's
+  raw pointer with `string_retain` / `string_release` for lifetime —
+  but those are no-ops on a non-magic `char*`, so every plain-`char*`
+  element (a `string.concat` / `split` result) was never reclaimed:
+  the list couldn't free it and the caller's free was suppressed by
+  the `@retain` annotation. The list now owns an independent
+  NUL-terminated copy of each element (`sl_dup_item`, caps-accounted)
+  and frees its own copies on `string_list_free`.
+
+- **`std.fs` / `std.io` / `std.os` owned-heap string returns now
+  classified for auto-free** (`compiler/codegen/codegen_stmt.c`).
+  `@heap` only parses on tuple positions, so these single-value
+  `-> string` externs were missing from the by-name heap classifier
+  and the caller never freed the result. Added: `path_clean`,
+  `path_rel`, `io_read_file_raw`, `file_read_all_raw`, `os_exec_raw`,
+  `os_run_capture_raw`. Leak counts went 10→0 (lexical paths),
+  5→0 (file io), 4→0 (fs_move/copy), 3→0 (atomic rename).
+
+- **`std.ulid` / `std.ksuid` scratch buffer leaks** (`std/ulid/module.ae`,
+  `std/ksuid/module.ae`). The id generators allocated intermediate
+  `bytes` buffers that were only read from (never handed to
+  `bytes.finish`) and so were never reclaimed — a leak per generated
+  id. Both now `bytes.free()` their intermediates. Test leaks 6→0.
+
+- **`test_string_seq_combinators` leak tail** (`tests/regression/
+  test_string_seq_combinators.ae`). Test created seqs that weren't
+  freed and passed `split_to_seq` results inline to `seq_concat` with
+  no owning local to reclaim. Added explicit frees and captured the
+  inline operands. 67→32 leaks; residual 32 are the
+  StringBuilder-finish ownership-through-wrapper-chain gap, under
+  investigation. Also classified `aether_strbuilder_finish` as
+  heap-returning. Rewrote a recursive `string.concat` accumulator
+  as an iterative `std.strbuilder` join (amortised-O(1)).
+
+- **`test_string_format` arg-list leaks** (`tests/regression/
+  test_string_format.ae`). Format-args `std.list` instances `a1..a5`
+  were never freed. Added `list_free` for each. 13→2 leaks; residual
+  2 are a `from_int` value stored into a generic borrowing
+  `std.list` (escape analysis clears its heap flag at the `list_add`
+  sink) — the borrowed-container-holds-a-heap-value class, tracked
+  with the other container-ownership items.
+
+### Changed
+
+- **Windows CI tuning** (`.github/workflows/ci.yml`). Reverted an
+  oversubscription attempt that made the Windows job slower (NPROC=8
+  thrashed the 4-vCPU runner's RAM during the heavy
+  openssl/nghttp2/zlib/pcre2 statically-linked builds — one link
+  ballooned to ~11 min). Use the runner default (nproc=4) and raise
+  the timeout backstop to 45 min (above the natural ~32-36 min
+  runtime, fires only on a real hang). Kept the Defender real-time
+  scan exclusion. Root cause for remaining slowness: `ae build`
+  links the full TLS/HTTP stack into every test exe unconditionally;
+  cutting that needs conditional per-test linking or `lld`, tracked
+  as a follow-up.
+
 ## [0.223.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,28 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.225.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **`contrib.templating.liquid` — sandbox gate verification**
+  (`tests/integration/liquid_sandbox_gate/`,
+  `contrib/templating/liquid/README.md` correction). Pure shell-driver
+  test that asserts the `--emit=lib` capability gate covers the
+  Liquid module transitively. Cases: (1) `--emit=lib` without
+  `--with=fs` rejects `import contrib.templating.liquid` with the
+  standard capability-empty error (because the module imports
+  `std.fs` for `{% include %}` / `parse_file`); (2) `--emit=lib
+  --with=fs` accepts the import; (3) direct `import std.fs` without
+  `--with=fs` still rejected (control); (4) `--emit=exe` (default)
+  accepts the import — only `--emit=lib` applies the gate. The
+  Liquid README earlier claimed the gate was "not yet wired up";
+  this PR's investigation showed the gate IS transitive and works
+  correctly, so the README is corrected and pinned with a test.
 
 ## [0.225.0]
 

--- a/TODO.md
+++ b/TODO.md
@@ -272,10 +272,19 @@ World-touching (gated):
 - [ ] Recursion limit (Liquid caps at depth 100 — match that)
 - [ ] Cache parsed partials by absolute path so a partial used N times
       is parsed once
-- [ ] **Gate via `--with=fs` when --emit=lib** — sandbox story: the
-      contrib module imports `std.fs`, so a `--emit=lib` user without
-      `--with=fs` cannot use the include path. `parse_string` /
-      programmatic API stays available without `--with=fs`.
+- [x] **Gate via `--with=fs` when --emit=lib** — verified working
+      transitively (the import gate walks `program->children` after
+      module-merging, so `import contrib.templating.liquid` surfaces
+      the transitive `import std.fs` and the gate fires). Covered by
+      `liquid_sandbox_gate/`. NOTE: this is stricter than the original
+      TODO sketch — `parse_string` / programmatic API is NOT available
+      without `--with=fs` under `--emit=lib` because the module-level
+      `import std.fs` trips the gate regardless of which symbols the
+      consumer actually uses. To relax (e.g. allow `parse_string`-only
+      consumers without fs), the module would need to be split into
+      `contrib.templating.liquid.core` (no fs) and
+      `contrib.templating.liquid.fs` (includes/parse_file). Defer
+      until a downstream user asks.
 
 **5. Layouts** (`{% extends 'parent' %}` + `{% block name %}...{% endblock %}`):
 
@@ -446,10 +455,10 @@ case (no `--with=fs` → engine errors clearly):
 - [ ] `{% extends 'base' %}` + `{% block %}` — child overrides parent
 - [ ] Chain: child → middle → base
 - [ ] Missing parent → error
-- [ ] No `--with=fs` under `--emit=lib` → import gate rejects the
-      contrib module (this falls out of Aether's existing
-      capability-gate machinery; add the test that asserts the error
-      message points at the right opt-in)
+- [x] No `--with=fs` under `--emit=lib` → import gate rejects the
+      contrib module — landed in `liquid_sandbox_gate/` (4 cells:
+      `--emit=lib` reject without `--with=fs`, accept with `--with=fs`,
+      direct `import std.fs` reject control, `--emit=exe` accept).
 
 **Layer 8 — error reporting:**
 

--- a/contrib/templating/liquid/README.md
+++ b/contrib/templating/liquid/README.md
@@ -190,10 +190,14 @@ an explicit root directory; partials resolved against that root are
 checked with `std.fs.is_within_base` so an attacker-supplied filename
 like `'../../etc/passwd'` is rejected.
 
-The `--with=fs` capability gate for `--emit=lib` is not yet wired up
-(see `TODO.md`). For now, treat the renderer as "safe-by-default for
-`{{ … }}` and `{% if %}` / `{% for %}` etc., but `{% include %}`
-requires explicit caller opt-in via the include root."
+Under `--emit=lib`, `import contrib.templating.liquid` requires
+`--with=fs` — the module transitively imports `std.fs`, and Aether's
+import gate refuses the transitive dependency without explicit
+opt-in. So a host that links your `.so` and embeds Liquid renders
+is making an explicit acknowledgement that its filesystem surface
+is in scope. Without `--with=fs`, the build fails with the standard
+capability-empty error. Verified by
+`tests/integration/liquid_sandbox_gate/`.
 
 ## What's NOT supported
 

--- a/tests/integration/liquid_sandbox_gate/test_liquid_sandbox_gate.sh
+++ b/tests/integration/liquid_sandbox_gate/test_liquid_sandbox_gate.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Verifies the --emit=lib + --with=fs sandbox story documented in
+# contrib/templating/liquid/README.md.
+#
+# `import contrib.templating.liquid` pulls in `std.fs` transitively
+# (for {% include %} / {% render %} / parse_file). Under --emit=lib
+# without --with=fs, the import gate must reject this transitively.
+# With --with=fs, the import must succeed.
+#
+# Cases:
+#   1.  --emit=lib (no --with) rejects with the capability-empty error
+#   2.  --emit=lib --with=fs accepts the import
+#   3.  Direct `import std.fs` (without contrib.templating.liquid)
+#       under --emit=lib without --with=fs still rejected — control
+#       that confirms the gate is doing its job
+#   4.  --emit=exe (the default) accepts the import — only --emit=lib
+#       gates apply
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP] liquid_sandbox_gate on Windows"; exit 0 ;;
+esac
+
+TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
+pass=0; fail=0
+
+# The probe program just imports the module and defines a no-op
+# function so the compiler has something to emit. We're not exercising
+# render — we're exercising the gate.
+cat > "$TMPDIR/probe.ae" <<'EOF'
+import contrib.templating.liquid
+
+aether_noop(x: int) -> int { return x }
+EOF
+
+# Case 1: --emit=lib without --with=fs must reject.
+if AETHER_HOME="$ROOT" "$ROOT/build/aetherc" --emit=lib "$TMPDIR/probe.ae" "$TMPDIR/probe.c" >"$TMPDIR/stdout" 2>"$TMPDIR/stderr"; then
+    echo "  [FAIL] 1: --emit=lib accepted contrib.templating.liquid without --with=fs"
+    fail=$((fail + 1))
+elif grep -q "capability-empty" "$TMPDIR/stderr"; then
+    echo "  [PASS] 1: --emit=lib rejected contrib.templating.liquid without --with=fs"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] 1: rejected but message did not contain 'capability-empty'"
+    cat "$TMPDIR/stderr"
+    fail=$((fail + 1))
+fi
+
+# Case 2: --emit=lib --with=fs must accept.
+if AETHER_HOME="$ROOT" "$ROOT/build/aetherc" --emit=lib --with=fs "$TMPDIR/probe.ae" "$TMPDIR/probe.c" >"$TMPDIR/stdout" 2>"$TMPDIR/stderr"; then
+    echo "  [PASS] 2: --emit=lib --with=fs accepted contrib.templating.liquid"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] 2: --emit=lib --with=fs rejected — expected success"
+    cat "$TMPDIR/stderr"
+    fail=$((fail + 1))
+fi
+
+# Case 3: control — direct `import std.fs` still rejected without --with=fs.
+cat > "$TMPDIR/direct.ae" <<'EOF'
+import std.fs
+
+aether_noop(x: int) -> int { return x }
+EOF
+
+if AETHER_HOME="$ROOT" "$ROOT/build/aetherc" --emit=lib "$TMPDIR/direct.ae" "$TMPDIR/direct.c" >"$TMPDIR/stdout" 2>"$TMPDIR/stderr"; then
+    echo "  [FAIL] 3 control: direct import std.fs accepted without --with=fs"
+    fail=$((fail + 1))
+elif grep -q "capability-empty" "$TMPDIR/stderr"; then
+    echo "  [PASS] 3 control: direct import std.fs rejected (gate working)"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] 3 control: rejected but wrong message"
+    cat "$TMPDIR/stderr"
+    fail=$((fail + 1))
+fi
+
+# Case 4: --emit=exe (default) accepts contrib.templating.liquid even
+# without --with=fs — gates only apply in lib mode. We need a `main`
+# for emit=exe.
+cat > "$TMPDIR/exe.ae" <<'EOF'
+import contrib.templating.liquid
+
+main() {
+    ctx = liquid.context_new()
+    liquid.context_free(ctx)
+}
+EOF
+
+if AETHER_HOME="$ROOT" "$ROOT/build/aetherc" "$TMPDIR/exe.ae" "$TMPDIR/exe.c" >"$TMPDIR/stdout" 2>"$TMPDIR/stderr"; then
+    echo "  [PASS] 4: --emit=exe accepted contrib.templating.liquid without --with=fs"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] 4: --emit=exe rejected — expected success"
+    cat "$TMPDIR/stderr"
+    fail=$((fail + 1))
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+    echo "  [PASS] liquid_sandbox_gate: $pass/4"
+    exit 0
+else
+    echo "  [FAIL] liquid_sandbox_gate: $pass passed, $fail failed"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Pins down the `--emit=lib` + `--with=fs` sandbox story documented
in `contrib/templating/liquid/README.md` with a 4-case shell-driver
integration test. Also corrects the README which had claimed the
gate was "not yet wired up" — the gate IS transitive and works
correctly.

**Stacked on PR #657** (filter polish + README). The base is the
polish branch, not main. Once #657 merges, GitHub should
auto-retarget this PR's base to `main`.

## What's tested

`tests/integration/liquid_sandbox_gate/` (no `.ae` files — pure
shell driver invoking `aetherc` directly):

1. `--emit=lib` without `--with=fs` → **rejects** `import
   contrib.templating.liquid` with the standard `"capability-empty"`
   error. The Liquid module transitively imports `std.fs`; Aether's
   import gate walks `program->children` after module-merging and
   surfaces the transitive dep.
2. `--emit=lib --with=fs` → **accepts** the import.
3. Control: direct `import std.fs` without `--with=fs` still
   rejected. Confirms the gate is functioning.
4. `--emit=exe` (default) → accepts the import. Gates only apply
   in lib mode.

## README correction

The earlier README claimed: *"The `--with=fs` capability gate for
`--emit=lib` is not yet wired up (see TODO.md)."* That was wrong —
the gate IS wired up transitively. Reworded to describe the actual
behaviour and pinned by the new test.

## TODO note

The gate is **module-level**, not symbol-level: importing
`contrib.templating.liquid` under `--emit=lib` requires `--with=fs`
even for `parse_string`-only consumers who never use
`{% include %}` / `parse_file`. To relax, the module would need to
be split into `contrib.templating.liquid.core` (no fs) and
`contrib.templating.liquid.fs` (includes/parse_file). Deferred
until a downstream user asks.

## Test plan

- [x] `tests/integration/liquid_sandbox_gate/`: 4/4 cells pass
- [x] Full Liquid suite: 316/316 across 23 directories
- [x] `make ci`: 623 passed, 3 failed — all HTTP/2 networking
      flakes (pre-existing); zero Liquid failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)