### PR TITLE
fix(codegen): hoist fixed-array locals as T name[N], not T[N] name

### DIFF
--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -2671,6 +2671,26 @@ static ASTNode* find_branch_decl(ASTNode* body, const char* name) {
 // Aether level, and the existing scope-restore in AST_IF_STATEMENT
 // keeps that locality. Names already declared before the if are also
 // skipped (they're already in scope).
+/* Emit a hoisted C local declaration `<type> <name>;` that is correct
+ * for ARRAY types too. get_c_type(TYPE_ARRAY) returns "T[N]", which is
+ * a valid type spelling only in the postfix-declarator position
+ * (`T name[N]`), NOT as a prefix (`T[N] name;` is invalid C). The
+ * loop/branch var hoisters below pre-declare a var as `<c_type> <name>;`
+ * — fine for scalars/pointers, but for a `byte[8]`-style fixed array it
+ * produced `unsigned char[8] name;`. Split the array case out so it
+ * emits `elem name[N];`. (Hit repeatedly by the Redis port's per-loop
+ * scratch buffers; the first-statement-in-block decl path already does
+ * this correctly, this fixes the not-first / hoisted path.) */
+static void emit_hoisted_local_decl(CodeGenerator* gen, Type* var_type,
+                                     const char* name) {
+    if (var_type && var_type->kind == TYPE_ARRAY && var_type->array_size > 0) {
+        const char* elem = get_c_type(var_type->element_type);
+        fprintf(gen->output, "%s %s[%d];\n", elem, name, var_type->array_size);
+        return;
+    }
+    fprintf(gen->output, "%s %s;\n", get_c_type(var_type), name);
+}
+
 static void hoist_if_else_common_vars(CodeGenerator* gen,
                                        ASTNode* then_body,
                                        ASTNode* else_body) {
@@ -2712,9 +2732,8 @@ static void hoist_if_else_common_vars(CodeGenerator* gen,
                 var_type = decl->children[0]->node_type;
             }
         }
-        const char* c_type = get_c_type(var_type);
         print_indent(gen);
-        fprintf(gen->output, "%s %s;\n", c_type, n);
+        emit_hoisted_local_decl(gen, var_type, n);
     }
 }
 
@@ -2774,7 +2793,7 @@ static void hoist_loop_vars(CodeGenerator* gen, ASTNode* body) {
                         }
                     }
                 } else {
-                    fprintf(gen->output, "%s %s;\n", c_type, child->value);
+                    emit_hoisted_local_decl(gen, var_type, child->value);
                 }
             }
         }

--- a/tests/regression/test_hoist_array_local_in_loop.ae
+++ b/tests/regression/test_hoist_array_local_in_loop.ae
@@ -1,0 +1,42 @@
+// Regression: a fixed-array local (`byte[N]` / `T[N]`) declared inside a
+// loop or branch body — and NOT as the first statement of that block —
+// must hoist to function scope as `T name[N];`, not the invalid
+// `T[N] name;`.
+//
+// Bug shape: the loop/branch var-hoisters emitted `<get_c_type> <name>;`,
+// and get_c_type(TYPE_ARRAY) returns "T[N]" (valid only postfix), so a
+// per-iteration scratch buffer like `byte[8] buf` inside a `while` body
+// produced `unsigned char[8] buf;` — a C syntax error ("expected
+// identifier before '['"), and the var came out undeclared at its use
+// sites. The first-statement-in-block decl path was already correct;
+// this covers the not-first / hoisted path. Hit repeatedly by the Redis
+// port's per-loop scratch buffers (t_list, t_set, rax).
+//
+// Exercises: a byte[] scratch buffer declared after another statement
+// inside a while loop, written and read each iteration, must round-trip.
+
+import std.mem
+
+extern exit(code: int)
+
+sum_packed(n: int) -> long {
+    long total = 0
+    long i = 0
+    while i < n {
+        // a statement precedes the array decl, and the decl is nested
+        // in the loop body — the trigger for the hoist bug.
+        total = total + i
+        byte[8] scratch
+        mem.set_long(scratch, 0, i * 2)
+        total = total + mem.get_long(scratch, 0)
+        i = i + 1
+    }
+    return total
+}
+
+main() {
+    // i=0: +0 +0 ; i=1: +1 +2 ; i=2: +2 +4  -> 0+0+1+2+2+4 = 9
+    if sum_packed(3) != 9 { exit(1) }
+    if sum_packed(0) != 0 { exit(2) }
+    exit(0)
+}


### PR DESCRIPTION
A `byte[N]`/`T[N]` local declared inside a loop or branch body (not the block's first statement) was pre-declared at function scope as `<get_c_type> <name>;`. Since `get_c_type(TYPE_ARRAY)` returns `T[N]` (valid only postfix), the hoist emitted invalid C `unsigned char[8] buf;` and the var came out undeclared at use sites.

Fix: `emit_hoisted_local_decl()` special-cases TYPE_ARRAY to `elem name[N];`; both hoist sites (branch-decl + loop-var) route through it. The first-statement-in-block path was already correct.

Found via the aedis Redis port — t_list/t_set/rax all hit this with per-loop scratch buffers and hand-hoisted around it. Regression test added; suite 665 pass / 3 fail (pre-existing curl HTTP2 env failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)