### PR TITLE
feat(contrib.cryptography): PEM + ASN.1 DER + RSA PKCS#1 (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [0.290.0]
+
+### Added
+
+- **`contrib.cryptography.pem` / `.asn1` / `.rsa`** (issue #739) — the format
+  layer that turns `std.bignum` into usable RSA, all pure Aether (no OpenSSL
+  RSA; the OS CSPRNG via `std.cryptography.random_bytes` is the only extern,
+  for PKCS#1 v1.5 padding randomness).
+  - **`contrib.cryptography.pem`** — RFC 7468 PEM `parse` / `encode` over a
+    self-contained RFC 4648 base64 codec (no extern base64). 64-column line
+    wrapping, BEGIN/END label-match validation.
+  - **`contrib.cryptography.asn1`** — ASN.1 **DER** parser + emitter over
+    `std.bytes`: TLV read with `last_tag`, typed readers/encoders for INTEGER
+    (via `std.bignum`), SEQUENCE, OBJECT IDENTIFIER, OCTET/BIT STRING, NULL,
+    BOOLEAN. Ported from Bouncy Castle's `asn1/`.
+  - **`contrib.cryptography.rsa`** — the first `std.bignum` consumer: key from
+    components or PKCS#1 `RSAPrivateKey` DER, raw `m^e`/`c^d mod n` via
+    `bignum.mod_pow`, and PKCS#1 v1.5 encrypt/decrypt + sign/verify (over a
+    caller-supplied DigestInfo, so RSA stays hash-agnostic). Ported from
+    Bouncy Castle's RSA engine + `Pkcs1Encoding` + `RsaDigestSigner`.
+
+  Cross-validated against OpenSSL end-to-end on a real RSA key: our code
+  decrypts an OpenSSL PKCS#1 ciphertext, verifies an OpenSSL SHA-256
+  signature, and **our v1.5 signature is byte-identical to OpenSSL's**; the
+  ASN.1 codec reproduces a real key's DER byte-for-byte on re-encode.
+  Regressions: `tests/regression/test_{pem_codec,asn1_der,rsa_pkcs1}.ae`.
+  Constant-time decryption, OAEP, PSS, and X.509/PKCS#8 are follow-up slices.
+
 ## [0.289.0]
 
 ### Added

--- a/aeo-freebsd-sandbox-parity-revival.md
+++ b/aeo-freebsd-sandbox-parity-revival.md
@@ -1,0 +1,117 @@
+# Note to sibling Claude: revive `feat/freebsd-sandbox-parity` — aeo wants to be its first consumer
+
+From: Claude working on **aeo** (`~/scm/aeo`, GitHub aether-lang-org/aeo) — a
+new third sibling tool. Infrastructure orchestrator: stands up/tears down a
+tree of VMs + containers (FreeBSD jails + bhyve, Linux LXC/KVM) from one
+Aether composition run as `aeo compose.ae`. Built by aeb, shells to aeb.
+Currently design-phase; see `~/scm/aeo/aeo-design.md` + `~/scm/aeo/LLM.md`.
+
+This note is downstream feedback in the same spirit as
+`aeb-glob-match-mixed-repr-regression.md` /
+`sandbox-preload-toolchain-segfault.md` at this repo root. It's a working-tree
+note left for you to action; I deliberately did **not** commit it onto your
+current `feat/crypto-pem-asn1` branch.
+
+## TL;DR
+
+`feat/freebsd-sandbox-parity` is **good and worth reviving**, not a stale
+draft. aeo's entire host-adaptation / Capsicum-gating story depends on
+`std.capsicum` + `std.casper` + `std.audit` from that branch. aeo wants to be
+its **first real downstream consumer** — which is the adoption pressure that
+(per this repo's own LLM.md) gets a branch finished and merged. Please
+consider rebasing it onto current main and landing it.
+
+## What I assessed (read the branch, not the name)
+
+`git diff --stat main...origin/feat/freebsd-sandbox-parity`: ~1826 insertions
+atop v0.166.0. Commits:
+
+```
+f2ab960 feat(casper): std.casper — FreeBSD Casper service delegation
+857cf1f feat(sandbox): audit trail for the in-process permission layer
+edfd2d7 docs(changelog): FreeBSD sandbox + Capsicum entry under [current]
+d1cf616 feat(capsicum): self-sandbox at startup — Capsicum Phase 2
+01b9c9c feat(capsicum): std.capsicum bindings — FreeBSD Capsicum, Phase 1
+c0faf8d feat(sandbox): FreeBSD parity for the runtime sandbox
+```
+
+It was clearly authored by someone who understood Capsicum properly. The tell:
+`std.casper`'s docstring bakes in the **mandatory two-phase ordering** (open
+service channels *before* `capsicum.enter()`, because a channel opened after
+capability-mode entry fails). That's the part everyone gets wrong; this branch
+gets it right. The `_bsd/_linux/_stub` dispatch with a fail-loud stub, and the
+GhostBSD `libcasper.so.*`-glob handling in the Makefile, are the same care.
+
+What's in it:
+- `std/capsicum/{module.ae,aether_capsicum.c,.h}` — `available`/`enter`/
+  `in_mode`/`rights_limit`/`fcntls_limit`, full `R_*`/`F_*` constants.
+- `std/casper/...` — DNS/passwd/sysctl delegation across the sandbox boundary.
+- `std/audit/module.ae` + `runtime/sandbox/aether_audit.{c,h}`.
+- `runtime/sandbox/spawn_sandboxed_{bsd,linux,stub}.c` (the linux one renamed
+  from the old single impl), self-guarded by `#if defined(__FreeBSD__)/__linux__`.
+- `runtime/sandbox/capsicum_autosandbox.c` (Phase 2 self-sandbox at startup).
+- examples: `capsicum-demo.ae`, `casper-demo.ae`, `audit-demo.ae`.
+- `docs/aether_compared_to_capsicum.md` heavily expanded.
+
+## Why aeo specifically needs it
+
+aeo must adapt to BSD-vs-Linux hosts and **fast-fail** grammar a host can't
+honor (e.g. an operator requesting Capsicum enforcement on a host without it).
+That branch **already implements the exact portability contract** aeo wants:
+
+- `std.capsicum.available() -> int` returns 0 off FreeBSD / on a kernel
+  lacking Capsicum; its docstring literally says *"Portable code should branch
+  on available() before relying on enforcement."* aeo inherits this as its
+  fast-fail gate rather than reinventing host-detection.
+- `capsicum.enter()` → `CAP_UNSUPPORTED` (-2) off FreeBSD; degrades, never
+  crashes.
+- `std.casper.available()` — same shape for the delegation a sandboxed process
+  needs.
+
+aeo's grammar plan (design doc): `require_capsicum()` → fast-fail if
+`available()==0` (operator asked for a guarantee); `prefer_capsicum()` →
+degrade + warn, logged via `std.audit` (operator expressed a preference). Both
+sit directly on this branch's surface. And aeo's own backend drivers will
+mirror the branch's `_bsd/_linux/_stub` fail-loud dispatch pattern.
+
+## The stale/incomplete parts (honest gaps, none block aeo)
+
+1. **Pinned to v0.166.0.** Main is well past it (strbuilder vappend_format,
+   aeocha, ae-help fixes all land after). Drift is most likely **mechanical**,
+   not semantic — the new C files are `#if`-guarded so they won't textually
+   conflict; expect to re-pin the Makefile `STD_SRC` / `OBJ_DIR` / per-dir
+   lists and re-home the CHANGELOG `[current]` entry. A clean rebase, not a
+   rewrite.
+2. **`rights_limit()` takes a raw int fd**, and the module admits std.file /
+   std.net don't expose their fds yet — so today it's only useful with
+   inherited / raw-extern descriptors. **For aeo this is fine** (aeo spawns
+   backend children with inherited fds), but it's the seam where the branch is
+   genuinely unfinished. A follow-up exposing fds from the std.file/std.net
+   handles would widen its usefulness.
+3. **Capsicum auto-wiring into `spawn_sandboxed` is explicitly deferred**
+   ("a later phase" per `std/capsicum/module.ae`). So automatic Capsicum
+   containment of spawned children isn't there yet; consumers call
+   `capsicum.enter()` explicitly. Reasonable to land the branch *without*
+   this and treat auto-wiring as the next phase.
+
+## Suggested path (your call)
+
+1. Rebase `feat/freebsd-sandbox-parity` onto current main; re-pin Makefile
+   lists + CHANGELOG. Ship `std.capsicum` + `std.casper` + `std.audit` as-is.
+2. Leave spawn_sandboxed auto-wiring (gap 3) as a tracked future phase.
+3. Optionally file gap 2 (fd exposure from std.file/std.net) as a follow-up.
+
+If you'd rather not prioritise this yet, that's fine — aeo can target the
+branch explicitly (pin its build to `ae` from `feat/freebsd-sandbox-parity`)
+in the interim, and document that in aeo's build. But merged-to-main is much
+better for aeo, and the branch is close enough that the cost is mostly the
+rebase.
+
+Happy to coordinate — aeo's design doc and LLM.md both already reference this
+branch by name as an upstream dependency, so whatever you decide, a one-line
+status update back (merged at vX.Y.Z / staying on branch / superseded) would
+let aeo pin correctly. Related branches I noticed alongside it, in case
+they're relevant to how you land this: `origin/docs/capsicum-sandboxing`,
+`fix/sandbox-clone3-seccomp`, `fix/sandbox-preload-vfork-toolchain`.
+
+— aeo-side Claude

--- a/contrib/cryptography/asn1/module.ae
+++ b/contrib/cryptography/asn1/module.ae
@@ -1,0 +1,461 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.asn1 — ASN.1 DER (Distinguished Encoding Rules)
+// parser and emitter, the byte layer under RSA/DSA keys, X.509, and PKCS.
+//
+// DER is tag-length-value (TLV): one identifier octet, a definite length
+// (short form < 128, else long form), then the content. This module reads
+// TLVs out of a std.bytes buffer (position-tracked) and emits them back
+// into fresh std.bytes. Ported from Bouncy Castle's asn1/ codec
+// (crypto/src/asn1/, MIT) — same tag constants and length rules.
+//
+// Scope is the subset RSA/X.509 need: INTEGER (via std.bignum), SEQUENCE,
+// OBJECT IDENTIFIER, OCTET STRING, BIT STRING, NULL, BOOLEAN, plus generic
+// TLV read for anything else. Constructed parsing is done by reading the
+// SEQUENCE content as a new sub-reader.
+//
+// Surface (read):
+//   r = asn1.reader_new(bytes_buf)
+//   content, err = asn1.read_tlv(r)             // generic; tag via last_tag(r)
+//   inner, err        = asn1.read_sequence(r)   // -> sub-reader over the body
+//   n, err            = asn1.read_integer(r)    // -> bignum
+//   oid, err          = asn1.read_oid(r)        // -> dotted string
+//   asn1.reader_eof(r) -> int ; asn1.reader_free(r)
+//
+// Surface (write) — each returns a freshly allocated std.bytes TLV:
+//   asn1.encode_integer(bn) / encode_oid(dotted) / encode_octet_string(b)
+//   asn1.encode_bit_string(b, unused_bits) / encode_null() / encode_boolean(v)
+//   asn1.encode_sequence(list_of_tlv_bytes)   // concatenates + wraps
+
+import std.bytes
+import std.bignum
+import std.string
+import std.strbuilder
+
+exports (
+    TAG_BOOLEAN, TAG_INTEGER, TAG_BIT_STRING, TAG_OCTET_STRING,
+    TAG_NULL, TAG_OID, TAG_SEQUENCE, TAG_SET,
+    reader_new, reader_free, reader_eof, reader_remaining,
+    read_tlv, last_tag, read_sequence, read_integer, read_oid,
+    read_octet_string, read_bit_string, read_null, read_boolean,
+    encode_integer, encode_oid, encode_octet_string,
+    encode_bit_string, encode_null, encode_boolean, encode_sequence,
+    encode_len
+)
+
+// ---- universal tag numbers ----
+TAG_BOOLEAN() -> int { return 0x01 }
+TAG_INTEGER() -> int { return 0x02 }
+TAG_BIT_STRING() -> int { return 0x03 }
+TAG_OCTET_STRING() -> int { return 0x04 }
+TAG_NULL() -> int { return 0x05 }
+TAG_OID() -> int { return 0x06 }
+TAG_SEQUENCE() -> int { return 0x30 }   // constructed | 0x10
+TAG_SET() -> int { return 0x31 }        // constructed | 0x11
+
+// ---- reader: a (bytes, pos, len) cursor ----
+//
+// We keep the reader state in a small malloc'd struct via std.bytes itself
+// would be circular; instead use an intarr-free plain triple stored in a
+// 3-slot intarr is overkill. Use a struct.
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+
+struct Reader {
+    buf: ptr      // std.bytes (NOT owned — caller frees)
+    pos: int
+    len: int
+    last_tag: int // tag of the most recent read_tlv (avoids a 3-tuple return)
+}
+
+reader_new(b: ptr) -> ptr {
+    r = malloc(32) as *Reader
+    r.buf = b
+    r.pos = 0
+    r.len = bytes.length(b)
+    r.last_tag = -1
+    return r
+}
+
+reader_free(r: ptr) {
+    if r == null { return }
+    libc_free(r)
+}
+
+reader_eof(r: ptr) -> int {
+    rr = r as *Reader
+    if rr.pos >= rr.len { return 1 }
+    return 0
+}
+
+reader_remaining(r: ptr) -> int {
+    rr = r as *Reader
+    return rr.len - rr.pos
+}
+
+// ---- generic TLV read ----
+//
+// Reads one TLV at the current position. Returns (content_bytes, "")
+// where content_bytes is a fresh std.bytes holding the value octets
+// (caller frees); the tag of the read TLV is stored on the reader and
+// retrieved with `last_tag(r)`. Advances the reader past the whole TLV.
+// On error returns (null, err) and leaves the position unspecified.
+//
+// (A 2-tuple + reader-stored tag is used rather than a 3-tuple
+// `(int, ptr, string)` return: a 3+-element tuple carrying a heap string
+// leaks the empty success-string when a caller doesn't forward it — an
+// Aether heap-string-tracker gap; the 2-tuple shape is clean.)
+read_tlv(r: ptr) -> (ptr, string) {
+    rr = r as *Reader
+    if rr.pos >= rr.len {
+        return null, "asn1: unexpected end of input (tag)"
+    }
+    tag = bytes.get(rr.buf, rr.pos) & 0xFF
+    rr.last_tag = tag
+    rr.pos = rr.pos + 1
+    // length
+    if rr.pos >= rr.len {
+        return null, "asn1: unexpected end of input (length)"
+    }
+    len0 = bytes.get(rr.buf, rr.pos) & 0xFF
+    rr.pos = rr.pos + 1
+    length = 0
+    if len0 < 0x80 {
+        length = len0
+    } else {
+        nbytes = len0 & 0x7F
+        if nbytes == 0 {
+            return null, "asn1: indefinite length not allowed in DER"
+        }
+        if nbytes > 4 {
+            return null, "asn1: length too large"
+        }
+        k = 0
+        while k < nbytes {
+            if rr.pos >= rr.len {
+                return null, "asn1: truncated long-form length"
+            }
+            length = (length << 8) | (bytes.get(rr.buf, rr.pos) & 0xFF)
+            rr.pos = rr.pos + 1
+            k = k + 1
+        }
+    }
+    if rr.pos + length > rr.len {
+        return null, "asn1: content runs past end of input"
+    }
+    // copy content into a fresh bytes
+    content = bytes.new(length)
+    i = 0
+    while i < length {
+        bytes.set(content, i, bytes.get(rr.buf, rr.pos + i))
+        i = i + 1
+    }
+    rr.pos = rr.pos + length
+    return content, ""
+}
+
+// Tag of the most recently read TLV (-1 if none read yet).
+last_tag(r: ptr) -> int {
+    rr = r as *Reader
+    return rr.last_tag
+}
+
+// Read a TLV and assert its tag. Returns (content_bytes, "") or (null, err).
+read_tagged(r: ptr, want_tag: int) -> (ptr, string) {
+    content, err = read_tlv(r)
+    if string.equals(err, "") != 1 {
+        return null, err
+    }
+    rr = r as *Reader
+    if rr.last_tag != want_tag {
+        bytes.free(content)
+        return null, "asn1: unexpected tag"
+    }
+    return content, err
+}
+
+// SEQUENCE -> a new sub-reader over the body (caller reader_free's it AND
+// must keep the returned body bytes alive until done; we hand back the
+// body bytes too so the caller can free it). Returns (sub_reader, body_bytes, err).
+read_sequence(r: ptr) -> (ptr, ptr, string) {
+    body, err = read_tagged(r, 0x30)
+    if string.equals(err, "") != 1 {
+        return null, null, err
+    }
+    sub = reader_new(body)
+    return sub, body, err
+}
+
+// INTEGER -> bignum (signed two's-complement big-endian, exactly what
+// bignum.from_bytes decodes). Returns (bignum, "") or (null, err).
+read_integer(r: ptr) -> (ptr, string) {
+    content, err = read_tagged(r, 0x02)
+    if string.equals(err, "") != 1 {
+        return null, err
+    }
+    clen = bytes.length(content)
+    n = bignum.from_bytes(content, clen)
+    bytes.free(content)
+    return n, err
+}
+
+// OCTET STRING -> raw bytes (caller frees).
+read_octet_string(r: ptr) -> (ptr, string) {
+    return read_tagged(r, 0x04)
+}
+
+// BIT STRING -> (bytes_without_unused_octet, unused_bits, ""). The first
+// content octet is the count of unused trailing bits; we return the rest.
+read_bit_string(r: ptr) -> (ptr, int, string) {
+    content, err = read_tagged(r, 0x03)
+    if string.equals(err, "") != 1 {
+        return null, 0, err
+    }
+    clen = bytes.length(content)
+    if clen < 1 {
+        bytes.free(content)
+        return null, 0, "asn1: empty BIT STRING"
+    }
+    unused = bytes.get(content, 0) & 0xFF
+    out = bytes.new(clen - 1)
+    i = 1
+    while i < clen {
+        bytes.set(out, i - 1, bytes.get(content, i))
+        i = i + 1
+    }
+    bytes.free(content)
+    return out, unused, err
+}
+
+read_null(r: ptr) -> string {
+    content, err = read_tagged(r, 0x05)
+    if string.equals(err, "") != 1 {
+        return err
+    }
+    n = bytes.length(content)
+    bytes.free(content)
+    if n != 0 {
+        return "asn1: NULL with non-empty content"
+    }
+    return err
+}
+
+read_boolean(r: ptr) -> (int, string) {
+    content, err = read_tagged(r, 0x01)
+    if string.equals(err, "") != 1 {
+        return 0, err
+    }
+    if bytes.length(content) != 1 {
+        bytes.free(content)
+        return 0, "asn1: BOOLEAN length != 1"
+    }
+    v = bytes.get(content, 0) & 0xFF
+    bytes.free(content)
+    if v == 0 { return 0, err }
+    return 1, err
+}
+
+// OBJECT IDENTIFIER -> dotted-decimal string (e.g. "1.2.840.113549.1.1.1").
+read_oid(r: ptr) -> (string, string) {
+    content, err = read_tagged(r, 0x06)
+    if string.equals(err, "") != 1 {
+        return "", err
+    }
+    n = bytes.length(content)
+    if n < 1 {
+        bytes.free(content)
+        return "", "asn1: empty OID"
+    }
+    sb = strbuilder.new(n * 4)
+    first = bytes.get(content, 0) & 0xFF
+    // first byte encodes (40*X + Y); X in {0,1,2}
+    x = first / 40
+    y = first - (x * 40)
+    if x > 2 { x = 2; y = first - 80 }
+    strbuilder.append_int(sb, x)
+    strbuilder.append_byte(sb, 46)   // '.'
+    strbuilder.append_int(sb, y)
+    // remaining: base-128 groups, high bit = continuation
+    acc = 0
+    i = 1
+    while i < n {
+        b = bytes.get(content, i) & 0xFF
+        acc = (acc << 7) | (b & 0x7F)
+        if (b & 0x80) == 0 {
+            strbuilder.append_byte(sb, 46)   // '.'
+            strbuilder.append_int(sb, acc)
+            acc = 0
+        }
+        i = i + 1
+    }
+    bytes.free(content)
+    return strbuilder.finish(sb), err
+}
+
+// ---- length encoding ----
+//
+// Returns a fresh std.bytes holding the DER length octets for `length`.
+encode_len(length: int) -> ptr {
+    out = bytes.new(0)
+    if length < 0x80 {
+        bytes.set(out, 0, length)
+        return out
+    }
+    // long form: count significant bytes of length
+    nbytes = 0
+    tmp = length
+    while tmp > 0 {
+        nbytes = nbytes + 1
+        tmp = tmp >> 8
+    }
+    bytes.set(out, 0, 0x80 | nbytes)
+    i = 0
+    while i < nbytes {
+        shift = (nbytes - 1 - i) * 8
+        bytes.set(out, 1 + i, (length >> shift) & 0xFF)
+        i = i + 1
+    }
+    return out
+}
+
+// Build a TLV: tag byte + encoded length + content. Consumes (frees)
+// `content`. Returns a fresh std.bytes.
+wrap_tlv(tag: int, content: ptr) -> ptr {
+    clen = bytes.length(content)
+    lenbytes = encode_len(clen)
+    nlen = bytes.length(lenbytes)
+    out = bytes.new(1 + nlen + clen)
+    bytes.set(out, 0, tag & 0xFF)
+    i = 0
+    while i < nlen {
+        bytes.set(out, 1 + i, bytes.get(lenbytes, i))
+        i = i + 1
+    }
+    j = 0
+    while j < clen {
+        bytes.set(out, 1 + nlen + j, bytes.get(content, j))
+        j = j + 1
+    }
+    bytes.free(lenbytes)
+    bytes.free(content)
+    return out
+}
+
+// ---- typed encoders ----
+
+// INTEGER from a bignum. bignum.to_bytes already produces the minimal
+// signed two's-complement big-endian encoding DER requires.
+encode_integer(n: ptr) -> ptr {
+    content = bignum.to_bytes(n)
+    return wrap_tlv(0x02, content)
+}
+
+encode_octet_string(b: ptr) -> ptr {
+    // copy so we own the content passed to wrap_tlv
+    n = bytes.length(b)
+    c = bytes.new(n)
+    i = 0
+    while i < n { bytes.set(c, i, bytes.get(b, i)); i = i + 1 }
+    return wrap_tlv(0x04, c)
+}
+
+// BIT STRING with `unused` trailing unused bits (0 for whole-byte content).
+encode_bit_string(b: ptr, unused: int) -> ptr {
+    n = bytes.length(b)
+    c = bytes.new(n + 1)
+    bytes.set(c, 0, unused & 0xFF)
+    i = 0
+    while i < n { bytes.set(c, 1 + i, bytes.get(b, i)); i = i + 1 }
+    return wrap_tlv(0x03, c)
+}
+
+encode_null() -> ptr {
+    return wrap_tlv(0x05, bytes.new(0))
+}
+
+encode_boolean(v: int) -> ptr {
+    c = bytes.new(1)
+    if v != 0 { bytes.set(c, 0, 0xFF) } else { bytes.set(c, 0, 0x00) }
+    return wrap_tlv(0x01, c)
+}
+
+// OBJECT IDENTIFIER from a dotted-decimal string.
+encode_oid(dotted: string) -> ptr {
+    // parse arcs
+    content = bytes.new(0)
+    clen = 0
+    n = string.length(dotted)
+    // collect arcs into a small list via repeated parse
+    arc1 = -1
+    arc2 = -1
+    cur = 0
+    have = 0
+    arccount = 0
+    i = 0
+    while i <= n {
+        ch = 0
+        if i < n { ch = string_char_at_n(dotted, n, i) }
+        if i == n {
+            ch = 46   // force flush of last arc
+        }
+        if ch == 46 {
+            if arccount == 0 {
+                arc1 = cur
+            } else {
+                if arccount == 1 {
+                    arc2 = cur
+                    // emit first byte = 40*arc1 + arc2
+                    bytes.set(content, clen, (40 * arc1) + arc2)
+                    clen = clen + 1
+                } else {
+                    clen = emit_base128(content, clen, cur)
+                }
+            }
+            arccount = arccount + 1
+            cur = 0
+            have = 0
+        } else {
+            cur = (cur * 10) + (ch - 48)
+            have = 1
+        }
+        i = i + 1
+    }
+    return wrap_tlv(0x06, content)
+}
+
+// emit `v` as base-128 with continuation bits into `content` at offset
+// `off`; returns the new offset.
+emit_base128(content: ptr, off: int, v: int) -> int {
+    if v == 0 {
+        bytes.set(content, off, 0)
+        return off + 1
+    }
+    // collect 7-bit groups, most-significant first
+    ngroups = 0
+    tmp = v
+    while tmp > 0 {
+        ngroups = ngroups + 1
+        tmp = tmp >> 7
+    }
+    g = ngroups - 1
+    while g >= 0 {
+        shift = g * 7
+        byteval = (v >> shift) & 0x7F
+        if g != 0 { byteval = byteval | 0x80 }   // continuation on all but last
+        bytes.set(content, off, byteval)
+        off = off + 1
+        g = g - 1
+    }
+    return off
+}
+
+// Convenience: wrap a pre-concatenated body of child TLVs as a SEQUENCE.
+// `body` is consumed (freed).
+encode_sequence(body: ptr) -> ptr {
+    return wrap_tlv(0x30, body)
+}

--- a/contrib/cryptography/pem/module.ae
+++ b/contrib/cryptography/pem/module.ae
@@ -1,0 +1,214 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.pem — PEM (RFC 7468) text <-> DER bytes codec.
+//
+// PEM is the "-----BEGIN <label>-----" / base64 body / "-----END <label>-----"
+// envelope that wraps DER-encoded keys and certificates. This module is the
+// text layer; the DER inside is handled by contrib.cryptography.asn1.
+//
+// Structure follows Bouncy Castle's PemReader / PemWriter
+// (crypto/src/util/io/pem/). The base64 codec is a pure-Aether RFC 4648
+// implementation — NO OpenSSL extern, so PEM stays self-contained and
+// matches the cryptography port's no-externs rule (issue #739).
+//
+// Surface:
+//
+//   import contrib.cryptography.pem
+//
+//   der, label, err = pem.parse(pem_text)   // first PEM block in the text
+//   text, err       = pem.encode(label, der_bytes)
+//
+//   `der` is a std.bytes (caller frees with bytes.free); `label` is the
+//   block type (e.g. "CERTIFICATE", "RSA PRIVATE KEY"). On failure
+//   parse returns (null, "", err); encode returns ("", err).
+
+import std.string
+import std.bytes
+import std.strbuilder
+
+exports (
+    parse, encode,
+    base64_decode, base64_encode
+)
+
+// ---- pure-Aether base64 (RFC 4648 standard alphabet) ----
+
+b64_alphabet() -> string {
+    return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+}
+
+// value of a base64 character, or -1 if not a base64 char (incl. '=').
+b64_val(c: int) -> int {
+    if c >= 65 { if c <= 90 { return c - 65 } }        // A-Z -> 0..25
+    if c >= 97 { if c <= 122 { return c - 71 } }       // a-z -> 26..51
+    if c >= 48 { if c <= 57 { return c + 4 } }         // 0-9 -> 52..61
+    if c == 43 { return 62 }                           // '+'
+    if c == 47 { return 63 }                           // '/'
+    return -1
+}
+
+// Decode a base64 string (ignoring whitespace/newlines) into std.bytes.
+// Returns (bytes, err). On malformed input returns (null, err).
+base64_decode(s: string) -> (ptr, string) {
+    n = string.length(s)
+    out = bytes.new(0)
+    outlen = 0
+    acc = 0      // accumulated bits
+    nbits = 0    // number of bits in acc
+    i = 0
+    while i < n {
+        c = string_char_at_n(s, n, i)
+        i = i + 1
+        // skip whitespace
+        if c == 32 { } else {
+        if c == 9 { } else {
+        if c == 10 { } else {
+        if c == 13 { } else {
+        if c == 61 {
+            // '=' padding — stop consuming data bits
+            nbits = 0
+        } else {
+            v = b64_val(c)
+            if v < 0 {
+                bytes.free(out)
+                return null, "pem: invalid base64 character"
+            }
+            acc = (acc << 6) | v
+            nbits = nbits + 6
+            if nbits >= 8 {
+                nbits = nbits - 8
+                byteval = (acc >> nbits) & 0xFF
+                bytes.set(out, outlen, byteval)
+                outlen = outlen + 1
+            }
+        }
+        }}}}
+    }
+    return out, ""
+}
+
+// Encode std.bytes as base64 (standard alphabet, '=' padded). Returns a
+// string with NO line breaks (the PEM writer inserts them at 64 cols).
+base64_encode(b: ptr) -> string {
+    alpha = b64_alphabet()
+    n = bytes.length(b)
+    sb = strbuilder.new(((n + 2) / 3) * 4 + 1)
+    i = 0
+    while i + 3 <= n {
+        b0 = bytes.get(b, i)
+        b1 = bytes.get(b, i + 1)
+        b2 = bytes.get(b, i + 2)
+        trip = (b0 << 16) | (b1 << 8) | b2
+        emit_b64_char(sb, alpha, (trip >> 18) & 0x3F)
+        emit_b64_char(sb, alpha, (trip >> 12) & 0x3F)
+        emit_b64_char(sb, alpha, (trip >> 6) & 0x3F)
+        emit_b64_char(sb, alpha, trip & 0x3F)
+        i = i + 3
+    }
+    rem = n - i
+    if rem == 1 {
+        b0 = bytes.get(b, i)
+        trip = b0 << 16
+        emit_b64_char(sb, alpha, (trip >> 18) & 0x3F)
+        emit_b64_char(sb, alpha, (trip >> 12) & 0x3F)
+        strbuilder.append_byte(sb, 61)   // '='
+        strbuilder.append_byte(sb, 61)   // '='
+    }
+    if rem == 2 {
+        b0 = bytes.get(b, i)
+        b1 = bytes.get(b, i + 1)
+        trip = (b0 << 16) | (b1 << 8)
+        emit_b64_char(sb, alpha, (trip >> 18) & 0x3F)
+        emit_b64_char(sb, alpha, (trip >> 12) & 0x3F)
+        emit_b64_char(sb, alpha, (trip >> 6) & 0x3F)
+        strbuilder.append_byte(sb, 61)   // '='
+    }
+    return strbuilder.finish(sb)
+}
+
+emit_b64_char(sb: ptr, alpha: string, v: int) {
+    strbuilder.append_byte(sb, string_char_at_n(alpha, 64, v))
+}
+
+// ---- PEM parse ----
+
+// Parse the first PEM block in `text`. Returns (der_bytes, label, "") on
+// success, (null, "", err) otherwise. Whitespace before/after is tolerated.
+parse(text: string) -> (ptr, string, string) {
+    n = string.length(text)
+    begin = "-----BEGIN "
+    bidx = string.index_of(text, begin)
+    if bidx < 0 {
+        return null, "", "pem: no BEGIN marker"
+    }
+    // label runs from after "-----BEGIN " to the closing "-----"
+    label_start = bidx + string.length(begin)
+    dashes = "-----"
+    label_end = string.index_of_from(text, dashes, label_start)
+    if label_end < 0 {
+        return null, "", "pem: malformed BEGIN line"
+    }
+    // body starts after the BEGIN line's trailing "-----"
+    body_start = label_end + string.length(dashes)
+    // END marker must match the label. Locate it BEFORE materialising the
+    // returned `label` so the error paths don't strand a heap string (the
+    // Aether tracker doesn't reclaim a heap local that's returned on one
+    // branch but dropped on another). The "-----END " token alone is enough
+    // to find the trailer; we then confirm the label between the markers.
+    end_tok = "-----END "
+    end_tok_idx = string.index_of_from(text, end_tok, body_start)
+    if end_tok_idx < 0 {
+        return null, "", "pem: no matching END marker"
+    }
+    end_label_end = string.index_of_from(text, dashes, end_tok_idx + string.length(end_tok))
+    if end_label_end < 0 {
+        return null, "", "pem: malformed END line"
+    }
+    // confirm BEGIN and END labels match
+    begin_label = string.substring(text, label_start, label_end)
+    end_label = string.substring(text, end_tok_idx + string.length(end_tok), end_label_end)
+    if string.equals(begin_label, end_label) != 1 {
+        return null, "", "pem: BEGIN/END label mismatch"
+    }
+    body = string.substring(text, body_start, end_tok_idx)
+    der, derr = base64_decode(body)
+    if string.equals(derr, "") != 1 {
+        return null, "", derr
+    }
+    return der, begin_label, ""
+}
+
+// ---- PEM encode ----
+
+// Encode DER bytes under `label` into a PEM block (LF line endings, base64
+// wrapped at 64 columns per RFC 7468). Returns (text, "").
+encode(label: string, der: ptr) -> (string, string) {
+    b64 = base64_encode(der)
+    blen = string.length(b64)
+    sb = strbuilder.new(blen + 128)
+    append_str(sb, "-----BEGIN ")
+    append_str(sb, label)
+    append_str(sb, "-----\n")
+    // wrap body at 64 chars (substrings are heap-tracked / auto-freed)
+    i = 0
+    while i < blen {
+        e = i + 64
+        if e > blen { e = blen }
+        line = string.substring(b64, i, e)
+        append_str(sb, line)
+        strbuilder.append_byte(sb, 10)   // '\n'
+        i = e
+    }
+    append_str(sb, "-----END ")
+    append_str(sb, label)
+    append_str(sb, "-----\n")
+    return strbuilder.finish(sb), ""
+}
+
+append_str(sb: ptr, s: string) {
+    strbuilder.append(sb, s)
+}

--- a/contrib/cryptography/rsa/module.ae
+++ b/contrib/cryptography/rsa/module.ae
@@ -1,0 +1,298 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.rsa — RSA, the first consumer of std.bignum.
+//
+// Pure Aether: the modular exponentiation is std.bignum.mod_pow, the key
+// is parsed from PKCS#1 DER via contrib.cryptography.asn1, and PKCS#1 v1.5
+// padding is built byte-by-byte. No OpenSSL RSA — only the OS CSPRNG
+// (std.cryptography.random_bytes) for type-2 encryption padding, which is
+// a randomness source, not a reimplemented crypto algorithm.
+//
+// Ported from Bouncy Castle's RsaCoreEngine + Pkcs1Encoding +
+// RsaDigestSigner (crypto/src/crypto/{engines,encodings,signers}/, MIT).
+//
+// Scope (this slice):
+//   - key_from_components(n, e, d) / key_free
+//   - key_from_pkcs1_der(bytes) — parse an RSAPrivateKey SEQUENCE
+//   - raw encrypt/decrypt primitives (m^e mod n / c^d mod n)
+//   - PKCS#1 v1.5 encrypt (type 2) / decrypt
+//   - PKCS#1 v1.5 sign (type 1) / verify over a caller-supplied DigestInfo
+//     blob (keeps RSA hash-agnostic; the digest+DigestInfo prefix is built
+//     by the caller, so any std.cryptography digest composes).
+//
+// NOTE: this is the textbook construction for correctness and as the first
+// bignum consumer. Constant-time decryption, OAEP, PSS, and Montgomery
+// acceleration are follow-up slices (see docs/bignum-deferred-optimizations.md
+// for the mod_pow speedup).
+
+import std.string
+import std.bignum
+import std.bytes
+import std.cryptography
+import contrib.cryptography.asn1
+
+exports (
+    key_from_components, key_from_pkcs1_der, key_free,
+    modulus_bytes, modulus_bits,
+    raw_encrypt, raw_decrypt,
+    encrypt_pkcs1, decrypt_pkcs1,
+    sign_pkcs1, verify_pkcs1
+)
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+
+// An RSA key owns its component bignums (n, e, d). For a public-only key
+// `d` is null; raw_decrypt / sign require a private key.
+struct RsaKey {
+    n: ptr    // modulus (bignum)
+    e: ptr    // public exponent (bignum)
+    d: ptr    // private exponent (bignum) or null
+}
+
+// Build a key from already-parsed bignums. The key TAKES OWNERSHIP of n,
+// e, d (frees them in key_free) — pass clones if you need to keep them.
+key_from_components(n: ptr, e: ptr, d: ptr) -> ptr {
+    k = malloc(24) as *RsaKey
+    k.n = n
+    k.e = e
+    k.d = d
+    return k
+}
+
+key_free(k: ptr) {
+    if k == null { return }
+    kk = k as *RsaKey
+    if kk.n != null { bignum.free(kk.n) }
+    if kk.e != null { bignum.free(kk.e) }
+    if kk.d != null { bignum.free(kk.d) }
+    libc_free(k)
+}
+
+// Parse a PKCS#1 RSAPrivateKey DER (SEQUENCE { version, n, e, d, p, q,
+// dp, dq, qinv }). Returns (key, "") or (null, err). We keep n, e, d and
+// free the CRT params (this slice doesn't use CRT).
+key_from_pkcs1_der(der: ptr) -> (ptr, string) {
+    r = asn1.reader_new(der)
+    sub, body, serr = asn1.read_sequence(r)
+    if string.equals(serr, "") != 1 {
+        asn1.reader_free(r)
+        return null, serr
+    }
+    ver, verr = asn1.read_integer(sub)
+    if string.equals(verr, "") != 1 {
+        asn1.reader_free(sub); bytes.free(body); asn1.reader_free(r)
+        return null, verr
+    }
+    bignum.free(ver)
+    n, nerr = asn1.read_integer(sub)
+    e, eerr = asn1.read_integer(sub)
+    d, derr = asn1.read_integer(sub)
+    asn1.reader_free(sub); bytes.free(body); asn1.reader_free(r)
+    if string.equals(nerr, "") != 1 { return null, nerr }
+    if string.equals(eerr, "") != 1 { return null, eerr }
+    if string.equals(derr, "") != 1 { return null, derr }
+    return key_from_components(n, e, d), derr
+}
+
+// Byte length of the modulus (the RSA block size k).
+modulus_bytes(k: ptr) -> int {
+    kk = k as *RsaKey
+    return (bignum.bit_length(kk.n) + 7) / 8
+}
+
+modulus_bits(k: ptr) -> int {
+    kk = k as *RsaKey
+    return bignum.bit_length(kk.n)
+}
+
+// ---- raw primitives ----
+//
+// raw_encrypt: m^e mod n. raw_decrypt: c^d mod n. Input/output are
+// fixed-width k-byte big-endian std.bytes (caller frees). The integer
+// must be < n; callers go through the PKCS#1 wrappers normally.
+raw_encrypt(k: ptr, m_bytes: ptr) -> ptr {
+    kk = k as *RsaKey
+    klen = modulus_bytes(k)
+    m = bignum.from_bytes_unsigned(m_bytes, bytes.length(m_bytes))
+    c = bignum.mod_pow(m, kk.e, kk.n)
+    out = to_fixed(c, klen)
+    bignum.free(m); bignum.free(c)
+    return out
+}
+
+raw_decrypt(k: ptr, c_bytes: ptr) -> ptr {
+    kk = k as *RsaKey
+    klen = modulus_bytes(k)
+    c = bignum.from_bytes_unsigned(c_bytes, bytes.length(c_bytes))
+    m = bignum.mod_pow(c, kk.d, kk.n)
+    out = to_fixed(m, klen)
+    bignum.free(c); bignum.free(m)
+    return out
+}
+
+// bignum -> exactly `width` big-endian bytes, left-zero-padded. The
+// unsigned magnitude is right-aligned into a fresh std.bytes.
+to_fixed(n: ptr, width: int) -> ptr {
+    mag = bignum.to_bytes_unsigned(n)
+    mlen = bytes.length(mag)
+    out = bytes.new(width)
+    z = 0
+    while z < width { bytes.set(out, z, 0); z = z + 1 }
+    // copy mag into the low (rightmost) bytes
+    off = width - mlen
+    i = 0
+    while i < mlen {
+        if off + i >= 0 {
+            bytes.set(out, off + i, bytes.get(mag, i))
+        }
+        i = i + 1
+    }
+    bytes.free(mag)
+    return out
+}
+
+// ---- PKCS#1 v1.5 ----
+//
+// EME-PKCS1-v1_5 encryption block (type 2):
+//   0x00 || 0x02 || PS(random nonzero, >= 8 bytes) || 0x00 || M
+// Returns (ciphertext_bytes, "") or (null, err). `msg` must satisfy
+// len(msg) <= k - 11.
+encrypt_pkcs1(k: ptr, msg: ptr) -> (ptr, string) {
+    klen = modulus_bytes(k)
+    mlen = bytes.length(msg)
+    if mlen > klen - 11 {
+        return null, "rsa: message too long for PKCS#1 v1.5"
+    }
+    block = bytes.new(klen)
+    bytes.set(block, 0, 0x00)
+    bytes.set(block, 1, 0x02)
+    pslen = klen - mlen - 3
+    // fill PS with nonzero random bytes
+    rnd, rn, rerr = cryptography.random_bytes(pslen * 2 + 16)
+    if string.equals(rerr, "") != 1 {
+        bytes.free(block)
+        return null, rerr
+    }
+    filled = 0
+    ri = 0
+    while filled < pslen {
+        rb = 0
+        if ri < rn { rb = string_char_at_n(rnd, rn, ri) & 0xFF }
+        ri = ri + 1
+        if rb != 0 {
+            bytes.set(block, 2 + filled, rb)
+            filled = filled + 1
+        }
+        // if we run out of random, top up deterministically with a nonzero
+        if ri >= rn { ri = 0 }
+    }
+    bytes.set(block, 2 + pslen, 0x00)
+    i = 0
+    while i < mlen {
+        bytes.set(block, 3 + pslen + i, bytes.get(msg, i))
+        i = i + 1
+    }
+    c = raw_encrypt(k, block)
+    bytes.free(block)
+    string.free(rnd)
+    return c, rerr
+}
+
+// Decrypt + strip PKCS#1 v1.5 type-2 padding. Returns (message, "") or
+// (null, err). (Not constant-time — a hardening follow-up.)
+decrypt_pkcs1(k: ptr, ct: ptr) -> (ptr, string) {
+    klen = modulus_bytes(k)
+    block = raw_decrypt(k, ct)
+    // expect 0x00 0x02 PS 0x00 M
+    ok = 1
+    if bytes.get(block, 0) != 0x00 { ok = 0 }
+    if bytes.get(block, 1) != 0x02 { ok = 0 }
+    // find the 0x00 separator after >= 8 padding bytes
+    sep = -1
+    i = 2
+    while i < klen {
+        if bytes.get(block, i) == 0x00 {
+            sep = i
+            i = klen
+        } else {
+            i = i + 1
+        }
+    }
+    if sep < 0 { ok = 0 }
+    if ok == 1 { if sep < 10 { ok = 0 } }   // 2 prefix + >=8 PS
+    if ok != 1 {
+        bytes.free(block)
+        return null, "rsa: PKCS#1 v1.5 decryption error"
+    }
+    mlen = klen - sep - 1
+    out = bytes.new(mlen)
+    j = 0
+    while j < mlen {
+        bytes.set(out, j, bytes.get(block, sep + 1 + j))
+        j = j + 1
+    }
+    bytes.free(block)
+    return out, ""
+}
+
+// ---- PKCS#1 v1.5 signatures (type 1) ----
+//
+// EMSA-PKCS1-v1_5 over a caller-supplied DigestInfo blob `di` (the DER
+// of the AlgorithmIdentifier+digest; the caller composes it so RSA stays
+// hash-agnostic):
+//   0x00 || 0x01 || PS(0xFF, >= 8 bytes) || 0x00 || di
+// sign returns the raw signature (k bytes). verify recomputes the block
+// and compares.
+sign_pkcs1(k: ptr, di: ptr) -> (ptr, string) {
+    klen = modulus_bytes(k)
+    dlen = bytes.length(di)
+    if dlen > klen - 11 {
+        return null, "rsa: DigestInfo too long for modulus"
+    }
+    block = build_emsa(di, klen)
+    s = raw_decrypt(k, block)   // signing = private-key op (c^d mod n)
+    bytes.free(block)
+    return s, ""
+}
+
+// verify: public-key op on the signature, rebuild the expected EMSA block
+// from `di`, compare byte-for-byte. Returns 1 (valid) / 0 (invalid).
+verify_pkcs1(k: ptr, di: ptr, sig: ptr) -> int {
+    klen = modulus_bytes(k)
+    recovered = raw_encrypt(k, sig)   // s^e mod n
+    expected = build_emsa(di, klen)
+    ok = 1
+    if bytes.length(recovered) != bytes.length(expected) { ok = 0 }
+    if ok == 1 {
+        i = 0
+        while i < bytes.length(expected) {
+            if bytes.get(recovered, i) != bytes.get(expected, i) { ok = 0 }
+            i = i + 1
+        }
+    }
+    bytes.free(recovered); bytes.free(expected)
+    return ok
+}
+
+// Build the type-1 EMSA block: 0x00 0x01 FF...FF 0x00 di  (k bytes).
+build_emsa(di: ptr, klen: int) -> ptr {
+    dlen = bytes.length(di)
+    block = bytes.new(klen)
+    bytes.set(block, 0, 0x00)
+    bytes.set(block, 1, 0x01)
+    pslen = klen - dlen - 3
+    i = 0
+    while i < pslen { bytes.set(block, 2 + i, 0xFF); i = i + 1 }
+    bytes.set(block, 2 + pslen, 0x00)
+    j = 0
+    while j < dlen {
+        bytes.set(block, 3 + pslen + j, bytes.get(di, j))
+        j = j + 1
+    }
+    return block
+}

--- a/tests/leaks_known.txt
+++ b/tests/leaks_known.txt
@@ -15,3 +15,13 @@
 # returned to the OS at exit. Confirmed: an explicit atexit(OPENSSL_cleanup)
 # changed the leaks count by zero.
 test_cryptography_hmac_md4_md5 122
+
+# test_rsa_pkcs1 uses std.cryptography.random_bytes (OpenSSL RAND) for
+# PKCS#1 v1.5 type-2 padding, so it inherits the same OPENSSL_cleanup
+# atexit false-positive as the entry above (memory returned to the OS at
+# exit; leaks(1) --atExit samples before atexit handlers run). The small
+# remainder is the Aether heap-string-tracker's empty-string ("") quirk on
+# cross-module (ptr, string) success returns — 1 byte each, exit-only,
+# documented in feedback_aether_heap_string_no_manual_free; tracked for a
+# compiler fix. Cap covers both with no headroom for a real regression.
+test_rsa_pkcs1 130

--- a/tests/regression/test_asn1_der.ae
+++ b/tests/regression/test_asn1_der.ae
@@ -1,0 +1,127 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// Regression: contrib.cryptography.asn1 DER parser + emitter (issue #739).
+// The headline case parses a REAL RSA-512 PKCS#1 private key emitted by
+// `openssl rsa -traditional -outform DER`, checks the modulus/exponent
+// against `openssl rsa -text`, then re-encodes all nine INTEGERs back into
+// a SEQUENCE and asserts the result is byte-identical to the original DER.
+// Plus targeted OID / INTEGER / SEQUENCE / length-form encode vectors.
+
+import contrib.cryptography.asn1
+import std.bytes
+import std.bignum
+import std.string
+
+hv(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    return 0
+}
+hb(h: string) -> ptr {
+    n = string.length(h); b = bytes.new(n / 2); i = 0
+    while i < n { bytes.set(b, i / 2, hv(string_char_at_n(h, n, i)) * 16 + hv(string_char_at_n(h, n, i + 1))); i = i + 2 }
+    return b
+}
+bhex(b: ptr) -> string {
+    d = "0123456789abcdef"; out = ""; n = bytes.length(b); i = 0
+    while i < n {
+        v = bytes.get(b, i)
+        out = string.concat(out, string.concat(string.substring(d, (v / 16) & 15, ((v / 16) & 15) + 1), string.substring(d, v & 15, (v & 15) + 1)))
+        i = i + 1
+    }
+    return out
+}
+cat_into(dst: ptr, doff: int, src: ptr) -> int {
+    n = bytes.length(src); i = 0
+    while i < n { bytes.set(dst, doff + i, bytes.get(src, i)); i = i + 1 }
+    return doff + n
+}
+
+// real RSA-512 PKCS#1 RSAPrivateKey DER (openssl genrsa 512 -traditional)
+RSA512_DER() -> string {
+    return "3082013b020100024100c371e9b9bf96ae5babab1d6d4fdc0b9220370dddbeb582047d4db7f84cdd363a4e58d89ca6f7fef8f598d889b066f6d3b889662ef90e77a10777c3d11c1663db020301000102401c7ae7022846fed560e8a87b1b5e07599dd427f31e2d38eb0a8f5eb5920dd22edfaaa1a5aab543a67ed8430c43184453cbc017dada257136bd935d38f9684b41022100e877ee2e62a69a8a07a44493fff6742ee751db2c3d564884b05ccb337bc1798b022100d73a9308c4cd637988123a85195858b7945ea31c69e617f1f7151b221607e8f1022100ae0872e888f41f07acb6de9c49e8908c38a2c0493b56280e2616220dd5dd3f07022059adab542d04535d7127ff4034264e98f776534a64899e1290dc3779056af851022100c3bf2d99dfcd11e6331fd34e027e340ef6e1e6235ba54300f67bc8cb89864ab5"
+}
+
+main() {
+    print("=== contrib.cryptography.asn1 DER ===\n")
+    fails = 0
+
+    // ---- targeted encode vectors ----
+    oidt = asn1.encode_oid("1.2.840.113549.1.1.1")   // rsaEncryption
+    if string.equals(bhex(oidt), "06092a864886f70d010101") != 1 { print("FAIL oid encode\n"); fails = fails + 1 }
+    ro = asn1.reader_new(oidt)
+    od, oerr = asn1.read_oid(ro)
+    if string.equals(oerr, "") != 1 { print("FAIL oid read err\n"); fails = fails + 1 }
+    if string.equals(od, "1.2.840.113549.1.1.1") != 1 { print("FAIL oid decode\n"); fails = fails + 1 }
+    asn1.reader_free(ro); bytes.free(oidt)
+
+    e = bignum.from_int(65537)
+    et = asn1.encode_integer(e)
+    if string.equals(bhex(et), "0203010001") != 1 { print("FAIL int encode\n"); fails = fails + 1 }
+    bignum.free(e); bytes.free(et)
+
+    // length long-form: 200-byte content -> 0x81 0xC8
+    ll = asn1.encode_len(200)
+    if string.equals(bhex(ll), "81c8") != 1 { print("FAIL len long-form\n"); fails = fails + 1 }
+    bytes.free(ll)
+
+    // ---- real RSA key parse + byte-identical re-encode ----
+    orig = hb(RSA512_DER())
+    r = asn1.reader_new(orig)
+    sub, body, serr = asn1.read_sequence(r)
+    if string.equals(serr, "") != 1 { print("FAIL seq: ${serr}\n"); fails = fails + 1 }
+
+    ver, verr = asn1.read_integer(sub)
+    if string.equals(verr, "") != 1 { print("FAIL ver err\n"); fails = fails + 1 }
+    if string.equals(bignum.to_hex(ver), "0") != 1 { print("FAIL version\n"); fails = fails + 1 }
+
+    n, nerr = asn1.read_integer(sub)
+    if string.equals(nerr, "") != 1 { print("FAIL n err\n"); fails = fails + 1 }
+    en = "c371e9b9bf96ae5babab1d6d4fdc0b9220370dddbeb582047d4db7f84cdd363a4e58d89ca6f7fef8f598d889b066f6d3b889662ef90e77a10777c3d11c1663db"
+    if string.equals(bignum.to_hex(n), en) != 1 { print("FAIL modulus\n"); fails = fails + 1 }
+
+    e2, e2err = asn1.read_integer(sub)
+    if string.equals(e2err, "") != 1 { print("FAIL e err\n"); fails = fails + 1 }
+    if string.equals(bignum.to_hex(e2), "10001") != 1 { print("FAIL exponent\n"); fails = fails + 1 }
+
+    // re-encode: version + n + e already read; read the remaining 6 and
+    // rebuild the whole 9-INTEGER SEQUENCE, comparing to the original.
+    out = bytes.new(0); off = 0
+    tv = asn1.encode_integer(ver); off = cat_into(out, off, tv); bytes.free(tv)
+    tn = asn1.encode_integer(n); off = cat_into(out, off, tn); bytes.free(tn)
+    te = asn1.encode_integer(e2); off = cat_into(out, off, te); bytes.free(te)
+    bignum.free(ver); bignum.free(n); bignum.free(e2)
+    cnt = 0
+    while cnt < 6 {
+        m, merr = asn1.read_integer(sub)
+        if string.equals(merr, "") != 1 { print("FAIL int ${cnt}\n"); fails = fails + 1 }
+        tm = asn1.encode_integer(m); off = cat_into(out, off, tm); bytes.free(tm)
+        bignum.free(m)
+        cnt = cnt + 1
+    }
+    reseq = asn1.encode_sequence(out)
+    ok = 1
+    if bytes.length(reseq) != bytes.length(orig) { ok = 0 }
+    if ok == 1 {
+        i = 0
+        while i < bytes.length(orig) {
+            if bytes.get(reseq, i) != bytes.get(orig, i) { ok = 0 }
+            i = i + 1
+        }
+    }
+    if ok != 1 { print("FAIL DER round-trip not byte-identical\n"); fails = fails + 1 }
+
+    asn1.reader_free(sub); bytes.free(body); asn1.reader_free(r)
+    bytes.free(orig); bytes.free(reseq)
+
+    if fails == 0 {
+        print("PASS: contrib.cryptography.asn1 DER\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}

--- a/tests/regression/test_pem_codec.ae
+++ b/tests/regression/test_pem_codec.ae
@@ -1,0 +1,76 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// Regression: contrib.cryptography.pem (issue #739). Pure-Aether RFC 4648
+// base64 + RFC 7468 PEM envelope. Covers the canonical base64 vectors
+// ("Man"/"TWFu", "Ma"/"TWE=", "M"/"TQ=="), a full encode->parse round-trip
+// over a 256-byte binary payload (exercises 64-col line wrapping and label
+// matching), and a label-mismatch / missing-marker error path.
+
+import contrib.cryptography.pem
+import std.bytes
+import std.string
+
+bstr(s: string) -> ptr {
+    n = string.length(s); b = bytes.new(n); i = 0
+    while i < n { bytes.set(b, i, string_char_at_n(s, n, i)); i = i + 1 }
+    return b
+}
+bascii(b: ptr) -> string {
+    out = ""; n = bytes.length(b); i = 0
+    while i < n { out = string.concat(out, string.from_char(bytes.get(b, i))); i = i + 1 }
+    return out
+}
+
+main() {
+    print("=== contrib.cryptography.pem ===\n")
+    fails = 0
+
+    // base64 known vectors (RFC 4648 §10)
+    man = bstr("Man")
+    if string.equals(pem.base64_encode(man), "TWFu") != 1 { print("FAIL b64 Man\n"); fails = fails + 1 }
+    bytes.free(man)
+    ma = bstr("Ma")
+    if string.equals(pem.base64_encode(ma), "TWE=") != 1 { print("FAIL b64 Ma\n"); fails = fails + 1 }
+    bytes.free(ma)
+    m1 = bstr("M")
+    if string.equals(pem.base64_encode(m1), "TQ==") != 1 { print("FAIL b64 M\n"); fails = fails + 1 }
+    bytes.free(m1)
+
+    // base64 decode of a padded vector
+    dec, derr = pem.base64_decode("TWFu")
+    if string.equals(derr, "") != 1 { print("FAIL b64 decode err\n"); fails = fails + 1 }
+    if string.equals(bascii(dec), "Man") != 1 { print("FAIL b64 decode Man\n"); fails = fails + 1 }
+    bytes.free(dec)
+
+    // full PEM encode -> parse round-trip over 256 binary bytes
+    payload = bytes.new(256); i = 0
+    while i < 256 { bytes.set(payload, i, (i * 31 + 7) & 0xFF); i = i + 1 }
+    text, eerr = pem.encode("TEST KEY", payload)
+    if string.equals(eerr, "") != 1 { print("FAIL encode err\n"); fails = fails + 1 }
+    // header/footer present
+    if string.contains(text, "-----BEGIN TEST KEY-----") != 1 { print("FAIL no begin\n"); fails = fails + 1 }
+    if string.contains(text, "-----END TEST KEY-----") != 1 { print("FAIL no end\n"); fails = fails + 1 }
+    der, label, perr = pem.parse(text)
+    if string.equals(perr, "") != 1 { print("FAIL parse err: ${perr}\n"); fails = fails + 1 }
+    if string.equals(label, "TEST KEY") != 1 { print("FAIL label ${label}\n"); fails = fails + 1 }
+    rt = 1
+    if bytes.length(der) != 256 { rt = 0 }
+    if rt == 1 { j = 0; while j < 256 { if bytes.get(der, j) != ((j * 31 + 7) & 0xFF) { rt = 0 } j = j + 1 } }
+    if rt != 1 { print("FAIL round-trip bytes\n"); fails = fails + 1 }
+    bytes.free(der); bytes.free(payload)
+
+    // error path: missing END marker
+    bad, blabel, berr = pem.parse("-----BEGIN X-----\nTWFu\n")
+    if string.equals(berr, "") == 1 { print("FAIL missing-END not rejected\n"); fails = fails + 1 }
+
+    if fails == 0 {
+        print("PASS: contrib.cryptography.pem\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}

--- a/tests/regression/test_rsa_pkcs1.ae
+++ b/tests/regression/test_rsa_pkcs1.ae
@@ -1,0 +1,109 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// Regression: contrib.cryptography.rsa raw + PKCS#1 v1.5 (issue #739), the
+// first end-to-end consumer of std.bignum. All fixtures are produced by
+// OpenSSL against a real RSA-512 key, so this cross-validates the whole
+// stack (bignum.mod_pow -> ASN.1 key parse -> PKCS#1 padding) against the
+// reference implementation:
+//   - parse the PKCS#1 RSAPrivateKey DER (openssl genrsa -traditional)
+//   - decrypt a ciphertext OpenSSL produced (openssl pkeyutl -encrypt)
+//   - our PKCS#1 v1.5 SHA-256 signature is BYTE-IDENTICAL to OpenSSL's
+//     (openssl dgst -sha256 -sign), and we verify OpenSSL's signature
+//   - self round-trips for encrypt/decrypt and sign/verify + tamper reject
+//
+// RSA-512 is used so the test runs fast in CI; the code path is size-agnostic.
+
+import contrib.cryptography.rsa
+import std.bytes
+import std.string
+
+hv(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    return 0
+}
+hb(h: string) -> ptr {
+    n = string.length(h); b = bytes.new(n / 2); i = 0
+    while i < n { bytes.set(b, i / 2, hv(string_char_at_n(h, n, i)) * 16 + hv(string_char_at_n(h, n, i + 1))); i = i + 2 }
+    return b
+}
+bhex(b: ptr) -> string {
+    d = "0123456789abcdef"; out = ""; n = bytes.length(b); i = 0
+    while i < n {
+        v = bytes.get(b, i)
+        out = string.concat(out, string.concat(string.substring(d, (v / 16) & 15, ((v / 16) & 15) + 1), string.substring(d, v & 15, (v & 15) + 1)))
+        i = i + 1
+    }
+    return out
+}
+beq(a: ptr, b: ptr) -> int {
+    if bytes.length(a) != bytes.length(b) { return 0 }
+    i = 0
+    while i < bytes.length(a) { if bytes.get(a, i) != bytes.get(b, i) { return 0 } i = i + 1 }
+    return 1
+}
+
+KEY_DER() -> string { return "3082013b020100024100c371e9b9bf96ae5babab1d6d4fdc0b9220370dddbeb582047d4db7f84cdd363a4e58d89ca6f7fef8f598d889b066f6d3b889662ef90e77a10777c3d11c1663db020301000102401c7ae7022846fed560e8a87b1b5e07599dd427f31e2d38eb0a8f5eb5920dd22edfaaa1a5aab543a67ed8430c43184453cbc017dada257136bd935d38f9684b41022100e877ee2e62a69a8a07a44493fff6742ee751db2c3d564884b05ccb337bc1798b022100d73a9308c4cd637988123a85195858b7945ea31c69e617f1f7151b221607e8f1022100ae0872e888f41f07acb6de9c49e8908c38a2c0493b56280e2616220dd5dd3f07022059adab542d04535d7127ff4034264e98f776534a64899e1290dc3779056af851022100c3bf2d99dfcd11e6331fd34e027e340ef6e1e6235ba54300f67bc8cb89864ab5" }
+OSSL_SIG() -> string { return "4939dd00dca0a7be1dbada403905fd9c9efdd658ca730bcdaa916715721cec8051ff3b8eee8dbb3af7cc8dd6ccaf3acbcdfbe359e7b0243fdfe3db33cb13b9bc" }
+OSSL_CT() -> string { return "7641b9456e75cadce8ea7d8c9e98c6fa94b204cb2b09d5cfad5188f67d4e52b313d0103c79e0fd466ceaf10b686766ebfddfa2428d63374987258d806c394e58" }
+DIGEST_INFO() -> string { return "3031300d06096086480165030402010500042012dca15385cb4f9629b0366561a5ede04d8a955605f41cdc693d774621b23f66" }   // SHA-256 DigestInfo of "hello rsa"
+PLAINTEXT() -> string { return "696e7465726f7021" }     // "interop!" that OSSL_CT decrypts to
+
+main() {
+    print("=== contrib.cryptography.rsa PKCS#1 ===\n")
+    fails = 0
+
+    der = hb(KEY_DER())
+    k, kerr = rsa.key_from_pkcs1_der(der)
+    bytes.free(der)
+    if string.equals(kerr, "") != 1 { print("FAIL key parse: ${kerr}\n"); exit(1) }
+    if rsa.modulus_bits(k) != 512 { print("FAIL modulus bits ${rsa.modulus_bits(k)}\n"); fails = fails + 1 }
+
+    // decrypt OpenSSL's PKCS#1 v1.5 ciphertext
+    ct = hb(OSSL_CT())
+    pt, perr = rsa.decrypt_pkcs1(k, ct)
+    if string.equals(perr, "") != 1 { print("FAIL decrypt openssl ct: ${perr}\n"); fails = fails + 1 }
+    expect_pt = hb(PLAINTEXT())
+    if beq(pt, expect_pt) != 1 { print("FAIL openssl ct plaintext ${bhex(pt)}\n"); fails = fails + 1 }
+    bytes.free(ct); bytes.free(pt); bytes.free(expect_pt)
+
+    // our PKCS#1 v1.5 signature must equal OpenSSL's, and we verify OpenSSL's
+    di = hb(DIGEST_INFO())
+    ours, sgerr = rsa.sign_pkcs1(k, di)
+    if string.equals(sgerr, "") != 1 { print("FAIL sign err\n"); fails = fails + 1 }
+    if string.equals(bhex(ours), OSSL_SIG()) != 1 { print("FAIL sig != openssl\n"); fails = fails + 1 }
+    osig = hb(OSSL_SIG())
+    if rsa.verify_pkcs1(k, di, osig) != 1 { print("FAIL verify openssl sig\n"); fails = fails + 1 }
+    bytes.free(ours); bytes.free(osig)
+
+    // tamper -> reject
+    di2 = hb(DIGEST_INFO())
+    bytes.set(di2, 5, (bytes.get(di2, 5) ^ 0xFF) & 0xFF)
+    sig2, sg2err = rsa.sign_pkcs1(k, di)
+    if string.equals(sg2err, "") != 1 { fails = fails + 1 }
+    if rsa.verify_pkcs1(k, di2, sig2) != 0 { print("FAIL tamper accepted\n"); fails = fails + 1 }
+    bytes.free(sig2); bytes.free(di2); bytes.free(di)
+
+    // self encrypt/decrypt round-trip
+    msg = bytes.new(0); m = 0
+    while m < 16 { bytes.set(msg, m, (m * 17 + 3) & 0xFF); m = m + 1 }
+    ec, ecerr = rsa.encrypt_pkcs1(k, msg)
+    if string.equals(ecerr, "") != 1 { print("FAIL encrypt: ${ecerr}\n"); fails = fails + 1 }
+    rt, rterr = rsa.decrypt_pkcs1(k, ec)
+    if string.equals(rterr, "") != 1 { print("FAIL decrypt: ${rterr}\n"); fails = fails + 1 }
+    if beq(rt, msg) != 1 { print("FAIL enc/dec round-trip\n"); fails = fails + 1 }
+    bytes.free(ec); bytes.free(rt); bytes.free(msg)
+
+    rsa.key_free(k)
+
+    if fails == 0 {
+        print("PASS: contrib.cryptography.rsa PKCS#1\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}


### PR DESCRIPTION
The format layer that turns `std.bignum` into usable **RSA** — three new pure-Aether contrib modules, ported from Bouncy Castle (MIT). The only extern is the OS CSPRNG (`std.cryptography.random_bytes`) for PKCS#1 v1.5 padding randomness; no OpenSSL RSA.

This is the Tier-3 format infra from issue #739 that the BigInteger work unblocked, plus RSA as its first real consumer (all in one PR per request).

## Modules

- **`contrib.cryptography.pem`** — RFC 7468 `parse` / `encode` over a self-contained RFC 4648 base64 codec (no extern base64). 64-column wrapping, BEGIN/END label-match validation.
- **`contrib.cryptography.asn1`** — ASN.1 **DER** parser + emitter over `std.bytes`. Generic TLV read (`last_tag`) + typed INTEGER (via `std.bignum`), SEQUENCE, OBJECT IDENTIFIER, OCTET/BIT STRING, NULL, BOOLEAN.
- **`contrib.cryptography.rsa`** — first `std.bignum` consumer. Key from components or PKCS#1 `RSAPrivateKey` DER; raw `m^e`/`c^d mod n` via `bignum.mod_pow`; PKCS#1 v1.5 encrypt/decrypt + sign/verify over a caller-supplied DigestInfo (so RSA stays hash-agnostic).

## Verification — cross-validated against OpenSSL

On a real OpenSSL-generated RSA key:
- we **decrypt an OpenSSL PKCS#1 v1.5 ciphertext** back to plaintext
- we **verify an OpenSSL SHA-256 signature**
- **our PKCS#1 v1.5 signature is byte-identical to OpenSSL's** (deterministic v1.5)
- the ASN.1 codec **re-encodes a real key's DER byte-for-byte**

All three modules ASan-clean. Regressions: `tests/regression/test_{pem_codec,asn1_der,rsa_pkcs1}.ae`. The RSA test's `leaks_known.txt` budget covers the OpenSSL `OPENSSL_cleanup` atexit false-positive (from `random_bytes`) plus a few heap-string-tracker empty-string bytes.

## Attribution

Bouncy Castle (MIT) only — **no Go stdlib used**, so no new license/attribution is needed beyond the existing MIT block in `THIRD_PARTY_LICENSES.md`. (Considered Go's PEM/ASN.1 as the roadmap suggested, but bc-csharp's `asn1/` was already MIT-credited and avoided adding a second license.)

## Follow-ups

Constant-time RSA decryption, OAEP, PSS, and X.509/PKCS#8 parsing are later slices. Also folds in `aeo-freebsd-sandbox-parity-revival.md` — an inbound ask doc from the **aeo** sibling tool requesting revival of `feat/freebsd-sandbox-parity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)