### PR TITLE
fix(codegen): compute 64-bit-context int shifts in 64 bits, not C int (#697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Fixed
+
+- **Int-shift sign-extension into 64-bit values** (#697). Shifting a
+  32-bit-`int` operand (e.g. a `std.mem` byte accessor's result) and
+  combining it into a `uint64`/`int64` expression — the canonical
+  `u = u | (byte << 24)` binary-decode pattern — evaluated the shift in C
+  `int`: for a byte >= 0x80 the sign bit overflowed and was sign-extended
+  across the high 32 bits (`0x86000000` became `0xFFFFFFFF86000000`), and
+  counts >= 32 were undefined behaviour. This silently corrupted binary
+  codecs (the aedis Redis listpack/siphash port). The typechecker now
+  propagates a 64-bit result context down into int arithmetic operands
+  (left-shift and the value-combining `+ - * | & ^`; `>>` is excluded so
+  arithmetic-shift signedness is preserved), and codegen casts narrow
+  operands to the 64-bit type at the use site, so the value is built in
+  64 bits. Pure-int arithmetic is unchanged. Covers the OR-combining and
+  `uint64 x = byte << n` declaration forms.
+
 ## [0.244.0]
 
 ### Fixed

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -626,6 +626,43 @@ static TypeKind wider_integer_kind(TypeKind a, TypeKind b) {
     return TYPE_INT;
 }
 
+/* #697: downward integer-width propagation.
+ *
+ * Type inference is bottom-up, so a sub-expression like `byte << 24`
+ * (int << int) is typed 32-bit `int` even when its result is immediately
+ * combined into a 64-bit value (`u | (byte << 24)`). C then evaluates the
+ * shift in 32-bit — overflowing the sign bit and sign-extending into the
+ * high 32 bits of the uint64 — silently corrupting binary-protocol codecs.
+ *
+ * When a binary integer op resolves to a 64-bit type, walk its operands
+ * and re-type any narrower-int arithmetic operand whose VALUE is computed
+ * (a nested arith/bitwise/left-shift binary expression) to the same 64-bit
+ * kind, so codegen widens it before the operation. Leaf operands
+ * (variables, literals, calls) keep their own type and are cast at the use
+ * site by codegen. `>>` is intentionally NOT widened: promoting a signed
+ * right-shift to unsigned would turn an arithmetic shift into a logical
+ * one and change the value of negative operands. Division/modulo are
+ * likewise excluded (their 32-bit result is well-defined and widening
+ * could only change a value the source already committed to). */
+static void propagate_int_width_64(ASTNode* node, TypeKind wide) {
+    if (!node || node->type != AST_BINARY_EXPRESSION || !node->node_type) return;
+    /* Only widen nodes currently typed as 32-bit int — leave anything
+     * already 64-bit (or non-integer) alone. */
+    if (node->node_type->kind != TYPE_INT) return;
+    if (!node->value) return;
+    const char* op = node->value;
+    int width_sensitive =
+        strcmp(op, "<<") == 0 || strcmp(op, "+") == 0 || strcmp(op, "-") == 0 ||
+        strcmp(op, "*") == 0  || strcmp(op, "|") == 0 || strcmp(op, "&") == 0 ||
+        strcmp(op, "^") == 0;
+    if (!width_sensitive) return;
+    node->node_type->kind = wide;
+    if (node->child_count >= 2) {
+        propagate_int_width_64(node->children[0], wide);
+        propagate_int_width_64(node->children[1], wide);
+    }
+}
+
 // Count the number of formal parameters of a function definition node
 // Skips _ctx parameters (auto-injected by builder context)
 static int count_function_params(ASTNode* func) {
@@ -1135,9 +1172,9 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
         }
         
         case AST_BINARY_EXPRESSION:
-            return infer_binary_type(expr->children[0], expr->children[1], 
+            return infer_binary_type(expr->children[0], expr->children[1],
                                    get_token_type_from_string(expr->value));
-            
+
         case AST_UNARY_EXPRESSION:
             return infer_unary_type(expr->children[0], 
                                   get_token_type_from_string(expr->value));
@@ -2726,6 +2763,14 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                     type_error("Type mismatch in variable initialization", stmt->line, stmt->column);
                     return 0;
                 }
+                /* #697: declared 64-bit but the initializer is a 32-bit-int
+                 * arithmetic expression (e.g. `uint64 x = byte << 24`) —
+                 * widen it so the computation happens in 64 bits, not C int. */
+                if (stmt->node_type &&
+                    (stmt->node_type->kind == TYPE_INT64 ||
+                     stmt->node_type->kind == TYPE_UINT64)) {
+                    propagate_int_width_64(init, stmt->node_type->kind);
+                }
                 /* `byte b = <int literal>` — fresh declaration with explicit
                  * `byte` type. Reject out-of-range literals at compile time
                  * (literal-range check). Non-literal int is accepted (runtime
@@ -3792,6 +3837,13 @@ int typecheck_binary_expression(ASTNode* expr, SymbolTable* table) {
             return 0;
         }
         expr->node_type = result_type;
+        /* #697: this op is 64-bit — widen any 32-bit-int arithmetic
+         * operands so the computation happens in 64 bits, not in C int. */
+        if (result_type && (result_type->kind == TYPE_INT64 ||
+                            result_type->kind == TYPE_UINT64)) {
+            propagate_int_width_64(left, result_type->kind);
+            propagate_int_width_64(right, result_type->kind);
+        }
     }
 
     free_type(left_type);

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2161,8 +2161,28 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                     }
                     int duration_ratio = expr->value && strcmp(expr->value, "/") == 0 &&
                         ltype && rtype && ltype->kind == TYPE_DURATION && rtype->kind == TYPE_DURATION;
+                    /* #697: a 64-bit integer arithmetic/bitwise/shift op whose
+                     * operand is a narrower 32-bit int must compute in 64-bit,
+                     * or C promotes the operand in 32-bit and sign-extends it
+                     * into the high half (e.g. `byte << 24` polluting a uint64).
+                     * The typechecker (propagate_int_width_64) already re-typed
+                     * computed sub-expressions; here we cast narrow leaf/value
+                     * operands at the use site. Not for assignment (the `=`
+                     * conversion is handled by the LHS type) or comparisons
+                     * (bool result). */
+                    const char* wide_cast = NULL;
+                    if (!is_assignment && expr->node_type &&
+                        (expr->node_type->kind == TYPE_INT64 ||
+                         expr->node_type->kind == TYPE_UINT64)) {
+                        wide_cast = (expr->node_type->kind == TYPE_UINT64)
+                                    ? "(uint64_t)" : "(int64_t)";
+                    }
+                    #define AE_IS_NARROW_INT(t) ((t) && ((t)->kind == TYPE_INT || \
+                        (t)->kind == TYPE_BYTE || (t)->kind == TYPE_UINT32 || \
+                        (t)->kind == TYPE_UINT16 || (t)->kind == TYPE_UINT8))
                     if (duration_ratio) fprintf(gen->output, "(double)");
                     if (ptr_int_cmp && lhs_is_ptr) fprintf(gen->output, "(intptr_t)");
+                    if (wide_cast && AE_IS_NARROW_INT(ltype)) fprintf(gen->output, "%s", wide_cast);
                     generate_expression(gen, expr->children[0]);
                     if (is_assignment) {
                         gen->generating_lvalue = 0;
@@ -2216,8 +2236,10 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                 "_aether_box_closure((_AeClosure){ .fn = (void(*)(void))_aether_bare_adapter_%s, .env = NULL })",
                                 bn ? bn : "unknown");
                     } else {
+                        if (wide_cast && AE_IS_NARROW_INT(rtype)) fprintf(gen->output, "%s", wide_cast);
                         generate_expression(gen, expr->children[1]);
                     }
+                    #undef AE_IS_NARROW_INT
                     if (!skip_parens) fprintf(gen->output, ")");
                 }
             }

--- a/tests/regression/test_int_shift_width.ae
+++ b/tests/regression/test_int_shift_width.ae
@@ -1,0 +1,63 @@
+// Regression (#697): shifting a 32-bit-int operand into a 64-bit
+// expression must compute in 64-bit, not in C `int`.
+//
+// Before the fix, `byte << 24` lowered to a plain C int shift: for a
+// byte >= 0x80 the int32 sign bit overflowed, and OR-ing the negative
+// int into a uint64 sign-extended it — setting all the high 32 bits
+// (e.g. 0x86000000 became 0xFFFFFFFF86000000). Shift counts >= 32 were
+// outright UB (gcc masks the count to 5 bits, so `<< 48` landed at bit
+// 16). This silently corrupted binary-protocol codecs (the aedis Redis
+// listpack/siphash port).
+//
+// The typechecker now widens int arithmetic operands whose result feeds
+// a 64-bit context, and codegen casts narrow operands to 64-bit at the
+// shift, so the value is built in 64 bits.
+
+extern exit(code: int)
+
+main() {
+    println("=== test_int_shift_width ===")
+
+    // The canonical case: assemble a uint64 from byte shifts, high byte >= 0x80.
+    b1 = 0x21
+    b2 = 0x43
+    b3 = 0x65
+    b4 = 0x86            // >= 0x80 — the sign-bit trap
+    uint64 u = 0
+    u = u | b1
+    u = u | (b2 << 8)
+    u = u | (b3 << 16)
+    u = u | (b4 << 24)
+    if u != 2254783265 {        // 0x86654321
+        println("  FAIL: assembled u=${u} want 2254783265 (0x86654321)")
+        exit(1)
+    }
+
+    // Shift count >= 32 (UB as an int shift): byte landed at the wrong bit.
+    b5 = 0xC8                    // 200
+    uint64 hi = 0
+    hi = hi | (b5 << 48)
+    if hi != 56294995342131200 {  // 0xC8 << 48
+        println("  FAIL: high shift hi=${hi} want 56294995342131200")
+        exit(1)
+    }
+
+    // A single shift directly assigned to a uint64 local (declaration).
+    bv = 0x80
+    uint64 single = bv << 24
+    if single != 2147483648 {   // 0x80000000 — must NOT sign-extend
+        println("  FAIL: single=${single} want 2147483648")
+        exit(1)
+    }
+
+    // Pure-int arithmetic must be UNAFFECTED (32-bit wraparound preserved).
+    x = 1
+    y = x << 4
+    if y != 16 {
+        println("  FAIL: int shift y=${y} want 16")
+        exit(1)
+    }
+
+    println("  PASS: 64-bit-context int shifts compute in 64 bits")
+    println("=== test_int_shift_width passed ===")
+}


### PR DESCRIPTION
Closes #697.

## The bug (silent data corruption)

Shifting a 32-bit-`int` operand and combining it into a 64-bit value — the canonical binary-decode pattern — evaluated the shift in C `int`:

```aether
uint64 u = get_byte(p,1)
u = u | (get_byte(p,4) << 24)   // byte >= 0x80: int32 sign bit overflows,
                                 // then sign-extends across the high 32 bits
```

For a byte of `0x86` the expression contributed `0xFFFFFFFF86000000` instead of `0x86000000`; shift counts >= 32 were outright UB. This was the root cause of silent corruption in the aedis Redis port's listpack/siphash codecs (925 fuzz failures → 0 after the fix + #698).

## Fix (two coordinated parts)

1. **Typechecker** (`propagate_int_width_64`): when a binary integer op resolves to a 64-bit type, re-type its narrower-int *arithmetic* operand sub-expressions (nested `<<`, `+ - * | & ^`) to the 64-bit kind, so the computation happens in 64 bits. `>>` is **excluded** (so a signed arithmetic right-shift isn't silently turned logical); `/`/`%` excluded (their 32-bit result is already well-defined). Hooked at the binary-op result and at 64-bit-typed declaration initializers.
2. **Codegen**: a 64-bit arithmetic/bitwise/shift op casts its narrow-int operands to the result's C type at the use site — `(uint64_t)bv << (uint64_t)24` — widening the byte **before** the shift. Not applied to assignment or comparisons.

Pure-int arithmetic is unchanged (32-bit wraparound preserved).

## Scope

Covers the OR-combining (`u = u | (byte << n)`) and declaration (`uint64 x = byte << n`) forms — the patterns the issue reports and real codecs use. A bare lone-shift *re-assignment* to an existing local (`x = byte << n`, no combining op, no declaration) takes a different typecheck path and is not yet widened; it's a rare pattern (real codecs OR-combine or hoist to a typed temp) and is noted as a follow-up.

## Validation (macOS)
- New `tests/regression/test_int_shift_width.ae` asserts the assembled uint64, a `<< 48` (former UB), the declaration form, and that pure-int shifts are unaffected.
- Unit suite **227/227**; full `.ae` regression suite **462/0**; generated C shows the 64-bit cast. Zero warnings.

Companion bug **#698** (silent int-narrowing on inferred locals, same aedis debugging session) is a separate mid-size branch.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
