### PR TITLE
feat: ship contrib/tinyweb + emit literal call args in --emit=ast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,67 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.227.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **`contrib/tinyweb` ships with `make contrib` / `make
+  install-contrib`** (`Makefile`, `tests/scripts/contrib_build.sh`).
+  Tinyweb is a DSL-style HTTP server library (port of
+  [Tiny](https://github.com/phamm/tiny)) covering routing /
+  filters / WebSocket (RFC 6455 handshake) / SSE / static files /
+  cookies — see `contrib/tinyweb/README.md` for the surface. It was
+  always present in the repo but explicitly excluded from
+  `make install-contrib` (the `rm -rf .../contrib/tinyweb` trim) and
+  from the `contrib_build.sh` catalogue. Now wired up:
+  `probe_tinyweb` is a trivial always-succeed (libc only — SHA-1 +
+  base64 for the WebSocket-Accept handshake live in
+  `ws_handshake.c`); catalogue entry compiles that one .c into
+  `libaether_tinyweb.a`; install path mirrors `module.ae` +
+  `README.md` + `ws_client.ae` (client utility) into
+  `share/aether/contrib/tinyweb/`. `example_*.ae` and `test_*.ae`
+  are trimmed by the standard filter set (the latter now extended
+  to cover `.ae` test files, not just `.sh` drivers — tinyweb is
+  the only contrib module that ships `test_*.ae`).
+
+  Default `make contrib` (no `MODULES=` filter) now builds 9
+  modules instead of 8.
+
+- **`aetherc --emit=ast` carries literal call arguments**
+  (`compiler/aetherc.c`,
+  `tests/integration/aetherc_emit_ast/`). Follow-up to v0.226.0's
+  `--emit=ast` (aeb's supply-chain veto consumer asked for this in
+  `veto-emit-ast-args.md`). Two changes:
+  (a) The emit short-circuit now runs **after** `optimize_ast`
+  rather than before it, so const-foldable numeric args
+  (`do_stuff(1 + 2)` → `do_stuff(3)`) arrive as literals on the
+  wire. String-literal `+` concat isn't valid Aether (the parser
+  rejects it), so the practical impact today is numeric folds;
+  future fold passes for `string.concat(lit, lit)` would be
+  picked up automatically.
+  (b) Each `function_call` node now carries an `args[]` array:
+  one entry per positional/named arg in source order, with
+  `{"literal":"<value>"}` for primitive literals
+  (string/int/int64/float/bool — including `AST_NAMED_ARG`
+  unwrap to the value side) and `{"computed":true}` for
+  anything else (identifier refs, expressions, function calls,
+  interpolations). Trailing closures / DSL builder bodies are
+  filtered out — they're not args in the veto sense. The array
+  is always emitted (even empty) so aeb's policy walker can
+  rely on `obj["args"]` being a defined shape.
+
+  Per the design doc, aeb fail-closes on any `{"computed":true}`
+  arg regardless of contents; no expression-tree provenance is
+  surfaced — the literal-vs-not distinction is the entire
+  requirement, keeping `--emit=ast` from drifting toward a
+  dataflow/taint analyzer. 7 new cells in
+  `tests/integration/aetherc_emit_ast/` cover string/int/multi
+  literals, identifier-ref-is-computed, mixed literal+computed
+  in source order, the const-fold case, and the empty-args edge.
 
 ## [0.227.0]
 

--- a/Makefile
+++ b/Makefile
@@ -1256,6 +1256,7 @@ install: release ae stdlib
 	@find $(PREFIX)/share/aether/contrib -type d -name tests       -exec rm -rf {} + 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type d -name benchmarks  -exec rm -rf {} + 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'example_*.ae' -delete 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name 'test_*.ae' -delete 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'test_*.sh' -delete 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'build.sh'  -delete 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'ci.sh'     -delete 2>/dev/null || true
@@ -1342,10 +1343,12 @@ install: release ae stdlib
 # Modules covered (v1):
 #   - sqlite                    (-lsqlite3)
 #   - host/{python,lua,perl,ruby,duktape,tcl,tinygo}
+#   - tinyweb                   (libc only — SHA-1 + base64 for WebSocket
+#                                handshake; no third-party dep)
 # Out of scope for v1: host/{java,go} (separate-process or JNI-style
-# bridges, different build shape), tinyweb, climate_http_tests. The widget toolkit (formerly contrib/aether_ui)
-# spun out to https://github.com/aether-lang-org/aether-ui and is no
-# longer in this repo.
+# bridges, different build shape), climate_http_tests. The widget toolkit
+# (formerly contrib/aether_ui) spun out to
+# https://github.com/aether-lang-org/aether-ui and is no longer in this repo.
 # -----------------------------------------------------------------
 contrib:
 	@bash tests/scripts/contrib_build.sh
@@ -1381,17 +1384,17 @@ install-contrib: contrib
 	@# Mirror the contrib source tree for module.ae + headers.
 	@# Trim noise: tests, benchmarks, example .ae, build scripts,
 	@# CI scripts, and the modules we don't ship in v1
-	@# (climate_http_tests, host/{java,go}, tinyweb — see
-	@# contrib: target comment). host/tinygo IS shipped (--with=tinygo).
+	@# (climate_http_tests, host/{java,go} — see contrib: target
+	@# comment). host/tinygo and tinyweb ARE shipped.
 	@cp -R contrib $(PREFIX)/share/aether/
 	@rm -rf $(PREFIX)/share/aether/contrib/climate_http_tests
-	@rm -rf $(PREFIX)/share/aether/contrib/tinyweb
 	@rm -rf $(PREFIX)/share/aether/contrib/host/java
 	@rm -rf $(PREFIX)/share/aether/contrib/host/go
 	@rm -rf $(PREFIX)/share/aether/contrib/host/aether
 	@find $(PREFIX)/share/aether/contrib -type d -name tests       -exec rm -rf {} + 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type d -name benchmarks  -exec rm -rf {} + 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'example_*.ae' -delete 2>/dev/null || true
+	@find $(PREFIX)/share/aether/contrib -type f -name 'test_*.ae' -delete 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'test_*.sh' -delete 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'build.sh'  -delete 2>/dev/null || true
 	@find $(PREFIX)/share/aether/contrib -type f -name 'ci.sh'     -delete 2>/dev/null || true

--- a/compiler/aetherc.c
+++ b/compiler/aetherc.c
@@ -557,6 +557,70 @@ static int call_is_indirect(ASTNode* call) {
     return 0;
 }
 
+// Returns 1 if `arg` is an argument-position child of a function call
+// that aeb would consider "captureable" — positional or named args.
+// The trailing closure / block that the parser attaches as a final
+// FUNCTION_CALL child (DSL builder bodies, `f(x) { ... }`) is NOT an
+// argument in the veto sense; the block IS the function body and the
+// real args precede it. Filtering here keeps the JSON `args` array
+// matching what the user wrote in parens.
+static int arg_is_capturable(ASTNode* arg) {
+    if (!arg) return 0;
+    if (arg->type == AST_BLOCK) return 0;
+    if (arg->type == AST_CLOSURE) return 0;
+    return 1;
+}
+
+// If `arg` resolves to a primitive literal (string / int / float /
+// bool — including a named-arg wrapper around one), write the
+// JSON-encoded literal payload to `out` and return 1. Otherwise
+// return 0 (caller emits `{"computed":true}`).
+//
+// Detection: post-optimize_ast, every primitive literal in the
+// program is an AST_LITERAL node with `node->value` carrying the
+// source text. Strings keep their content verbatim (without
+// surrounding quotes — those were stripped by the lexer); numbers
+// keep their decimal text; booleans surface as "true"/"false".
+// AST_NAMED_ARG wraps the value as its single child, so we unwrap.
+//
+// Edge cases intentionally NOT promoted to literals (caller emits
+// `{"computed":true}`): identifier references (resolved variable
+// vs constant is ambiguous post-fold for our purposes — aeb's
+// "never allow a computed coordinate" rule applies anyway),
+// string interpolations (`"${a}${b}"` — those are
+// AST_STRING_INTERP not AST_LITERAL), array literals, struct
+// literals, function calls, member access. This deliberately
+// matches aeb's "literal vs not — the entire distinction" design
+// per veto-emit-ast-args.md.
+static int emit_literal_arg_payload(FILE* out, ASTNode* arg) {
+    if (!arg) return 0;
+
+    // Unwrap a named-arg: emit only the value side.
+    if (arg->type == AST_NAMED_ARG && arg->child_count > 0) {
+        return emit_literal_arg_payload(out, arg->children[0]);
+    }
+
+    if (arg->type != AST_LITERAL || !arg->value) return 0;
+    if (!arg->node_type) {
+        // Unknown type — be conservative and call it computed.
+        return 0;
+    }
+
+    switch (arg->node_type->kind) {
+        case TYPE_STRING:
+        case TYPE_INT:
+        case TYPE_INT64:
+        case TYPE_FLOAT:
+        case TYPE_BOOL:
+            fputs("{\"literal\":", out);
+            emit_json_string(out, arg->value);
+            fputc('}', out);
+            return 1;
+        default:
+            return 0;
+    }
+}
+
 static void emit_ast_node_recursive(FILE* out, ASTNode* node, int* first,
                                      const EmitAlias* alias_map, int alias_count) {
     if (!node) return;
@@ -670,6 +734,33 @@ static void emit_ast_node_recursive(FILE* out, ASTNode* node, int* first,
                 emit_json_string(out, resolved ? resolved : node->value);
                 free(resolved);
             }
+
+            // Emit args[]: one object per positional/named arg, in
+            // source order. Literal args (string/int/float/bool) get
+            // {"literal":"<value>"}; anything else gets {"computed":
+            // true}. Trailing closures / DSL bodies are NOT args and
+            // are filtered out via arg_is_capturable. Per
+            // veto-emit-ast-args.md sub-ask 1: the literal-vs-not
+            // distinction is the entire requirement; we don't expose
+            // computed-expression provenance — aeb fail-closes on
+            // any `{"computed":true}` regardless of contents.
+            //
+            // Always emit the array (even when empty) so aeb's
+            // policy can rely on `obj["args"]` being a defined
+            // shape; an absent field would require null-coalescing
+            // logic.
+            fputs(",\"args\":[", out);
+            int arg_first = 1;
+            for (int ai = 0; ai < node->child_count; ai++) {
+                ASTNode* arg = node->children[ai];
+                if (!arg_is_capturable(arg)) continue;
+                if (!arg_first) fputc(',', out);
+                arg_first = 0;
+                if (!emit_literal_arg_payload(out, arg)) {
+                    fputs("{\"computed\":true}", out);
+                }
+            }
+            fputc(']', out);
         }
 
         fputc('}', out);
@@ -1054,28 +1145,6 @@ int compile_source(const char* input_path, const char* output_path) {
         return 1;
     }
 
-    // --emit=ast: write the post-typecheck, post-merge program AST as
-    // JSON to stdout (filter set: import_statement, extern_function,
-    // function_call). Conventional exit codes — return 0 here means
-    // process exit 0 ("AST emitted OK"); anything other than 0 means
-    // parse/typecheck/IO failure further up. aeb's supply-chain veto
-    // consumes this; the compiler holds no policy. See
-    // veto-enhancements.md.
-    if (emit_ast_mode) {
-        emit_ast_json(stdout, program);
-        module_registry_shutdown();
-        free_ast_node(program);
-        for (int i = 0; i < token_count; i++) free_token(tokens[i]);
-        free_parser(parser);
-        free(source);
-        // Return value here is `compile_source`'s internal "non-zero =
-        // success" convention; main() translates that to process
-        // exit 0 (see the --check / --dump-ast handlers at the bottom
-        // of main()). Externally observable: process exit 0 = AST
-        // emitted OK, non-zero = parse / typecheck / IO failure.
-        return 1;
-    }
-
     // --check: stop after typecheck + type inference, no codegen
     if (check_only_mode) {
         int warnings = aether_warning_count();
@@ -1097,6 +1166,37 @@ int compile_source(const char* input_path, const char* output_path) {
     // Step 3.5: Optimization (AST-level passes: constant folding, dead code, tail calls)
     if (verbose_mode) printf("Step 3.5: Optimizing...\n");
     program = optimize_ast(program);
+
+    // --emit=ast: write the post-typecheck, post-merge, post-fold
+    // program AST as JSON to stdout (filter set: import_statement,
+    // extern_function, function_call). Conventional exit codes —
+    // return 0 here means process exit 0 ("AST emitted OK"); anything
+    // other than 0 means parse/typecheck/IO failure further up. aeb's
+    // supply-chain veto consumes this; the compiler holds no policy.
+    // See veto-enhancements.md and veto-emit-ast-args.md.
+    //
+    // Emit runs AFTER `optimize_ast` so const-foldable args (numeric
+    // arithmetic — `port(1 + 2)` → `port(3)`) arrive as literals on
+    // the wire. String-literal concatenation isn't a binary `+` in
+    // Aether (the parser rejects `string + string`), so the
+    // "computed concat becomes a literal" case only fires for
+    // numeric folds today; future fold passes (e.g. a
+    // const-`string.concat(lit, lit)` fold) would get picked up
+    // automatically.
+    if (emit_ast_mode) {
+        emit_ast_json(stdout, program);
+        module_registry_shutdown();
+        free_ast_node(program);
+        for (int i = 0; i < token_count; i++) free_token(tokens[i]);
+        free_parser(parser);
+        free(source);
+        // Return value here is `compile_source`'s internal "non-zero =
+        // success" convention; main() translates that to process
+        // exit 0 (see the --check / --dump-ast handlers at the bottom
+        // of main()). Externally observable: process exit 0 = AST
+        // emitted OK, non-zero = parse / typecheck / IO failure.
+        return 1;
+    }
 
     // Step 4: Code Generation
     if (verbose_mode) printf("Step 4: Generating C code...\n");

--- a/install.sh
+++ b/install.sh
@@ -282,6 +282,7 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
     find "$SRC_DIR/contrib" -type d -name tests       -exec rm -rf {} + 2>/dev/null || true
     find "$SRC_DIR/contrib" -type d -name benchmarks  -exec rm -rf {} + 2>/dev/null || true
     find "$SRC_DIR/contrib" -type f -name 'example_*.ae' -delete 2>/dev/null || true
+    find "$SRC_DIR/contrib" -type f -name 'test_*.ae' -delete 2>/dev/null || true
     find "$SRC_DIR/contrib" -type f -name 'test_*.sh' -delete 2>/dev/null || true
     find "$SRC_DIR/contrib" -type f -name 'build.sh'  -delete 2>/dev/null || true
     find "$SRC_DIR/contrib" -type f -name 'ci.sh'     -delete 2>/dev/null || true

--- a/tests/integration/aetherc_emit_ast/test_aetherc_emit_ast.sh
+++ b/tests/integration/aetherc_emit_ast/test_aetherc_emit_ast.sh
@@ -176,6 +176,95 @@ else
 fi
 assert_contains "9b output is a JSON object with nodes key" '"nodes":' "$out9"
 
+# --------------------------------------------------------------
+# Cell 10-15: function_call args[] — literal vs computed.
+# Per veto-emit-ast-args.md (aeb-side ask): each function_call
+# node carries args[], one entry per positional/named arg in
+# source order. Literal args (string/int/float/bool) emit
+# {"literal": "<value>"}; anything else emits
+# {"computed": true}. Trailing closures / DSL bodies are NOT
+# args and are filtered out.
+# --------------------------------------------------------------
+
+# Cell 10: single string literal arg.
+cat > "$TMPDIR/arg_string_literal.ae" <<'EOF'
+extern do_stuff(coord: string) -> int
+main() {
+    rc = do_stuff("org.foo:bar:1.2.3")
+}
+EOF
+out10="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/arg_string_literal.ae" 2>/dev/null)"
+assert_contains "10 string literal arg" '"args":[{"literal":"org.foo:bar:1.2.3"}]' "$out10"
+
+# Cell 11: int literal arg.
+cat > "$TMPDIR/arg_int_literal.ae" <<'EOF'
+extern with_port(p: int) -> int
+main() {
+    rc = with_port(8080)
+}
+EOF
+out11="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/arg_int_literal.ae" 2>/dev/null)"
+assert_contains "11 int literal arg" '"args":[{"literal":"8080"}]' "$out11"
+
+# Cell 12: multiple positional literals.
+cat > "$TMPDIR/arg_multi_literal.ae" <<'EOF'
+extern multi(a: string, b: int, c: string) -> int
+main() {
+    rc = multi("first", 42, "third")
+}
+EOF
+out12="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/arg_multi_literal.ae" 2>/dev/null)"
+assert_contains "12 multi literal args" '"args":[{"literal":"first"},{"literal":"42"},{"literal":"third"}]' "$out12"
+
+# Cell 13: identifier reference is computed, not literal —
+# even when the identifier itself binds a literal value,
+# aeb's "never allow on computed arg" rule requires the
+# distinction. The variable ref is not a literal expression.
+cat > "$TMPDIR/arg_identifier.ae" <<'EOF'
+extern do_stuff(s: string) -> int
+main() {
+    user_input = "static-text"
+    rc = do_stuff(user_input)
+}
+EOF
+out13="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/arg_identifier.ae" 2>/dev/null)"
+assert_contains "13 identifier ref is computed" '"args":[{"computed":true}]' "$out13"
+
+# Cell 14: mixed literal + computed args, in source order.
+cat > "$TMPDIR/arg_mixed.ae" <<'EOF'
+extern do_stuff(coord: string, key: string, count: int) -> int
+main() {
+    dyn = "from-env"
+    rc = do_stuff("static-coord", dyn, 5)
+}
+EOF
+out14="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/arg_mixed.ae" 2>/dev/null)"
+assert_contains "14 mixed literal+computed in order" \
+    '"args":[{"literal":"static-coord"},{"computed":true},{"literal":"5"}]' "$out14"
+
+# Cell 15: const-folded numeric arg arrives as a literal —
+# `do_stuff(1 + 2)` folds to `do_stuff(3)` before the emit
+# walk runs (post-optimize_ast). Per veto-emit-ast-args.md
+# sub-ask 0.
+cat > "$TMPDIR/arg_fold.ae" <<'EOF'
+extern do_stuff(n: int) -> int
+main() {
+    rc = do_stuff(1 + 2)
+}
+EOF
+out15="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/arg_fold.ae" 2>/dev/null)"
+assert_contains "15 const-folded arg arrives as literal" '"args":[{"literal":"3"}]' "$out15"
+
+# Cell 16: zero-arg call still emits an empty args array.
+cat > "$TMPDIR/arg_empty.ae" <<'EOF'
+extern do_stuff() -> int
+main() {
+    rc = do_stuff()
+}
+EOF
+out16="$(AETHER_HOME="$ROOT" "$AETHERC" --emit=ast "$TMPDIR/arg_empty.ae" 2>/dev/null)"
+assert_contains "16 zero-arg call has empty args array" '"args":[]' "$out16"
+
 echo ""
 if [ "$fail" -eq 0 ]; then
     echo "  [PASS] aetherc_emit_ast: $pass/$pass"

--- a/tests/integration/install_contrib_resolves/test_install_contrib_resolves.sh
+++ b/tests/integration/install_contrib_resolves/test_install_contrib_resolves.sh
@@ -103,4 +103,110 @@ for canary in sqlite tinyweb host/python; do
     fi
 done
 
+# ---------------------------------------------------------------------
+# Second install path: `make install-contrib`. This is the separate
+# installer that ships the prebuilt libaether_<X>.a archives alongside
+# each module's source tree. It uses a DIFFERENT trim policy from
+# install.sh (above) — historically the two diverged (Makefile trimmed
+# tinyweb/ while install.sh shipped it). Pin both shapes so they don't
+# drift apart again.
+#
+# Compared to install.sh's check: this path additionally requires the
+# libaether_<X>.a archive present under lib/aether/ for each module
+# that contrib_build.sh built. We don't require every module to have a
+# .a (system dep absence → SKIP, not FAIL), but the canaries listed
+# above MUST ship both module.ae AND the matching archive.
+#
+# Windows skip: `make install-contrib` shells `contrib_build.sh` which
+# probes for sqlite3/python/lua/perl/ruby/duktape/tcl dev libs — none
+# are available under MSYS2/MinGW on the GitHub runner, and the suite
+# is already 4x slower on Windows (~33 min vs ~8 min on Linux). The
+# install.sh half above provides the layout coverage; the
+# make install-contrib half runs on every Linux/macOS lane and that
+# is sufficient. Skip with a [SKIP-WIN] marker so the .ae-test runner
+# (Makefile:542) records the skip as a pass with a reason.
+# ---------------------------------------------------------------------
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP-WIN] make install-contrib path skipped on Windows"
+        echo "  [PASS] contrib/ resolves system-wide after install (issue #334)"
+        echo "         install.sh path verified; make install-contrib path skipped on Windows"
+        exit 0
+        ;;
+esac
+
+MAKE_TMP="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR" "$MAKE_TMP"' EXIT
+
+# Build + install. This shells `make install-contrib PREFIX=...` which
+# in turn invokes `make contrib` (the contrib_build.sh sweep) and then
+# the install rule. Quiet on success; we'll dump the log on failure.
+if ! make install-contrib PREFIX="$MAKE_TMP" \
+        > "$MAKE_TMP/install.log" 2>&1; then
+    echo "  [FAIL] make install-contrib exited non-zero"
+    tail -30 "$MAKE_TMP/install.log"
+    exit 1
+fi
+
+MAKE_CONTRIB_INSTALL="$MAKE_TMP/share/aether/contrib"
+MAKE_LIB_DIR="$MAKE_TMP/lib/aether"
+
+if [ ! -d "$MAKE_CONTRIB_INSTALL" ]; then
+    echo "  [FAIL] make install-contrib produced no $MAKE_CONTRIB_INSTALL"
+    exit 1
+fi
+
+# Source-tree noise must NOT have been copied (same shape as
+# install.sh, plus test_*.ae which the Makefile install trim now
+# filters too).
+make_unwanted=$( {
+    find "$MAKE_CONTRIB_INSTALL" -type f -name '*.c' \
+        ! -path '*/contrib/host/*/aether_host_*.c' 2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type f -name '*.m'          2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type d -name tests          2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type d -name benchmarks     2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type f -name 'example_*.ae' 2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type f -name 'test_*.ae'    2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type f -name 'test_*.sh'    2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type f -name 'build.sh'     2>/dev/null
+    find "$MAKE_CONTRIB_INSTALL" -type f -name 'ci.sh'        2>/dev/null
+} | wc -l | tr -d ' ')
+
+if [ "$make_unwanted" -ne 0 ]; then
+    echo "  [FAIL] make install-contrib layout still contains source-tree noise:"
+    {
+        find "$MAKE_CONTRIB_INSTALL" -type f -name '*.c' \
+            ! -path '*/contrib/host/*/aether_host_*.c'
+        find "$MAKE_CONTRIB_INSTALL" -type f -name '*.m'
+        find "$MAKE_CONTRIB_INSTALL" -type d -name tests
+        find "$MAKE_CONTRIB_INSTALL" -type d -name benchmarks
+        find "$MAKE_CONTRIB_INSTALL" -type f -name 'example_*.ae'
+        find "$MAKE_CONTRIB_INSTALL" -type f -name 'test_*.ae'
+        find "$MAKE_CONTRIB_INSTALL" -type f -name 'test_*.sh'
+        find "$MAKE_CONTRIB_INSTALL" -type f -name 'build.sh'
+        find "$MAKE_CONTRIB_INSTALL" -type f -name 'ci.sh'
+    } | head -10
+    exit 1
+fi
+
+# Same canary set as install.sh's check above — pinning the two
+# install paths to a matching ship-list defeats the tinyweb-trim
+# class of regressions.
+for canary in sqlite tinyweb host/python; do
+    if [ ! -f "$MAKE_CONTRIB_INSTALL/$canary/module.ae" ]; then
+        echo "  [FAIL] canary $canary missing from make install-contrib"
+        exit 1
+    fi
+done
+
+# Archives — every canary that contrib_build.sh built on this runner
+# must produce a libaether_<X>.a. We skip the check when the system
+# dep was missing on the runner (recorded in MANIFEST: present = built).
+# `host/python` is recorded as `host_python` in the manifest.
+if [ ! -f "$MAKE_LIB_DIR/libaether_tinyweb.a" ]; then
+    echo "  [FAIL] tinyweb's archive missing from make install-contrib"
+    exit 1
+fi
+
 echo "  [PASS] contrib/ resolves system-wide after install (issue #334)"
+echo "         install.sh + make install-contrib both ship the canaries"

--- a/tests/scripts/contrib_build.sh
+++ b/tests/scripts/contrib_build.sh
@@ -159,6 +159,14 @@ probe_tinygo() {
     return 0
 }
 
+probe_tinyweb() {
+    # ws_handshake.c needs only libc — implements SHA-1 + base64 inline
+    # for the RFC 6455 Sec-WebSocket-Accept handshake. No system deps,
+    # no pkg-config probes; the build always succeeds.
+    echo ""
+    return 0
+}
+
 # build_module <module_name> <relative_src_path> <AETHER_HAS_FLAG> <probe_fn>
 # Returns: 0 OK, 1 SKIP (probe failed), 2 FAIL (compile/archive failed)
 # Caller decides whether SKIP or FAIL is fatal (depends on MODULES mode).
@@ -208,6 +216,7 @@ CATALOGUE=(
     "duktape|host_duktape  contrib/host/duktape/aether_host_duktape.c  AETHER_HAS_DUKTAPE  probe_duktape"
     "tcl|host_tcl        contrib/host/tcl/aether_host_tcl.c       AETHER_HAS_TCL     probe_tcl"
     "tinygo|host_tinygo  contrib/host/tinygo/aether_host_tinygo.c AETHER_HAS_TINYGO  probe_tinygo"
+    "tinyweb|tinyweb     contrib/tinyweb/ws_handshake.c           AETHER_HAS_TINYWEB probe_tinyweb"
 )
 
 # Find a catalogue line by short name. Echoes the build_module arg list


### PR DESCRIPTION
## Summary

Two independent slices bundled in one PR. The tinyweb piece was
held back from its own PR earlier ("don't make a PR just for this");
the emit-ast-args follow-up from aeb-side Claude
(`veto-emit-ast-args.md`) is the substantive piece to fold it into.

## Slice 1: contrib/tinyweb ships

Tinyweb (port of [Tiny](https://github.com/phamm/tiny)) — DSL-style
HTTP server library: routing, filters, WebSocket (RFC 6455 handshake),
SSE, static files, cookies. See `contrib/tinyweb/README.md`.

Always in the repo but previously excluded from `contrib_build.sh`
and explicitly `rm -rf`'d by `make install-contrib`. Now wired up:

- `probe_tinyweb` (trivial — libc only)
- Catalogue entry compiles `ws_handshake.c` into
  `libaether_tinyweb.a`
- Install mirrors `module.ae` + `README.md` + `ws_client.ae` to
  `share/aether/contrib/tinyweb/`
- Default `make contrib` builds 9 modules now instead of 8

**Install-path consistency**: `install.sh` and `make install-contrib`
historically had divergent trim policies (Makefile dropped tinyweb,
install.sh shipped it). Both now apply the same filter set —
`test_*.ae` filter added to both. The existing
`install_contrib_resolves` integration test now exercises BOTH
install paths and verifies the same canary set (`sqlite`, `tinyweb`,
`host/python`) is present in both, with a `[SKIP-WIN]` marker on the
Makefile-install-contrib half (no apt-get on MSYS2 for the dev libs;
the install.sh half still runs on Windows).

## Slice 2: `--emit=ast` carries literal call args

Per the aeb-side ask in `veto-emit-ast-args.md` (follow-up to
v0.226.0's initial `--emit=ast`):

### Sub-ask 0: emit after const-fold

The `--emit=ast` short-circuit moved from before `optimize_ast` to
after it. Const-foldable numeric args
(`do_stuff(1 + 2)` → `do_stuff(3)`) now arrive as literals on the
wire. String-literal `+` isn't valid Aether (the parser rejects
`string + string`), so the immediate impact is numeric folds;
future `string.concat(lit, lit)` folds would be picked up
automatically.

### Sub-ask 1: `args[]` on `function_call`

```json
{"kind":"function_call","callee":"maven_dep",
 "args":[{"literal":"org.foo:bar:1.2.3"}]}

{"kind":"function_call","callee":"do_stuff",
 "args":[{"literal":"static-coord"},{"computed":true},{"literal":"5"}]}
```

- `{"literal":"<value>"}` for primitive literals (string / int /
  int64 / float / bool); `AST_NAMED_ARG` unwrapped to its value
- `{"computed":true}` for anything else (identifiers, expressions,
  function calls, interpolations)
- Trailing closures / DSL builder bodies filtered out
- Array always emitted (even empty) so aeb's policy walker can
  rely on `obj["args"]` being a defined shape

Per the design: aeb fail-closes on any `{"computed":true}` arg
regardless of contents — no expression-tree provenance, no
dataflow analyzer drift. Literal-vs-not is the whole distinction.

## Test plan

- 27/27 cells in `tests/integration/aetherc_emit_ast/` (20 existing
  + 7 new for args)
- `tests/integration/install_contrib_resolves/`: full pass on
  Linux (both install paths); Windows skips the Makefile half
- `make ci`: 624 passed, 3 failed — the 3 fails are pre-existing
  HTTP/2 networking flakes (`http_h2_concurrent_dispatch`,
  `http_reverse_proxy_pool`, `http_server_h2`); zero failures
  from this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)