### PR TITLE
parser: extend is_newline_led_statement with `[` branch for array-literal (issue #528, partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,29 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Parser
+
+- **Newline-led `[` array-literal recognised as a fresh statement,
+  not folded into the previous line as indexing** (issue #528,
+  `compiler/parser/parser.c`,
+  `tests/regression/test_expr_parser_newline_bracket.ae`). The `*`
+  guard PR #527 added covered the typed-pointer / deref-store
+  cases; this extends `is_newline_led_statement` with a `[` branch
+  for the array-literal shape. Discriminator: a newline-led `[`
+  followed by a single-token primary (identifier / number / string
+  / `true` / `false` / `null`) and a top-level `,` provably can't
+  be a continuation index, because indexing accepts a single
+  expression. Other line-led `[` shapes (single-element multi-line
+  indexing, multi-token first elements) are left to fold as before
+  — the conservative bias is "don't break legit code." See the
+  comment block above the function for the per-operator decision
+  log including the operators (`-`, `+`, `(`) deliberately NOT
+  added because no inspection-cheap discriminator exists; the
+  honest fix for those is lexer-level newline significance, a
+  separate decision parked in #528.
+
 ## [0.256.0]
 
 ### Added

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -1210,16 +1210,56 @@ ASTNode* parse_primary_expression(Parser* parser) {
  * return 1 when the post-operator tokens strongly signal a fresh
  * statement.
  *
- * Currently handled — TOKEN_MULTIPLY:
+ * ## Currently handled
+ *
+ * TOKEN_MULTIPLY:
  *   `*StructName name [= ...]`  (typed-pointer local declaration)
  *   `*ident = ...`              (deref-store via a named ptr)
+ *   These shapes are unambiguous: an expression context never has
+ *   `* IDENT IDENT` or `* IDENT =`, so detecting them never breaks
+ *   a legitimate multi-line `*`-led continuation.
  *
- * Theoretical hazards documented in #528 but not (yet) detected:
- *   `-x = ...` / `+x = ...`     (unary-prefixed expression statement)
- *   `(expr) = ...`              (parenthesised expression statement)
- *   `[a, b, c]`                 (array-literal statement)
- * These are vanishingly rare in practice; add branches if/when they
- * actually bite. */
+ * TOKEN_LEFT_BRACKET:
+ *   `[ <literal-or-ident> ,` (array-literal expression statement,
+ *   common-shape detection only — multi-token first elements like
+ *   `[a+b, c]` aren't detected to keep lookahead bounded). The `,`
+ *   after the first element is the discriminator: indexing accepts a
+ *   single expression, so a `[` line-led by a comma-bearing bracket
+ *   group provably can't be a continuation index. The first-element
+ *   token set covers TOKEN_IDENTIFIER, TOKEN_NUMBER, string literals
+ *   (TOKEN_STRING_LITERAL / TOKEN_INTERP_STRING), and TRUE / FALSE /
+ *   NULL keywords — the primaries that fit in one lexeme.
+ *
+ * ## Considered and intentionally NOT added (this round)
+ *
+ * The remaining hazards documented in #528 do not have an
+ * inspection-cheap shape that distinguishes statement from
+ * continuation. Adding ambiguous guards would silently break
+ * legitimate multi-line expressions, which is worse than the
+ * (vanishingly rare) ambiguity the issue called out. The honest
+ * fix for these is lexer-level newline significance (ASI-style),
+ * which is a separate decision recorded in #528.
+ *
+ * TOKEN_MINUS / TOKEN_PLUS:
+ *   The hazard is `-foo()` or `+foo()` as an expression statement
+ *   after a previous line that ends in a complete expression. But
+ *   `prev - foo()` and `prev + foo()` — multi-line arithmetic — are
+ *   the same shape lexically. There is no post-operator token
+ *   pattern that proves "this is a fresh statement, not a
+ *   continuation." Detection requires lexer ASI.
+ *
+ * TOKEN_LEFT_PAREN:
+ *   The hazard is `(handler)(args)` or similar paren-led expression
+ *   statement after a previous-line expression. But `prev(arg)`
+ *   call-continuation across newlines is the same shape. No safe
+ *   discriminator without ASI. Also: Aether's tuple-destructure
+ *   uses bare `a, b = ...` not `(a, b) = ...`, so the parenthesised-
+ *   LHS hazard the issue mentions doesn't actually fire in current
+ *   Aether.
+ *
+ * If a real user-facing miscompile in any of these surfaces, the
+ * answer is to revisit the lexer-ASI decision in #528, not to keep
+ * extending this helper with progressively more dangerous guards. */
 static int is_newline_led_statement(Parser* parser, Token* op) {
     if (!op) return 0;
 
@@ -1240,6 +1280,32 @@ static int is_newline_led_statement(Parser* parser, Token* op) {
             /* `*ident = ...` deref-store. `*` + IDENT + `=`. */
             if (a1 && a1->type == TOKEN_IDENTIFIER &&
                 a2 && a2->type == TOKEN_ASSIGN) {
+                return 1;
+            }
+            return 0;
+        case TOKEN_LEFT_BRACKET:
+            /* `[ LITERAL , ...` or `[ IDENT , ...` — array-literal
+             * statement. Indexing takes one expression, so a `[`-led
+             * group that contains a comma at depth 0 can't be a
+             * continuation index. We approximate with a bounded
+             * lookahead that catches the common forms (the first
+             * element is a single token); multi-token first-element
+             * cases like `[a+b, c]` fall through to the old behaviour.
+             *
+             * Discriminating-token set for the first array element:
+             * identifier, int, float, char, or string literal. Other
+             * primaries (parens, nested `[`, prefix `-`) need more
+             * lookahead than peek_ahead can give cheaply, so they're
+             * left unflagged — the conservative bias is "don't break
+             * legit multi-line indexing." */
+            if (a1 && (a1->type == TOKEN_IDENTIFIER ||
+                       a1->type == TOKEN_NUMBER ||
+                       a1->type == TOKEN_STRING_LITERAL ||
+                       a1->type == TOKEN_INTERP_STRING ||
+                       a1->type == TOKEN_TRUE ||
+                       a1->type == TOKEN_FALSE ||
+                       a1->type == TOKEN_NULL) &&
+                a2 && a2->type == TOKEN_COMMA) {
                 return 1;
             }
             return 0;

--- a/tests/regression/test_expr_parser_newline_bracket.ae
+++ b/tests/regression/test_expr_parser_newline_bracket.ae
@@ -1,0 +1,37 @@
+// Regression test for issue #528 — the `[` branch added to
+// is_newline_led_statement must NOT break legitimate multi-line
+// indexing.
+//
+// The guard fires only when a newline-led `[` is followed by
+// `<literal-or-ident> ,` — i.e. the bracket group contains a
+// top-level comma, which is impossible in a continuation index
+// (indexing accepts a single expression). Any other line-led `[`
+// is left to fold into the previous expression as before. This
+// test exercises the second behaviour: a single-element line-led
+// bracket group MUST still parse as indexing continuation.
+
+main() {
+    data = [10, 20, 30, 40, 50]
+
+    // Single-token index continuation across a newline — must fold
+    // as `data[2]` (continuation), not break out into a fresh `[2]`
+    // expression-statement. The guard explicitly does NOT fire here
+    // because `[ 2 ]` has no comma after the first element.
+    m = data
+        [2]
+    if m != 30 {
+        println("FAIL: single-token multi-line index broke (data[2] expected 30, got ${m})")
+        return
+    }
+
+    // Same with an identifier index.
+    i = 3
+    n = data
+        [i]
+    if n != 40 {
+        println("FAIL: identifier multi-line index broke (data[i] expected 40, got ${n})")
+        return
+    }
+
+    println("OK")
+}


### PR DESCRIPTION
## Summary

- Picks Option 2 from issue #528 (extend the existing heuristic guard, NOT the lexer-ASI rewrite).
- Adds the `[` branch — newline-led `[ <single-token-primary> ,` is recognised as an array-literal statement and not folded into the previous line as indexing.
- Documents the per-operator analysis for `-` / `+` / `(` showing why no inspection-cheap discriminator exists for those, and that the honest fix needs lexer-level newline significance (separate decision, parked in #528).
- Issue stays open: this PR closes the `[` case; the lexer-ASI question for the remaining hazards is deliberately left for the maintainer to weigh later.

## Discriminator (the `[` branch)

A newline-led `[` followed by `<literal-or-ident> ,` provably can't be a continuation index, because indexing accepts a single expression. Bounded lookahead (`peek_ahead(1)`, `peek_ahead(2)`); covers the primary set (identifier, number, string literal, interp string, true/false/null). Multi-token first elements like `[a+b, c]` slip through to the old behaviour — the conservative bias is "don't break legit multi-line indexing."

## Test plan

- [x] `make test` 227/227 unchanged
- [x] `make test-ae`: new `test_expr_parser_newline_bracket.ae` passes; pre-existing `test_c_typed_pointers.ae` (the `*` guard) still passes; only failures are the pre-known HTTP h2/proxy port-binding flakes documented in CLAUDE.md memory
- [x] Single-token multi-line indexing (`data\n  [2]`) still folds as continuation (no break)

## Follow-up

Per the maintainer's call, I will post a comment on #528 summarising what landed and what's deliberately left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)