### PR TITLE
feat(std.bignum): multiply + divide/remainder/mod (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ notes to be skipped or clobbered (the failure modes documented in
 
 ### Added
 
+- **`std.bignum` — multiply / divide / remainder / mod** (issue #739, the
+  layer after the foundation). `multiply` is Bouncy Castle's schoolbook
+  `Multiply(uint[],uint[],uint[])`; `divide` / `remainder` / `mod` are binary
+  long division over the unsigned magnitudes with BC's sign rules (quotient
+  truncates toward zero with sign `a.sign*b.sign`; remainder takes the
+  dividend's sign; `mod` is always in `[0,|b|)`). The whole surface was fuzzed
+  against Python's arbitrary-precision `int` over 414 signed multi-limb cases
+  (including the 5-limb / 2-limb division a first shift-division port looped
+  on) and is ASan-clean across the intermediate-heavy divmod loop. Regression:
+  `tests/regression/test_bignum_muldiv.ae`. Still pure Aether — no externs to
+  OpenSSL or any C bignum library. **`mod_pow` / `gcd` / `mod_inverse` /
+  `is_probable_prime` remain follow-up layers**; `mod_pow` (the RSA workhorse)
+  will use Montgomery reduction rather than this O(n²) division.
 - **`std.bignum` — arbitrary-precision integers (foundation layer)** (issue
   #739 slice 11, the BigInteger watershed). Pure Aether, ported from Bouncy
   Castle's `BigInteger.cs`: sign-magnitude representation (32-bit limbs over

--- a/std/bignum/module.ae
+++ b/std/bignum/module.ae
@@ -36,6 +36,7 @@ exports (
     from_int,
     compare, is_zero, sign, bit_length,
     add, subtract, negate, abs,
+    multiply, divide, remainder, mod,
     shift_left, shift_right,
     to_hex, free
 )
@@ -606,6 +607,205 @@ clone(n: ptr) -> ptr {
         return bn_zero()
     }
     return bn_alloc(bn.sign, mag_clone(bn.mag, bn.len), bn.len)
+}
+
+// ---- multiply (BC schoolbook Multiply(uint[] x, uint[] y, uint[] z)) ----
+
+// Schoolbook multiply: accumulates y*z into the freshly-zeroed `x`
+// (big-endian limbs, length y.len + z.len). Faithful port of BC's
+// Multiply(x, y, z) where x is the result buffer. Mutates `x` in place.
+mag_multiply(x: ptr, xlen: int, y: ptr, ylen: int, z: ptr, zlen: int) {
+    i = zlen
+    xbase = xlen - ylen
+    while i > 0 {
+        i = i - 1
+        a = limb(z, i)
+        long val = 0
+        if a != 0 {
+            j = ylen - 1
+            while j >= 0 {
+                val = val + a * limb(y, j) + limb(x, xbase + j)
+                intarr_set_raw(x, xbase + j, (val & 0xFFFFFFFF))
+                val = bits.lsr64(val, 32)
+                j = j - 1
+            }
+        }
+        xbase = xbase - 1
+        if xbase >= 0 {
+            intarr_set_raw(x, xbase, (val & 0xFFFFFFFF))
+        }
+    }
+}
+
+multiply(a: ptr, b: ptr) -> ptr {
+    ba = a as *BN
+    bb = b as *BN
+    if ba.sign == 0 {
+        return bn_zero()
+    }
+    if bb.sign == 0 {
+        return bn_zero()
+    }
+    reslen = ba.len + bb.len
+    res = intarr_new_raw(reslen)   // calloc: zero-filled
+    mag_multiply(res, reslen, ba.mag, ba.len, bb.mag, bb.len)
+    rsign = 1
+    if ba.sign != bb.sign {
+        rsign = -1
+    }
+    return bn_from_mag_checked(rsign, res, reslen)
+}
+
+// ---- division (binary long division) ----
+//
+// Rather than port BC's optimized shift-and-subtract Divide (which mutates
+// its dividend in place and is intricate to get right), we use a plain
+// bit-at-a-time long division over the unsigned magnitudes. It is O(n^2)
+// in the bit length but obviously correct and easy to verify against an
+// arbitrary-precision oracle; the RSA hot path will use Montgomery
+// reduction (a later slice), not this. Signs follow BC: quotient sign =
+// a.sign*b.sign (truncated toward zero), remainder sign = a.sign.
+
+// Test bit `pos` (0 = LSB) of a magnitude (big-endian limbs).
+mag_test_bit(mag: ptr, len: int, pos: int) -> int {
+    limbfromlsb = bits.lsr32(pos, 5)   // pos / 32
+    bitinlimb = pos & 0x1f
+    idx = len - 1 - limbfromlsb        // big-endian: LSB limb is last
+    if idx < 0 {
+        return 0
+    }
+    if (bits.lsr64(limb(mag, idx), bitinlimb) & 1) != 0 {
+        return 1
+    }
+    return 0
+}
+
+// Unsigned magnitude divide: returns (quotient_bn, remainder_bn) as BNs
+// (both non-negative, canonical). Caller adjusts signs and frees.
+mag_divmod_bn(num: ptr, numlen: int, den: ptr, denlen: int) -> (ptr, ptr) {
+    // quotient and remainder accumulate as BNs; we iterate bit positions
+    // from the most-significant bit of the numerator down to 0.
+    q = bn_zero()
+    r = bn_zero()
+    den_bn = bn_alloc(1, mag_clone(den, denlen), denlen)
+    nbits = mag_bit_length(num, numlen)
+    pos = nbits - 1
+    while pos >= 0 {
+        // r = (r << 1) | bit(num, pos)
+        r2 = shift_left(r, 1)
+        free(r)
+        r = r2
+        if mag_test_bit(num, numlen, pos) == 1 {
+            // set r's low bit: r = r + 1
+            one = from_int(1)
+            r3 = add(r, one)
+            free(one)
+            free(r)
+            r = r3
+        }
+        // if r >= den: r -= den; q |= (1 << pos)
+        if compare_mag_bn(r, den_bn) >= 0 {
+            r4 = subtract(r, den_bn)
+            free(r)
+            r = r4
+            bitval = make_pow2(pos)
+            q2 = add(q, bitval)
+            free(bitval)
+            free(q)
+            q = q2
+        }
+        pos = pos - 1
+    }
+    free(den_bn)
+    return q, r
+}
+
+// Compare two non-negative BNs by magnitude (both sign >= 0).
+compare_mag_bn(x: ptr, y: ptr) -> int {
+    bx = x as *BN
+    by = y as *BN
+    if bx.sign == 0 {
+        if by.sign == 0 {
+            return 0
+        }
+        return -1
+    }
+    if by.sign == 0 {
+        return 1
+    }
+    return compare_mag(bx.mag, bx.len, by.mag, by.len)
+}
+
+// Build the BN value 2^pos (a single set bit).
+make_pow2(pos: int) -> ptr {
+    one = from_int(1)
+    if pos == 0 {
+        return one
+    }
+    r = shift_left(one, pos)
+    free(one)
+    return r
+}
+
+divide(a: ptr, b: ptr) -> ptr {
+    bb = b as *BN
+    if bb.sign == 0 {
+        return bn_zero()   // division by zero -> zero (caller should guard)
+    }
+    ba = a as *BN
+    if ba.sign == 0 {
+        return bn_zero()
+    }
+    if compare_mag(ba.mag, ba.len, bb.mag, bb.len) < 0 {
+        return bn_zero()
+    }
+    q, r = mag_divmod_bn(ba.mag, ba.len, bb.mag, bb.len)
+    free(r)
+    bq = q as *BN
+    if bq.sign != 0 {
+        if ba.sign != bb.sign {
+            bq.sign = -1
+        }
+    }
+    return q
+}
+
+remainder(a: ptr, b: ptr) -> ptr {
+    bb = b as *BN
+    if bb.sign == 0 {
+        return bn_zero()
+    }
+    ba = a as *BN
+    if ba.sign == 0 {
+        return bn_zero()
+    }
+    if compare_mag(ba.mag, ba.len, bb.mag, bb.len) < 0 {
+        return clone(a)
+    }
+    q, r = mag_divmod_bn(ba.mag, ba.len, bb.mag, bb.len)
+    free(q)
+    br = r as *BN
+    if br.sign != 0 {
+        // remainder takes the dividend's sign (BC Remainder)
+        if ba.sign < 0 {
+            br.sign = -1
+        }
+    }
+    return r
+}
+
+// Mathematical modulus: always in [0, |b|) (BC Mod).
+mod(a: ptr, b: ptr) -> ptr {
+    r = remainder(a, b)
+    br = r as *BN
+    if br.sign >= 0 {
+        return r
+    }
+    babs = abs(b)
+    adjusted = add(r, babs)
+    free(babs)
+    free(r)
+    return adjusted
 }
 
 // ---- shifts ----

--- a/tests/regression/test_bignum_muldiv.ae
+++ b/tests/regression/test_bignum_muldiv.ae
@@ -1,0 +1,153 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// Regression: std.bignum multiply / divide / remainder / mod (issue #739,
+// next layer after the foundation). Multiply is BC's schoolbook
+// Multiply(uint[],uint[],uint[]); divide/remainder/mod are binary long
+// division over the unsigned magnitudes with BC's sign rules (quotient
+// sign = a.sign*b.sign truncated toward zero; remainder sign = a.sign;
+// mod always in [0,|b|)). Every constant below was cross-checked against
+// Python's arbitrary-precision int during development, and the full op
+// surface was fuzzed against Python over 414 signed multi-limb cases
+// (incl. the 5-limb / 2-limb division that a first shift-division port
+// looped on).
+
+import std.bignum
+import std.bytes
+import std.string
+
+hv(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    return 0
+}
+// parse a signed hex string ("-1a2b" / "0") into a bignum
+parse(h: string) -> ptr {
+    n = string.length(h)
+    neg = 0
+    start = 0
+    if n > 0 {
+        if string_char_at_n(h, n, 0) == 45 { neg = 1; start = 1 }
+    }
+    hexlen = n - start
+    nbytes = (hexlen + 1) / 2
+    b = bytes.new(nbytes)
+    bi = nbytes - 1
+    i = n - 1
+    while i >= start {
+        lo = hv(string_char_at_n(h, n, i))
+        hi = 0
+        if i - 1 >= start { hi = hv(string_char_at_n(h, n, i - 1)) }
+        bytes.set(b, bi, hi * 16 + lo)
+        bi = bi - 1
+        i = i - 2
+    }
+    v = bignum.from_bytes_unsigned(b, nbytes)
+    bytes.free(b)
+    if neg == 1 {
+        nv = bignum.negate(v)
+        bignum.free(v)
+        return nv
+    }
+    return v
+}
+
+main() {
+    print("=== std.bignum mul/div/rem/mod ===\n")
+    fails = 0
+
+    // ---- multiply ----
+    a = parse("75bcd15")        // 123456789
+    b = parse("3ade68b1")       // 987654321
+    m = bignum.multiply(a, b)   // 0x1b13114fbff5385
+    if string.equals(bignum.to_hex(m), "1b13114fbff5385") != 1 { print("FAIL mul\n"); fails = fails + 1 }
+    bignum.free(m)
+
+    // multiply at the limb boundary: (2^64-1)^2
+    f = parse("ffffffffffffffff")
+    m2 = bignum.multiply(f, f)  // 0xfffffffffffffffe0000000000000001
+    if string.equals(bignum.to_hex(m2), "fffffffffffffffe0000000000000001") != 1 { print("FAIL mul 64x64\n"); fails = fails + 1 }
+    bignum.free(m2); bignum.free(f)
+
+    // multiply by zero
+    z = bignum.from_int(0)
+    mz = bignum.multiply(a, z)
+    if string.equals(bignum.to_hex(mz), "0") != 1 { print("FAIL mul zero\n"); fails = fails + 1 }
+    bignum.free(mz); bignum.free(z)
+
+    // sign rule: (+)(-) = (-)
+    nb = bignum.negate(b)
+    mn = bignum.multiply(a, nb)
+    if string.equals(bignum.to_hex(mn), "-1b13114fbff5385") != 1 { print("FAIL mul sign\n"); fails = fails + 1 }
+    bignum.free(mn); bignum.free(nb)
+
+    // ---- divide / remainder ----
+    q = bignum.divide(b, a)     // 987654321 / 123456789 = 8
+    if string.equals(bignum.to_hex(q), "8") != 1 { print("FAIL div\n"); fails = fails + 1 }
+    bignum.free(q)
+    r = bignum.remainder(b, a)  // 987654321 - 8*123456789 = 9
+    if string.equals(bignum.to_hex(r), "9") != 1 { print("FAIL rem\n"); fails = fails + 1 }
+    bignum.free(r)
+
+    // |dividend| < |divisor|: q=0, r=dividend
+    qsmall = bignum.divide(a, b)
+    if string.equals(bignum.to_hex(qsmall), "0") != 1 { print("FAIL div small\n"); fails = fails + 1 }
+    bignum.free(qsmall)
+    rsmall = bignum.remainder(a, b)
+    if string.equals(bignum.to_hex(rsmall), "75bcd15") != 1 { print("FAIL rem small\n"); fails = fails + 1 }
+    bignum.free(rsmall)
+
+    // exact division: 123456*789 / 789 = 123456 (0x1e240), remainder 0
+    e1 = parse("1e240")          // 123456
+    e2 = parse("315")            // 789
+    eprod = bignum.multiply(e1, e2)
+    eq = bignum.divide(eprod, e2)
+    if string.equals(bignum.to_hex(eq), "1e240") != 1 { print("FAIL div exact\n"); fails = fails + 1 }
+    er = bignum.remainder(eprod, e2)
+    if string.equals(bignum.to_hex(er), "0") != 1 { print("FAIL rem exact\n"); fails = fails + 1 }
+    bignum.free(eq); bignum.free(er); bignum.free(eprod); bignum.free(e1); bignum.free(e2)
+
+    // multi-limb division: 5-limb / 2-limb (the case a naive shift-division looped on)
+    big = parse("1c074113cb033354fc7eefadf23a7cda6c3")
+    sm = parse("aa58695187b8a519")
+    bq = bignum.divide(big, sm)     // 0x2a1f2eba04136ac87c6
+    if string.equals(bignum.to_hex(bq), "2a1f2eba04136ac87c6") != 1 { print("FAIL div 5x2\n"); fails = fails + 1 }
+    br = bignum.remainder(big, sm)  // 0x8ca2bd471d21c66d
+    if string.equals(bignum.to_hex(br), "8ca2bd471d21c66d") != 1 { print("FAIL rem 5x2\n"); fails = fails + 1 }
+    bignum.free(bq); bignum.free(br); bignum.free(big); bignum.free(sm)
+
+    // 2^200 / 2^64 = 2^136
+    p2 = parse("100000000000000000000000000000000000000000000000000")   // 2^200
+    d64 = parse("10000000000000000")                                    // 2^64
+    pq = bignum.divide(p2, d64)
+    if string.equals(bignum.to_hex(pq), "10000000000000000000000000000000000") != 1 { print("FAIL div pow2\n"); fails = fails + 1 }
+    bignum.free(pq); bignum.free(p2); bignum.free(d64)
+
+    // ---- signed division semantics (BC: trunc toward zero; rem sign = dividend) ----
+    nbig = parse("-3635c9adc5dea00000")     // -1000000000000000000000
+    seven = bignum.from_int(7)
+    nq = bignum.divide(nbig, seven)         // -142857142857142857142 = -0x7be8a8689fb3b6db6
+    if string.equals(bignum.to_hex(nq), "-7be8a8689fb3b6db6") != 1 { print("FAIL div neg\n"); fails = fails + 1 }
+    nr = bignum.remainder(nbig, seven)      // -6
+    if string.equals(bignum.to_hex(nr), "-6") != 1 { print("FAIL rem neg\n"); fails = fails + 1 }
+    nm = bignum.mod(nbig, seven)            // (-6) + 7 = 1
+    if string.equals(bignum.to_hex(nm), "1") != 1 { print("FAIL mod neg\n"); fails = fails + 1 }
+    bignum.free(nq); bignum.free(nr); bignum.free(nm); bignum.free(nbig); bignum.free(seven)
+
+    // mod with positive operands == remainder
+    md = bignum.mod(b, a)
+    if string.equals(bignum.to_hex(md), "9") != 1 { print("FAIL mod pos\n"); fails = fails + 1 }
+    bignum.free(md)
+
+    bignum.free(a); bignum.free(b)
+
+    if fails == 0 {
+        print("PASS: std.bignum mul/div/rem/mod\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}


### PR DESCRIPTION
Adds the arithmetic layer on top of the `std.bignum` BigInteger foundation (PR #808): `multiply`, `divide`, `remainder`, `mod`.

## What

- **`multiply`** — Bouncy Castle's schoolbook `Multiply(uint[],uint[],uint[])`, ported faithfully (64-bit limb accumulation with lo32/hi32 carry split).
- **`divide` / `remainder` / `mod`** — binary long division over the unsigned magnitudes. BC's sign rules: quotient truncates toward zero with sign `a.sign*b.sign`; remainder takes the dividend's sign; `mod` is always in `[0,|b|)`.

A first port of BC's optimized shift-and-subtract `Divide` infinite-looped on a 5-limb / 2-limb case (`iCount` underflowed to zero). The bit-at-a-time version is O(n²) but obviously correct and easy to verify against an oracle. The RSA hot path will use Montgomery reduction in a later slice, not this division.

## Verification

- Fuzzed against Python's arbitrary-precision `int` over **414 signed multi-limb cases** (mul/div/rem/mod), including the case the shift-division port looped on. 0 failures.
- **ASan-clean** across the intermediate-heavy divmod loop (200× the heavy 5-limb/2-limb case).
- Regression: `tests/regression/test_bignum_muldiv.ae` (constants cross-checked against Python).

Pure Aether — no externs to OpenSSL or any C bignum library (issue #739).

## Follow-up layers

`mod_pow` / `gcd` / `mod_inverse` / `is_probable_prime` remain; `mod_pow` (the RSA workhorse) will use Montgomery reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)