### PR TITLE
feat(aetherc): --emit=ast for aeb's supply-chain veto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,50 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.226.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **`aetherc --emit=ast` — post-typecheck AST as JSON for aeb's
+  supply-chain veto** (`compiler/aetherc.c`,
+  `tests/integration/aetherc_emit_ast/`). A third post-typecheck
+  walker beside `--list-functions` and `--diagnose=ownership`,
+  emitting the program's AST in a small filter set
+  (`import_statement`, `extern_function`, `function_call`) as
+  stable JSON on stdout. The compiler holds zero veto policy; it
+  just hands aeb the AST it already built. aeb's `lib/veto`
+  consumes this and applies operator-owned deny rules
+  (`deny extern` / `deny exec` / `deny net` / `deny import`)
+  against an operator policy `.ae`. Designed in
+  `veto-enhancements.md` (cross-repo note from the aeb-side
+  Claude), greenlit in `veto-enhancements-reply2.md`.
+
+  Per-node fields: `kind`, `file` (source-of-origin, NULL for
+  compiler-synthesised nodes), `line`. For
+  `function_call`: `callee` is the resolved binding (post-merge,
+  post-alias-resolution canonicalisation) — `import std.os` plus
+  `os.system(...)` emits `callee: "os_system"`, defeating the
+  alias-spelling tricks a regex would miss. Indirect calls
+  (function-pointer dispatch, no static target) emit
+  `indirect: true` instead of `callee`; aeb fail-closes on those.
+  For `extern_function`: `name` plus `variadic: true` flag on
+  varargs externs. For `import_statement`: `module` path, plus
+  `alias` (for `import X as Y`), `selected[]` (for `import X (a,
+  b)`), `glob: true` (for `import X (*)`).
+
+  Exit codes are conventional: 0 = AST emitted OK, non-zero =
+  parse / typecheck / IO failure. aeb's `--vet` treats non-zero
+  as fail-closed (no AST ⇒ no veto-clearance ⇒ no build).
+
+  20 cells in `tests/integration/aetherc_emit_ast/` cover the
+  qualified-call canonicalisation case, selective imports
+  (`selected[]` + bare-call canonicalisation), glob imports,
+  variadic extern flag, per-node file/line, and the fail-closed
+  exit on parse and typecheck errors.
 
 ## [0.226.0]
 

--- a/compiler/aetherc.c
+++ b/compiler/aetherc.c
@@ -110,6 +110,28 @@ static bool list_functions_mode = false;
 // can unmask.
 static bool diagnose_ownership_mode = false;
 
+// --emit=ast: post-typecheck AST emit as JSON to stdout. A third walker
+// beside --list-functions and --diagnose=ownership, runs at the same
+// post-typecheck / pre-codegen point so node->value carries the
+// resolved (namespace-prefixed) binding rather than the as-written
+// spelling (`os.system` → `os_system`, alias-rewrites resolved).
+//
+// Consumer use case: aeb's supply-chain veto walks the emitted JSON
+// to apply operator-owned deny rules (`deny extern`, `deny exec`,
+// `deny net`, `deny import`). The compiler itself contains zero
+// veto policy — that lives in aeb. See aeb's lib/veto and
+// veto-enhancements.md (cross-repo design note).
+//
+// Filter set (intentionally small, additive later):
+//   - import_statement   (module, alias, selected[], glob)
+//   - extern_function    (name, variadic)
+//   - function_call      (callee resolved post-merge, or indirect:true)
+//
+// Exit codes are conventional (no inversion): 0 = emitted OK,
+// non-zero = parse/typecheck/IO failure. See the post-typecheck
+// short-circuit further down for the explicit return-0 path.
+static bool emit_ast_mode = false;
+
 #ifdef _WIN32
     #include <windows.h>
     #include <io.h>
@@ -387,6 +409,278 @@ static void emit_function_list(FILE* out, ASTNode* program) {
             param_count++;
         }
         fputc('\n', out);
+    }
+}
+
+// Helper: write a JSON-escaped string literal (including the surrounding
+// quotes) for an arbitrary C string. NULL is emitted as a JSON null
+// literal (no quotes). Used by emit_ast_json — the strings we surface
+// (file paths, identifier names) are 7-bit printable in practice, but
+// handle the general case so a future caller passing weird input
+// doesn't break the schema.
+static void emit_json_string(FILE* out, const char* s) {
+    if (!s) {
+        fputs("null", out);
+        return;
+    }
+    fputc('"', out);
+    for (const char* p = s; *p; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (c == '"') fputs("\\\"", out);
+        else if (c == '\\') fputs("\\\\", out);
+        else if (c == '\n') fputs("\\n", out);
+        else if (c == '\r') fputs("\\r", out);
+        else if (c == '\t') fputs("\\t", out);
+        else if (c < 0x20) fprintf(out, "\\u%04x", c);
+        else fputc((int)c, out);
+    }
+    fputc('"', out);
+}
+
+// Walk one AST node, emit a JSON object on stdout if it falls in the
+// veto filter set, then recurse into children. The `first` flag tracks
+// whether the next emitted object needs a leading comma — passed by
+// pointer so siblings + descendants share the comma cursor.
+//
+// `alias_map` / `alias_count` carry the program's import aliases
+// (`import std.os as o` → "o" → "std.os") so qualified call sites
+// can be canonicalised at emit time. See `resolve_callee_name`.
+typedef struct { const char* alias; const char* module; } EmitAlias;
+static void emit_ast_node_recursive(FILE* out, ASTNode* node, int* first,
+                                     const EmitAlias* alias_map, int alias_count);
+
+// Given a parsed `prefix.suffix` callee spelling, return a malloc'd
+// resolved name `<module>_<suffix>` if `prefix` is a known module
+// alias, otherwise NULL. Caller must free.
+static char* resolve_callee_name(const char* callee,
+                                  const EmitAlias* alias_map, int alias_count) {
+    if (!callee) return NULL;
+    const char* dot = strchr(callee, '.');
+    if (!dot) return NULL;
+
+    size_t prefix_len = (size_t)(dot - callee);
+    char prefix_buf[128];
+    if (prefix_len >= sizeof(prefix_buf)) return NULL;
+    memcpy(prefix_buf, callee, prefix_len);
+    prefix_buf[prefix_len] = '\0';
+    const char* suffix = dot + 1;
+
+    // Try the alias map first (`import X as Y` rewrites Y → X).
+    const char* module = NULL;
+    for (int i = 0; i < alias_count; i++) {
+        if (strcmp(alias_map[i].alias, prefix_buf) == 0) {
+            module = alias_map[i].module;
+            break;
+        }
+    }
+    // If no alias, the prefix IS the module name (`import std.os`
+    // gives `os.system(...)` where prefix=`os` and the module path
+    // is `std.os`; the symbol's namespace is the last dotted
+    // component of the path, which for `std.os` is `os`). So the
+    // callee already canonicalises to `os_system` via prefix_<suffix>.
+    if (!module) module = prefix_buf;
+
+    // Module is dotted (`std.os`) — the symbol's namespace is the
+    // last segment after the final `.`. Match the rule used at
+    // typechecker.c:543: `snprintf(name, "%s_%s", prefix, suffix)`
+    // where prefix is the *short* namespace.
+    const char* short_ns = strrchr(module, '.');
+    short_ns = short_ns ? short_ns + 1 : module;
+
+    size_t out_len = strlen(short_ns) + 1 + strlen(suffix) + 1;
+    char* resolved = malloc(out_len);
+    if (!resolved) return NULL;
+    snprintf(resolved, out_len, "%s_%s", short_ns, suffix);
+    return resolved;
+}
+
+// Walk the program's top-level import statements and populate an
+// alias map. Caller owns the array; the const char* entries borrow
+// from AST nodes (don't free them).
+static int collect_import_aliases(ASTNode* program, EmitAlias* out, int max) {
+    if (!program) return 0;
+    int count = 0;
+    for (int i = 0; i < program->child_count && count < max; i++) {
+        ASTNode* imp = program->children[i];
+        if (!imp || imp->type != AST_IMPORT_STATEMENT || !imp->value) continue;
+        // Look for an AST_IDENTIFIER child with annotation == "module_alias".
+        for (int j = 0; j < imp->child_count; j++) {
+            ASTNode* c = imp->children[j];
+            if (!c || c->type != AST_IDENTIFIER || !c->value) continue;
+            if (c->annotation && strcmp(c->annotation, "module_alias") == 0) {
+                out[count].alias = c->value;
+                out[count].module = imp->value;
+                count++;
+                break;
+            }
+        }
+    }
+    return count;
+}
+
+// --emit=ast: write the post-typecheck AST as JSON to `out`. Emits
+// `{"nodes":[ {...}, {...}, ... ]}` with one object per node in the
+// filter set (import_statement, extern_function, function_call).
+// Other node kinds are walked through but not emitted — we recurse so
+// nested calls inside function bodies are reached.
+//
+// `node->value` on AST_FUNCTION_CALL carries the resolved binding
+// (post-merge, post-alias-resolution) — e.g. `os_system` for what the
+// user wrote as `o.system(...)` after `import std.os as o`. That's the
+// load-bearing field for aeb's veto: it defeats alias-spelling tricks
+// a regex would miss.
+static void emit_ast_json(FILE* out, ASTNode* program) {
+    if (!out || !program) return;
+    // Collect import aliases up-front so qualified call sites can be
+    // canonicalised — `o.system` post `import std.os as o` becomes
+    // `os_system` on the wire (which is what aeb's veto rules match
+    // against). Cap at 128 — pathological programs with more aliases
+    // get the tail dropped; aeb sees the as-written spelling for
+    // those and can decide.
+    EmitAlias aliases[128];
+    int alias_count = collect_import_aliases(program, aliases, 128);
+
+    fputs("{\"nodes\":[", out);
+    int first = 1;
+    emit_ast_node_recursive(out, program, &first, aliases, alias_count);
+    fputs("]}\n", out);
+}
+
+// Returns 1 if the call node's `value` looks like a function-pointer
+// indirect call rather than a static target. Today the parser emits
+// AST_FUNCTION_CALL with `value == NULL` for some indirect-call shapes
+// (the callee expression is the first child rather than baked into
+// value). aeb fail-closes on these per the design doc.
+static int call_is_indirect(ASTNode* call) {
+    if (!call) return 0;
+    if (!call->value || call->value[0] == '\0') return 1;
+    return 0;
+}
+
+static void emit_ast_node_recursive(FILE* out, ASTNode* node, int* first,
+                                     const EmitAlias* alias_map, int alias_count) {
+    if (!node) return;
+
+    int matched = 0;
+    if (node->type == AST_IMPORT_STATEMENT) matched = 1;
+    else if (node->type == AST_EXTERN_FUNCTION) matched = 1;
+    else if (node->type == AST_FUNCTION_CALL) matched = 1;
+
+    if (matched) {
+        if (!*first) fputc(',', out);
+        *first = 0;
+        fputc('{', out);
+
+        // kind
+        fputs("\"kind\":", out);
+        if (node->type == AST_IMPORT_STATEMENT) {
+            emit_json_string(out, "import_statement");
+        } else if (node->type == AST_EXTERN_FUNCTION) {
+            emit_json_string(out, "extern_function");
+        } else {
+            emit_json_string(out, "function_call");
+        }
+
+        // file (origin) — NULL for synthetic compiler-emitted nodes;
+        // aeb treats those as trusted-origin per veto-enhancements.md.
+        fputs(",\"file\":", out);
+        emit_json_string(out, node->source_file);
+
+        // line — 1-based, matches the user's editor.
+        fprintf(out, ",\"line\":%d", node->line);
+
+        if (node->type == AST_IMPORT_STATEMENT) {
+            // module — the import path (`std.os`).
+            fputs(",\"module\":", out);
+            emit_json_string(out, node->value);
+
+            // alias / selected[] / glob — inspect child AST_IDENTIFIER
+            // nodes. `import X as Y` carries one child with
+            // annotation="module_alias". Glob imports carry
+            // annotation="glob_import" on the *statement* (per
+            // aether_module.c:1488). Selective imports
+            // (`import X (a, b)`) carry one AST_IDENTIFIER per name,
+            // un-annotated.
+            int is_glob = (node->annotation
+                           && strcmp(node->annotation, "glob_import") == 0);
+            if (is_glob) {
+                fputs(",\"glob\":true", out);
+            }
+            const char* alias = NULL;
+            int sel_count = 0;
+            for (int i = 0; i < node->child_count; i++) {
+                ASTNode* c = node->children[i];
+                if (!c || c->type != AST_IDENTIFIER || !c->value) continue;
+                if (c->annotation
+                    && strcmp(c->annotation, "module_alias") == 0) {
+                    alias = c->value;
+                } else if (!is_glob) {
+                    sel_count++;
+                }
+            }
+            if (alias) {
+                fputs(",\"alias\":", out);
+                emit_json_string(out, alias);
+            }
+            if (sel_count > 0) {
+                fputs(",\"selected\":[", out);
+                int sel_first = 1;
+                for (int i = 0; i < node->child_count; i++) {
+                    ASTNode* c = node->children[i];
+                    if (!c || c->type != AST_IDENTIFIER || !c->value) continue;
+                    if (c->annotation
+                        && strcmp(c->annotation, "module_alias") == 0) continue;
+                    if (!sel_first) fputc(',', out);
+                    sel_first = 0;
+                    emit_json_string(out, c->value);
+                }
+                fputc(']', out);
+            }
+        } else if (node->type == AST_EXTERN_FUNCTION) {
+            // name — the extern's C symbol.
+            fputs(",\"name\":", out);
+            emit_json_string(out, node->value);
+
+            // variadic — parser stamps `annotation = "varargs"` on
+            // `extern foo(..., ...)` declarations (compiler/parser/
+            // parser.c, the `TOKEN_DOTDOTDOT` path).
+            if (node->annotation && strcmp(node->annotation, "varargs") == 0) {
+                fputs(",\"variadic\":true", out);
+            }
+        } else {
+            // AST_FUNCTION_CALL
+            if (call_is_indirect(node)) {
+                // No static target — aeb fail-closes on this per
+                // veto-enhancements.md (the design doc explicitly
+                // distinguishes "couldn't resolve" from "resolved
+                // to benign").
+                fputs(",\"indirect\":true", out);
+            } else {
+                // Canonicalise the callee. For qualified calls
+                // (`os.system`, `o.system`) the rewriter resolves
+                // the prefix against the program's import-alias
+                // map and produces the post-merge symbol
+                // (`os_system`) — defeating alias-spelling tricks
+                // a regex would miss. Bare-name calls
+                // (intra-module helpers, top-level user
+                // functions) flow through unchanged.
+                char* resolved = resolve_callee_name(node->value,
+                                                     alias_map, alias_count);
+                fputs(",\"callee\":", out);
+                emit_json_string(out, resolved ? resolved : node->value);
+                free(resolved);
+            }
+        }
+
+        fputc('}', out);
+    }
+
+    // Recurse into children regardless of whether this node matched —
+    // calls live inside function bodies, which themselves aren't
+    // emitted but contain the AST_FUNCTION_CALL nodes we care about.
+    for (int i = 0; i < node->child_count; i++) {
+        emit_ast_node_recursive(out, node->children[i], first,
+                                alias_map, alias_count);
     }
 }
 
@@ -757,6 +1051,28 @@ int compile_source(const char* input_path, const char* output_path) {
         for (int i = 0; i < token_count; i++) free_token(tokens[i]);
         free_parser(parser);
         free(source);
+        return 1;
+    }
+
+    // --emit=ast: write the post-typecheck, post-merge program AST as
+    // JSON to stdout (filter set: import_statement, extern_function,
+    // function_call). Conventional exit codes — return 0 here means
+    // process exit 0 ("AST emitted OK"); anything other than 0 means
+    // parse/typecheck/IO failure further up. aeb's supply-chain veto
+    // consumes this; the compiler holds no policy. See
+    // veto-enhancements.md.
+    if (emit_ast_mode) {
+        emit_ast_json(stdout, program);
+        module_registry_shutdown();
+        free_ast_node(program);
+        for (int i = 0; i < token_count; i++) free_token(tokens[i]);
+        free_parser(parser);
+        free(source);
+        // Return value here is `compile_source`'s internal "non-zero =
+        // success" convention; main() translates that to process
+        // exit 0 (see the --check / --dump-ast handlers at the bottom
+        // of main()). Externally observable: process exit 0 = AST
+        // emitted OK, non-zero = parse / typecheck / IO failure.
         return 1;
     }
 
@@ -1193,6 +1509,9 @@ void print_help(const char* program_name) {
     printf("  --no-contracts                   Skip runtime emission of `requires`/`ensures` checks (#348)\n");
     printf("  --dump-ast                       Print AST and exit (no code generation)\n");
     printf("  --diagnose=ownership             Print string-ownership verdicts and exit (no code generation)\n");
+    printf("  --emit=ast                       Print post-typecheck AST as JSON to stdout and exit (no code generation).\n");
+    printf("                                   Filter set: import_statement, extern_function, function_call.\n");
+    printf("                                   Used by aeb's supply-chain veto. Compiler holds no policy.\n");
     printf("  --help, -h                       Show this help message\n");
     printf("\n");
     printf("Examples:\n");
@@ -1307,8 +1626,16 @@ int main(int argc, char *argv[]) {
             } else if (strcmp(val, "both") == 0) {
                 emit_exe = true;
                 emit_lib = true;
+            } else if (strcmp(val, "ast") == 0) {
+                // --emit=ast: post-typecheck AST → JSON on stdout. A
+                // peer of --check / --dump-ast / --diagnose=ownership
+                // (no codegen, no output file). Distinct from
+                // --emit=exe / lib / both which control codegen
+                // targets — ast bypasses codegen entirely. See
+                // veto-enhancements.md for the design.
+                emit_ast_mode = true;
             } else {
-                fprintf(stderr, "Error: --emit must be one of: exe, lib, both (got '%s')\n", val);
+                fprintf(stderr, "Error: --emit must be one of: exe, lib, both, ast (got '%s')\n", val);
                 return 1;
             }
             arg_offset++;
@@ -1462,6 +1789,17 @@ int main(int argc, char *argv[]) {
 
     // --check: type-check only, no output file needed
     if (check_only_mode) {
+        if (!compile_source(argv[arg_offset], "/dev/null")) {
+            return 1;
+        }
+        return 0;
+    }
+
+    // --emit=ast: post-typecheck AST → JSON on stdout. Same input-only
+    // shape as --check / --dump-ast / --diagnose=ownership: the file
+    // is read but no .c is written; the short-circuit inside
+    // compile_source returns before codegen.
+    if (emit_ast_mode) {
         if (!compile_source(argv[arg_offset], "/dev/null")) {
             return 1;
         }

--- a/tests/integration/aetherc_emit_ast/test_aetherc_emit_ast.sh
+++ b/tests/integration/aetherc_emit_ast/test_aetherc_emit_ast.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# Verifies aetherc --emit=ast emits a stable, parseable JSON
+# representation of the post-typecheck program AST for aeb's
+# supply-chain veto. See veto-enhancements.md / .reply.md /
+# .reply2.md for the cross-repo design.
+#
+# Cells:
+#   1.  Qualified call (`import std.os` + `os.system(...)`) — callee
+#       canonicalises to `os_system`. Defeats the regex case.
+#   2.  Selective import (`import std.os (system)` + bare `system(...)`)
+#       — selected[] list present, callee canonicalises via the merger.
+#   3.  Bare `extern` declaration — surfaced as
+#       extern_function with name + variadic flag.
+#   4.  Variadic extern — variadic:true flag present.
+#   5.  Glob import (`import std.os (*)`) — glob:true flag present.
+#   6.  Per-node file + line populated.
+#   7.  Parse failure → non-zero exit (aeb fail-closes on this).
+#   8.  Typecheck failure → non-zero exit (ditto).
+#   9.  Empty file → exit 0, empty nodes array.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AETHERC="$ROOT/build/aetherc"
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP] aetherc_emit_ast on Windows"; exit 0 ;;
+esac
+
+TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
+pass=0; fail=0
+
+assert_contains() {
+    label="$1"; needle="$2"; haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "  [PASS] $label"
+        pass=$((pass + 1))
+    else
+        echo "  [FAIL] $label — '$needle' not in output:"
+        echo "$haystack" | sed 's/^/      /'
+        fail=$((fail + 1))
+    fi
+}
+
+assert_not_contains() {
+    label="$1"; needle="$2"; haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "  [FAIL] $label — '$needle' unexpectedly present:"
+        echo "$haystack" | sed 's/^/      /'
+        fail=$((fail + 1))
+    else
+        echo "  [PASS] $label"
+        pass=$((pass + 1))
+    fi
+}
+
+# Cell 1: qualified call canonicalisation.
+cat > "$TMPDIR/qualified.ae" <<'EOF'
+import std.os
+
+main() {
+    rc = os.system("echo hi")
+}
+EOF
+out1="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/qualified.ae" 2>/dev/null)"
+rc1=$?
+[ "$rc1" -eq 0 ] && { echo "  [PASS] 1a exit 0"; pass=$((pass+1)); } || { echo "  [FAIL] 1a exit nonzero"; fail=$((fail+1)); }
+assert_contains "1b callee canonicalises to os_system" '"callee":"os_system"' "$out1"
+assert_contains "1c module is std.os" '"module":"std.os"' "$out1"
+
+# Cell 2: selective import.
+cat > "$TMPDIR/selective.ae" <<'EOF'
+import std.os (system)
+
+main() {
+    rc = system("echo hi")
+}
+EOF
+out2="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/selective.ae" 2>/dev/null)"
+rc2=$?
+[ "$rc2" -eq 0 ] && { echo "  [PASS] 2a exit 0"; pass=$((pass+1)); } || { echo "  [FAIL] 2a exit nonzero"; fail=$((fail+1)); }
+assert_contains "2b selected list emitted" '"selected":["system"]' "$out2"
+assert_contains "2c bare call canonicalises to os_system" '"callee":"os_system"' "$out2"
+
+# Cell 3: bare extern.
+cat > "$TMPDIR/bare_extern.ae" <<'EOF'
+extern syscall(n: int) -> int
+
+main() {
+    rc = syscall(0)
+}
+EOF
+out3="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/bare_extern.ae" 2>/dev/null)"
+rc3=$?
+[ "$rc3" -eq 0 ] && { echo "  [PASS] 3a exit 0"; pass=$((pass+1)); } || { echo "  [FAIL] 3a exit nonzero"; fail=$((fail+1)); }
+assert_contains "3b extern_function emitted" '"kind":"extern_function"' "$out3"
+assert_contains "3c extern name is syscall" '"name":"syscall"' "$out3"
+assert_not_contains "3d non-variadic extern has no variadic flag" '"variadic":true' "$out3"
+
+# Cell 4: variadic extern.
+cat > "$TMPDIR/variadic_extern.ae" <<'EOF'
+extern dprintf(fd: int, fmt: string, ...) -> int
+
+main() {
+    dprintf(1, "hi\n")
+}
+EOF
+out4="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/variadic_extern.ae" 2>/dev/null)"
+rc4=$?
+[ "$rc4" -eq 0 ] && { echo "  [PASS] 4a exit 0"; pass=$((pass+1)); } || { echo "  [FAIL] 4a exit nonzero"; fail=$((fail+1)); }
+assert_contains "4b variadic flag present" '"variadic":true' "$out4"
+
+# Cell 5: glob import.
+cat > "$TMPDIR/glob_import.ae" <<'EOF'
+import std.os (*)
+
+main() {
+    rc = system("echo hi")
+}
+EOF
+out5="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/glob_import.ae" 2>/dev/null)"
+rc5=$?
+[ "$rc5" -eq 0 ] && { echo "  [PASS] 5a exit 0"; pass=$((pass+1)); } || { echo "  [FAIL] 5a exit nonzero"; fail=$((fail+1)); }
+assert_contains "5b glob flag present" '"glob":true' "$out5"
+
+# Cell 6: per-node file + line populated. Use the qualified probe.
+assert_contains "6a file field present" '"file":"' "$out1"
+assert_contains "6b line field present" '"line":' "$out1"
+
+# Cell 7: parse failure → non-zero exit.
+cat > "$TMPDIR/syntax_err.ae" <<'EOF'
+this is not valid aether code === ===
+EOF
+out7="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/syntax_err.ae" 2>/dev/null)"
+rc7=$?
+if [ "$rc7" -ne 0 ]; then
+    echo "  [PASS] 7 parse failure → non-zero exit ($rc7)"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] 7 parse failure but exit was 0"
+    fail=$((fail + 1))
+fi
+
+# Cell 8: typecheck failure → non-zero exit.
+cat > "$TMPDIR/typecheck_err.ae" <<'EOF'
+main() {
+    rc = nonexistent_function(0)
+}
+EOF
+out8="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/typecheck_err.ae" 2>/dev/null)"
+rc8=$?
+if [ "$rc8" -ne 0 ]; then
+    echo "  [PASS] 8 typecheck failure → non-zero exit ($rc8)"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] 8 typecheck failure but exit was 0"
+    fail=$((fail + 1))
+fi
+
+# Cell 9: empty (function-only) file → exit 0, nodes array contains only
+# the synthetic main bookkeeping (no imports, no externs, no user calls).
+cat > "$TMPDIR/empty.ae" <<'EOF'
+main() {
+}
+EOF
+out9="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/empty.ae" 2>/dev/null)"
+rc9=$?
+if [ "$rc9" -eq 0 ]; then
+    echo "  [PASS] 9a exit 0 on empty file"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] 9a exit was non-zero on empty file"
+    fail=$((fail + 1))
+fi
+assert_contains "9b output is a JSON object with nodes key" '"nodes":' "$out9"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+    echo "  [PASS] aetherc_emit_ast: $pass/$pass"
+    exit 0
+else
+    echo "  [FAIL] aetherc_emit_ast: $pass passed, $fail failed"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds **`aetherc --emit=ast <file.ae>`** — a third post-typecheck
walker beside `--list-functions` and `--diagnose=ownership`,
emitting the program AST as JSON on stdout for aeb's supply-chain
veto consumer.

**The compiler holds zero veto policy.** It just hands aeb the AST
it already built. aeb's `lib/veto` walks the JSON, applies
operator-owned deny rules against an operator policy `.ae`, and
emits the verdict on aeb's side. This PR is the *primitive*; the
policy layer lives entirely in aeb.

Designed in `veto-enhancements.md` (cross-repo note from the
aeb-side Claude). Greenlit by them in
`veto-enhancements-reply2.md`. Both notes were transient scratch
files for the cross-repo handshake and are not part of this PR.

## Schema

Top-level `{"nodes":[...]}`. Per-node fields:

```json
{"kind":"import_statement","file":"...","line":N,"module":"std.os","alias":"...","selected":["..."],"glob":true}
{"kind":"extern_function","file":"...","line":N,"name":"syscall","variadic":true}
{"kind":"function_call","file":"...","line":N,"callee":"os_system"}
{"kind":"function_call","file":"...","line":N,"indirect":true}
```

`alias` / `selected` / `glob` / `variadic` are only emitted when
applicable.

## Load-bearing property: resolved `callee`

The whole reason aeb wants the AST instead of grepping source:
`os.system(...)` after `import std.os` emits `callee: "os_system"`
(post-merge canonicalisation), not the as-written spelling. Same
canonicalisation also applies to selective imports
(`import std.os (system)` + bare `system(...)` → `os_system`),
which is what the existing module-merger does anyway.

Implementation: collect import aliases from the program's top-level
`AST_IMPORT_STATEMENT`s, then for each `AST_FUNCTION_CALL` with a
`prefix.suffix` value, rewrite the prefix to the short namespace
name and emit `<ns>_<suffix>` — matching `typechecker.c:543`'s
internal resolution rule.

## Exit codes

Conventional, no inversion games:

| Exit | Meaning | aeb's `--vet` action |
|---|---|---|
| `0` | AST emitted OK | walk + apply policy |
| non-`0` | parse / typecheck / IO failure | fail-closed (no AST ⇒ no build) |

## Test plan

`tests/integration/aetherc_emit_ast/` — 20 cells in a pure shell
driver (no `.ae` probes, so no `.ae`-test-harness involvement):

- Qualified call canonicalises to resolved callee
- Selective import: `selected[]` list + bare-call canonicalisation
- Bare extern: `name` + no spurious `variadic` flag
- Variadic extern: `variadic: true` flag
- Glob import: `glob: true` flag
- Per-node `file` + `line` populated
- Parse error → non-zero exit
- Typecheck error → non-zero exit
- Empty (function-only) file → exit 0 with `"nodes":` key

`make ci`: 624 passed, 3 failed — the 3 fails are the pre-existing
HTTP/2 networking flakes (`http_h2_concurrent_dispatch`,
`http_reverse_proxy_pool`, `http_server_h2`); zero failures
from this PR.

## Known limitations surfaced

Two pre-existing language limits that aeb should be aware of:

- **`import X as Y` doesn't typecheck for qualified calls today.**
  The parser stamps `module_alias` on the alias node, but the
  typechecker doesn't fully route `Y.symbol(...)` through the
  alias map — calls error as "Undefined function 'Y.symbol'". My
  alias-rewriting code in `emit_ast.c` is wired and ready for when
  that lands; today aeb won't see aliased calls because the
  programs containing them don't typecheck.
- **Indirect calls via bare-name function-pointer locals don't
  typecheck either.** Aether requires typed function-pointer
  parameters or closure captures. The `indirect:true` schema
  branch is wired but only fires for closure-captured callees,
  not for `fn_ptr(x)` syntax.

Both are pre-existing, not regressions from this PR. Filed in
the commit body so aeb's policy can fail-closed on what *doesn't*
appear in the JSON rather than expecting it to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)