### PR TITLE
fix(os/win): make os.run* spawn on Windows (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,21 +19,31 @@ notes to be skipped or clobbered (the failure modes documented in
 ### Fixed
 
 - **Windows `os.run` / `os.run_capture` / `os.run_supervised` couldn't
-  spawn an argv-specified child** (#706). The three `CreateProcessW`
-  call sites in `std/os/aether_os.c` (`win_launch`, the supervised
-  variant, and `os_run_full_raw`) passed the program path as
-  `lpApplicationName`. Per MSDN, when `lpApplicationName` is non-NULL it
-  must be a *full path* — `CreateProcessW` does not do `execvp`-style
-  PATH search, doesn't append `.exe`, and doesn't recognize built-ins
-  like `cmd`. A bare `"cmd"` therefore became a literal CWD-relative
-  filename lookup, failed with `ERROR_FILE_NOT_FOUND`, and bubbled up
-  as `rc=-1` / `err="spawn failed"`. Switched all three sites to
-  `lpApplicationName=NULL` and let `CreateProcessW` parse the first
-  token of `lpCommandLine`, which `build_command_line` already
-  quotes correctly via `append_escaped_arg`. (`os.system()`, the shell
-  string path, was unaffected — it routes through `system()` not
-  `CreateProcessW`.) Discriminator: literal-argv calls failed too, so
-  this is distinct from the heap-string issue (#688) already fixed.
+  spawn an argv-specified child** (#706). Two independent bugs in the
+  Windows process-spawn path, both in `std/os/aether_os.c`:
+  1. All three `CreateProcessW` call sites (`win_launch`, the supervised
+     variant, and `os_run_full_raw`) passed the program path as
+     `lpApplicationName`. Per MSDN, a non-NULL `lpApplicationName` must
+     be a full path — `CreateProcessW` does no `execvp`-style PATH
+     search, no `.exe` append, no built-in resolution. A bare `"cmd"`
+     therefore became a literal CWD-relative filename, failed with
+     `ERROR_FILE_NOT_FOUND`, and bubbled up as `rc=-1` /
+     `err="spawn failed"`. Switched all three sites to
+     `lpApplicationName=NULL` so `CreateProcessW` parses and PATH-
+     resolves the first token of `lpCommandLine`.
+  2. `build_command_line` then disagreed with the POSIX `build_argv_array`
+     on the argv convention: POSIX seeds `argv[0]` with `prog` and treats
+     `argv_list` as the *whole* argument vector; the Windows builder
+     treated `argv_list[0]` as the program and dropped `prog`. So
+     `os.run("cmd", ["/c","echo","x"])` — correct on Linux — produced
+     the command line `/c echo x` on Windows and tried to spawn a program
+     named `/c`. Re-aligned `build_command_line` to always seed with
+     `prog` then append the whole `argv_list`. Together with the
+     `lpApplicationName=NULL` flip the whole `os.run*` family now works
+     on Windows. (`os.system()`, the shell-string path, was unaffected
+     all along — it routes through libc `system()` not `CreateProcessW`.)
+     Discriminator: literal-argv calls failed too, so this is distinct
+     from the heap-string issue (#688) already fixed.
 
 ## [0.243.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Fixed
+
+- **Windows `os.run` / `os.run_capture` / `os.run_supervised` couldn't
+  spawn an argv-specified child** (#706). The three `CreateProcessW`
+  call sites in `std/os/aether_os.c` (`win_launch`, the supervised
+  variant, and `os_run_full_raw`) passed the program path as
+  `lpApplicationName`. Per MSDN, when `lpApplicationName` is non-NULL it
+  must be a *full path* — `CreateProcessW` does not do `execvp`-style
+  PATH search, doesn't append `.exe`, and doesn't recognize built-ins
+  like `cmd`. A bare `"cmd"` therefore became a literal CWD-relative
+  filename lookup, failed with `ERROR_FILE_NOT_FOUND`, and bubbled up
+  as `rc=-1` / `err="spawn failed"`. Switched all three sites to
+  `lpApplicationName=NULL` and let `CreateProcessW` parse the first
+  token of `lpCommandLine`, which `build_command_line` already
+  quotes correctly via `append_escaped_arg`. (`os.system()`, the shell
+  string path, was unaffected — it routes through `system()` not
+  `CreateProcessW`.) Discriminator: literal-argv calls failed too, so
+  this is distinct from the heap-string issue (#688) already fixed.
+
 ## [0.243.0]
 
 ### Fixed

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -1996,11 +1996,11 @@ static wchar_t* build_environ_block(void* env_list) {
 static int win_launch(const char* prog, void* argv_list, void* env_list,
                       int capture_stdout,
                       int* out_exit_code, char** out_capture) {
+    (void)prog; /* Used only to seed build_command_line's argv[0] when
+                   argv_list is empty; CreateProcessW receives lpApplicationName=NULL
+                   and parses the command line itself (see below). */
     wchar_t* cmdline = build_command_line(prog, argv_list);
     if (!cmdline) return -1;
-
-    wchar_t* wprog = utf8_to_wide(prog);
-    if (!wprog) { free(cmdline); return -1; }
 
     wchar_t* wenv = build_environ_block(env_list);
     // NULL from build_environ_block when env_list is NULL means "inherit" —
@@ -2019,7 +2019,7 @@ static int win_launch(const char* prog, void* argv_list, void* env_list,
         sa.bInheritHandle = TRUE;
         sa.lpSecurityDescriptor = NULL;
         if (!CreatePipe(&read_pipe, &write_pipe, &sa, 0)) {
-            free(cmdline); free(wprog); free(wenv);
+            free(cmdline); free(wenv);
             return -1;
         }
         // The read end must NOT be inherited by the child.
@@ -2035,8 +2035,18 @@ static int win_launch(const char* prog, void* argv_list, void* env_list,
     memset(&pi, 0, sizeof(pi));
 
     DWORD flags = CREATE_UNICODE_ENVIRONMENT;
+    /* lpApplicationName=NULL so CreateProcessW parses the first whitespace-
+     * delimited token of lpCommandLine and runs its own PATH + .exe + .bat
+     * resolution. Passing a bare program name (e.g. "cmd", "gcc") as
+     * lpApplicationName makes Win32 treat it as a literal filename in CWD
+     * — no PATH search, no extension append — and CreateProcessW returns
+     * ERROR_FILE_NOT_FOUND. That broke os.run / os.run_capture /
+     * os.run_supervised on Windows for every PATH-resolved program
+     * (issue #706). The argv[0] in cmdline (built by build_command_line)
+     * already carries the program name, properly quoted by append_escaped_arg,
+     * which is what CreateProcessW will parse. */
     BOOL ok = CreateProcessW(
-        wprog,         // application name
+        NULL,          // application name — let CreateProcessW PATH-resolve cmdline[0]
         cmdline,       // command line (modifiable — CreateProcessW may write)
         NULL, NULL,
         capture_stdout ? TRUE : FALSE,  // inherit handles only when capturing
@@ -2047,7 +2057,6 @@ static int win_launch(const char* prog, void* argv_list, void* env_list,
         &pi);
 
     free(cmdline);
-    free(wprog);
     free(wenv);
 
     if (capture_stdout) {
@@ -2290,12 +2299,10 @@ _tuple_int_string os_run_supervised_raw(const char* prog, void* argv_list, void*
 
     wchar_t* cmdline = build_command_line(prog, argv_list);
     if (!cmdline) { out._1 = "argv build failed"; return out; }
-    wchar_t* wprog = utf8_to_wide(prog);
-    if (!wprog) { free(cmdline); out._1 = "argv build failed"; return out; }
     wchar_t* wenv = build_environ_block(env_list); /* NULL = inherit */
 
     HANDLE job = CreateJobObjectW(NULL, NULL);
-    if (!job) { free(cmdline); free(wprog); free(wenv); out._1 = "job create failed"; return out; }
+    if (!job) { free(cmdline); free(wenv); out._1 = "job create failed"; return out; }
 
     /* Arm kill-on-close only when reap_group is set: closing the job then
      * tears down the whole tree (the Windows group-reap). Without it,
@@ -2315,8 +2322,11 @@ _tuple_int_string os_run_supervised_raw(const char* prog, void* argv_list, void*
     DWORD flags = CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED;
     if (new_process_group) flags |= CREATE_NEW_PROCESS_GROUP;
 
-    BOOL ok = CreateProcessW(wprog, cmdline, NULL, NULL, FALSE, flags, wenv, NULL, &si, &pi);
-    free(cmdline); free(wprog); free(wenv);
+    /* lpApplicationName=NULL — same reason as win_launch (issue #706):
+     * let CreateProcessW PATH-resolve cmdline[0] rather than treating
+     * the bare prog name as a literal CWD filename. */
+    BOOL ok = CreateProcessW(NULL, cmdline, NULL, NULL, FALSE, flags, wenv, NULL, &si, &pi);
+    free(cmdline); free(wenv);
     if (!ok) { CloseHandle(job); out._1 = "spawn failed"; return out; }
 
     AssignProcessToJobObject(job, pi.hProcess);
@@ -2427,10 +2437,9 @@ _tuple_string_string_int_string os_run_full_raw(const char* prog, void* argv_lis
     SetHandleInformation(err_r, HANDLE_FLAG_INHERIT, 0);
 
     wchar_t* cmdline = build_command_line(prog, argv_list);
-    wchar_t* wprog = utf8_to_wide(prog);
     wchar_t* wenv = build_environ_block(env_list); /* NULL = inherit */
-    if (!cmdline || !wprog) {
-        free(cmdline); free(wprog); free(wenv);
+    if (!cmdline) {
+        free(cmdline); free(wenv);
         CloseHandle(in_r); CloseHandle(in_w); CloseHandle(out_r);
         CloseHandle(out_w); CloseHandle(err_r); CloseHandle(err_w);
         out._3 = "argv build failed"; return out;
@@ -2443,9 +2452,12 @@ _tuple_string_string_int_string os_run_full_raw(const char* prog, void* argv_lis
     si.hStdError  = err_w;
     PROCESS_INFORMATION pi; memset(&pi, 0, sizeof pi);
 
-    BOOL ok = CreateProcessW(wprog, cmdline, NULL, NULL, TRUE,
+    /* lpApplicationName=NULL — same reason as win_launch (issue #706):
+     * let CreateProcessW PATH-resolve cmdline[0] rather than treating
+     * the bare prog name as a literal CWD filename. */
+    BOOL ok = CreateProcessW(NULL, cmdline, NULL, NULL, TRUE,
                              CREATE_UNICODE_ENVIRONMENT, wenv, NULL, &si, &pi);
-    free(cmdline); free(wprog); free(wenv);
+    free(cmdline); free(wenv);
     /* Close the child-side ends in the parent so EOF propagates correctly. */
     CloseHandle(in_r); CloseHandle(out_w); CloseHandle(err_w);
     if (!ok) {

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -1944,17 +1944,20 @@ static void append_escaped_arg(WBuf* b, const wchar_t* arg) {
 static wchar_t* build_command_line(const char* prog, void* argv_list) {
     WBuf b; wbuf_init(&b);
 
+    /* Match the POSIX argv convention used by build_argv_array: the program
+     * is always prog, and argv_list holds the caller's arguments starting at
+     * position 0. The earlier shape — treating argv_list[0] as the program
+     * when the list was non-empty — meant os.run("cmd", ["/c","echo","x"])
+     * produced the command line `/c echo x` and tried to spawn a program
+     * named `/c`. Discovered chasing the second half of issue #706 once
+     * lpApplicationName=NULL exposed cmdline[0] to CreateProcessW's parser. */
+    wchar_t* wprog = utf8_to_wide(prog);
+    if (!wprog) { free(b.data); return NULL; }
+    append_escaped_arg(&b, wprog);
+    free(wprog);
+
     int n = argv_list ? list_size(argv_list) : 0;
-
-    const char* arg0_utf8 = (n > 0) ? aether_string_data(list_get_raw(argv_list, 0)) : prog;
-    if (!arg0_utf8) arg0_utf8 = prog;
-    wchar_t* warg0 = utf8_to_wide(arg0_utf8);
-    if (!warg0) { free(b.data); return NULL; }
-    append_escaped_arg(&b, warg0);
-    free(warg0);
-
-    int start_index = (n > 0) ? 1 : 0;
-    for (int i = start_index; i < n; i++) {
+    for (int i = 0; i < n; i++) {
         const char* item = aether_string_data(list_get_raw(argv_list, i));
         if (!item) continue;
         wchar_t* w = utf8_to_wide(item);
@@ -1996,9 +1999,9 @@ static wchar_t* build_environ_block(void* env_list) {
 static int win_launch(const char* prog, void* argv_list, void* env_list,
                       int capture_stdout,
                       int* out_exit_code, char** out_capture) {
-    (void)prog; /* Used only to seed build_command_line's argv[0] when
-                   argv_list is empty; CreateProcessW receives lpApplicationName=NULL
-                   and parses the command line itself (see below). */
+    /* prog seeds build_command_line's argv[0] (matching POSIX
+     * build_argv_array). CreateProcessW receives lpApplicationName=NULL
+     * and PATH-resolves that first token itself (see below). */
     wchar_t* cmdline = build_command_line(prog, argv_list);
     if (!cmdline) return -1;
 


### PR DESCRIPTION
Closes #706.

## Summary

On Windows, `os.run` / `os.run_capture` / `os.run_supervised` couldn't spawn an argv-specified child for **any** program, literal or heap argv — `rc=-1`, `err=\"spawn failed\"`. (`os.system()` was unaffected — it routes through libc `system()`, not `CreateProcessW`.) Two independent bugs in `std/os/aether_os.c`.

## Bug 1 — `lpApplicationName` pinned program to a literal CWD path

All three `CreateProcessW` call sites passed the wide-encoded program path as `lpApplicationName`:

- `win_launch` (powers `os.run` + `os.run_capture`)
- `os_run_supervised_raw` Windows branch (powers `os.run_supervised`)
- `os_run_full_raw` Windows branch (powers `os.run` with stdin + stderr capture)

Per MSDN: a non-NULL `lpApplicationName` must be a *full path*. `CreateProcessW` does no `execvp`-style PATH search, no `.exe` append, no recognition of built-ins like `cmd`. A bare `\"cmd\"` therefore became a literal CWD-relative filename, failed with `ERROR_FILE_NOT_FOUND`, and bubbled up as `rc=-1`.

**Fix:** all three sites now pass `lpApplicationName=NULL` and let `CreateProcessW` parse and PATH-resolve the first token of `lpCommandLine`. `wprog` / `utf8_to_wide(prog)` drops out entirely (the program name still lives in `cmdline` via `build_command_line`).

## Bug 2 — argv convention mismatch with the POSIX builder

Once Bug 1 was fixed, `cmdline[0]` became the program-name token CreateProcessW would actually look up — which exposed a second, independent bug:

- **POSIX** `build_argv_array`: `av[0] = prog`, `argv_list` is the *whole* caller-supplied argument vector (Aether contract; see also #688).
- **Windows** `build_command_line`: treated `argv_list[0]` as the program name and *dropped* `prog` entirely when the list was non-empty.

So `os.run(\"cmd\", [\"/c\",\"echo\",\"x\"])` — correct on Linux — produced the Windows command line `/c echo x` and tried to spawn a program named `/c`.

**Fix:** `build_command_line` now mirrors `build_argv_array` — always seed with `prog`, then append the whole `argv_list` from `i=0`.

## Validation

Sibling on Windows 11 + MinGW64 (`/mingw64/bin` gcc) verified the branch end-to-end (commits `dcacfb4` then `9cd2977`):

| call | before | after |
| --- | --- | --- |
| `os.run(\"cmd\", [\"/c\",\"echo\",\"x\"], null)` | `rc=-1` spawn failed | `rc=0`, child prints `x` |
| `os.run_capture(\"cmd\", [\"/c\",\"echo\",\"x\"], null)` | `out=\"\"` err `\"spawn failed\"` | `out=\"x\\r\\n\"`, rc 0 |
| `os.run_supervised(...)` (aeb's launcher) | rc -1 spawn failed | spawns, aeb-cli runs |
| `os.system(\"cmd /c echo x\")` | already worked | unchanged |

Linux: full stdlib rebuild clean — the changes are in `#ifdef _WIN32` regions only and `build_command_line` is the Windows file's, not POSIX's.

## Discriminator vs. prior #706-adjacent fixes

- Not #688 (heap-string corruption — fixed in v0.240). *Literal* argv calls failed too, so the bug wasn't in the heap-vs-literal axis.
- Not #693 (stale `runtime/memory/memory.c` reference — fixed in v0.243). Build was clean; only the spawn was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)