### PR TITLE
feat(std): native HMAC + HMAC-DRBG in pure Aether (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Added
+
+- **Native HMAC + HMAC-DRBG** (`std.cryptography.hmac`,
+  `std.cryptography.drbg`, issue #739) — pure Aether on the native SHA-2.
+  - **`std.cryptography.hmac`** — RFC 2104 HMAC over any native SHA-2 digest,
+    working entirely in `bytes` buffers (so it's binary-safe for arbitrary
+    keys/messages, including the key-longer-than-block hashed-key path).
+    One-shot (`hmac_sha256` / `_hex`, `hmac_sha512`, generic `hmac_bytes` /
+    `hmac_hex`) and streaming (`new(algo, key, key_len)` → `update` →
+    `final_bytes` / `final_hex`). Verified against `openssl dgst -mac HMAC`
+    on RFC 4231 vectors.
+  - **`std.cryptography.drbg`** — SP800-90A HMAC-DRBG, ported from Bouncy
+    Castle's `HMacSP800Drbg.cs`. Deterministic (caller supplies entropy):
+    `new(algo, entropy, …, nonce, …, perso, …)` → `generate` /
+    `generate_with_input` / `reseed`. Verified against Bouncy Castle's own
+    `HMacDrbgTest.cs` SHA-256 vector (two generates match byte-for-byte).
+  - Also adds `sha2.update_bytes(ctx, bytes, len)` — a binary-safe streaming
+    update the HMAC construction needs.
+
+  No externs to OpenSSL or any C crypto library. Regression:
+  `tests/regression/test_hmac_drbg_native.ae`. Bouncy Castle (MIT) attribution
+  on the DRBG; HMAC is the generic RFC 2104 construction. CTR-DRBG is deferred
+  until native AES lands.
+
 ## [0.285.0]
 
 ### Added

--- a/std/cryptography/drbg/module.ae
+++ b/std/cryptography/drbg/module.ae
@@ -1,0 +1,275 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.drbg — HMAC_DRBG (NIST SP800-90A) in pure Aether,
+// ported from Bouncy Castle's HMacSP800Drbg.cs. NO externs to OpenSSL
+// or any C crypto: it sits on the native std.cryptography.hmac, which in
+// turn sits on the native std.cryptography.sha2.
+//
+// Import with:  import std.cryptography.drbg
+//
+// This is the DETERMINISTIC core: the caller supplies the entropy,
+// nonce and (optional) personalization / additional input, so it is
+// fully reproducible and testable against the NIST CAVP vectors. It is
+// NOT the OS CSPRNG — wiring a real entropy source in front of it is a
+// separate concern.
+//
+// State per SP800-90A 10.1.2:
+//   K, V : each mac_size bytes
+//   reseed_counter
+//
+// Update(provided_data):
+//   K = HMAC(K, V || 0x00 || provided_data); V = HMAC(K, V)
+//   if provided_data non-empty:
+//     K = HMAC(K, V || 0x01 || provided_data); V = HMAC(K, V)
+//
+// Instantiate: K = 0x00.., V = 0x01.., Update(entropy||nonce||perso),
+//   reseed_counter = 1.
+// Reseed: Update(entropy||addl), reseed_counter = 1.
+// Generate(n, addl): if addl: Update(addl). Build output by repeatedly
+//   V = HMAC(K, V) and appending V until n bytes; then Update(addl);
+//   reseed_counter++.
+
+import std.bytes
+import std.cryptography.hmac
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+
+exports (
+    new, generate, generate_with_input, reseed, free_ctx
+)
+
+struct DrbgCtx {
+    k: ptr            // std.bytes, mac_size bytes
+    v: ptr            // std.bytes, mac_size bytes
+    mac_size: int     // HMAC output length in bytes
+    algo: string      // underlying sha2 algo
+    reseed_counter: long
+}
+
+// HMAC output (= digest) size for an algo, in bytes. 0 if unknown.
+mac_size_for(algo: string) -> int {
+    if algo == "sha256" {
+        return 32
+    } else if algo == "sha224" {
+        return 28
+    } else if algo == "sha512" {
+        return 64
+    } else if algo == "sha384" {
+        return 48
+    } else if algo == "sha512-224" {
+        return 28
+    } else if algo == "sha512-256" {
+        return 32
+    }
+    return 0
+}
+
+// SP800-90A 10.1.2.2 Update. `provided_data` may be null (treated as
+// empty). Replaces ctx.k / ctx.v in place.
+update(ctx: *DrbgCtx, provided_data: ptr, pd_len: int) {
+    ms = ctx.mac_size
+
+    // K = HMAC(K, V || 0x00 || provided_data)
+    buf = bytes.new(ms + 1 + pd_len)
+    i = 0
+    while i < ms {
+        bytes.set(buf, i, bytes.get(ctx.v, i))
+        i = i + 1
+    }
+    bytes.set(buf, ms, 0x00)
+    j = 0
+    while j < pd_len {
+        bytes.set(buf, ms + 1 + j, bytes.get(provided_data, j))
+        j = j + 1
+    }
+    new_k = hmac.hmac_bytes(ctx.algo, ctx.k, ms, buf, ms + 1 + pd_len)
+    bytes.free(buf)
+    bytes.free(ctx.k)
+    ctx.k = new_k
+
+    // V = HMAC(K, V)
+    new_v = hmac.hmac_bytes(ctx.algo, ctx.k, ms, ctx.v, ms)
+    bytes.free(ctx.v)
+    ctx.v = new_v
+
+    if pd_len <= 0 {
+        return
+    }
+
+    // K = HMAC(K, V || 0x01 || provided_data)
+    buf2 = bytes.new(ms + 1 + pd_len)
+    i = 0
+    while i < ms {
+        bytes.set(buf2, i, bytes.get(ctx.v, i))
+        i = i + 1
+    }
+    bytes.set(buf2, ms, 0x01)
+    j = 0
+    while j < pd_len {
+        bytes.set(buf2, ms + 1 + j, bytes.get(provided_data, j))
+        j = j + 1
+    }
+    new_k2 = hmac.hmac_bytes(ctx.algo, ctx.k, ms, buf2, ms + 1 + pd_len)
+    bytes.free(buf2)
+    bytes.free(ctx.k)
+    ctx.k = new_k2
+
+    // V = HMAC(K, V)
+    new_v2 = hmac.hmac_bytes(ctx.algo, ctx.k, ms, ctx.v, ms)
+    bytes.free(ctx.v)
+    ctx.v = new_v2
+}
+
+// Concatenate up to three (ptr,len) chunks (any may be null/0) into a
+// fresh std.bytes buffer. Caller frees.
+concat3(a: ptr, alen: int, b: ptr, blen: int, c: ptr, clen: int) -> ptr {
+    total = alen + blen + clen
+    out = bytes.new(total)
+    off = 0
+    i = 0
+    while i < alen {
+        bytes.set(out, off, bytes.get(a, i))
+        off = off + 1
+        i = i + 1
+    }
+    i = 0
+    while i < blen {
+        bytes.set(out, off, bytes.get(b, i))
+        off = off + 1
+        i = i + 1
+    }
+    i = 0
+    while i < clen {
+        bytes.set(out, off, bytes.get(c, i))
+        off = off + 1
+        i = i + 1
+    }
+    return out
+}
+
+// Instantiate an HMAC_DRBG. `algo` is a sha2 family name. entropy and
+// nonce are required; perso may be null with perso_len 0. Returns
+// (ctx, "") or (null, error).
+new(algo: string, entropy: ptr, entropy_len: int, nonce: ptr, nonce_len: int, perso: ptr, perso_len: int) -> {
+    ms = mac_size_for(algo)
+    if ms == 0 {
+        return null, "unknown algorithm"
+    }
+    ctx = malloc(48) as *DrbgCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.mac_size = ms
+    ctx.algo = algo
+
+    // V = 0x01 0x01 ... ; K = 0x00 0x00 ...
+    v = bytes.new(ms)
+    k = bytes.new(ms)
+    i = 0
+    while i < ms {
+        bytes.set(v, i, 0x01)
+        bytes.set(k, i, 0x00)
+        i = i + 1
+    }
+    ctx.v = v
+    ctx.k = k
+
+    // seed_material = entropy || nonce || perso
+    pl = perso_len
+    if perso == null {
+        pl = 0
+    }
+    seed = concat3(entropy, entropy_len, nonce, nonce_len, perso, pl)
+    update(ctx, seed, bytes.length(seed))
+    bytes.free(seed)
+    ctx.reseed_counter = 1
+    return ctx, ""
+}
+
+// Reseed with fresh entropy and optional additional input.
+reseed(ctx: ptr, entropy: ptr, entropy_len: int, addl: ptr, addl_len: int) {
+    c = ctx as *DrbgCtx
+    al = addl_len
+    if addl == null {
+        al = 0
+    }
+    seed = concat3(entropy, entropy_len, addl, al, null, 0)
+    update(c, seed, bytes.length(seed))
+    bytes.free(seed)
+    c.reseed_counter = 1
+}
+
+// Core generate. Produces `num_bytes` of output as an AetherBytes
+// buffer. `addl` is optional additional input (null/0 if none).
+generate_core(c: *DrbgCtx, num_bytes: int, addl: ptr, addl_len: int) -> ptr {
+    ms = c.mac_size
+    al = addl_len
+    if addl == null {
+        al = 0
+    }
+    if al > 0 {
+        update(c, addl, al)
+    }
+
+    out = bytes.new(num_bytes)
+    produced = 0
+    while produced < num_bytes {
+        // V = HMAC(K, V)
+        new_v = hmac.hmac_bytes(c.algo, c.k, ms, c.v, ms)
+        bytes.free(c.v)
+        c.v = new_v
+        // append min(ms, remaining) bytes of V
+        remaining = num_bytes - produced
+        take = ms
+        if remaining < ms {
+            take = remaining
+        }
+        i = 0
+        while i < take {
+            bytes.set(out, produced + i, bytes.get(c.v, i))
+            i = i + 1
+        }
+        produced = produced + take
+    }
+
+    // Update with addl (or empty) and bump the reseed counter.
+    if al > 0 {
+        update(c, addl, al)
+    } else {
+        update(c, null, 0)
+    }
+    c.reseed_counter = c.reseed_counter + 1
+    return out
+}
+
+// Generate `num_bytes` of output (no additional input).
+generate(ctx: ptr, num_bytes: int) -> ptr {
+    c = ctx as *DrbgCtx
+    return generate_core(c, num_bytes, null, 0)
+}
+
+// Generate `num_bytes` of output with additional input.
+generate_with_input(ctx: ptr, num_bytes: int, addl: ptr, addl_len: int) -> ptr {
+    c = ctx as *DrbgCtx
+    return generate_core(c, num_bytes, addl, addl_len)
+}
+
+// Destroy a DRBG context. NULL-safe.
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *DrbgCtx
+    if c.k != null {
+        bytes.free(c.k)
+        c.k = null
+    }
+    if c.v != null {
+        bytes.free(c.v)
+        c.v = null
+    }
+    free(ctx)
+}

--- a/std/cryptography/hmac/module.ae
+++ b/std/cryptography/hmac/module.ae
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.hmac — keyed-hash message authentication (RFC 2104)
+// in pure Aether on top of the native std.cryptography.sha2 family. NO
+// externs to OpenSSL or any C crypto library: the ipad/opad construction
+// and the double-hash are all done here over std.bytes buffers.
+//
+// Import with:  import std.cryptography.hmac
+//
+// HMAC works over BINARY data — keys, the ipad/opad blocks, and the
+// intermediate digest are all full of NUL bytes — so every byte path
+// goes through std.bytes and sha2.update_bytes (never the string-based
+// sha2.update, which truncates at the first NUL).
+//
+//   HMAC(K, m) = H( (K0 ^ opad) || H( (K0 ^ ipad) || m ) )
+//
+// where K0 is the key padded/hashed to the hash's block size B:
+//   B = 64  for sha256 / sha224
+//   B = 128 for sha512 / sha384 / sha512-224 / sha512-256
+//
+// Two shapes are exposed:
+//   one-shot:   hmac_sha256_bytes(key, key_len, msg, msg_len)  (+_hex)
+//   streaming:  ctx = new("sha256", key, key_len)
+//               update(ctx, msg, msg_len); final_hex(ctx)
+
+import std.bits
+import std.bytes
+import std.cryptography.sha2
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+
+exports (
+    new, update, final_bytes, final_hex, free_ctx,
+    hmac_bytes, hmac_hex,
+    hmac_sha256, hmac_sha256_hex,
+    hmac_sha512, hmac_sha512_hex
+)
+
+// ---- Streaming context ----
+//
+// We keep the inner sha2 ctx already primed with (K0 ^ ipad), plus the
+// opad block (K0 ^ 0x5c) so finalization can run the outer hash. The
+// algo string lets the outer/inner hashes pick the same core.
+struct HmacCtx {
+    inner: ptr        // sha2 ctx, already fed (K0 ^ ipad)
+    opad: ptr         // std.bytes buffer, B bytes: K0 ^ 0x5c
+    block_size: int   // B
+    digest_len: int   // hash output length
+    algo: string      // sha2 algo name
+}
+
+// Block size B for a given algo. Returns 0 for an unknown algo.
+block_size_for(algo: string) -> int {
+    if algo == "sha256" {
+        return 64
+    } else if algo == "sha224" {
+        return 64
+    } else if algo == "sha512" {
+        return 128
+    } else if algo == "sha384" {
+        return 128
+    } else if algo == "sha512-224" {
+        return 128
+    } else if algo == "sha512-256" {
+        return 128
+    }
+    return 0
+}
+
+// Compute K0 (the block-sized key) into a fresh std.bytes buffer of B
+// bytes. If key_len > B, K0 = H(key) zero-padded to B; otherwise the
+// key is copied and zero-padded to B. Returns the buffer, or null on a
+// bad algo. The caller owns and frees the result.
+make_k0(algo: string, key: ptr, key_len: int, block_size: int) -> ptr {
+    k0 = bytes.new(block_size)
+    // Zero-fill the whole block first so the pad is implicit.
+    j = 0
+    while j < block_size {
+        bytes.set(k0, j, 0)
+        j = j + 1
+    }
+    if key_len > block_size {
+        // K0 = H(key) (binary-safe), padded with zeros to B.
+        hctx, herr = sha2.new(algo)
+        if herr != "" {
+            bytes.free(k0)
+            return null
+        }
+        sha2.update_bytes(hctx, key, key_len)
+        digest = sha2.final_bytes(hctx)
+        dl = bytes.length(digest)
+        i = 0
+        while i < dl {
+            bytes.set(k0, i, bytes.get(digest, i))
+            i = i + 1
+        }
+        bytes.free(digest)
+    } else {
+        i = 0
+        while i < key_len {
+            bytes.set(k0, i, bytes.get(key, i))
+            i = i + 1
+        }
+    }
+    return k0
+}
+
+// Create a streaming HMAC context. `algo` is one of the sha2 family
+// names ("sha256", "sha512", ...). `key` / `key_len` is the (binary)
+// key as an AetherBytes buffer. Returns (ctx, "") on success or
+// (null, error). Thread the handle through update / final_*.
+new(algo: string, key: ptr, key_len: int) -> {
+    bs = block_size_for(algo)
+    if bs == 0 {
+        return null, "unknown algorithm"
+    }
+    ctx = malloc(48) as *HmacCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    k0 = make_k0(algo, key, key_len, bs)
+    if k0 == null {
+        free(ctx)
+        return null, "unknown algorithm"
+    }
+
+    // Build ipad = K0 ^ 0x36 and opad = K0 ^ 0x5c.
+    ipad = bytes.new(bs)
+    opad = bytes.new(bs)
+    i = 0
+    while i < bs {
+        kb = bytes.get(k0, i)
+        bytes.set(ipad, i, (kb ^ 0x36) & 255)
+        bytes.set(opad, i, (kb ^ 0x5c) & 255)
+        i = i + 1
+    }
+    bytes.free(k0)
+
+    // Start the inner hash and feed it the ipad block.
+    inner, ierr = sha2.new(algo)
+    if ierr != "" {
+        bytes.free(ipad)
+        bytes.free(opad)
+        free(ctx)
+        return null, ierr
+    }
+    sha2.update_bytes(inner, ipad, bs)
+    bytes.free(ipad)
+
+    ctx.inner = inner
+    ctx.opad = opad
+    ctx.block_size = bs
+    ctx.algo = algo
+    ctx.digest_len = 0
+    return ctx, ""
+}
+
+// Feed message bytes (binary-safe) into the inner hash.
+update(ctx: ptr, data: ptr, len: int) {
+    c = ctx as *HmacCtx
+    sha2.update_bytes(c.inner, data, len)
+}
+
+// Finalize: inner = H(ipad || msg); return H(opad || inner) as an
+// AetherBytes buffer of digest_len bytes. FREES the context (the inner
+// sha2 ctx is freed by final_bytes; the outer one by final_hex/_bytes).
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *HmacCtx
+    // inner digest (frees the inner sha2 ctx)
+    inner_digest = sha2.final_bytes(c.inner)
+    c.inner = null
+    idl = bytes.length(inner_digest)
+
+    outer, oerr = sha2.new(c.algo)
+    if oerr != "" {
+        bytes.free(inner_digest)
+        bytes.free(c.opad)
+        free(ctx)
+        return null
+    }
+    sha2.update_bytes(outer, c.opad, c.block_size)
+    sha2.update_bytes(outer, inner_digest, idl)
+    bytes.free(inner_digest)
+    result = sha2.final_bytes(outer)
+
+    bytes.free(c.opad)
+    c.opad = null
+    free(ctx)
+    return result
+}
+
+// Finalize and return the MAC as lowercase hex. FREES the context.
+final_hex(ctx: ptr) -> string {
+    res = final_bytes(ctx)
+    if res == null {
+        return ""
+    }
+    s = bytes_to_hex(res)
+    bytes.free(res)
+    return s
+}
+
+// Abandon a context without finalizing. NULL-safe.
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *HmacCtx
+    if c.inner != null {
+        sha2.free_ctx(c.inner)
+        c.inner = null
+    }
+    if c.opad != null {
+        bytes.free(c.opad)
+        c.opad = null
+    }
+    free(ctx)
+}
+
+// ---- One-shot convenience ----
+
+// General one-shot: HMAC over `algo` of `msg` keyed by `key`. Returns
+// an AetherBytes of the MAC, or null on a bad algo / allocation failure.
+hmac_bytes(algo: string, key: ptr, key_len: int, msg: ptr, msg_len: int) -> ptr {
+    ctx, err = new(algo, key, key_len)
+    if err != "" {
+        return null
+    }
+    update(ctx, msg, msg_len)
+    return final_bytes(ctx)
+}
+
+hmac_hex(algo: string, key: ptr, key_len: int, msg: ptr, msg_len: int) -> string {
+    ctx, err = new(algo, key, key_len)
+    if err != "" {
+        return ""
+    }
+    update(ctx, msg, msg_len)
+    return final_hex(ctx)
+}
+
+hmac_sha256(key: ptr, key_len: int, msg: ptr, msg_len: int) -> ptr {
+    return hmac_bytes("sha256", key, key_len, msg, msg_len)
+}
+hmac_sha256_hex(key: ptr, key_len: int, msg: ptr, msg_len: int) -> string {
+    return hmac_hex("sha256", key, key_len, msg, msg_len)
+}
+hmac_sha512(key: ptr, key_len: int, msg: ptr, msg_len: int) -> ptr {
+    return hmac_bytes("sha512", key, key_len, msg, msg_len)
+}
+hmac_sha512_hex(key: ptr, key_len: int, msg: ptr, msg_len: int) -> string {
+    return hmac_hex("sha512", key, key_len, msg, msg_len)
+}
+
+// ---- Internal helpers ----
+
+// Lowercase-hex encode an AetherBytes buffer into an owned string.
+bytes_to_hex(b: ptr) -> string {
+    n = bytes.length(b)
+    hexbuf = bytes.new(n * 2)
+    i = 0
+    while i < n {
+        v = bytes.get(b, i)
+        hi = (v >> 4) & 15
+        lo = v & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    return bytes.finish(hexbuf, n * 2)
+}

--- a/std/cryptography/sha2/module.ae
+++ b/std/cryptography/sha2/module.ae
@@ -32,7 +32,7 @@ extern malloc(size: int) -> ptr
 extern free(p: ptr)
 
 exports (
-    new, update, final_hex, final_bytes, free_ctx,
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
     sha256_hex, sha256_bytes,
     sha224_hex, sha224_bytes,
     sha512_hex, sha512_bytes,
@@ -431,6 +431,36 @@ update(ctx: ptr, data: string, length: int) {
 }
 
 extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+// Binary-safe sibling of `update`: feed `length` bytes from an
+// AetherBytes buffer `data` (read via std.bytes.get) into the context.
+// HMAC and other binary constructions need this because routing raw
+// key / ipad / digest bytes through an Aether `string` truncates at the
+// first embedded NUL. Mirrors `update`'s inner loop exactly, only the
+// byte source differs. Does NOT free the context.
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Sha2Ctx
+    if length <= 0 {
+        return
+    }
+    bs = c.block_size
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == bs {
+            process_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    old_lo = c.count_lo
+    c.count_lo = c.count_lo + length
+    if bits.ucmp64(c.count_lo, old_lo) < 0 {
+        c.count_hi = c.count_hi + 1
+    }
+}
 
 // Append a single byte to the block buffer, processing on fill. Used by
 // the padding logic inside finalize.

--- a/tests/regression/test_hmac_drbg_native.ae
+++ b/tests/regression/test_hmac_drbg_native.ae
@@ -1,0 +1,115 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// Regression: native HMAC (std.cryptography.hmac) + HMAC-DRBG
+// (std.cryptography.drbg), issue #739. HMAC vectors are RFC 4231
+// (cross-checked against `openssl dgst -mac HMAC` during development); the
+// HMAC-DRBG vector is the first SHA-256 vector from Bouncy Castle's own
+// HMacDrbgTest.cs. Pure Aether over the native SHA-2 — no OpenSSL.
+
+import std.cryptography.hmac
+import std.cryptography.drbg
+import std.bytes
+import std.string
+
+hv(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    if c >= 65 { if c <= 70 { return c - 55 } }
+    return 0
+}
+// hex string -> AetherBytes
+hb(h: string) -> ptr {
+    n = string.length(h)
+    b = bytes.new(0)
+    i = 0
+    while i < n {
+        bytes.set(b, i / 2, hv(string_char_at_n(h, n, i)) * 16 + hv(string_char_at_n(h, n, i + 1)))
+        i = i + 2
+    }
+    return b
+}
+// ASCII string -> AetherBytes
+sb(s: string) -> ptr {
+    n = string.length(s)
+    b = bytes.new(0)
+    i = 0
+    while i < n { bytes.set(b, i, string_char_at_n(s, n, i)); i = i + 1 }
+    return b
+}
+// AetherBytes -> lowercase hex of first n bytes
+bh(b: ptr, n: int) -> string {
+    d = "0123456789abcdef"
+    out = ""
+    i = 0
+    while i < n {
+        v = bytes.get(b, i)
+        hi = string.substring(d, (v / 16) & 15, ((v / 16) & 15) + 1)
+        lo = string.substring(d, v & 15, (v & 15) + 1)
+        out = string.concat(out, string.concat(hi, lo))
+        i = i + 1
+    }
+    return out
+}
+
+main() {
+    print("=== std.cryptography hmac + drbg ===\n")
+    fails = 0
+
+    // ---- HMAC-SHA256, RFC 4231 ----
+    k1 = hb("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+    m1 = sb("Hi There")
+    if string.equals(hmac.hmac_sha256_hex(k1, 20, m1, 8),
+        "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7") != 1 {
+        print("FAIL hmac TC1\n"); fails = fails + 1 }
+    bytes.free(k1)
+    bytes.free(m1)
+
+    k2 = sb("Jefe")
+    m2 = sb("what do ya want for nothing?")
+    if string.equals(hmac.hmac_sha256_hex(k2, 4, m2, 28),
+        "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843") != 1 {
+        print("FAIL hmac TC2\n"); fails = fails + 1 }
+    bytes.free(k2)
+    bytes.free(m2)
+
+    // TC6: key longer than block size (131 x 0xaa) -> hashed key path
+    k6 = bytes.new(0)
+    z = 0
+    while z < 131 { bytes.set(k6, z, 0xaa); z = z + 1 }
+    m6 = sb("Test Using Larger Than Block-Size Key - Hash Key First")
+    if string.equals(hmac.hmac_sha256_hex(k6, 131, m6, 54),
+        "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54") != 1 {
+        print("FAIL hmac TC6 (long key)\n"); fails = fails + 1 }
+    bytes.free(k6)
+    bytes.free(m6)
+
+    // ---- HMAC-DRBG SHA-256, Bouncy Castle HMacDrbgTest.cs vector #1 ----
+    ent = hb("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536")
+    non = hb("2021222324252627")
+    d, err = drbg.new("sha256", ent, 55, non, 8, null, 0)
+    if string.equals(err, "") != 1 { print("FAIL drbg new: ${err}\n"); fails = fails + 1 }
+    g1 = drbg.generate(d, 64)
+    if string.equals(bh(g1, 64),
+        "d67b8c1734f46fa3f763cf57c6f9f4f2dc1089bd8bc1f6f023950bfc5617635208c8501238ad7a4400defee46c640b61af77c2d1a3bfaa90ede5d207406e5403") != 1 {
+        print("FAIL drbg generate #1\n"); fails = fails + 1 }
+    g2 = drbg.generate(d, 64)
+    if string.equals(bh(g2, 64),
+        "8fdaec20f8b421407059e3588920da7eda9dce3cf8274dfa1c59c108c1d0aa9b0fa38da5c792037c4d33cd070ca7cd0c5608dba8b885654639de2187b74cb263") != 1 {
+        print("FAIL drbg generate #2\n"); fails = fails + 1 }
+    bytes.free(g1)
+    bytes.free(g2)
+    drbg.free_ctx(d)
+    bytes.free(ent)
+    bytes.free(non)
+
+    if fails == 0 {
+        print("PASS: hmac + drbg\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}


### PR DESCRIPTION
Next Bouncy Castle tranche for issue #739: **native HMAC + HMAC-DRBG**, pure Aether on the native SHA-2 that landed in #804. No externs to OpenSSL or any C crypto library.

## What

- **`std.cryptography.hmac`** — RFC 2104 HMAC over any native SHA-2 digest, working entirely in `bytes` buffers (binary-safe for arbitrary keys/messages, including the key-longer-than-block hashed-key path). One-shot (`hmac_sha256` / `_hex`, `hmac_sha512`, generic `hmac_bytes` / `hmac_hex`) + streaming (`new(algo, key, key_len)` → `update` → `final_bytes` / `final_hex`).
- **`std.cryptography.drbg`** — SP800-90A HMAC-DRBG, ported from Bouncy Castle's `HMacSP800Drbg.cs`. Deterministic (caller supplies entropy, so it's the testable core): `new(algo, entropy, …, nonce, …, perso, …)` → `generate` / `generate_with_input` / `reseed` / `free_ctx`.
- **`sha2.update_bytes(ctx, bytes, len)`** — a binary-safe streaming update the HMAC construction needs (the existing string `update` truncates at NUL).

## Verification (independent oracles, not self-report)

- **HMAC** cross-checked against live `openssl dgst -sha256 -mac HMAC` on RFC 4231 TC1/TC2/TC6 — including TC6's >64-byte key (exercises the K = H(key) path). All match openssl byte-for-byte.
- **HMAC-DRBG** checked against **Bouncy Castle's own** `HMacDrbgTest.cs` SHA-256 vector #1 (entropy/nonce literal from the test's entropy provider) — both 64-byte generates match exactly. (Note: the test's "128" is security-strength bits; generate length is 64 bytes — confirmed against the expected-hex length.)

Committed regression: `tests/regression/test_hmac_drbg_native.ae` (RFC 4231 + the BC DRBG vector), leak-clean — every input buffer freed, and `drbg.new` copies its inputs so post-call frees are safe.

## Scope notes

- CTR-DRBG deferred until native AES lands (it needs a block cipher); Hash-DRBG can follow.
- This native HMAC can later retire the OpenSSL-backed one-shot `hmac_sha256` in `std.cryptography` — not touched in this PR.
- Pure `.ae`, zero C, zero Makefile changes (resolves by directory).
- Bouncy Castle (MIT) attribution on the DRBG; HMAC carries an Aether-only header (generic RFC 2104 construction).
- Only sweep failures on this box are the pre-existing HTTP/2 server/proxy flakes — unrelated to a hashing/PRNG module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
