### PR TITLE
fix(actors): retain message strings into state; feat(cryptography): KDF + AEAD tranche

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [0.295.0]
+
+### Added
+
+- **Key derivation, AES MAC/wrap, and a ChaCha20-Poly1305 AEAD** — a large
+  pure-Aether tranche of the Bouncy Castle port (#739), all validated against
+  RFC test vectors, no externs to OpenSSL.
+  - **`std.cryptography.hkdf`** — HKDF (RFC 5869) extract/expand over the
+    existing HMAC. Validated against RFC 5869 Test Case 1.
+  - **`std.cryptography.pbkdf2`** — PBKDF2 (PKCS#5 v2 / RFC 8018) over HMAC.
+    Validated against published PBKDF2-HMAC-SHA256 vectors.
+  - **`contrib.cryptography.aes`** gains `cmac` (AES-CMAC, RFC 4493) and
+    `key_wrap` / `key_unwrap` (AES Key Wrap, RFC 3394) on the existing block
+    primitive. Validated against all four RFC 4493 CMAC vectors and the
+    RFC 3394 wrap vector (+ unwrap integrity check).
+  - **`contrib.cryptography.chacha20poly1305`** — ChaCha20, Poly1305, and the
+    ChaCha20-Poly1305 AEAD (RFC 8439): `chacha20_xor`, `poly1305_mac`,
+    `aead_seal`, `aead_open` (constant-time tag compare). The pure-Aether
+    counterpart to AES-GCM. Validated against the RFC 8439 §2.5.2 and §2.8.2
+    vectors (seal reproduces the exact spec ciphertext+tag; tampered tags are
+    rejected).
+
+### Fixed
+
+- **Actors: a string message field retained into actor state no longer
+  corrupts.** `SetN(in_n) -> { n = in_n }` stored a raw pointer into the
+  message envelope's string, which is freed right after the handler returns,
+  so a later message read freed bytes. The retain now copies the borrowed
+  string into an owned AetherString (freeing any prior copy). Also fixes the
+  defensive-copy workaround `n = string.concat(in_n, "")`, which previously
+  failed to compile (`'_heap_n' undeclared`) because actor handlers skipped
+  the function-scope heap-string hoist pass. (Reported by aeo.)
+
 ## [0.294.0]
 
 ### Added

--- a/compiler/codegen/codegen_actor.c
+++ b/compiler/codegen/codegen_actor.c
@@ -297,6 +297,21 @@ void generate_actor_definition(CodeGenerator* gen, ASTNode* actor) {
                             &gen->current_promoted_captures,
                             &gen->current_promoted_capture_count);
 
+                        // Pre-hoist `_heap_<name>` companions for string
+                        // locals in the handler body, exactly as
+                        // generate_function_definition does for regular
+                        // functions (codegen_func.c) and main (codegen.c).
+                        // Without this, a handler that builds a heap string
+                        // — e.g. `n = string.concat(in_n, "")` to retain a
+                        // message field into state — emits a `_heap_n`
+                        // tracker reference that is never declared, producing
+                        // `'_heap_n' undeclared` in the generated C. The
+                        // handler is its own C function, so it needs the same
+                        // function-scope hoist pass.
+                        if (arm_body && arm_body->type == AST_BLOCK) {
+                            hoist_heap_string_trackers(gen, arm_body);
+                        }
+
                         // Generate handler body
                         if (arm_body && arm_body->type == AST_BLOCK) {
                             for (int k = 0; k < arm_body->child_count; k++) {

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -3649,6 +3649,29 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                                 stmt->value);
                         fprintf(gen->output, " _heap_%s = 1; }\n", stmt->value);
                     }
+                } else if (stmt->child_count > 0 && stmt->children[0] &&
+                           stmt->children[0]->type == AST_IDENTIFIER &&
+                           stmt->children[0]->node_type &&
+                           stmt->children[0]->node_type->kind == TYPE_STRING &&
+                           !is_heap_string_var(gen, stmt->children[0]->value)) {
+                    /* Retaining a BORROWED string into actor state — the
+                     * classic case is a message pattern field (`SetN(in_n)
+                     * -> { n = in_n }`). The field is owned by the message
+                     * envelope and freed by `<Msg>_release_fields` right
+                     * after this handler returns, so storing the raw pointer
+                     * into `self->field` dangles and a LATER message reads
+                     * freed bytes (the aeo actor-state-string corruption).
+                     * Copy into an owned AetherString — the same idiom the
+                     * message SEND site uses for string fields — and free any
+                     * prior owned copy. Marked via `_heap_<field>` so a
+                     * subsequent retain frees the previous one. */
+                    fprintf(gen->output, "{ const char* _tmp_old = self->%s; ", stmt->value);
+                    fprintf(gen->output, "const char* _src = (const char*)(");
+                    generate_expression(gen, stmt->children[0]);
+                    fprintf(gen->output, "); self->%s = _src ? (const char*)string_new_with_length(aether_string_data(_src), (int)aether_string_length(_src)) : _src;",
+                            stmt->value);
+                    fprintf(gen->output, " if (_heap_%s) aether_heap_str_free(_tmp_old);", stmt->value);
+                    fprintf(gen->output, " _heap_%s = 1; }\n", stmt->value);
                 } else {
                     fprintf(gen->output, "self->%s", stmt->value);
                     if (stmt->child_count > 0) {

--- a/contrib/cryptography/aes/module.ae
+++ b/contrib/cryptography/aes/module.ae
@@ -43,7 +43,8 @@ exports (
     new_encryptor, new_decryptor, process_block, free,
     block_size, ecb_encrypt, ecb_decrypt, ctr_xor,
     cbc_encrypt, cbc_decrypt, cbc_encrypt_pkcs7, cbc_decrypt_pkcs7,
-    pkcs7_pad, pkcs7_unpad
+    pkcs7_pad, pkcs7_unpad,
+    cmac, key_wrap, key_unwrap
 )
 
 extern malloc(size: int) -> ptr
@@ -480,4 +481,234 @@ cbc_decrypt_pkcs7(ctx: ptr, iv: ptr, data: ptr) -> {
     out, err = pkcs7_unpad(raw)
     bytes.free(raw)
     return out, err
+}
+
+// ---- AES-CMAC (RFC 4493) ----
+// One-shot CMAC over `data` (len bytes) with AES key `key`/`keylen`.
+// Returns a fresh 16-byte tag. `key` is the raw AES key (16/24/32).
+//
+// Subkeys: L = AES-Enc(0^128); K1 = dbl(L); K2 = dbl(K1), where dbl(x) is
+// a left shift by 1 with a conditional XOR of Rb=0x87 when the high bit
+// was set (GF(2^128) doubling). The MAC is CBC-MAC with the final block
+// XOR'd by K1 (when the message is a non-empty multiple of 16) or, after
+// 10*..0 padding, by K2.
+cmac(key: ptr, keylen: int, data: ptr, len: int) -> ptr {
+    enc = new_encryptor(key, keylen)
+
+    // L = E(0^128)
+    zero = bytes.new(16)
+    z = 0
+    while z < 16 { bytes.set(zero, z, 0); z = z + 1 }
+    L = process_block(enc, zero)
+    bytes.free(zero)
+
+    k1 = cmac_dbl(L)
+    k2 = cmac_dbl(k1)
+    bytes.free(L)
+
+    // Number of 16-byte blocks; whether the last is complete.
+    n = (len + 15) / 16
+    complete = 0
+    if len > 0 { if (len % 16) == 0 { complete = 1 } }
+    if n == 0 { n = 1 }   // empty message → one padded block
+
+    // Build the last block M_last.
+    last = bytes.new(16)
+    if complete == 1 {
+        // last full block XOR K1
+        base = (n - 1) * 16
+        j = 0
+        while j < 16 {
+            bytes.set(last, j, (bytes.get(data, base + j) ^ bytes.get(k1, j)) & 0xFF)
+            j = j + 1
+        }
+    } else {
+        // copy remaining bytes, append 0x80, zero-pad, XOR K2
+        base = (n - 1) * 16
+        rem = len - base
+        j = 0
+        while j < 16 {
+            b = 0
+            if j < rem {
+                b = bytes.get(data, base + j)
+            } else if j == rem {
+                b = 0x80
+            }
+            bytes.set(last, j, (b ^ bytes.get(k2, j)) & 0xFF)
+            j = j + 1
+        }
+    }
+    bytes.free(k1)
+    bytes.free(k2)
+
+    // CBC-MAC: X = 0; for each block except the last, X = E(X XOR M_i);
+    // then tag = E(X XOR M_last).
+    x = bytes.new(16)
+    z = 0
+    while z < 16 { bytes.set(x, z, 0); z = z + 1 }
+
+    i = 0
+    while i < n - 1 {
+        blk = bytes.new(16)
+        base = i * 16
+        j = 0
+        while j < 16 {
+            bytes.set(blk, j, (bytes.get(x, j) ^ bytes.get(data, base + j)) & 0xFF)
+            j = j + 1
+        }
+        eb = process_block(enc, blk)
+        bytes.free(blk)
+        bytes.free(x)
+        x = eb
+        i = i + 1
+    }
+
+    // Final block.
+    fin = bytes.new(16)
+    j = 0
+    while j < 16 {
+        bytes.set(fin, j, (bytes.get(x, j) ^ bytes.get(last, j)) & 0xFF)
+        j = j + 1
+    }
+    bytes.free(x)
+    bytes.free(last)
+    tag = process_block(enc, fin)
+    bytes.free(fin)
+    free(enc)
+    return tag
+}
+
+// GF(2^128) doubling of a 16-byte big-endian value (RFC 4493 dbl).
+cmac_dbl(inp: ptr) -> ptr {
+    out = bytes.new(16)
+    carry = 0
+    i = 15
+    while i >= 0 {
+        v = bytes.get(inp, i) & 0xFF
+        nv = ((v << 1) | carry) & 0xFF
+        carry = (v >> 7) & 1
+        bytes.set(out, i, nv)
+        i = i - 1
+    }
+    // If the original high bit was set, XOR the low byte with Rb=0x87.
+    if (bytes.get(inp, 0) & 0x80) != 0 {
+        bytes.set(out, 15, (bytes.get(out, 15) ^ 0x87) & 0xFF)
+    }
+    return out
+}
+
+// ---- AES Key Wrap (RFC 3394) ----
+// Wrap `data` (len bytes, must be a multiple of 8 and >= 16) with the KEK
+// `key`/`keylen`. Returns ciphertext of len+8 bytes, or null on bad input.
+// The default IV A6A6A6A6A6A6A6A6 is used.
+key_wrap(key: ptr, keylen: int, data: ptr, len: int) -> ptr {
+    if len < 16 { return null }
+    if (len % 8) != 0 { return null }
+    nblk = len / 8                 // number of 64-bit blocks
+
+    enc = new_encryptor(key, keylen)
+
+    // A = IV; R[1..n] = plaintext blocks.
+    a = bytes.new(8)
+    i = 0
+    while i < 8 { bytes.set(a, i, 0xA6); i = i + 1 }
+    r = bytes.new(len)
+    bytes.copy_from_bytes(r, 0, data, 0, len)
+
+    blk = bytes.new(16)
+    j = 0
+    while j < 6 {
+        i = 0
+        while i < nblk {
+            // B = AES-Enc(A | R[i])
+            k = 0
+            while k < 8 { bytes.set(blk, k, bytes.get(a, k)); k = k + 1 }
+            k = 0
+            while k < 8 { bytes.set(blk, 8 + k, bytes.get(r, i * 8 + k)); k = k + 1 }
+            b = process_block(enc, blk)
+            // A = MSB64(B) XOR t, where t = (n*j)+(i+1)
+            t = nblk * j + (i + 1)
+            k = 0
+            while k < 8 { bytes.set(a, k, bytes.get(b, k)); k = k + 1 }
+            // XOR t into A big-endian (t fits well within 64 bits)
+            bytes.set(a, 7, (bytes.get(a, 7) ^ (t & 0xFF)) & 0xFF)
+            bytes.set(a, 6, (bytes.get(a, 6) ^ ((t >> 8) & 0xFF)) & 0xFF)
+            bytes.set(a, 5, (bytes.get(a, 5) ^ ((t >> 16) & 0xFF)) & 0xFF)
+            bytes.set(a, 4, (bytes.get(a, 4) ^ ((t >> 24) & 0xFF)) & 0xFF)
+            // R[i] = LSB64(B)
+            k = 0
+            while k < 8 { bytes.set(r, i * 8 + k, bytes.get(b, 8 + k)); k = k + 1 }
+            bytes.free(b)
+            i = i + 1
+        }
+        j = j + 1
+    }
+    bytes.free(blk)
+
+    out = bytes.new(len + 8)
+    bytes.copy_from_bytes(out, 0, a, 0, 8)
+    bytes.copy_from_bytes(out, 8, r, 0, len)
+    bytes.free(a)
+    bytes.free(r)
+    free(enc)
+    return out
+}
+
+// Unwrap RFC 3394 ciphertext (`data`/`len`, len multiple of 8 and >= 24)
+// with KEK `key`/`keylen`. Returns (plaintext, "") on a valid integrity
+// check, or (null, error) if the unwrapped IV != A6A6A6A6A6A6A6A6.
+key_unwrap(key: ptr, keylen: int, data: ptr, len: int) -> {
+    if len < 24 { return null, "ciphertext too short" }
+    if (len % 8) != 0 { return null, "length not a multiple of 8" }
+    nblk = (len / 8) - 1           // number of plaintext blocks
+
+    dec = new_decryptor(key, keylen)
+
+    a = bytes.new(8)
+    bytes.copy_from_bytes(a, 0, data, 0, 8)
+    r = bytes.new(nblk * 8)
+    bytes.copy_from_bytes(r, 0, data, 8, nblk * 8)
+
+    blk = bytes.new(16)
+    j = 5
+    while j >= 0 {
+        i = nblk - 1
+        while i >= 0 {
+            // B = AES-Dec((A XOR t) | R[i]),  t = (n*j)+(i+1)
+            t = nblk * j + (i + 1)
+            k = 0
+            while k < 8 { bytes.set(blk, k, bytes.get(a, k)); k = k + 1 }
+            bytes.set(blk, 7, (bytes.get(blk, 7) ^ (t & 0xFF)) & 0xFF)
+            bytes.set(blk, 6, (bytes.get(blk, 6) ^ ((t >> 8) & 0xFF)) & 0xFF)
+            bytes.set(blk, 5, (bytes.get(blk, 5) ^ ((t >> 16) & 0xFF)) & 0xFF)
+            bytes.set(blk, 4, (bytes.get(blk, 4) ^ ((t >> 24) & 0xFF)) & 0xFF)
+            k = 0
+            while k < 8 { bytes.set(blk, 8 + k, bytes.get(r, i * 8 + k)); k = k + 1 }
+            b = process_block(dec, blk)
+            // A = MSB64(B); R[i] = LSB64(B)
+            k = 0
+            while k < 8 { bytes.set(a, k, bytes.get(b, k)); k = k + 1 }
+            k = 0
+            while k < 8 { bytes.set(r, i * 8 + k, bytes.get(b, 8 + k)); k = k + 1 }
+            bytes.free(b)
+            i = i - 1
+        }
+        j = j - 1
+    }
+    bytes.free(blk)
+    free(dec)
+
+    // Integrity: A must equal the default IV A6A6A6A6A6A6A6A6.
+    ok = 1
+    k = 0
+    while k < 8 {
+        if (bytes.get(a, k) & 0xFF) != 0xA6 { ok = 0 }
+        k = k + 1
+    }
+    bytes.free(a)
+    if ok == 0 {
+        bytes.free(r)
+        return null, "integrity check failed"
+    }
+    return r, ""
 }

--- a/contrib/cryptography/chacha20poly1305/module.ae
+++ b/contrib/cryptography/chacha20poly1305/module.ae
@@ -1,0 +1,387 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.chacha20poly1305 — ChaCha20, Poly1305, and the
+// ChaCha20-Poly1305 AEAD (RFC 8439) in pure Aether. NO externs to OpenSSL.
+// The pure-Aether counterpart to AES-GCM: a modern authenticated cipher
+// with no big lookup tables and no block-cipher dependency.
+//
+// Surface:
+//   chacha20_xor(key32, nonce12, counter, data, len) -> ptr
+//       ChaCha20 keystream XOR (encrypt == decrypt). 256-bit key, 96-bit
+//       nonce, 32-bit initial block counter.
+//   poly1305_mac(key32, data, len) -> ptr          // 16-bv tag
+//   aead_seal(key32, nonce12, aad, aad_len, plaintext, pt_len)
+//       -> ptr ciphertext-with-tag (pt_len + 16 bytes; tag appended)
+//   aead_open(key32, nonce12, aad, aad_len, ct_with_tag, ct_len)
+//       -> (plaintext, "") on a valid tag, or (null, error)
+//
+// All buffers are std.bytes (caller frees results).
+//
+// Aether-specific care:
+//   * ChaCha works on 32-bit words; Aether int/long are 64-bit, so every
+//     32-bit add is masked with & 0xFFFFFFFF and rotates go through
+//     std.bits.rotl32 on a pre-masked value. Everything is LITTLE-endian.
+//   * Poly1305 needs 130-bit modular arithmetic. We use the standard
+//     5 x 26-bit limb representation: each limb fits in a 64-bit Aether
+//     int, products (26+26+carry bits) stay well under 63 bits, and the
+//     mod 2^130-5 reduction folds the top via *5. (Mirrors the portable
+//     "poly1305-donna" 32-bit limb scheme.)
+
+import std.bytes
+import std.bits
+import std.intarr
+import std.longarr
+
+exports (
+    chacha20_xor, poly1305_mac, aead_seal, aead_open
+)
+
+m32(x: long) -> long {
+    return x & 0xFFFFFFFF
+}
+rl(x: long, n: int) -> long {
+    return bits.rotl32(x & 0xFFFFFFFF, n) & 0xFFFFFFFF
+}
+
+// ---- ChaCha20 (RFC 8439 §2.3) ----
+
+// One ChaCha20 quarter-round on state words at indices a,b,c,d.
+qr(st: ptr, a: int, b: int, c: int, d: int) {
+    va = longarr_get_unchecked(st, a)
+    vb = longarr_get_unchecked(st, b)
+    vc = longarr_get_unchecked(st, c)
+    vd = longarr_get_unchecked(st, d)
+    va = m32(va + vb); vd = rl(vd ^ va, 16)
+    vc = m32(vc + vd); vb = rl(vb ^ vc, 12)
+    va = m32(va + vb); vd = rl(vd ^ va, 8)
+    vc = m32(vc + vd); vb = rl(vb ^ vc, 7)
+    longarr_set_unchecked(st, a, va)
+    longarr_set_unchecked(st, b, vb)
+    longarr_set_unchecked(st, c, vc)
+    longarr_set_unchecked(st, d, vd)
+}
+
+// Produce one 64-byte ChaCha20 block into `out` (offset 0..63) for the
+// given key (32 bytes), nonce (12 bytes), and 32-bit counter.
+chacha_block(key: ptr, nonce: ptr, counter: long, out: ptr) {
+    st = longarr_new_raw(16)
+    // Constants "expand 32-byte k"
+    longarr_set_unchecked(st, 0, 0x61707865)
+    longarr_set_unchecked(st, 1, 0x3320646e)
+    longarr_set_unchecked(st, 2, 0x79622d32)
+    longarr_set_unchecked(st, 3, 0x6b206574)
+    i = 0
+    while i < 8 {
+        longarr_set_unchecked(st, 4 + i, le32(key, i * 4))
+        i = i + 1
+    }
+    longarr_set_unchecked(st, 12, counter & 0xFFFFFFFF)
+    longarr_set_unchecked(st, 13, le32(nonce, 0))
+    longarr_set_unchecked(st, 14, le32(nonce, 4))
+    longarr_set_unchecked(st, 15, le32(nonce, 8))
+
+    work = longarr_new_raw(16)
+    i = 0
+    while i < 16 { longarr_set_unchecked(work, i, longarr_get_unchecked(st, i)); i = i + 1 }
+
+    r = 0
+    while r < 10 {
+        // column rounds
+        qr(work, 0, 4, 8, 12)
+        qr(work, 1, 5, 9, 13)
+        qr(work, 2, 6, 10, 14)
+        qr(work, 3, 7, 11, 15)
+        // diagonal rounds
+        qr(work, 0, 5, 10, 15)
+        qr(work, 1, 6, 11, 12)
+        qr(work, 2, 7, 8, 13)
+        qr(work, 3, 4, 9, 14)
+        r = r + 1
+    }
+
+    i = 0
+    while i < 16 {
+        v = m32(longarr_get_unchecked(work, i) + longarr_get_unchecked(st, i))
+        set_le32(out, i * 4, v)
+        i = i + 1
+    }
+    longarr_free(st)
+    longarr_free(work)
+}
+
+le32(b: ptr, off: int) -> long {
+    // Use 64-bit limbs: a byte >= 0x80 in position 3 would otherwise set
+    // bit 31 of a 32-bit int expression, sign-extending to a negative
+    // int64_t on widening and corrupting the value (and any later
+    // arithmetic `>>`). See the int-truncate-shift hazard.
+    long b0 = bytes.get(b, off) & 0xFF
+    long b1 = bytes.get(b, off + 1) & 0xFF
+    long b2 = bytes.get(b, off + 2) & 0xFF
+    long b3 = bytes.get(b, off + 3) & 0xFF
+    return b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+}
+set_le32(b: ptr, off: int, v: long) {
+    bytes.set(b, off,     v & 0xFF)
+    bytes.set(b, off + 1, bits.lsr64(v, 8) & 0xFF)
+    bytes.set(b, off + 2, bits.lsr64(v, 16) & 0xFF)
+    bytes.set(b, off + 3, bits.lsr64(v, 24) & 0xFF)
+}
+
+// ChaCha20 keystream XOR over `data`. `counter` is the initial block
+// counter (1 for AEAD payload; 0 produces the block used for the Poly1305
+// key). Returns a fresh buffer of `len` bytes.
+chacha20_xor(key: ptr, nonce: ptr, counter: long, data: ptr, len: int) -> ptr {
+    out = bytes.new(len)
+    ks = bytes.new(64)
+    off = 0
+    blk = counter
+    while off < len {
+        chacha_block(key, nonce, blk, ks)
+        j = 0
+        while j < 64 {
+            if off + j < len {
+                bytes.set(out, off + j, (bytes.get(data, off + j) ^ bytes.get(ks, j)) & 0xFF)
+            }
+            j = j + 1
+        }
+        off = off + 64
+        blk = blk + 1
+    }
+    bytes.free(ks)
+    return out
+}
+
+// ---- Poly1305 (RFC 8439 §2.5), 5x26-bit limbs ----
+
+// One-shot Poly1305: 32-byte one-time key (r||s), message of `len` bytes.
+// Returns a fresh 16-byte tag.
+poly1305_mac(key: ptr, data: ptr, len: int) -> ptr {
+    // Clamp r (RFC 8439): r &= 0x0ffffffc0ffffffc0ffffffc0fffffff
+    // Load r as 5 26-bit limbs from the 16 clamped key bytes.
+    t0 = le32(key, 0)
+    t1 = le32(key, 4)
+    t2 = le32(key, 8)
+    t3 = le32(key, 12)
+
+    r0 = t0 & 0x3ffffff
+    r1 = ((t0 >> 26) | (t1 << 6)) & 0x3ffff03
+    r2 = ((t1 >> 20) | (t2 << 12)) & 0x3ffc0ff
+    r3 = ((t2 >> 14) | (t3 << 18)) & 0x3f03fff
+    r4 = (t3 >> 8) & 0x00fffff
+
+    // Precompute 5*r1..5*r4 for the reduction.
+    s1 = r1 * 5
+    s2 = r2 * 5
+    s3 = r3 * 5
+    s4 = r4 * 5
+
+    long h0 = 0
+    long h1 = 0
+    long h2 = 0
+    long h3 = 0
+    long h4 = 0
+
+    off = 0
+    while off < len {
+        // Build the next 16-byte (or shorter) block + the high bit.
+        nblk = len - off
+        if nblk > 16 { nblk = 16 }
+        long b0 = 0
+        long b1 = 0
+        long b2 = 0
+        long b3 = 0
+        long hibit = 0
+        // assemble up to 16 bytes little-endian into b0..b3 (32 bits each)
+        // bv is `long` so `bv << 24` (byte >= 0x80) doesn't set bit 31 of a
+        // 32-bit int and sign-extend negative into the limb.
+        k = 0
+        long bv = 0
+        while k < nblk {
+            bv = bytes.get(data, off + k) & 0xFF
+            sh = (k % 4) * 8
+            word = k / 4
+            if word == 0 { b0 = b0 | (bv << sh) }
+            if word == 1 { b1 = b1 | (bv << sh) }
+            if word == 2 { b2 = b2 | (bv << sh) }
+            if word == 3 { b3 = b3 | (bv << sh) }
+            k = k + 1
+        }
+        if nblk == 16 {
+            hibit = 1 << 24      // 2^128 bit, distributed into limb 4 below
+        } else {
+            // append the 0x01 byte at position nblk
+            sh = (nblk % 4) * 8
+            word = nblk / 4
+            bv = 1
+            if word == 0 { b0 = b0 | (bv << sh) }
+            if word == 1 { b1 = b1 | (bv << sh) }
+            if word == 2 { b2 = b2 | (bv << sh) }
+            if word == 3 { b3 = b3 | (bv << sh) }
+        }
+
+        // Add the block to the accumulator (as 5 26-bit limbs).
+        h0 = h0 + (b0 & 0x3ffffff)
+        h1 = h1 + (((b0 >> 26) | (b1 << 6)) & 0x3ffffff)
+        h2 = h2 + (((b1 >> 20) | (b2 << 12)) & 0x3ffffff)
+        h3 = h3 + (((b2 >> 14) | (b3 << 18)) & 0x3ffffff)
+        h4 = h4 + ((b3 >> 8) | hibit)
+
+        // h *= r  (mod 2^130 - 5), schoolbook with the *5 fold.
+        d0 = h0*r0 + h1*s4 + h2*s3 + h3*s2 + h4*s1
+        d1 = h0*r1 + h1*r0 + h2*s4 + h3*s3 + h4*s2
+        d2 = h0*r2 + h1*r1 + h2*r0 + h3*s4 + h4*s3
+        d3 = h0*r3 + h1*r2 + h2*r1 + h3*r0 + h4*s4
+        d4 = h0*r4 + h1*r3 + h2*r2 + h3*r1 + h4*r0
+
+        // Carry-propagate.
+        c = bits.lsr64(d0, 26); h0 = d0 & 0x3ffffff
+        d1 = d1 + c; c = bits.lsr64(d1, 26); h1 = d1 & 0x3ffffff
+        d2 = d2 + c; c = bits.lsr64(d2, 26); h2 = d2 & 0x3ffffff
+        d3 = d3 + c; c = bits.lsr64(d3, 26); h3 = d3 & 0x3ffffff
+        d4 = d4 + c; c = bits.lsr64(d4, 26); h4 = d4 & 0x3ffffff
+        h0 = h0 + c * 5
+        c = bits.lsr64(h0, 26); h0 = h0 & 0x3ffffff
+        h1 = h1 + c
+
+        off = off + nblk
+    }
+
+    // Final carry.
+    c = bits.lsr64(h1, 26); h1 = h1 & 0x3ffffff
+    h2 = h2 + c; c = bits.lsr64(h2, 26); h2 = h2 & 0x3ffffff
+    h3 = h3 + c; c = bits.lsr64(h3, 26); h3 = h3 & 0x3ffffff
+    h4 = h4 + c; c = bits.lsr64(h4, 26); h4 = h4 & 0x3ffffff
+    h0 = h0 + c * 5; c = bits.lsr64(h0, 26); h0 = h0 & 0x3ffffff
+    h1 = h1 + c
+
+    // Compute h - p (p = 2^130-5); select if h >= p.
+    g0 = h0 + 5; c = bits.lsr64(g0, 26); g0 = g0 & 0x3ffffff
+    g1 = h1 + c; c = bits.lsr64(g1, 26); g1 = g1 & 0x3ffffff
+    g2 = h2 + c; c = bits.lsr64(g2, 26); g2 = g2 & 0x3ffffff
+    g3 = h3 + c; c = bits.lsr64(g3, 26); g3 = g3 & 0x3ffffff
+    g4 = h4 + c - (1 << 26)
+
+    // mask = (g4 >> 63) ? all-ones (h<p, keep h) : 0 (use g)
+    mask = bits.lsr64(g4, 63) & 1
+    // if mask==1 keep h; else use g. Build select.
+    if mask == 0 {
+        h0 = g0; h1 = g1; h2 = g2; h3 = g3; h4 = g4 & 0x3ffffff
+    }
+
+    // Serialize h (mod 2^128) as 4 little-endian 32-bit words, then add s.
+    f0 = (h0 | (h1 << 26)) & 0xFFFFFFFF
+    f1 = ((h1 >> 6) | (h2 << 20)) & 0xFFFFFFFF
+    f2 = ((h2 >> 12) | (h3 << 14)) & 0xFFFFFFFF
+    f3 = ((h3 >> 18) | (h4 << 8)) & 0xFFFFFFFF
+
+    // Add s (key bytes 16..31), with carry.
+    s0v = le32(key, 16)
+    s1v = le32(key, 20)
+    s2v = le32(key, 24)
+    s3v = le32(key, 28)
+    acc = f0 + s0v; o0 = acc & 0xFFFFFFFF; carry = bits.lsr64(acc, 32)
+    acc = f1 + s1v + carry; o1 = acc & 0xFFFFFFFF; carry = bits.lsr64(acc, 32)
+    acc = f2 + s2v + carry; o2 = acc & 0xFFFFFFFF; carry = bits.lsr64(acc, 32)
+    acc = f3 + s3v + carry; o3 = acc & 0xFFFFFFFF
+
+    tag = bytes.new(16)
+    set_le32(tag, 0, o0)
+    set_le32(tag, 4, o1)
+    set_le32(tag, 8, o2)
+    set_le32(tag, 12, o3)
+    return tag
+}
+
+// ---- AEAD (RFC 8439 §2.8) ----
+
+// Derive the Poly1305 one-time key = ChaCha20 block(counter 0)[0:32].
+poly_key_for(key: ptr, nonce: ptr) -> ptr {
+    blk = bytes.new(64)
+    chacha_block(key, nonce, 0, blk)
+    pk = bytes.new(32)
+    bytes.copy_from_bytes(pk, 0, blk, 0, 32)
+    bytes.free(blk)
+    return pk
+}
+
+// Build the Poly1305 MAC input: AAD || pad16 || CT || pad16 ||
+// le64(aad_len) || le64(ct_len). Returns a fresh buffer + sets its length
+// implicitly via bytes.length.
+mac_data(aad: ptr, aad_len: int, ct: ptr, ct_len: int) -> ptr {
+    pad_a = (16 - (aad_len % 16)) % 16
+    pad_c = (16 - (ct_len % 16)) % 16
+    total = aad_len + pad_a + ct_len + pad_c + 16
+    out = bytes.new(total)
+    off = 0
+    if aad_len > 0 { bytes.copy_from_bytes(out, off, aad, 0, aad_len) }
+    off = off + aad_len
+    z = 0
+    while z < pad_a { bytes.set(out, off + z, 0); z = z + 1 }
+    off = off + pad_a
+    if ct_len > 0 { bytes.copy_from_bytes(out, off, ct, 0, ct_len) }
+    off = off + ct_len
+    z = 0
+    while z < pad_c { bytes.set(out, off + z, 0); z = z + 1 }
+    off = off + pad_c
+    set_le64(out, off, aad_len)
+    set_le64(out, off + 8, ct_len)
+    return out
+}
+
+set_le64(b: ptr, off: int, v: long) {
+    i = 0
+    while i < 8 {
+        bytes.set(b, off + i, bits.lsr64(v, i * 8) & 0xFF)
+        i = i + 1
+    }
+}
+
+// AEAD seal: returns ciphertext (pt_len bytes) with the 16-bv Poly1305
+// tag appended → pt_len + 16 bytes.
+aead_seal(key: ptr, nonce: ptr, aad: ptr, aad_len: int, plaintext: ptr, pt_len: int) -> ptr {
+    ct = chacha20_xor(key, nonce, 1, plaintext, pt_len)
+    pk = poly_key_for(key, nonce)
+    md = mac_data(aad, aad_len, ct, pt_len)
+    tag = poly1305_mac(pk, md, bytes.length(md))
+    bytes.free(pk)
+    bytes.free(md)
+
+    out = bytes.new(pt_len + 16)
+    bytes.copy_from_bytes(out, 0, ct, 0, pt_len)
+    bytes.copy_from_bytes(out, pt_len, tag, 0, 16)
+    bytes.free(ct)
+    bytes.free(tag)
+    return out
+}
+
+// AEAD open: verifies the trailing 16-bv tag (constant-time compare),
+// then decrypts. Returns (plaintext, "") or (null, error).
+aead_open(key: ptr, nonce: ptr, aad: ptr, aad_len: int, ct_with_tag: ptr, ct_len: int) -> {
+    if ct_len < 16 {
+        return null, "ciphertext too short"
+    }
+    body_len = ct_len - 16
+    // Recompute the tag over the ciphertext body.
+    pk = poly_key_for(key, nonce)
+    md = mac_data(aad, aad_len, ct_with_tag, body_len)
+    want = poly1305_mac(pk, md, bytes.length(md))
+    bytes.free(pk)
+    bytes.free(md)
+
+    // Constant-time compare against the supplied tag at offset body_len.
+    diff = 0
+    i = 0
+    while i < 16 {
+        diff = diff | ((bytes.get(want, i) ^ bytes.get(ct_with_tag, body_len + i)) & 0xFF)
+        i = i + 1
+    }
+    bytes.free(want)
+    if diff != 0 {
+        return null, "authentication failed"
+    }
+
+    pt = chacha20_xor(key, nonce, 1, ct_with_tag, body_len)
+    return pt, ""
+}

--- a/std/cryptography/hkdf/module.ae
+++ b/std/cryptography/hkdf/module.ae
@@ -1,0 +1,172 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.hkdf — HKDF (HMAC-based Extract-and-Expand KDF, RFC 5869)
+// in pure Aether, ported from Bouncy Castle's HkdfBytesGenerator. NO externs
+// to OpenSSL — built entirely on std.cryptography.hmac (which is itself pure
+// Aether over std.cryptography.sha2).
+//
+// HKDF is the modern key-derivation workhorse (TLS 1.3, Signal, Noise).
+// Two phases:
+//   PRK = HKDF-Extract(salt, IKM)         = HMAC(salt, IKM)
+//   OKM = HKDF-Expand(PRK, info, L)       = T(1) | T(2) | ... truncated to L,
+//         where T(0)="" and T(i) = HMAC(PRK, T(i-1) | info | byte(i)).
+//
+// Import with:  import std.cryptography.hkdf
+//
+//   hkdf_extract(algo, salt, salt_len, ikm, ikm_len) -> ptr (PRK bytes)
+//   hkdf_expand(algo, prk, prk_len, info, info_len, out_len) -> ptr (OKM)
+//   hkdf(algo, salt, salt_len, ikm, ikm_len, info, info_len, out_len) -> ptr
+//
+// `algo` is any std.cryptography.hmac algorithm ("sha256", "sha512", ...).
+// All buffers are std.bytes (caller frees results). A NULL salt is treated
+// as a string of HashLen zero bytes (RFC 5869 §2.2). out_len must be
+// <= 255*HashLen (RFC 5869 §2.3) — over-length returns null.
+
+import std.bytes
+import std.cryptography.hmac
+
+exports (
+    hkdf_extract, hkdf_expand, hkdf, hash_len
+)
+
+// Output length of the underlying hash, in bytes.
+hash_len(algo: string) -> int {
+    if algo == "sha256" {
+        return 32
+    }
+    if algo == "sha224" {
+        return 28
+    }
+    if algo == "sha512" {
+        return 64
+    }
+    if algo == "sha384" {
+        return 48
+    }
+    if algo == "sha512-224" {
+        return 28
+    }
+    if algo == "sha512-256" {
+        return 32
+    }
+    if algo == "sha1" {
+        return 20
+    }
+    return 0
+}
+
+// HKDF-Extract: PRK = HMAC(salt, IKM). A NULL/empty salt becomes HashLen
+// zero bytes per RFC 5869 §2.2. Returns PRK (HashLen bytes), or null.
+hkdf_extract(algo: string, salt: ptr, salt_len: int, ikm: ptr, ikm_len: int) -> ptr {
+    hl = hash_len(algo)
+    if hl == 0 {
+        return null
+    }
+    use_salt = salt
+    use_salt_len = salt_len
+    made = null
+    if salt == null || salt_len <= 0 {
+        made = bytes.new(hl)
+        i = 0
+        while i < hl {
+            bytes.set(made, i, 0)
+            i = i + 1
+        }
+        use_salt = made
+        use_salt_len = hl
+    }
+    prk = hmac.hmac_bytes(algo, use_salt, use_salt_len, ikm, ikm_len)
+    if made != null {
+        bytes.free(made)
+    }
+    return prk
+}
+
+// HKDF-Expand: OKM = T(1)|T(2)|... truncated to out_len, where
+// T(i) = HMAC(PRK, T(i-1) | info | byte(i)). Returns OKM, or null if
+// out_len exceeds 255*HashLen or on error.
+hkdf_expand(algo: string, prk: ptr, prk_len: int, info: ptr, info_len: int, out_len: int) -> ptr {
+    hl = hash_len(algo)
+    if hl == 0 {
+        return null
+    }
+    if out_len <= 0 {
+        return bytes.new(0)
+    }
+    if out_len > 255 * hl {
+        return null
+    }
+    inf_len = info_len
+    if info == null {
+        inf_len = 0
+    }
+
+    out = bytes.new(out_len)
+    produced = 0
+    counter = 1
+    prev = null          // T(i-1) bytes buffer (null for T(0))
+    prev_len = 0
+
+    while produced < out_len {
+        // Build the HMAC input: T(i-1) | info | byte(i).
+        tlen = prev_len + inf_len + 1
+        tin = bytes.new(tlen)
+        off = 0
+        if prev != null {
+            bytes.copy_from_bytes(tin, off, prev, 0, prev_len)
+            off = off + prev_len
+        }
+        if inf_len > 0 {
+            bytes.copy_from_bytes(tin, off, info, 0, inf_len)
+            off = off + inf_len
+        }
+        bytes.set(tin, off, counter & 0xFF)
+
+        ti = hmac.hmac_bytes(algo, prk, prk_len, tin, tlen)
+        bytes.free(tin)
+        if ti == null {
+            if prev != null {
+                bytes.free(prev)
+            }
+            bytes.free(out)
+            return null
+        }
+
+        // Copy min(hl, remaining) bytes of T(i) into the output.
+        remaining = out_len - produced
+        take = hl
+        if remaining < take {
+            take = remaining
+        }
+        bytes.copy_from_bytes(out, produced, ti, 0, take)
+        produced = produced + take
+
+        if prev != null {
+            bytes.free(prev)
+        }
+        prev = ti
+        prev_len = hl
+        counter = counter + 1
+    }
+    if prev != null {
+        bytes.free(prev)
+    }
+    return out
+}
+
+// Full HKDF: extract then expand. Returns out_len bytes of OKM, or null.
+hkdf(algo: string, salt: ptr, salt_len: int, ikm: ptr, ikm_len: int, info: ptr, info_len: int, out_len: int) -> ptr {
+    hl = hash_len(algo)
+    if hl == 0 {
+        return null
+    }
+    prk = hkdf_extract(algo, salt, salt_len, ikm, ikm_len)
+    if prk == null {
+        return null
+    }
+    okm = hkdf_expand(algo, prk, bytes.length(prk), info, info_len, out_len)
+    bytes.free(prk)
+    return okm
+}

--- a/std/cryptography/pbkdf2/module.ae
+++ b/std/cryptography/pbkdf2/module.ae
@@ -1,0 +1,140 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.pbkdf2 — PBKDF2 (PKCS#5 v2 / RFC 8018 §5.2) in pure
+// Aether, ported from Bouncy Castle's Pkcs5S2ParametersGenerator. NO externs
+// to OpenSSL — built on std.cryptography.hmac.
+//
+// PBKDF2 stretches a password into a derived key using a salt and an
+// iteration count:
+//   DK = T(1) | T(2) | ... | T(l)   truncated to dkLen
+//   T(i) = F(P, S, c, i) = U(1) XOR U(2) XOR ... XOR U(c)
+//   U(1) = HMAC(P, S | INT_BE32(i)),  U(j) = HMAC(P, U(j-1))
+//
+// Import with:  import std.cryptography.pbkdf2
+//
+//   pbkdf2(algo, password, pw_len, salt, salt_len, iterations, dk_len) -> ptr
+//
+// `algo` is any std.cryptography.hmac algorithm ("sha256", "sha512", ...).
+// All buffers are std.bytes (caller frees the result). Returns null on a
+// bad algo / non-positive iterations / allocation failure.
+
+import std.bytes
+import std.cryptography.hmac
+
+exports (
+    pbkdf2, hash_len
+)
+
+hash_len(algo: string) -> int {
+    if algo == "sha256" {
+        return 32
+    }
+    if algo == "sha224" {
+        return 28
+    }
+    if algo == "sha512" {
+        return 64
+    }
+    if algo == "sha384" {
+        return 48
+    }
+    if algo == "sha512-224" {
+        return 28
+    }
+    if algo == "sha512-256" {
+        return 32
+    }
+    if algo == "sha1" {
+        return 20
+    }
+    return 0
+}
+
+// Compute one T(i) block into `out` at offset `out_off`, taking `take`
+// bytes. i is the 1-based block index.
+derive_block(algo: string, password: ptr, pw_len: int, salt: ptr, salt_len: int, iterations: int, i: int, out: ptr, out_off: int, take: int) -> int {
+    hl = hash_len(algo)
+    // U(1) = HMAC(P, S | INT_BE32(i))
+    sin_len = salt_len + 4
+    sin = bytes.new(sin_len)
+    if salt_len > 0 {
+        bytes.copy_from_bytes(sin, 0, salt, 0, salt_len)
+    }
+    bytes.set(sin, salt_len + 0, (i >> 24) & 0xFF)
+    bytes.set(sin, salt_len + 1, (i >> 16) & 0xFF)
+    bytes.set(sin, salt_len + 2, (i >> 8) & 0xFF)
+    bytes.set(sin, salt_len + 3, i & 0xFF)
+
+    u = hmac.hmac_bytes(algo, password, pw_len, sin, sin_len)
+    bytes.free(sin)
+    if u == null {
+        return 0
+    }
+
+    // accumulator = U(1)
+    acc = bytes.new(hl)
+    bytes.copy_from_bytes(acc, 0, u, 0, hl)
+
+    // U(j) = HMAC(P, U(j-1)); XOR each into the accumulator.
+    j = 1
+    while j < iterations {
+        next = hmac.hmac_bytes(algo, password, pw_len, u, hl)
+        bytes.free(u)
+        if next == null {
+            bytes.free(acc)
+            return 0
+        }
+        u = next
+        k = 0
+        while k < hl {
+            bytes.set(acc, k, (bytes.get(acc, k) ^ bytes.get(u, k)) & 0xFF)
+            k = k + 1
+        }
+        j = j + 1
+    }
+    bytes.free(u)
+
+    bytes.copy_from_bytes(out, out_off, acc, 0, take)
+    bytes.free(acc)
+    return 1
+}
+
+// Derive `dk_len` bytes from the password+salt with `iterations` rounds.
+pbkdf2(algo: string, password: ptr, pw_len: int, salt: ptr, salt_len: int, iterations: int, dk_len: int) -> ptr {
+    hl = hash_len(algo)
+    if hl == 0 {
+        return null
+    }
+    if iterations <= 0 {
+        return null
+    }
+    if dk_len <= 0 {
+        return bytes.new(0)
+    }
+    use_salt = salt
+    use_salt_len = salt_len
+    if salt == null {
+        use_salt_len = 0
+    }
+
+    out = bytes.new(dk_len)
+    produced = 0
+    i = 1
+    while produced < dk_len {
+        remaining = dk_len - produced
+        take = hl
+        if remaining < take {
+            take = remaining
+        }
+        ok = derive_block(algo, password, pw_len, use_salt, use_salt_len, iterations, i, out, produced, take)
+        if ok == 0 {
+            bytes.free(out)
+            return null
+        }
+        produced = produced + take
+        i = i + 1
+    }
+    return out
+}

--- a/tests/integration/actor_state_string_retain/repro.ae
+++ b/tests/integration/actor_state_string_retain/repro.ae
@@ -1,0 +1,42 @@
+// Regression: a string carried in as a MESSAGE FIELD and retained into
+// ACTOR STATE must survive past the originating message's release. The
+// message's string field is freed by <Msg>_release_fields right after the
+// handler returns, so storing the raw pointer dangled and a LATER message
+// read freed bytes (the aeo actor-state-string corruption). The compiler
+// now copies a borrowed string into an owned AetherString on the
+// `self->field = <message-string>` retain, freeing any prior copy.
+//
+// Also exercises:
+//   - the `string.concat(in_n, "")` defensive-copy idiom, which previously
+//     failed to COMPILE (`'_heap_n' undeclared`) because actor handlers
+//     skipped the function-scope `_heap_<name>` hoist pass.
+//   - reassignment (the prior owned copy must be freed, not leaked/UAF).
+import std.string
+
+message SetN { in_n: string }
+message SetC { in_c: string }
+message Show {}
+
+actor A {
+    state n = ""
+    state c = ""
+    receive {
+        SetN(in_n) -> { n = in_n }                       // direct retain
+        SetC(in_c) -> { c = string.concat(in_c, "!") }   // defensive copy
+        Show       -> { println("n=${n} c=${c}") }
+    }
+}
+
+main() {
+    a = spawn(A())
+    a ! SetN { in_n: "aeo-db" }
+    a ! SetC { in_c: "cfg" }
+    sleep(60)
+    a ! Show {}                                          // expect: n=aeo-db c=cfg!
+    sleep(60)
+    a ! SetN { in_n: "second-longer-value" }             // reassign → free first
+    sleep(60)
+    a ! Show {}                                          // expect: n=second-longer-value c=cfg!
+    sleep(60)
+    wait_for_idle()
+}

--- a/tests/integration/actor_state_string_retain/test_actor_state_string_retain.sh
+++ b/tests/integration/actor_state_string_retain/test_actor_state_string_retain.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Regression: a string carried in as a MESSAGE FIELD and retained into
+# ACTOR STATE survives past the originating message's release.
+#
+# The message's string field is freed by <Msg>_release_fields immediately
+# after the handler returns, so `self->field = <message-string>` stored a
+# raw pointer that dangled — a LATER message printed freed bytes (the aeo
+# actor-state-string corruption). The compiler now copies a borrowed
+# string into an owned AetherString on the retain (freeing any prior
+# copy). This also covers the `string.concat(in, "")` defensive-copy
+# idiom, which previously failed to COMPILE (`'_heap_n' undeclared`)
+# because actor handlers skipped the function-scope heap-string hoist.
+#
+# Pass: prints the two expected lines with the retained values intact.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+ACTUAL="$TMPDIR/actual.txt"
+if ! AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/repro.ae" >"$ACTUAL" 2>"$TMPDIR/err.log"; then
+    echo "  [FAIL] ae run exited non-zero — actor-state-string regression?"
+    head -30 "$TMPDIR/err.log"
+    exit 1
+fi
+
+if ! grep -q '^n=aeo-db c=cfg!$' "$ACTUAL"; then
+    echo "  [FAIL] expected 'n=aeo-db c=cfg!' (retained message strings intact)"
+    echo "--- stdout ---"; cat "$ACTUAL"
+    exit 1
+fi
+if ! grep -q '^n=second-longer-value c=cfg!$' "$ACTUAL"; then
+    echo "  [FAIL] expected 'n=second-longer-value c=cfg!' after reassignment"
+    echo "--- stdout ---"; cat "$ACTUAL"
+    exit 1
+fi
+
+echo "  [PASS] actor_state_string_retain: message string retained into state survives"

--- a/tests/integration/crypto_aes_cmac_keywrap/test_crypto_aes_cmac_keywrap.ae
+++ b/tests/integration/crypto_aes_cmac_keywrap/test_crypto_aes_cmac_keywrap.ae
@@ -1,0 +1,43 @@
+// Validate contrib.cryptography.aes CMAC (RFC 4493) and AES Key Wrap
+// (RFC 3394) against the spec test vectors.
+import contrib.cryptography.aes
+import std.bytes
+import std.string
+import std.io
+
+hv(c: int) -> int { if c>=48 { if c<=57 { return c-48 } } if c>=97 { if c<=102 { return c-87 } } return 0 }
+hb(h: string) -> ptr { n=string.length(h); b=bytes.new(n/2); i=0; while i<n { bytes.set(b,i/2,hv(string_char_at_n(h,n,i))*16+hv(string_char_at_n(h,n,i+1))); i=i+2 } return b }
+bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
+beq(a: ptr, b: ptr) -> int { if bytes.length(a)!=bytes.length(b) { return 0 } i=0; while i<bytes.length(a) { if bytes.get(a,i)!=bytes.get(b,i) { return 0 } i=i+1 } return 1 }
+
+check(label: string, got: string, want: string) -> int {
+    if got == want { println("ok   ${label}"); return 0 }
+    println("FAIL ${label}"); println("  got:  ${got}"); println("  want: ${want}"); return 1
+}
+
+main() {
+    fails = 0
+    k = hb("2b7e151628aed2a6abf7158809cf4f3c")
+
+    // RFC 4493 AES-128 CMAC, the four canonical lengths (0/16/40/64).
+    e0 = bytes.new(0)
+    fails = fails + check("cmac empty", bh(aes.cmac(k, 16, e0, 0)), "bb1d6929e95937287fa37d129b756746")
+    m16 = hb("6bc1bee22e409f96e93d7e117393172a")
+    fails = fails + check("cmac 16", bh(aes.cmac(k, 16, m16, 16)), "070a16b46b4d4144f79bdd9dd04a287c")
+    m40 = hb("6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411")
+    fails = fails + check("cmac 40", bh(aes.cmac(k, 16, m40, 40)), "dfa66747de9ae63030ca32611497c827")
+    m64 = hb("6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710")
+    fails = fails + check("cmac 64", bh(aes.cmac(k, 16, m64, 64)), "51f0bebf7e3b9d92fc49741779363cfe")
+
+    // RFC 3394 AES-128 Key Wrap.
+    kek = hb("000102030405060708090a0b0c0d0e0f")
+    kdata = hb("00112233445566778899aabbccddeeff")
+    w = aes.key_wrap(kek, 16, kdata, 16)
+    fails = fails + check("keywrap", bh(w), "1fa68b0a8112b447aef34bd8fb5a7b829d3e862371d2cfe5")
+    uw, uerr = aes.key_unwrap(kek, 16, w, bytes.length(w))
+    if uerr != "" { println("FAIL keyunwrap err ${uerr}"); fails = fails + 1 }
+    if beq(uw, kdata) != 1 { println("FAIL keyunwrap roundtrip"); fails = fails + 1 } else { println("ok   keyunwrap roundtrip") }
+
+    if fails == 0 { println("ALL PASS"); return }
+    println("FAILURES"); exit(1)
+}

--- a/tests/integration/crypto_chacha20poly1305/test_crypto_chacha20poly1305.ae
+++ b/tests/integration/crypto_chacha20poly1305/test_crypto_chacha20poly1305.ae
@@ -1,0 +1,52 @@
+// Validate contrib.cryptography.chacha20poly1305 against RFC 8439 vectors:
+// the Poly1305 §2.5.2 tag and the ChaCha20-Poly1305 AEAD §2.8.2 example
+// (seal produces the exact spec ciphertext+tag; open round-trips and a
+// tampered tag is rejected).
+import contrib.cryptography.chacha20poly1305
+import std.bytes
+import std.string
+import std.io
+
+hv(c: int) -> int { if c>=48 { if c<=57 { return c-48 } } if c>=97 { if c<=102 { return c-87 } } return 0 }
+hb(h: string) -> ptr { n=string.length(h); b=bytes.new(n/2); i=0; while i<n { bytes.set(b,i/2,hv(string_char_at_n(h,n,i))*16+hv(string_char_at_n(h,n,i+1))); i=i+2 } return b }
+bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
+sb(s: string) -> ptr { n=string.length(s); b=bytes.new(n); i=0; while i<n { bytes.set(b,i,string_char_at_n(s,n,i)&0xFF); i=i+1 } return b }
+beq(a: ptr, b: ptr) -> int { if bytes.length(a)!=bytes.length(b) { return 0 } i=0; while i<bytes.length(a) { if bytes.get(a,i)!=bytes.get(b,i) { return 0 } i=i+1 } return 1 }
+
+check(label: string, got: string, want: string) -> int {
+    if got == want { println("ok   ${label}"); return 0 }
+    println("FAIL ${label}"); println("  got:  ${got}"); println("  want: ${want}"); return 1
+}
+
+main() {
+    fails = 0
+
+    // RFC 8439 §2.5.2 Poly1305
+    pk = hb("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b")
+    msg = sb("Cryptographic Forum Research Group")
+    fails = fails + check("poly1305 §2.5.2",
+        bh(chacha20poly1305.poly1305_mac(pk, msg, bytes.length(msg))),
+        "a8061dc1305136c6c22b8baf0c0127a9")
+
+    // RFC 8439 §2.8.2 AEAD
+    key = hb("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f")
+    nonce = hb("070000004041424344454647")
+    aad = hb("50515253c0c1c2c3c4c5c6c7")
+    pt = sb("Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.")
+    sealed = chacha20poly1305.aead_seal(key, nonce, aad, bytes.length(aad), pt, bytes.length(pt))
+    want = string.concat("d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116",
+                         "1ae10b594f09e26a7e902ecbd0600691")
+    fails = fails + check("aead §2.8.2 seal", bh(sealed), want)
+
+    op, err = chacha20poly1305.aead_open(key, nonce, aad, bytes.length(aad), sealed, bytes.length(sealed))
+    if err != "" { println("FAIL aead open err ${err}"); fails = fails + 1 }
+    if beq(op, pt) != 1 { println("FAIL aead open roundtrip"); fails = fails + 1 } else { println("ok   aead open roundtrip") }
+
+    // Tamper the last tag byte → open must reject.
+    bytes.set(sealed, bytes.length(sealed) - 1, (bytes.get(sealed, bytes.length(sealed) - 1) ^ 0x01) & 0xFF)
+    _, terr = chacha20poly1305.aead_open(key, nonce, aad, bytes.length(aad), sealed, bytes.length(sealed))
+    if terr == "" { println("FAIL aead must reject tampered tag"); fails = fails + 1 } else { println("ok   aead rejects tampered tag") }
+
+    if fails == 0 { println("ALL PASS"); return }
+    println("FAILURES"); exit(1)
+}

--- a/tests/integration/crypto_kdf/test_crypto_kdf.ae
+++ b/tests/integration/crypto_kdf/test_crypto_kdf.ae
@@ -1,0 +1,41 @@
+// Validate std.cryptography.hkdf (RFC 5869) and std.cryptography.pbkdf2
+// (RFC 8018) against published test vectors.
+import std.cryptography.hkdf
+import std.cryptography.pbkdf2
+import std.bytes
+import std.string
+import std.io
+
+hv(c: int) -> int { if c>=48 { if c<=57 { return c-48 } } if c>=97 { if c<=102 { return c-87 } } return 0 }
+hb(h: string) -> ptr { n=string.length(h); b=bytes.new(n/2); i=0; while i<n { bytes.set(b,i/2,hv(string_char_at_n(h,n,i))*16+hv(string_char_at_n(h,n,i+1))); i=i+2 } return b }
+bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
+
+check(label: string, got: string, want: string) -> int {
+    if got == want { println("ok   ${label}"); return 0 }
+    println("FAIL ${label}"); println("  got:  ${got}"); println("  want: ${want}"); return 1
+}
+
+main() {
+    fails = 0
+
+    // RFC 5869 Test Case 1 (HKDF-SHA256)
+    ikm = hb("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+    salt = hb("000102030405060708090a0b0c")
+    info = hb("f0f1f2f3f4f5f6f7f8f9")
+    okm = hkdf.hkdf("sha256", salt, bytes.length(salt), ikm, bytes.length(ikm), info, bytes.length(info), 42)
+    fails = fails + check("hkdf rfc5869 tc1", bh(okm),
+        "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865")
+
+    // PBKDF2-HMAC-SHA256 (widely-published vectors)
+    pw = hb("70617373776f7264")   // "password"
+    sp = hb("73616c74")          // "salt"
+    dk1 = pbkdf2.pbkdf2("sha256", pw, bytes.length(pw), sp, bytes.length(sp), 1, 32)
+    fails = fails + check("pbkdf2 sha256 c=1", bh(dk1),
+        "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b")
+    dk2 = pbkdf2.pbkdf2("sha256", pw, bytes.length(pw), sp, bytes.length(sp), 4096, 32)
+    fails = fails + check("pbkdf2 sha256 c=4096", bh(dk2),
+        "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a")
+
+    if fails == 0 { println("ALL PASS"); return }
+    println("FAILURES"); exit(1)
+}


### PR DESCRIPTION
Addresses the two aeo-reported actor bugs (one was already fixed on main), then a large pure-Aether crypto tranche of the Bouncy Castle port (#739). All RFC-vectored, no externs to OpenSSL.

## Actor fix (from `aeo-actor-state-string-and-makefile-typo.md`)
A string carried in as a **message field** and retained into **actor state** (`SetN(in_n) -> { n = in_n }`) dangled: the field is freed by `<Msg>_release_fields` right after the handler returns, so `self->field` held freed memory and a later message read garbage. Two related codegen bugs:

1. **Data corruption** — the `self->field = <borrowed message string>` retain now **copies** into an owned AetherString (the same idiom the message *send* site uses) and frees any prior copy via the `_heap_<field>` tracker.
2. **`'_heap_n' undeclared`** — the defensive-copy workaround `n = string.concat(in_n, "")` failed to compile because actor receive handlers skipped the function-scope `hoist_heap_string_trackers` pass that regular functions and `main` run. Now run it for handler bodies.

Regression test: `tests/integration/actor_state_string_retain` (direct retain + concat idiom + reassignment-frees-prior). The Makefile dir-list typo (issue 2 in the note) was **already fixed on main** (the obj-dir space restoration during the FreeBSD work) — verified no concatenated entries remain.

## Crypto tranche
| Module | Spec | Notes |
|--------|------|-------|
| `std.cryptography.hkdf` | RFC 5869 | extract/expand over existing HMAC |
| `std.cryptography.pbkdf2` | RFC 8018 | over HMAC |
| `contrib.cryptography.aes` → `cmac` | RFC 4493 | AES-CMAC on the block primitive |
| `contrib.cryptography.aes` → `key_wrap`/`key_unwrap` | RFC 3394 | AES Key Wrap + integrity check |
| `contrib.cryptography.chacha20poly1305` | RFC 8439 | ChaCha20 + Poly1305 + AEAD seal/open (constant-time tag compare) — the pure-Aether AES-GCM counterpart |

**Validation** (all in `tests/integration/crypto_*`): RFC 5869 TC1; PBKDF2-HMAC-SHA256 (c=1, c=4096); all four RFC 4493 CMAC lengths (0/16/40/64); RFC 3394 wrap+unwrap; RFC 8439 §2.5.2 Poly1305 and §2.8.2 AEAD — seal reproduces the **exact spec ciphertext+tag**, open round-trips, tampered tags are rejected.

Poly1305/ChaCha `le32` use 64-bit limbs to dodge the int-shift sign-extension hazard (`byte >= 0x80 << 24` goes negative in a 32-bit int slot).

## Notes
Local `make test-ae`: **710/713 pass**; the 3 failures are pre-existing HTTP/2 + reverse-proxy port-bind/curl flakes on this box, unrelated. The compiler change is exercised by the full actor test suite (all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)