### PR TITLE
fix(contrib): lua + tcl host bridges build against newer Homebrew / Tcl 9 libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Fixed
+
+- **contrib host bridges: lua + tcl compile against newer Homebrew /
+  Tcl-9 libraries** (`contrib/host/lua/aether_host_lua.c`,
+  `contrib/host/tcl/aether_host_tcl.c`). Both dlopen bridges name C-API
+  functions as struct fields and call them as `g_lib.Fn(...)`, which the
+  preprocessor mangles when the library header turned `Fn` into a
+  function-like macro:
+  - **Lua 5.4** (Homebrew): `luaL_openlibs(L)` is
+    `#define`d to `luaL_openselectedlibs(L, ~0, 0)`, so
+    `g_lua.luaL_openlibs(L)` rewrote to a non-existent
+    `luaL_openselectedlibs` member (macOS build break; Debian's Lua 5.4
+    ships it as a real declaration, which is why Linux CI never saw it).
+    Fix: `#undef luaL_openlibs` after the headers and dlsym the real
+    exported symbol (present in every shipping liblua).
+  - **Tcl 9.0** (Homebrew): `Tcl_GetStringResult` and `Tcl_GetString`
+    became function-like macros over `Tcl_GetStringFromObj` and are no
+    longer exported, so the struct-field calls referenced non-existent
+    members. Fix: `#undef` both, resolve the lowest-common-denominator
+    real exports `Tcl_GetStringFromObj` + `Tcl_GetObjResult` (present in
+    both 8.6 and 9.0), and recompose the two accessors as local helpers.
+  Both verified by compiling each bridge against the real (8.6 / 5.3 /
+  5.4) headers and against simulated Homebrew-macro headers — clean with
+  the fix, reproduces the reported break without it. No behavioural
+  change on platforms that were already building (the `#undef`s are
+  no-ops where the macro is absent). Surfaced on a macOS/Homebrew
+  `make install-contrib` (Lua 5.4.x, Tcl 9.0.3).
+
 ## [0.275.0]
 
 ### Added
@@ -119,6 +149,7 @@ notes to be skipped or clobbered (the failure modes documented in
   raxWalk/command-table iteration; qsort, signal handlers, libcurl/sqlite
   hooks). See [docs/language-reference.md](docs/language-reference.md)
   (Function-pointer parameters).
+
 ## [0.270.0]
 
 ### Fixed

--- a/contrib/host/lua/aether_host_lua.c
+++ b/contrib/host/lua/aether_host_lua.c
@@ -37,6 +37,21 @@
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
+
+/* Lua 5.4+ defines luaL_openlibs as a function-like macro:
+ *   #define luaL_openlibs(L) luaL_openselectedlibs(L, ~0, 0)
+ * Left in place, it rewrites our struct-field call
+ * `g_lua.luaL_openlibs(L)` (and the RESOLVE(luaL_openlibs, ...)
+ * registration) into a reference to a non-existent
+ * `luaL_openselectedlibs` member — the macOS/Homebrew Lua 5.4 build
+ * break. We dlsym the real exported `luaL_openlibs` symbol, which
+ * every shipping liblua provides, so undo the macro and call it as a
+ * plain function pointer. (Lua 5.3 has no such macro; the #undef is a
+ * harmless no-op there — matching the version-indifference this bridge
+ * is built for.) */
+#ifdef luaL_openlibs
+#undef luaL_openlibs
+#endif
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/contrib/host/tcl/aether_host_tcl.c
+++ b/contrib/host/tcl/aether_host_tcl.c
@@ -12,10 +12,13 @@
 // ABI-portable across deploy-host Tcl minor versions (8.6 / 9.0
 // supported).
 //
-// Tcl's C API is conventionally non-macro — the headers expose
-// real exported `Tcl_*` functions, no `pTHX_`-style context
-// passing, no struct-tag bit-twiddling. The bridge just needs a
-// dlsym table; no macro re-expression required.
+// Tcl's C API is MOSTLY non-macro — most `Tcl_*` symbols are real
+// exported functions, so the bridge is largely a plain dlsym table.
+// The exception (since Tcl 9.0): `Tcl_GetStringResult` and
+// `Tcl_GetString` became function-like macros over
+// `Tcl_GetStringFromObj` and are no longer exported. We dlsym the
+// stable LCD exports (`Tcl_GetStringFromObj`, `Tcl_GetObjResult`) and
+// recompose those two accessors — see the #undef + helpers below.
 
 #include "aether_host_tcl.h"
 #include "../../../runtime/aether_sandbox.h"
@@ -28,6 +31,25 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Tcl 9.0 turned the result/string accessors into macros that route
+ * through Tcl_GetStringFromObj:
+ *   #define Tcl_GetStringResult(i) Tcl_GetString(Tcl_GetObjResult(i))
+ *   #define Tcl_GetString(o)       Tcl_GetStringFromObj(o, (Tcl_Size*)NULL)
+ * Left in place these rewrite our struct-field calls into references to
+ * non-existent g_tcl members (the macOS/Homebrew Tcl 9.0 break). Tcl 8.6
+ * exported Tcl_GetStringResult / Tcl_GetString as real functions; Tcl 9.0
+ * does not. The lowest common denominator — a real export in BOTH 8.6 and
+ * 9.0 — is Tcl_GetStringFromObj + Tcl_GetObjResult, so we dlsym those and
+ * build the two accessors ourselves below. Undo the macros so our plain
+ * function-pointer fields keep their names. (Harmless no-op on 8.6, which
+ * lacks the macros.) */
+#ifdef Tcl_GetStringResult
+#undef Tcl_GetStringResult
+#endif
+#ifdef Tcl_GetString
+#undef Tcl_GetString
+#endif
+
 // --- libtcl dlopen table ----------------------------------------------------
 
 static void* libtcl_handle = NULL;
@@ -39,11 +61,16 @@ static struct {
     int          (*Tcl_Init)(Tcl_Interp* interp);
     void         (*Tcl_DeleteInterp)(Tcl_Interp* interp);
     void         (*Tcl_Finalize)(void);
-    // Eval + result extraction.
+    // Eval + result extraction. We resolve the LCD real exports
+    // (present in both 8.6 and 9.0) rather than the now-macro
+    // Tcl_GetStringResult / Tcl_GetString, then compose them in the
+    // tcl_string_result() / tcl_obj_string() helpers below. The last
+    // arg of Tcl_GetStringFromObj is int* on 8.6 and Tcl_Size* on 9.0;
+    // we only ever pass NULL, so type it void* to stay width-agnostic.
     int          (*Tcl_Eval)(Tcl_Interp* interp, const char* script);
-    const char*  (*Tcl_GetStringResult)(Tcl_Interp* interp);
+    Tcl_Obj*     (*Tcl_GetObjResult)(Tcl_Interp* interp);
+    const char*  (*Tcl_GetStringFromObj)(Tcl_Obj* objPtr, void* lengthPtr);
     // Object/string helpers (for the shared-map command callbacks).
-    const char*  (*Tcl_GetString)(Tcl_Obj* objPtr);
     Tcl_Obj*     (*Tcl_NewStringObj)(const char* bytes, int length);
     void         (*Tcl_SetObjResult)(Tcl_Interp* interp, Tcl_Obj* resultObjPtr);
     void         (*Tcl_WrongNumArgs)(Tcl_Interp* interp, int objc,
@@ -69,14 +96,24 @@ static int resolve_tcl_symbols(void* h) {
     RESOLVE(Tcl_DeleteInterp,      "Tcl_DeleteInterp");
     RESOLVE(Tcl_Finalize,          "Tcl_Finalize");
     RESOLVE(Tcl_Eval,              "Tcl_Eval");
-    RESOLVE(Tcl_GetStringResult,   "Tcl_GetStringResult");
-    RESOLVE(Tcl_GetString,         "Tcl_GetString");
+    RESOLVE(Tcl_GetObjResult,      "Tcl_GetObjResult");
+    RESOLVE(Tcl_GetStringFromObj,  "Tcl_GetStringFromObj");
     RESOLVE(Tcl_NewStringObj,      "Tcl_NewStringObj");
     RESOLVE(Tcl_SetObjResult,      "Tcl_SetObjResult");
     RESOLVE(Tcl_WrongNumArgs,      "Tcl_WrongNumArgs");
     RESOLVE(Tcl_CreateObjCommand,  "Tcl_CreateObjCommand");
     return 0;
 #undef RESOLVE
+}
+
+/* Replacements for the Tcl_GetStringResult / Tcl_GetString macros,
+ * composed from the two LCD real exports. NULL length pointer = "don't
+ * report the length" on both 8.6 (int*) and 9.0 (Tcl_Size*). */
+static const char* tcl_string_result(Tcl_Interp* interp) {
+    return g_tcl.Tcl_GetStringFromObj(g_tcl.Tcl_GetObjResult(interp), NULL);
+}
+static const char* tcl_obj_string(Tcl_Obj* obj) {
+    return g_tcl.Tcl_GetStringFromObj(obj, NULL);
 }
 
 static void* try_dlopen(const char* name) {
@@ -176,7 +213,7 @@ int tcl_init(void) {
     T = g_tcl.Tcl_CreateInterp();
     if (!T) return -1;
     if (g_tcl.Tcl_Init(T) != TCL_OK) {
-        fprintf(stderr, "[tcl] init: %s\n", g_tcl.Tcl_GetStringResult(T));
+        fprintf(stderr, "[tcl] init: %s\n", tcl_string_result(T));
         g_tcl.Tcl_DeleteInterp(T);
         T = NULL;
         return -1;
@@ -196,7 +233,7 @@ int tcl_run(const char* code) {
     if (!code) return -1;
     if (tcl_init() != 0) return -1;
     if (g_tcl.Tcl_Eval(T, code) != TCL_OK) {
-        fprintf(stderr, "[tcl] %s\n", g_tcl.Tcl_GetStringResult(T));
+        fprintf(stderr, "[tcl] %s\n", tcl_string_result(T));
         return -1;
     }
     return 0;
@@ -213,7 +250,7 @@ int tcl_run_sandboxed(void* perms, const char* code) {
 
     int result = 0;
     if (g_tcl.Tcl_Eval(T, code) != TCL_OK) {
-        fprintf(stderr, "[tcl] %s\n", g_tcl.Tcl_GetStringResult(T));
+        fprintf(stderr, "[tcl] %s\n", tcl_string_result(T));
         result = -1;
     }
 
@@ -234,7 +271,7 @@ static int tcl_aether_map_get(ClientData cd, Tcl_Interp* interp,
         g_tcl.Tcl_WrongNumArgs(interp, 1, objv, "key");
         return TCL_ERROR;
     }
-    const char* key = g_tcl.Tcl_GetString(objv[1]);
+    const char* key = tcl_obj_string(objv[1]);
     const char* val = aether_shared_map_get_by_token(current_map_token, key);
     if (val) {
         g_tcl.Tcl_SetObjResult(interp, g_tcl.Tcl_NewStringObj(val, -1));
@@ -251,8 +288,8 @@ static int tcl_aether_map_put(ClientData cd, Tcl_Interp* interp,
         g_tcl.Tcl_WrongNumArgs(interp, 1, objv, "key value");
         return TCL_ERROR;
     }
-    const char* key = g_tcl.Tcl_GetString(objv[1]);
-    const char* val = g_tcl.Tcl_GetString(objv[2]);
+    const char* key = tcl_obj_string(objv[1]);
+    const char* val = tcl_obj_string(objv[2]);
     aether_shared_map_put_by_token(current_map_token, key, val);
     return TCL_OK;
 }
@@ -281,7 +318,7 @@ int tcl_run_sandboxed_with_map(void* perms, const char* code, uint64_t map_token
 
     int result = 0;
     if (g_tcl.Tcl_Eval(T, code) != TCL_OK) {
-        fprintf(stderr, "[tcl] %s\n", g_tcl.Tcl_GetStringResult(T));
+        fprintf(stderr, "[tcl] %s\n", tcl_string_result(T));
         result = -1;
     }
 


### PR DESCRIPTION
Reported from a macOS/Homebrew `make install-contrib` (Lua 5.4.x, Tcl 9.0.3): two host bridges fail to compile.

```
host_lua  FAIL  no member named 'luaL_openselectedlibs' in 'struct (g_lua)'
host_tcl  FAIL  no member named 'Tcl_GetStringFromObj' in 'struct (g_tcl)'
```

## Root cause (same class, two libs)

Both dlopen bridges declare each C-API function as a struct field and call it `g_lib.Fn(...)`. When the library header turns `Fn` into a **function-like macro**, the preprocessor rewrites the call site into a reference to a non-existent struct member.

- **Lua 5.4 (Homebrew)** — `luaL_openlibs(L)` is `#define`d to `luaL_openselectedlibs(L, ~0, 0)`, so `g_lua.luaL_openlibs(L)` → `g_lua.luaL_openselectedlibs(...)`, which isn't a member. (Debian's Lua 5.4 ships `luaL_openlibs` as a real *declaration*, not a macro — which is why Linux CI never caught it.)
- **Tcl 9.0 (Homebrew)** — `Tcl_GetStringResult` and `Tcl_GetString` became function-like macros over `Tcl_GetStringFromObj` and are no longer exported symbols.

## Fix

- **Lua**: `#undef luaL_openlibs` after the headers; dlsym the real exported `luaL_openlibs` (present in every shipping liblua).
- **Tcl**: `#undef Tcl_GetStringResult` and `#undef Tcl_GetString`; resolve the lowest-common-denominator real exports `Tcl_GetStringFromObj` + `Tcl_GetObjResult` (present in **both** 8.6 and 9.0) and recompose the two accessors as local `tcl_string_result()` / `tcl_obj_string()` helpers. Also corrected the now-false "Tcl C API is non-macro" header comment.

Both `#undef`s are no-ops on platforms where the macro is absent, so there's no behavioural change for already-building configs.

## Verification

Done on Linux (which has Tcl 8.6 + Lua 5.3/5.4):
- `make install-contrib` → `host_lua OK`, `host_tcl OK` against the real installed headers.
- Compiled each bridge against a **simulated Homebrew-macro header** (the `luaL_openselectedlibs` form / the Tcl 9.0 unconditional macros): **reproduces the reported break without the `#undef`, compiles clean with it.**

(Couldn't run on actual macOS from here; the simulated-header test isolates exactly the macro behaviour that differs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)