### PR TITLE
contrib(templating.native): pretty-print for HTML and XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Added
+
+- **`contrib.templating.native`: `pretty_print_html` / `pretty_print_xml`
+  (debug-only).** Two post-processors that take the tight output of
+  `render_html()` / `render_xml()` (or any externally well-formed
+  HTML / XML string with this module's escape conventions) and return
+  an indented version with `\n` line endings between elements.
+  Surface:
+  ```aether
+  pretty_print_html(s: string, indent_size: int) -> string
+  pretty_print_xml(s: string, indent_size: int)  -> string
+  ```
+  `indent_size` honoured in the range `1..8`; out-of-range falls
+  back to 2. Pretty-print is for human reading / diffing during
+  development; production paths should use `render_html()` /
+  `render_xml()` directly. **HTML carve-outs:** `<pre>`,
+  `<textarea>`, `<script>`, and `<style>` pause depth tracking for
+  their subtree — their bodies pass through byte-for-byte because
+  whitespace inside them is significant to rendering / behaviour.
+  **XML has no whitelist:** every element gets indented; if your
+  XML uses mixed content or CDATA-sensitive data, render the tight
+  version instead. The post-processor understands `<name>` /
+  `</name>` / `<name/>` plus pass-through for `<?...?>`,
+  `<!--...-->`, and `<![CDATA[...]]>`. Once the v2 XML attribute
+  story lands, the parser here will need updating to skip
+  `key="value"` runs inside `<`...`>`. New test
+  `tests/integration/native_templating_pretty/` (10 cases — flat
+  body, nested elements, `<pre>` and `<script>` carve-outs, XML
+  prolog handling, self-close elements, indent size choice with
+  out-of-range fallback, end-to-end DSL → pretty round-trip).
+
 ## [0.249.0]
 
 ### Added

--- a/contrib/templating/native/README.md
+++ b/contrib/templating/native/README.md
@@ -102,6 +102,67 @@ attributes), processing instructions other than the prolog, DOCTYPE,
 schema-aware emission. Use `xml_raw` for trusted markup if you need
 any of these.
 
+### Pretty-print (debug-only)
+
+Both `render_html()` and `render_xml()` emit tight output — no
+indentation, no inter-element whitespace, byte-deterministic. For
+human reading or diffing during development, two post-processors
+take that tight output and return an indented version:
+
+```aether
+tight = native.render_html() {
+    native.tag("ul") {
+        native.tag("li") { native.text("a") }
+        native.tag("li") { native.text("b") }
+    }
+}
+println(native.pretty_print_html(tight, 2))
+//   <ul>
+//     <li>a</li>
+//     <li>b</li>
+//   </ul>
+
+println(native.pretty_print_xml(some_xml, 4))     // 4-space indent
+```
+
+Surface:
+
+```aether
+pretty_print_html(s: string, indent_size: int) -> string
+pretty_print_xml(s: string, indent_size: int)  -> string
+```
+
+`indent_size` is 2 or 4 in normal use; any value in `1..8` is
+honoured, anything out of range falls back to 2. Line endings are
+always `\n` — pretty-print is for humans, not machines.
+
+**Caveats — read these before using pretty-print in production:**
+
+- **It's for debugging, not serving.** The tight output is the
+  ground truth; pretty-print is a transform layer for human eyes.
+  Production paths should use `render_html()` / `render_xml()`
+  directly.
+- **HTML carve-outs.** Inside `<pre>`, `<textarea>`, `<script>`,
+  and `<style>`, depth tracking pauses and the body passes through
+  byte-for-byte. These four elements have whitespace-significant
+  content and indenting inside them would change the rendered
+  page.
+- **XML has no whitelist.** Every XML element gets indented. If
+  your XML uses mixed content (text and elements interleaved
+  inside the same parent) or carries CDATA-sensitive data, the
+  pretty-printed output is *not equivalent* to the tight version
+  for the consuming parser. Use the tight renderer for such cases.
+- **Not a general formatter.** The post-processor understands tags
+  this module emits — `<name>`, `</name>`, `<name/>`, plus a
+  fall-through for `<?...?>`, `<!--...-->`, and `<![CDATA[...]]>`.
+  Arbitrary HTML / XML with attributes (today) or unusual entity
+  use will be formatted on a best-effort basis. For arbitrary
+  input, reach for `xmllint --format`, `tidy`, or your IDE.
+- **Attributes (when they land).** The v2 XML attribute story
+  hasn't shipped; when it does, the parser here will need updating
+  to skip `key="value"` runs inside `<`...`>`. Until then, treat
+  attribute-bearing markup as undefined for the formatter.
+
 ### Plain functions (escape hatch for hot paths)
 
 If you want to avoid the per-tag strbuilder allocation the DSL

--- a/contrib/templating/native/module.ae
+++ b/contrib/templating/native/module.ae
@@ -50,7 +50,8 @@ import std.string
 exports (
     html_text, html_raw, html_tag_open, html_tag_close, html_tag,
     render_html, tag, text, raw,
-    render_xml, xml_tag, xml_self_close, xml_text, xml_raw
+    render_xml, xml_tag, xml_self_close, xml_text, xml_raw,
+    pretty_print_html, pretty_print_xml
 )
 
 // HTML-escape one byte into `sb`. Covers the five canonical entities
@@ -342,4 +343,324 @@ builder render_xml(): string with strbuilder_factory_64 {
     out = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
     body = strbuilder.finish(_builder)
     return string.concat(out, body)
+}
+
+// ---------------------------------------------------------------------
+// Pretty-print — skinny v1.
+// ---------------------------------------------------------------------
+//
+// `pretty_print_html(s, indent_size)` and `pretty_print_xml(s, indent_size)`
+// take output produced by render_html / render_xml (or any externally
+// well-formed HTML / XML string with our escape conventions) and
+// return an indented version with `\n` newlines between elements.
+//
+//   render_html() { tag("div") { tag("p") { text("hi") } } }
+//   // tight: "<div><p>hi</p></div>"
+//   pretty_print_html("<div><p>hi</p></div>", 2)
+//   // pretty:
+//   //   <div>
+//   //     <p>hi</p>
+//   //   </div>
+//
+// Rules
+// -----
+//
+//   - A newline + (indent * depth) is emitted before each opening
+//     tag and before each closing tag whose matching open is on a
+//     different "line" (i.e. that contains nested elements). Tags
+//     wrapping plain text only — like `<p>hi</p>` — stay on one line.
+//   - Self-closing `<tag/>` (XML) is treated like an open+close pair
+//     with no body.
+//   - `\n` line endings only. Pretty-print is for human debugging;
+//     consumers that need CRLF can post-process.
+//   - HTML only: inside `<pre>`, `<textarea>`, `<script>`, and
+//     `<style>`, depth tracking pauses for the subtree's body — the
+//     bytes pass through unchanged so whitespace stays significant.
+//     XML has no equivalent whitelist; if your XML uses mixed content
+//     or CDATA-sensitive data, render the tight version instead.
+//   - The XML prolog (`<?xml ... ?>`) is emitted on its own line at
+//     the top, with no leading newline.
+//
+// Limits
+// ------
+//
+//   - The post-processor only understands tags this module emits:
+//     `<name>` / `</name>` / `<name/>` with no attributes. When the
+//     v2 XML attribute story lands, the parser will need updating to
+//     skip `key="value"` runs inside `<`...`>`.
+//   - It does not pretty-print attributes onto separate lines; once
+//     attributes land they'll stay on the open-tag line.
+//   - It is NOT a general HTML/XML formatter. Use `xmllint --format`,
+//     `tidy`, or your IDE for arbitrary input. This is a "make our
+//     own renderer's output legible" helper.
+
+// HTML elements where whitespace inside the element is significant
+// to rendering or behaviour — we don't insert indentation inside
+// their bodies. Inlined check rather than a const array because
+// Aether's `const` declarations don't accept array initialisers.
+//
+// Return 1 if `name` is in the HTML no-pretty-print whitelist.
+is_no_indent_html_tag(name: string) -> int {
+    n = string_length(name)
+    // Tag names from our emitter are case-sensitive (we emit
+    // exactly what the user passed). We compare case-sensitively;
+    // anyone emitting `<PRE>` won't get the carve-out, which is
+    // fine because we don't emit upper-case HTML.
+    if n == 3 {
+        if string.equals(name, "pre") == 1 { return 1 }
+    }
+    if n == 5 {
+        if string.equals(name, "style") == 1 { return 1 }
+    }
+    if n == 6 {
+        if string.equals(name, "script") == 1 { return 1 }
+    }
+    if n == 8 {
+        if string.equals(name, "textarea") == 1 { return 1 }
+    }
+    return 0
+}
+
+// Internal: append `n` copies of `unit` to `sb`.
+append_repeat(sb: ptr, unit: string, n: int) {
+    i = 0
+    while i < n {
+        strbuilder.append(sb, unit)
+        i = i + 1
+    }
+}
+
+// Internal: validate indent_size; treat anything outside [1..8] as 2.
+clamp_indent(indent_size: int) -> int {
+    if indent_size < 1 { return 2 }
+    if indent_size > 8 { return 2 }
+    return indent_size
+}
+
+// The core walker. `respect_pre_whitelist` is 1 for HTML, 0 for XML.
+pretty_print_impl(s: string, indent_size: int, respect_pre_whitelist: int) -> string {
+    n = string_length(s)
+    indent = clamp_indent(indent_size)
+    indent_unit = ""
+    j = 0
+    while j < indent {
+        indent_unit = string.concat(indent_unit, " ")
+        j = j + 1
+    }
+
+    sb = strbuilder.new(n + 64)
+    depth = 0
+    i = 0
+    // When > 0, we're inside a no-pretty subtree (e.g. <pre>); emit
+    // bytes verbatim until matching </pre> at the same nesting level.
+    // We track the *nesting depth at which the pre opened*, so a
+    // nested <pre> inside a <pre> still pops correctly.
+    pre_depth = -1
+
+    // For knowing whether to put a closing tag on its own line, we
+    // remember if the most recent emission inside the current parent
+    // was another tag (so the parent had children) or text. The
+    // simplest signal is "did we last emit a closing tag?" — if yes,
+    // the next thing (a closing tag or a sibling open) wants a
+    // newline + indent. We track this via `wrote_tag_at_depth`.
+    wrote_tag = 0
+
+    while i < n {
+        c = string.char_at_n(s, n, i)
+        if c == 60 {     // '<'
+            // Look at the next char to classify.
+            next = 0
+            if i + 1 < n { next = string.char_at_n(s, n, i + 1) }
+
+            // Special-pass-throughs we don't pretty-print:
+            //   - <?... ?>  processing instruction (XML prolog)
+            //   - <!--...--> comment
+            //   - <![CDATA[ ... ]]>
+            // For each, find its end and copy verbatim.
+            if next == 63 {   // '?'
+                // PI: emit verbatim up to '?>'.
+                end = -1
+                k = i + 2
+                while k < n - 1 {
+                    if string.char_at_n(s, n, k) == 63 {
+                        if string.char_at_n(s, n, k + 1) == 62 {
+                            end = k + 1
+                            break
+                        }
+                    }
+                    k = k + 1
+                }
+                if end < 0 { end = n - 1 }
+                strbuilder.append(sb, string.substring_n(s, n, i, end + 1))
+                // No explicit newline — the next tag emission will
+                // add `\n` because the sb is non-empty, putting the
+                // root element on its own line.
+                i = end + 1
+                wrote_tag = 0
+                continue
+            }
+            if next == 33 {   // '!'
+                // Comment or CDATA — find matching '>' (cheap; we
+                // don't currently emit either, but pass-through if
+                // someone hand-built one with raw()/xml_raw()).
+                end = -1
+                k = i + 1
+                while k < n {
+                    if string.char_at_n(s, n, k) == 62 {
+                        end = k
+                        break
+                    }
+                    k = k + 1
+                }
+                if end < 0 { end = n - 1 }
+                strbuilder.append(sb, string.substring_n(s, n, i, end + 1))
+                i = end + 1
+                wrote_tag = 0
+                continue
+            }
+
+            // Regular tag. Find the matching '>'.
+            tag_end = -1
+            k = i + 1
+            while k < n {
+                if string.char_at_n(s, n, k) == 62 {
+                    tag_end = k
+                    break
+                }
+                k = k + 1
+            }
+            if tag_end < 0 {
+                // Malformed; bail by copying the rest verbatim.
+                strbuilder.append(sb, string.substring_n(s, n, i, n))
+                i = n
+                continue
+            }
+            // Tag body is s[i+1 .. tag_end] (exclusive of '>').
+            body_start = i + 1
+            body_end = tag_end
+            is_close = 0
+            is_self_close = 0
+            name_start = body_start
+            if next == 47 {   // '/'
+                is_close = 1
+                name_start = body_start + 1
+            }
+            // Self-close: trailing '/'? (e.g. "<br/>" body == "br/")
+            // Check the char just before '>'.
+            if body_end - 1 >= name_start {
+                if string.char_at_n(s, n, body_end - 1) == 47 {
+                    is_self_close = 1
+                    body_end = body_end - 1   // drop the trailing '/'
+                }
+            }
+            // Tag name runs from name_start to first space-or-end-of-body.
+            // We don't have attributes today; future v2 attrs would
+            // need scanning here.
+            name_end = body_end
+            k = name_start
+            while k < body_end {
+                ch = string.char_at_n(s, n, k)
+                if ch == 32 {                 // ' '
+                    name_end = k
+                    break
+                }
+                k = k + 1
+            }
+            name = string.substring_n(s, n, name_start, name_end)
+
+            if respect_pre_whitelist == 1 {
+                if pre_depth >= 0 {
+                    // We're inside a no-pretty subtree; emit the tag
+                    // verbatim. Track whether this is the closing tag
+                    // that ends our pre region.
+                    strbuilder.append(sb, string.substring_n(s, n, i, tag_end + 1))
+                    if is_close == 1 {
+                        if depth == pre_depth + 1 {
+                            // Match. Exit pre mode.
+                            pre_depth = -1
+                            depth = depth - 1
+                            wrote_tag = 1
+                            i = tag_end + 1
+                            continue
+                        }
+                    }
+                    if is_self_close == 0 {
+                        if is_close == 0 {
+                            depth = depth + 1
+                        } else {
+                            depth = depth - 1
+                        }
+                    }
+                    i = tag_end + 1
+                    continue
+                }
+            }
+
+            // Emit newline + indent before any tag that isn't the
+            // very first thing in the output.
+            //   - Before an opening tag, always.
+            //   - Before a closing tag, only if its matching open
+            //     had children (we proxy this with wrote_tag — if
+            //     the last emission was a closing tag, this close
+            //     belongs on its own line).
+            //   - Before a self-close, always.
+            if is_close == 1 {
+                if wrote_tag == 1 {
+                    strbuilder.append(sb, "\n")
+                    append_repeat(sb, indent_unit, depth - 1)
+                }
+                // Emit the closing tag.
+                strbuilder.append(sb, string.substring_n(s, n, i, tag_end + 1))
+                depth = depth - 1
+                wrote_tag = 1
+                i = tag_end + 1
+                continue
+            }
+            // Opening or self-closing tag — newline + indent first
+            // (unless we're at the very start with empty sb).
+            if strbuilder.length(sb) > 0 {
+                strbuilder.append(sb, "\n")
+            }
+            append_repeat(sb, indent_unit, depth)
+            // Emit the tag.
+            strbuilder.append(sb, string.substring_n(s, n, i, tag_end + 1))
+            if is_self_close == 1 {
+                // No depth change.
+                wrote_tag = 1
+            } else {
+                depth = depth + 1
+                wrote_tag = 1
+                // If HTML and this is a no-pretty tag, enter pre mode.
+                if respect_pre_whitelist == 1 {
+                    if is_no_indent_html_tag(name) == 1 {
+                        pre_depth = depth - 1
+                    }
+                }
+            }
+            i = tag_end + 1
+            continue
+        }
+        // Plain text byte. Append and clear wrote_tag — the next
+        // closing tag should stay on the same line as this text.
+        strbuilder.append_byte(sb, c)
+        wrote_tag = 0
+        i = i + 1
+    }
+    return strbuilder.finish(sb)
+}
+
+// HTML pretty-print. `<pre>`, `<textarea>`, `<script>`, `<style>`
+// pause depth tracking — their bodies stay byte-for-byte. Use 2 or
+// 4 (or any value 1..8); out-of-range falls back to 2.
+pretty_print_html(s: string, indent_size: int) -> string {
+    return pretty_print_impl(s, indent_size, 1)
+}
+
+// XML pretty-print. No element whitelist — every element gets
+// indented. If you need to preserve whitespace inside specific
+// elements, emit those subtrees as `xml_raw(string)` and let the
+// pretty-printer's PI / comment / CDATA fall-throughs do the right
+// thing for `<!CDATA[...]]>` blocks.
+pretty_print_xml(s: string, indent_size: int) -> string {
+    return pretty_print_impl(s, indent_size, 0)
 }

--- a/tests/integration/native_templating_pretty/probe.ae
+++ b/tests/integration/native_templating_pretty/probe.ae
@@ -1,0 +1,95 @@
+// contrib.templating.native — pretty_print_html / pretty_print_xml.
+//
+// What this exercises:
+//   1. pretty_print_html on flat element content (text-only body).
+//   2. pretty_print_html on nested elements.
+//   3. <pre> carve-out — body bytes pass through unchanged.
+//   4. <textarea> / <script> / <style> in the same whitelist.
+//   5. pretty_print_xml on nested elements.
+//   6. XML prolog goes on its own line; root opens on the next.
+//   7. Self-closing elements (XML) get their own line.
+//   8. Indent size choice (2 vs 4); out-of-range falls back to 2.
+//   9. End-to-end: render_html() output piped through
+//      pretty_print_html.
+
+import contrib.templating.native
+import std.string
+
+extern exit(code: int)
+
+expect_eq(actual: string, want: string, label: string) {
+    if string.equals(actual, want) != 1 {
+        println("FAIL ${label}:")
+        println("  got:")
+        println(actual)
+        println("  want:")
+        println(want)
+        exit(1)
+    }
+    println("PASS ${label}")
+}
+
+main() {
+    // (1) Flat element with text body — stays on one line.
+    out1 = native.pretty_print_html("<p>hello</p>", 2)
+    expect_eq(out1, "<p>hello</p>", "1 flat text body")
+
+    // (2) Nested elements get indented.
+    out2 = native.pretty_print_html("<ul><li>a</li><li>b</li></ul>", 2)
+    expect_eq(out2,
+              "<ul>\n  <li>a</li>\n  <li>b</li>\n</ul>",
+              "2 nested list")
+
+    // (3) <pre> carve-out — internal whitespace preserved verbatim,
+    //     no indent added inside.
+    out3 = native.pretty_print_html("<div><pre>line1\nline2</pre></div>", 2)
+    expect_eq(out3,
+              "<div>\n  <pre>line1\nline2</pre>\n</div>",
+              "3 pre carve-out")
+
+    // (4) <script> also carved out (same whitelist).
+    out4 = native.pretty_print_html("<head><script>var x = 1;\nvar y = 2;</script></head>", 2)
+    expect_eq(out4,
+              "<head>\n  <script>var x = 1;\nvar y = 2;</script>\n</head>",
+              "4 script carve-out")
+
+    // (5) pretty_print_xml on nested elements.
+    out5 = native.pretty_print_xml("<rss><channel><title>Hi</title></channel></rss>", 2)
+    expect_eq(out5,
+              "<rss>\n  <channel>\n    <title>Hi</title>\n  </channel>\n</rss>",
+              "5 nested XML")
+
+    // (6) Prolog on its own line; root on the next.
+    out6 = native.pretty_print_xml("<?xml version=\"1.0\" encoding=\"UTF-8\"?><doc><a>hi</a></doc>", 2)
+    expect_eq(out6,
+              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<doc>\n  <a>hi</a>\n</doc>",
+              "6 XML prolog newline")
+
+    // (7) Self-close in XML.
+    out7 = native.pretty_print_xml("<doc><a/><b><c/></b></doc>", 2)
+    expect_eq(out7,
+              "<doc>\n  <a/>\n  <b>\n    <c/>\n  </b>\n</doc>",
+              "7 self-close")
+
+    // (8) Indent size 4 honoured; 0 (out of range) falls back to 2.
+    out8a = native.pretty_print_xml("<a><b>x</b></a>", 4)
+    expect_eq(out8a, "<a>\n    <b>x</b>\n</a>", "8a indent 4")
+    out8b = native.pretty_print_xml("<a><b>x</b></a>", 0)
+    expect_eq(out8b, "<a>\n  <b>x</b>\n</a>", "8b indent 0 falls back to 2")
+
+    // (9) End-to-end: render_html DSL output → pretty_print_html.
+    items = ["alpha", "beta", "<gamma>"]
+    tight = native.render_html() {
+        native.tag("ul") {
+            for i in 0..3 {
+                native.tag("li") { native.text(items[i]) }
+            }
+        }
+    }
+    pretty = native.pretty_print_html(tight, 2)
+    expect_eq(pretty,
+              "<ul>\n  <li>alpha</li>\n  <li>beta</li>\n  <li>&lt;gamma&gt;</li>\n</ul>",
+              "9 end-to-end DSL → pretty")
+
+    println("All PASS")
+}

--- a/tests/integration/native_templating_pretty/test_native_templating_pretty.sh
+++ b/tests/integration/native_templating_pretty/test_native_templating_pretty.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# contrib.templating.native — pretty_print_html / pretty_print_xml.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+OUT="$(AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/probe.ae" 2>&1)"
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "  [FAIL] native_templating_pretty (exit $RC):"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+if ! echo "$OUT" | grep -q "All PASS"; then
+    echo "  [FAIL] native_templating_pretty — no 'All PASS' line:"
+    echo "$OUT" | sed 's/^/    /'
+    exit 1
+fi
+
+echo "  [PASS] native_templating_pretty: 10/10"


### PR DESCRIPTION
Two post-processors that take the tight output of `render_html()` / `render_xml()` (or any externally well-formed HTML / XML string with this module's escape conventions) and return an indented version with `\n` line endings between elements.

```aether
tight = native.render_html() {
    native.tag("ul") {
        native.tag("li") { native.text("a") }
        native.tag("li") { native.text("b") }
    }
}
pretty = native.pretty_print_html(tight, 2)
// <ul>
//   <li>a</li>
//   <li>b</li>
// </ul>
```

## Surface

```aether
pretty_print_html(s: string, indent_size: int) -> string
pretty_print_xml(s: string, indent_size: int)  -> string
```

`indent_size` honoured in `1..8`; out-of-range falls back to 2. Line endings always `\n` — pretty-print is for humans, not machines.

## Design choice — post-processor over emission-time formatting

Considered both:
- **Emission-time depth tracking** would have needed the per-tag `builder ... with factory` mechanism to let the factory see the parent's current depth, which the documented machinery doesn't support — the factory is nullary.
- **A thread-local depth counter** would work but introduces hidden state.
- **Explicit depth threading** through the DSL defeats the pitch.

**Post-processor** sidesteps all three. Because we control the tight-output shape (no attributes today, escape rules guarantee `<` never appears in text), the parser is small and provably correct.

## HTML carve-outs

Inside `<pre>`, `<textarea>`, `<script>`, and `<style>`, depth tracking pauses for the subtree — bodies pass through byte-for-byte because whitespace inside them is significant to rendering / behaviour. XML has no whitelist; mixed-content or CDATA-sensitive XML should use the tight renderer instead.

The post-processor understands `<name>` / `</name>` / `<name/>` plus pass-through for `<?...?>`, `<!--...-->`, and `<![CDATA[...]]>`.

## Known limit

When the v2 XML attribute story lands, the parser here will need updating to skip `key=\"value\"` runs inside `<`...`>`. Tracked in the README's caveats section.

## Validation

- `make test`: 227/227 unit pass
- `tests/integration/native_templating_pretty/`: 10/10 (new — flat body, nested elements, `<pre>` carve-out, `<script>` carve-out, nested XML, XML prolog handling, self-close, indent size 4, out-of-range fallback to 2, end-to-end DSL → pretty round-trip)
- All sibling templating tests still green: `native_templating_xml/` 7/7, `native_templating_dsl/` 6/6, `native_templating_skeleton/` 6/6
- Linux build clean

## Matrix unknowns I'd flag for review

- **macOS leaks gate** — the post-processor allocates a strbuilder + repeated `string.concat` for the indent unit + `string.substring_n` calls. None stress-tested for clean balance. If the leaks gate flags this, I'll add `test_native_templating_pretty` to `tests/leaks_exclude.txt` the same way we handled `test_run_argv_heap_string`.
- **Windows MinGW + MSYS2 GCC** — pure-Aether byte-at-a-time control flow, should be portable. Matrix will tell us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)