### PR TITLE
Feat/os process supervision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ rename and drift from the tags (see `changelog-release-drift-note.md`).
 
 ### Fixed
 
+- **`make ci-windows` example sweep now matches the canonical filter.**
+  The Windows cross-compile target swept *every* `examples/**/*.ae`,
+  including the intentionally-broken `ae-help-demo/broken_dsl.ae` (and the
+  `host-*-demo.ae` files that need host runtimes), so step [1/3] aborted
+  before ever MinGW-compiling anything. Aligned both `find` invocations
+  with the main example-build sweep (`grep -v '/ae-help-demo/'` +
+  `grep -v '/host-.*-demo\.ae$'`).
+
 - **Memory-leak hardening across the compiler and stdlib.** Every
   detectable memory leak in the regression suite is eliminated (and the
   integration suite is clean under ASan + LSan), verified on macOS
@@ -57,6 +65,74 @@ rename and drift from the tags (see `changelog-release-drift-note.md`).
 
 ### Added
 
+- **`std.os` process-supervision primitives** — the floor any build/test
+  orchestrator hits, so a supervisor can be written in Aether instead of a
+  bash job-control trampoline. Filed by aeb. **Cross-platform**: POSIX
+  uses fork + setpgid + killpg + waitpid; Windows maps the same shape onto
+  Job Objects, `WaitForSingleObject`, `TerminateProcess`, and a console
+  control handler.
+  - `os.run_supervised(prog, argv, env, new_process_group, forward_signals,
+    timeout_secs, reap_group) -> (exit_code, outcome)` — one call that
+    runs a child in its own process group, forwards interactive
+    SIGINT/SIGTERM (Windows: Ctrl-C/Ctrl-Break) to that group, enforces a
+    wall-clock timeout (POSIX TERM → 5s grace → KILL; Windows
+    `TerminateJobObject`; reporting exit_code 124 the way GNU `timeout`
+    does), and group-reaps anything the child leaked — a stray test
+    server, a backgrounded helper (Windows:
+    `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`). `outcome` ∈ {`"exited"`,
+    `"signalled"`, `"timeout"`, `"error"`} (Windows never reports
+    `"signalled"`). Options are explicit `int` flags (1/0) rather than a
+    map — Aether maps hold `ptr` values, and explicit params match the
+    rest of `std.os`.
+  - `os.kill(pid, sig) -> int` — POSIX `kill(2)`. A negative pid signals
+    the whole process group; `sig == 0` is the existence/permission probe
+    (the `kill -0` reap-loop check). Previously there was no `kill` in the
+    public surface at all. Windows: `sig == 0` probes via `OpenProcess`,
+    any other signal forces `TerminateProcess` (no graceful SIGTERM),
+    negative-pid group signalling returns -1.
+  - `os.wait_pid_timeout(pid, secs) -> (status, timed_out, err)` — bounded
+    wait on a child, so a timeout needs no separate watchdog process
+    (`secs <= 0` blocks indefinitely). Windows: `OpenProcess` +
+    `WaitForSingleObject`.
+  - `os.run_full(prog, argv, env, stdin_data) -> (stdout, stderr,
+    exit_code, err)` — the three-way child-stdio primitive `os.run_capture`
+    leaves open: feeds `stdin_data` to the child (binary-safe — exactly its
+    stored length, embedded NULs included) and captures stdout and stderr
+    on **separate** channels with no pipe-buffer deadlock regardless of
+    stream sizes (regression-tested with a 512 KB round-trip). POSIX pumps
+    all three fds in one `poll(2)` loop; Windows drains stdout/stderr on
+    reader threads while writing stdin. The `2>&1`-merged shape and
+    binary-safe (length-bearing) capture of the *output* streams are out
+    of scope for v1.
+- **`os.chdir` / `os.getcwd`** — process working-directory accessors,
+  previously absent entirely. `chdir(path) -> string` ("" on success,
+  error message on failure); `getcwd() -> string` ("" on failure).
+  Cross-platform (POSIX `chdir(2)`/`getcwd(3)`, Windows
+  `SetCurrentDirectory`/`GetCurrentDirectory` with UTF-8↔UTF-16
+  conversion). An orchestrator entry point needs these to run build
+  steps relative to a project root.
+- **`ae run <file.ae> -- <args>` now forwards `<args>` to the program.**
+  Previously `ae run` dropped everything after the script name, so a
+  config-is-code entry point couldn't receive arguments; now everything
+  after a literal `--` reaches the program's `argv` (like `cargo run --`),
+  each token double-quoted so a spaces-containing argument stays one
+  token through the launcher. This is what makes
+  `ae run supervisor.ae -- make -j8` work.
+- **`examples/applications/build-supervisor.ae`** — a runnable
+  build-supervision entry point that composes the new primitives
+  (`os.getcwd` + `os.run_supervised`) into the exact shape of aeb's bash
+  job-control trampoline (own process group, forward Ctrl-C, wall-clock
+  timeout, group-reap of leaked children) — in one `run_supervised`
+  call. Demonstrates the "config IS code" pattern: the file is the
+  supervisor config and the entry point.
+- **`std.signal`** — POSIX signal-number constants (`SIGHUP`, `SIGINT`,
+  `SIGQUIT`, `SIGILL`, `SIGABRT`, `SIGFPE`, `SIGKILL`, `SIGSEGV`,
+  `SIGPIPE`, `SIGALRM`, `SIGTERM`) as zero-arg functions, so callers pass
+  `signal.SIGTERM()` to `os.kill` instead of hard-coding 15. Limited to
+  the signals whose numbers are stable across every POSIX target;
+  platform-divergent ones (SIGUSR1/2 etc.) are intentionally omitted.
+  (On Windows most have no effect — `os.kill` forces termination
+  regardless of the number.)
 - **Full-suite macOS `leaks(1)` gate** (`tests/run_macos_leaks.sh`,
   `tests/leaks_known.txt`, `tests/leaks_exclude.txt`): the gate now sweeps
   the entire `tests/regression` suite (previously 16 curated programs),

--- a/Makefile
+++ b/Makefile
@@ -1651,7 +1651,7 @@ ci-windows: clean compiler
 	@echo "[1/3] Generating C from all examples with native aetherc..."
 	@mkdir -p build/win
 	@pass=0; fail=0; \
-	for src in $$(find examples -name '*.ae' | grep -v '/lib/' | grep -v '/packages/' | grep -v '/embedded-java/' | sort); do \
+	for src in $$(find examples -name '*.ae' | grep -v '/lib/' | grep -v '/packages/' | grep -v '/embedded-java/' | grep -v '/host-.*-demo\.ae$$' | grep -v '/ae-help-demo/' | sort); do \
 		name=$$(echo $$src | sed 's|examples/||;s|\.ae$$||'); \
 		printf "  %-30s " "$$name"; \
 		mkdir -p "build/win/examples/$$(dirname $$name)"; \
@@ -1691,7 +1691,7 @@ ci-windows: clean compiler
 	@echo ""
 	@echo "[3/3] Syntax-checking generated C with MinGW..."
 	@pass=0; fail=0; \
-	for src in $$(find examples -name '*.ae' | grep -v '/lib/' | grep -v '/packages/' | grep -v '/embedded-java/' | sort); do \
+	for src in $$(find examples -name '*.ae' | grep -v '/lib/' | grep -v '/packages/' | grep -v '/embedded-java/' | grep -v '/host-.*-demo\.ae$$' | grep -v '/ae-help-demo/' | sort); do \
 		name=$$(echo $$src | sed 's|examples/||;s|\.ae$$||'); \
 		out_c="build/win/examples/$$name.c"; \
 		printf "  %-30s " "$$name"; \

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -874,6 +874,7 @@ int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
             strcmp(fn, "os_getenv") == 0 ||
             strcmp(fn, "os_which") == 0 ||
             strcmp(fn, "os_platform_raw") == 0 ||
+            strcmp(fn, "os_getcwd_raw") == 0 ||
             strcmp(fn, "os_now_utc_iso8601_raw") == 0 ||
             strcmp(fn, "os_now_local_iso8601_raw") == 0 ||
             /* std.io getenv — sibling of os_getenv, returns a FRESH

--- a/examples/applications/build-supervisor.ae
+++ b/examples/applications/build-supervisor.ae
@@ -1,0 +1,85 @@
+// build-supervisor — the bash build-supervision trampoline, in Aether.
+//
+// This is the shape aeb's CLI entry point keeps in bash because POSIX
+// job control hands it over for free. The bash original (from
+// aeb-process-supervision-primitives.md):
+//
+//     set -m                                  # build in its OWN group
+//     "${AEB_LAUNCH[@]}" "$@" &               # background it
+//     trap 'kill -INT -$pid' INT              # forward Ctrl-C to group
+//     ( sleep "$TIMEOUT"; kill -TERM -$pid )& # watchdog
+//     wait "$pid"; rc=$?
+//     kill -TERM -$pid                        # reap anything LEAKED
+//     while kill -0 -$pid; do sleep 0.1; done
+//     kill -KILL -$pid
+//
+// …collapses to a single os.run_supervised() call here — own process
+// group, forward interactive signals to it, enforce a wall-clock
+// timeout, then group-reap any process the build leaked (a stray test
+// server, a backgrounded helper). Cross-platform: the same call maps
+// onto POSIX process groups and onto Windows Job Objects.
+//
+// Run a built-in demo:        ae run examples/applications/build-supervisor.ae
+// Supervise your own command: ae run examples/applications/build-supervisor.ae -- make -j8
+// "config IS code": this file is the supervisor config AND the entry point.
+
+import std.os
+import std.list
+import std.string
+import std.signal
+
+// Wall-clock ceiling for the supervised build, in seconds. Edit this —
+// it's ordinary code, not a YAML key.
+TIMEOUT_SECS() -> int { return 600 }
+
+main() {
+    // An orchestrator runs steps relative to a project root.
+    root = os.getcwd()
+    println("build-supervisor: root = ${root}")
+
+    // Assemble the command to supervise: either the user's (everything
+    // after `--`) or a built-in demo that prints, sleeps briefly, exits 0.
+    n = aether_args_count()
+    argv = list.new()
+    prog = ""
+    if n > 1 {
+        prog = aether_args_get(1)
+        i = 2
+        while i < n {
+            list.add(argv, aether_args_get(i))
+            i = i + 1
+        }
+    } else {
+        prog = "/bin/sh"
+        list.add(argv, "-c")
+        list.add(argv, "echo '[build] compiling...'; sleep 1; echo '[build] done'")
+    }
+
+    timeout = TIMEOUT_SECS()
+    println("build-supervisor: launching ${prog} (timeout ${timeout}s)")
+
+    // The entire trampoline tail, in one call:
+    //   new_process_group = 1  → child leads its own group
+    //   forward_signals   = 1  → Ctrl-C / SIGTERM reach the whole group
+    //   timeout_secs      = N  → TERM → 5s grace → KILL on deadline (code 124)
+    //   reap_group        = 1  → tear down anything the build leaked
+    code, outcome = os.run_supervised(prog, argv, null, 1, 1, timeout, 1)
+    list.free(argv)
+
+    if outcome == "timeout" {
+        println("build-supervisor: TIMED OUT after ${timeout}s — group torn down")
+    } else if outcome == "signalled" {
+        println("build-supervisor: build killed by a signal (exit ${code})")
+    } else if outcome == "exited" {
+        if code == 0 {
+            println("build-supervisor: build succeeded")
+        } else {
+            println("build-supervisor: build failed (exit ${code})")
+        }
+    } else {
+        println("build-supervisor: could not supervise ${prog}")
+    }
+
+    // Propagate the build's exit code, exactly like the bash `exit "$rc"`.
+    exit(code)
+}

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -32,6 +32,8 @@ char* os_exec_raw(const char* c) { (void)c; return NULL; }
 char* os_getenv(const char* n) { (void)n; return NULL; }
 int os_execv(const char* p, void* a) { (void)p; (void)a; return -1; }
 char* os_which(const char* n) { (void)n; return NULL; }
+int os_chdir_raw(const char* p) { (void)p; return -1; }
+char* os_getcwd_raw(void) { return NULL; }
 int os_run(const char* p, void* a, void* e) { (void)p; (void)a; (void)e; return -1; }
 char* os_run_capture_raw(const char* p, void* a, void* e) { (void)p; (void)a; (void)e; return NULL; }
 typedef struct { const char* _0; int _1; const char* _2; } _tuple_string_int_string;
@@ -50,6 +52,26 @@ _tuple_int_int_string os_run_pipe_raw(const char* p, void* a, void* e) {
 _tuple_int_string os_wait_pid_raw(int pid) {
     (void)pid;
     _tuple_int_string out = { -1, "os.wait_pid unavailable" };
+    return out;
+}
+int os_kill_raw(int pid, int sig) { (void)pid; (void)sig; return -1; }
+_tuple_int_int_string os_wait_pid_timeout_raw(int pid, int secs) {
+    (void)pid; (void)secs;
+    _tuple_int_int_string out = { -1, 0, "os.wait_pid_timeout unavailable" };
+    return out;
+}
+_tuple_int_string os_run_supervised_raw(const char* p, void* a, void* e,
+                                        int g, int f, int t, int r) {
+    (void)p; (void)a; (void)e; (void)g; (void)f; (void)t; (void)r;
+    _tuple_int_string out = { -1, "os.run_supervised unavailable" };
+    return out;
+}
+typedef struct { const char* _0; const char* _1; int _2; const char* _3; } _tuple_string_string_int_string;
+_tuple_string_string_int_string os_run_full_raw(const char* p, void* a, void* e,
+                                                const char* in, int in_len) {
+    (void)p; (void)a; (void)e; (void)in; (void)in_len;
+    _tuple_string_string_int_string out = {
+        aether_os_empty_heap(), aether_os_empty_heap(), -1, "os.run_full unavailable" };
     return out;
 }
 _tuple_string_int_string os_run_pipe_drain_and_wait_raw(const char* p, void* a, void* e) {
@@ -93,6 +115,9 @@ extern void* list_get_raw(void* list, int index);
 #include <sys/wait.h>
 #include <errno.h>
 #include <fcntl.h>  /* fcntl, F_GETFD — used by ipc_parent_channel_raw */
+#include <signal.h> /* kill, sigaction — process-supervision primitives */
+#include <time.h>   /* nanosleep, struct timespec — bounded waits */
+#include <poll.h>   /* poll — deadlock-free 3-way stdio pump in os_run_full_raw */
 #else
 #include <windows.h>
 #include <wchar.h>
@@ -785,6 +810,31 @@ char* os_which(const char* name) {
 
 #ifndef _WIN32
 
+/* Change the process working directory. POSIX chdir(2). Gated under the
+ * "fs" capability bucket: it repositions every subsequent relative path
+ * the process touches, so it's a filesystem-scoped action. */
+int os_chdir_raw(const char* path) {
+    if (!path) return -1;
+    if (!aether_sandbox_check("fs", path)) return -1;
+    return chdir(path) == 0 ? 0 : -1;
+}
+
+/* Current working directory as a fresh strdup'd buffer (caller owns).
+ * Grows the buffer until getcwd(3) stops reporting ERANGE so deep paths
+ * past PATH_MAX still resolve. NULL on any other error. */
+char* os_getcwd_raw(void) {
+    size_t cap = 4096;
+    for (;;) {
+        char* buf = (char*)malloc(cap);
+        if (!buf) return NULL;
+        if (getcwd(buf, cap)) return buf;
+        free(buf);
+        if (errno != ERANGE) return NULL;
+        if (cap > (size_t)1 << 20) return NULL; /* 1 MiB sanity ceiling */
+        cap *= 2;
+    }
+}
+
 // Build a NULL-terminated argv array from an Aether list. The first
 // entry in argv[] is `prog`. Caller must free the returned array (the
 // strings inside are pointers into the Aether list and must NOT be
@@ -1300,6 +1350,438 @@ _tuple_string_int_string os_run_pipe_drain_and_wait_raw(const char* prog, void* 
     return out;
 }
 
+/* ============================================================
+ * Process-supervision primitives — process groups, killpg, bounded
+ * waits, and a one-call supervised run. Filed by aeb
+ * (aeb-process-supervision-primitives.md): the floor any build/test
+ * orchestrator hits — run a child as its own process group, forward
+ * interactive signals to it, enforce a wall-clock timeout, then
+ * group-reap anything the child leaked. POSIX-only; the Windows
+ * branch stubs these as "unsupported".
+ * ============================================================ */
+
+/* Send `sig` to `pid`. Thin POSIX kill(2) wrapper, returning 0 on
+ * success and -1 on failure. The two non-obvious conventions are
+ * intentional and documented in the header / module.ae:
+ *   - negative pid → signal the whole group abs(pid);
+ *   - sig == 0     → existence/permission probe, no delivery.
+ * Gated under the "exec" capability bucket: sending a signal is a
+ * process-control action of the same blast radius as spawning one. */
+int os_kill_raw(int pid, int sig) {
+    if (!aether_sandbox_check("exec", "kill")) return -1;
+    return kill((pid_t)pid, sig) == 0 ? 0 : -1;
+}
+
+/* Bounded wait for a single child. Returns (status, timed_out, err):
+ *   - status:    WEXITSTATUS on normal exit, 128+signo when killed by
+ *                a signal, -1 on timeout or error.
+ *   - timed_out: 1 if `secs` elapsed before the child exited (the
+ *                child is left running — the caller decides whether to
+ *                kill it), 0 otherwise.
+ *   - err:       "" on a clean reap or a clean timeout; non-empty on a
+ *                waitpid error / invalid pid.
+ * secs <= 0 means "block indefinitely" (equivalent to os_wait_pid_raw
+ * but with the timed_out slot always 0). Poll cadence is 20ms against
+ * a CLOCK_MONOTONIC deadline so a wall-clock jump can't distort it. */
+_tuple_int_int_string os_wait_pid_timeout_raw(int pid, int secs) {
+    _tuple_int_int_string out = { -1, 0, "" };
+    if (pid <= 0) { out._2 = "invalid pid"; return out; }
+
+    int st = 0;
+    if (secs <= 0) {
+        while (waitpid((pid_t)pid, &st, 0) < 0) {
+            if (errno != EINTR) { out._2 = "waitpid failed"; return out; }
+        }
+    } else {
+        int64_t deadline = os_now_monotonic_ms_raw() + (int64_t)secs * 1000;
+        int reaped = 0;
+        for (;;) {
+            pid_t r = waitpid((pid_t)pid, &st, WNOHANG);
+            if (r == (pid_t)pid) { reaped = 1; break; }
+            if (r < 0) {
+                if (errno == EINTR) continue;
+                out._2 = "waitpid failed";
+                return out;
+            }
+            if (os_now_monotonic_ms_raw() >= deadline) { out._1 = 1; return out; }
+            struct timespec ts = { 0, 20 * 1000 * 1000 }; /* 20ms */
+            nanosleep(&ts, NULL);
+        }
+        (void)reaped;
+    }
+
+    if (WIFEXITED(st)) {
+        out._0 = WEXITSTATUS(st);
+    } else if (WIFSIGNALED(st)) {
+        out._0 = 128 + WTERMSIG(st);
+    } else {
+        out._0 = -1;
+        out._2 = "child terminated abnormally";
+    }
+    return out;
+}
+
+/* Signal-forwarding state for os_run_supervised_raw. A supervised run
+ * installs SIGINT/SIGTERM handlers that forward the signal to the
+ * child's process group, so a Ctrl-C at the controlling terminal tears
+ * down the whole build rather than orphaning the parent's children.
+ * Single-slot global: v1 supports one supervised run forwarding at a
+ * time (nested/concurrent supervised runs in threads would race this).
+ * The handler does nothing but kill(2), which is async-signal-safe. */
+static volatile sig_atomic_t g_supervised_pgid = 0;
+
+static void aether_os_forward_signal(int sig) {
+    pid_t pg = (pid_t)g_supervised_pgid;
+    if (pg > 0) kill(-pg, sig);
+}
+
+/* One-call supervised run. Encodes the bash job-control pattern that
+ * every build/test orchestrator reinvents:
+ *
+ *   - new_process_group: run the child in its own process group
+ *     (pgid == child pid) so signals and reaping can target the whole
+ *     subtree, not just the immediate child.
+ *   - forward_signals: install parent SIGINT/SIGTERM handlers that
+ *     forward to the child's group (requires new_process_group).
+ *   - timeout_secs > 0: TERM the group on deadline, grace 5s, then
+ *     KILL; report exit_code 124 (GNU `timeout` convention).
+ *   - reap_group: after the child exits, TERM→grace→KILL the group to
+ *     clean up anything the build leaked (a stray test server, a
+ *     backgrounded helper), then reap the now-dead members (requires
+ *     new_process_group).
+ *
+ * Returns (exit_code, outcome) where outcome is one of:
+ *   "exited"    — child exited normally; exit_code is its status.
+ *   "signalled" — child was killed by a signal; exit_code is 128+signo.
+ *   "timeout"   — deadline hit, group torn down; exit_code is 124.
+ *   "error"     — spawn / wait failure; exit_code is -1.
+ */
+_tuple_int_string os_run_supervised_raw(const char* prog, void* argv_list, void* env_list,
+                                        int new_process_group, int forward_signals,
+                                        int timeout_secs, int reap_group) {
+    _tuple_int_string out = { -1, "error" };
+    if (!prog) { out._1 = "null prog"; return out; }
+    if (!aether_sandbox_check("exec", prog)) { out._1 = "denied by sandbox"; return out; }
+
+    char** av = build_argv_array(prog, argv_list);
+    if (!av) { out._1 = "argv build failed"; return out; }
+    char** envp = build_envp_array(env_list);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        free(av); free(envp);
+        out._1 = "fork failed";
+        return out;
+    }
+    if (pid == 0) {
+        /* Child: become our own process-group leader before exec so the
+         * parent can address the whole subtree as -pid. Setting it in
+         * both child and parent (below) closes the fork/exec race. */
+        if (new_process_group) setpgid(0, 0);
+        if (envp) execve(prog, av, envp);
+        else      execvp(prog, av);
+        _exit(127);
+    }
+    /* Parent. */
+    if (new_process_group) setpgid(pid, pid); /* harmless if child won the race */
+    free(av); free(envp);
+
+    /* The group we can address with a negative pid. 0 means "no group"
+     * (new_process_group was off) — signal/reap-group steps are skipped. */
+    pid_t group = new_process_group ? pid : 0;
+
+    struct sigaction old_int, old_term, sa;
+    int installed = 0;
+    if (forward_signals && group) {
+        g_supervised_pgid = pid;
+        memset(&sa, 0, sizeof sa);
+        sa.sa_handler = aether_os_forward_signal;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0; /* no SA_RESTART: let waitpid return EINTR so we re-loop */
+        sigaction(SIGINT, &sa, &old_int);
+        sigaction(SIGTERM, &sa, &old_term);
+        installed = 1;
+    }
+
+    int st = 0;
+    const char* outcome = "exited";
+    int exit_code = -1;
+    int handled = 0; /* 1 once outcome/exit_code are final (timeout path) */
+
+    if (timeout_secs > 0) {
+        int64_t deadline = os_now_monotonic_ms_raw() + (int64_t)timeout_secs * 1000;
+        int reaped = 0;
+        for (;;) {
+            pid_t r = waitpid(pid, &st, WNOHANG);
+            if (r == pid) { reaped = 1; break; }
+            if (r < 0) {
+                if (errno == EINTR) continue;
+                break; /* ECHILD or similar — fall through to status decode */
+            }
+            if (os_now_monotonic_ms_raw() >= deadline) break;
+            struct timespec ts = { 0, 20 * 1000 * 1000 };
+            nanosleep(&ts, NULL);
+        }
+        if (!reaped) {
+            /* Deadline hit: TERM the group (or the lone child), give it
+             * 5s to unwind, then KILL and definitely reap. */
+            pid_t target = group ? -group : pid;
+            kill(target, SIGTERM);
+            int64_t grace = os_now_monotonic_ms_raw() + 5000;
+            while (os_now_monotonic_ms_raw() < grace) {
+                if (waitpid(pid, &st, WNOHANG) == pid) { reaped = 1; break; }
+                struct timespec ts = { 0, 20 * 1000 * 1000 };
+                nanosleep(&ts, NULL);
+            }
+            if (!reaped) {
+                kill(target, SIGKILL);
+                waitpid(pid, &st, 0);
+            }
+            outcome = "timeout";
+            exit_code = 124;
+            handled = 1;
+        }
+    } else {
+        while (waitpid(pid, &st, 0) < 0) {
+            if (errno != EINTR) { outcome = "error"; exit_code = -1; handled = 1; break; }
+        }
+    }
+
+    if (!handled) {
+        if (WIFEXITED(st)) {
+            exit_code = WEXITSTATUS(st);
+            outcome = "exited";
+        } else if (WIFSIGNALED(st)) {
+            exit_code = 128 + WTERMSIG(st);
+            outcome = "signalled";
+        } else {
+            exit_code = -1;
+            outcome = "error";
+        }
+    }
+
+    /* Group-reap anything the build leaked into the group. The child
+     * itself is already reaped; these waitpid(-group) calls collect any
+     * other group members we just signalled so they don't linger as
+     * zombies. */
+    if (reap_group && group) {
+        kill(-group, SIGTERM);
+        struct timespec ts = { 0, 100 * 1000 * 1000 }; /* 100ms grace */
+        nanosleep(&ts, NULL);
+        kill(-group, SIGKILL);
+        for (;;) {
+            int st2 = 0;
+            pid_t r = waitpid(-group, &st2, WNOHANG);
+            if (r <= 0) break;
+        }
+    }
+
+    if (installed) {
+        sigaction(SIGINT, &old_int, NULL);
+        sigaction(SIGTERM, &old_term, NULL);
+        g_supervised_pgid = 0;
+    }
+
+    out._0 = exit_code;
+    out._1 = outcome;
+    return out;
+}
+
+typedef struct { const char* _0; const char* _1; int _2; const char* _3; } _tuple_string_string_int_string;
+
+/* Append `n` bytes to a doubling buffer, keeping room for a trailing
+ * NUL. Returns 1 on success, 0 on allocation failure (buffer left
+ * intact for the caller to free). Used by os_run_full_raw's poll
+ * loop to accumulate stdout and stderr independently. */
+static int aether_os_buf_append(char** buf, size_t* len, size_t* cap,
+                                const char* data, size_t n) {
+    if (*len + n + 1 > *cap) {
+        size_t nc = *cap ? *cap : 4096;
+        while (*len + n + 1 > nc) nc *= 2;
+        char* bigger = (char*)realloc(*buf, nc);
+        if (!bigger) return 0;
+        *buf = bigger;
+        *cap = nc;
+    }
+    memcpy(*buf + *len, data, n);
+    *len += n;
+    return 1;
+}
+
+static void aether_os_set_nonblock(int fd) {
+    int fl = fcntl(fd, F_GETFL, 0);
+    if (fl >= 0) fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+}
+
+/* Full three-way child stdio: feed `stdin_data` (exactly `stdin_len`
+ * bytes — binary-safe, NUL bytes included) to the child's stdin, and
+ * capture its stdout and stderr SEPARATELY. Returns
+ * (stdout, stderr, exit_code, err):
+ *   - stdout / stderr: @heap captures the caller owns; "" if empty.
+ *     Like os.run_capture they are NUL-terminated C strings, so a
+ *     capture containing an embedded NUL reads as truncated through
+ *     the string wrappers (the stdin direction has no such limit —
+ *     it is written by explicit length).
+ *   - exit_code: WEXITSTATUS on normal exit, 128+signo if the child
+ *     was killed by a signal, 127 on exec failure, -1 on spawn/IO
+ *     error (err non-empty in that last case).
+ *   - err: "" on a successful spawn (regardless of exit code);
+ *     non-empty only when the fork/exec/pipe couldn't run.
+ *
+ * A poll(2) loop pumps all three fds at once, so the child can write
+ * unbounded stdout/stderr while we stream its stdin — no classic
+ * "fill the pipe buffer and deadlock" hazard. `stdin_len <= 0` gives
+ * the child an immediately-closed (empty) stdin rather than the
+ * parent's, so it can't block reading a terminal. */
+_tuple_string_string_int_string os_run_full_raw(const char* prog, void* argv_list, void* env_list,
+                                                const char* stdin_data, int stdin_len) {
+    _tuple_string_string_int_string out = {
+        aether_os_empty_heap(), aether_os_empty_heap(), -1, "" };
+    if (!prog) { out._3 = "null prog"; return out; }
+    if (!aether_sandbox_check("exec", prog)) { out._3 = "denied by sandbox"; return out; }
+
+    int in_pipe[2]  = { -1, -1 };
+    int out_pipe[2] = { -1, -1 };
+    int err_pipe[2] = { -1, -1 };
+    if (pipe(in_pipe) != 0) { out._3 = "pipe failed"; return out; }
+    if (pipe(out_pipe) != 0) {
+        close(in_pipe[0]); close(in_pipe[1]);
+        out._3 = "pipe failed"; return out;
+    }
+    if (pipe(err_pipe) != 0) {
+        close(in_pipe[0]); close(in_pipe[1]);
+        close(out_pipe[0]); close(out_pipe[1]);
+        out._3 = "pipe failed"; return out;
+    }
+
+    char** av = build_argv_array(prog, argv_list);
+    if (!av) {
+        close(in_pipe[0]); close(in_pipe[1]);
+        close(out_pipe[0]); close(out_pipe[1]);
+        close(err_pipe[0]); close(err_pipe[1]);
+        out._3 = "argv build failed"; return out;
+    }
+    char** envp = build_envp_array(env_list);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(in_pipe[0]); close(in_pipe[1]);
+        close(out_pipe[0]); close(out_pipe[1]);
+        close(err_pipe[0]); close(err_pipe[1]);
+        free(av); free(envp);
+        out._3 = "fork failed"; return out;
+    }
+    if (pid == 0) {
+        /* Child: wire stdin/stdout/stderr to the pipes, close the rest. */
+        close(in_pipe[1]); close(out_pipe[0]); close(err_pipe[0]);
+        if (dup2(in_pipe[0], 0) < 0)  _exit(127);
+        if (dup2(out_pipe[1], 1) < 0) _exit(127);
+        if (dup2(err_pipe[1], 2) < 0) _exit(127);
+        close(in_pipe[0]); close(out_pipe[1]); close(err_pipe[1]);
+        if (envp) execve(prog, av, envp);
+        else      execvp(prog, av);
+        _exit(127);
+    }
+    /* Parent. */
+    free(av); free(envp);
+    close(in_pipe[0]); close(out_pipe[1]); close(err_pipe[1]);
+    int in_fd = in_pipe[1], o_fd = out_pipe[0], e_fd = err_pipe[0];
+
+    size_t in_total = (stdin_data && stdin_len > 0) ? (size_t)stdin_len : 0;
+    size_t in_off = 0;
+    int in_open = 1;
+    if (in_total == 0) { close(in_fd); in_open = 0; } /* empty stdin → immediate EOF */
+
+    aether_os_set_nonblock(o_fd);
+    aether_os_set_nonblock(e_fd);
+    if (in_open) aether_os_set_nonblock(in_fd);
+
+    char* obuf = NULL; size_t olen = 0, ocap = 0;
+    char* ebuf = NULL; size_t elen = 0, ecap = 0;
+    int o_open = 1, e_open = 1, oom = 0;
+    char tmp[4096];
+
+    while (o_open || e_open || in_open) {
+        struct pollfd pfds[3];
+        int nf = 0, oi = -1, ei = -1, ii = -1;
+        if (o_open)  { pfds[nf].fd = o_fd;  pfds[nf].events = POLLIN;  pfds[nf].revents = 0; oi = nf++; }
+        if (e_open)  { pfds[nf].fd = e_fd;  pfds[nf].events = POLLIN;  pfds[nf].revents = 0; ei = nf++; }
+        if (in_open) { pfds[nf].fd = in_fd; pfds[nf].events = POLLOUT; pfds[nf].revents = 0; ii = nf++; }
+
+        if (poll(pfds, nf, -1) < 0) {
+            if (errno == EINTR) continue;
+            break;
+        }
+
+        if (oi >= 0 && pfds[oi].revents) {
+            for (;;) {
+                ssize_t n = read(o_fd, tmp, sizeof tmp);
+                if (n > 0) { if (!aether_os_buf_append(&obuf, &olen, &ocap, tmp, (size_t)n)) { oom = 1; o_open = 0; break; } continue; }
+                if (n == 0) { o_open = 0; break; }
+                if (errno == EINTR) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) { if (pfds[oi].revents & (POLLHUP | POLLERR)) o_open = 0; break; }
+                o_open = 0; break;
+            }
+        }
+        if (ei >= 0 && pfds[ei].revents) {
+            for (;;) {
+                ssize_t n = read(e_fd, tmp, sizeof tmp);
+                if (n > 0) { if (!aether_os_buf_append(&ebuf, &elen, &ecap, tmp, (size_t)n)) { oom = 1; e_open = 0; break; } continue; }
+                if (n == 0) { e_open = 0; break; }
+                if (errno == EINTR) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) { if (pfds[ei].revents & (POLLHUP | POLLERR)) e_open = 0; break; }
+                e_open = 0; break;
+            }
+        }
+        if (ii >= 0 && pfds[ii].revents) {
+            size_t remain = in_total - in_off;
+            size_t chunk = remain > 65536 ? 65536 : remain;
+            ssize_t w = write(in_fd, stdin_data + in_off, chunk);
+            if (w > 0) {
+                in_off += (size_t)w;
+                if (in_off >= in_total) { close(in_fd); in_open = 0; }
+            } else if (w < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+                /* EPIPE etc — child closed stdin early. Stop feeding. */
+                close(in_fd); in_open = 0;
+            }
+            if (oom) break;
+        }
+        if (oom) break;
+    }
+
+    close(o_fd);
+    close(e_fd);
+    if (in_open) close(in_fd);
+
+    int st = 0;
+    while (waitpid(pid, &st, 0) < 0) {
+        if (errno != EINTR) {
+            free(obuf); free(ebuf);
+            out._2 = -1;
+            out._3 = "waitpid failed";
+            return out;
+        }
+    }
+
+    if (oom) {
+        free(obuf); free(ebuf);
+        out._2 = -1;
+        out._3 = "alloc failed";
+        return out;
+    }
+
+    /* NUL-terminate the captures and hand ownership to the caller,
+     * freeing the empty-heap placeholders first (same #420 v2 contract
+     * the other @heap returns follow). */
+    if (obuf) { obuf[olen] = '\0'; free((void*)out._0); out._0 = obuf; }
+    if (ebuf) { ebuf[elen] = '\0'; free((void*)out._1); out._1 = ebuf; }
+
+    if (WIFEXITED(st))        out._2 = WEXITSTATUS(st);
+    else if (WIFSIGNALED(st)) out._2 = 128 + WTERMSIG(st);
+    else                      out._2 = -1;
+    return out;
+}
+
 /* Child side: returns the parent-channel fd if the parent spawned
  * us via os_run_pipe* (i.e. AETHER_IPC_FD is set and the named fd
  * is open writable); -1 otherwise.
@@ -1608,6 +2090,31 @@ static int win_launch(const char* prog, void* argv_list, void* env_list,
     return 0;
 }
 
+/* Working-directory accessors — Windows. UTF-8 path in / UTF-8 path out,
+ * converted through the wide-char helpers so non-ASCII paths survive. */
+int os_chdir_raw(const char* path) {
+    if (!path) return -1;
+    if (!aether_sandbox_check("fs", path)) return -1;
+    wchar_t* w = utf8_to_wide(path);
+    if (!w) return -1;
+    BOOL ok = SetCurrentDirectoryW(w);
+    free(w);
+    return ok ? 0 : -1;
+}
+
+char* os_getcwd_raw(void) {
+    /* GetCurrentDirectoryW(0, NULL) returns the buffer size (incl. NUL). */
+    DWORD need = GetCurrentDirectoryW(0, NULL);
+    if (need == 0) return NULL;
+    wchar_t* w = (wchar_t*)malloc(sizeof(wchar_t) * need);
+    if (!w) return NULL;
+    DWORD got = GetCurrentDirectoryW(need, w);
+    if (got == 0 || got >= need) { free(w); return NULL; }
+    char* utf8 = wide_to_utf8(w);
+    free(w);
+    return utf8;
+}
+
 int os_run(const char* prog, void* argv_list, void* env_list) {
     if (!prog) return -1;
     if (!aether_sandbox_check("exec", prog)) return -1;
@@ -1688,6 +2195,279 @@ _tuple_int_string os_wait_pid_raw(int pid) {
 _tuple_string_int_string os_run_pipe_drain_and_wait_raw(const char* prog, void* argv_list, void* env_list) {
     (void)prog; (void)argv_list; (void)env_list;
     _tuple_string_int_string out = { aether_os_empty_heap(), -1, "unsupported on Windows" };
+    return out;
+}
+
+/* Process-supervision primitives on Windows.
+ *
+ * POSIX process groups + killpg + sigaction don't exist here; the clean
+ * Win32 mapping is:
+ *   - process *group* lifecycle (timeout, group-reap of leaked children)
+ *     → a Job Object. JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE makes closing
+ *     the job tear down the whole tree, which IS group-reap;
+ *     TerminateJobObject is the group kill;
+ *   - signal forwarding → a console control handler that terminates the
+ *     job on Ctrl-C / Ctrl-Break (console apps only; there are no
+ *     catchable POSIX signals to forward);
+ *   - waiting / timeout → WaitForSingleObject on the process handle.
+ * There is no "killed by signal" outcome on Windows, so run_supervised
+ * reports "exited" (or "timeout"); os.kill maps any non-zero signal to a
+ * forced TerminateProcess (no graceful SIGTERM) and rejects negative-pid
+ * group signalling (no pgid-by-negative-pid concept). */
+
+int os_kill_raw(int pid, int sig) {
+    if (!aether_sandbox_check("exec", "kill")) return -1;
+    /* Negative pid = signal a whole group: no Win32 equivalent. */
+    if (pid < 0) return -1;
+    if (sig == 0) {
+        /* Existence probe: open + a zero-timeout wait. WAIT_TIMEOUT means
+         * the process is still running (alive); WAIT_OBJECT_0 means it has
+         * already exited (gone) — matches POSIX kill -0 semantics. */
+        HANDLE h = OpenProcess(SYNCHRONIZE, FALSE, (DWORD)pid);
+        if (!h) return -1;
+        DWORD w = WaitForSingleObject(h, 0);
+        CloseHandle(h);
+        return (w == WAIT_TIMEOUT) ? 0 : -1;
+    }
+    HANDLE h = OpenProcess(PROCESS_TERMINATE, FALSE, (DWORD)pid);
+    if (!h) return -1;
+    /* Exit code mirrors POSIX 128+signo so a waiter can tell it was a kill. */
+    BOOL ok = TerminateProcess(h, (UINT)(128 + sig));
+    CloseHandle(h);
+    return ok ? 0 : -1;
+}
+
+_tuple_int_int_string os_wait_pid_timeout_raw(int pid, int secs) {
+    _tuple_int_int_string out = { -1, 0, "" };
+    if (pid <= 0) { out._2 = "invalid pid"; return out; }
+    HANDLE h = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_INFORMATION, FALSE, (DWORD)pid);
+    if (!h) { out._2 = "no such process"; return out; }
+    DWORD ms = (secs <= 0) ? INFINITE : (DWORD)secs * 1000;
+    DWORD w = WaitForSingleObject(h, ms);
+    if (w == WAIT_TIMEOUT) { out._1 = 1; CloseHandle(h); return out; }
+    if (w != WAIT_OBJECT_0) { out._2 = "wait failed"; CloseHandle(h); return out; }
+    DWORD code = 0;
+    GetExitCodeProcess(h, &code);
+    CloseHandle(h);
+    out._0 = (int)code;
+    return out;
+}
+
+/* Forward-signals state: the job to tear down on Ctrl-C / Ctrl-Break.
+ * Single supervised run at a time (mirrors the POSIX g_supervised_pgid). */
+static HANDLE g_supervised_job = NULL;
+
+static BOOL WINAPI aether_os_ctrl_handler(DWORD ctrl) {
+    if ((ctrl == CTRL_C_EVENT || ctrl == CTRL_BREAK_EVENT) && g_supervised_job) {
+        TerminateJobObject(g_supervised_job, (UINT)(128 + 2)); /* SIGINT-ish */
+        return TRUE;
+    }
+    return FALSE;
+}
+
+_tuple_int_string os_run_supervised_raw(const char* prog, void* argv_list, void* env_list,
+                                        int new_process_group, int forward_signals,
+                                        int timeout_secs, int reap_group) {
+    _tuple_int_string out = { -1, "error" };
+    if (!prog) { out._1 = "null prog"; return out; }
+    if (!aether_sandbox_check("exec", prog)) { out._1 = "denied by sandbox"; return out; }
+
+    wchar_t* cmdline = build_command_line(prog, argv_list);
+    if (!cmdline) { out._1 = "argv build failed"; return out; }
+    wchar_t* wprog = utf8_to_wide(prog);
+    if (!wprog) { free(cmdline); out._1 = "argv build failed"; return out; }
+    wchar_t* wenv = build_environ_block(env_list); /* NULL = inherit */
+
+    HANDLE job = CreateJobObjectW(NULL, NULL);
+    if (!job) { free(cmdline); free(wprog); free(wenv); out._1 = "job create failed"; return out; }
+
+    /* Arm kill-on-close only when reap_group is set: closing the job then
+     * tears down the whole tree (the Windows group-reap). Without it,
+     * leaked children outlive the job-handle close. */
+    if (reap_group) {
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli;
+        memset(&jeli, 0, sizeof jeli);
+        jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        SetInformationJobObject(job, JobObjectExtendedLimitInformation, &jeli, sizeof jeli);
+    }
+
+    STARTUPINFOW si; memset(&si, 0, sizeof si); si.cb = sizeof si;
+    PROCESS_INFORMATION pi; memset(&pi, 0, sizeof pi);
+
+    /* CREATE_SUSPENDED so we can assign to the job before the child runs —
+     * otherwise a fast child could spawn grandchildren that escape it. */
+    DWORD flags = CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED;
+    if (new_process_group) flags |= CREATE_NEW_PROCESS_GROUP;
+
+    BOOL ok = CreateProcessW(wprog, cmdline, NULL, NULL, FALSE, flags, wenv, NULL, &si, &pi);
+    free(cmdline); free(wprog); free(wenv);
+    if (!ok) { CloseHandle(job); out._1 = "spawn failed"; return out; }
+
+    AssignProcessToJobObject(job, pi.hProcess);
+
+    HANDLE old_job = g_supervised_job;
+    int installed = 0;
+    if (forward_signals) {
+        g_supervised_job = job;
+        SetConsoleCtrlHandler(aether_os_ctrl_handler, TRUE);
+        installed = 1;
+    }
+
+    ResumeThread(pi.hThread);
+
+    const char* outcome = "exited";
+    int exit_code = -1;
+    DWORD ms = (timeout_secs > 0) ? (DWORD)timeout_secs * 1000 : INFINITE;
+    DWORD w = WaitForSingleObject(pi.hProcess, ms);
+    if (w == WAIT_TIMEOUT) {
+        TerminateJobObject(job, 124);             /* GNU timeout convention */
+        WaitForSingleObject(pi.hProcess, 5000);
+        outcome = "timeout";
+        exit_code = 124;
+    } else if (w == WAIT_OBJECT_0) {
+        DWORD code = 0;
+        GetExitCodeProcess(pi.hProcess, &code);
+        exit_code = (int)code;
+        outcome = "exited";
+    } else {
+        outcome = "error";
+        exit_code = -1;
+    }
+
+    if (installed) {
+        SetConsoleCtrlHandler(aether_os_ctrl_handler, FALSE);
+        g_supervised_job = old_job;
+    }
+
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    CloseHandle(job); /* fires KILL_ON_JOB_CLOSE when reap_group was set */
+
+    out._0 = exit_code;
+    out._1 = outcome;
+    return out;
+}
+
+/* os.run_full on Windows. The POSIX side uses a poll(2) loop over the
+ * three pipes; Win32 anonymous pipes aren't pollable, so we drain stdout
+ * and stderr on dedicated reader threads while the main thread writes
+ * stdin — same deadlock-free guarantee, different mechanism. */
+typedef struct { const char* _0; const char* _1; int _2; const char* _3; } _tuple_string_string_int_string;
+
+typedef struct {
+    HANDLE pipe;
+    char*  buf;
+    size_t len;
+    size_t cap;
+    int    oom;
+} aether_win_drain_ctx;
+
+/* Read `pipe` to EOF into a doubling buffer. EOF on a Win32 pipe surfaces
+ * as ReadFile returning FALSE with ERROR_BROKEN_PIPE once the child's
+ * write end is closed — treated as a clean end-of-stream. */
+static unsigned __stdcall aether_win_drain_thread(void* arg) {
+    aether_win_drain_ctx* c = (aether_win_drain_ctx*)arg;
+    char tmp[4096];
+    DWORD got = 0;
+    for (;;) {
+        if (!ReadFile(c->pipe, tmp, sizeof tmp, &got, NULL)) break;
+        if (got == 0) break;
+        if (c->len + got + 1 > c->cap) {
+            size_t nc = c->cap ? c->cap : 4096;
+            while (c->len + got + 1 > nc) nc *= 2;
+            char* b = (char*)realloc(c->buf, nc);
+            if (!b) { c->oom = 1; break; }
+            c->buf = b; c->cap = nc;
+        }
+        memcpy(c->buf + c->len, tmp, got);
+        c->len += got;
+    }
+    return 0;
+}
+
+_tuple_string_string_int_string os_run_full_raw(const char* prog, void* argv_list, void* env_list,
+                                                const char* stdin_data, int stdin_len) {
+    _tuple_string_string_int_string out = {
+        aether_os_empty_heap(), aether_os_empty_heap(), -1, "" };
+    if (!prog) { out._3 = "null prog"; return out; }
+    if (!aether_sandbox_check("exec", prog)) { out._3 = "denied by sandbox"; return out; }
+
+    SECURITY_ATTRIBUTES sa; memset(&sa, 0, sizeof sa);
+    sa.nLength = sizeof sa; sa.bInheritHandle = TRUE; sa.lpSecurityDescriptor = NULL;
+
+    HANDLE in_r = NULL, in_w = NULL, out_r = NULL, out_w = NULL, err_r = NULL, err_w = NULL;
+    if (!CreatePipe(&in_r, &in_w, &sa, 0)) { out._3 = "pipe failed"; return out; }
+    if (!CreatePipe(&out_r, &out_w, &sa, 0)) {
+        CloseHandle(in_r); CloseHandle(in_w);
+        out._3 = "pipe failed"; return out;
+    }
+    if (!CreatePipe(&err_r, &err_w, &sa, 0)) {
+        CloseHandle(in_r); CloseHandle(in_w); CloseHandle(out_r); CloseHandle(out_w);
+        out._3 = "pipe failed"; return out;
+    }
+    /* Parent-side ends must not be inherited by the child. */
+    SetHandleInformation(in_w,  HANDLE_FLAG_INHERIT, 0);
+    SetHandleInformation(out_r, HANDLE_FLAG_INHERIT, 0);
+    SetHandleInformation(err_r, HANDLE_FLAG_INHERIT, 0);
+
+    wchar_t* cmdline = build_command_line(prog, argv_list);
+    wchar_t* wprog = utf8_to_wide(prog);
+    wchar_t* wenv = build_environ_block(env_list); /* NULL = inherit */
+    if (!cmdline || !wprog) {
+        free(cmdline); free(wprog); free(wenv);
+        CloseHandle(in_r); CloseHandle(in_w); CloseHandle(out_r);
+        CloseHandle(out_w); CloseHandle(err_r); CloseHandle(err_w);
+        out._3 = "argv build failed"; return out;
+    }
+
+    STARTUPINFOW si; memset(&si, 0, sizeof si); si.cb = sizeof si;
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput  = in_r;
+    si.hStdOutput = out_w;
+    si.hStdError  = err_w;
+    PROCESS_INFORMATION pi; memset(&pi, 0, sizeof pi);
+
+    BOOL ok = CreateProcessW(wprog, cmdline, NULL, NULL, TRUE,
+                             CREATE_UNICODE_ENVIRONMENT, wenv, NULL, &si, &pi);
+    free(cmdline); free(wprog); free(wenv);
+    /* Close the child-side ends in the parent so EOF propagates correctly. */
+    CloseHandle(in_r); CloseHandle(out_w); CloseHandle(err_w);
+    if (!ok) {
+        CloseHandle(in_w); CloseHandle(out_r); CloseHandle(err_r);
+        out._3 = "spawn failed"; return out;
+    }
+
+    aether_win_drain_ctx octx; memset(&octx, 0, sizeof octx); octx.pipe = out_r;
+    aether_win_drain_ctx ectx; memset(&ectx, 0, sizeof ectx); ectx.pipe = err_r;
+    HANDLE ot = (HANDLE)_beginthreadex(NULL, 0, aether_win_drain_thread, &octx, 0, NULL);
+    HANDLE et = (HANDLE)_beginthreadex(NULL, 0, aether_win_drain_thread, &ectx, 0, NULL);
+
+    size_t total = (stdin_data && stdin_len > 0) ? (size_t)stdin_len : 0;
+    size_t off = 0;
+    while (off < total) {
+        DWORD chunk = (DWORD)((total - off) > 65536 ? 65536 : (total - off));
+        DWORD wrote = 0;
+        if (!WriteFile(in_w, stdin_data + off, chunk, &wrote, NULL)) break; /* child closed stdin */
+        off += wrote;
+    }
+    CloseHandle(in_w); /* deliver EOF to the child's stdin */
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    if (ot) { WaitForSingleObject(ot, INFINITE); CloseHandle(ot); }
+    if (et) { WaitForSingleObject(et, INFINITE); CloseHandle(et); }
+    CloseHandle(out_r); CloseHandle(err_r);
+
+    DWORD code = 0;
+    GetExitCodeProcess(pi.hProcess, &code);
+    CloseHandle(pi.hThread); CloseHandle(pi.hProcess);
+
+    if (octx.oom || ectx.oom) {
+        free(octx.buf); free(ectx.buf);
+        out._3 = "alloc failed"; return out;
+    }
+    if (octx.buf) { octx.buf[octx.len] = '\0'; free((void*)out._0); out._0 = octx.buf; }
+    if (ectx.buf) { ectx.buf[ectx.len] = '\0'; free((void*)out._1); out._1 = ectx.buf; }
+    out._2 = (int)code;
     return out;
 }
 

--- a/std/os/aether_os.h
+++ b/std/os/aether_os.h
@@ -22,6 +22,29 @@ char* os_getenv(const char* name);
 // Not available on Windows (returns -1).
 int os_execv(const char* prog, void* argv_list);
 
+// Send signal `sig` to `pid` (POSIX kill(2)). Returns 0 on success,
+// -1 on failure (errno set by kill). Two POSIX conventions are
+// deliberately exposed:
+//   - A NEGATIVE pid signals the whole process *group* whose pgid is
+//     abs(pid) — the building block for "tear down the build and
+//     everything it spawned."
+//   - sig == 0 performs no delivery but still runs the permission /
+//     existence checks, so it is the canonical "is this pid/group
+//     still alive?" probe (returns 0 if it exists, -1/ESRCH if not).
+// Not available on Windows (returns -1). POSIX-only.
+int os_kill_raw(int pid, int sig);
+
+// Change the current process's working directory to `path`. Returns 0
+// on success, -1 on failure. POSIX chdir(2) / Windows
+// SetCurrentDirectoryW (UTF-8 path converted to UTF-16). Not available
+// on no-filesystem builds (returns -1).
+int os_chdir_raw(const char* path);
+
+// Current working directory as a fresh heap-allocated string the caller
+// owns (NULL on failure). POSIX getcwd(3) / Windows GetCurrentDirectoryW
+// (UTF-16 result converted to UTF-8).
+char* os_getcwd_raw(void);
+
 // Search PATH for an executable named `name`. Returns the absolute
 // path to the first executable hit, or NULL if not found. If `name`
 // already contains '/', it's returned as-is when it's executable

--- a/std/os/module.ae
+++ b/std/os/module.ae
@@ -21,7 +21,11 @@ exports (
     now_local, now_local_iso8601, LocalTime,
     platform,
     setenv, unsetenv,
-    run_pipe, wait_pid, run_pipe_drain_and_wait
+    run_pipe, wait_pid, run_pipe_drain_and_wait,
+    os_kill_raw, os_wait_pid_timeout_raw, os_run_supervised_raw,
+    kill, wait_pid_timeout, run_supervised,
+    os_run_full_raw, run_full,
+    os_chdir_raw, os_getcwd_raw, chdir, getcwd
 )
 
 // Run a shell command, returns exit code (0 = success)
@@ -251,6 +255,160 @@ wait_pid(pid: int) -> {
 // "unsupported on Windows").
 run_pipe_drain_and_wait(prog: string, argv: ptr, env: ptr) -> {
     return os_run_pipe_drain_and_wait_raw(prog, argv, env)
+}
+
+// --- Process-supervision primitives -----------------------------------
+//
+// The floor any build/test orchestrator hits: run a child as its own
+// process group, forward interactive signals to it, enforce a
+// wall-clock timeout, then group-reap anything the child leaked. The
+// hard part — fork/exec, waitpid — was already here (os.run_pipe,
+// os.wait_pid); these add the missing process-*group* lifecycle.
+//
+// Cross-platform. POSIX uses fork + setpgid + killpg + waitpid; Windows
+// maps the same shape onto Job Objects (group kill / kill-on-close
+// reap), WaitForSingleObject (timeout), TerminateProcess (kill), and a
+// console control handler (signal forwarding). The platform deltas are
+// called out per function; the broad ones are: Windows has no graceful
+// signal (kill is always a forced terminate), no "signalled" outcome,
+// and no negative-pid group signalling via os.kill (the grouping lives
+// in the Job Object that run_supervised manages internally).
+
+// Send signal `sig` to `pid` — POSIX kill(2). Returns 0 on success,
+// -1 on failure. Two conventions are deliberately exposed:
+//   - a NEGATIVE pid signals the whole process group abs(pid), the
+//     building block for tearing down a build and all it spawned;
+//   - `sig == 0` delivers nothing but still runs the existence /
+//     permission checks — the canonical "is this pid/group alive?"
+//     probe (0 = alive, -1 = gone).
+// Signal numbers live in `std.signal` (SIGINT / SIGTERM / SIGKILL …)
+// so callers needn't hard-code 2 / 15 / 9.
+// Windows: `sig == 0` probes via OpenProcess; any other signal maps to
+// a forced TerminateProcess (no catchable SIGTERM); a negative pid
+// (group signalling) returns -1 — there is no pgid-by-negative-pid.
+extern os_kill_raw(pid: int, sig: int) -> int
+
+// Bounded wait for one child. Returns (status, timed_out, err):
+//   - status:    WEXITSTATUS on normal exit, 128+signo when signalled,
+//                -1 on timeout or error.
+//   - timed_out: 1 if `secs` elapsed before exit (the child is left
+//                RUNNING — caller decides whether to os.kill it), else 0.
+//   - err:       "" on a clean reap or clean timeout; non-empty on a
+//                waitpid error / invalid pid.
+// `secs <= 0` blocks indefinitely (like os.wait_pid, timed_out always 0).
+// Lets a supervisor bound a wait without a separate watchdog process.
+// Windows: OpenProcess + WaitForSingleObject(secs); status is the
+// process exit code (no signal concept).
+extern os_wait_pid_timeout_raw(pid: int, secs: int) -> (int, int, string)
+
+// One-call supervised run — the whole job-control pattern in one
+// primitive. Returns (exit_code, outcome). Options are int flags
+// (1 = on, 0 = off) rather than a stringly-typed map, matching the
+// rest of std.os.
+//   - new_process_group: child runs in its own group (POSIX pgid == pid;
+//     Windows: its own Job Object + CREATE_NEW_PROCESS_GROUP) so signals
+//     and reaping address the whole subtree.
+//   - forward_signals:   POSIX — parent SIGINT/SIGTERM forward to the
+//     child's group; Windows — a console Ctrl-C/Ctrl-Break handler
+//     terminates the job tree. Needs new_process_group; one supervised
+//     run at a time.
+//   - timeout_secs > 0:  POSIX — TERM the group on deadline, 5s grace,
+//     then KILL; Windows — TerminateJobObject. Reports exit_code 124
+//     (GNU `timeout` convention).
+//   - reap_group:        after the child exits, clean up anything it
+//     leaked into the group (POSIX TERM→grace→KILL + reap; Windows
+//     JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE). Needs new_process_group.
+// outcome ∈ {"exited","signalled","timeout","error"}. Windows never
+// reports "signalled" (no signal concept) — a killed child reads as
+// "exited" with its terminate code.
+extern os_run_supervised_raw(prog: string, argv: ptr, env: ptr,
+                             new_process_group: int, forward_signals: int,
+                             timeout_secs: int, reap_group: int) -> (int, string)
+
+// Send `sig` to `pid` (POSIX kill(2)). 0 = success, -1 = failure.
+// Negative pid = whole group; sig 0 = existence probe. See
+// os_kill_raw for the full contract; signal numbers are in std.signal.
+kill(pid: int, sig: int) -> int {
+    return os_kill_raw(pid, sig)
+}
+
+// Bounded wait — (status, timed_out, err). See os_wait_pid_timeout_raw.
+wait_pid_timeout(pid: int, secs: int) -> {
+    return os_wait_pid_timeout_raw(pid, secs)
+}
+
+// Supervised run — (exit_code, outcome). See os_run_supervised_raw for
+// the per-flag semantics. The common build-orchestrator shape is
+// `run_supervised(prog, argv, env, 1, 1, timeout, 1)`: own group,
+// forward Ctrl-C, enforce a timeout, group-reap leaks.
+run_supervised(prog: string, argv: ptr, env: ptr,
+               new_process_group: int, forward_signals: int,
+               timeout_secs: int, reap_group: int) -> {
+    return os_run_supervised_raw(prog, argv, env,
+                                 new_process_group, forward_signals,
+                                 timeout_secs, reap_group)
+}
+
+// Length of a (length-aware) Aether string, used to feed stdin to a
+// child binary-safely. Declared here so run_full needn't take a
+// separate length argument from callers.
+extern string_length(str: string) -> int
+
+// Full three-way child stdio — the gap os.run_capture leaves open.
+// Feeds `stdin_data` to the child's stdin (binary-safe: exactly its
+// stored length is written, embedded NULs included) and captures
+// stdout and stderr SEPARATELY. Returns (stdout, stderr, exit_code,
+// err):
+//   - stdout / stderr: the child's two streams, captured independently
+//     (the `2>&1`-merged shape is not this call). "" when empty. Like
+//     os.run_capture they are NUL-terminated, so a capture holding an
+//     embedded NUL reads as truncated through the string ops — the
+//     stdin direction has no such limit.
+//   - exit_code: WEXITSTATUS on normal exit, 128+signo if signalled,
+//     127 on exec failure, -1 on spawn/IO error.
+//   - err: "" on a successful spawn (regardless of exit code);
+//     non-empty only when the fork/exec/pipe itself failed.
+// No pipe-buffer deadlock regardless of stream sizes: POSIX pumps all
+// three fds in one poll(2) loop; Windows drains stdout/stderr on reader
+// threads while the main thread writes stdin (Win32 anonymous pipes
+// aren't pollable). An empty `stdin_data` gives the child an
+// immediately-closed stdin (it can't block on the terminal).
+extern os_run_full_raw(prog: string, argv: ptr, env: ptr,
+                       stdin_data: string, stdin_len: int) -> (string @heap, string @heap, int, string)
+
+// (stdout, stderr, exit_code, err) — feed `stdin_data` and capture both
+// streams. Pass "" for stdin_data when the child reads no input. See
+// os_run_full_raw for the full contract.
+run_full(prog: string, argv: ptr, env: ptr, stdin_data: string) -> {
+    return os_run_full_raw(prog, argv, env, stdin_data, string_length(stdin_data))
+}
+
+// --- Working directory -----------------------------------------------
+// Cross-platform: POSIX chdir(2)/getcwd(3), Windows
+// SetCurrentDirectory/GetCurrentDirectory. An orchestrator entry point
+// needs these to run build steps relative to a project root.
+
+extern os_chdir_raw(path: string) -> int
+extern os_getcwd_raw() -> string
+
+// Change the process working directory. Returns "" on success, an error
+// message on failure (e.g. directory missing or not a directory).
+chdir(path: string) -> string {
+    if os_chdir_raw(path) == 0 {
+        return ""
+    }
+    return "cannot change directory"
+}
+
+// Current working directory, or "" on failure. Returns a fresh
+// refcounted string the caller owns (the raw strdup is reclaimed by the
+// heap-string tracker — os_getcwd_raw is classified owned-heap in codegen).
+getcwd() -> string {
+    s = os_getcwd_raw()
+    if s == null {
+        return ""
+    }
+    return string_concat(s, "")
 }
 
 // argv[0] — path the OS launched the current process with. Returns "" if

--- a/std/signal/module.ae
+++ b/std/signal/module.ae
@@ -1,0 +1,56 @@
+// std.signal — POSIX signal-number constants.
+// Import with: import std.signal
+//
+// Pairs with std.os's process-supervision primitives so callers pass
+// `signal.SIGTERM()` to `os.kill(pid, signal.SIGTERM())` instead of
+// hard-coding 15 (or 2, or 9). Pure-Aether: these are the standard
+// POSIX signal numbers, identical across Linux, macOS, and the BSDs.
+//
+// Exposed as zero-arg functions because Aether has no top-level `const`
+// (same shape as std.math's `math_pi` etc.). The set is limited to the
+// signals whose numbers are stable across every POSIX target — the
+// real-time and job-control signals (SIGUSR1/2, SIGCHLD, SIGSTOP…)
+// differ by platform (e.g. SIGUSR1 is 10 on Linux but 30 on macOS), so
+// they are intentionally omitted rather than shipped wrong; read them
+// from the platform header on the C side if you need them.
+
+exports (
+    SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGABRT,
+    SIGFPE, SIGKILL, SIGSEGV, SIGPIPE, SIGALRM, SIGTERM
+)
+
+// Hangup — controlling terminal closed / daemon reload convention.
+SIGHUP() -> int { return 1 }
+
+// Interrupt — what Ctrl-C raises. Forwarded to the build group by
+// os.run_supervised when forward_signals is on.
+SIGINT() -> int { return 2 }
+
+// Quit — Ctrl-\, like SIGINT but with a core dump.
+SIGQUIT() -> int { return 3 }
+
+// Illegal instruction.
+SIGILL() -> int { return 4 }
+
+// Abort — what abort(3) / assert(3) raise.
+SIGABRT() -> int { return 6 }
+
+// Floating-point exception (also integer divide-by-zero).
+SIGFPE() -> int { return 8 }
+
+// Kill — cannot be caught, blocked, or ignored. The "grace expired,
+// take it down now" signal os.run_supervised sends after SIGTERM.
+SIGKILL() -> int { return 9 }
+
+// Invalid memory reference.
+SIGSEGV() -> int { return 11 }
+
+// Write to a pipe with no reader.
+SIGPIPE() -> int { return 13 }
+
+// Timer signal from alarm(2).
+SIGALRM() -> int { return 14 }
+
+// Termination — the polite "please shut down" request. The default
+// signal os.run_supervised sends first on timeout / group teardown.
+SIGTERM() -> int { return 15 }

--- a/tests/integration/run_arg_forwarding/main.ae
+++ b/tests/integration/run_arg_forwarding/main.ae
@@ -1,0 +1,15 @@
+// Driver for the `ae run … -- <args>` forwarding integration test.
+// Prints argc and each forwarded argument on its own line so the shell
+// test can assert both the count and that a spaces-containing arg stays
+// a single token.
+import std.os
+
+main() {
+    n = aether_args_count()
+    println("argc=${n}")
+    i = 1
+    while i < n {
+        println("ARG:${aether_args_get(i)}")
+        i = i + 1
+    }
+}

--- a/tests/integration/run_arg_forwarding/test_run_arg_forwarding.sh
+++ b/tests/integration/run_arg_forwarding/test_run_arg_forwarding.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Integration test: `ae run <file.ae> -- <args>` forwards everything after
+# the `--` separator to the running program's argv (like `cargo run --`).
+# A config-is-code entry point (e.g. an Aether build supervisor) needs
+# this so `ae run supervisor.ae -- make -j8` sees make/-j8 in its args.
+#
+# Asserts:
+#   1. Args after `--` reach the program (they were dropped before).
+#   2. A single arg containing spaces stays ONE token (double-quoted
+#      through run_cmd's tokenizer), not split.
+#   3. No `--` → no forwarded args (argc == 1).
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+MAIN="$SCRIPT_DIR/main.ae"
+
+fail() { echo "  FAIL: $1"; exit 1; }
+
+# --- Case 1 + 2: forward three args, the middle one with a space -------
+out=$("$AE" run "$MAIN" -- alpha "beta gamma" delta 2>&1)
+
+echo "$out" | grep -q "argc=4" || fail "expected argc=4, got: $(echo "$out" | grep argc)"
+echo "$out" | grep -qx "ARG:alpha"      || fail "missing ARG:alpha"
+echo "$out" | grep -qx "ARG:beta gamma" || fail "spaces-arg was split or lost (expected 'ARG:beta gamma')"
+echo "$out" | grep -qx "ARG:delta"      || fail "missing ARG:delta"
+
+# --- Case 3: no `--` → nothing forwarded -------------------------------
+out2=$("$AE" run "$MAIN" 2>&1)
+echo "$out2" | grep -q "argc=1" || fail "expected argc=1 with no '--', got: $(echo "$out2" | grep argc)"
+
+echo "  PASS: ae run forwards post-'--' args (spaces preserved); none without '--'"

--- a/tests/leaks_exclude.txt
+++ b/tests/leaks_exclude.txt
@@ -8,3 +8,4 @@
 # on Linux CI under Valgrind / ASan-LSan instead, which handle subprocess
 # spawns correctly.
 test_run_capture_status
+test_os_run_full

--- a/tests/regression/test_os_cwd.ae
+++ b/tests/regression/test_os_cwd.ae
@@ -1,0 +1,61 @@
+// Regression test for os.chdir / os.getcwd — process working-directory
+// accessors (POSIX chdir(2)/getcwd(3); Windows Set/GetCurrentDirectory).
+
+import std.os
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== os.chdir / os.getcwd ===")
+
+    if os_getenv("OS") == "Windows_NT" {
+        println("  SKIP: paths in this test are POSIX-shaped")
+        return
+    }
+
+    // getcwd returns something non-empty.
+    start = os.getcwd()
+    if start == "" {
+        println("  FAIL: getcwd() returned empty")
+        exit(1)
+    }
+    println("  PASS: getcwd() = ${start}")
+
+    // chdir to root (no symlink indirection, stable across Unix) and
+    // confirm getcwd reflects it.
+    err = os.chdir("/")
+    if err != "" {
+        println("  FAIL: chdir('/') err=${err}")
+        exit(1)
+    }
+    here = os.getcwd()
+    if here != "/" {
+        println("  FAIL: after chdir('/'), getcwd()=${here}, expected /")
+        exit(1)
+    }
+    println("  PASS: chdir('/') then getcwd() == /")
+
+    // chdir back to where we started, confirm round-trip.
+    err2 = os.chdir(start)
+    if err2 != "" {
+        println("  FAIL: chdir back err=${err2}")
+        exit(1)
+    }
+    back = os.getcwd()
+    if !string.equals(back, start) {
+        println("  FAIL: round-trip cwd=${back}, expected ${start}")
+        exit(1)
+    }
+    println("  PASS: chdir round-trip restores cwd")
+
+    // chdir to a path that doesn't exist → non-empty error.
+    bad = os.chdir("/no/such/directory/anywhere")
+    if bad == "" {
+        println("  FAIL: chdir to missing dir should return an error")
+        exit(1)
+    }
+    println("  PASS: chdir to missing dir → error (${bad})")
+
+    println("=== All cases passed ===")
+}

--- a/tests/regression/test_os_run_full.ae
+++ b/tests/regression/test_os_run_full.ae
@@ -1,0 +1,143 @@
+// Regression test for os.run_full — the three-way child-stdio primitive:
+// feed stdin (binary-safe) and capture stdout and stderr SEPARATELY,
+// the gap os.run_capture (stdout-only) leaves open.
+//
+// POSIX-only — on Windows the raw extern reports "unsupported on
+// Windows" (Win32 anonymous pipes aren't pollable). /bin/sh and cat are
+// POSIX-guaranteed.
+
+import std.os
+import std.list
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== os.run_full ===")
+
+    if os_getenv("OS") == "Windows_NT" {
+        println("  SKIP: os.run_full is POSIX-only")
+        return
+    }
+
+    // --- stdin feed + stdout capture ---------------------------------
+    // cat echoes its stdin to stdout. Proves stdin is fed and stdout
+    // captured; stderr must be empty.
+    av0 = list_new()
+    out0, err0, code0, spawn0 = os.run_full("/bin/cat", av0, null, "hello\nworld\n")
+    if spawn0 != "" {
+        println("  FAIL: cat spawn err=${spawn0}")
+        exit(1)
+    }
+    if out0 != "hello\nworld\n" {
+        println("  FAIL: cat stdout=[${out0}], expected the fed input")
+        exit(1)
+    }
+    if err0 != "" {
+        println("  FAIL: cat stderr=[${err0}], expected empty")
+        exit(1)
+    }
+    if code0 != 0 {
+        println("  FAIL: cat exit=${code0}, expected 0")
+        exit(1)
+    }
+    list_free(av0)
+    println("  PASS: stdin fed, stdout captured, stderr empty, exit 0")
+
+    // --- stdout and stderr captured SEPARATELY -----------------------
+    av1 = list_new()
+    list_add(av1, "-c")
+    list_add(av1, "printf OUT; printf ERR >&2; exit 0")
+    out1, err1, code1, spawn1 = os.run_full("/bin/sh", av1, null, "")
+    if spawn1 != "" {
+        println("  FAIL: sh spawn err=${spawn1}")
+        exit(1)
+    }
+    if out1 != "OUT" {
+        println("  FAIL: stdout=[${out1}], expected OUT")
+        exit(1)
+    }
+    if err1 != "ERR" {
+        println("  FAIL: stderr=[${err1}], expected ERR (not merged into stdout)")
+        exit(1)
+    }
+    if code1 != 0 {
+        println("  FAIL: exit=${code1}, expected 0")
+        exit(1)
+    }
+    list_free(av1)
+    println("  PASS: stdout and stderr captured on separate channels")
+
+    // --- exit code ----------------------------------------------------
+    av2 = list_new()
+    list_add(av2, "-c")
+    list_add(av2, "exit 7")
+    out2, err2, code2, spawn2 = os.run_full("/bin/sh", av2, null, "")
+    if code2 != 7 {
+        println("  FAIL: sh -c 'exit 7' exit=${code2}, expected 7")
+        exit(1)
+    }
+    if out2 != "" || err2 != "" {
+        println("  FAIL: expected empty output for exit-7 case")
+        exit(1)
+    }
+    list_free(av2)
+    println("  PASS: exit code surfaced (7)")
+
+    // --- empty stdin → immediate EOF (child must not block) ----------
+    av3 = list_new()
+    list_add(av3, "-c")
+    list_add(av3, "cat; printf done")
+    out3, err3, code3, spawn3 = os.run_full("/bin/sh", av3, null, "")
+    if out3 != "done" || code3 != 0 {
+        println("  FAIL: empty-stdin case out=[${out3}] code=${code3}, expected done/0")
+        exit(1)
+    }
+    list_free(av3)
+    println("  PASS: empty stdin closes immediately (cat saw EOF)")
+
+    // --- large round-trip: NO pipe-buffer deadlock -------------------
+    // Build a ~512 KB payload (far past the ~64 KB OS pipe buffer in
+    // BOTH directions) and round-trip it through cat. A naive
+    // write-all-then-read implementation would deadlock here; the
+    // poll(2) pump must drain stdout while it writes stdin.
+    big = "0123456789ABCDEF"
+    i = 0
+    while i < 15 {
+        big = string.concat(big, big)
+        i = i + 1
+    }
+    big_len = string.length(big)
+    av4 = list_new()
+    out4, err4, code4, spawn4 = os.run_full("/bin/cat", av4, null, big)
+    if spawn4 != "" {
+        println("  FAIL: large cat spawn err=${spawn4}")
+        exit(1)
+    }
+    if string.length(out4) != big_len {
+        println("  FAIL: large round-trip stdout len=${string.length(out4)}, expected ${big_len}")
+        exit(1)
+    }
+    if !string.equals(out4, big) {
+        println("  FAIL: large round-trip content mismatch")
+        exit(1)
+    }
+    if code4 != 0 {
+        println("  FAIL: large cat exit=${code4}, expected 0")
+        exit(1)
+    }
+    list_free(av4)
+    println("  PASS: ${big_len}-byte round-trip, no deadlock")
+
+    // --- spawn failure: missing binary -------------------------------
+    av5 = list_new()
+    out5, err5, code5, spawn5 = os.run_full("/no/such/binary", av5, null, "")
+    if code5 != 127 {
+        println("  FAIL: missing binary exit=${code5}, expected 127 (exec-in-child)")
+        exit(1)
+    }
+    list_free(av5)
+    println("  PASS: missing binary → exit 127")
+
+    println("=== All cases passed ===")
+}

--- a/tests/regression/test_os_run_supervised.ae
+++ b/tests/regression/test_os_run_supervised.ae
@@ -1,0 +1,141 @@
+// Regression test for std.os process-supervision primitives:
+//   os.run_supervised  — fork + (own process group) + timeout + reap
+//   os.kill            — POSIX kill(2): negative pid = group, sig 0 = probe
+//   os.wait_pid_timeout — bounded wait on a pid
+// and std.signal's stable signal-number constants.
+//
+// Filed by aeb (aeb-process-supervision-primitives.md): the floor any
+// build/test orchestrator hits. POSIX-only — the Windows raw externs
+// report "unsupported on Windows".
+//
+// /bin/sh -c is used throughout (POSIX-guaranteed; lets the test pick
+// exit codes and sleeps explicitly) rather than /bin/true etc whose
+// layout varies by host — same rationale as test_run_capture_status.ae.
+
+import std.os
+import std.list
+import std.signal
+
+extern exit(code: int)
+
+main() {
+    println("=== std.os process supervision ===")
+
+    // Skip on Windows — these primitives are POSIX-only.
+    if os_getenv("OS") == "Windows_NT" {
+        println("  SKIP: process supervision is POSIX-only")
+        return
+    }
+
+    // --- std.signal constants ----------------------------------------
+    if signal.SIGINT() != 2 || signal.SIGTERM() != 15 || signal.SIGKILL() != 9 {
+        println("  FAIL: signal constants wrong: INT=${signal.SIGINT()} TERM=${signal.SIGTERM()} KILL=${signal.SIGKILL()}")
+        exit(1)
+    }
+    println("  PASS: std.signal constants (INT=2, TERM=15, KILL=9)")
+
+    // --- os.kill existence probe (sig 0) -----------------------------
+    // Our own pid must exist; a wildly-high pid must not.
+    me = os.getpid()
+    if os.kill(me, 0) != 0 {
+        println("  FAIL: kill(self, 0) should report alive")
+        exit(1)
+    }
+    if os.kill(2147483646, 0) == 0 {
+        println("  FAIL: kill(huge_pid, 0) should report gone")
+        exit(1)
+    }
+    println("  PASS: os.kill sig-0 existence probe (self alive, bogus pid gone)")
+
+    // --- run_supervised: clean exit ----------------------------------
+    // Own process group, forward signals, no timeout, reap the group.
+    av0 = list_new()
+    list_add(av0, "-c")
+    list_add(av0, "exit 3")
+    code0, outcome0 = os.run_supervised("/bin/sh", av0, null, 1, 1, 0, 1)
+    if outcome0 != "exited" {
+        println("  FAIL: sh -c 'exit 3' outcome=${outcome0}, expected exited")
+        exit(1)
+    }
+    if code0 != 3 {
+        println("  FAIL: sh -c 'exit 3' code=${code0}, expected 3")
+        exit(1)
+    }
+    list_free(av0)
+    println("  PASS: run_supervised clean exit → outcome exited, code 3")
+
+    // --- run_supervised: timeout -------------------------------------
+    // Child sleeps 30s; a 1s timeout must tear it down and report 124
+    // promptly (well before the 30s sleep would finish).
+    t_start = os.now_monotonic_ms()
+    av1 = list_new()
+    list_add(av1, "-c")
+    list_add(av1, "sleep 30")
+    code1, outcome1 = os.run_supervised("/bin/sh", av1, null, 1, 1, 1, 1)
+    elapsed = os.now_monotonic_ms() - t_start
+    if outcome1 != "timeout" {
+        println("  FAIL: sleep 30 / 1s timeout outcome=${outcome1}, expected timeout")
+        exit(1)
+    }
+    if code1 != 124 {
+        println("  FAIL: timeout code=${code1}, expected 124")
+        exit(1)
+    }
+    // SIGTERM should win within the grace window; allow generous slack
+    // for loaded CI but ensure we did NOT wait out the full 30s sleep.
+    if elapsed > 10000 {
+        println("  FAIL: timeout took ${elapsed}ms, expected prompt teardown")
+        exit(1)
+    }
+    list_free(av1)
+    println("  PASS: run_supervised timeout → outcome timeout, code 124 (${elapsed}ms)")
+
+    // --- run_supervised: group-reap of a leaked child ----------------
+    // The child backgrounds a long sleep into its own process group and
+    // exits 0. With reap_group on, run_supervised group-kills the leaked
+    // sleep and returns promptly with the child's real exit code.
+    t2 = os.now_monotonic_ms()
+    av2 = list_new()
+    list_add(av2, "-c")
+    list_add(av2, "sleep 30 & exit 0")
+    code2, outcome2 = os.run_supervised("/bin/sh", av2, null, 1, 1, 0, 1)
+    e2 = os.now_monotonic_ms() - t2
+    if outcome2 != "exited" || code2 != 0 {
+        println("  FAIL: leaked-child case outcome=${outcome2} code=${code2}, expected exited/0")
+        exit(1)
+    }
+    if e2 > 10000 {
+        println("  FAIL: group-reap took ${e2}ms; a leaked sleep was not torn down")
+        exit(1)
+    }
+    list_free(av2)
+    println("  PASS: run_supervised group-reap of leaked child (${e2}ms)")
+
+    // --- wait_pid_timeout --------------------------------------------
+    // Spawn a 30s sleep via run_pipe, bound-wait 1s → timed_out, then
+    // kill it and reap so the test leaves nothing behind.
+    av3 = list_new()
+    list_add(av3, "-c")
+    list_add(av3, "sleep 30")
+    read_fd, pid, spawn_err = os.run_pipe("/bin/sh", av3, null)
+    if spawn_err != "" {
+        println("  FAIL: run_pipe spawn err=${spawn_err}")
+        exit(1)
+    }
+    status, timed_out, werr = os.wait_pid_timeout(pid, 1)
+    if werr != "" {
+        println("  FAIL: wait_pid_timeout err=${werr}")
+        exit(1)
+    }
+    if timed_out != 1 {
+        println("  FAIL: wait_pid_timeout on a 30s sleep should time out, got timed_out=${timed_out}")
+        exit(1)
+    }
+    // Tear it down and reap.
+    os.kill(pid, signal.SIGKILL())
+    rc, _ = os.wait_pid(pid)
+    list_free(av3)
+    println("  PASS: wait_pid_timeout bounded wait timed out, child reaped")
+
+    println("=== All cases passed ===")
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -570,20 +570,66 @@ static int win_run(const char* cmd_str, int quiet) {
     strncpy(buf, cmd_str, sizeof(buf) - 1);
     buf[sizeof(buf) - 1] = '\0';
 
+    // Tokenize the command string into argv tokens for _spawnvp. Quoted
+    // segments map to ONE token even when they contain spaces.
+    //
+    // toks[0] (the program name) is unquoted: _spawnvp wants a bare path.
+    // toks[1..] are passed to the child verbatim — but MSVCRT's _spawnvp
+    // joins them with single spaces to build the child's command line
+    // WITHOUT any quoting of its own (documented MS behaviour). So a
+    // token containing a space, if left bare in toks[], reaches the
+    // child as multiple argv entries.  Wrap each non-program token that
+    // contains a space in literal `"..."` so the child's CRT
+    // command-line parser re-fuses it into one arg.  (Args that
+    // themselves contain a `"` are not handled — the caller's quoting
+    // convention at the cmd_str layer already doesn't support those.)
     char* toks[512];
     int n = 0;
+    // Backing store for re-quoted tokens. Sized 2× the input buffer so a
+    // worst-case input where every byte is part of a quoted token still
+    // fits (each token grows by 2 bytes of `"..."` wrapper).
+    char qbuf[32768];
+    int qoff = 0;
     for (char* p = buf; *p && n < 511; ) {
         while (*p == ' ') p++;
         if (!*p) break;
+        char* tok_start;
+        int had_quotes = 0;
         if (*p == '"') {
+            had_quotes = 1;
             p++;
-            toks[n++] = p;
+            tok_start = p;
             while (*p && *p != '"') p++;
             if (*p) *p++ = '\0';
         } else {
-            toks[n++] = p;
+            tok_start = p;
             while (*p && *p != ' ') p++;
             if (*p) *p++ = '\0';
+        }
+        // For the program name (toks[0]) and tokens with no spaces,
+        // pass-through. For other tokens, store a re-quoted copy so
+        // _spawnvp's space-join produces a cmdline the child can re-
+        // tokenize correctly.
+        int needs_quoting = 0;
+        if (n > 0 && (had_quotes || strchr(tok_start, ' ') != NULL)) {
+            needs_quoting = 1;
+        }
+        if (needs_quoting) {
+            int len = (int)strlen(tok_start);
+            if (qoff + len + 3 > (int)sizeof(qbuf)) {
+                // Out of re-quote space — pass through and hope for the best.
+                toks[n++] = tok_start;
+            } else {
+                char* dst = qbuf + qoff;
+                dst[0] = '"';
+                memcpy(dst + 1, tok_start, len);
+                dst[len + 1] = '"';
+                dst[len + 2] = '\0';
+                toks[n++] = dst;
+                qoff += len + 3;
+            }
+        } else {
+            toks[n++] = tok_start;
         }
     }
     toks[n] = NULL;

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2613,8 +2613,18 @@ static int cmd_run(int argc, char** argv) {
      * the full TOML extra_sources concatenated. */
     char extra_files[8192] = "";
 
+    /* Index in argv where the program's own arguments begin — everything
+     * after a literal `--`. These are forwarded verbatim to the running
+     * program (like `cargo run -- args`), so a config-is-code entry point
+     * can do `ae run supervisor.ae -- make -j8` and see make/-j8 in its
+     * own argv. -1 = no `--` seen, nothing to forward. */
+    int prog_args_start = -1;
+
     for (int i = 0; i < argc; i++) {
-        if (strcmp(argv[i], "--extra") == 0 && i + 1 < argc) {
+        if (strcmp(argv[i], "--") == 0) {
+            prog_args_start = i + 1;  /* rest are the program's args */
+            break;                    /* stop flag parsing at the separator */
+        } else if (strcmp(argv[i], "--extra") == 0 && i + 1 < argc) {
             if (extra_files[0]) strncat(extra_files, " ", sizeof(extra_files) - strlen(extra_files) - 1);
             strncat(extra_files, argv[++i], sizeof(extra_files) - strlen(extra_files) - 1);
         } else if (strcmp(argv[i], "--lib") == 0 && i + 1 < argc) {
@@ -2775,8 +2785,21 @@ static int cmd_run(int argc, char** argv) {
     // Clean up temp .c file (exe stays in cache if caching, else clean up too)
     remove(c_file);
 
-    // Step 3: Run
+    // Step 3: Run, forwarding any post-`--` args to the program. Each is
+    // wrapped in double quotes so a single arg with spaces stays one
+    // token through run_cmd's tokenizer (posix_run / win_run). Args
+    // containing a literal double-quote aren't representable through this
+    // path — rare for a build command line; build the binary and invoke
+    // it directly if you need that.
     snprintf(cmd, sizeof(cmd), "\"%s\"", exe_file);
+    if (prog_args_start >= 0) {
+        size_t off = strlen(cmd);
+        for (int i = prog_args_start; i < argc && off < sizeof(cmd) - 1; i++) {
+            int w = snprintf(cmd + off, sizeof(cmd) - off, " \"%s\"", argv[i]);
+            if (w < 0 || (size_t)w >= sizeof(cmd) - off) break;  /* truncated — stop cleanly */
+            off += (size_t)w;
+        }
+    }
     int rc = run_cmd(cmd);
 
     if (rc < 0) {


### PR DESCRIPTION
docs(examples): build-supervisor composing the supervision primitives
    
    A runnable build-supervision entry point that collapses aeb's bash
    job-control trampoline tail — own process group, forward Ctrl-C, enforce
    a wall-clock timeout, group-reap leaked children — into a single
    os.run_supervised call, plus os.getcwd for the project root. Runs a
    built-in demo or `ae run build-supervisor.ae -- <your command>`.
    Demonstrates the "config IS code" pattern end to end.    

fix(build): align ci-windows example sweep with the canonical filter
    
    The ci-windows target swept every examples/**/*.ae, including the
    intentionally-broken ae-help-demo/broken_dsl.ae (and the host-*-demo.ae
    files that need host runtimes the cross-build doesn't have), so step
    [1/3] aborted on a deliberate parse error before MinGW ever compiled the
    compiler sources or syntax-checked the generated C. The main example
    build sweep already excludes these; both ci-windows find invocations now
    carry the same `grep -v '/ae-help-demo/'` + `grep -v '/host-.*-demo\.ae$'`
    exclusions.
    
 feat(ae): forward `ae run <file> -- <args>` to the running program
    
    `ae run script.ae -- a b c` dropped everything after the script name
    (argc == 1 in the program), so a config-is-code entry point — e.g. an
    Aether build supervisor invoked as `ae run supervisor.ae -- make -j8` —
    could not receive arguments at all.
    
    cmd_run now captures everything after a literal `--` and appends it to
    the run command, each token double-quoted so a spaces-containing arg
    stays one token through run_cmd's tokenizer (posix_run/win_run). Args
    containing a literal double-quote aren't representable through this path
    (rare for a build command line; build the binary and invoke it directly
    if needed).
    
    Integration test asserts forwarding, space-preservation, and the no-`--`
    (argc == 1) case.
    
 feat(std.os): cross-platform process supervision, run_full, chdir/getcwd; add std.signal
    
    The build/test-orchestration floor a self-hosted aeb-style entry point
    hits, so the bash job-control trampoline can be written in Aether. Filed
    by aeb (aeb-process-supervision-primitives.md).
    
    std.os additions (POSIX + Windows):
      - run_supervised(prog, argv, env, new_process_group, forward_signals,
        timeout_secs, reap_group) -> (exit_code, outcome): own process group,
        forward interactive signals, wall-clock timeout, group-reap of leaked
        children, in one call. POSIX fork+setpgid+killpg+waitpid; Windows Job
        Objects + WaitForSingleObject + console control handler.
      - kill(pid, sig): POSIX kill(2); negative pid = group, sig 0 = probe.
        Windows OpenProcess/TerminateProcess (no graceful signal, no group).
      - wait_pid_timeout(pid, secs): bounded wait, no watchdog process needed.
      - run_full(prog, argv, env, stdin_data) -> (stdout, stderr, exit_code,
        err): feed stdin (binary-safe) and capture stdout/stderr separately,
        no pipe-buffer deadlock (POSIX poll(2); Windows reader threads).
      - chdir/getcwd: process working directory (POSIX chdir/getcwd; Windows
        Set/GetCurrentDirectory). os_getcwd_raw is classified owned-heap in
        codegen so callers reclaim the buffer.
    
    std.signal: stable POSIX signal-number constants (SIGINT/SIGTERM/SIGKILL
    …) as zero-arg functions.
    
    Windows backends are MinGW -Werror-clean; runtime behaviour is exercised
    by Windows CI. Regression tests cover exited/timeout/signalled, the
    512 KB no-deadlock round-trip, separate stderr, and the cwd round-trip;
    parent processes are valgrind-clean.