### PR TITLE
feat(ae): top-level install / upgrade / use version commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ replaces `## [0.231.0]` with the next version number before tagging the
 release — so a hardcoded version header here would be skipped by the
 rename and drift from the tags (see `changelog-release-drift-note.md`).
 
+## [current]
+
+### Added
+
+- **Top-level `ae install`, `ae upgrade`, and `ae use` commands.** The
+  version-management functionality was only reachable through the longer
+  `ae version install` / `ae version use` forms, so the intuitive
+  `ae install` / `ae upgrade` (the muscle-memory from rustup/nvm/pyenv)
+  returned "Unknown command" — making the toolchain feel broken. Now:
+  - `ae install [<version>]` installs a release into
+    `~/.aether/versions/` (the latest release if no version is given).
+  - `ae upgrade` (alias `ae update`) installs the latest release and
+    switches to it — a no-op with a notice when already current.
+  - `ae use <version>` switches the active version.
+
+  These delegate to the existing install/switch logic; `ae version
+  install <v>` / `ae version use <v>` are unchanged and equivalent.
+  `ae help` lists the new top-level forms.
+
 ## [0.231.0]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -130,13 +130,17 @@ Installs to `~/.aether` and adds `ae` to your PATH. Restart your terminal or run
 
 GCC is downloaded automatically the first time you run a program (~80 MB, one-time) — no MSYS2 or manual toolchain setup required.
 
-**All platforms — manage versions with `ae version`:**
+**All platforms — install, upgrade, and switch versions:**
 
 ```bash
+ae upgrade                   # install the latest release and switch to it
+ae install v0.25.0           # install a specific release (latest if omitted)
+ae use v0.25.0               # switch to an installed version
 ae version list              # see all available releases
-ae version install v0.25.0   # download and install a specific version
-ae version use v0.25.0       # switch to that version
 ```
+
+(The longer `ae version install <v>` / `ae version use <v>` forms still
+work and are equivalent to `ae install` / `ae use`.)
 
 ### Your First Program
 
@@ -194,9 +198,10 @@ ae repl                  # Start interactive REPL
 ae cache                 # Show build cache info
 ae cache clear           # Clear the build cache
 ae version               # Show current version
+ae upgrade               # Install the latest release and switch to it
+ae install <v>           # Install a specific release (latest if omitted)
+ae use <v>               # Switch to an installed version
 ae version list          # List all available releases
-ae version install <v>   # Install a specific version
-ae version use <v>       # Switch to an installed version
 ae help                  # Show all commands
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -599,18 +599,23 @@ Left-most entry wins on a name collision; each `import` walks the chain independ
 - Explore [Standard Library Documentation](stdlib-reference.md)
 - See [Architecture](architecture.md) for compiler and runtime internals
 - See [Runtime Optimizations](runtime-optimizations.md) for performance details
-- Use `ae version list` to see available releases and `ae version install <v>` to switch versions
+- Use `ae upgrade` to get the latest release, or `ae version list` to see and switch between releases
 
 ## Version Management
 
-Switch between Aether releases without reinstalling:
+Install, upgrade, and switch between Aether releases without reinstalling:
 
 ```bash
+ae upgrade              # Install the latest release and switch to it
+ae install v0.25.0      # Install a specific release (latest if omitted)
+ae use v0.25.0          # Switch to an installed version
 ae version              # Show current version
 ae version list         # List all available releases (marks installed/active)
-ae version install v0.25.0  # Download and install a specific version
-ae version use v0.25.0      # Switch to an installed version
 ```
+
+`ae install` / `ae use` are the short forms of `ae version install` /
+`ae version use`, which still work. `ae upgrade` (alias `ae update`) is a
+no-op when you are already on the latest release.
 
 Versions are stored in `~/.aether/versions/`. The active version is symlinked to `~/.aether/current` (Linux/macOS) or copied to `~/.aether/bin/` (Windows).
 

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -6470,6 +6470,79 @@ static const char* get_active_version(void) {
     return AE_VERSION;
 }
 
+// Fetch the newest release tag (e.g. "v0.231.0") from GitHub into `out`.
+// Returns 0 on success, non-zero on network/parse failure. GitHub returns
+// releases newest-first, so the first "tag_name" is the latest — same
+// scan cmd_version_list uses.
+static int fetch_latest_release_tag(char* out, size_t outlen) {
+    char json_path[512];
+    snprintf(json_path, sizeof(json_path), "%s/ae_latest_%d.json",
+             get_temp_dir(), (int)getpid());
+    char url[256];
+    snprintf(url, sizeof(url),
+        "https://api.github.com/repos/" AE_GITHUB_REPO "/releases?per_page=5");
+    if (ae_download(url, json_path) != 0) return -1;
+    FILE* f = fopen(json_path, "r");
+    if (!f) { remove(json_path); return -1; }
+    char buf[65536];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    remove(json_path);
+    buf[n] = '\0';
+    char* p = strstr(buf, "\"tag_name\"");
+    if (!p) return -1;
+    p += 10;
+    char* q = strchr(p, '"'); if (!q) return -1; q++;   // opening quote
+    char* e = strchr(q, '"'); if (!e) return -1;         // closing quote
+    size_t len = (size_t)(e - q);
+    if (len == 0 || len >= outlen) return -1;
+    memcpy(out, q, len);
+    out[len] = '\0';
+    return 0;
+}
+
+// "ae install [<version>]" — install a release into ~/.aether/versions/.
+// With no version, resolves and installs the latest. A discoverable
+// top-level alias for "ae version install" (matches rustup/nvm muscle
+// memory). Does NOT switch the active version — that's "ae use <v>" or
+// "ae upgrade".
+static int cmd_install(int argc, char** argv) {
+    if (argc >= 1 && argv[0] && argv[0][0]) {
+        return cmd_version_install(argv[0]);
+    }
+    char latest[64];
+    printf("Resolving latest release...\n");
+    if (fetch_latest_release_tag(latest, sizeof(latest)) != 0) {
+        fprintf(stderr, "Could not determine the latest release.\n");
+        fprintf(stderr, "Check your connection, or name a version: ae install <v>\n");
+        fprintf(stderr, "('ae version list' shows what's available.)\n");
+        return 1;
+    }
+    return cmd_version_install(latest);
+}
+
+// "ae upgrade" / "ae update" — install the latest release and switch to it.
+// The one-shot "get me the newest Aether" command; a no-op (with a notice)
+// when already current.
+static int cmd_upgrade(void) {
+    char latest[64];
+    printf("Checking for the latest release...\n");
+    if (fetch_latest_release_tag(latest, sizeof(latest)) != 0) {
+        fprintf(stderr, "Could not determine the latest release. Check your connection.\n");
+        return 1;
+    }
+    const char* latest_ver = (latest[0] == 'v') ? latest + 1 : latest;
+    const char* active = get_active_version();   // no leading 'v'
+    if (active && strcmp(active, latest_ver) == 0) {
+        printf("Already on the latest version (%s).\n", latest);
+        return 0;
+    }
+    printf("Upgrading %s -> %s\n", (active && active[0]) ? active : "(unknown)", latest);
+    int rc = cmd_version_install(latest);
+    if (rc != 0) return rc;
+    return cmd_version_use(latest);
+}
+
 static int cmd_version(int argc, char** argv) {
     if (argc == 0) {
         printf("ae %s (Aether Language)\n", get_active_version());
@@ -6730,10 +6803,11 @@ static void print_usage(void) {
     printf("  lib-path             Print the resolved module-search chain\n");
     printf("  examples             List and run example programs\n");
     printf("  repl                 Start interactive REPL\n");
-    printf("  version              Show version / manage installed versions\n");
+    printf("  install [<v>]        Install a release (latest if omitted)\n");
+    printf("  upgrade              Install the latest release and switch to it\n");
+    printf("  use <v>              Switch to an installed version\n");
+    printf("  version              Show version / list installed versions\n");
     printf("  version list         List all available releases\n");
-    printf("  version install <v>  Download and install a specific version\n");
-    printf("  version use <v>      Switch to an installed version\n");
     printf("  help                 Show this help\n");
     printf("\nExamples:\n");
     printf("  ae init myproject          Create a new project\n");
@@ -6998,6 +7072,23 @@ int main(int argc, char** argv) {
     }
     if (strcmp(cmd, "version") == 0 || strcmp(cmd, "--version") == 0) {
         return cmd_version(sub_argc, sub_argv);
+    }
+    // Top-level version-management aliases (no toolchain needed). These
+    // make the intuitive commands work instead of only the longer
+    // "ae version install/use" forms.
+    if (strcmp(cmd, "install") == 0) {
+        return cmd_install(sub_argc, sub_argv);
+    }
+    if (strcmp(cmd, "upgrade") == 0 || strcmp(cmd, "update") == 0) {
+        return cmd_upgrade();
+    }
+    if (strcmp(cmd, "use") == 0) {
+        if (sub_argc < 1) {
+            fprintf(stderr, "Usage: ae use <version>   (e.g. ae use v0.231.0)\n");
+            fprintf(stderr, "Run 'ae version list' to see installed/available versions.\n");
+            return 1;
+        }
+        return cmd_version_use(sub_argv[0]);
     }
     if (strcmp(cmd, "init") == 0) {
         return cmd_init(sub_argc, sub_argv);


### PR DESCRIPTION
## Summary

Adds the top-level `ae install` / `ae upgrade` / `ae use` commands so the muscle-memory from rustup / nvm / pyenv works directly, instead of requiring the longer `ae version install` / `ae version use` forms.

- **`ae install [<version>]`** — installs a release into `~/.aether/versions/` (the latest release if no version is given).
- **`ae upgrade`** (alias **`ae update`**) — fetches the latest release, installs it, and switches to it; a no-op if the current version is already latest.
- **`ae use <version>`** — switches the active version.

These delegate to the existing install/switch machinery (`cmd_version_install` / `cmd_version_use`); the `ae version install <v>` / `ae version use <v>` forms are unchanged and remain equivalent. `ae upgrade` resolves the latest release tag from the GitHub releases API.

## What changed

- `tools/ae.c` — `fetch_latest_release_tag`, `cmd_install`, `cmd_upgrade`; dispatch for `install` / `upgrade` / `update` / `use`; updated `print_usage` banner.
- `README.md`, `docs/getting-started.md` — document the new commands.
- `CHANGELOG.md` — entry under `## [current]`.

## Validation

- Clean build of `ae` — zero warnings.
- `ae --help` lists `install` / `upgrade` / `use`.
- `ae use <nonexistent>` fails cleanly with an actionable message (`Version … is not installed. Install it first: …`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
