### PR TITLE
fix(runtime/sandbox): remove unsafe vfork() LD_PRELOAD wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,32 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.228.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Fixed
+
+- **`spawn_sandboxed` no longer corrupts the parent stack when the
+  contained child uses `vfork()`** (`runtime/libaether_sandbox_preload.c`,
+  `tests/integration/sandbox_toolchain/`). Removed the LD_PRELOAD `vfork()`
+  wrapper: glibc's `vfork()` has a strict contract (the child must call
+  only `_exit()` or `execve()`, and the calling function must not
+  return) because vfork shares the parent's stack until the child execs.
+  Wrapping the symbol in a regular C function violates that — the child
+  returns *through our wrapper frame* on the shared stack, corrupting
+  the parent. The visible effect was a sandboxed child running the
+  `ae`/`aetherc` → `gcc` → `cc1`/`as`/`ld` toolchain failing (`Build
+  failed`, `rc=-1`) — and, for a deeper aeb orchestrator child, segfaults
+  in the parent after the `wait4`. The `fork()` and `execve()`
+  interceptors continue to gate process creation (`fork()` is safe to
+  wrap; the dangerous follow-up is the `execve` which we still see); a
+  bare `vfork()+_exit()` was never the threat model. Reported by aeb as
+  the upstream blocker for `aeb --sandbox <target>`. New regression test
+  exercises the full `ae build` toolchain under `spawn_sandboxed`;
+  verified pre-fix → FAIL, post-fix → PASS.
 
 ## [0.228.0]
 

--- a/runtime/libaether_sandbox_preload.c
+++ b/runtime/libaether_sandbox_preload.c
@@ -496,16 +496,17 @@ long clone3(struct clone_args* args, size_t size) {
     return real_clone3(args, size);
 }
 
-// vfork — same restriction as fork
-static pid_t (*real_vfork)(void) = NULL;
-pid_t vfork(void) {
-    if (!real_vfork) real_vfork = dlsym(RTLD_NEXT, "vfork");
-    if (sandbox_active && !check_grant("fork", "*")) {
-        errno = EPERM;
-        return -1;
-    }
-    return real_vfork();
-}
+// vfork — NOT intercepted. A C-language wrapper around vfork() is unsafe:
+// vfork's contract requires the child to call only _exit() or execve()
+// before returning from the function that called vfork(). Wrapping vfork
+// in our own C function means the child returns from *our* frame on the
+// parent's shared stack, corrupting it — which manifests as the calling
+// program (gcc driver, etc.) segfaulting after the wait4. We rely on the
+// fork() and execve() interceptors to gate process creation: a vfork()
+// without a follow-up execve() is virtually unheard of outside of glibc
+// internals (where it's harmless), and any exec by a vfork'd child is
+// caught by the execve interceptor below. See
+// sandbox-preload-toolchain-segfault.md for the bug this fixes.
 
 // mmap — block PROT_EXEC to prevent shellcode execution from byte arrays
 void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {

--- a/tests/integration/sandbox_toolchain/test_sandbox_toolchain.sh
+++ b/tests/integration/sandbox_toolchain/test_sandbox_toolchain.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# Regression: a child invoked via spawn_sandboxed must be able to run the
+# `ae`/`aetherc` -> `cc`/`gcc` -> `as`/`ld` toolchain.
+#
+# Was failing before the fix in runtime/libaether_sandbox_preload.c that
+# removed the C-language vfork() wrapper: glibc's vfork() has a contract
+# (the child must call only _exit/execve and the calling function must
+# not return) that is violated by wrapping the symbol in a regular C
+# function — the child returns through the wrapper frame on the parent's
+# shared stack, corrupting it. gcc-on-Linux uses vfork() heavily, so a
+# build inside spawn_sandboxed died with "Build failed" / rc=-1, and a
+# real aeb orchestrator (the reporter) saw segfaults from the corrupted
+# parent stack. Upstream report:
+# sandbox-preload-toolchain-segfault.md.
+#
+# This test bakes in the property the fix establishes: a sandboxed child
+# with enough grants can successfully run the toolchain to build and
+# execute a trivial Aether program.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP-WIN] sandbox preload is Linux-only (LD_PRELOAD)"
+        exit 0 ;;
+    Darwin)
+        # spawn_sandboxed uses fork/shm_open/LD_PRELOAD — Linux-only.
+        echo "  [SKIP] sandbox preload is Linux-only (LD_PRELOAD)"
+        exit 0 ;;
+esac
+
+AE="$ROOT/build/ae"
+PRELOAD_SRC="$ROOT/runtime/libaether_sandbox_preload.c"
+if [ ! -x "$AE" ]; then
+    echo "  [SKIP] $AE not built (run make first)"
+    exit 0
+fi
+if [ ! -f "$PRELOAD_SRC" ]; then
+    echo "  [FAIL] preload source missing: $PRELOAD_SRC"
+    exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# 1. Build the preload (matches what install.sh does for downstreams).
+cc -shared -fPIC -o "$TMPDIR/libaether_sandbox.so" "$PRELOAD_SRC" -ldl -lrt 2>"$TMPDIR/preload-cc.log" || {
+    echo "  [FAIL] preload .so build failed:"
+    cat "$TMPDIR/preload-cc.log"
+    exit 1
+}
+
+# 2. A trivial Aether program for the sandboxed child to compile.
+cat > "$TMPDIR/inner.ae" <<'AE'
+extern println(s: string)
+main() { println("sandboxed-toolchain-ok") }
+AE
+
+# 3. The script the sandboxed child runs: invoke the full ae->gcc pipeline.
+cat > "$TMPDIR/inner-build.sh" <<SH
+#!/bin/sh
+cd "$TMPDIR" || exit 71
+rm -f inner.out
+"$AE" build inner.ae -o inner.out 2>&1
+ECODE=\$?
+echo "ae-build-exit=\$ECODE"
+# Absolute path required: the preload's exec grant pattern uses
+# prefix-glob, and "/*" doesn't match a "./relative" execve target.
+[ -x inner.out ] && "$TMPDIR/inner.out"
+SH
+chmod +x "$TMPDIR/inner-build.sh"
+
+# 4. The launcher: spawn_sandboxed the script with generous grants so the
+#    only thing being tested is whether the toolchain works under the
+#    preload, not whether the grant set is sufficient.
+cat > "$TMPDIR/launcher.ae" <<AE
+import std.list
+extern println(s: string)
+main() {
+    g = list.new()
+    list.add(g, "fork");      list.add(g, "*")
+    list.add(g, "exec");      list.add(g, "/*")
+    list.add(g, "fs_read");   list.add(g, "/*")
+    list.add(g, "fs_write");  list.add(g, "/*")
+    list.add(g, "env");       list.add(g, "*")
+    list.add(g, "native");    list.add(g, "*")
+    rc = spawn_sandboxed(g, "sh", "$TMPDIR/inner-build.sh")
+    println("rc=\${rc}")
+}
+AE
+
+# 5. Build and run the launcher (outside the sandbox).
+"$AE" build "$TMPDIR/launcher.ae" -o "$TMPDIR/launcher" >"$TMPDIR/launcher-build.log" 2>&1 || {
+    echo "  [FAIL] launcher build failed:"
+    tail -20 "$TMPDIR/launcher-build.log"
+    exit 1
+}
+
+cd "$TMPDIR"
+./launcher > out.log 2>&1 || {
+    echo "  [FAIL] launcher exited non-zero:"
+    cat out.log
+    exit 1
+}
+
+# Assertions: the sandboxed child's ae build must have succeeded AND the
+# produced binary must have run.
+if ! grep -q '^ae-build-exit=0$' out.log; then
+    echo "  [FAIL] sandboxed ae build did not exit 0:"
+    cat out.log
+    exit 1
+fi
+if ! grep -q '^sandboxed-toolchain-ok$' out.log; then
+    echo "  [FAIL] sandboxed-built binary did not print the expected line:"
+    cat out.log
+    exit 1
+fi
+if ! grep -q '^rc=0$' out.log; then
+    echo "  [FAIL] spawn_sandboxed returned non-zero:"
+    cat out.log
+    exit 1
+fi
+
+echo "  [PASS] toolchain (ae -> gcc -> cc1/as/ld) runs cleanly under spawn_sandboxed"


### PR DESCRIPTION
## Summary

- The LD_PRELOAD `vfork()` wrapper in `runtime/libaether_sandbox_preload.c` was breaking glibc's vfork contract: the child returns *through our wrapper frame* on the parent's shared stack, corrupting it. A spawn_sandboxed'd child running the `ae`/`aetherc` → `gcc` → `cc1`/`as`/`ld` toolchain was failing (`Build failed`, `rc=-1`), and the aeb orchestrator at depth saw the resulting SIGSEGV.
- Reported upstream by aeb as the blocker for `aeb --sandbox <target>`.
- Fix: drop the vfork wrapper. `fork()` is still wrapped (safe — separate address space), and the dangerous follow-up exec a vfork child does is still gated by the `execve()` wrapper. A bare `vfork()+_exit()` was never the threat model.

## What changed

- `runtime/libaether_sandbox_preload.c` — remove the `vfork()` LD_PRELOAD wrapper; replace with a comment explaining why it was unsafe.
- `tests/integration/sandbox_toolchain/test_sandbox_toolchain.sh` — new regression: builds the preload, spawn_sandboxed's a child running the full `ae build` pipeline, asserts the build succeeds AND the produced binary runs. Verified pre-fix → FAIL, post-fix → PASS.
- `CHANGELOG.md` — `### Fixed` entry under `[current]`.

## Out of scope (filed as separate issue)

`clone3()` syscall-level forks bypass our libc-level fork/vfork wrappers entirely (libc doesn't export `clone3` as a symbol; glibc's vfork uses raw `syscall(SYS_clone3, …)`). Modern gcc forks this way. So the `fork:*` deny policy is currently honored only by cooperative callers — not the toolchains we most want to fence. That's a layer-3 hardening conversation (seccomp-bpf), filed separately so it doesn't block this fix.

## Test plan

- [x] `tests/integration/sandbox_toolchain/test_sandbox_toolchain.sh` passes on Linux x86_64
- [x] Verified the test FAILS without the source-tree fix (reverted via `git stash`, re-ran)
- [ ] CI runs the new test as part of the integration sweep
- [ ] HARDEN=1 sweep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)