### PR TITLE
fix(os): argv heap-string corruption in run/run_capture/run_supervised (#688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Fixed
+
+- **`os.run` / `os.run_capture` / `os.run_supervised` argv corruption for
+  heap-allocated strings** (#688). The argv (and envp) builders read each
+  list entry with `list_get_raw()` and blind-cast the result to `char*`.
+  String literals and `aether_args_get()` returns happen to be raw
+  `const char*`, so the cast lands on the payload; but heap-built
+  strings (`string.concat`, `substring`, interpolation results, etc.)
+  are magic-wrapped `AetherString*` whose first 16 bytes are the struct
+  header, not the payload — execve(2) then received the header bytes,
+  and the child process saw garbage like `\336\300W\256\1` in place of
+  the intended argv. Routed every `list_get_raw` result destined for a
+  `const char*` consumer through `aether_string_data()`, which unwraps
+  the magic header and passes raw pointers through unchanged. Same fix
+  applied to the sandbox grant-list reader (`aether_spawn_sandboxed.c`
+  serialize_grants / is_fork_granted) and `fs.glob_multi`'s pattern
+  list (`std/fs/aether_fs.c`), which had the same shape.
+
 ## [0.239.0]
 
 ### Added

--- a/runtime/aether_spawn_sandboxed.c
+++ b/runtime/aether_spawn_sandboxed.c
@@ -26,6 +26,10 @@
 // From libaether.a — list operations
 extern int list_size(void*);
 extern void* list_get_raw(void*, int);
+// String-ABI accessor: list_get_raw may return a magic AetherString* or
+// a raw const char*; aether_string_data unwraps both to a plain
+// C-string. Required for argv / grant-pattern reads — see issue #688.
+extern const char* aether_string_data(const void*);
 
 // Find libaether_sandbox.so next to the running binary
 static int find_preload_path(char* buf, int bufsize) {
@@ -69,8 +73,8 @@ static int serialize_grants(void* grant_list) {
     char buf[8192];
     int pos = 0;
     for (int i = 0; i < n && pos < 8000; i += 2) {
-        const char* cat = (const char*)list_get_raw(grant_list, i);
-        const char* pat = (const char*)list_get_raw(grant_list, i + 1);
+        const char* cat = aether_string_data(list_get_raw(grant_list, i));
+        const char* pat = aether_string_data(list_get_raw(grant_list, i + 1));
         if (!cat || !pat) continue;
         pos += snprintf(buf + pos, sizeof(buf) - pos, "%s:%s\n", cat, pat);
     }
@@ -111,8 +115,8 @@ static int is_fork_granted(void* grant_list) {
     int n = list_size(grant_list);
     if (n <= 0 || n % 2 != 0) return 0;
     for (int i = 0; i < n; i += 2) {
-        const char* cat = (const char*)list_get_raw(grant_list, i);
-        const char* pat = (const char*)list_get_raw(grant_list, i + 1);
+        const char* cat = aether_string_data(list_get_raw(grant_list, i));
+        const char* pat = aether_string_data(list_get_raw(grant_list, i + 1));
         if (!cat || !pat) continue;
         if (cat[0] == '*' && cat[1] == '\0' &&
             pat[0] == '*' && pat[1] == '\0') {

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -2014,6 +2014,10 @@ DirList* fs_glob_raw(const char* pattern) {
 // The list is an ArrayList (from std.list) containing string pointers.
 extern int list_size(void*);
 extern void* list_get_raw(void*, int);
+// String-ABI accessor: list_get_raw may return a magic AetherString*
+// (heap-built) or a raw const char* (literal/args_get). Unwrap so we
+// hand fs_glob_raw the payload pointer, not the struct header (#688).
+extern const char* aether_string_data(const void*);
 
 DirList* fs_glob_multi_raw(void* pattern_list) {
     if (!pattern_list) return NULL;
@@ -2025,7 +2029,7 @@ DirList* fs_glob_multi_raw(void* pattern_list) {
 
     int n = list_size(pattern_list);
     for (int i = 0; i < n; i++) {
-        const char* pattern = (const char*)list_get_raw(pattern_list, i);
+        const char* pattern = aether_string_data(list_get_raw(pattern_list, i));
         if (!pattern) continue;
 
         DirList* partial = fs_glob_raw(pattern);

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -109,6 +109,15 @@ int64_t os_now_unix_ms_raw(void) { return 0; }
 extern int list_size(void* list);
 extern void* list_get_raw(void* list, int index);
 
+// String-ABI accessor: list_get_raw returns either an AetherString*
+// (heap-built strings — concat, substring, interp, etc.) or a raw
+// const char* (string literals, args_get). aether_string_data dispatches
+// on the magic header and returns a plain C-string in both cases. Argv
+// / envp arrays MUST go through this — the execve(2) family expects
+// const char*, and a blind (char*)cast of a magic AetherString* yields
+// the struct header bytes, not the payload (issue #688).
+extern const char* aether_string_data(const void* s);
+
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/types.h>
@@ -128,6 +137,7 @@ extern void* list_get_raw(void* list, int index);
 // to include the collections header (which would create a build cycle).
 extern int   list_size(void* list);
 extern void* list_get_raw(void* list, int index);
+extern const char* aether_string_data(const void* s);
 
 #ifdef _WIN32
 // Forward declaration — implementation at the bottom of the file.
@@ -616,7 +626,11 @@ int os_execv(const char* prog, void* argv_list) {
                 free(argv);
                 return -1;
             }
-            argv[ai++] = (char*)item;
+            // aether_string_data unwraps a magic AetherString* to its
+            // payload pointer; for raw const char* it returns the input
+            // verbatim. Required: a blind (char*)cast of a heap-built
+            // string would give execvp the struct header (issue #688).
+            argv[ai++] = (char*)aether_string_data(item);
         }
     }
     argv[ai] = NULL;
@@ -845,7 +859,9 @@ static char** build_argv_array(const char* prog, void* argv_list) {
     if (!av) return NULL;
     av[0] = (char*)prog;
     for (int i = 0; i < n; i++) {
-        av[i + 1] = (char*)list_get_raw(argv_list, i);
+        // Unwrap magic AetherString* to its payload; pass plain char*
+        // through unchanged. See aether_os.c header comment + issue #688.
+        av[i + 1] = (char*)aether_string_data(list_get_raw(argv_list, i));
     }
     av[n + 1] = NULL;
     return av;
@@ -861,7 +877,7 @@ static char** build_envp_array(void* env_list) {
     char** envp = (char**)malloc(sizeof(char*) * (size_t)(n + 1));
     if (!envp) return NULL;
     for (int i = 0; i < n; i++) {
-        envp[i] = (char*)list_get_raw(env_list, i);
+        envp[i] = (char*)aether_string_data(list_get_raw(env_list, i));
     }
     envp[n] = NULL;
     return envp;
@@ -1930,7 +1946,7 @@ static wchar_t* build_command_line(const char* prog, void* argv_list) {
 
     int n = argv_list ? list_size(argv_list) : 0;
 
-    const char* arg0_utf8 = (n > 0) ? (const char*)list_get_raw(argv_list, 0) : prog;
+    const char* arg0_utf8 = (n > 0) ? aether_string_data(list_get_raw(argv_list, 0)) : prog;
     if (!arg0_utf8) arg0_utf8 = prog;
     wchar_t* warg0 = utf8_to_wide(arg0_utf8);
     if (!warg0) { free(b.data); return NULL; }
@@ -1939,7 +1955,7 @@ static wchar_t* build_command_line(const char* prog, void* argv_list) {
 
     int start_index = (n > 0) ? 1 : 0;
     for (int i = start_index; i < n; i++) {
-        const char* item = (const char*)list_get_raw(argv_list, i);
+        const char* item = aether_string_data(list_get_raw(argv_list, i));
         if (!item) continue;
         wchar_t* w = utf8_to_wide(item);
         if (!w) { free(b.data); return NULL; }
@@ -1961,7 +1977,7 @@ static wchar_t* build_environ_block(void* env_list) {
     WBuf b; wbuf_init(&b);
 
     for (int i = 0; i < n; i++) {
-        const char* item = (const char*)list_get_raw(env_list, i);
+        const char* item = aether_string_data(list_get_raw(env_list, i));
         if (!item) continue;
         wchar_t* w = utf8_to_wide(item);
         if (!w) { free(b.data); return NULL; }

--- a/tests/leaks_exclude.txt
+++ b/tests/leaks_exclude.txt
@@ -9,3 +9,4 @@
 # spawns correctly.
 test_run_capture_status
 test_os_run_full
+test_run_argv_heap_string

--- a/tests/regression/test_run_argv_heap_string.ae
+++ b/tests/regression/test_run_argv_heap_string.ae
@@ -1,0 +1,62 @@
+// os.run* with heap-allocated argv entries (issue #688).
+//
+// Bug: os.run / os.run_capture / os.run_supervised built argv by
+// blind-casting list_get_raw() results to char*. For literal-string
+// argv entries the cast happened to land on the payload; for
+// heap-allocated AetherStrings (concat / substring / interp results)
+// it gave the child process the struct-header bytes instead of the
+// payload, so `echo $(concat "hel" "lo")` printed garbage.
+//
+// Fix: route each argv entry through aether_string_data(), which
+// unwraps a magic AetherString* and passes raw const char* through
+// unchanged.
+
+import std.os
+import std.list
+import std.string
+
+extern exit(code: int)
+extern println(s: string)
+
+_check(label: string, got: string, want: string) {
+    if got != want {
+        println(string.concat(string.concat(label, ": got '"), string.concat(got, string.concat("' want '", string.concat(want, "'")))))
+        exit(1)
+    }
+}
+
+main() {
+    println("=== test_run_argv_heap_string ===")
+
+    // Literal control — the case that was already passing.
+    argv_lit = list.new()
+    list.add(argv_lit, "hello")
+    out_lit, _, _ = os.run_capture("echo", argv_lit, null)
+    out_lit_t = string.trim(out_lit)
+    _check("literal argv", out_lit_t, "hello")
+
+    // Heap argv — the failing case from the bug report.
+    argv_heap = list.new()
+    list.add(argv_heap, string.concat("hel", "lo"))
+    out_heap, _, _ = os.run_capture("echo", argv_heap, null)
+    out_heap_t = string.trim(out_heap)
+    _check("heap argv (concat)", out_heap_t, "hello")
+
+    // Mixed literal + heap in one argv.
+    argv_mixed = list.new()
+    list.add(argv_mixed, string.concat("foo", ""))
+    list.add(argv_mixed, "bar")
+    list.add(argv_mixed, string.concat("ba", "z"))
+    out_mixed, _, _ = os.run_capture("echo", argv_mixed, null)
+    out_mixed_t = string.trim(out_mixed)
+    _check("mixed argv", out_mixed_t, "foo bar baz")
+
+    // Substring-derived heap string.
+    argv_sub = list.new()
+    list.add(argv_sub, string.substring("xxworldxx", 2, 7))
+    out_sub, _, _ = os.run_capture("echo", argv_sub, null)
+    out_sub_t = string.trim(out_sub)
+    _check("substring argv", out_sub_t, "world")
+
+    println("=== all cases passed ===")
+}

--- a/tests/regression/test_run_argv_heap_string.ae
+++ b/tests/regression/test_run_argv_heap_string.ae
@@ -28,6 +28,15 @@ _check(label: string, got: string, want: string) {
 main() {
     println("=== test_run_argv_heap_string ===")
 
+    // Skip on Windows — `echo` here is a shell builtin under MSYS2 and
+    // isn't an external binary CreateProcessW can launch on its own. The
+    // fix being exercised (argv string-ABI dispatch) is POSIX + Win32
+    // alike; the *test harness* just can't use `echo` portably.
+    if os_getenv("OS") == "Windows_NT" {
+        println("  SKIP: bare `echo` isn't an external on Windows")
+        return
+    }
+
     // Literal control — the case that was already passing.
     argv_lit = list.new()
     list.add(argv_lit, "hello")


### PR DESCRIPTION
Closes #688.

## Summary

`os.run` / `os.run_capture` / `os.run_supervised` passed **garbage** to the child for any argv entry that was a heap-allocated string — `string.concat` results, interpolation output, anything computed. String literals and `aether_args_get()` returns worked; computed strings produced bytes like `\336\300W\256\1` in the child's argv.

This blocked any launcher pattern that builds argv from computed paths (`os.getcwd()` + `string.concat`'d targets), which is exactly what aeb's pure-Aether `aeb-cli` does.

## Root cause

The argv/envp builders read each list entry with `list_get_raw()` and blind-cast to `char*`:

```c
av[i + 1] = (char*)list_get_raw(argv_list, i);   // ← unsafe
```

For a raw `const char*` payload (literals, args_get) the cast lands on bytes the child can read. For a magic `AetherString*` (concat / substring / interp results) the cast hands execve the **struct header** (`magic`, `ref_count`, `length`, `capacity`, `data*`), not the payload — child sees garbage.

## Fix

Route every `list_get_raw` result destined for a `const char*` consumer through `aether_string_data()`, the existing string-ABI accessor that dispatches on the magic header (`is_aether_string(s) ? s->data : s`). Same sites/shape across:

| file | sites |
| --- | --- |
| `std/os/aether_os.c` | POSIX `os_run_supervised_raw` argv loop, `build_argv_array`, `build_envp_array`, Win32 `build_command_line` (×2 + arg0), Win32 `build_environ_block` |
| `runtime/aether_spawn_sandboxed.c` | `serialize_grants`, `is_fork_granted` |
| `std/fs/aether_fs.c` | `fs_glob_multi_raw` pattern list |

Each file adds one `extern const char* aether_string_data(const void*)` forward decl (matches how `list_get_raw` is already forward-declared to avoid the collections-header cycle).

## Validation

- New regression test `tests/regression/test_run_argv_heap_string.ae`:
  - literal argv (the case that was already passing)
  - heap argv via `string.concat` (the failing case from the report)
  - mixed literal + heap entries in one argv
  - substring-derived heap string
- Verified the test **fails** on `main` without the fix (got `\336\300W\256` for the heap case) and **passes** with it.
- `make test` — **226/226** unit pass.
- `make ci` — **641/644** (3 known h2 / proxy-pool flakes: `http_h2_concurrent_dispatch`, `http_server_h2`, `http_reverse_proxy_pool`).
- `HARDEN=1 make ci` — **640/644** (same flakes + `http_reverse_proxy_pool_extra`). None touched by this PR; all are pre-existing network-bind flakes pre-warned by paul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)