### PR TITLE
fix(parser): accept fn name(...) as a top-level function definition (#791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Fixed
+
+- **`fn name(...)` is now a first-class top-level function definition**
+  (#791). `fn` is not a reserved word (it doubles as the function-pointer
+  type head `fn(...) -> R`), so a top-level `fn name()` previously only
+  survived via parse-error recovery: the parser raised "unexpected
+  identifier at top level" on `fn`, recovery skipped the token, and
+  `name(...)` then parsed as a function. That recovery is silent when a
+  module is imported but fatal on a standalone / strict re-parse, so at
+  full module-graph scale a re-parsed sibling module that used the `fn`
+  spelling (e.g. std.uuid, std.url) surfaced the recovery as a spurious
+  top-level parse error attributed to that module. The top-level parser
+  now recognises `fn` + name + `(` as a function definition directly, so
+  the spelling is first-class and parses identically on every path
+  (standalone build, import, and re-parse). `fn`-typed parameters
+  (`f: fn(int) -> int`) still parse as types — the definition form is
+  distinguished by the identifier between `fn` and `(`.
+
 ## [0.281.0]
 
 ### Fixed

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -4751,6 +4751,30 @@ ASTNode* parse_program(Parser* parser) {
             case TOKEN_IDENTIFIER: {
                 // Check if this is a function: identifier(...)
                 Token* next = peek_ahead(parser, 1);
+                // `fn name(...)` — `fn` as a function-definition keyword.
+                // `fn` is NOT a lexer keyword (it doubles as the fn-pointer
+                // type head `fn(...) -> R`), so the definition form is
+                // recognised here by shape: `fn` + name + `(`. The std
+                // library uses this spelling (std.uuid, std.url). Before,
+                // a top-level `fn name()` only survived via parse-error
+                // recovery — the "unexpected identifier" error fired on
+                // `fn`, recovery skipped it, and `name(` then parsed as a
+                // function. That recovery is non-fatal when a module is
+                // imported but fatal on a standalone/strict parse, so at
+                // full module-graph scale a re-parsed sibling module that
+                // used `fn` surfaced the recovery as a spurious top-level
+                // parse error in that module (#791). Accepting `fn` here
+                // makes the spelling first-class and the parse identical on
+                // every path.
+                if (token->value && strcmp(token->value, "fn") == 0 &&
+                    next && next->type == TOKEN_IDENTIFIER) {
+                    Token* after = peek_ahead(parser, 2);
+                    if (after && after->type == TOKEN_LEFT_PAREN) {
+                        advance_token(parser);  // consume `fn`
+                        node = parse_function_definition(parser);
+                        break;
+                    }
+                }
                 if (next && next->type == TOKEN_LEFT_PAREN) {
                     // Function without 'func' keyword
                     node = parse_function_definition(parser);

--- a/tests/regression/test_fn_keyword_function_def.ae
+++ b/tests/regression/test_fn_keyword_function_def.ae
@@ -1,0 +1,34 @@
+// Regression (#791): `fn name(...)` is a valid top-level function
+// definition spelling — first-class, not surviving via parse-error
+// recovery. The std library uses it (std.uuid, std.url); before this
+// fix a standalone `fn name()` errored ("unexpected identifier at top
+// level"), and a module using `fn` only parsed because error recovery
+// skipped the `fn` token — which surfaced as a spurious parse error in
+// that module when it was re-parsed under a strict path at full
+// module-graph scale.
+//
+// `fn` is intentionally NOT a reserved word (it doubles as the
+// fn-pointer type head `fn(...) -> R`); the definition form is
+// recognised by shape (`fn` + name + `(`). Mixing `fn`- and bare-style
+// definitions in one file must work, and a `fn(...)`-typed parameter
+// must still parse as a type, not a definition.
+
+extern exit(code: int)
+
+fn add(a: int, b: int) -> int { return a + b }
+
+// bare-style definition in the same file
+mul(a: int, b: int) -> int { return a * b }
+
+// `fn` def whose parameter is itself a fn-pointer type (the `fn` head
+// must read as a type here, not a nested definition).
+fn apply(f: fn(int, int) -> int, x: int, y: int) -> int {
+    return f(x, y)
+}
+
+main() {
+    if add(40, 2) != 42 { println("FAIL: fn add"); exit(1) }
+    if mul(6, 7) != 42  { println("FAIL: bare mul"); exit(1) }
+    if apply(add as fn(int, int) -> int, 20, 22) != 42 { println("FAIL: fn apply + fn-ptr param"); exit(1) }
+    println("OK: fn-keyword function definitions")
+}


### PR DESCRIPTION
Closes #791.

## Root cause

`fn` is **not** a reserved word — it doubles as the function-pointer *type* head (`fn(...) -> R`). So a top-level `fn name()` never had real parser support; it only survived via **parse-error recovery**:
1. `parse_program` raised `E0100: Unexpected identifier at top level` on the `fn` token,
2. recovery skipped `fn`,
3. `name(...)` then parsed as a function (the bare-name form).

That recovery is **non-fatal when a module is imported** but **fatal on a standalone / strict parse**. So at full module-graph scale, when resolving an unqualified glob-imported wrapper re-parses a sibling module that uses the `fn` spelling (std.uuid, std.url), the recovery surfaced as the reported error — a spurious top-level parse error misattributed to `std/uuid/module.ae`:

```
error[E0100]: Unexpected identifier at top level (expected actor, struct, or function)
  --> .../std/uuid/module.ae:29:3
29 | fn format_uuid(b: string) -> string {
```

I reproduced the mechanism directly without the full graph: a standalone `fn foo() -> int { … }` errors today, and `std.uuid` (which uses `fn`) only parses because import is lenient.

## Fix

The top-level dispatch now recognises `fn` + name + `(` as a function definition (consume `fn`, then the existing `parse_function_definition`). The spelling is first-class and parses identically on every path — standalone build, import, and re-parse — so the misattributed error can't occur. A `fn`-typed *parameter* (`f: fn(int) -> int`) still reads as a type; the definition form is distinguished by the identifier between `fn` and `(`.

This also removes the std library's reliance on error recovery for its own `fn`-spelled functions, and makes a standalone `fn foo()` build.

## Validation

- Standalone `fn foo()` builds + runs; `std/uuid/module.ae` parses clean standalone (was relying on recovery).
- Unit **229/229**, examples **80/0**, `-Werror` clean.
- Regression test `tests/regression/test_fn_keyword_function_def.ae` (fn- and bare-style defs in one file + an `fn` def taking a fn-pointer parameter).

> The one `.ae` regression miss in my run, `fs_join_clean`, is an unrelated pre-existing missing-export regression — fixed separately in #794.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
