### PR TITLE
feat(std.bignum): mod_pow + gcd + mod_inverse + is_probable_prime (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [0.289.0]
+
+### Added
+
+- **`std.bignum` — `mod_pow` / `gcd` / `mod_inverse` / `is_probable_prime`**
+  (issue #739, the layer that completes the BigInteger surface for RSA/DSA).
+  `mod_pow` is square-and-multiply modular exponentiation; `gcd` is Euclid;
+  `mod_inverse` is iterative extended Euclid (returns `null` when no inverse
+  exists, i.e. `gcd(a,m) != 1`); `is_probable_prime(n, rounds)` is Miller-Rabin
+  over a fixed set of small witness bases (deterministic for all n < 3.3e24,
+  a strong probable-prime test beyond). Bouncy Castle uses Barrett/Montgomery
+  reduction for `ModPow` and Montgomery-form Miller-Rabin; the textbook forms
+  here give identical results with no extern crypto — the Montgomery fast paths
+  are a tracked follow-up optimization. Fuzzed against Python over 366
+  `mod_pow`/`gcd`/`mod_inverse` cases (operands up to 128 bits) plus a primality
+  sweep over 2..2000 and several 32-bit knowns (incl. the Carmichael number
+  561 and the Mersenne prime M31); ASan-clean across a heavy mixed-op loop.
+  Regression: `tests/regression/test_bignum_modpow.ae`. This completes the
+  arbitrary-precision integer surface (#739 Tier-2 gate) that unblocks
+  RSA/DSA/ECDSA/X.509. Still pure Aether — no externs to OpenSSL or any C
+  bignum library.
+
 ## [0.287.0]
 
 ### Added

--- a/docs/bignum-deferred-optimizations.md
+++ b/docs/bignum-deferred-optimizations.md
@@ -1,0 +1,68 @@
+# std.bignum — deferred optimizations
+
+The arbitrary-precision integer surface (`std/bignum/module.ae`, issue #739) is
+**functionally complete and oracle-verified** — representation, byte I/O,
+compare, add/sub/negate/abs/shift, multiply, divide/remainder/mod, mod_pow,
+gcd, mod_inverse, is_probable_prime. Every operation has been fuzzed against
+Python's arbitrary-precision `int` and is ASan-clean.
+
+What remains is **performance**, not correctness. The current implementations
+favour "obviously correct and easy to verify against an oracle" over speed.
+This is the punch-list of perfections we deliberately deferred, in rough
+priority order for the RSA/EC work that builds on this.
+
+## 1. `mod_pow` — Montgomery / Barrett reduction (highest value)
+
+Current: textbook square-and-multiply. Each step does a full `multiply`
+followed by a full `mod` (which is binary long division). For a k-bit modulus
+and k-bit exponent that's O(k) modmuls, each O(k²) multiply + O(k²·?) division.
+
+Bouncy Castle's `ModPow` (BigInteger.cs):
+- odd modulus → `ModPowMonty` (Montgomery reduction, `MultiplyMonty` /
+  `MontgomeryReduce`, with `GetMQuote` = -m⁻¹ mod 2³²), plus a sliding-window
+  exponentiation (`ExpWindowThresholds`, `GetWindowList`).
+- even modulus → `ModPowBarrett` (`ReduceBarrett`, precomputed `yu = 2^(64k)/m`).
+
+This is the RSA hot path; it's the first thing to port when bignum perf matters.
+
+## 2. `divide` / `remainder` — optimized long division
+
+Current: bit-at-a-time binary long division (shift remainder left one bit,
+compare, conditional subtract). O(bits × limbs).
+
+Bouncy Castle's `Divide(uint[] x, uint[] y)` is a shift-and-subtract algorithm
+that mutates the dividend in place to leave the remainder and returns the
+quotient. A first port of it **infinite-looped** on a 5-limb / 2-limb case
+(the `iCount` slice right-shifted to all-zeros and the unbounded
+`while c[cStart]==0` / `while iCount[iCountStart]==0` advancers ran off the end
+— see the muldiv PR discussion). The optimized version needs that index
+bookkeeping understood and ported correctly, guarded by the same 414-case
+Python oracle. Until then the binary version is the safe choice.
+
+## 3. `multiply` — Karatsuba above a threshold
+
+Current: schoolbook `Multiply(uint[],uint[],uint[])` (BC's, ported faithfully).
+Fine for small operands; O(n²). BC switches to faster paths for large inputs.
+Add Karatsuba (or Toom-Cook) above a limb-count threshold.
+
+## 4. `is_probable_prime` — random witnesses + Montgomery-form MR
+
+Current: Miller-Rabin over a **fixed** set of the first 13 small primes as
+witness bases. This is *deterministic* for all n < 3.317 × 10²⁴; beyond that it
+is a strong probable-prime test with those fixed bases (not a random one).
+
+Bouncy Castle's `RabinMillerTest` picks **random** bases (count scaled by bit
+length and requested certainty) and works in Montgomery form. Once a vetted
+random source + Montgomery `mod_pow` exist, switch large-n primality to random
+witnesses so the certainty argument is meaningful past the deterministic range.
+Also: small-prime trial division before MR (BC's `primeProducts` / `primeLists`)
+to reject obvious composites cheaply.
+
+## Why deferred
+
+The doctrine for this port is *verify against an external oracle, never trust a
+clever implementation you can't check*. The optimized algorithms (Montgomery,
+Knuth division, Karatsuba) are exactly the kind of code where a subtle index or
+carry bug hides behind correct-looking round-trips. Landing the textbook forms
+first gives a trusted reference to differentially-test the fast versions against
+when they're ported. Tracked as task #233.

--- a/std/bignum/module.ae
+++ b/std/bignum/module.ae
@@ -19,8 +19,13 @@
 // Logical shifts route through std.bits (lsr32 / lsr64) since Aether `>>`
 // is arithmetic.
 //
-// This is layer 1: representation + from/to_bytes + compare + add/sub/
-// negate/abs/shift + bit_length. Multiply / divide / modpow land later.
+// The full surface: representation + from/to_bytes + compare + add/sub/
+// negate/abs/shift + bit_length + multiply + divide/remainder/mod + mod_pow
+// + gcd + mod_inverse + is_probable_prime. The arithmetic uses textbook
+// algorithms chosen for verifiability (binary long division, square-and-
+// multiply mod_pow, fixed-base Miller-Rabin); the BC-style Montgomery /
+// Barrett / Karatsuba fast paths are deferred perfections, tracked in
+// docs/bignum-deferred-optimizations.md.
 //
 // A bignum is an opaque `ptr` to a heap-allocated BN struct. Operations
 // return NEW bignums and never mutate their inputs. There is no GC;
@@ -37,6 +42,7 @@ exports (
     compare, is_zero, sign, bit_length,
     add, subtract, negate, abs,
     multiply, divide, remainder, mod,
+    mod_pow, gcd, mod_inverse, is_probable_prime,
     shift_left, shift_right,
     to_hex, free
 )
@@ -806,6 +812,255 @@ mod(a: ptr, b: ptr) -> ptr {
     free(babs)
     free(r)
     return adjusted
+}
+
+// ---- modular exponentiation / gcd / inverse / primality ----
+//
+// These build on multiply + mod (and the binary divide underneath). BC's
+// ModPow uses Barrett / Montgomery reduction and its primality test uses
+// Montgomery-form Miller-Rabin; we use the textbook square-and-multiply +
+// extended-Euclid + plain Miller-Rabin instead — same results, no extern
+// crypto, and obviously correct against an arbitrary-precision oracle. The
+// constant-time / Montgomery fast paths are a later optimization slice.
+
+// modular exponentiation: base^exp mod m (exp >= 0, m > 0). Square-and-
+// multiply, MSB-to-LSB. Matches BC ModPow for non-negative exponents.
+mod_pow(base: ptr, exp: ptr, m: ptr) -> ptr {
+    bm = m as *BN
+    if bm.sign < 1 {
+        // modulus must be positive; mirror BC by returning zero defensively
+        return bn_zero()
+    }
+    // m == 1 -> everything is 0
+    one = from_int(1)
+    if compare(m, one) == 0 {
+        free(one)
+        return bn_zero()
+    }
+    be = exp as *BN
+    if be.sign == 0 {
+        // exp == 0 -> 1
+        return one
+    }
+    bb = base as *BN
+    if bb.sign == 0 {
+        free(one)
+        return bn_zero()
+    }
+    // square-and-multiply over the exponent's magnitude bits, MSB->LSB.
+    // acc starts at 1; base_mod = base mod m handles base >= m / negative base.
+    nbits = mag_bit_length(be.mag, be.len)
+    i = nbits - 1
+    acc = from_int(1)
+    base_mod = mod(base, m)
+    while i >= 0 {
+        // acc = acc^2 mod m
+        sq = multiply(acc, acc)
+        sqm = mod(sq, m)
+        free(sq)
+        free(acc)
+        acc = sqm
+        if mag_test_bit(be.mag, be.len, i) == 1 {
+            // acc = acc * base_mod mod m
+            pr = multiply(acc, base_mod)
+            prm = mod(pr, m)
+            free(pr)
+            free(acc)
+            acc = prm
+        }
+        i = i - 1
+    }
+    free(base_mod)
+    free(one)
+    return acc
+}
+
+// gcd(|a|, |b|) via Euclid (BC Gcd). Always non-negative.
+gcd(a: ptr, b: ptr) -> ptr {
+    ba = a as *BN
+    bb = b as *BN
+    if bb.sign == 0 {
+        return abs(a)
+    }
+    if ba.sign == 0 {
+        return abs(b)
+    }
+    u = abs(a)
+    v = abs(b)
+    while is_zero(v) != 1 {
+        r = mod(u, v)
+        free(u)
+        u = v
+        v = r
+    }
+    free(v)
+    return u
+}
+
+// modular inverse: a^(-1) mod m, in [0, m). Iterative extended Euclid.
+// Returns null if gcd(a, m) != 1 (no inverse exists). m must be > 0.
+mod_inverse(a: ptr, m: ptr) -> ptr {
+    bm = m as *BN
+    if bm.sign < 1 {
+        return null
+    }
+    one = from_int(1)
+    if compare(m, one) == 0 {
+        // mod 1: inverse is 0
+        free(one)
+        return bn_zero()
+    }
+    // work with d = a mod m in [0, m)
+    d = mod(a, m)
+    // extended Euclid: track (old_r, r) and (old_s, s) with
+    //   old_r = old_s*a' + ...  ; on termination old_s is the inverse.
+    old_r = clone(m)
+    r = d              // d owned here
+    old_s = from_int(0)
+    s = from_int(1)
+    while is_zero(r) != 1 {
+        q = divide(old_r, r)
+        // (old_r, r) = (r, old_r - q*r)
+        qr = multiply(q, r)
+        nr = subtract(old_r, qr)
+        free(qr)
+        free(old_r)
+        old_r = r
+        r = nr
+        // (old_s, s) = (s, old_s - q*s)
+        qs = multiply(q, s)
+        ns = subtract(old_s, qs)
+        free(qs)
+        free(old_s)
+        old_s = s
+        s = ns
+        free(q)
+    }
+    free(r)
+    free(s)
+    // old_r is gcd(a, m); must be 1 for an inverse to exist
+    if compare(old_r, one) != 0 {
+        free(old_r)
+        free(old_s)
+        free(one)
+        return null
+    }
+    free(old_r)
+    free(one)
+    // normalize old_s into [0, m)
+    bs = old_s as *BN
+    if bs.sign < 0 {
+        adj = add(old_s, m)
+        free(old_s)
+        return adj
+    }
+    return old_s
+}
+
+// Miller-Rabin primality test with a fixed set of small witness bases.
+// `rounds` caps how many bases to try (the fixed list is deterministic for
+// all n < 3.317e24 with the first 13 primes; beyond that it is a strong
+// probable-prime test). Returns 1 for probable prime, 0 for composite.
+is_probable_prime(n: ptr, rounds: int) -> int {
+    bn = n as *BN
+    if bn.sign <= 0 {
+        return 0
+    }
+    two = from_int(2)
+    three = from_int(3)
+    // n < 2 -> not prime; n == 2 or 3 -> prime
+    if compare(n, two) < 0 {
+        free(two); free(three)
+        return 0
+    }
+    if compare(n, two) == 0 {
+        free(two); free(three)
+        return 1
+    }
+    if compare(n, three) == 0 {
+        free(two); free(three)
+        return 1
+    }
+    // even -> composite
+    if mag_test_bit(bn.mag, bn.len, 0) == 0 {
+        free(two); free(three)
+        return 0
+    }
+    // write n-1 = d * 2^s with d odd
+    one = from_int(1)
+    nm1 = subtract(n, one)
+    s = 0
+    d = clone(nm1)
+    bd = d as *BN
+    while mag_test_bit(bd.mag, bd.len, 0) == 0 {
+        d2 = shift_right(d, 1)
+        free(d)
+        d = d2
+        bd = d as *BN
+        s = s + 1
+    }
+    // fixed deterministic witness bases (first 13 primes)
+    bases = intarr_new_raw(13)
+    intarr_set_raw(bases, 0, 2);   intarr_set_raw(bases, 1, 3)
+    intarr_set_raw(bases, 2, 5);   intarr_set_raw(bases, 3, 7)
+    intarr_set_raw(bases, 4, 11);  intarr_set_raw(bases, 5, 13)
+    intarr_set_raw(bases, 6, 17);  intarr_set_raw(bases, 7, 19)
+    intarr_set_raw(bases, 8, 23);  intarr_set_raw(bases, 9, 29)
+    intarr_set_raw(bases, 10, 31); intarr_set_raw(bases, 11, 37)
+    intarr_set_raw(bases, 12, 41)
+    nbases = 13
+    limit = rounds
+    if limit > nbases { limit = nbases }
+    if limit < 1 { limit = 1 }
+    result = 1
+    bi = 0
+    while bi < limit {
+        a = from_int(intarr_get_raw(bases, bi))
+        // skip bases >= n-1 (only relevant for tiny n, already handled above)
+        if compare(a, nm1) >= 0 {
+            free(a)
+            bi = bi + 1
+        } else {
+            // x = a^d mod n
+            x = mod_pow(a, d, n)
+            // if x == 1 or x == n-1, this base passes
+            passes = 0
+            if compare(x, one) == 0 {
+                passes = 1
+            }
+            if compare(x, nm1) == 0 {
+                passes = 1
+            }
+            if passes == 0 {
+                // repeat s-1 times: x = x^2 mod n; pass if x == n-1
+                rr = 1
+                while rr < s {
+                    sq = multiply(x, x)
+                    x2 = mod(sq, n)
+                    free(sq)
+                    free(x)
+                    x = x2
+                    if compare(x, nm1) == 0 {
+                        passes = 1
+                        rr = s   // break
+                    } else {
+                        rr = rr + 1
+                    }
+                }
+            }
+            free(x)
+            free(a)
+            if passes == 0 {
+                result = 0
+                bi = limit   // composite — stop
+            } else {
+                bi = bi + 1
+            }
+        }
+    }
+    intarr_free(bases)
+    free(one); free(two); free(three); free(nm1); free(d)
+    return result
 }
 
 // ---- shifts ----

--- a/tests/regression/test_bignum_modpow.ae
+++ b/tests/regression/test_bignum_modpow.ae
@@ -1,0 +1,148 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// Regression: std.bignum mod_pow / gcd / mod_inverse / is_probable_prime
+// (issue #739, the layer that completes the BigInteger surface for RSA/DSA).
+// mod_pow is square-and-multiply; gcd is Euclid; mod_inverse is iterative
+// extended Euclid; is_probable_prime is Miller-Rabin over a fixed set of
+// small witness bases (deterministic for all n < 3.3e24). BC uses Barrett /
+// Montgomery reduction for mod_pow and Montgomery-form Miller-Rabin — the
+// textbook forms here give identical results without extern crypto; the
+// Montgomery fast paths are a later optimization slice.
+//
+// Constants below were cross-checked against Python's pow()/math.gcd()/an
+// extended-Euclid modinv, and the full surface was fuzzed against Python
+// over 366 mod_pow/gcd/mod_inverse cases (operands up to 128 bits) plus a
+// primality sweep over 2..2000 and several 32-bit knowns.
+
+import std.bignum
+import std.bytes
+import std.string
+
+hv(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    return 0
+}
+// parse an unsigned hex string into a bignum
+parse(h: string) -> ptr {
+    n = string.length(h)
+    nbytes = (n + 1) / 2
+    b = bytes.new(nbytes)
+    bi = nbytes - 1
+    i = n - 1
+    while i >= 0 {
+        lo = hv(string_char_at_n(h, n, i))
+        hi = 0
+        if i - 1 >= 0 { hi = hv(string_char_at_n(h, n, i - 1)) }
+        bytes.set(b, bi, hi * 16 + lo)
+        bi = bi - 1
+        i = i - 2
+    }
+    v = bignum.from_bytes_unsigned(b, nbytes)
+    bytes.free(b)
+    return v
+}
+
+main() {
+    print("=== std.bignum mod_pow / gcd / mod_inverse / prime ===\n")
+    fails = 0
+
+    // ---- mod_pow ----
+    // 4^13 mod 497 = 445
+    b1 = bignum.from_int(4); e1 = bignum.from_int(13); m1 = bignum.from_int(497)
+    r1 = bignum.mod_pow(b1, e1, m1)
+    if string.equals(bignum.to_hex(r1), "1bd") != 1 { print("FAIL modpow small\n"); fails = fails + 1 }
+    bignum.free(r1); bignum.free(b1); bignum.free(e1); bignum.free(m1)
+
+    // exp 0 -> 1; modulus 1 -> 0
+    b0 = bignum.from_int(99); e0 = bignum.from_int(0); m0 = bignum.from_int(7)
+    r0 = bignum.mod_pow(b0, e0, m0)
+    if string.equals(bignum.to_hex(r0), "1") != 1 { print("FAIL modpow exp0\n"); fails = fails + 1 }
+    bignum.free(r0); bignum.free(e0)
+    e0b = bignum.from_int(5); m1b = bignum.from_int(1)
+    r0b = bignum.mod_pow(b0, e0b, m1b)
+    if string.equals(bignum.to_hex(r0b), "0") != 1 { print("FAIL modpow mod1\n"); fails = fails + 1 }
+    bignum.free(r0b); bignum.free(e0b); bignum.free(m1b); bignum.free(b0); bignum.free(m0)
+
+    // toy RSA encrypt: 0x1234 ^ 0x10001 mod 0xfffffffffffffffffffffffffffffffb
+    msg = parse("1234"); pe = parse("10001"); modulus = parse("fffffffffffffffffffffffffffffffb")
+    ct = bignum.mod_pow(msg, pe, modulus)
+    if string.equals(bignum.to_hex(ct), "e9d57aa4a6a259f111f8f71d79847d01") != 1 { print("FAIL modpow rsa\n"); fails = fails + 1 }
+    bignum.free(ct); bignum.free(msg); bignum.free(pe); bignum.free(modulus)
+
+    // 7 ^ 0x1ffff mod 0xabcdef0123456789
+    b7 = parse("7"); e7 = parse("1ffff"); m7 = parse("abcdef0123456789")
+    r7 = bignum.mod_pow(b7, e7, m7)
+    if string.equals(bignum.to_hex(r7), "81b3112d9ab3e961") != 1 { print("FAIL modpow big\n"); fails = fails + 1 }
+    bignum.free(r7); bignum.free(b7); bignum.free(e7); bignum.free(m7)
+
+    // ---- gcd ----
+    g1 = bignum.from_int(1071); g2 = bignum.from_int(462)
+    g = bignum.gcd(g1, g2)       // 21
+    if string.equals(bignum.to_hex(g), "15") != 1 { print("FAIL gcd\n"); fails = fails + 1 }
+    bignum.free(g); bignum.free(g1); bignum.free(g2)
+
+    // gcd over 64-bit operands: gcd(0xfffffffffffffffe, 0xaaaaaaaaaaaaaaaa) = 2
+    gb1 = parse("fffffffffffffffe"); gb2 = parse("aaaaaaaaaaaaaaaa")
+    gb = bignum.gcd(gb1, gb2)
+    if string.equals(bignum.to_hex(gb), "2") != 1 { print("FAIL gcd 64\n"); fails = fails + 1 }
+    bignum.free(gb); bignum.free(gb1); bignum.free(gb2)
+
+    // coprime -> gcd 1
+    cp1 = bignum.from_int(17); cp2 = bignum.from_int(3120)
+    cg = bignum.gcd(cp1, cp2)
+    if string.equals(bignum.to_hex(cg), "1") != 1 { print("FAIL gcd coprime\n"); fails = fails + 1 }
+    bignum.free(cg); bignum.free(cp1); bignum.free(cp2)
+
+    // ---- mod_inverse ----
+    a = bignum.from_int(3); nmod = bignum.from_int(11)
+    inv = bignum.mod_inverse(a, nmod)   // 4
+    if string.equals(bignum.to_hex(inv), "4") != 1 { print("FAIL modinv\n"); fails = fails + 1 }
+    bignum.free(inv); bignum.free(a); bignum.free(nmod)
+
+    // classic RSA d: 17^(-1) mod 3120 = 2753
+    ed = bignum.from_int(17); phi = bignum.from_int(3120)
+    d = bignum.mod_inverse(ed, phi)
+    if string.equals(bignum.to_hex(d), "ac1") != 1 { print("FAIL modinv rsa\n"); fails = fails + 1 }
+    bignum.free(d); bignum.free(ed); bignum.free(phi)
+
+    // 65537^(-1) mod 0xfffffffffffffffffffffffffffffffb
+    e65537 = parse("10001"); pmod = parse("fffffffffffffffffffffffffffffffb")
+    inv65537 = bignum.mod_inverse(e65537, pmod)
+    if string.equals(bignum.to_hex(inv65537), "c0003fffc0003fffc0003fffc0003ffc") != 1 { print("FAIL modinv 65537\n"); fails = fails + 1 }
+    bignum.free(inv65537); bignum.free(e65537); bignum.free(pmod)
+
+    // no inverse when not coprime (gcd != 1)
+    ni1 = bignum.from_int(6); ni2 = bignum.from_int(9)
+    none = bignum.mod_inverse(ni1, ni2)
+    if none != null { print("FAIL modinv none\n"); fails = fails + 1 }
+    bignum.free(ni1); bignum.free(ni2)
+
+    // ---- is_probable_prime ----
+    pa = bignum.from_int(97)
+    if bignum.is_probable_prime(pa, 13) != 1 { print("FAIL prime 97\n"); fails = fails + 1 }
+    bignum.free(pa)
+    pc = bignum.from_int(91)            // 7*13
+    if bignum.is_probable_prime(pc, 13) != 0 { print("FAIL composite 91\n"); fails = fails + 1 }
+    bignum.free(pc)
+    pm = bignum.from_int(561)           // Carmichael number (composite)
+    if bignum.is_probable_prime(pm, 13) != 0 { print("FAIL carmichael 561\n"); fails = fails + 1 }
+    bignum.free(pm)
+    pbig = bignum.from_int(2147483647)  // Mersenne prime M31
+    if bignum.is_probable_prime(pbig, 13) != 1 { print("FAIL prime M31\n"); fails = fails + 1 }
+    bignum.free(pbig)
+    pcomp = bignum.from_int(2147483649) // 3 * 715827883
+    if bignum.is_probable_prime(pcomp, 13) != 0 { print("FAIL composite 2147483649\n"); fails = fails + 1 }
+    bignum.free(pcomp)
+
+    if fails == 0 {
+        print("PASS: std.bignum mod_pow / gcd / mod_inverse / prime\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}


### PR DESCRIPTION
Completes the `std.bignum` arbitrary-precision integer surface — the #739 Tier-2 gate that unblocks RSA/DSA/ECDSA/X.509.

## What

- **`mod_pow(base, exp, m)`** — square-and-multiply modular exponentiation.
- **`gcd(a, b)`** — Euclid via `mod` (BC `Gcd`).
- **`mod_inverse(a, m)`** — iterative extended Euclid; returns `null` when no inverse exists (`gcd(a,m) != 1`).
- **`is_probable_prime(n, rounds)`** — Miller-Rabin over a fixed set of the first 13 small primes as witness bases (deterministic for all n < 3.3×10²⁴).

Bouncy Castle uses Barrett/Montgomery reduction for `ModPow` and Montgomery-form Miller-Rabin; the textbook forms here give identical results with no extern crypto. The performance fast paths (Montgomery/Barrett `mod_pow`, optimized Knuth division, Karatsuba multiply, random-witness MR) are **deferred perfections** — documented in `docs/bignum-deferred-optimizations.md` and tracked separately. They're perf, not correctness.

## Verification

- Fuzzed against Python over **366 `mod_pow`/`gcd`/`mod_inverse` cases** (operands up to 128 bits). 0 failures.
- Primality sweep over **2..2000** + 32-bit knowns including the **Carmichael number 561** (composite, fools weak tests) and the **Mersenne prime M31** (2147483647).
- **ASan-clean** across a heavy mixed-op loop.
- Self-contained regression `tests/regression/test_bignum_modpow.ae` with Python-verified constants (incl. a toy RSA encrypt round and the classic 17⁻¹ mod 3120 = 2753 RSA `d`).

Pure Aether — no externs to OpenSSL or any C bignum library.

## Follow-up

`docs/bignum-deferred-optimizations.md` is the punch-list for the Montgomery/Barrett/Karatsuba/Knuth optimizations (RSA hot path first). The bignum surface is now feature-complete; next is building RSA/DSA on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)