### PR TITLE
feat(contrib.cryptography.aes): AES-128/192/256 + ECB + CTR (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [0.291.0]
+
+### Added
+
+- **`contrib.cryptography.aes` — AES (FIPS-197)** (issue #739) — the
+  block-cipher core that unblocks the entire symmetric surface (CBC / CTR /
+  CFB / OFB / ECB / GCM / CCM / EAX / OCB / AES-key-wrap / AES-CMAC /
+  AES-CTR-DRBG all drive exactly this primitive). Pure Aether, byte-oriented
+  FIPS-197 reference form (256-byte S-box + inverse, GF(2⁸) `xtime`) — chosen
+  over Bouncy Castle's T-box `AesEngine` for auditability and to avoid the
+  cache-timing surface of big T-tables (a T-box/AES-NI fast path is a later
+  perf slice). 128/192/256-bit keys. Surface: `new_encryptor` / `new_decryptor`
+  / `process_block` (the 16-byte primitive the modes call), plus `ecb_encrypt`
+  / `ecb_decrypt` (block-aligned, no padding) and `ctr_xor` (CTR stream).
+  Verified against the FIPS-197 Appendix B/C known-answer vectors for all three
+  key sizes and the NIST SP800-38A F.5 AES-128-CTR vector (also reproduced via
+  `openssl enc -aes-128-ctr`); ASan-clean. Regression:
+  `tests/regression/test_aes.ae`. No OpenSSL AES — the round functions, key
+  schedule, and modes are all Aether. Padded modes (CBC/PKCS#7), the AEADs
+  (GCM/CCM/ChaCha20-Poly1305), and key-wrap are follow-up slices on this core.
+
 ## [0.290.0]
 
 ### Added

--- a/contrib/cryptography/aes/module.ae
+++ b/contrib/cryptography/aes/module.ae
@@ -1,0 +1,330 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.aes — AES (FIPS-197), the block-cipher core that
+// every symmetric mode drives. This is the "log-jam remover" for issue
+// #739's symmetric surface: CBC / CTR / CFB / OFB / ECB / GCM / CCM / EAX /
+// OCB / AES-key-wrap / AES-CMAC / AES-CTR-DRBG all sit on exactly this
+// primitive and nothing else.
+//
+// Byte-oriented FIPS-197 reference form (one 256-byte S-box + inverse,
+// GF(2^8) xtime for MixColumns) rather than Bouncy Castle's T-box
+// `AesEngine.cs`. Smaller, obviously correct against the FIPS-197 / NIST KAT
+// vectors, and not cache-timing-leaky the way big T-tables are. A T-box /
+// AES-NI fast path is a later perf slice; the mode layers don't care which
+// sits underneath. Algorithm + S-box from FIPS-197; structure follows
+// Bouncy Castle's AesEngine.
+//
+// Block primitive (what modes call):
+//   ctx   = aes.new_encryptor(key_bytes, key_len)   // key_len = 16/24/32
+//   ctx   = aes.new_decryptor(key_bytes, key_len)
+//   out16 = aes.process_block(ctx, in16)            // single 16-byte block
+//   aes.free(ctx)
+//
+// Convenience modes in this slice:
+//   aes.ecb_encrypt / ecb_decrypt  — block-aligned, NO padding
+//   aes.ctr_xor                    — CTR keystream over arbitrary length
+//
+// All buffers are std.bytes (caller frees results).
+
+import std.bytes
+import std.bits
+import std.intarr
+import std.string
+
+exports (
+    new_encryptor, new_decryptor, process_block, free,
+    block_size, ecb_encrypt, ecb_decrypt, ctr_xor
+)
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+
+block_size() -> int { return 16 }
+
+// Round-key schedule (bytes, 16*(rounds+1) slots), round count, direction.
+struct AesCtx {
+    rk: ptr       // intarr of round-key bytes
+    rounds: int
+    encrypt: int  // 1 = encryptor, 0 = decryptor
+}
+
+// ---- S-boxes (FIPS-197) ----
+SBOX_HEX() -> string {
+    return "637c777bf26b6fc53001672bfed7ab76ca82c97dfa5947f0add4a2af9ca472c0b7fd9326363ff7cc34a5e5f171d8311504c723c31896059a071280e2eb27b27509832c1a1b6e5aa0523bd6b329e32f8453d100ed20fcb15b6acbbe394a4c58cfd0efaafb434d338545f9027f503c9fa851a3408f929d38f5bcb6da2110fff3d2cd0c13ec5f974417c4a77e3d645d197360814fdc222a908846eeb814de5e0bdbe0323a0a4906245cc2d3ac629195e479e7c8376d8dd54ea96c56f4ea657aae08ba78252e1ca6b4c6e8dd741f4bbd8b8a703eb5664803f60e613557b986c11d9ee1f8981169d98e949b1e87e9ce5528df8ca1890dbfe6426841992d0fb054bb16"
+}
+ISBOX_HEX() -> string {
+    return "52096ad53036a538bf40a39e81f3d7fb7ce339829b2fff87348e4344c4dee9cb547b9432a6c2233dee4c950b42fac34e082ea16628d924b2765ba2496d8bd12572f8f66486689816d4a45ccc5d65b6926c704850fdedb9da5e154657a78d9d8490d8ab008cbcd30af7e45805b8b34506d02c1e8fca3f0f02c1afbd0301138a6b3a9111414f67dcea97f2cfcef0b4e67396ac7422e7ad3585e2f937e81c75df6e47f11a711d29c5896fb7620eaa18be1bfc563e4bc6d279209adbc0fe78cd5af41fdda8338807c731b11210592780ec5f60517fa919b54a0d2de57a9f93c99cefa0e03b4dae2af5b0c8ebbb3c83539961172b047eba77d626e169146355210c7d"
+}
+
+hexval(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    return 0
+}
+// 256-byte table from a 512-char hex string.
+make_box(h: string) -> ptr {
+    t = intarr_new_raw(256)
+    n = string.length(h)
+    i = 0
+    idx = 0
+    while i + 1 < n {
+        hi = hexval(string_char_at_n(h, n, i))
+        lo = hexval(string_char_at_n(h, n, i + 1))
+        intarr_set_raw(t, idx, (hi * 16 + lo) & 0xFF)
+        idx = idx + 1
+        i = i + 2
+    }
+    return t
+}
+
+// ---- GF(2^8) ----
+xtime(x: int) -> int {
+    r = (x << 1) & 0xFF
+    if (x & 0x80) != 0 { r = r ^ 0x1b }
+    return r & 0xFF
+}
+gmul(a: int, b: int) -> int {
+    p = 0
+    aa = a & 0xFF
+    bb = b & 0xFF
+    k = 0
+    while k < 8 {
+        if (bb & 1) != 0 { p = p ^ aa }
+        aa = xtime(aa)
+        bb = bits.lsr32(bb, 1)
+        k = k + 1
+    }
+    return p & 0xFF
+}
+
+// state accessors (state is a 16-slot intarr, column-major: idx = col*4 + row)
+g(s: ptr, i: int) -> int { return intarr_get_raw(s, i) & 0xFF }
+p(s: ptr, i: int, v: int) { intarr_set_raw(s, i, v & 0xFF) }
+
+// ---- key expansion ----
+new_ctx(key: ptr, keylen: int, sbox: ptr, encrypt: int) -> ptr {
+    nk = keylen / 4            // 4 / 6 / 8
+    rounds = nk + 6            // 10 / 12 / 14
+    total_words = 4 * (rounds + 1)
+    w = intarr_new_raw(total_words * 4)
+    i = 0
+    while i < nk * 4 {
+        intarr_set_raw(w, i, bytes.get(key, i) & 0xFF)
+        i = i + 1
+    }
+    rcon = 1
+    wi = nk
+    while wi < total_words {
+        pp = (wi - 1) * 4
+        t0 = intarr_get_raw(w, pp + 0) & 0xFF
+        t1 = intarr_get_raw(w, pp + 1) & 0xFF
+        t2 = intarr_get_raw(w, pp + 2) & 0xFF
+        t3 = intarr_get_raw(w, pp + 3) & 0xFF
+        if (wi % nk) == 0 {
+            r0 = t1; r1 = t2; r2 = t3; r3 = t0
+            t0 = (intarr_get_raw(sbox, r0) & 0xFF) ^ rcon
+            t1 = intarr_get_raw(sbox, r1) & 0xFF
+            t2 = intarr_get_raw(sbox, r2) & 0xFF
+            t3 = intarr_get_raw(sbox, r3) & 0xFF
+            rcon = xtime(rcon)
+        } else {
+            if nk > 6 {
+                if (wi % nk) == 4 {
+                    t0 = intarr_get_raw(sbox, t0) & 0xFF
+                    t1 = intarr_get_raw(sbox, t1) & 0xFF
+                    t2 = intarr_get_raw(sbox, t2) & 0xFF
+                    t3 = intarr_get_raw(sbox, t3) & 0xFF
+                }
+            }
+        }
+        q = (wi - nk) * 4
+        o = wi * 4
+        intarr_set_raw(w, o + 0, (intarr_get_raw(w, q + 0) ^ t0) & 0xFF)
+        intarr_set_raw(w, o + 1, (intarr_get_raw(w, q + 1) ^ t1) & 0xFF)
+        intarr_set_raw(w, o + 2, (intarr_get_raw(w, q + 2) ^ t2) & 0xFF)
+        intarr_set_raw(w, o + 3, (intarr_get_raw(w, q + 3) ^ t3) & 0xFF)
+        wi = wi + 1
+    }
+    c = malloc(24) as *AesCtx
+    c.rk = w
+    c.rounds = rounds
+    c.encrypt = encrypt
+    return c
+}
+
+new_encryptor(key: ptr, keylen: int) -> ptr {
+    sbox = make_box(SBOX_HEX())
+    ctx = new_ctx(key, keylen, sbox, 1)
+    intarr_free(sbox)
+    return ctx
+}
+new_decryptor(key: ptr, keylen: int) -> ptr {
+    sbox = make_box(SBOX_HEX())
+    ctx = new_ctx(key, keylen, sbox, 0)
+    intarr_free(sbox)
+    return ctx
+}
+free(ctx: ptr) {
+    if ctx == null { return }
+    c = ctx as *AesCtx
+    if c.rk != null { intarr_free(c.rk) }
+    libc_free(ctx)
+}
+
+// ---- round transforms ----
+add_round_key(s: ptr, rk: ptr, rnd: int) {
+    base = rnd * 16
+    i = 0
+    while i < 16 {
+        p(s, i, g(s, i) ^ (intarr_get_raw(rk, base + i) & 0xFF))
+        i = i + 1
+    }
+}
+sub_bytes(s: ptr, sbox: ptr) {
+    i = 0
+    while i < 16 { p(s, i, intarr_get_raw(sbox, g(s, i))); i = i + 1 }
+}
+inv_sub_bytes(s: ptr, isbox: ptr) {
+    i = 0
+    while i < 16 { p(s, i, intarr_get_raw(isbox, g(s, i))); i = i + 1 }
+}
+// byte index = col*4 + row; shift row k left by k.
+shift_rows(s: ptr) {
+    t = g(s,1); p(s,1,g(s,5)); p(s,5,g(s,9)); p(s,9,g(s,13)); p(s,13,t)
+    t = g(s,2); u = g(s,6); p(s,2,g(s,10)); p(s,6,g(s,14)); p(s,10,t); p(s,14,u)
+    t = g(s,15); p(s,15,g(s,11)); p(s,11,g(s,7)); p(s,7,g(s,3)); p(s,3,t)
+}
+inv_shift_rows(s: ptr) {
+    t = g(s,13); p(s,13,g(s,9)); p(s,9,g(s,5)); p(s,5,g(s,1)); p(s,1,t)
+    t = g(s,2); u = g(s,6); p(s,2,g(s,10)); p(s,6,g(s,14)); p(s,10,t); p(s,14,u)
+    t = g(s,3); p(s,3,g(s,7)); p(s,7,g(s,11)); p(s,11,g(s,15)); p(s,15,t)
+}
+mix_columns(s: ptr) {
+    c = 0
+    while c < 4 {
+        b = c * 4
+        a0 = g(s,b+0); a1 = g(s,b+1); a2 = g(s,b+2); a3 = g(s,b+3)
+        p(s, b+0, xtime(a0) ^ xtime(a1) ^ a1 ^ a2 ^ a3)
+        p(s, b+1, a0 ^ xtime(a1) ^ xtime(a2) ^ a2 ^ a3)
+        p(s, b+2, a0 ^ a1 ^ xtime(a2) ^ xtime(a3) ^ a3)
+        p(s, b+3, xtime(a0) ^ a0 ^ a1 ^ a2 ^ xtime(a3))
+        c = c + 1
+    }
+}
+inv_mix_columns(s: ptr) {
+    c = 0
+    while c < 4 {
+        b = c * 4
+        a0 = g(s,b+0); a1 = g(s,b+1); a2 = g(s,b+2); a3 = g(s,b+3)
+        p(s, b+0, gmul(a0,14) ^ gmul(a1,11) ^ gmul(a2,13) ^ gmul(a3,9))
+        p(s, b+1, gmul(a0,9) ^ gmul(a1,14) ^ gmul(a2,11) ^ gmul(a3,13))
+        p(s, b+2, gmul(a0,13) ^ gmul(a1,9) ^ gmul(a2,14) ^ gmul(a3,11))
+        p(s, b+3, gmul(a0,11) ^ gmul(a1,13) ^ gmul(a2,9) ^ gmul(a3,14))
+        c = c + 1
+    }
+}
+
+// ---- single block ----
+process_block(ctx: ptr, in16: ptr) -> ptr {
+    c = ctx as *AesCtx
+    out = bytes.new(16)
+    if c.encrypt == 1 { encrypt_block(c, in16, out) } else { decrypt_block(c, in16, out) }
+    return out
+}
+
+encrypt_block(c: *AesCtx, in16: ptr, out: ptr) {
+    sbox = make_box(SBOX_HEX())
+    s = intarr_new_raw(16)
+    i = 0
+    while i < 16 { p(s, i, bytes.get(in16, i)); i = i + 1 }
+    add_round_key(s, c.rk, 0)
+    r = 1
+    while r < c.rounds {
+        sub_bytes(s, sbox); shift_rows(s); mix_columns(s); add_round_key(s, c.rk, r)
+        r = r + 1
+    }
+    sub_bytes(s, sbox); shift_rows(s); add_round_key(s, c.rk, c.rounds)
+    i = 0
+    while i < 16 { bytes.set(out, i, g(s, i)); i = i + 1 }
+    intarr_free(s); intarr_free(sbox)
+}
+
+decrypt_block(c: *AesCtx, in16: ptr, out: ptr) {
+    isbox = make_box(ISBOX_HEX())
+    s = intarr_new_raw(16)
+    i = 0
+    while i < 16 { p(s, i, bytes.get(in16, i)); i = i + 1 }
+    add_round_key(s, c.rk, c.rounds)
+    r = c.rounds - 1
+    while r >= 1 {
+        inv_shift_rows(s); inv_sub_bytes(s, isbox); add_round_key(s, c.rk, r); inv_mix_columns(s)
+        r = r - 1
+    }
+    inv_shift_rows(s); inv_sub_bytes(s, isbox); add_round_key(s, c.rk, 0)
+    i = 0
+    while i < 16 { bytes.set(out, i, g(s, i)); i = i + 1 }
+    intarr_free(s); intarr_free(isbox)
+}
+
+// ---- ECB (block-aligned, NO padding) ----
+ecb_encrypt(ctx: ptr, data: ptr) -> ptr { return ecb_run(ctx, data) }
+ecb_decrypt(ctx: ptr, data: ptr) -> ptr { return ecb_run(ctx, data) }
+ecb_run(ctx: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    out = bytes.new(n)
+    off = 0
+    while off + 16 <= n {
+        blk = bytes.new(16)
+        j = 0
+        while j < 16 { bytes.set(blk, j, bytes.get(data, off + j)); j = j + 1 }
+        eb = process_block(ctx, blk)
+        k = 0
+        while k < 16 { bytes.set(out, off + k, bytes.get(eb, k)); k = k + 1 }
+        bytes.free(blk); bytes.free(eb)
+        off = off + 16
+    }
+    return out
+}
+
+// ---- CTR (stream; encrypt == decrypt) ----
+// `ctx` must be an ENCRYPTOR (CTR always runs the cipher forward). `iv` is
+// the initial 16-byte counter block, incremented big-endian per block.
+ctr_xor(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    out = bytes.new(n)
+    ctr = bytes.new(16)
+    i = 0
+    while i < 16 { bytes.set(ctr, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        ks = process_block(ctx, ctr)
+        j = 0
+        while j < 16 {
+            if off + j < n {
+                bytes.set(out, off + j, (bytes.get(data, off + j) ^ bytes.get(ks, j)) & 0xFF)
+            }
+            j = j + 1
+        }
+        bytes.free(ks)
+        ctr_increment(ctr)
+        off = off + 16
+    }
+    bytes.free(ctr)
+    return out
+}
+ctr_increment(ctr: ptr) {
+    i = 15
+    carry = 1
+    while i >= 0 {
+        if carry == 1 {
+            v = (bytes.get(ctr, i) + 1) & 0xFF
+            bytes.set(ctr, i, v)
+            if v != 0 { carry = 0 }
+        }
+        i = i - 1
+    }
+}

--- a/tests/regression/test_aes.ae
+++ b/tests/regression/test_aes.ae
@@ -1,0 +1,74 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// Regression: contrib.cryptography.aes (FIPS-197), issue #739 — the
+// block-cipher core every symmetric mode drives. Block KATs are the
+// canonical FIPS-197 Appendix B/C vectors (AES-128/192/256); CTR is the
+// NIST SP800-38A F.5 vector, also reproduced via `openssl enc -aes-128-ctr`.
+// Covers encrypt + decrypt block, ECB, and CTR (symmetric round-trip).
+
+import contrib.cryptography.aes
+import std.bytes
+import std.string
+
+hv(c: int) -> int { if c>=48 { if c<=57 { return c-48 } } if c>=97 { if c<=102 { return c-87 } } return 0 }
+hb(h: string) -> ptr { n=string.length(h); b=bytes.new(n/2); i=0; while i<n { bytes.set(b,i/2,hv(string_char_at_n(h,n,i))*16+hv(string_char_at_n(h,n,i+1))); i=i+2 } return b }
+bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
+beq(a: ptr, b: ptr) -> int { if bytes.length(a)!=bytes.length(b) { return 0 } i=0; while i<bytes.length(a) { if bytes.get(a,i)!=bytes.get(b,i) { return 0 } i=i+1 } return 1 }
+
+main() {
+    print("=== contrib.cryptography.aes ===\n")
+    fails = 0
+    pt = hb("00112233445566778899aabbccddeeff")
+
+    // AES-128 (FIPS-197 Appendix B / C.1)
+    k = hb("000102030405060708090a0b0c0d0e0f")
+    e = aes.new_encryptor(k, 16); ct = aes.process_block(e, pt)
+    if string.equals(bh(ct), "69c4e0d86a7b0430d8cdb78070b4c55a") != 1 { print("FAIL aes128 enc\n"); fails=fails+1 }
+    d = aes.new_decryptor(k, 16); rt = aes.process_block(d, ct)
+    if beq(rt, pt) != 1 { print("FAIL aes128 dec\n"); fails=fails+1 }
+    aes.free(e); aes.free(d); bytes.free(ct); bytes.free(rt); bytes.free(k)
+
+    // AES-192 (FIPS-197 C.2)
+    k2 = hb("000102030405060708090a0b0c0d0e0f1011121314151617")
+    e2 = aes.new_encryptor(k2, 24); ct2 = aes.process_block(e2, pt)
+    if string.equals(bh(ct2), "dda97ca4864cdfe06eaf70a0ec0d7191") != 1 { print("FAIL aes192 enc ${bh(ct2)}\n"); fails=fails+1 }
+    d2 = aes.new_decryptor(k2, 24); rt2 = aes.process_block(d2, ct2)
+    if beq(rt2, pt) != 1 { print("FAIL aes192 dec\n"); fails=fails+1 }
+    aes.free(e2); aes.free(d2); bytes.free(ct2); bytes.free(rt2); bytes.free(k2)
+
+    // AES-256 (FIPS-197 C.3)
+    k3 = hb("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+    e3 = aes.new_encryptor(k3, 32); ct3 = aes.process_block(e3, pt)
+    if string.equals(bh(ct3), "8ea2b7ca516745bfeafc49904b496089") != 1 { print("FAIL aes256 enc\n"); fails=fails+1 }
+    d3 = aes.new_decryptor(k3, 32); rt3 = aes.process_block(d3, ct3)
+    if beq(rt3, pt) != 1 { print("FAIL aes256 dec\n"); fails=fails+1 }
+    aes.free(e3); aes.free(d3); bytes.free(ct3); bytes.free(rt3); bytes.free(k3)
+
+    // ECB over two blocks (block-aligned)
+    ke = hb("000102030405060708090a0b0c0d0e0f")
+    two = hb("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+    ee = aes.new_encryptor(ke, 16); ecb = aes.ecb_encrypt(ee, two)
+    if string.equals(bh(ecb), "69c4e0d86a7b0430d8cdb78070b4c55a69c4e0d86a7b0430d8cdb78070b4c55a") != 1 { print("FAIL ecb\n"); fails=fails+1 }
+    de = aes.new_decryptor(ke, 16); ecbrt = aes.ecb_decrypt(de, ecb)
+    if beq(ecbrt, two) != 1 { print("FAIL ecb rt\n"); fails=fails+1 }
+    aes.free(ee); aes.free(de); bytes.free(ecb); bytes.free(ecbrt); bytes.free(two); bytes.free(ke)
+
+    // AES-128-CTR (NIST SP800-38A F.5.1 / openssl -aes-128-ctr), 2 blocks
+    kc = hb("2b7e151628aed2a6abf7158809cf4f3c")
+    iv = hb("f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff")
+    ptc = hb("6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51")
+    ec = aes.new_encryptor(kc, 16)
+    ctc = aes.ctr_xor(ec, iv, ptc)
+    if string.equals(bh(ctc), "874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff") != 1 { print("FAIL ctr ${bh(ctc)}\n"); fails=fails+1 }
+    // CTR is symmetric: re-running on ciphertext recovers plaintext
+    rtc = aes.ctr_xor(ec, iv, ctc)
+    if beq(rtc, ptc) != 1 { print("FAIL ctr rt\n"); fails=fails+1 }
+    aes.free(ec); bytes.free(ctc); bytes.free(rtc); bytes.free(ptc); bytes.free(iv); bytes.free(kc)
+
+    bytes.free(pt)
+    if fails == 0 { print("PASS: contrib.cryptography.aes\n") } else { print("FAILED: ${fails}\n"); exit(1) }
+}


### PR DESCRIPTION
**The log-jam remover for the symmetric surface.** Issue #739's biggest blank was symmetric crypto (0 / ~108 operation-sides), and it was jammed on *one* missing piece: an AES block-cipher core. **CBC / CTR / CFB / OFB / ECB / GCM / CCM / EAX / OCB / AES-key-wrap / AES-CMAC / AES-CTR-DRBG all drive exactly this primitive and nothing else** — so this single module unblocks the whole cluster.

## What

`contrib.cryptography.aes` — pure-Aether AES, **byte-oriented FIPS-197 reference form** (256-byte S-box + inverse, GF(2⁸) `xtime` MixColumns), 128/192/256-bit keys.

- **Block primitive (what modes call):** `new_encryptor` / `new_decryptor` / `process_block(ctx, in16)` / `free`
- **Modes in this slice:** `ecb_encrypt` / `ecb_decrypt` (block-aligned, no padding), `ctr_xor` (CTR stream, symmetric)

Chosen over Bouncy Castle's T-box `AesEngine` deliberately: the reference form is smaller, obviously correct against the published KATs, and avoids the cache-timing surface of big T-tables. A T-box / AES-NI fast path is a later perf slice — the mode layers don't care which sits underneath.

## Verification

- **FIPS-197 Appendix B/C known-answer vectors** for AES-128, -192, **and** -256 (encrypt + decrypt round-trip).
- **NIST SP800-38A F.5 AES-128-CTR** vector — also reproduced via `openssl enc -aes-128-ctr`, byte-identical.
- ECB two-block + CTR symmetric round-trip.
- **ASan-clean.** Regression: `tests/regression/test_aes.ae`.

No OpenSSL AES — round functions, key schedule, and modes are all Aether.

## Scorecard impact (#739)

Moves **ciphers** 0 → 2 sides (AES enc+dec) and **modes/AEAD** 0 → 4 sides (ECB, CTR × enc+dec) off zero — the first symmetric coverage in the port. Padded CBC (PKCS#7), the AEADs (GCM / CCM / ChaCha20-Poly1305), and key-wrap are follow-up slices that build directly on this core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)