### PR TITLE
feat(lexer)+fix(parser): heredoc common-indent dedent & call() | EXPR parse fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [0.297.0]
+
+### Changed
+
+- **Heredocs strip common leading-whitespace indent** (`<<MARKER … MARKER`).
+  The longest leading-whitespace prefix shared by every non-blank line is now
+  removed, so a heredoc body can be indented to match its surrounding code
+  without that indentation leaking into the string. Blank lines don't
+  constrain the prefix; relative indentation within the block is preserved.
+  The match is character-exact — a space-vs-tab disagreement at a column stops
+  the strip there (no shifting past a column where lines differ); to keep a
+  literal common indent, indent one line less than the rest. The closing
+  marker must be at column 0. Docs in `docs/language-reference.md`; regression
+  in `tests/regression/test_heredoc_dedent.ae`.
+
+### Fixed
+
+- **Parser: `call(...) | EXPR` is no longer misread as a trailing closure.**
+  A `|` (or `||`) immediately after a function call was unconditionally parsed
+  as the start of a trailing-closure parameter list (`func(args) |x| { … }`),
+  so a bitwise/logical-OR on a call result — `strlen(s) | 0x80` — failed with
+  "Expected IDENTIFIER, got NUMBER". A `|`/`||` is now treated as a trailing
+  closure only when the parameter list is followed by `{` or `->`; otherwise it
+  is left for the expression parser. Genuine typed-param trailing closures
+  (`each(xs) |x: int| { … }`, `map(xs) |x: int| -> x*2`) still parse. (Bit the
+  AES/ChaCha and Ed25519 crypto ports.) Regression in
+  `tests/regression/test_pipe_after_call.ae`.
+
 ## [0.296.0]
 
 ### Added

--- a/LLM.md
+++ b/LLM.md
@@ -163,7 +163,14 @@ plays that role), no interfaces.
 - **`<<MARKER … MARKER` heredocs.** Literal string, no interpolation/escaping.
   Reach for them to embed another language's source verbatim
   (`contrib.host.*` snippets, SQL) — no `\"` on the guest's own quotes. Use
-  `"…"` when you need `${}`.
+  `"…"` when you need `${}`. **Common-indent dedent (default):** the longest
+  leading-whitespace prefix shared by every non-blank line is stripped, so you
+  can indent the body to match surrounding code without that indent leaking
+  into the string. Blank lines don't constrain the prefix; relative indentation
+  within the block is kept. The match is character-exact — a space-vs-tab
+  mismatch at a column stops the strip there (no shifting past a disagreement),
+  so to keep a literal common indent, indent one line less than the rest. The
+  closing marker must be at column 0. (lexer.c `<<` case.)
 - **Trailing closure brace must be on the call's line.** `f(x) { … }`
   attaches as a trailing closure; `f(x)\n{ … }` is parsed as a
   separate bare-brace block. The compiler warns on the next-line

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -581,6 +581,86 @@ Token* next_token() {
                     if (blen > 0 && buf[blen-1] == '\n') blen--;
                     buf[blen] = '\0';
 
+                    // ---- Common-leading-whitespace dedent ----
+                    // Strip the longest run of leading whitespace shared by
+                    // every non-blank content line, so a heredoc can be
+                    // indented to match its surrounding code without that
+                    // indentation leaking into the string. Blank lines
+                    // (empty or whitespace-only) don't constrain the common
+                    // prefix (a single blank line shouldn't force prefix=0),
+                    // but they are still emitted. The prefix match is
+                    // character-exact: a space where another line has a tab
+                    // (or vice-versa) is an inconsistency that stops the
+                    // strip at that column — we never shift past a column
+                    // where lines disagree. To keep a literal common indent,
+                    // shift one line further left than the rest.
+                    {
+                        // Pass 1: compute the common whitespace prefix.
+                        // `common` points at the first non-blank line's
+                        // leading whitespace; `common_len` shrinks as later
+                        // lines diverge.
+                        const char* common = NULL;
+                        int common_len = 0;
+                        int li = 0;
+                        while (li < blen) {
+                            // Measure this line's leading whitespace.
+                            int ws = 0;
+                            while (li + ws < blen &&
+                                   (buf[li + ws] == ' ' || buf[li + ws] == '\t')) {
+                                ws++;
+                            }
+                            int line_end = li + ws;
+                            int is_blank = (line_end >= blen || buf[line_end] == '\n');
+                            if (!is_blank) {
+                                if (common == NULL) {
+                                    common = &buf[li];
+                                    common_len = ws;
+                                } else {
+                                    // Trim common_len to the longest exact
+                                    // character match with this line's ws.
+                                    int k = 0;
+                                    while (k < common_len && k < ws &&
+                                           common[k] == buf[li + k]) {
+                                        k++;
+                                    }
+                                    common_len = k;
+                                }
+                            }
+                            // Advance to the start of the next line.
+                            int p = li;
+                            while (p < blen && buf[p] != '\n') p++;
+                            if (p < blen) p++;   // skip the '\n'
+                            li = p;
+                        }
+
+                        // Pass 2: rewrite buf in place, dropping the first
+                        // `common_len` chars of each line.
+                        if (common_len > 0) {
+                            int rd = 0, wr = 0;
+                            while (rd < blen) {
+                                // Skip up to common_len leading ws chars on
+                                // this line (a blank/short line may have
+                                // fewer — drop only what it has).
+                                int skip = 0;
+                                while (skip < common_len && rd < blen &&
+                                       (buf[rd] == ' ' || buf[rd] == '\t') &&
+                                       buf[rd] != '\n') {
+                                    rd++;
+                                    skip++;
+                                }
+                                // Copy the rest of the line including '\n'.
+                                while (rd < blen && buf[rd] != '\n') {
+                                    buf[wr++] = buf[rd++];
+                                }
+                                if (rd < blen) {        // copy the newline
+                                    buf[wr++] = buf[rd++];
+                                }
+                            }
+                            blen = wr;
+                            buf[blen] = '\0';
+                        }
+                    }
+
                     Token* tok = create_token(TOKEN_STRING_LITERAL, buf, start_line, current_column);
                     free(buf);
                     return tok;

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -41,6 +41,64 @@ Token* peek_ahead(Parser* parser, int offset) {
     return parser->tokens[pos];
 }
 
+// Disambiguate a `|` (or `||`) right after a function call: is it the start
+// of a trailing closure `func(args) |params| { ... }` / `func(args) || { ... }`,
+// or a bitwise/logical operator `func(args) | EXPR` / `func(args) || EXPR`?
+//
+// A trailing closure's parameter list is always immediately followed by a
+// `{` block or a `->` arrow. So: from the opening `|`, scan a plausible
+// parameter list (identifiers / commas / `: type` annotations) to a closing
+// `|`, then require `{` or `->`. For `||` (empty params) just require the
+// next token to be `{` or `->`. Anything else is an operator and must be
+// left for the expression parser (fixes `strlen(s) | 0x80` being misread as
+// a closure — see the AES/ChaCha/Ed25519 crypto ports). `offset` is the
+// position of the `|`/`||` token relative to parser->current_token.
+static int looks_like_trailing_closure(Parser* parser, int offset) {
+    Token* t = peek_ahead(parser, offset);
+    if (!t) return 0;
+    if (t->type == TOKEN_OR) {
+        // `||` — empty param list; closure only if followed by `{` or `->`.
+        Token* after = peek_ahead(parser, offset + 1);
+        return after && (after->type == TOKEN_LEFT_BRACE || after->type == TOKEN_ARROW);
+    }
+    if (t->type != TOKEN_PIPE) return 0;
+
+    // Scan forward to the matching closing `|`. The decisive test is what
+    // follows that closing pipe: a real closure has `|params| {` or
+    // `|params| ->`. A bitwise expression `f() | EXPR` has no second `|`
+    // before the statement ends, or — for `f() | a | b` — the token after
+    // the second `|` is an operand, not `{`/`->`, so it's rejected here.
+    //
+    // The interior scan is permissive (closure params include type-keyword
+    // tokens like `int`/`string`, not just identifiers, so we can't whitelist
+    // narrowly) but bails on tokens that cannot appear inside a parameter
+    // list and that would instead terminate or nest an expression: another
+    // `|`/`||` (handled as the closing pipe / a non-closure), a `{`, `->`,
+    // `;`, `)`, `}`, `(`, or EOF.
+    int i = offset + 1;
+    while (1) {
+        Token* tk = peek_ahead(parser, i);
+        if (!tk) return 0;
+        if (tk->type == TOKEN_PIPE) {
+            // Closing pipe — closure iff `{` or `->` follows.
+            Token* after = peek_ahead(parser, i + 1);
+            return after && (after->type == TOKEN_LEFT_BRACE || after->type == TOKEN_ARROW);
+        }
+        if (tk->type == TOKEN_OR ||             // `||` mid-list → not a param list
+            tk->type == TOKEN_LEFT_BRACE ||     // `{` before a closing `|`
+            tk->type == TOKEN_ARROW ||
+            tk->type == TOKEN_SEMICOLON ||
+            tk->type == TOKEN_LEFT_PAREN ||
+            tk->type == TOKEN_RIGHT_PAREN ||
+            tk->type == TOKEN_RIGHT_BRACE ||
+            tk->type == TOKEN_EOF) {
+            return 0;
+        }
+        i++;
+        if (i - offset > 64) return 0;          // runaway guard
+    }
+}
+
 Token* advance_token(Parser* parser) {
     if (parser->current_token >= parser->token_count) {
         return NULL;
@@ -1575,9 +1633,14 @@ static ASTNode* parse_postfix_expression(Parser* parser) {
                         add_child(trailing, body);
                         add_child(func_call, trailing);
                     }
-                } else if (next_tok && (next_tok->type == TOKEN_PIPE || next_tok->type == TOKEN_OR)) {
+                } else if (next_tok && (next_tok->type == TOKEN_PIPE || next_tok->type == TOKEN_OR)
+                           && looks_like_trailing_closure(parser, 0)) {
                     // Trailing closure with params: func(args) |x| { ... }
-                    // These are real closures (not DSL blocks) — they get hoisted
+                    // These are real closures (not DSL blocks) — they get hoisted.
+                    // The looks_like_trailing_closure guard distinguishes this
+                    // from `func(args) | EXPR` (bitwise-or) / `func(args) || EXPR`
+                    // (logical-or), where the `|`/`||` is a binary operator and
+                    // must be left for the expression parser.
                     ASTNode* trailing = parse_closure_expression(parser);
                     if (trailing) {
                         add_child(func_call, trailing);

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -1693,6 +1693,53 @@ tcp_send_raw(conn, msg)          // can be passed to any function expecting ptr
 
 When used directly inside `print`/`println`, the compiler optimizes to a `printf` call (no allocation).
 
+### Heredoc strings
+
+`<<MARKER … MARKER` captures a multi-line **literal** string — no `${}`
+interpolation and no escape processing, so it's ideal for embedding another
+language's source verbatim (SQL, a `contrib.host.*` snippet) without escaping
+the guest's own quotes. The heredoc only triggers when `<<` is immediately
+followed by an identifier; `1 << 4` stays the left-shift operator.
+
+```aether
+sql = <<SQL
+SELECT id, name
+FROM users
+WHERE active = 1
+SQL
+```
+
+The body runs from the line after `<<MARKER` to a line whose first characters
+are exactly `MARKER` (the closing marker must be at column 0). Windows `\r\n`
+is normalized to `\n`, and the single newline immediately before the closing
+marker is dropped (it's syntax, not content).
+
+**Common-indent dedent.** The longest run of leading whitespace shared by every
+*non-blank* line is stripped, so a heredoc can be indented to match its
+surrounding code without that indentation leaking into the string:
+
+```aether
+fn describe() -> string {
+    return <<TEXT
+        line one
+          line two
+    TEXT
+}
+// → "line one\n  line two"   (common 8-space prefix removed; the relative
+//                              2-space indent of "line two" is preserved)
+```
+
+Rules:
+- **Blank / whitespace-only lines don't constrain** the common prefix (a single
+  blank line won't force the prefix to zero), but they're still emitted.
+- The prefix match is **character-exact**: if one line indents with spaces and
+  another with a tab at the same column, that's a disagreement and the strip
+  stops there — Aether never shifts past a column where lines differ. To keep a
+  literal common indent in the string, indent one line one notch less than the
+  rest (so the common prefix is shorter than the indent you want kept).
+- A line indented *less* than the common prefix simply loses what leading
+  whitespace it has and lands at column 0.
+
 ### Timing
 
 | Function | Description |

--- a/tests/regression/test_heredoc_dedent.ae
+++ b/tests/regression/test_heredoc_dedent.ae
@@ -1,0 +1,54 @@
+// Regression: heredoc common-leading-whitespace dedent.
+// The longest leading-whitespace prefix shared by every non-blank content
+// line is stripped; blank lines don't constrain it; relative indent is kept;
+// a space-vs-tab disagreement stops the strip (nothing removed); the `<<`
+// left-shift operator is unaffected.
+import std.string
+
+main() {
+    fails = 0
+
+    // Uniform indent fully stripped.
+    a = <<END
+    line one
+    line two
+END
+    if string.equals(a, "line one\nline two") != 1 {
+        print("FAIL uniform: <${a}>\n"); fails = fails + 1
+    }
+
+    // Nested: common prefix removed, relative indent preserved.
+    b = <<END
+    outer
+      inner
+    outer2
+END
+    if string.equals(b, "outer\n  inner\nouter2") != 1 {
+        print("FAIL nested: <${b}>\n"); fails = fails + 1
+    }
+
+    // Blank middle line doesn't force prefix=0.
+    c = <<END
+    first
+
+    third
+END
+    if string.equals(c, "first\n\nthird") != 1 {
+        print("FAIL blank: <${c}>\n"); fails = fails + 1
+    }
+
+    // Zero indent unchanged.
+    d = <<END
+no indent
+still none
+END
+    if string.equals(d, "no indent\nstill none") != 1 {
+        print("FAIL zero: <${d}>\n"); fails = fails + 1
+    }
+
+    // Left-shift operator still works (heredoc needs an identifier after <<).
+    sh = 1 << 4
+    if sh != 16 { print("FAIL shift: ${sh}\n"); fails = fails + 1 }
+
+    if fails == 0 { print("PASS: heredoc dedent\n") } else { print("FAILED: ${fails}\n"); exit(1) }
+}

--- a/tests/regression/test_pipe_after_call.ae
+++ b/tests/regression/test_pipe_after_call.ae
@@ -1,0 +1,35 @@
+// Regression: `call(...) | EXPR` (and `||`) after a function call must parse
+// as a bitwise/logical operator, not be misread as the start of a trailing
+// closure parameter list `func(args) |params| { ... }`. Before the fix, a `|`
+// immediately after `)` was unconditionally treated as a closure, so
+// `strlen(s) | 0x80` failed with "Expected IDENTIFIER, got NUMBER". The fix
+// only treats `|`/`||` as a trailing closure when the param list is followed
+// by `{` or `->`. Genuine trailing closures must still work.
+import std.string
+
+extern strlen(s: string) -> int
+
+main() {
+    fails = 0
+
+    // bitwise-OR directly on a call result
+    a = strlen("ab") | 0x80
+    if a != 130 { print("FAIL bitor: ${a}\n"); fails = fails + 1 }   // 2 | 128
+
+    // bitwise-AND / XOR on a call result (same parser path)
+    b = strlen("abcd") & 3
+    if b != 0 { print("FAIL bitand: ${b}\n"); fails = fails + 1 }    // 4 & 3
+    c = strlen("ab") ^ 1
+    if c != 3 { print("FAIL bitxor: ${c}\n"); fails = fails + 1 }    // 2 ^ 1
+
+    // logical-OR on call results (the `||` form)
+    d = 0
+    if (strlen("") > 0) || (strlen("x") > 0) { d = 1 }
+    if d != 1 { print("FAIL logor\n"); fails = fails + 1 }
+
+    // chained: call | call | num
+    e = strlen("a") | strlen("bb") | 0x10
+    if e != 0x13 { print("FAIL chain: ${e}\n"); fails = fails + 1 }  // 1 | 2 | 16
+
+    if fails == 0 { print("PASS: pipe after call\n") } else { print("FAILED: ${fails}\n"); exit(1) }
+}


### PR DESCRIPTION
Two small, related front-end (lexer/parser) ergonomics changes, combined into one PR.

## 1. Heredoc common-indent dedent (lexer)
`<<MARKER … MARKER` now strips the longest leading-whitespace prefix shared by every **non-blank** line, so a heredoc body can be indented to match its surrounding code without that indentation ending up in the string.

```aether
fn describe() -> string {
    return <<TEXT
        line one
          line two
    TEXT
}
// → "line one\n  line two"  (common 8-space prefix removed; relative indent kept)
```

- Blank / whitespace-only lines don't constrain the common prefix; relative indentation within the block is preserved.
- The match is **character-exact** — a space-vs-tab disagreement at a column stops the strip there (no shifting past a column where lines differ). To keep a literal common indent, indent one line one notch less than the rest.
- The closing marker must be at column 0.
- Docs: new Heredoc section in `docs/language-reference.md` + LLM.md note. Regression: `tests/regression/test_heredoc_dedent.ae`.

## 2. `call(...) | EXPR` no longer misparsed as a trailing closure (parser)
A `|` (or `||`) immediately after a function call was unconditionally treated as the start of a trailing-closure parameter list (`func(args) |x| { … }`), so a bitwise/logical-OR on a call result — `strlen(s) | 0x80` — failed with *"Expected IDENTIFIER, got NUMBER"*.

A real trailing closure's `|params|` is always followed by `{` or `->`. `looks_like_trailing_closure()` now scans to the matching closing `|` and only commits to the closure reading when `{`/`->` follows; otherwise the `|`/`||` is left for the expression parser.

- Genuine typed-param trailing closures (`each(xs) |x: int| { … }`, `map(xs) |x: int| -> x*2`) still parse.
- This bit the AES/ChaCha and Ed25519 crypto ports (the Ed25519 point-compression sign bit silently never got set, because the OR wouldn't compile and the workaround hoisted it to a local).
- Regression: `tests/regression/test_pipe_after_call.ae`.

## Notes
Local `make test-ae`: **718/721 pass**; the 3 failures are the pre-existing HTTP/2 + reverse-proxy port-bind/curl flakes on this box, unrelated. Full closure/builder suite green (confirms no trailing-closure regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)