### PR TITLE
test(c_import): regression guard for struct-without-typedef emission

### DIFF
--- a/tests/integration/c_import_struct_no_typedef/aether.toml
+++ b/tests/integration/c_import_struct_no_typedef/aether.toml
@@ -1,0 +1,11 @@
+[[bin]]
+name = "probe"
+path = "probe.ae"
+
+[build]
+# Force-include the C header that owns `struct widget` into every TU,
+# including the Aether-generated .gen.c.  The header deliberately does
+# NOT carry a `typedef struct widget widget;`, so the only way this
+# compiles is if aetherc emits `struct widget *` (not bare `widget *`)
+# wherever it renders a pointer to the @c_import struct.
+cflags = "-include widget.h -I."

--- a/tests/integration/c_import_struct_no_typedef/probe.ae
+++ b/tests/integration/c_import_struct_no_typedef/probe.ae
@@ -1,0 +1,51 @@
+// Integration test for `@c_import` against a header that defines its
+// struct WITHOUT a convenience typedef.  POSIX headers do this all
+// the time — `struct tm` in <time.h>, `struct stat` in <sys/stat.h>,
+// `struct sockaddr`, etc.  Aetherc must emit `struct N *` (not bare
+// `N *`) when rendering pointers to these `@c_import` structs.
+//
+// This probe:
+//   - declares `widget` with `@c_import` (no Aether-emitted typedef),
+//   - casts a raw `ptr` to `*widget`,
+//   - writes and reads fields,
+//   - links against widget.h which has NO `typedef struct widget widget;`
+//   - succeeds only when aetherc emits `struct widget *` everywhere.
+
+extern struct widget @c_import {
+    serial: int
+    weight: int
+    payload: ptr
+}
+
+extern malloc(n: size_t) -> ptr
+extern free(p: ptr)
+
+bump_weight(w: *widget, delta: int) {
+    w.weight = w.weight + delta
+}
+
+main() {
+    p = malloc(32)
+
+    w = (p as *widget)
+    w.serial = 42
+    w.weight = 100
+    w.payload = null
+
+    bump_weight(w, 7)
+
+    int s = w.serial
+    int wt = w.weight
+    if s != 42 {
+        println("FAIL: serial=${s}, want 42")
+        return
+    }
+    if wt != 107 {
+        println("FAIL: weight=${wt}, want 107")
+        return
+    }
+    println("serial=${s} weight=${wt}")
+
+    free(p)
+    println("OK")
+}

--- a/tests/integration/c_import_struct_no_typedef/test_c_import_struct_no_typedef.sh
+++ b/tests/integration/c_import_struct_no_typedef/test_c_import_struct_no_typedef.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Integration test for `@c_import` against a C header that defines
+# its struct WITHOUT a convenience typedef.  This is the shape of
+# POSIX's `struct tm` (<time.h>), `struct stat` (<sys/stat.h>),
+# `struct sockaddr` (<sys/socket.h>), and many other system structs:
+# the layout is named via `struct tag`, no `typedef struct tag tag;`
+# is supplied.
+#
+# Aedis surfaced this porting localtime.c: aetherc was emitting bare
+# `tm *` everywhere it rendered a pointer to a `@c_import struct tm`,
+# but `<time.h>` doesn't ship a `typedef struct tm tm;` so the
+# generated C failed with `unknown type name 'tm'`.  Aetherc now
+# emits `struct Name *` for any `@c_import` struct, which always
+# works whether the header carries the typedef or not.
+#
+# The test header (widget.h) deliberately omits the typedef.  The
+# probe builds and runs only when aetherc emits `struct widget *`
+# wherever it renders a pointer to widget.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cd "$SCRIPT_DIR" || exit 1
+
+build_log="$tmpdir/build.log"
+if ! "$AE" build probe.ae -o "$tmpdir/probe" >"$build_log" 2>&1; then
+    echo "  [FAIL] c_import_struct_no_typedef: ae build failed"
+    sed 's/^/    /' "$build_log" | head -25
+    exit 1
+fi
+
+# Sanity: the generated C should reference `struct widget` (the
+# typedef-less form), not bare `widget`.
+genc="$(find "$tmpdir" -name '*.gen.c' 2>/dev/null | head -1)"
+if [ -z "$genc" ]; then
+    genc="$(find "$SCRIPT_DIR" -name 'probe*.c' 2>/dev/null | head -1)"
+fi
+if [ -n "$genc" ]; then
+    if grep -Eq 'typedef struct widget' "$genc"; then
+        echo "  [FAIL] c_import_struct_no_typedef: emitted a typedef for 'widget'"
+        echo "         (the C header owns the type — Aether must suppress)"
+        exit 1
+    fi
+    if ! grep -q 'struct widget' "$genc"; then
+        echo "  [FAIL] c_import_struct_no_typedef: no 'struct widget' in genc"
+        echo "         (aetherc must emit the struct-prefixed pointer form)"
+        exit 1
+    fi
+fi
+
+if ! "$tmpdir/probe" > "$tmpdir/run.out" 2>&1; then
+    echo "  [FAIL] c_import_struct_no_typedef: binary failed to run"
+    sed 's/^/    /' "$tmpdir/run.out" | head -10
+    exit 1
+fi
+
+if ! grep -q '^serial=42 weight=107$' "$tmpdir/run.out" || \
+   ! grep -q '^OK$' "$tmpdir/run.out"; then
+    echo "  [FAIL] c_import_struct_no_typedef: unexpected output"
+    sed 's/^/    /' "$tmpdir/run.out" | head -10
+    exit 1
+fi
+
+echo "  [PASS] c_import_struct_no_typedef"
+exit 0

--- a/tests/integration/c_import_struct_no_typedef/widget.h
+++ b/tests/integration/c_import_struct_no_typedef/widget.h
@@ -1,0 +1,21 @@
+/* A C header that owns a struct WITHOUT shipping a convenience
+ * typedef.  This is the shape of POSIX's `struct tm` in <time.h>,
+ * `struct stat` in <sys/stat.h>, `struct sockaddr` in <sys/socket.h>,
+ * and several other system structs.  The Aether port needs to be able
+ * to declare them with `@c_import` and have generated C compile —
+ * which means aetherc must emit `struct widget *` rather than the
+ * bare `widget *` that requires a typedef.
+ *
+ * Force-included into the Aether-generated TU via aether.toml's
+ * `cflags = "-include widget.h"`. */
+#ifndef C_IMPORT_STRUCT_NO_TYPEDEF_WIDGET_H
+#define C_IMPORT_STRUCT_NO_TYPEDEF_WIDGET_H
+
+/* Deliberately NO `typedef struct widget widget;` here. */
+struct widget {
+    int   serial;
+    int   weight;
+    void* payload;
+};
+
+#endif


### PR DESCRIPTION
The fix that makes `aetherc` emit `struct Name *` (rather than bare `Name *`) for pointers to `@c_import` structs **landed on main via #534**, but its regression test never did — so there's currently no guard against that codegen path regressing.

This is a **test-only** PR adding that guard:

- `widget.h` — a header that deliberately ships **no** `typedef struct widget widget;`, mirroring POSIX's `struct tm` (`<time.h>`), `struct stat` (`<sys/stat.h>`), `struct sockaddr` (`<sys/socket.h>`), etc.
- `probe.ae` — `@c_import`s that struct, casts a raw `ptr` to `*widget`, reads fields, prints them.
- The `.sh` driver asserts the generated C contains `struct widget` (and emits **no** typedef for it), compiles + links against the bare header, runs, and produces the expected output.

Without the fix, the generated C fails with *"unknown type name 'widget'"*. Verified **PASS** against current main (the fix is present; only the test was missing).

No production code changes — this just plugs a coverage gap left when the original `feat/std-mem-byte-sz` branch's code half merged (squashed) without its test half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)