### PR TITLE
feat(codegen): @packed extern structs (#747 item 1, sds.c blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ notes to be skipped or clobbered (the failure modes documented in
 
 ### Added
 
+- **`@packed` extern structs** (#747 item 1, the Redis sds.c blocker). An
+  `extern struct ... @packed { ... }` emits the C body with
+  `__attribute__((packed))`, so the layout has no inter-field padding or
+  trailing alignment — the `sdshdr8/16/32/64` shape where the length/
+  alloc/flags header sits at fixed packed offsets before the string data.
+  `sizeof(S)` / `offsetof(S, f)` lower to C and report the packed numbers,
+  and a `*S` overlay reads/writes fields at their packed offsets (verified
+  by round-trip). `@packed` is mutually exclusive with `@c_import` (a
+  header-defined struct's packing is the header's job; combining them is a
+  parse error). Bit-width fields and a trailing flexible array still work
+  under `@packed`. Note: pure `@c_import` overlays already inherit the
+  header's packed layout (no body emitted), so `@packed` is the tool when
+  Aether owns the struct body (a pure-Aether port with no C header). See
+  [docs/c-interop.md](docs/c-interop.md) (Packed structs).
+
+## [current]
+
+### Added
+
 - **Function-pointer struct fields** (#749 Ask A). A struct field typed
   `fn(T1, T2) -> R` now emits the C function-pointer member
   `R (*name)(T1, T2)` (instead of an untyped `void*`), and a call through

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -1743,10 +1743,23 @@ void generate_struct_definition(CodeGenerator* gen, ASTNode* struct_def) {
      *    flexible-array `T name[];` instead of the pointer-shaped
      *    `T* name;` an Aether-managed dynamic array would use. */
     int is_extern = struct_def->annotation &&
-                    strcmp(struct_def->annotation, "extern") == 0;
+                    (strcmp(struct_def->annotation, "extern") == 0 ||
+                     strcmp(struct_def->annotation, "extern_packed") == 0);
+
+    /* #747: `@packed` emits the C body with __attribute__((packed)) so
+     * the layout has no inter-field padding — the sdshdr8/16/32/64 shape
+     * a port needs to overlay a packed C struct. The attribute goes
+     * between `struct` and the tag (GCC/Clang spelling) so it applies to
+     * the type. */
+    int is_packed = struct_def->annotation &&
+                    strcmp(struct_def->annotation, "extern_packed") == 0;
 
     // Generate C struct
-    print_line(gen, "typedef struct %s {", struct_def->value);
+    if (is_packed) {
+        print_line(gen, "typedef struct __attribute__((packed)) %s {", struct_def->value);
+    } else {
+        print_line(gen, "typedef struct %s {", struct_def->value);
+    }
     indent(gen);
 
     /* Heap-string ownership tracking for struct fields (#465).

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -3449,20 +3449,47 @@ ASTNode* parse_extern_declaration(Parser* parser) {
          * own typedef collides with the header's.  See
          * redis-porting-language-gaps.md "P0: Header-Defined C Struct
          * Interop". */
-        if (peek_token(parser) && peek_token(parser)->type == TOKEN_AT) {
+        /* Zero or more `@`-attributes after the name:
+         *   @c_import  — layout imported from a C header (no body emitted)
+         *   @packed    — emit the C body with __attribute__((packed)) so
+         *                its layout has no inter-field padding (#747): the
+         *                Redis sdshdr8/16/32/64 shape. Mutually exclusive
+         *                with @c_import (a header-defined struct's packing
+         *                is the header's job; @packed only governs a body
+         *                Aether emits). */
+        int has_c_import = 0, has_packed = 0;
+        while (peek_token(parser) && peek_token(parser)->type == TOKEN_AT) {
             advance_token(parser);  // consume '@'
             Token* attr = peek_token(parser);
             if (attr && attr->type == TOKEN_IDENTIFIER && attr->value &&
                 strcmp(attr->value, "c_import") == 0) {
-                advance_token(parser);  // consume 'c_import'
-                free(sd->annotation);
-                sd->annotation = strdup("extern_c_import");
+                advance_token(parser);
+                has_c_import = 1;
+            } else if (attr && attr->type == TOKEN_IDENTIFIER && attr->value &&
+                       strcmp(attr->value, "packed") == 0) {
+                advance_token(parser);
+                has_packed = 1;
             } else {
                 parser_error(parser,
-                    "unknown extern-struct attribute (expected @c_import)");
+                    "unknown extern-struct attribute (expected @c_import or @packed)");
                 free_ast_node(sd);
                 return NULL;
             }
+        }
+        if (has_c_import && has_packed) {
+            parser_error(parser,
+                "@packed and @c_import are mutually exclusive — a @c_import "
+                "struct's layout (incl. packing) comes from the C header; "
+                "use @packed only on a struct whose body Aether emits");
+            free_ast_node(sd);
+            return NULL;
+        }
+        if (has_c_import) {
+            free(sd->annotation);
+            sd->annotation = strdup("extern_c_import");
+        } else if (has_packed) {
+            free(sd->annotation);
+            sd->annotation = strdup("extern_packed");
         }
 
         if (!expect_token(parser, TOKEN_LEFT_BRACE)) {

--- a/docs/c-interop.md
+++ b/docs/c-interop.md
@@ -694,6 +694,20 @@ Access via dotted notation: `d.u.f64`, `d.u.func.length`, `d.u.getset.get_func_n
 - Pure Aether structs (without the `extern` annotation) reject `union { ... }` at parse time — Aether's normal value semantics aren't compatible with overlapping fields.
 - `union` is now a reserved keyword and can't be used as an identifier name anywhere.
 
+### Packed structs — `extern struct ... @packed`
+
+A `@packed` attribute on an `extern struct` emits the C body with `__attribute__((packed))`, so the layout has **no inter-field padding** and no trailing alignment:
+
+```aether
+extern struct sdshdr16 @packed { len: uint16  alloc: uint16  flags: byte }
+// sizeof == 5 (not 6); offsetof(flags) == 4
+```
+
+This is the shape a packed C header struct needs — e.g. the Redis `sdshdr8/16/32/64` headers, where the length/alloc/flags sit at fixed packed offsets immediately before the string data. `sizeof(StructName)` and `offsetof(StructName, field)` lower to C and therefore report the packed numbers, and a `*StructName` overlay on a raw buffer reads/writes the fields at their packed offsets.
+
+- `@packed` governs only a struct body **Aether emits**. It is mutually exclusive with `@c_import` (whose layout — including packing — comes from the included C header); combining them is a parse error.
+- Bit-width fields (`name: type : NN`) and a trailing flexible array still work under `@packed`, exactly as for a plain `extern struct`.
+
 ### Aether-side string-builder return types
 
 Aether-side primitives that build strings split into two camps:

--- a/tests/regression/test_packed_struct.ae
+++ b/tests/regression/test_packed_struct.ae
@@ -1,0 +1,50 @@
+// Regression (#747 item 1): `@packed` on an Aether-emitted extern struct
+// emits `__attribute__((packed))` so the C layout has no inter-field
+// padding — the Redis sdshdr8/16/32/64 shape, where the length/alloc/
+// flags header sits at fixed packed offsets before the string data.
+//
+// Without packing, `uint16 len; uint16 alloc; byte flags;` rounds the
+// struct size up to the alignment of its widest member (6, not 5) and a
+// 64-bit field would pad to an 8-byte boundary — drifting every offset
+// and corrupting the header. `sizeof`/`offsetof` lower to C, so emitting
+// the struct with `__attribute__((packed))` makes them report the packed
+// numbers. This gate compares a @packed struct against an identical
+// unpacked one and round-trips a field through a `*sdshdr` overlay.
+
+import std.mem
+extern exit(code: int)
+extern malloc(n: long) -> ptr
+
+extern struct sdshdr16   @packed { len: uint16  alloc: uint16  flags: byte }
+extern struct unpacked16          { len: uint16  alloc: uint16  flags: byte }
+
+// A wider variant: packed keeps the 8-bit flags adjacent to the 64-bit
+// fields (offset 16, size 17) where unpacked would pad to 24.
+extern struct sdshdr64   @packed { len: uint64  alloc: uint64  flags: byte }
+
+main() {
+    println("=== test_packed_struct ===")
+
+    // Packed removes the trailing/inter-field padding.
+    if sizeof(sdshdr16) != 5            { println("FAIL: sizeof packed16 = ${sizeof(sdshdr16)} (want 5)"); exit(1) }
+    if sizeof(unpacked16) == 5          { println("FAIL: unpacked16 should be padded, not 5"); exit(1) }
+    if offsetof(sdshdr16, len) != 0     { println("FAIL: off(len)"); exit(1) }
+    if offsetof(sdshdr16, alloc) != 2   { println("FAIL: off(alloc)"); exit(1) }
+    if offsetof(sdshdr16, flags) != 4   { println("FAIL: off(flags) = ${offsetof(sdshdr16, flags)} (want 4)"); exit(1) }
+
+    if sizeof(sdshdr64) != 17           { println("FAIL: sizeof packed64 = ${sizeof(sdshdr64)} (want 17)"); exit(1) }
+    if offsetof(sdshdr64, flags) != 16  { println("FAIL: off64(flags) = ${offsetof(sdshdr64, flags)} (want 16)"); exit(1) }
+
+    // Round-trip a field through a *sdshdr16 overlay on a raw buffer —
+    // proves the packed layout is real, not just a sizeof number.
+    *sdshdr16 h = malloc(8) as *sdshdr16
+    h.len = 300
+    h.alloc = 512
+    h.flags = 7
+    if h.len != 300    { println("FAIL: overlay len round-trip"); exit(1) }
+    if h.alloc != 512  { println("FAIL: overlay alloc round-trip"); exit(1) }
+    if h.flags != 7    { println("FAIL: overlay flags round-trip"); exit(1) }
+
+    println("  PASS: @packed struct layout (sizeof/offsetof + overlay round-trip)")
+    println("OK")
+}


### PR DESCRIPTION
Part of #747 (item 1: packed structs — "the single highest-leverage item", gating Redis `sds.c` → `object.c`).

## What this adds

`@packed` on an `extern struct` emits the C body with `__attribute__((packed))` — no inter-field padding, no trailing alignment:

```aether
extern struct sdshdr16 @packed { len: uint16  alloc: uint16  flags: byte }
// sizeof == 5 (not 6); offsetof(flags) == 4
```

The `sdshdr8/16/32/64` shape: a packed header whose len/alloc/flags sit at fixed offsets immediately before the string data. `sizeof(S)` / `offsetof(S, f)` already lower to C, so once the struct is emitted packed they report the packed numbers with no Aether-side offset logic, and a `*S` overlay reads/writes fields at their packed offsets.

## How

- **Parser** — the extern-struct attribute slot now parses zero-or-more `@`-attributes (`@c_import`, `@packed`). `@packed` → annotation `"extern_packed"`. **`@packed` + `@c_import` is a parse error**: a `@c_import` struct's layout (incl. packing) comes from the included header, so `@packed` (which only governs a body Aether emits) would be meaningless there.
- **Codegen** — `generate_struct_definition` treats `"extern_packed"` as an extern struct (keeps bit-width fields + flexible-array support) and emits `typedef struct __attribute__((packed)) Name { ... } Name;`.

```c
typedef struct __attribute__((packed)) sdshdr16 {
    uint16_t len; uint16_t alloc; unsigned char flags;
} sdshdr16;
```

> Note: pure `@c_import` overlays **already** inherit the header's packed layout (they emit no body), so `@packed` is specifically for the pure-Aether-port case where Aether owns the struct body and there's no C header — exactly what porting `sds.c` off C needs.

## Scope within #747

- **Item 1 (packed structs):** this PR.
- **Item 3 (fn-pointer struct fields + by-value structs):** already shipped — #777 (fn-ptr fields), #775/#746 (by-value structs). So `dict.c`/`object.c`'s vtable + by-value needs are met.
- **Item 2 (zmalloc: atomics + aligned + `#ifdef` backend):** still open; depends on #483 (platform conditionals) — zmalloc can remain the permanent allocator C edge.

## Validation (macOS)

Unit **229/229**, examples **80/0**, `.ae` regression **680/0** (existing `@c_import` tests still pass — the parser attribute-loop change is backward-compatible), `-Werror` clean. Regression test `tests/regression/test_packed_struct.ae` asserts packed `sizeof`/`offsetof` against an identical unpacked struct for 16- and 64-bit variants and round-trips fields through a `*sdshdr16` overlay. Docs updated (`c-interop.md`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
