### PR TITLE
fix(std.fs): export join_clean and first_element (fixes red fs_join_clean test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Fixed
+
+- **`std.fs`: export `join_clean` and `first_element`.** The two
+  path-cleaning wrappers added in `std.fs: add join_clean + first_element`
+  were defined but omitted from the module `exports (...)` list, so
+  `fs.join_clean(...)` / `fs.first_element(...)` failed at the call site
+  with `E0301: Undefined function` (the `tests/integration/fs_join_clean`
+  regression went red). Added both to the export list.
+
 ## [0.279.0]
 
 ### Added

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -35,7 +35,7 @@ exports (
     dir_list_count, dir_list_get, dir_list_free,
     path_join, path_dirname, path_basename, path_extension, path_is_absolute,
     path_clean, path_is_within_base, path_rel,
-    clean, is_within_base, rel,
+    clean, is_within_base, rel, join_clean, first_element,
     fs_pwrite_raw, fs_pread_raw, fs_get_pread, fs_get_pread_length,
     fs_release_pread, fs_ftruncate_raw, fs_fsync_raw,
     pwrite, pread, ftruncate, fsync,


### PR DESCRIPTION
A regression fix discovered while triaging the issue backlog.

## The bug

`std.fs`'s `join_clean` and `first_element` (added today in *"std.fs: add join_clean + first_element"*, fbs-core ask #3) were **defined but never added to the module `exports (...)` list**. So any importer calling them hit:

```
error[E0301]: Undefined function 'fs.join_clean'
error[E0301]: Undefined function 'fs.first_element'
```

and the `tests/integration/fs_join_clean` regression (added in the same commit) went **red**.

## The fix

One line — add `join_clean, first_element` to the export list, next to the sibling lexical-path ops (`clean`, `is_within_base`, `rel`). An audit of `std/fs/module.ae` (every top-level `name(...)` def vs the exports list) confirms these were the **only** two defined-but-unexported functions.

## Validation

`tests/integration/fs_join_clean` now passes:
```
[PASS] fs_join_clean: join_clean cleans traversals; first_element returns leading segment
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)
