### PR TITLE
feat(cryptography): AES CBC + PKCS#7, RIPEMD-256/320 digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [0.294.0]
+
+### Added
+
+- **AES CBC mode + PKCS#7 padding** in `contrib.cryptography.aes`, layered
+  over the existing FIPS-197 block primitive (no externs to OpenSSL).
+  - `cbc_encrypt` / `cbc_decrypt` — block-aligned CBC (C_i = E(P_i XOR C_{i-1})).
+  - `pkcs7_pad` / `pkcs7_unpad` — RFC 5652 §6.3 padding (a full extra block is
+    added when the input is already a multiple of 16; `pkcs7_unpad` returns
+    `(plaintext, err)` and rejects malformed padding).
+  - `cbc_encrypt_pkcs7` / `cbc_decrypt_pkcs7` — arbitrary-length CBC.
+  - Validated against NIST SP800-38A F.2.1/F.2.2 CBC vectors plus PKCS#7
+    round-trip and bad-padding-rejection cases.
+- **RIPEMD-256 and RIPEMD-320 digests** in `std.cryptography`, ported in pure
+  Aether from Bouncy Castle's `RipeMD256Digest` / `RipeMD320Digest`. These run
+  the two RIPEMD-128 / -160 lines side by side for a wider (256-/320-bit)
+  output at the same security level as -128 / -160. Same streaming + one-shot
+  surface as the other digests; validated against the published RIPEMD
+  reference vectors.
+  - **`std.cryptography.ripemd256`** — 256-bit, 8-word dual-line.
+  - **`std.cryptography.ripemd320`** — 320-bit, 10-word dual-line.
+
 ## [0.293.0]
 
 ### Added

--- a/contrib/cryptography/aes/module.ae
+++ b/contrib/cryptography/aes/module.ae
@@ -27,6 +27,10 @@
 // Convenience modes in this slice:
 //   aes.ecb_encrypt / ecb_decrypt  — block-aligned, NO padding
 //   aes.ctr_xor                    — CTR keystream over arbitrary length
+//   aes.cbc_encrypt / cbc_decrypt  — block-aligned CBC, NO padding
+//   aes.cbc_encrypt_pkcs7 / cbc_decrypt_pkcs7
+//                                  — CBC with PKCS#7 padding (arbitrary length)
+//   aes.pkcs7_pad / pkcs7_unpad    — standalone PKCS#7 helpers
 //
 // All buffers are std.bytes (caller frees results).
 
@@ -37,7 +41,9 @@ import std.string
 
 exports (
     new_encryptor, new_decryptor, process_block, free,
-    block_size, ecb_encrypt, ecb_decrypt, ctr_xor
+    block_size, ecb_encrypt, ecb_decrypt, ctr_xor,
+    cbc_encrypt, cbc_decrypt, cbc_encrypt_pkcs7, cbc_decrypt_pkcs7,
+    pkcs7_pad, pkcs7_unpad
 )
 
 extern malloc(size: int) -> ptr
@@ -327,4 +333,151 @@ ctr_increment(ctr: ptr) {
         }
         i = i - 1
     }
+}
+
+// ---- CBC (block-aligned, NO padding) ----
+// `ctx` is an encryptor for cbc_encrypt and a decryptor for cbc_decrypt.
+// `iv` is the 16-byte initialization vector. Input length MUST be a
+// multiple of 16; a non-multiple returns an empty buffer (use the
+// _pkcs7 variants for arbitrary-length data).
+//
+// CBC encrypt: C_i = E(P_i XOR C_{i-1}), with C_{-1} = IV.
+cbc_encrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    if n % 16 != 0 {
+        return bytes.new(0)
+    }
+    out = bytes.new(n)
+    prev = bytes.new(16)
+    i = 0
+    while i < 16 { bytes.set(prev, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        blk = bytes.new(16)
+        j = 0
+        while j < 16 {
+            bytes.set(blk, j, (bytes.get(data, off + j) ^ bytes.get(prev, j)) & 0xFF)
+            j = j + 1
+        }
+        eb = process_block(ctx, blk)
+        k = 0
+        while k < 16 {
+            v = bytes.get(eb, k)
+            bytes.set(out, off + k, v)
+            bytes.set(prev, k, v)   // ciphertext becomes the next XOR mask
+            k = k + 1
+        }
+        bytes.free(blk); bytes.free(eb)
+        off = off + 16
+    }
+    bytes.free(prev)
+    return out
+}
+
+// CBC decrypt: P_i = D(C_i) XOR C_{i-1}, with C_{-1} = IV.
+cbc_decrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    if n % 16 != 0 {
+        return bytes.new(0)
+    }
+    out = bytes.new(n)
+    prev = bytes.new(16)
+    i = 0
+    while i < 16 { bytes.set(prev, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        blk = bytes.new(16)
+        j = 0
+        while j < 16 { bytes.set(blk, j, bytes.get(data, off + j)); j = j + 1 }
+        db = process_block(ctx, blk)
+        k = 0
+        while k < 16 {
+            bytes.set(out, off + k, (bytes.get(db, k) ^ bytes.get(prev, k)) & 0xFF)
+            bytes.set(prev, k, bytes.get(blk, k))   // this ciphertext block
+            k = k + 1
+        }
+        bytes.free(blk); bytes.free(db)
+        off = off + 16
+    }
+    bytes.free(prev)
+    return out
+}
+
+// ---- PKCS#7 padding ----
+// Append (16 - n mod 16) bytes, each equal to that count. A full extra
+// block is added when the input is already a multiple of 16, so the
+// padding is always present and unambiguous (RFC 5652 §6.3).
+pkcs7_pad(data: ptr) -> ptr {
+    n = bytes.length(data)
+    pad = 16 - (n % 16)        // 1..16
+    out = bytes.new(n + pad)
+    i = 0
+    while i < n { bytes.set(out, i, bytes.get(data, i)); i = i + 1 }
+    j = 0
+    while j < pad { bytes.set(out, n + j, pad); j = j + 1 }
+    return out
+}
+
+// Strip PKCS#7 padding. Returns (plaintext, "") on success or
+// (empty-buffer, error) if the padding is malformed (bad length, pad byte
+// out of range, or trailing bytes that don't all match the count). The
+// check walks all `pad` trailing bytes regardless of an early mismatch so
+// the work is independent of where the first bad byte is.
+pkcs7_unpad(data: ptr) -> {
+    n = bytes.length(data)
+    if n == 0 {
+        return bytes.new(0), "empty input"
+    }
+    if n % 16 != 0 {
+        return bytes.new(0), "length not a multiple of 16"
+    }
+    pad = bytes.get(data, n - 1) & 0xFF
+    if pad < 1 {
+        return bytes.new(0), "bad padding"
+    }
+    if pad > 16 {
+        return bytes.new(0), "bad padding"
+    }
+    bad = 0
+    i = 0
+    while i < pad {
+        if (bytes.get(data, n - 1 - i) & 0xFF) != pad {
+            bad = 1
+        }
+        i = i + 1
+    }
+    if bad == 1 {
+        return bytes.new(0), "bad padding"
+    }
+    outlen = n - pad
+    out = bytes.new(outlen)
+    j = 0
+    while j < outlen { bytes.set(out, j, bytes.get(data, j)); j = j + 1 }
+    return out, ""
+}
+
+// ---- CBC + PKCS#7 (arbitrary length) ----
+// Pads then CBC-encrypts; ciphertext length is always a multiple of 16 and
+// strictly greater than the plaintext. `ctx` is an encryptor.
+cbc_encrypt_pkcs7(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    padded = pkcs7_pad(data)
+    out = cbc_encrypt(ctx, iv, padded)
+    bytes.free(padded)
+    return out
+}
+
+// CBC-decrypts then strips PKCS#7. `ctx` is a decryptor. Returns
+// (plaintext, "") or (empty, error) for a bad length / bad padding.
+cbc_decrypt_pkcs7(ctx: ptr, iv: ptr, data: ptr) -> {
+    n = bytes.length(data)
+    if n == 0 {
+        return bytes.new(0), "empty input"
+    }
+    if n % 16 != 0 {
+        return bytes.new(0), "length not a multiple of 16"
+    }
+    raw = cbc_decrypt(ctx, iv, data)
+    out, err = pkcs7_unpad(raw)
+    bytes.free(raw)
+    return out, err
 }

--- a/std/cryptography/ripemd256/module.ae
+++ b/std/cryptography/ripemd256/module.ae
@@ -1,0 +1,465 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.ripemd256 — RIPEMD-256 in pure Aether, ported from
+// Bouncy Castle's RipeMD256Digest / GeneralDigest. NO externs to OpenSSL.
+//
+// RIPEMD-256 runs the two RIPEMD-128 lines independently to produce a
+// 256-bit (8-word) output. Security level equals RIPEMD-128 (the extra
+// width is collision domain only); it's a wider digest, not a stronger
+// one. After each of the 4 rounds the two lines swap a single register
+// (a<->aa, b<->bb, c<->cc, d<->dd in turn); the output is both lines'
+// four words concatenated. Step functions / constants are identical to
+// std.cryptography.ripemd128.
+//
+// Import with:  import std.cryptography.ripemd256
+//   one-shot:   ripemd256_hex(data, len) / ripemd256_bytes(data, len)
+//   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//
+// Little-endian word load/store/length; 32-bit adds masked; left rotates.
+
+import std.bits
+import std.bytes
+import std.intarr
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    ripemd256_hex, ripemd256_bytes
+)
+
+struct Rmd256Ctx {
+    h0: long
+    h1: long
+    h2: long
+    h3: long
+    h4: long
+    h5: long
+    h6: long
+    h7: long
+    block: ptr
+    block_len: int
+    count_lo: long
+    count_hi: long
+    x: ptr            // intarr(16)
+}
+
+m32(x: long) -> long {
+    return x & 0xFFFFFFFF
+}
+rl(x: long, n: int) -> long {
+    return bits.rotl32(x & 0xFFFFFFFF, n) & 0xFFFFFFFF
+}
+f1(x: long, y: long, z: long) -> long {
+    return (x ^ y ^ z) & 0xFFFFFFFF
+}
+f2(x: long, y: long, z: long) -> long {
+    return ((x & y) | ((~x) & z)) & 0xFFFFFFFF
+}
+f3(x: long, y: long, z: long) -> long {
+    return ((x | (~y)) ^ z) & 0xFFFFFFFF
+}
+f4(x: long, y: long, z: long) -> long {
+    return ((x & z) | (y & (~z))) & 0xFFFFFFFF
+}
+xg(ctx: *Rmd256Ctx, i: int) -> long {
+    return intarr_get_unchecked(ctx.x, i) & 0xFFFFFFFF
+}
+
+// Left-line step functions (same as RIPEMD-128).
+sf1(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f1(b,c,d) + x), s)
+}
+sf2(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f2(b,c,d) + x + 0x5a827999), s)
+}
+sf3(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f3(b,c,d) + x + 0x6ed9eba1), s)
+}
+sf4(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f4(b,c,d) + x + 0x8f1bbcdc), s)
+}
+// Right-line step functions.
+sff1(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f1(b,c,d) + x), s)
+}
+sff2(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f2(b,c,d) + x + 0x6d703ef3), s)
+}
+sff3(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f3(b,c,d) + x + 0x5c4dd124), s)
+}
+sff4(a: long, b: long, c: long, d: long, x: long, s: int) -> long {
+    return rl(m32(a + f4(b,c,d) + x + 0x50a28be6), s)
+}
+
+process_block(ctx: *Rmd256Ctx) {
+    a = m32(ctx.h0)
+    b = m32(ctx.h1)
+    c = m32(ctx.h2)
+    d = m32(ctx.h3)
+    aa = m32(ctx.h4)
+    bb = m32(ctx.h5)
+    cc = m32(ctx.h6)
+    dd = m32(ctx.h7)
+
+    // ---- Round 1: left F1, right FF4 ----
+    a = sf1(a, b, c, d, xg(ctx, 0), 11)
+    d = sf1(d, a, b, c, xg(ctx, 1), 14)
+    c = sf1(c, d, a, b, xg(ctx, 2), 15)
+    b = sf1(b, c, d, a, xg(ctx, 3), 12)
+    a = sf1(a, b, c, d, xg(ctx, 4),  5)
+    d = sf1(d, a, b, c, xg(ctx, 5),  8)
+    c = sf1(c, d, a, b, xg(ctx, 6),  7)
+    b = sf1(b, c, d, a, xg(ctx, 7),  9)
+    a = sf1(a, b, c, d, xg(ctx, 8), 11)
+    d = sf1(d, a, b, c, xg(ctx, 9), 13)
+    c = sf1(c, d, a, b, xg(ctx,10), 14)
+    b = sf1(b, c, d, a, xg(ctx,11), 15)
+    a = sf1(a, b, c, d, xg(ctx,12),  6)
+    d = sf1(d, a, b, c, xg(ctx,13),  7)
+    c = sf1(c, d, a, b, xg(ctx,14),  9)
+    b = sf1(b, c, d, a, xg(ctx,15),  8)
+
+    aa = sff4(aa, bb, cc, dd, xg(ctx, 5),  8)
+    dd = sff4(dd, aa, bb, cc, xg(ctx,14),  9)
+    cc = sff4(cc, dd, aa, bb, xg(ctx, 7),  9)
+    bb = sff4(bb, cc, dd, aa, xg(ctx, 0), 11)
+    aa = sff4(aa, bb, cc, dd, xg(ctx, 9), 13)
+    dd = sff4(dd, aa, bb, cc, xg(ctx, 2), 15)
+    cc = sff4(cc, dd, aa, bb, xg(ctx,11), 15)
+    bb = sff4(bb, cc, dd, aa, xg(ctx, 4),  5)
+    aa = sff4(aa, bb, cc, dd, xg(ctx,13),  7)
+    dd = sff4(dd, aa, bb, cc, xg(ctx, 6),  7)
+    cc = sff4(cc, dd, aa, bb, xg(ctx,15),  8)
+    bb = sff4(bb, cc, dd, aa, xg(ctx, 8), 11)
+    aa = sff4(aa, bb, cc, dd, xg(ctx, 1), 14)
+    dd = sff4(dd, aa, bb, cc, xg(ctx,10), 14)
+    cc = sff4(cc, dd, aa, bb, xg(ctx, 3), 12)
+    bb = sff4(bb, cc, dd, aa, xg(ctx,12),  6)
+
+    t = a; a = aa; aa = t
+
+    // ---- Round 2: left F2, right FF3 ----
+    a = sf2(a, b, c, d, xg(ctx, 7),  7)
+    d = sf2(d, a, b, c, xg(ctx, 4),  6)
+    c = sf2(c, d, a, b, xg(ctx,13),  8)
+    b = sf2(b, c, d, a, xg(ctx, 1), 13)
+    a = sf2(a, b, c, d, xg(ctx,10), 11)
+    d = sf2(d, a, b, c, xg(ctx, 6),  9)
+    c = sf2(c, d, a, b, xg(ctx,15),  7)
+    b = sf2(b, c, d, a, xg(ctx, 3), 15)
+    a = sf2(a, b, c, d, xg(ctx,12),  7)
+    d = sf2(d, a, b, c, xg(ctx, 0), 12)
+    c = sf2(c, d, a, b, xg(ctx, 9), 15)
+    b = sf2(b, c, d, a, xg(ctx, 5),  9)
+    a = sf2(a, b, c, d, xg(ctx, 2), 11)
+    d = sf2(d, a, b, c, xg(ctx,14),  7)
+    c = sf2(c, d, a, b, xg(ctx,11), 13)
+    b = sf2(b, c, d, a, xg(ctx, 8), 12)
+
+    aa = sff3(aa, bb, cc, dd, xg(ctx, 6),  9)
+    dd = sff3(dd, aa, bb, cc, xg(ctx,11), 13)
+    cc = sff3(cc, dd, aa, bb, xg(ctx, 3), 15)
+    bb = sff3(bb, cc, dd, aa, xg(ctx, 7),  7)
+    aa = sff3(aa, bb, cc, dd, xg(ctx, 0), 12)
+    dd = sff3(dd, aa, bb, cc, xg(ctx,13),  8)
+    cc = sff3(cc, dd, aa, bb, xg(ctx, 5),  9)
+    bb = sff3(bb, cc, dd, aa, xg(ctx,10), 11)
+    aa = sff3(aa, bb, cc, dd, xg(ctx,14),  7)
+    dd = sff3(dd, aa, bb, cc, xg(ctx,15),  7)
+    cc = sff3(cc, dd, aa, bb, xg(ctx, 8), 12)
+    bb = sff3(bb, cc, dd, aa, xg(ctx,12),  7)
+    aa = sff3(aa, bb, cc, dd, xg(ctx, 4),  6)
+    dd = sff3(dd, aa, bb, cc, xg(ctx, 9), 15)
+    cc = sff3(cc, dd, aa, bb, xg(ctx, 1), 13)
+    bb = sff3(bb, cc, dd, aa, xg(ctx, 2), 11)
+
+    t = b; b = bb; bb = t
+
+    // ---- Round 3: left F3, right FF2 ----
+    a = sf3(a, b, c, d, xg(ctx, 3), 11)
+    d = sf3(d, a, b, c, xg(ctx,10), 13)
+    c = sf3(c, d, a, b, xg(ctx,14),  6)
+    b = sf3(b, c, d, a, xg(ctx, 4),  7)
+    a = sf3(a, b, c, d, xg(ctx, 9), 14)
+    d = sf3(d, a, b, c, xg(ctx,15),  9)
+    c = sf3(c, d, a, b, xg(ctx, 8), 13)
+    b = sf3(b, c, d, a, xg(ctx, 1), 15)
+    a = sf3(a, b, c, d, xg(ctx, 2), 14)
+    d = sf3(d, a, b, c, xg(ctx, 7),  8)
+    c = sf3(c, d, a, b, xg(ctx, 0), 13)
+    b = sf3(b, c, d, a, xg(ctx, 6),  6)
+    a = sf3(a, b, c, d, xg(ctx,13),  5)
+    d = sf3(d, a, b, c, xg(ctx,11), 12)
+    c = sf3(c, d, a, b, xg(ctx, 5),  7)
+    b = sf3(b, c, d, a, xg(ctx,12),  5)
+
+    aa = sff2(aa, bb, cc, dd, xg(ctx,15),  9)
+    dd = sff2(dd, aa, bb, cc, xg(ctx, 5),  7)
+    cc = sff2(cc, dd, aa, bb, xg(ctx, 1), 15)
+    bb = sff2(bb, cc, dd, aa, xg(ctx, 3), 11)
+    aa = sff2(aa, bb, cc, dd, xg(ctx, 7),  8)
+    dd = sff2(dd, aa, bb, cc, xg(ctx,14),  6)
+    cc = sff2(cc, dd, aa, bb, xg(ctx, 6),  6)
+    bb = sff2(bb, cc, dd, aa, xg(ctx, 9), 14)
+    aa = sff2(aa, bb, cc, dd, xg(ctx,11), 12)
+    dd = sff2(dd, aa, bb, cc, xg(ctx, 8), 13)
+    cc = sff2(cc, dd, aa, bb, xg(ctx,12),  5)
+    bb = sff2(bb, cc, dd, aa, xg(ctx, 2), 14)
+    aa = sff2(aa, bb, cc, dd, xg(ctx,10), 13)
+    dd = sff2(dd, aa, bb, cc, xg(ctx, 0), 13)
+    cc = sff2(cc, dd, aa, bb, xg(ctx, 4),  7)
+    bb = sff2(bb, cc, dd, aa, xg(ctx,13),  5)
+
+    t = c; c = cc; cc = t
+
+    // ---- Round 4: left F4, right FF1 ----
+    a = sf4(a, b, c, d, xg(ctx, 1), 11)
+    d = sf4(d, a, b, c, xg(ctx, 9), 12)
+    c = sf4(c, d, a, b, xg(ctx,11), 14)
+    b = sf4(b, c, d, a, xg(ctx,10), 15)
+    a = sf4(a, b, c, d, xg(ctx, 0), 14)
+    d = sf4(d, a, b, c, xg(ctx, 8), 15)
+    c = sf4(c, d, a, b, xg(ctx,12),  9)
+    b = sf4(b, c, d, a, xg(ctx, 4),  8)
+    a = sf4(a, b, c, d, xg(ctx,13),  9)
+    d = sf4(d, a, b, c, xg(ctx, 3), 14)
+    c = sf4(c, d, a, b, xg(ctx, 7),  5)
+    b = sf4(b, c, d, a, xg(ctx,15),  6)
+    a = sf4(a, b, c, d, xg(ctx,14),  8)
+    d = sf4(d, a, b, c, xg(ctx, 5),  6)
+    c = sf4(c, d, a, b, xg(ctx, 6),  5)
+    b = sf4(b, c, d, a, xg(ctx, 2), 12)
+
+    aa = sff1(aa, bb, cc, dd, xg(ctx, 8), 15)
+    dd = sff1(dd, aa, bb, cc, xg(ctx, 6),  5)
+    cc = sff1(cc, dd, aa, bb, xg(ctx, 4),  8)
+    bb = sff1(bb, cc, dd, aa, xg(ctx, 1), 11)
+    aa = sff1(aa, bb, cc, dd, xg(ctx, 3), 14)
+    dd = sff1(dd, aa, bb, cc, xg(ctx,11), 14)
+    cc = sff1(cc, dd, aa, bb, xg(ctx,15),  6)
+    bb = sff1(bb, cc, dd, aa, xg(ctx, 0), 14)
+    aa = sff1(aa, bb, cc, dd, xg(ctx, 5),  6)
+    dd = sff1(dd, aa, bb, cc, xg(ctx,12),  9)
+    cc = sff1(cc, dd, aa, bb, xg(ctx, 2), 12)
+    bb = sff1(bb, cc, dd, aa, xg(ctx,13),  9)
+    aa = sff1(aa, bb, cc, dd, xg(ctx, 9), 12)
+    dd = sff1(dd, aa, bb, cc, xg(ctx, 7),  5)
+    cc = sff1(cc, dd, aa, bb, xg(ctx,10), 15)
+    bb = sff1(bb, cc, dd, aa, xg(ctx,14),  8)
+
+    t = d; d = dd; dd = t
+
+    ctx.h0 = m32(ctx.h0 + a)
+    ctx.h1 = m32(ctx.h1 + b)
+    ctx.h2 = m32(ctx.h2 + c)
+    ctx.h3 = m32(ctx.h3 + d)
+    ctx.h4 = m32(ctx.h4 + aa)
+    ctx.h5 = m32(ctx.h5 + bb)
+    ctx.h6 = m32(ctx.h6 + cc)
+    ctx.h7 = m32(ctx.h7 + dd)
+}
+
+new() -> {
+    ctx = malloc(128) as *Rmd256Ctx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.h0 = 0x67452301
+    ctx.h1 = 0xefcdab89
+    ctx.h2 = 0x98badcfe
+    ctx.h3 = 0x10325476
+    ctx.h4 = 0x76543210
+    ctx.h5 = 0xfedcba98
+    ctx.h6 = 0x89abcdef
+    ctx.h7 = 0x01234567
+    ctx.block_len = 0
+    ctx.count_lo = 0
+    ctx.count_hi = 0
+    ctx.block = bytes.new(64)
+    j = 0
+    while j < 64 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    ctx.x = intarr_new_raw(16)
+    return ctx, ""
+}
+
+absorb_block(c: *Rmd256Ctx) {
+    i = 0
+    while i < 16 {
+        w = bytes.get_le32(c.block, i * 4)
+        intarr_set_unchecked(c.x, i, w)
+        i = i + 1
+    }
+    process_block(c)
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *Rmd256Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            absorb_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    old_lo = c.count_lo
+    c.count_lo = c.count_lo + length
+    if bits.ucmp64(c.count_lo, old_lo) < 0 {
+        c.count_hi = c.count_hi + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Rmd256Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            absorb_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    old_lo = c.count_lo
+    c.count_lo = c.count_lo + length
+    if bits.ucmp64(c.count_lo, old_lo) < 0 {
+        c.count_hi = c.count_hi + 1
+    }
+}
+
+push_pad_byte(c: *Rmd256Ctx, b: int) {
+    bytes.set(c.block, c.block_len, b & 255)
+    c.block_len = c.block_len + 1
+    if c.block_len == 64 {
+        absorb_block(c)
+        c.block_len = 0
+    }
+}
+
+finalize_to_bytes(c: *Rmd256Ctx) -> ptr {
+    bit_lo = c.count_lo << 3
+    bit_hi = (c.count_hi << 3) | bits.lsr64(c.count_lo, 61)
+
+    push_pad_byte(c, 0x80)
+    while c.block_len != 56 {
+        push_pad_byte(c, 0)
+    }
+    bytes.set_le32(c.block, 56, bit_lo & 0xFFFFFFFF)
+    bytes.set_le32(c.block, 60, bit_hi & 0xFFFFFFFF)
+    absorb_block(c)
+    c.block_len = 0
+
+    out = bytes.new(32)
+    emit_le32(out, 0, c.h0)
+    emit_le32(out, 4, c.h1)
+    emit_le32(out, 8, c.h2)
+    emit_le32(out, 12, c.h3)
+    emit_le32(out, 16, c.h4)
+    emit_le32(out, 20, c.h5)
+    emit_le32(out, 24, c.h6)
+    emit_le32(out, 28, c.h7)
+    return out
+}
+
+emit_le32(out: ptr, off: int, v: long) {
+    bytes.set(out, off,     v & 255)
+    bytes.set(out, off + 1, bits.lsr64(v, 8) & 255)
+    bytes.set(out, off + 2, bits.lsr64(v, 16) & 255)
+    bytes.set(out, off + 3, bits.lsr64(v, 24) & 255)
+}
+
+free_internals(c: *Rmd256Ctx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+    if c.x != null {
+        intarr_free(c.x)
+        c.x = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *Rmd256Ctx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 32)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(32)
+    bytes.copy_from_string(res, 0, s, 32)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *Rmd256Ctx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(64)
+    i = 0
+    while i < 32 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 64)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *Rmd256Ctx
+    free_internals(c)
+    free(ctx)
+}
+
+ripemd256_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+ripemd256_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/ripemd320/module.ae
+++ b/std/cryptography/ripemd320/module.ae
@@ -1,0 +1,500 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.ripemd320 — RIPEMD-320 in pure Aether, ported from
+// Bouncy Castle's RipeMD320Digest / GeneralDigest. NO externs to OpenSSL.
+//
+// RIPEMD-320 runs the two RIPEMD-160 lines side by side to produce a
+// 320-bit (10-word) output. Security level equals RIPEMD-160 (the extra
+// width is collision domain only). After each of rounds 1-4 the two lines
+// swap a single register (a<->aa, b<->bb, c<->cc, d<->dd in turn); a final
+// e<->ee swap is folded into the H4/H9 fold. The per-round bodies are
+// identical to std.cryptography.ripemd160's left/right lines.
+//
+// Import with:  import std.cryptography.ripemd320
+//   one-shot:   ripemd320_hex(data, len) / ripemd320_bytes(data, len)
+//   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//
+// Little-endian word load/store/length; 32-bit adds masked; left rotates.
+
+import std.bits
+import std.bytes
+import std.intarr
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    ripemd320_hex, ripemd320_bytes
+)
+
+struct Rmd320Ctx {
+    h0: long
+    h1: long
+    h2: long
+    h3: long
+    h4: long
+    h5: long
+    h6: long
+    h7: long
+    h8: long
+    h9: long
+    block: ptr
+    block_len: int
+    count_lo: long
+    count_hi: long
+    x: ptr            // intarr(16)
+}
+
+m32(x: long) -> long {
+    return x & 0xFFFFFFFF
+}
+rl(x: long, n: int) -> long {
+    return bits.rotl32(x & 0xFFFFFFFF, n) & 0xFFFFFFFF
+}
+f1(x: long, y: long, z: long) -> long {
+    return (x ^ y ^ z) & 0xFFFFFFFF
+}
+f2(x: long, y: long, z: long) -> long {
+    return ((x & y) | ((~x) & z)) & 0xFFFFFFFF
+}
+f3(x: long, y: long, z: long) -> long {
+    return ((x | (~y)) ^ z) & 0xFFFFFFFF
+}
+f4(x: long, y: long, z: long) -> long {
+    return ((x & z) | (y & (~z))) & 0xFFFFFFFF
+}
+f5(x: long, y: long, z: long) -> long {
+    return (x ^ (y | (~z))) & 0xFFFFFFFF
+}
+xg(ctx: *Rmd320Ctx, i: int) -> long {
+    return intarr_get_unchecked(ctx.x, i) & 0xFFFFFFFF
+}
+
+process_block(ctx: *Rmd320Ctx) {
+    a = m32(ctx.h0)
+    b = m32(ctx.h1)
+    c = m32(ctx.h2)
+    d = m32(ctx.h3)
+    e = m32(ctx.h4)
+    aa = m32(ctx.h5)
+    bb = m32(ctx.h6)
+    cc = m32(ctx.h7)
+    dd = m32(ctx.h8)
+    ee = m32(ctx.h9)
+
+    kl1 = 0x5a827999
+    kl2 = 0x6ed9eba1
+    kl3 = 0x8f1bbcdc
+    kl4 = 0xa953fd4e
+    kr0 = 0x50a28be6
+    kr1 = 0x5c4dd124
+    kr2 = 0x6d703ef3
+    kr3 = 0x7a6d76e9
+
+    // ---- Rounds 1-16 ----
+    // left
+    a = m32(rl(m32(a + f1(b,c,d) + xg(ctx, 0)), 11) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f1(a,b,c) + xg(ctx, 1)), 14) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f1(e,a,b) + xg(ctx, 2)), 15) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f1(d,e,a) + xg(ctx, 3)), 12) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f1(c,d,e) + xg(ctx, 4)),  5) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f1(b,c,d) + xg(ctx, 5)),  8) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f1(a,b,c) + xg(ctx, 6)),  7) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f1(e,a,b) + xg(ctx, 7)),  9) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f1(d,e,a) + xg(ctx, 8)), 11) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f1(c,d,e) + xg(ctx, 9)), 13) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f1(b,c,d) + xg(ctx,10)), 14) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f1(a,b,c) + xg(ctx,11)), 15) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f1(e,a,b) + xg(ctx,12)),  6) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f1(d,e,a) + xg(ctx,13)),  7) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f1(c,d,e) + xg(ctx,14)),  9) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f1(b,c,d) + xg(ctx,15)),  8) + e); c = rl(c, 10)
+    // right
+    aa = m32(rl(m32(aa + f5(bb,cc,dd) + xg(ctx, 5) + kr0),  8) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f5(aa,bb,cc) + xg(ctx,14) + kr0),  9) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f5(ee,aa,bb) + xg(ctx, 7) + kr0),  9) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f5(dd,ee,aa) + xg(ctx, 0) + kr0), 11) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f5(cc,dd,ee) + xg(ctx, 9) + kr0), 13) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f5(bb,cc,dd) + xg(ctx, 2) + kr0), 15) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f5(aa,bb,cc) + xg(ctx,11) + kr0), 15) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f5(ee,aa,bb) + xg(ctx, 4) + kr0),  5) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f5(dd,ee,aa) + xg(ctx,13) + kr0),  7) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f5(cc,dd,ee) + xg(ctx, 6) + kr0),  7) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f5(bb,cc,dd) + xg(ctx,15) + kr0),  8) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f5(aa,bb,cc) + xg(ctx, 8) + kr0), 11) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f5(ee,aa,bb) + xg(ctx, 1) + kr0), 14) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f5(dd,ee,aa) + xg(ctx,10) + kr0), 14) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f5(cc,dd,ee) + xg(ctx, 3) + kr0), 12) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f5(bb,cc,dd) + xg(ctx,12) + kr0),  6) + ee); cc = rl(cc, 10)
+
+    t = a; a = aa; aa = t
+
+    // ---- Rounds 16-31 ----
+    // left (F2)
+    e = m32(rl(m32(e + f2(a,b,c) + xg(ctx, 7) + kl1),  7) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f2(e,a,b) + xg(ctx, 4) + kl1),  6) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f2(d,e,a) + xg(ctx,13) + kl1),  8) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f2(c,d,e) + xg(ctx, 1) + kl1), 13) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f2(b,c,d) + xg(ctx,10) + kl1), 11) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f2(a,b,c) + xg(ctx, 6) + kl1),  9) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f2(e,a,b) + xg(ctx,15) + kl1),  7) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f2(d,e,a) + xg(ctx, 3) + kl1), 15) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f2(c,d,e) + xg(ctx,12) + kl1),  7) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f2(b,c,d) + xg(ctx, 0) + kl1), 12) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f2(a,b,c) + xg(ctx, 9) + kl1), 15) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f2(e,a,b) + xg(ctx, 5) + kl1),  9) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f2(d,e,a) + xg(ctx, 2) + kl1), 11) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f2(c,d,e) + xg(ctx,14) + kl1),  7) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f2(b,c,d) + xg(ctx,11) + kl1), 13) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f2(a,b,c) + xg(ctx, 8) + kl1), 12) + d); b = rl(b, 10)
+    // right (F4)
+    ee = m32(rl(m32(ee + f4(aa,bb,cc) + xg(ctx, 6) + kr1),  9) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f4(ee,aa,bb) + xg(ctx,11) + kr1), 13) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f4(dd,ee,aa) + xg(ctx, 3) + kr1), 15) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f4(cc,dd,ee) + xg(ctx, 7) + kr1),  7) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f4(bb,cc,dd) + xg(ctx, 0) + kr1), 12) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f4(aa,bb,cc) + xg(ctx,13) + kr1),  8) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f4(ee,aa,bb) + xg(ctx, 5) + kr1),  9) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f4(dd,ee,aa) + xg(ctx,10) + kr1), 11) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f4(cc,dd,ee) + xg(ctx,14) + kr1),  7) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f4(bb,cc,dd) + xg(ctx,15) + kr1),  7) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f4(aa,bb,cc) + xg(ctx, 8) + kr1), 12) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f4(ee,aa,bb) + xg(ctx,12) + kr1),  7) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f4(dd,ee,aa) + xg(ctx, 4) + kr1),  6) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f4(cc,dd,ee) + xg(ctx, 9) + kr1), 15) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f4(bb,cc,dd) + xg(ctx, 1) + kr1), 13) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f4(aa,bb,cc) + xg(ctx, 2) + kr1), 11) + dd); bb = rl(bb, 10)
+
+    t = b; b = bb; bb = t
+
+    // ---- Rounds 32-47 ----
+    // left (F3)
+    d = m32(rl(m32(d + f3(e,a,b) + xg(ctx, 3) + kl2), 11) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f3(d,e,a) + xg(ctx,10) + kl2), 13) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f3(c,d,e) + xg(ctx,14) + kl2),  6) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f3(b,c,d) + xg(ctx, 4) + kl2),  7) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f3(a,b,c) + xg(ctx, 9) + kl2), 14) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f3(e,a,b) + xg(ctx,15) + kl2),  9) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f3(d,e,a) + xg(ctx, 8) + kl2), 13) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f3(c,d,e) + xg(ctx, 1) + kl2), 15) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f3(b,c,d) + xg(ctx, 2) + kl2), 14) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f3(a,b,c) + xg(ctx, 7) + kl2),  8) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f3(e,a,b) + xg(ctx, 0) + kl2), 13) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f3(d,e,a) + xg(ctx, 6) + kl2),  6) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f3(c,d,e) + xg(ctx,13) + kl2),  5) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f3(b,c,d) + xg(ctx,11) + kl2), 12) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f3(a,b,c) + xg(ctx, 5) + kl2),  7) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f3(e,a,b) + xg(ctx,12) + kl2),  5) + c); a = rl(a, 10)
+    // right (F3)
+    dd = m32(rl(m32(dd + f3(ee,aa,bb) + xg(ctx,15) + kr2),  9) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f3(dd,ee,aa) + xg(ctx, 5) + kr2),  7) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f3(cc,dd,ee) + xg(ctx, 1) + kr2), 15) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f3(bb,cc,dd) + xg(ctx, 3) + kr2), 11) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f3(aa,bb,cc) + xg(ctx, 7) + kr2),  8) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f3(ee,aa,bb) + xg(ctx,14) + kr2),  6) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f3(dd,ee,aa) + xg(ctx, 6) + kr2),  6) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f3(cc,dd,ee) + xg(ctx, 9) + kr2), 14) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f3(bb,cc,dd) + xg(ctx,11) + kr2), 12) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f3(aa,bb,cc) + xg(ctx, 8) + kr2), 13) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f3(ee,aa,bb) + xg(ctx,12) + kr2),  5) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f3(dd,ee,aa) + xg(ctx, 2) + kr2), 14) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f3(cc,dd,ee) + xg(ctx,10) + kr2), 13) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f3(bb,cc,dd) + xg(ctx, 0) + kr2), 13) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f3(aa,bb,cc) + xg(ctx, 4) + kr2),  7) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f3(ee,aa,bb) + xg(ctx,13) + kr2),  5) + cc); aa = rl(aa, 10)
+
+    t = c; c = cc; cc = t
+
+    // ---- Rounds 48-63 ----
+    // left (F4)
+    c = m32(rl(m32(c + f4(d,e,a) + xg(ctx, 1) + kl3), 11) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f4(c,d,e) + xg(ctx, 9) + kl3), 12) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f4(b,c,d) + xg(ctx,11) + kl3), 14) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f4(a,b,c) + xg(ctx,10) + kl3), 15) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f4(e,a,b) + xg(ctx, 0) + kl3), 14) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f4(d,e,a) + xg(ctx, 8) + kl3), 15) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f4(c,d,e) + xg(ctx,12) + kl3),  9) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f4(b,c,d) + xg(ctx, 4) + kl3),  8) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f4(a,b,c) + xg(ctx,13) + kl3),  9) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f4(e,a,b) + xg(ctx, 3) + kl3), 14) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f4(d,e,a) + xg(ctx, 7) + kl3),  5) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f4(c,d,e) + xg(ctx,15) + kl3),  6) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f4(b,c,d) + xg(ctx,14) + kl3),  8) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f4(a,b,c) + xg(ctx, 5) + kl3),  6) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f4(e,a,b) + xg(ctx, 6) + kl3),  5) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f4(d,e,a) + xg(ctx, 2) + kl3), 12) + b); e = rl(e, 10)
+    // right (F2)
+    cc = m32(rl(m32(cc + f2(dd,ee,aa) + xg(ctx, 8) + kr3), 15) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f2(cc,dd,ee) + xg(ctx, 6) + kr3),  5) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f2(bb,cc,dd) + xg(ctx, 4) + kr3),  8) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f2(aa,bb,cc) + xg(ctx, 1) + kr3), 11) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f2(ee,aa,bb) + xg(ctx, 3) + kr3), 14) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f2(dd,ee,aa) + xg(ctx,11) + kr3), 14) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f2(cc,dd,ee) + xg(ctx,15) + kr3),  6) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f2(bb,cc,dd) + xg(ctx, 0) + kr3), 14) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f2(aa,bb,cc) + xg(ctx, 5) + kr3),  6) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f2(ee,aa,bb) + xg(ctx,12) + kr3),  9) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f2(dd,ee,aa) + xg(ctx, 2) + kr3), 12) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f2(cc,dd,ee) + xg(ctx,13) + kr3),  9) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f2(bb,cc,dd) + xg(ctx, 9) + kr3), 12) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f2(aa,bb,cc) + xg(ctx, 7) + kr3),  5) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f2(ee,aa,bb) + xg(ctx,10) + kr3), 15) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f2(dd,ee,aa) + xg(ctx,14) + kr3),  8) + bb); ee = rl(ee, 10)
+
+    t = d; d = dd; dd = t
+
+    // ---- Rounds 64-79 ----
+    // left (F5)
+    b = m32(rl(m32(b + f5(c,d,e) + xg(ctx, 4) + kl4),  9) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f5(b,c,d) + xg(ctx, 0) + kl4), 15) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f5(a,b,c) + xg(ctx, 5) + kl4),  5) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f5(e,a,b) + xg(ctx, 9) + kl4), 11) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f5(d,e,a) + xg(ctx, 7) + kl4),  6) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f5(c,d,e) + xg(ctx,12) + kl4),  8) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f5(b,c,d) + xg(ctx, 2) + kl4), 13) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f5(a,b,c) + xg(ctx,10) + kl4), 12) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f5(e,a,b) + xg(ctx,14) + kl4),  5) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f5(d,e,a) + xg(ctx, 1) + kl4), 12) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f5(c,d,e) + xg(ctx, 3) + kl4), 13) + a); d = rl(d, 10)
+    a = m32(rl(m32(a + f5(b,c,d) + xg(ctx, 8) + kl4), 14) + e); c = rl(c, 10)
+    e = m32(rl(m32(e + f5(a,b,c) + xg(ctx,11) + kl4), 11) + d); b = rl(b, 10)
+    d = m32(rl(m32(d + f5(e,a,b) + xg(ctx, 6) + kl4),  8) + c); a = rl(a, 10)
+    c = m32(rl(m32(c + f5(d,e,a) + xg(ctx,15) + kl4),  5) + b); e = rl(e, 10)
+    b = m32(rl(m32(b + f5(c,d,e) + xg(ctx,13) + kl4),  6) + a); d = rl(d, 10)
+    // right (F1, kr4 = 0)
+    bb = m32(rl(m32(bb + f1(cc,dd,ee) + xg(ctx,12)),  8) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f1(bb,cc,dd) + xg(ctx,15)),  5) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f1(aa,bb,cc) + xg(ctx,10)), 12) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f1(ee,aa,bb) + xg(ctx, 4)),  9) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f1(dd,ee,aa) + xg(ctx, 1)), 12) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f1(cc,dd,ee) + xg(ctx, 5)),  5) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f1(bb,cc,dd) + xg(ctx, 8)), 14) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f1(aa,bb,cc) + xg(ctx, 7)),  6) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f1(ee,aa,bb) + xg(ctx, 6)),  8) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f1(dd,ee,aa) + xg(ctx, 2)), 13) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f1(cc,dd,ee) + xg(ctx,13)),  6) + aa); dd = rl(dd, 10)
+    aa = m32(rl(m32(aa + f1(bb,cc,dd) + xg(ctx,14)),  5) + ee); cc = rl(cc, 10)
+    ee = m32(rl(m32(ee + f1(aa,bb,cc) + xg(ctx, 0)), 15) + dd); bb = rl(bb, 10)
+    dd = m32(rl(m32(dd + f1(ee,aa,bb) + xg(ctx, 3)), 13) + cc); aa = rl(aa, 10)
+    cc = m32(rl(m32(cc + f1(dd,ee,aa) + xg(ctx, 9)), 11) + bb); ee = rl(ee, 10)
+    bb = m32(rl(m32(bb + f1(cc,dd,ee) + xg(ctx,11)), 11) + aa); dd = rl(dd, 10)
+
+    // Final fold — the e<->ee swap is folded into H4/H9 (per BC).
+    ctx.h0 = m32(ctx.h0 + a)
+    ctx.h1 = m32(ctx.h1 + b)
+    ctx.h2 = m32(ctx.h2 + c)
+    ctx.h3 = m32(ctx.h3 + d)
+    ctx.h4 = m32(ctx.h4 + ee)
+    ctx.h5 = m32(ctx.h5 + aa)
+    ctx.h6 = m32(ctx.h6 + bb)
+    ctx.h7 = m32(ctx.h7 + cc)
+    ctx.h8 = m32(ctx.h8 + dd)
+    ctx.h9 = m32(ctx.h9 + e)
+}
+
+new() -> {
+    ctx = malloc(160) as *Rmd320Ctx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.h0 = 0x67452301
+    ctx.h1 = 0xefcdab89
+    ctx.h2 = 0x98badcfe
+    ctx.h3 = 0x10325476
+    ctx.h4 = 0xc3d2e1f0
+    ctx.h5 = 0x76543210
+    ctx.h6 = 0xfedcba98
+    ctx.h7 = 0x89abcdef
+    ctx.h8 = 0x01234567
+    ctx.h9 = 0x3c2d1e0f
+    ctx.block_len = 0
+    ctx.count_lo = 0
+    ctx.count_hi = 0
+    ctx.block = bytes.new(64)
+    j = 0
+    while j < 64 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    ctx.x = intarr_new_raw(16)
+    return ctx, ""
+}
+
+absorb_block(c: *Rmd320Ctx) {
+    i = 0
+    while i < 16 {
+        w = bytes.get_le32(c.block, i * 4)
+        intarr_set_unchecked(c.x, i, w)
+        i = i + 1
+    }
+    process_block(c)
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *Rmd320Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            absorb_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    old_lo = c.count_lo
+    c.count_lo = c.count_lo + length
+    if bits.ucmp64(c.count_lo, old_lo) < 0 {
+        c.count_hi = c.count_hi + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Rmd320Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            absorb_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    old_lo = c.count_lo
+    c.count_lo = c.count_lo + length
+    if bits.ucmp64(c.count_lo, old_lo) < 0 {
+        c.count_hi = c.count_hi + 1
+    }
+}
+
+push_pad_byte(c: *Rmd320Ctx, b: int) {
+    bytes.set(c.block, c.block_len, b & 255)
+    c.block_len = c.block_len + 1
+    if c.block_len == 64 {
+        absorb_block(c)
+        c.block_len = 0
+    }
+}
+
+finalize_to_bytes(c: *Rmd320Ctx) -> ptr {
+    bit_lo = c.count_lo << 3
+    bit_hi = (c.count_hi << 3) | bits.lsr64(c.count_lo, 61)
+
+    push_pad_byte(c, 0x80)
+    while c.block_len != 56 {
+        push_pad_byte(c, 0)
+    }
+    bytes.set_le32(c.block, 56, bit_lo & 0xFFFFFFFF)
+    bytes.set_le32(c.block, 60, bit_hi & 0xFFFFFFFF)
+    absorb_block(c)
+    c.block_len = 0
+
+    out = bytes.new(40)
+    emit_le32(out, 0, c.h0)
+    emit_le32(out, 4, c.h1)
+    emit_le32(out, 8, c.h2)
+    emit_le32(out, 12, c.h3)
+    emit_le32(out, 16, c.h4)
+    emit_le32(out, 20, c.h5)
+    emit_le32(out, 24, c.h6)
+    emit_le32(out, 28, c.h7)
+    emit_le32(out, 32, c.h8)
+    emit_le32(out, 36, c.h9)
+    return out
+}
+
+emit_le32(out: ptr, off: int, v: long) {
+    bytes.set(out, off,     v & 255)
+    bytes.set(out, off + 1, bits.lsr64(v, 8) & 255)
+    bytes.set(out, off + 2, bits.lsr64(v, 16) & 255)
+    bytes.set(out, off + 3, bits.lsr64(v, 24) & 255)
+}
+
+free_internals(c: *Rmd320Ctx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+    if c.x != null {
+        intarr_free(c.x)
+        c.x = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *Rmd320Ctx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 40)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(40)
+    bytes.copy_from_string(res, 0, s, 40)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *Rmd320Ctx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(80)
+    i = 0
+    while i < 40 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 80)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *Rmd320Ctx
+    free_internals(c)
+    free(ctx)
+}
+
+ripemd320_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+ripemd320_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/tests/integration/crypto_ripemd256/test_crypto_ripemd256.ae
+++ b/tests/integration/crypto_ripemd256/test_crypto_ripemd256.ae
@@ -1,0 +1,44 @@
+// Validate std.cryptography.ripemd256 against the published RIPEMD-256
+// reference test vectors (Bosselaers' set).
+import std.cryptography.ripemd256
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+main() {
+    fails = 0
+    fails = fails + check("empty",
+        ripemd256.ripemd256_hex("", 0),
+        "02ba4c4e5f8ecd1877fc52d64d30e37a2d9774fb1e5d026380ae0168e3c5522d")
+    fails = fails + check("a",
+        ripemd256.ripemd256_hex("a", 1),
+        "f9333e45d857f5d90a91bab70a1eba0cfb1be4b0783c9acfcd883a9134692925")
+    fails = fails + check("abc",
+        ripemd256.ripemd256_hex("abc", 3),
+        "afbd6e228b9d8cbbcef5ca2d03e6dba10ac0bc7dcbe4680e1e42d2e975459b65")
+    fails = fails + check("message digest",
+        ripemd256.ripemd256_hex("message digest", 14),
+        "87e971759a1ce47a514d5c914c392c9018c7c46bc14465554afcdf54a5070c0e")
+    fails = fails + check("alphabet",
+        ripemd256.ripemd256_hex("abcdefghijklmnopqrstuvwxyz", 26),
+        "649d3034751ea216776bf9a18acc81bc7896118a5197968782dd1fd97d8d5133")
+    fails = fails + check("A...Za...z0...9 (62)",
+        ripemd256.ripemd256_hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62),
+        "5740a408ac16b720b84424ae931cbb1fe363d1d0bf4017f1a89f7ea6de77a0b8")
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES")
+    exit(1)
+}

--- a/tests/integration/crypto_ripemd320/test_crypto_ripemd320.ae
+++ b/tests/integration/crypto_ripemd320/test_crypto_ripemd320.ae
@@ -1,0 +1,44 @@
+// Validate std.cryptography.ripemd320 against the published RIPEMD-320
+// reference test vectors (Bosselaers' set).
+import std.cryptography.ripemd320
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+main() {
+    fails = 0
+    fails = fails + check("empty",
+        ripemd320.ripemd320_hex("", 0),
+        "22d65d5661536cdc75c1fdf5c6de7b41b9f27325ebc61e8557177d705a0ec880151c3a32a00899b8")
+    fails = fails + check("a",
+        ripemd320.ripemd320_hex("a", 1),
+        "ce78850638f92658a5a585097579926dda667a5716562cfcf6fbe77f63542f99b04705d6970dff5d")
+    fails = fails + check("abc",
+        ripemd320.ripemd320_hex("abc", 3),
+        "de4c01b3054f8930a79d09ae738e92301e5a17085beffdc1b8d116713e74f82fa942d64cdbc4682d")
+    fails = fails + check("message digest",
+        ripemd320.ripemd320_hex("message digest", 14),
+        "3a8e28502ed45d422f68844f9dd316e7b98533fa3f2a91d29f84d425c88d6b4eff727df66a7c0197")
+    fails = fails + check("alphabet",
+        ripemd320.ripemd320_hex("abcdefghijklmnopqrstuvwxyz", 26),
+        "cabdb1810b92470a2093aa6bce05952c28348cf43ff60841975166bb40ed234004b8824463e6b009")
+    fails = fails + check("A...Za...z0...9 (62)",
+        ripemd320.ripemd320_hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62),
+        "ed544940c86d67f250d232c30b7b3e5770e0c60c8cb9a4cafe3b11388af9920e1b99230b843c86a4")
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES")
+    exit(1)
+}

--- a/tests/regression/test_aes.ae
+++ b/tests/regression/test_aes.ae
@@ -69,6 +69,52 @@ main() {
     if beq(rtc, ptc) != 1 { print("FAIL ctr rt\n"); fails=fails+1 }
     aes.free(ec); bytes.free(ctc); bytes.free(rtc); bytes.free(ptc); bytes.free(iv); bytes.free(kc)
 
+    // AES-128-CBC (NIST SP800-38A F.2.1 / F.2.2), 4 blocks, block-aligned.
+    kb = hb("2b7e151628aed2a6abf7158809cf4f3c")
+    ivb = hb("000102030405060708090a0b0c0d0e0f")
+    ptb = hb(string.concat("6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+                           "30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710"))
+    ecb_ = aes.new_encryptor(kb, 16)
+    cbc = aes.cbc_encrypt(ecb_, ivb, ptb)
+    want_cbc = string.concat("7649abac8119b246cee98e9b12e9197d5086cb9b507219ee95db113a917678b2",
+                             "73bed6b8e3c1743b7116e69e222295163ff1caa1681fac09120eca307586e1a7")
+    if string.equals(bh(cbc), want_cbc) != 1 { print("FAIL cbc enc ${bh(cbc)}\n"); fails=fails+1 }
+    dcb = aes.new_decryptor(kb, 16)
+    cbc_rt = aes.cbc_decrypt(dcb, ivb, cbc)
+    if beq(cbc_rt, ptb) != 1 { print("FAIL cbc dec\n"); fails=fails+1 }
+    aes.free(ecb_); aes.free(dcb); bytes.free(cbc); bytes.free(cbc_rt)
+    bytes.free(ptb); bytes.free(ivb); bytes.free(kb)
+
+    // CBC + PKCS#7 round-trip on a non-block-multiple payload (13 bytes).
+    kp = hb("2b7e151628aed2a6abf7158809cf4f3c")
+    ivp = hb("000102030405060708090a0b0c0d0e0f")
+    msg = hb("48656c6c6f2c20416574686572")   // "Hello, Aether" (13 bytes)
+    ep = aes.new_encryptor(kp, 16)
+    ctp = aes.cbc_encrypt_pkcs7(ep, ivp, msg)
+    if bytes.length(ctp) != 16 { print("FAIL pkcs7 ct length ${bytes.length(ctp)}\n"); fails=fails+1 }
+    dp = aes.new_decryptor(kp, 16)
+    ptp, perr = aes.cbc_decrypt_pkcs7(dp, ivp, ctp)
+    if perr != "" { print("FAIL pkcs7 unpad err ${perr}\n"); fails=fails+1 }
+    if beq(ptp, msg) != 1 { print("FAIL pkcs7 rt\n"); fails=fails+1 }
+    aes.free(ep); aes.free(dp); bytes.free(ctp); bytes.free(ptp)
+    bytes.free(msg); bytes.free(ivp); bytes.free(kp)
+
+    // PKCS#7 padding edge cases (standalone).
+    // (a) exact-block input → a full extra padding block (16 bytes of 0x10).
+    blk16 = hb("00112233445566778899aabbccddeeff")
+    padded = aes.pkcs7_pad(blk16)
+    if bytes.length(padded) != 32 { print("FAIL pkcs7 full-block pad len\n"); fails=fails+1 }
+    if (bytes.get(padded, 31) & 0xFF) != 16 { print("FAIL pkcs7 full-block pad byte\n"); fails=fails+1 }
+    unp, uerr = aes.pkcs7_unpad(padded)
+    if uerr != "" { print("FAIL pkcs7 full-block unpad ${uerr}\n"); fails=fails+1 }
+    if beq(unp, blk16) != 1 { print("FAIL pkcs7 full-block rt\n"); fails=fails+1 }
+    bytes.free(padded); bytes.free(unp); bytes.free(blk16)
+    // (b) corrupted padding is rejected.
+    bad = hb("00112233445566778899aabbccddee07")   // last byte says pad=7 but isn't
+    _, berr = aes.pkcs7_unpad(bad)
+    if berr == "" { print("FAIL pkcs7 should reject bad padding\n"); fails=fails+1 }
+    bytes.free(bad)
+
     bytes.free(pt)
     if fails == 0 { print("PASS: contrib.cryptography.aes\n") } else { print("FAILED: ${fails}\n"); exit(1) }
 }


### PR DESCRIPTION
Next tranche of the Bouncy Castle → Aether crypto port (#739): the most-used symmetric mode plus the two wide RIPEMD digests. All pure Aether — **no externs to OpenSSL or any C crypto**.

## AES CBC + PKCS#7 (`contrib.cryptography.aes`)
Layered over the existing FIPS-197 block primitive (the same `process_block` that ECB/CTR already drive):

- `cbc_encrypt(ctx, iv, data)` / `cbc_decrypt(ctx, iv, data)` — block-aligned CBC (`C_i = E(P_i XOR C_{i-1})`, `C_{-1}=IV`).
- `pkcs7_pad(data)` / `pkcs7_unpad(data) -> (pt, err)` — RFC 5652 §6.3. A full extra block is added when the input is already a multiple of 16; unpad rejects malformed padding (bad length, out-of-range count, mismatched trailing bytes).
- `cbc_encrypt_pkcs7` / `cbc_decrypt_pkcs7` — arbitrary-length CBC.

Validated against **NIST SP800-38A F.2.1/F.2.2** AES-128-CBC vectors, a PKCS#7 round-trip on a non-block-multiple payload, the exact-block-→-full-extra-block edge case, and bad-padding rejection (in the extended `tests/regression/test_aes.ae`).

## RIPEMD-256 / RIPEMD-320 (`std.cryptography`)
Ported from BC's `RipeMD256Digest` / `RipeMD320Digest`. These run the two RIPEMD-128 / -160 lines side by side for a wider output — **256/320-bit at the same security level as -128 / -160** (the extra width is collision domain only). Same streaming + one-shot surface as the rest of `std.cryptography`:

| Module | Output | Structure |
|--------|--------|-----------|
| `std.cryptography.ripemd256` | 256-bit | 8-word dual-line, register swap per round |
| `std.cryptography.ripemd320` | 320-bit | 10-word dual-line, `e<->ee` folded into final |

They reuse the -128 / -160 step functions and framing (little-endian, 32-bit masked adds, left rotates). Validated against the published RIPEMD reference vectors (empty / `a` / `abc` / `message digest` / alphabet / 62-char), cross-checked against the canonical values.

## Notes
Local `make test-ae`: **709/711 pass**; the 2 failures are the pre-existing HTTP/2 curl framing-layer flakes on this box, unrelated. No compiler/runtime/std C touched (the AES change is contrib; the digests are auto-discovered pure-Aether std submodules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)