### PR TITLE
feat(crypto): ML-KEM (FIPS 203), P-384/P-521, SM4/3DES, bignum perf, le64 retrofit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,39 @@ notes to be skipped or clobbered (the failure modes documented in
   Tiger, X448/Ed448) each reimplemented. Regression in
   `tests/regression/test_bytes_le64.ae`. (#838)
 
+## [current]
+
+### Added
+
+- **Post-quantum ML-KEM, more NIST curves, and two block ciphers** — a large
+  pure-Aether crypto tranche of the Bouncy Castle port (#739), no externs to
+  OpenSSL.
+  - **`std.cryptography.mlkem`** — ML-KEM / Kyber (FIPS 203), all three
+    parameter sets (512/768/1024): `mlkem{512,768,1024}_{keygen,encaps,decaps}`.
+    NTT over Z_3329 with Montgomery/Barrett reduction; SHAKE128/256 sampling
+    reusing `std.cryptography.sha3`. Aether's first post-quantum primitive.
+    Verified: KEM round-trip (encaps/decaps shared secret) + implicit-rejection
+    on all three sizes, plus a byte-exact keygen KAT for ML-KEM-1024 against the
+    Bouncy Castle vector. (Byte-exact ek/dk/ct/K KATs for 512/768 weren't in the
+    BC tree; those rest on round-trip + the 1024 KAT covering the shared core.)
+  - **`contrib.cryptography.p384` / `p521`** — NIST P-384 and P-521 ECDH +
+    ECDSA, parameter-swaps of the existing P-256 short-Weierstrass module.
+    Validated against the published 2·G doubling vectors + ECDSA round-trips.
+  - **`contrib.cryptography.sm4`** (GB/T 32907) and **`contrib.cryptography.des3`**
+    (3DES / TDEA) block ciphers, with the same ECB/CBC/CTR + PKCS#7 mode layer
+    as `aes`. Validated against the SM4 GB/T 32907 KAT and a BC 3DES KAT.
+
+### Changed
+
+- **`std.bignum` performance** (#233) — internal Karatsuba multiplication (for
+  large operands) and Montgomery `mod_pow` (for odd moduli, the RSA/DH hot
+  path), with the previous schoolbook code retained as the fallback. Public
+  API and all results are unchanged — purely faster. A 2048-bit `mod_pow`
+  drops from ~17 s to ~0.2 s (~90×); speeds up RSA and every elliptic curve.
+- **`std.cryptography` digests now use `std.bytes.get_le64`/`set_le64`** instead
+  of hand-rolled little-endian 64-bit byte assembly (blake2, skein, tiger,
+  sha3, argon2 — 12 sites). Behavior-preserving; follow-up to #838.
+
 ## [0.300.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Added
+
+- **Post-quantum ML-KEM, more NIST curves, and two block ciphers** — a large
+  pure-Aether crypto tranche of the Bouncy Castle port (#739), no externs to
+  OpenSSL.
+  - **`std.cryptography.mlkem`** — ML-KEM / Kyber (FIPS 203), all three
+    parameter sets (512/768/1024): `mlkem{512,768,1024}_{keygen,encaps,decaps}`.
+    NTT over Z_3329 with Montgomery/Barrett reduction; SHAKE128/256 sampling
+    reusing `std.cryptography.sha3`. Aether's first post-quantum primitive.
+    Validated **byte-exact against NIST ACVP** vectors: keyGen (ek/dk) and
+    encapDecap (ciphertext + shared secret) known-answers for all three
+    parameter sets, plus the implicit-rejection (VAL) path. The committed
+    integration test pins the ML-KEM-512 keyGen KAT (tcId 1) and the KEM
+    round-trip on all sizes.
+  - **`contrib.cryptography.p384` / `p521`** — NIST P-384 and P-521 ECDH +
+    ECDSA, parameter-swaps of the existing P-256 short-Weierstrass module.
+    Validated against the published 2·G doubling vectors + ECDSA round-trips.
+  - **`contrib.cryptography.sm4`** (GB/T 32907) and **`contrib.cryptography.des3`**
+    (3DES / TDEA) block ciphers, with the same ECB/CBC/CTR + PKCS#7 mode layer
+    as `aes`. Validated against the SM4 GB/T 32907 KAT and a BC 3DES KAT.
+
+### Changed
+
+- **`std.bignum` performance** (#233) — internal Karatsuba multiplication (for
+  large operands) and Montgomery `mod_pow` (for odd moduli, the RSA/DH hot
+  path), with the previous schoolbook code retained as the fallback. Public
+  API and all results are unchanged — purely faster. A 2048-bit `mod_pow`
+  drops from ~17 s to ~0.2 s (~90×); speeds up RSA and every elliptic curve.
+- **`std.cryptography` digests now use `std.bytes.get_le64`/`set_le64`** instead
+  of hand-rolled little-endian 64-bit byte assembly (blake2, skein, tiger,
+  sha3, argon2 — 12 sites). Behavior-preserving; follow-up to #838.
+
 ## [0.304.0]
 
 ### Documentation
@@ -59,39 +93,6 @@ notes to be skipped or clobbered (the failure modes documented in
   6+ crypto modules (Keccak/SHA-3, BLAKE2b, Salsa20/scrypt, Argon2, Skein/
   Tiger, X448/Ed448) each reimplemented. Regression in
   `tests/regression/test_bytes_le64.ae`. (#838)
-
-## [current]
-
-### Added
-
-- **Post-quantum ML-KEM, more NIST curves, and two block ciphers** — a large
-  pure-Aether crypto tranche of the Bouncy Castle port (#739), no externs to
-  OpenSSL.
-  - **`std.cryptography.mlkem`** — ML-KEM / Kyber (FIPS 203), all three
-    parameter sets (512/768/1024): `mlkem{512,768,1024}_{keygen,encaps,decaps}`.
-    NTT over Z_3329 with Montgomery/Barrett reduction; SHAKE128/256 sampling
-    reusing `std.cryptography.sha3`. Aether's first post-quantum primitive.
-    Verified: KEM round-trip (encaps/decaps shared secret) + implicit-rejection
-    on all three sizes, plus a byte-exact keygen KAT for ML-KEM-1024 against the
-    Bouncy Castle vector. (Byte-exact ek/dk/ct/K KATs for 512/768 weren't in the
-    BC tree; those rest on round-trip + the 1024 KAT covering the shared core.)
-  - **`contrib.cryptography.p384` / `p521`** — NIST P-384 and P-521 ECDH +
-    ECDSA, parameter-swaps of the existing P-256 short-Weierstrass module.
-    Validated against the published 2·G doubling vectors + ECDSA round-trips.
-  - **`contrib.cryptography.sm4`** (GB/T 32907) and **`contrib.cryptography.des3`**
-    (3DES / TDEA) block ciphers, with the same ECB/CBC/CTR + PKCS#7 mode layer
-    as `aes`. Validated against the SM4 GB/T 32907 KAT and a BC 3DES KAT.
-
-### Changed
-
-- **`std.bignum` performance** (#233) — internal Karatsuba multiplication (for
-  large operands) and Montgomery `mod_pow` (for odd moduli, the RSA/DH hot
-  path), with the previous schoolbook code retained as the fallback. Public
-  API and all results are unchanged — purely faster. A 2048-bit `mod_pow`
-  drops from ~17 s to ~0.2 s (~90×); speeds up RSA and every elliptic curve.
-- **`std.cryptography` digests now use `std.bytes.get_le64`/`set_le64`** instead
-  of hand-rolled little-endian 64-bit byte assembly (blake2, skein, tiger,
-  sha3, argon2 — 12 sites). Behavior-preserving; follow-up to #838.
 
 ## [0.300.0]
 

--- a/contrib/cryptography/des3/module.ae
+++ b/contrib/cryptography/des3/module.ae
@@ -1,0 +1,678 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.des3 — Triple-DES / TDEA (EDE3) over a 64-bit block,
+// in pure Aether. Part of the Bouncy Castle → Aether symmetric-crypto port
+// (#739). NO externs to OpenSSL.
+//
+// The core is single DES (FIPS 46-3 / ANSI X3.92): the 64-bit block is run
+// through IP, sixteen Feistel rounds driven by 48-bit subkeys (PC-1 / shift
+// schedule / PC-2), then IP⁻¹. This implementation follows Bouncy Castle's
+// DesEngine, which precomputes the eight S-boxes pre-permuted into the
+// SP1..SP8 combined tables and folds IP / IP⁻¹ into the bit-twiddling
+// DesFunc. EDE3 wraps three DES instances:
+//   encrypt(block) = E_K1( D_K2( E_K3(block) ) )    (BC order; see below)
+//   decrypt(block) = D_K1( E_K2( D_K3(block) ) )
+// Round keys, S-boxes and permutation tables are copied verbatim from
+// Bouncy Castle's DesEngine — they are NOT re-derived here.
+//
+// Note on key ordering: Bouncy Castle's DesEdeEngine schedules
+// key1 forward, key2 reversed, key3 forward for encryption, and reverses
+// the per-engine direction for decryption. Because a "decryptor" DES engine
+// is just an encryptor with its 16 subkeys reversed, the EDE here builds the
+// three subkey schedules once and runs DesFunc three times in the right
+// order. The result is byte-identical to BC's DesEdeEngine.
+//
+// Block primitive (what modes call):
+//   ctx   = des3.new_encryptor(key_bytes, key_len)   // key_len = 24 (or 16)
+//   ctx   = des3.new_decryptor(key_bytes, key_len)
+//   out8  = des3.process_block(ctx, in8)             // single 8-byte block
+//   des3.free(ctx)
+//
+// 16-byte keys are accepted as 2-key TDEA (K3 = K1).
+//
+// Convenience modes (mirroring contrib.cryptography.aes):
+//   des3.ecb_encrypt / ecb_decrypt  — block-aligned, NO padding
+//   des3.ctr_xor                    — CTR keystream over arbitrary length
+//   des3.cbc_encrypt / cbc_decrypt  — block-aligned CBC, NO padding
+//   des3.cbc_encrypt_pkcs7 / cbc_decrypt_pkcs7
+//                                   — CBC with PKCS#7 padding (arbitrary length)
+//   des3.pkcs7_pad / pkcs7_unpad    — standalone PKCS#7 helpers
+//
+// All buffers are std.bytes (caller frees results). Aether ints are 64-bit
+// and `>>` is arithmetic, so every 32-bit DES word is kept masked with
+// 0xFFFFFFFF and logical shifts go through std.bits.lsr32; the two 1-bit
+// pre/post rotations use std.bits.rotl32.
+
+import std.bytes
+import std.bits
+import std.intarr
+
+exports (
+    new_encryptor, new_decryptor, process_block, free,
+    block_size, ecb_encrypt, ecb_decrypt, ctr_xor,
+    cbc_encrypt, cbc_decrypt, cbc_encrypt_pkcs7, cbc_decrypt_pkcs7,
+    pkcs7_pad, pkcs7_unpad
+)
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+
+block_size() -> int { return 8 }
+
+// ---- permutation / shift schedule (verbatim from BC DesEngine) ----
+const PC1: int[56] = [
+    56, 48, 40, 32, 24, 16,  8,   0, 57, 49, 41, 33, 25, 17,
+    9,  1, 58, 50, 42, 34, 26,  18, 10,  2, 59, 51, 43, 35,
+    62, 54, 46, 38, 30, 22, 14,   6, 61, 53, 45, 37, 29, 21,
+    13,  5, 60, 52, 44, 36, 28,  20, 12,  4, 27, 19, 11,  3
+]
+
+const TOTROT: int[16] = [
+    1, 2, 4, 6, 8, 10, 12, 14,
+    15, 17, 19, 21, 23, 25, 27, 28
+]
+
+const PC2: int[48] = [
+    13, 16, 10, 23,  0,  4,  2, 27, 14,  5, 20,  9,
+    22, 18, 11,  3, 25,  7, 15,  6, 26, 19, 12,  1,
+    40, 51, 30, 36, 46, 54, 29, 39, 50, 44, 32, 47,
+    43, 48, 38, 55, 33, 52, 45, 41, 49, 35, 28, 31
+]
+
+const BYTEBIT: int[8] = [ 128, 64, 32, 16, 8, 4, 2, 1 ]
+
+const BIGBYTE: int[24] = [
+    0x800000, 0x400000, 0x200000, 0x100000,
+    0x80000,  0x40000,  0x20000,  0x10000,
+    0x8000,   0x4000,   0x2000,   0x1000,
+    0x800,    0x400,    0x200,    0x100,
+    0x80,     0x40,     0x20,     0x10,
+    0x8,      0x4,      0x2,      0x1
+]
+
+// ---- combined S-box / permutation tables (verbatim from BC DesEngine) ----
+const SP1: int[64] = [
+    0x01010400, 0x00000000, 0x00010000, 0x01010404,
+    0x01010004, 0x00010404, 0x00000004, 0x00010000,
+    0x00000400, 0x01010400, 0x01010404, 0x00000400,
+    0x01000404, 0x01010004, 0x01000000, 0x00000004,
+    0x00000404, 0x01000400, 0x01000400, 0x00010400,
+    0x00010400, 0x01010000, 0x01010000, 0x01000404,
+    0x00010004, 0x01000004, 0x01000004, 0x00010004,
+    0x00000000, 0x00000404, 0x00010404, 0x01000000,
+    0x00010000, 0x01010404, 0x00000004, 0x01010000,
+    0x01010400, 0x01000000, 0x01000000, 0x00000400,
+    0x01010004, 0x00010000, 0x00010400, 0x01000004,
+    0x00000400, 0x00000004, 0x01000404, 0x00010404,
+    0x01010404, 0x00010004, 0x01010000, 0x01000404,
+    0x01000004, 0x00000404, 0x00010404, 0x01010400,
+    0x00000404, 0x01000400, 0x01000400, 0x00000000,
+    0x00010004, 0x00010400, 0x00000000, 0x01010004
+]
+
+const SP2: int[64] = [
+    0x80108020, 0x80008000, 0x00008000, 0x00108020,
+    0x00100000, 0x00000020, 0x80100020, 0x80008020,
+    0x80000020, 0x80108020, 0x80108000, 0x80000000,
+    0x80008000, 0x00100000, 0x00000020, 0x80100020,
+    0x00108000, 0x00100020, 0x80008020, 0x00000000,
+    0x80000000, 0x00008000, 0x00108020, 0x80100000,
+    0x00100020, 0x80000020, 0x00000000, 0x00108000,
+    0x00008020, 0x80108000, 0x80100000, 0x00008020,
+    0x00000000, 0x00108020, 0x80100020, 0x00100000,
+    0x80008020, 0x80100000, 0x80108000, 0x00008000,
+    0x80100000, 0x80008000, 0x00000020, 0x80108020,
+    0x00108020, 0x00000020, 0x00008000, 0x80000000,
+    0x00008020, 0x80108000, 0x00100000, 0x80000020,
+    0x00100020, 0x80008020, 0x80000020, 0x00100020,
+    0x00108000, 0x00000000, 0x80008000, 0x00008020,
+    0x80000000, 0x80100020, 0x80108020, 0x00108000
+]
+
+const SP3: int[64] = [
+    0x00000208, 0x08020200, 0x00000000, 0x08020008,
+    0x08000200, 0x00000000, 0x00020208, 0x08000200,
+    0x00020008, 0x08000008, 0x08000008, 0x00020000,
+    0x08020208, 0x00020008, 0x08020000, 0x00000208,
+    0x08000000, 0x00000008, 0x08020200, 0x00000200,
+    0x00020200, 0x08020000, 0x08020008, 0x00020208,
+    0x08000208, 0x00020200, 0x00020000, 0x08000208,
+    0x00000008, 0x08020208, 0x00000200, 0x08000000,
+    0x08020200, 0x08000000, 0x00020008, 0x00000208,
+    0x00020000, 0x08020200, 0x08000200, 0x00000000,
+    0x00000200, 0x00020008, 0x08020208, 0x08000200,
+    0x08000008, 0x00000200, 0x00000000, 0x08020008,
+    0x08000208, 0x00020000, 0x08000000, 0x08020208,
+    0x00000008, 0x00020208, 0x00020200, 0x08000008,
+    0x08020000, 0x08000208, 0x00000208, 0x08020000,
+    0x00020208, 0x00000008, 0x08020008, 0x00020200
+]
+
+const SP4: int[64] = [
+    0x00802001, 0x00002081, 0x00002081, 0x00000080,
+    0x00802080, 0x00800081, 0x00800001, 0x00002001,
+    0x00000000, 0x00802000, 0x00802000, 0x00802081,
+    0x00000081, 0x00000000, 0x00800080, 0x00800001,
+    0x00000001, 0x00002000, 0x00800000, 0x00802001,
+    0x00000080, 0x00800000, 0x00002001, 0x00002080,
+    0x00800081, 0x00000001, 0x00002080, 0x00800080,
+    0x00002000, 0x00802080, 0x00802081, 0x00000081,
+    0x00800080, 0x00800001, 0x00802000, 0x00802081,
+    0x00000081, 0x00000000, 0x00000000, 0x00802000,
+    0x00002080, 0x00800080, 0x00800081, 0x00000001,
+    0x00802001, 0x00002081, 0x00002081, 0x00000080,
+    0x00802081, 0x00000081, 0x00000001, 0x00002000,
+    0x00800001, 0x00002001, 0x00802080, 0x00800081,
+    0x00002001, 0x00002080, 0x00800000, 0x00802001,
+    0x00000080, 0x00800000, 0x00002000, 0x00802080
+]
+
+const SP5: int[64] = [
+    0x00000100, 0x02080100, 0x02080000, 0x42000100,
+    0x00080000, 0x00000100, 0x40000000, 0x02080000,
+    0x40080100, 0x00080000, 0x02000100, 0x40080100,
+    0x42000100, 0x42080000, 0x00080100, 0x40000000,
+    0x02000000, 0x40080000, 0x40080000, 0x00000000,
+    0x40000100, 0x42080100, 0x42080100, 0x02000100,
+    0x42080000, 0x40000100, 0x00000000, 0x42000000,
+    0x02080100, 0x02000000, 0x42000000, 0x00080100,
+    0x00080000, 0x42000100, 0x00000100, 0x02000000,
+    0x40000000, 0x02080000, 0x42000100, 0x40080100,
+    0x02000100, 0x40000000, 0x42080000, 0x02080100,
+    0x40080100, 0x00000100, 0x02000000, 0x42080000,
+    0x42080100, 0x00080100, 0x42000000, 0x42080100,
+    0x02080000, 0x00000000, 0x40080000, 0x42000000,
+    0x00080100, 0x02000100, 0x40000100, 0x00080000,
+    0x00000000, 0x40080000, 0x02080100, 0x40000100
+]
+
+const SP6: int[64] = [
+    0x20000010, 0x20400000, 0x00004000, 0x20404010,
+    0x20400000, 0x00000010, 0x20404010, 0x00400000,
+    0x20004000, 0x00404010, 0x00400000, 0x20000010,
+    0x00400010, 0x20004000, 0x20000000, 0x00004010,
+    0x00000000, 0x00400010, 0x20004010, 0x00004000,
+    0x00404000, 0x20004010, 0x00000010, 0x20400010,
+    0x20400010, 0x00000000, 0x00404010, 0x20404000,
+    0x00004010, 0x00404000, 0x20404000, 0x20000000,
+    0x20004000, 0x00000010, 0x20400010, 0x00404000,
+    0x20404010, 0x00400000, 0x00004010, 0x20000010,
+    0x00400000, 0x20004000, 0x20000000, 0x00004010,
+    0x20000010, 0x20404010, 0x00404000, 0x20400000,
+    0x00404010, 0x20404000, 0x00000000, 0x20400010,
+    0x00000010, 0x00004000, 0x20400000, 0x00404010,
+    0x00004000, 0x00400010, 0x20004010, 0x00000000,
+    0x20404000, 0x20000000, 0x00400010, 0x20004010
+]
+
+const SP7: int[64] = [
+    0x00200000, 0x04200002, 0x04000802, 0x00000000,
+    0x00000800, 0x04000802, 0x00200802, 0x04200800,
+    0x04200802, 0x00200000, 0x00000000, 0x04000002,
+    0x00000002, 0x04000000, 0x04200002, 0x00000802,
+    0x04000800, 0x00200802, 0x00200002, 0x04000800,
+    0x04000002, 0x04200000, 0x04200800, 0x00200002,
+    0x04200000, 0x00000800, 0x00000802, 0x04200802,
+    0x00200800, 0x00000002, 0x04000000, 0x00200800,
+    0x04000000, 0x00200800, 0x00200000, 0x04000802,
+    0x04000802, 0x04200002, 0x04200002, 0x00000002,
+    0x00200002, 0x04000000, 0x04000800, 0x00200000,
+    0x04200800, 0x00000802, 0x00200802, 0x04200800,
+    0x00000802, 0x04000002, 0x04200802, 0x04200000,
+    0x00200800, 0x00000000, 0x00000002, 0x04200802,
+    0x00000000, 0x00200802, 0x04200000, 0x00000800,
+    0x04000002, 0x04000800, 0x00000800, 0x00200002
+]
+
+const SP8: int[64] = [
+    0x10001040, 0x00001000, 0x00040000, 0x10041040,
+    0x10000000, 0x10001040, 0x00000040, 0x10000000,
+    0x00040040, 0x10040000, 0x10041040, 0x00041000,
+    0x10041000, 0x00041040, 0x00001000, 0x00000040,
+    0x10040000, 0x10000040, 0x10001000, 0x00001040,
+    0x00041000, 0x00040040, 0x10040040, 0x10041000,
+    0x00001040, 0x00000000, 0x00000000, 0x10040040,
+    0x10000040, 0x10001000, 0x00041040, 0x00040000,
+    0x00041040, 0x00040000, 0x10041000, 0x00001000,
+    0x00000040, 0x10040040, 0x00001000, 0x00041040,
+    0x10001000, 0x00000040, 0x10000040, 0x10040000,
+    0x10040040, 0x10000000, 0x00040000, 0x10001040,
+    0x00000000, 0x10041040, 0x00040040, 0x10000040,
+    0x10040000, 0x10001000, 0x10001040, 0x00000000,
+    0x10041040, 0x00041000, 0x00041000, 0x00001040,
+    0x00001040, 0x00040040, 0x10000000, 0x10041000
+]
+
+// Three working-key schedules; each is intarr(32) of 32-bit words.
+struct Des3Ctx {
+    wk1: ptr      // applied first
+    wk2: ptr      // applied second
+    wk3: ptr      // applied third
+}
+
+// ---- single-DES key schedule (BC GenerateWorkingKey) ----
+// Returns intarr(32). `encrypting` selects the round ordering.
+generate_working_key(encrypting: int, key: ptr, key_off: int) -> ptr {
+    new_key = intarr_new_raw(32)
+    pc1m = intarr_new_raw(56)
+    pcr = intarr_new_raw(56)
+
+    j = 0
+    while j < 56 {
+        l = PC1[j]
+        kb = bytes.get(key, key_off + bits.lsr32(l, 3)) & 0xFF
+        if (kb & BYTEBIT[l & 7]) != 0 {
+            intarr_set_raw(pc1m, j, 1)
+        } else {
+            intarr_set_raw(pc1m, j, 0)
+        }
+        j = j + 1
+    }
+
+    i = 0
+    while i < 16 {
+        m = i << 1
+        if encrypting == 1 {
+            m = i << 1
+        } else {
+            m = (15 - i) << 1
+        }
+        n = m + 1
+        intarr_set_raw(new_key, m, 0)
+        intarr_set_raw(new_key, n, 0)
+
+        j = 0
+        while j < 28 {
+            l = j + TOTROT[i]
+            if l < 28 {
+                intarr_set_raw(pcr, j, intarr_get_raw(pc1m, l))
+            } else {
+                intarr_set_raw(pcr, j, intarr_get_raw(pc1m, l - 28))
+            }
+            j = j + 1
+        }
+        j = 28
+        while j < 56 {
+            l = j + TOTROT[i]
+            if l < 56 {
+                intarr_set_raw(pcr, j, intarr_get_raw(pc1m, l))
+            } else {
+                intarr_set_raw(pcr, j, intarr_get_raw(pc1m, l - 28))
+            }
+            j = j + 1
+        }
+
+        j = 0
+        while j < 24 {
+            if intarr_get_raw(pcr, PC2[j]) != 0 {
+                intarr_set_raw(new_key, m, intarr_get_raw(new_key, m) | BIGBYTE[j])
+            }
+            if intarr_get_raw(pcr, PC2[j + 24]) != 0 {
+                intarr_set_raw(new_key, n, intarr_get_raw(new_key, n) | BIGBYTE[j])
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    intarr_free(pc1m)
+    intarr_free(pcr)
+
+    // Pack the processed key.
+    i = 0
+    while i < 32 {
+        i1 = intarr_get_raw(new_key, i)
+        i2 = intarr_get_raw(new_key, i + 1)
+        v0 = (((i1 & 0x00fc0000) << 6) |
+              ((i1 & 0x00000fc0) << 10) |
+              bits.lsr32(i2 & 0x00fc0000, 10) |
+              bits.lsr32(i2 & 0x00000fc0, 6)) & 0xFFFFFFFF
+        v1 = (((i1 & 0x0003f000) << 12) |
+              ((i1 & 0x0000003f) << 16) |
+              bits.lsr32(i2 & 0x0003f000, 4) |
+              (i2 & 0x0000003f)) & 0xFFFFFFFF
+        intarr_set_raw(new_key, i, v0)
+        intarr_set_raw(new_key, i + 1, v1)
+        i = i + 2
+    }
+    return new_key
+}
+
+// ---- single-DES core (BC DesFunc), operating on two 32-bit halves ----
+// Returns the new (hi, lo) pair.
+des_func(wk: ptr, hi: int, lo: int) -> {
+    long left = hi & 0xFFFFFFFF
+    long right = lo & 0xFFFFFFFF
+    long work = 0
+    long fval = 0
+
+    work = (bits.lsr32(left, 4) ^ right) & 0x0f0f0f0f
+    right = right ^ work
+    left = (left ^ (work << 4)) & 0xFFFFFFFF
+    work = (bits.lsr32(left, 16) ^ right) & 0x0000ffff
+    right = right ^ work
+    left = (left ^ (work << 16)) & 0xFFFFFFFF
+    work = (bits.lsr32(right, 2) ^ left) & 0x33333333
+    left = left ^ work
+    right = (right ^ (work << 2)) & 0xFFFFFFFF
+    work = (bits.lsr32(right, 8) ^ left) & 0x00ff00ff
+    left = left ^ work
+    right = (right ^ (work << 8)) & 0xFFFFFFFF
+    right = ((right << 1) | bits.lsr32(right, 31)) & 0xFFFFFFFF
+    work = (left ^ right) & 0xaaaaaaaa
+    left = left ^ work
+    right = right ^ work
+    left = ((left << 1) | bits.lsr32(left, 31)) & 0xFFFFFFFF
+
+    round = 0
+    while round < 8 {
+        work = ((right << 28) | bits.lsr32(right, 4)) & 0xFFFFFFFF
+        work = (work ^ intarr_get_raw(wk, round * 4 + 0)) & 0xFFFFFFFF
+        fval = SP7[work & 0x3f]
+        fval = fval | SP5[bits.lsr32(work, 8) & 0x3f]
+        fval = fval | SP3[bits.lsr32(work, 16) & 0x3f]
+        fval = fval | SP1[bits.lsr32(work, 24) & 0x3f]
+        work = (right ^ intarr_get_raw(wk, round * 4 + 1)) & 0xFFFFFFFF
+        fval = fval | SP8[work & 0x3f]
+        fval = fval | SP6[bits.lsr32(work, 8) & 0x3f]
+        fval = fval | SP4[bits.lsr32(work, 16) & 0x3f]
+        fval = fval | SP2[bits.lsr32(work, 24) & 0x3f]
+        left = (left ^ fval) & 0xFFFFFFFF
+
+        work = ((left << 28) | bits.lsr32(left, 4)) & 0xFFFFFFFF
+        work = (work ^ intarr_get_raw(wk, round * 4 + 2)) & 0xFFFFFFFF
+        fval = SP7[work & 0x3f]
+        fval = fval | SP5[bits.lsr32(work, 8) & 0x3f]
+        fval = fval | SP3[bits.lsr32(work, 16) & 0x3f]
+        fval = fval | SP1[bits.lsr32(work, 24) & 0x3f]
+        work = (left ^ intarr_get_raw(wk, round * 4 + 3)) & 0xFFFFFFFF
+        fval = fval | SP8[work & 0x3f]
+        fval = fval | SP6[bits.lsr32(work, 8) & 0x3f]
+        fval = fval | SP4[bits.lsr32(work, 16) & 0x3f]
+        fval = fval | SP2[bits.lsr32(work, 24) & 0x3f]
+        right = (right ^ fval) & 0xFFFFFFFF
+        round = round + 1
+    }
+
+    right = (bits.lsr32(right, 1) | (right << 31)) & 0xFFFFFFFF
+    work = (left ^ right) & 0xaaaaaaaa
+    left = left ^ work
+    right = right ^ work
+    left = (bits.lsr32(left, 1) | (left << 31)) & 0xFFFFFFFF
+    work = (bits.lsr32(left, 8) ^ right) & 0x00ff00ff
+    right = right ^ work
+    left = (left ^ (work << 8)) & 0xFFFFFFFF
+    work = (bits.lsr32(left, 2) ^ right) & 0x33333333
+    right = right ^ work
+    left = (left ^ (work << 2)) & 0xFFFFFFFF
+    work = (bits.lsr32(right, 16) ^ left) & 0x0000ffff
+    left = left ^ work
+    right = (right ^ (work << 16)) & 0xFFFFFFFF
+    work = (bits.lsr32(right, 4) ^ left) & 0x0f0f0f0f
+    left = left ^ work
+    right = (right ^ (work << 4)) & 0xFFFFFFFF
+
+    // DesFunc swaps the halves on output: hi32 = right, lo32 = left.
+    long rhi = right & 0xFFFFFFFF
+    long rlo = left & 0xFFFFFFFF
+    return rhi, rlo
+}
+
+// ---- key expansion (EDE3) ----
+// `encrypt` selects EDE (encrypt) vs DED (decrypt) ordering. The three
+// subkey schedules are built so that running des_func(wk1) -> des_func(wk2)
+// -> des_func(wk3) reproduces BC's DesEdeEngine exactly.
+new_ctx(key: ptr, keylen: int, encrypt: int) -> ptr {
+    // BC: key1=key[0..8] (enc dir = forEncryption), key2=key[8..16]
+    // (enc dir = !forEncryption), key3=key[16..24] (enc dir = forEncryption,
+    // or = key1 when keylen==16). For encryption DesFunc runs k1,k2,k3; for
+    // decryption it runs k3,k2,k1. We fold the order into wk1/wk2/wk3.
+    fe = encrypt   // forEncryption flag
+
+    s1 = generate_working_key(fe, key, 0)
+    s2 = generate_working_key(1 - fe, key, 8)
+    s3 = null
+    if keylen == 24 {
+        s3 = generate_working_key(fe, key, 16)
+    } else {
+        // 2-key TDEA: K3 = K1 (same key bytes, same direction).
+        s3 = generate_working_key(fe, key, 0)
+    }
+
+    c = malloc(24) as *Des3Ctx
+    if encrypt == 1 {
+        // E_K1 then E(dir K2) then E_K3  → DesFunc(k1), DesFunc(k2), DesFunc(k3)
+        c.wk1 = s1
+        c.wk2 = s2
+        c.wk3 = s3
+    } else {
+        // decrypt runs DesFunc(k3), DesFunc(k2), DesFunc(k1)
+        c.wk1 = s3
+        c.wk2 = s2
+        c.wk3 = s1
+    }
+    return c
+}
+
+new_encryptor(key: ptr, keylen: int) -> ptr {
+    return new_ctx(key, keylen, 1)
+}
+new_decryptor(key: ptr, keylen: int) -> ptr {
+    return new_ctx(key, keylen, 0)
+}
+free(ctx: ptr) {
+    if ctx == null { return }
+    c = ctx as *Des3Ctx
+    if c.wk1 != null { intarr_free(c.wk1) }
+    if c.wk2 != null { intarr_free(c.wk2) }
+    if c.wk3 != null { intarr_free(c.wk3) }
+    libc_free(ctx)
+}
+
+// ---- single block (8 bytes) ----
+process_block(ctx: ptr, in8: ptr) -> ptr {
+    c = ctx as *Des3Ctx
+    out = bytes.new(8)
+    hi = bytes.get_be32(in8, 0)
+    lo = bytes.get_be32(in8, 4)
+    hi, lo = des_func(c.wk1, hi, lo)
+    hi, lo = des_func(c.wk2, hi, lo)
+    hi, lo = des_func(c.wk3, hi, lo)
+    bytes.set_be32(out, 0, hi)
+    bytes.set_be32(out, 4, lo)
+    return out
+}
+
+// ---- ECB (block-aligned, NO padding) ----
+ecb_encrypt(ctx: ptr, data: ptr) -> ptr { return ecb_run(ctx, data) }
+ecb_decrypt(ctx: ptr, data: ptr) -> ptr { return ecb_run(ctx, data) }
+ecb_run(ctx: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    out = bytes.new(n)
+    off = 0
+    while off + 8 <= n {
+        blk = bytes.new(8)
+        j = 0
+        while j < 8 { bytes.set(blk, j, bytes.get(data, off + j)); j = j + 1 }
+        eb = process_block(ctx, blk)
+        k = 0
+        while k < 8 { bytes.set(out, off + k, bytes.get(eb, k)); k = k + 1 }
+        bytes.free(blk); bytes.free(eb)
+        off = off + 8
+    }
+    return out
+}
+
+// ---- CTR (stream; encrypt == decrypt) ----
+// `ctx` must be an ENCRYPTOR. `iv` is the initial 8-byte counter block,
+// incremented big-endian per block.
+ctr_xor(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    out = bytes.new(n)
+    ctr = bytes.new(8)
+    i = 0
+    while i < 8 { bytes.set(ctr, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        ks = process_block(ctx, ctr)
+        j = 0
+        while j < 8 {
+            if off + j < n {
+                bytes.set(out, off + j, (bytes.get(data, off + j) ^ bytes.get(ks, j)) & 0xFF)
+            }
+            j = j + 1
+        }
+        bytes.free(ks)
+        ctr_increment(ctr)
+        off = off + 8
+    }
+    bytes.free(ctr)
+    return out
+}
+ctr_increment(ctr: ptr) {
+    i = 7
+    carry = 1
+    while i >= 0 {
+        if carry == 1 {
+            v = (bytes.get(ctr, i) + 1) & 0xFF
+            bytes.set(ctr, i, v)
+            if v != 0 { carry = 0 }
+        }
+        i = i - 1
+    }
+}
+
+// ---- CBC (block-aligned, NO padding) ----
+// `ctx` is an encryptor for cbc_encrypt and a decryptor for cbc_decrypt.
+// Input length MUST be a multiple of 8; otherwise an empty buffer is
+// returned (use the _pkcs7 variants for arbitrary-length data).
+cbc_encrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    if n % 8 != 0 {
+        return bytes.new(0)
+    }
+    out = bytes.new(n)
+    prev = bytes.new(8)
+    i = 0
+    while i < 8 { bytes.set(prev, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        blk = bytes.new(8)
+        j = 0
+        while j < 8 {
+            bytes.set(blk, j, (bytes.get(data, off + j) ^ bytes.get(prev, j)) & 0xFF)
+            j = j + 1
+        }
+        eb = process_block(ctx, blk)
+        k = 0
+        while k < 8 {
+            v = bytes.get(eb, k)
+            bytes.set(out, off + k, v)
+            bytes.set(prev, k, v)
+            k = k + 1
+        }
+        bytes.free(blk); bytes.free(eb)
+        off = off + 8
+    }
+    bytes.free(prev)
+    return out
+}
+
+cbc_decrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    if n % 8 != 0 {
+        return bytes.new(0)
+    }
+    out = bytes.new(n)
+    prev = bytes.new(8)
+    i = 0
+    while i < 8 { bytes.set(prev, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        blk = bytes.new(8)
+        j = 0
+        while j < 8 { bytes.set(blk, j, bytes.get(data, off + j)); j = j + 1 }
+        db = process_block(ctx, blk)
+        k = 0
+        while k < 8 {
+            bytes.set(out, off + k, (bytes.get(db, k) ^ bytes.get(prev, k)) & 0xFF)
+            bytes.set(prev, k, bytes.get(blk, k))
+            k = k + 1
+        }
+        bytes.free(blk); bytes.free(db)
+        off = off + 8
+    }
+    bytes.free(prev)
+    return out
+}
+
+// ---- PKCS#7 padding (block size 8) ----
+pkcs7_pad(data: ptr) -> ptr {
+    n = bytes.length(data)
+    pad = 8 - (n % 8)
+    out = bytes.new(n + pad)
+    i = 0
+    while i < n { bytes.set(out, i, bytes.get(data, i)); i = i + 1 }
+    j = 0
+    while j < pad { bytes.set(out, n + j, pad); j = j + 1 }
+    return out
+}
+
+pkcs7_unpad(data: ptr) -> {
+    n = bytes.length(data)
+    if n == 0 {
+        return bytes.new(0), "empty input"
+    }
+    if n % 8 != 0 {
+        return bytes.new(0), "length not a multiple of 8"
+    }
+    pad = bytes.get(data, n - 1) & 0xFF
+    if pad < 1 {
+        return bytes.new(0), "bad padding"
+    }
+    if pad > 8 {
+        return bytes.new(0), "bad padding"
+    }
+    bad = 0
+    i = 0
+    while i < pad {
+        if (bytes.get(data, n - 1 - i) & 0xFF) != pad {
+            bad = 1
+        }
+        i = i + 1
+    }
+    if bad == 1 {
+        return bytes.new(0), "bad padding"
+    }
+    outlen = n - pad
+    out = bytes.new(outlen)
+    j = 0
+    while j < outlen { bytes.set(out, j, bytes.get(data, j)); j = j + 1 }
+    return out, ""
+}
+
+// ---- CBC + PKCS#7 (arbitrary length) ----
+cbc_encrypt_pkcs7(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    padded = pkcs7_pad(data)
+    out = cbc_encrypt(ctx, iv, padded)
+    bytes.free(padded)
+    return out
+}
+
+cbc_decrypt_pkcs7(ctx: ptr, iv: ptr, data: ptr) -> {
+    n = bytes.length(data)
+    if n == 0 {
+        return bytes.new(0), "empty input"
+    }
+    if n % 8 != 0 {
+        return bytes.new(0), "length not a multiple of 8"
+    }
+    raw = cbc_decrypt(ctx, iv, data)
+    out, err = pkcs7_unpad(raw)
+    bytes.free(raw)
+    return out, err
+}

--- a/contrib/cryptography/p384/module.ae
+++ b/contrib/cryptography/p384/module.ae
@@ -1,0 +1,377 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.p384 — NIST P-384 (secp384r1) in pure Aether, on top of
+// std.bignum. NO externs to OpenSSL.
+//
+// Short-Weierstrass curve  y^2 = x^3 - 3x + b  over GF(p). Point arithmetic
+// is in Jacobian coordinates (X:Y:Z) with affine (x,y) = (X/Z^2, Y/Z^3).
+//
+//   scalar_mult_base(k48)            -> (x48, y48)     k*G (public key point)
+//   scalar_mult(k48, px48, py48)     -> (x48, y48)     k*P
+//   ecdh(priv48, pubx48, puby48)     -> shared_x48     priv * pub, x only
+//   ecdsa_sign(priv48, hash48, k48)  -> (r48, s48)     k = per-message nonce
+//   ecdsa_verify(pubx, puby, hash48, r48, s48) -> int  1 = valid
+//
+// 48-byte big-endian scalars / coordinates (the SEC1 / NIST wire order).
+//
+// NOTE: correctness-first port over the variable-time std.bignum — not
+// constant-time/side-channel-hardened, and ecdsa_sign takes the nonce `k`
+// as a parameter (caller supplies a CSPRNG value or an RFC 6979 derivation).
+// Validated against the priv=2 -> 2G generator vector and an ECDSA
+// sign/verify round-trip.
+
+import std.bytes
+import std.bignum
+
+exports (
+    scalar_mult_base, scalar_mult, ecdh, ecdsa_sign, ecdsa_verify
+)
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+extern strlen(s: string) -> int
+
+// ---- curve parameters ----
+P_HEX() -> string { return "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff" }
+B_HEX() -> string { return "b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef" }
+N_HEX() -> string { return "ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973" }
+GX_HEX() -> string { return "aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7" }
+GY_HEX() -> string { return "3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f" }
+
+hexv(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    if c >= 65 { if c <= 70 { return c - 55 } }
+    return 0
+}
+bn_hex(h: string) -> ptr {
+    n = strlen(h)
+    b = bytes.new(n / 2)
+    i = 0
+    while i < n {
+        hi = hexv(string_char_at_n(h, n, i))
+        lo = hexv(string_char_at_n(h, n, i + 1))
+        bytes.set(b, i / 2, hi * 16 + lo)
+        i = i + 2
+    }
+    r = bignum.from_bytes_unsigned(b, n / 2)
+    bytes.free(b)
+    return r
+}
+
+// ---- field ops mod p ----
+fadd(a: ptr, b: ptr, p: ptr) -> ptr { s = bignum.add(a, b); r = bignum.mod(s, p); bignum.free(s); return r }
+fsub(a: ptr, b: ptr, p: ptr) -> ptr { d = bignum.subtract(a, b); r = bignum.mod(d, p); bignum.free(d); return r }
+fmul(a: ptr, b: ptr, p: ptr) -> ptr { m = bignum.multiply(a, b); r = bignum.mod(m, p); bignum.free(m); return r }
+finv(a: ptr, p: ptr) -> ptr {
+    two = bignum.from_int(2)
+    e = bignum.subtract(p, two)
+    r = bignum.mod_pow(a, e, p)
+    bignum.free(two); bignum.free(e)
+    return r
+}
+
+// 48-byte big-endian encode / decode.
+to_be48(nn: ptr) -> ptr {
+    be = bignum.to_bytes_unsigned(nn)
+    blen = bytes.length(be)
+    out = bytes.new(48)
+    i = 0
+    while i < 48 { bytes.set(out, i, 0); i = i + 1 }
+    // right-align big-endian bytes
+    i = 0
+    while i < blen {
+        idx = 48 - blen + i
+        if idx >= 0 { bytes.set(out, idx, bytes.get(be, i)) }
+        i = i + 1
+    }
+    bytes.free(be)
+    return out
+}
+from_be48(b: ptr) -> ptr {
+    return bignum.from_bytes_unsigned(b, 48)
+}
+
+// ---- Jacobian point (X:Y:Z) ----
+struct Pt { x: ptr  y: ptr  z: ptr }
+pt_new(x: ptr, y: ptr, z: ptr) -> *Pt { q = malloc(24) as *Pt; q.x = x; q.y = y; q.z = z; return q }
+pt_free(q: *Pt) { bignum.free(q.x); bignum.free(q.y); bignum.free(q.z); libc_free(q) }
+
+// Point at infinity: Z = 0.
+pt_infinity() -> *Pt { return pt_new(bignum.from_int(1), bignum.from_int(1), bignum.from_int(0)) }
+is_infinity(q: *Pt) -> int { return bignum.is_zero(q.z) }
+
+// Affine -> Jacobian (Z = 1).
+affine_to_jac(x: ptr, y: ptr) -> *Pt { return pt_new(bignum.clone(x), bignum.clone(y), bignum.from_int(1)) }
+
+// Point doubling (Jacobian), a = -3:  standard "dbl-2009-l" with a=-3 form.
+pt_double(q: *Pt, p: ptr) -> *Pt {
+    if is_infinity(q) == 1 { return pt_infinity() }
+    // delta = Z^2; gamma = Y^2; beta = X*gamma
+    delta = fmul(q.z, q.z, p)
+    gamma = fmul(q.y, q.y, p)
+    beta = fmul(q.x, gamma, p)
+    // alpha = 3*(X-delta)*(X+delta)   (uses a=-3)
+    xmd = fsub(q.x, delta, p)
+    xpd = fadd(q.x, delta, p)
+    prod = fmul(xmd, xpd, p)
+    three = bignum.from_int(3)
+    alpha = fmul(three, prod, p)
+    // X3 = alpha^2 - 8*beta
+    a2 = fmul(alpha, alpha, p)
+    eight = bignum.from_int(8)
+    eb = fmul(eight, beta, p)
+    X3 = fsub(a2, eb, p)
+    // Z3 = (Y+Z)^2 - gamma - delta
+    ypz = fadd(q.y, q.z, p)
+    ypz2 = fmul(ypz, ypz, p)
+    t1 = fsub(ypz2, gamma, p)
+    Z3 = fsub(t1, delta, p)
+    // Y3 = alpha*(4*beta - X3) - 8*gamma^2
+    four = bignum.from_int(4)
+    fb = fmul(four, beta, p)
+    fbx = fsub(fb, X3, p)
+    ay = fmul(alpha, fbx, p)
+    g2 = fmul(gamma, gamma, p)
+    eg2 = fmul(eight, g2, p)
+    Y3 = fsub(ay, eg2, p)
+
+    bignum.free(delta); bignum.free(gamma); bignum.free(beta)
+    bignum.free(xmd); bignum.free(xpd); bignum.free(prod); bignum.free(three); bignum.free(alpha)
+    bignum.free(a2); bignum.free(eight); bignum.free(eb)
+    bignum.free(ypz); bignum.free(ypz2); bignum.free(t1)
+    bignum.free(four); bignum.free(fb); bignum.free(fbx); bignum.free(ay); bignum.free(g2); bignum.free(eg2)
+    return pt_new(X3, Y3, Z3)
+}
+
+// Point addition (Jacobian), "add-2007-bl". Handles infinity operands and the
+// doubling case (falls back to pt_double).
+pt_add(a: *Pt, b: *Pt, p: ptr) -> *Pt {
+    if is_infinity(a) == 1 { return pt_new(bignum.clone(b.x), bignum.clone(b.y), bignum.clone(b.z)) }
+    if is_infinity(b) == 1 { return pt_new(bignum.clone(a.x), bignum.clone(a.y), bignum.clone(a.z)) }
+    // U1 = X1*Z2^2; U2 = X2*Z1^2
+    z1z1 = fmul(a.z, a.z, p)
+    z2z2 = fmul(b.z, b.z, p)
+    U1 = fmul(a.x, z2z2, p)
+    U2 = fmul(b.x, z1z1, p)
+    // S1 = Y1*Z2^3; S2 = Y2*Z1^3
+    z2z2z2 = fmul(z2z2, b.z, p)
+    z1z1z1 = fmul(z1z1, a.z, p)
+    S1 = fmul(a.y, z2z2z2, p)
+    S2 = fmul(b.y, z1z1z1, p)
+
+    H = fsub(U2, U1, p)
+    rr = fsub(S2, S1, p)
+
+    if bignum.is_zero(H) == 1 {
+        if bignum.is_zero(rr) == 1 {
+            // a == b: double
+            bignum.free(z1z1); bignum.free(z2z2); bignum.free(U1); bignum.free(U2)
+            bignum.free(z2z2z2); bignum.free(z1z1z1); bignum.free(S1); bignum.free(S2)
+            bignum.free(H); bignum.free(rr)
+            return pt_double(a, p)
+        }
+        // a == -b: infinity
+        bignum.free(z1z1); bignum.free(z2z2); bignum.free(U1); bignum.free(U2)
+        bignum.free(z2z2z2); bignum.free(z1z1z1); bignum.free(S1); bignum.free(S2)
+        bignum.free(H); bignum.free(rr)
+        return pt_infinity()
+    }
+
+    // HH = H^2; HHH = H*HH; V = U1*HH
+    HH = fmul(H, H, p)
+    HHH = fmul(H, HH, p)
+    V = fmul(U1, HH, p)
+    // X3 = r^2 - HHH - 2*V
+    r2 = fmul(rr, rr, p)
+    two = bignum.from_int(2)
+    twoV = fmul(two, V, p)
+    t = fsub(r2, HHH, p)
+    X3 = fsub(t, twoV, p)
+    // Y3 = r*(V - X3) - S1*HHH
+    vmx = fsub(V, X3, p)
+    rvmx = fmul(rr, vmx, p)
+    s1h = fmul(S1, HHH, p)
+    Y3 = fsub(rvmx, s1h, p)
+    // Z3 = Z1*Z2*H
+    z1z2 = fmul(a.z, b.z, p)
+    Z3 = fmul(z1z2, H, p)
+
+    bignum.free(z1z1); bignum.free(z2z2); bignum.free(U1); bignum.free(U2)
+    bignum.free(z2z2z2); bignum.free(z1z1z1); bignum.free(S1); bignum.free(S2)
+    bignum.free(H); bignum.free(rr); bignum.free(HH); bignum.free(HHH); bignum.free(V)
+    bignum.free(r2); bignum.free(two); bignum.free(twoV); bignum.free(t)
+    bignum.free(vmx); bignum.free(rvmx); bignum.free(s1h); bignum.free(z1z2)
+    return pt_new(X3, Y3, Z3)
+}
+
+// k * P (double-and-add over bits of the scalar k, a *BN).
+jac_mul(k: ptr, P: *Pt, p: ptr) -> *Pt {
+    q = pt_infinity()
+    nbits = bignum.bit_length(k)
+    i = nbits - 1
+    while i >= 0 {
+        dbl = pt_double(q, p)
+        pt_free(q)
+        q = dbl
+        ki = bignum.shift_right(k, i)
+        if bit0(ki) == 1 {
+            sum = pt_add(q, P, p)
+            pt_free(q)
+            q = sum
+        }
+        bignum.free(ki)
+        i = i - 1
+    }
+    return q
+}
+
+bit0(n: ptr) -> int {
+    if bignum.is_zero(n) == 1 { return 0 }
+    two = bignum.from_int(2)
+    r = bignum.mod(n, two)
+    b = 0
+    if bignum.is_zero(r) != 1 { b = 1 }
+    bignum.free(two); bignum.free(r)
+    return b
+}
+
+// Jacobian -> affine (x, y) as two *BN. Returns (null, null) for infinity.
+jac_to_affine(q: *Pt, p: ptr) -> (ptr, ptr) {
+    if is_infinity(q) == 1 {
+        return null, null
+    }
+    zinv = finv(q.z, p)
+    zinv2 = fmul(zinv, zinv, p)
+    zinv3 = fmul(zinv2, zinv, p)
+    x = fmul(q.x, zinv2, p)
+    y = fmul(q.y, zinv3, p)
+    bignum.free(zinv); bignum.free(zinv2); bignum.free(zinv3)
+    return x, y
+}
+
+base_point() -> *Pt { return affine_to_jac_hex(GX_HEX(), GY_HEX()) }
+affine_to_jac_hex(xh: string, yh: string) -> *Pt {
+    x = bn_hex(xh); y = bn_hex(yh)
+    q = pt_new(x, y, bignum.from_int(1))
+    return q
+}
+
+// ---- public API ----
+
+// k * G as affine (x, y) 48-byte big-endian pair.
+scalar_mult_base(k: ptr) -> (ptr, ptr) {
+    p = bn_hex(P_HEX())
+    G = base_point()
+    kn = from_be48(k)
+    Q = jac_mul(kn, G, p)
+    x, y = jac_to_affine(Q, p)
+    ox = to_be48(x); oy = to_be48(y)
+    bignum.free(x); bignum.free(y)
+    pt_free(Q); pt_free(G); bignum.free(kn); bignum.free(p)
+    return ox, oy
+}
+
+// k * (px, py) as affine (x, y) 48-byte big-endian pair.
+scalar_mult(k: ptr, px: ptr, py: ptr) -> (ptr, ptr) {
+    p = bn_hex(P_HEX())
+    bx = from_be48(px); by = from_be48(py)
+    P = pt_new(bx, by, bignum.from_int(1))
+    kn = from_be48(k)
+    Q = jac_mul(kn, P, p)
+    x, y = jac_to_affine(Q, p)
+    ox = to_be48(x); oy = to_be48(y)
+    bignum.free(x); bignum.free(y)
+    pt_free(Q); pt_free(P); bignum.free(kn); bignum.free(p)
+    return ox, oy
+}
+
+// ECDH: priv * pub, returns the shared x-coordinate (48 bytes BE).
+ecdh(priv: ptr, pubx: ptr, puby: ptr) -> ptr {
+    sx, sy = scalar_mult(priv, pubx, puby)
+    bytes.free(sy)
+    return sx
+}
+
+// ECDSA sign: r = (k*G).x mod n; s = k^-1 (z + r*d) mod n. `hash` is the
+// 48-byte message hash, `d`=priv, `k`=per-message nonce (both 48 BE).
+// Returns (r, s) 48-byte BE.
+ecdsa_sign(priv: ptr, hash: ptr, k: ptr) -> (ptr, ptr) {
+    p = bn_hex(P_HEX())
+    n = bn_hex(N_HEX())
+    G = base_point()
+
+    kn = from_be48(k)
+    Q = jac_mul(kn, G, p)
+    qx, qy = jac_to_affine(Q, p)
+    r = bignum.mod(qx, n)
+
+    d = from_be48(priv)
+    z = from_be48(hash)
+    zmod = bignum.mod(z, n)
+
+    kinv = bignum.mod_inverse(kn, n)
+    rd = bignum.multiply(r, d)
+    zrd = bignum.add(zmod, rd)
+    ks = bignum.multiply(kinv, zrd)
+    s = bignum.mod(ks, n)
+
+    or = to_be48(r); os = to_be48(s)
+
+    bignum.free(qx); bignum.free(qy); bignum.free(r); bignum.free(d)
+    bignum.free(z); bignum.free(zmod); bignum.free(kinv); bignum.free(rd)
+    bignum.free(zrd); bignum.free(ks); bignum.free(s); bignum.free(kn)
+    pt_free(Q); pt_free(G); bignum.free(p); bignum.free(n)
+    return or, os
+}
+
+// ECDSA verify: returns 1 if (r,s) is a valid signature of `hash` under
+// public key (pubx, puby), else 0.
+ecdsa_verify(pubx: ptr, puby: ptr, hash: ptr, r: ptr, s: ptr) -> int {
+    p = bn_hex(P_HEX())
+    n = bn_hex(N_HEX())
+    G = base_point()
+
+    rn = from_be48(r)
+    sn = from_be48(s)
+    zero = bignum.from_int(0)
+
+    ok = 1
+    // 1 <= r,s <= n-1
+    if bignum.compare(rn, zero) <= 0 { ok = 0 }
+    if bignum.compare(sn, zero) <= 0 { ok = 0 }
+    if bignum.compare(rn, n) >= 0 { ok = 0 }
+    if bignum.compare(sn, n) >= 0 { ok = 0 }
+
+    result = 0
+    if ok == 1 {
+        z = from_be48(hash)
+        zmod = bignum.mod(z, n)
+        sinv = bignum.mod_inverse(sn, n)
+        // u1 = z*sinv mod n; u2 = r*sinv mod n
+        u1m = bignum.multiply(zmod, sinv); u1 = bignum.mod(u1m, n)
+        u2m = bignum.multiply(rn, sinv); u2 = bignum.mod(u2m, n)
+
+        Pub = pt_new(from_be48(pubx), from_be48(puby), bignum.from_int(1))
+        A = jac_mul(u1, G, p)
+        Bp = jac_mul(u2, Pub, p)
+        R = pt_add(A, Bp, p)
+        rx, ry = jac_to_affine(R, p)
+        if rx != null {
+            v = bignum.mod(rx, n)
+            if bignum.compare(v, rn) == 0 { result = 1 }
+            bignum.free(v); bignum.free(rx); bignum.free(ry)
+        }
+
+        bignum.free(z); bignum.free(zmod); bignum.free(sinv)
+        bignum.free(u1m); bignum.free(u1); bignum.free(u2m); bignum.free(u2)
+        pt_free(Pub); pt_free(A); pt_free(Bp); pt_free(R)
+    }
+
+    bignum.free(rn); bignum.free(sn); bignum.free(zero)
+    pt_free(G); bignum.free(p); bignum.free(n)
+    return result
+}

--- a/contrib/cryptography/p521/module.ae
+++ b/contrib/cryptography/p521/module.ae
@@ -1,0 +1,382 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.p521 — NIST P-521 (secp521r1) in pure Aether, on top of
+// std.bignum. NO externs to OpenSSL.
+//
+// Short-Weierstrass curve  y^2 = x^3 - 3x + b  over GF(p), p = 2^521 - 1.
+// Point arithmetic is in Jacobian coordinates (X:Y:Z) with affine
+// (x,y) = (X/Z^2, Y/Z^3).
+//
+//   scalar_mult_base(k66)            -> (x66, y66)     k*G (public key point)
+//   scalar_mult(k66, px66, py66)     -> (x66, y66)     k*P
+//   ecdh(priv66, pubx66, puby66)     -> shared_x66     priv * pub, x only
+//   ecdsa_sign(priv66, hash66, k66)  -> (r66, s66)     k = per-message nonce
+//   ecdsa_verify(pubx, puby, hash66, r66, s66) -> int  1 = valid
+//
+// 66-byte big-endian scalars / coordinates. P-521 is 521 bits, so the top
+// byte of a 66-byte buffer holds only the low bit; bignum's arbitrary-width
+// from/to_bytes_unsigned handle this and to_be66 right-aligns into 66 bytes.
+//
+// NOTE: correctness-first port over the variable-time std.bignum — not
+// constant-time/side-channel-hardened, and ecdsa_sign takes the nonce `k`
+// as a parameter (caller supplies a CSPRNG value or an RFC 6979 derivation).
+// Validated against the priv=2 -> 2G generator vector and an ECDSA
+// sign/verify round-trip.
+
+import std.bytes
+import std.bignum
+
+exports (
+    scalar_mult_base, scalar_mult, ecdh, ecdsa_sign, ecdsa_verify
+)
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+extern strlen(s: string) -> int
+
+// ---- curve parameters ----
+P_HEX() -> string { return "01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
+B_HEX() -> string { return "0051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00" }
+N_HEX() -> string { return "01fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409" }
+GX_HEX() -> string { return "00c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66" }
+GY_HEX() -> string { return "011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650" }
+
+hexv(c: int) -> int {
+    if c >= 48 { if c <= 57 { return c - 48 } }
+    if c >= 97 { if c <= 102 { return c - 87 } }
+    if c >= 65 { if c <= 70 { return c - 55 } }
+    return 0
+}
+bn_hex(h: string) -> ptr {
+    n = strlen(h)
+    b = bytes.new(n / 2)
+    i = 0
+    while i < n {
+        hi = hexv(string_char_at_n(h, n, i))
+        lo = hexv(string_char_at_n(h, n, i + 1))
+        bytes.set(b, i / 2, hi * 16 + lo)
+        i = i + 2
+    }
+    r = bignum.from_bytes_unsigned(b, n / 2)
+    bytes.free(b)
+    return r
+}
+
+// ---- field ops mod p ----
+fadd(a: ptr, b: ptr, p: ptr) -> ptr { s = bignum.add(a, b); r = bignum.mod(s, p); bignum.free(s); return r }
+fsub(a: ptr, b: ptr, p: ptr) -> ptr { d = bignum.subtract(a, b); r = bignum.mod(d, p); bignum.free(d); return r }
+fmul(a: ptr, b: ptr, p: ptr) -> ptr { m = bignum.multiply(a, b); r = bignum.mod(m, p); bignum.free(m); return r }
+finv(a: ptr, p: ptr) -> ptr {
+    two = bignum.from_int(2)
+    e = bignum.subtract(p, two)
+    r = bignum.mod_pow(a, e, p)
+    bignum.free(two); bignum.free(e)
+    return r
+}
+
+// 66-byte big-endian encode / decode. P-521 coordinates fit in 521 bits, so
+// to_bytes_unsigned yields up to 66 bytes; we right-align (zero-pad on the
+// left) into a fixed 66-byte buffer.
+to_be66(nn: ptr) -> ptr {
+    be = bignum.to_bytes_unsigned(nn)
+    blen = bytes.length(be)
+    out = bytes.new(66)
+    i = 0
+    while i < 66 { bytes.set(out, i, 0); i = i + 1 }
+    // right-align big-endian bytes
+    i = 0
+    while i < blen {
+        idx = 66 - blen + i
+        if idx >= 0 { bytes.set(out, idx, bytes.get(be, i)) }
+        i = i + 1
+    }
+    bytes.free(be)
+    return out
+}
+from_be66(b: ptr) -> ptr {
+    return bignum.from_bytes_unsigned(b, 66)
+}
+
+// ---- Jacobian point (X:Y:Z) ----
+struct Pt { x: ptr  y: ptr  z: ptr }
+pt_new(x: ptr, y: ptr, z: ptr) -> *Pt { q = malloc(24) as *Pt; q.x = x; q.y = y; q.z = z; return q }
+pt_free(q: *Pt) { bignum.free(q.x); bignum.free(q.y); bignum.free(q.z); libc_free(q) }
+
+// Point at infinity: Z = 0.
+pt_infinity() -> *Pt { return pt_new(bignum.from_int(1), bignum.from_int(1), bignum.from_int(0)) }
+is_infinity(q: *Pt) -> int { return bignum.is_zero(q.z) }
+
+// Affine -> Jacobian (Z = 1).
+affine_to_jac(x: ptr, y: ptr) -> *Pt { return pt_new(bignum.clone(x), bignum.clone(y), bignum.from_int(1)) }
+
+// Point doubling (Jacobian), a = -3:  standard "dbl-2009-l" with a=-3 form.
+pt_double(q: *Pt, p: ptr) -> *Pt {
+    if is_infinity(q) == 1 { return pt_infinity() }
+    // delta = Z^2; gamma = Y^2; beta = X*gamma
+    delta = fmul(q.z, q.z, p)
+    gamma = fmul(q.y, q.y, p)
+    beta = fmul(q.x, gamma, p)
+    // alpha = 3*(X-delta)*(X+delta)   (uses a=-3)
+    xmd = fsub(q.x, delta, p)
+    xpd = fadd(q.x, delta, p)
+    prod = fmul(xmd, xpd, p)
+    three = bignum.from_int(3)
+    alpha = fmul(three, prod, p)
+    // X3 = alpha^2 - 8*beta
+    a2 = fmul(alpha, alpha, p)
+    eight = bignum.from_int(8)
+    eb = fmul(eight, beta, p)
+    X3 = fsub(a2, eb, p)
+    // Z3 = (Y+Z)^2 - gamma - delta
+    ypz = fadd(q.y, q.z, p)
+    ypz2 = fmul(ypz, ypz, p)
+    t1 = fsub(ypz2, gamma, p)
+    Z3 = fsub(t1, delta, p)
+    // Y3 = alpha*(4*beta - X3) - 8*gamma^2
+    four = bignum.from_int(4)
+    fb = fmul(four, beta, p)
+    fbx = fsub(fb, X3, p)
+    ay = fmul(alpha, fbx, p)
+    g2 = fmul(gamma, gamma, p)
+    eg2 = fmul(eight, g2, p)
+    Y3 = fsub(ay, eg2, p)
+
+    bignum.free(delta); bignum.free(gamma); bignum.free(beta)
+    bignum.free(xmd); bignum.free(xpd); bignum.free(prod); bignum.free(three); bignum.free(alpha)
+    bignum.free(a2); bignum.free(eight); bignum.free(eb)
+    bignum.free(ypz); bignum.free(ypz2); bignum.free(t1)
+    bignum.free(four); bignum.free(fb); bignum.free(fbx); bignum.free(ay); bignum.free(g2); bignum.free(eg2)
+    return pt_new(X3, Y3, Z3)
+}
+
+// Point addition (Jacobian), "add-2007-bl". Handles infinity operands and the
+// doubling case (falls back to pt_double).
+pt_add(a: *Pt, b: *Pt, p: ptr) -> *Pt {
+    if is_infinity(a) == 1 { return pt_new(bignum.clone(b.x), bignum.clone(b.y), bignum.clone(b.z)) }
+    if is_infinity(b) == 1 { return pt_new(bignum.clone(a.x), bignum.clone(a.y), bignum.clone(a.z)) }
+    // U1 = X1*Z2^2; U2 = X2*Z1^2
+    z1z1 = fmul(a.z, a.z, p)
+    z2z2 = fmul(b.z, b.z, p)
+    U1 = fmul(a.x, z2z2, p)
+    U2 = fmul(b.x, z1z1, p)
+    // S1 = Y1*Z2^3; S2 = Y2*Z1^3
+    z2z2z2 = fmul(z2z2, b.z, p)
+    z1z1z1 = fmul(z1z1, a.z, p)
+    S1 = fmul(a.y, z2z2z2, p)
+    S2 = fmul(b.y, z1z1z1, p)
+
+    H = fsub(U2, U1, p)
+    rr = fsub(S2, S1, p)
+
+    if bignum.is_zero(H) == 1 {
+        if bignum.is_zero(rr) == 1 {
+            // a == b: double
+            bignum.free(z1z1); bignum.free(z2z2); bignum.free(U1); bignum.free(U2)
+            bignum.free(z2z2z2); bignum.free(z1z1z1); bignum.free(S1); bignum.free(S2)
+            bignum.free(H); bignum.free(rr)
+            return pt_double(a, p)
+        }
+        // a == -b: infinity
+        bignum.free(z1z1); bignum.free(z2z2); bignum.free(U1); bignum.free(U2)
+        bignum.free(z2z2z2); bignum.free(z1z1z1); bignum.free(S1); bignum.free(S2)
+        bignum.free(H); bignum.free(rr)
+        return pt_infinity()
+    }
+
+    // HH = H^2; HHH = H*HH; V = U1*HH
+    HH = fmul(H, H, p)
+    HHH = fmul(H, HH, p)
+    V = fmul(U1, HH, p)
+    // X3 = r^2 - HHH - 2*V
+    r2 = fmul(rr, rr, p)
+    two = bignum.from_int(2)
+    twoV = fmul(two, V, p)
+    t = fsub(r2, HHH, p)
+    X3 = fsub(t, twoV, p)
+    // Y3 = r*(V - X3) - S1*HHH
+    vmx = fsub(V, X3, p)
+    rvmx = fmul(rr, vmx, p)
+    s1h = fmul(S1, HHH, p)
+    Y3 = fsub(rvmx, s1h, p)
+    // Z3 = Z1*Z2*H
+    z1z2 = fmul(a.z, b.z, p)
+    Z3 = fmul(z1z2, H, p)
+
+    bignum.free(z1z1); bignum.free(z2z2); bignum.free(U1); bignum.free(U2)
+    bignum.free(z2z2z2); bignum.free(z1z1z1); bignum.free(S1); bignum.free(S2)
+    bignum.free(H); bignum.free(rr); bignum.free(HH); bignum.free(HHH); bignum.free(V)
+    bignum.free(r2); bignum.free(two); bignum.free(twoV); bignum.free(t)
+    bignum.free(vmx); bignum.free(rvmx); bignum.free(s1h); bignum.free(z1z2)
+    return pt_new(X3, Y3, Z3)
+}
+
+// k * P (double-and-add over bits of the scalar k, a *BN).
+jac_mul(k: ptr, P: *Pt, p: ptr) -> *Pt {
+    q = pt_infinity()
+    nbits = bignum.bit_length(k)
+    i = nbits - 1
+    while i >= 0 {
+        dbl = pt_double(q, p)
+        pt_free(q)
+        q = dbl
+        ki = bignum.shift_right(k, i)
+        if bit0(ki) == 1 {
+            sum = pt_add(q, P, p)
+            pt_free(q)
+            q = sum
+        }
+        bignum.free(ki)
+        i = i - 1
+    }
+    return q
+}
+
+bit0(n: ptr) -> int {
+    if bignum.is_zero(n) == 1 { return 0 }
+    two = bignum.from_int(2)
+    r = bignum.mod(n, two)
+    b = 0
+    if bignum.is_zero(r) != 1 { b = 1 }
+    bignum.free(two); bignum.free(r)
+    return b
+}
+
+// Jacobian -> affine (x, y) as two *BN. Returns (null, null) for infinity.
+jac_to_affine(q: *Pt, p: ptr) -> (ptr, ptr) {
+    if is_infinity(q) == 1 {
+        return null, null
+    }
+    zinv = finv(q.z, p)
+    zinv2 = fmul(zinv, zinv, p)
+    zinv3 = fmul(zinv2, zinv, p)
+    x = fmul(q.x, zinv2, p)
+    y = fmul(q.y, zinv3, p)
+    bignum.free(zinv); bignum.free(zinv2); bignum.free(zinv3)
+    return x, y
+}
+
+base_point() -> *Pt { return affine_to_jac_hex(GX_HEX(), GY_HEX()) }
+affine_to_jac_hex(xh: string, yh: string) -> *Pt {
+    x = bn_hex(xh); y = bn_hex(yh)
+    q = pt_new(x, y, bignum.from_int(1))
+    return q
+}
+
+// ---- public API ----
+
+// k * G as affine (x, y) 66-byte big-endian pair.
+scalar_mult_base(k: ptr) -> (ptr, ptr) {
+    p = bn_hex(P_HEX())
+    G = base_point()
+    kn = from_be66(k)
+    Q = jac_mul(kn, G, p)
+    x, y = jac_to_affine(Q, p)
+    ox = to_be66(x); oy = to_be66(y)
+    bignum.free(x); bignum.free(y)
+    pt_free(Q); pt_free(G); bignum.free(kn); bignum.free(p)
+    return ox, oy
+}
+
+// k * (px, py) as affine (x, y) 66-byte big-endian pair.
+scalar_mult(k: ptr, px: ptr, py: ptr) -> (ptr, ptr) {
+    p = bn_hex(P_HEX())
+    bx = from_be66(px); by = from_be66(py)
+    P = pt_new(bx, by, bignum.from_int(1))
+    kn = from_be66(k)
+    Q = jac_mul(kn, P, p)
+    x, y = jac_to_affine(Q, p)
+    ox = to_be66(x); oy = to_be66(y)
+    bignum.free(x); bignum.free(y)
+    pt_free(Q); pt_free(P); bignum.free(kn); bignum.free(p)
+    return ox, oy
+}
+
+// ECDH: priv * pub, returns the shared x-coordinate (66 bytes BE).
+ecdh(priv: ptr, pubx: ptr, puby: ptr) -> ptr {
+    sx, sy = scalar_mult(priv, pubx, puby)
+    bytes.free(sy)
+    return sx
+}
+
+// ECDSA sign: r = (k*G).x mod n; s = k^-1 (z + r*d) mod n. `hash` is the
+// 66-byte message hash, `d`=priv, `k`=per-message nonce (both 66 BE).
+// Returns (r, s) 66-byte BE.
+ecdsa_sign(priv: ptr, hash: ptr, k: ptr) -> (ptr, ptr) {
+    p = bn_hex(P_HEX())
+    n = bn_hex(N_HEX())
+    G = base_point()
+
+    kn = from_be66(k)
+    Q = jac_mul(kn, G, p)
+    qx, qy = jac_to_affine(Q, p)
+    r = bignum.mod(qx, n)
+
+    d = from_be66(priv)
+    z = from_be66(hash)
+    zmod = bignum.mod(z, n)
+
+    kinv = bignum.mod_inverse(kn, n)
+    rd = bignum.multiply(r, d)
+    zrd = bignum.add(zmod, rd)
+    ks = bignum.multiply(kinv, zrd)
+    s = bignum.mod(ks, n)
+
+    or = to_be66(r); os = to_be66(s)
+
+    bignum.free(qx); bignum.free(qy); bignum.free(r); bignum.free(d)
+    bignum.free(z); bignum.free(zmod); bignum.free(kinv); bignum.free(rd)
+    bignum.free(zrd); bignum.free(ks); bignum.free(s); bignum.free(kn)
+    pt_free(Q); pt_free(G); bignum.free(p); bignum.free(n)
+    return or, os
+}
+
+// ECDSA verify: returns 1 if (r,s) is a valid signature of `hash` under
+// public key (pubx, puby), else 0.
+ecdsa_verify(pubx: ptr, puby: ptr, hash: ptr, r: ptr, s: ptr) -> int {
+    p = bn_hex(P_HEX())
+    n = bn_hex(N_HEX())
+    G = base_point()
+
+    rn = from_be66(r)
+    sn = from_be66(s)
+    zero = bignum.from_int(0)
+
+    ok = 1
+    // 1 <= r,s <= n-1
+    if bignum.compare(rn, zero) <= 0 { ok = 0 }
+    if bignum.compare(sn, zero) <= 0 { ok = 0 }
+    if bignum.compare(rn, n) >= 0 { ok = 0 }
+    if bignum.compare(sn, n) >= 0 { ok = 0 }
+
+    result = 0
+    if ok == 1 {
+        z = from_be66(hash)
+        zmod = bignum.mod(z, n)
+        sinv = bignum.mod_inverse(sn, n)
+        // u1 = z*sinv mod n; u2 = r*sinv mod n
+        u1m = bignum.multiply(zmod, sinv); u1 = bignum.mod(u1m, n)
+        u2m = bignum.multiply(rn, sinv); u2 = bignum.mod(u2m, n)
+
+        Pub = pt_new(from_be66(pubx), from_be66(puby), bignum.from_int(1))
+        A = jac_mul(u1, G, p)
+        Bp = jac_mul(u2, Pub, p)
+        R = pt_add(A, Bp, p)
+        rx, ry = jac_to_affine(R, p)
+        if rx != null {
+            v = bignum.mod(rx, n)
+            if bignum.compare(v, rn) == 0 { result = 1 }
+            bignum.free(v); bignum.free(rx); bignum.free(ry)
+        }
+
+        bignum.free(z); bignum.free(zmod); bignum.free(sinv)
+        bignum.free(u1m); bignum.free(u1); bignum.free(u2m); bignum.free(u2)
+        pt_free(Pub); pt_free(A); pt_free(Bp); pt_free(R)
+    }
+
+    bignum.free(rn); bignum.free(sn); bignum.free(zero)
+    pt_free(G); bignum.free(p); bignum.free(n)
+    return result
+}

--- a/contrib/cryptography/sm4/module.ae
+++ b/contrib/cryptography/sm4/module.ae
@@ -1,0 +1,393 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+//
+// Portions copyright (c) 2026 Aether Developers.
+//
+// contrib.cryptography.sm4 — SM4 (GB/T 32907-2016), the Chinese national
+// 128-bit block cipher with a 128-bit key. Part of the Bouncy Castle →
+// Aether symmetric-crypto port (#739). NO externs to OpenSSL.
+//
+// SM4 is a 32-round unbalanced Feistel network over four 32-bit big-endian
+// words. Each round applies the mixer-substitution T = L(τ(.)): the
+// nonlinear τ substitutes each of the four bytes through a fixed 256-byte
+// S-box, then the linear L diffuses with a fan of rotate-lefts. The round
+// keys come from the FK / CK constants via the same construction with a
+// reduced linear transform L'. S-box, CK and FK are copied verbatim from
+// Bouncy Castle's SM4Engine.
+//
+// Block primitive (what modes call):
+//   ctx   = sm4.new_encryptor(key_bytes, key_len)   // key_len = 16
+//   ctx   = sm4.new_decryptor(key_bytes, key_len)
+//   out16 = sm4.process_block(ctx, in16)            // single 16-byte block
+//   sm4.free(ctx)
+//
+// Convenience modes (mirroring contrib.cryptography.aes):
+//   sm4.ecb_encrypt / ecb_decrypt  — block-aligned, NO padding
+//   sm4.ctr_xor                    — CTR keystream over arbitrary length
+//   sm4.cbc_encrypt / cbc_decrypt  — block-aligned CBC, NO padding
+//   sm4.cbc_encrypt_pkcs7 / cbc_decrypt_pkcs7
+//                                  — CBC with PKCS#7 padding (arbitrary length)
+//   sm4.pkcs7_pad / pkcs7_unpad    — standalone PKCS#7 helpers
+//
+// All buffers are std.bytes (caller frees results). Aether ints are 64-bit
+// and `>>` is arithmetic, so every 32-bit word is kept masked with
+// MASK32 = 0xFFFFFFFF and rotations go through std.bits.rotl32.
+
+import std.bytes
+import std.bits
+import std.intarr
+
+exports (
+    new_encryptor, new_decryptor, process_block, free,
+    block_size, ecb_encrypt, ecb_decrypt, ctr_xor,
+    cbc_encrypt, cbc_decrypt, cbc_encrypt_pkcs7, cbc_decrypt_pkcs7,
+    pkcs7_pad, pkcs7_unpad
+)
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+
+block_size() -> int { return 16 }
+
+// SM4 S-box (verbatim from Bouncy Castle SM4Engine.Sbox).
+const SBOX: int[256] = [
+    0xd6, 0x90, 0xe9, 0xfe, 0xcc, 0xe1, 0x3d, 0xb7, 0x16, 0xb6, 0x14, 0xc2, 0x28, 0xfb, 0x2c, 0x05,
+    0x2b, 0x67, 0x9a, 0x76, 0x2a, 0xbe, 0x04, 0xc3, 0xaa, 0x44, 0x13, 0x26, 0x49, 0x86, 0x06, 0x99,
+    0x9c, 0x42, 0x50, 0xf4, 0x91, 0xef, 0x98, 0x7a, 0x33, 0x54, 0x0b, 0x43, 0xed, 0xcf, 0xac, 0x62,
+    0xe4, 0xb3, 0x1c, 0xa9, 0xc9, 0x08, 0xe8, 0x95, 0x80, 0xdf, 0x94, 0xfa, 0x75, 0x8f, 0x3f, 0xa6,
+    0x47, 0x07, 0xa7, 0xfc, 0xf3, 0x73, 0x17, 0xba, 0x83, 0x59, 0x3c, 0x19, 0xe6, 0x85, 0x4f, 0xa8,
+    0x68, 0x6b, 0x81, 0xb2, 0x71, 0x64, 0xda, 0x8b, 0xf8, 0xeb, 0x0f, 0x4b, 0x70, 0x56, 0x9d, 0x35,
+    0x1e, 0x24, 0x0e, 0x5e, 0x63, 0x58, 0xd1, 0xa2, 0x25, 0x22, 0x7c, 0x3b, 0x01, 0x21, 0x78, 0x87,
+    0xd4, 0x00, 0x46, 0x57, 0x9f, 0xd3, 0x27, 0x52, 0x4c, 0x36, 0x02, 0xe7, 0xa0, 0xc4, 0xc8, 0x9e,
+    0xea, 0xbf, 0x8a, 0xd2, 0x40, 0xc7, 0x38, 0xb5, 0xa3, 0xf7, 0xf2, 0xce, 0xf9, 0x61, 0x15, 0xa1,
+    0xe0, 0xae, 0x5d, 0xa4, 0x9b, 0x34, 0x1a, 0x55, 0xad, 0x93, 0x32, 0x30, 0xf5, 0x8c, 0xb1, 0xe3,
+    0x1d, 0xf6, 0xe2, 0x2e, 0x82, 0x66, 0xca, 0x60, 0xc0, 0x29, 0x23, 0xab, 0x0d, 0x53, 0x4e, 0x6f,
+    0xd5, 0xdb, 0x37, 0x45, 0xde, 0xfd, 0x8e, 0x2f, 0x03, 0xff, 0x6a, 0x72, 0x6d, 0x6c, 0x5b, 0x51,
+    0x8d, 0x1b, 0xaf, 0x92, 0xbb, 0xdd, 0xbc, 0x7f, 0x11, 0xd9, 0x5c, 0x41, 0x1f, 0x10, 0x5a, 0xd8,
+    0x0a, 0xc1, 0x31, 0x88, 0xa5, 0xcd, 0x7b, 0xbd, 0x2d, 0x74, 0xd0, 0x12, 0xb8, 0xe5, 0xb4, 0xb0,
+    0x89, 0x69, 0x97, 0x4a, 0x0c, 0x96, 0x77, 0x7e, 0x65, 0xb9, 0xf1, 0x09, 0xc5, 0x6e, 0xc6, 0x84,
+    0x18, 0xf0, 0x7d, 0xec, 0x3a, 0xdc, 0x4d, 0x20, 0x79, 0xee, 0x5f, 0x3e, 0xd7, 0xcb, 0x39, 0x48
+]
+
+// Fixed system parameter FK (verbatim from Bouncy Castle SM4Engine.FK).
+const FK: int[4] = [
+    0xa3b1bac6, 0x56aa3350, 0x677d9197, 0xb27022dc
+]
+
+// Fixed key parameter CK (verbatim from Bouncy Castle SM4Engine.CK).
+const CK: int[32] = [
+    0x00070e15, 0x1c232a31, 0x383f464d, 0x545b6269,
+    0x70777e85, 0x8c939aa1, 0xa8afb6bd, 0xc4cbd2d9,
+    0xe0e7eef5, 0xfc030a11, 0x181f262d, 0x343b4249,
+    0x50575e65, 0x6c737a81, 0x888f969d, 0xa4abb2b9,
+    0xc0c7ced5, 0xdce3eaf1, 0xf8ff060d, 0x141b2229,
+    0x30373e45, 0x4c535a61, 0x686f767d, 0x848b9299,
+    0xa0a7aeb5, 0xbcc3cad1, 0xd8dfe6ed, 0xf4fb0209,
+    0x10171e25, 0x2c333a41, 0x484f565d, 0x646b7279
+]
+
+MASK32() -> int { return 0xFFFFFFFF }
+
+// 32 round keys.
+struct Sm4Ctx {
+    rk: ptr       // intarr(32) of 32-bit round keys
+    encrypt: int  // 1 = encryptor, 0 = decryptor (only differs in rk order)
+}
+
+// Nonlinear substitution τ: S-box each of the four bytes of A.
+tau(a: int) -> int {
+    b0 = SBOX[bits.lsr32(a, 24) & 0xFF]
+    b1 = SBOX[bits.lsr32(a, 16) & 0xFF]
+    b2 = SBOX[bits.lsr32(a, 8) & 0xFF]
+    b3 = SBOX[a & 0xFF]
+    return ((b0 << 24) | (b1 << 16) | (b2 << 8) | b3) & 0xFFFFFFFF
+}
+
+// Linear transform L for the round function.
+l_round(b: int) -> int {
+    bb = b & 0xFFFFFFFF
+    return (bb ^ bits.rotl32(bb, 2) ^ bits.rotl32(bb, 10) ^ bits.rotl32(bb, 18) ^ bits.rotl32(bb, 24)) & 0xFFFFFFFF
+}
+
+// Linear transform L' for the key schedule.
+l_key(b: int) -> int {
+    bb = b & 0xFFFFFFFF
+    return (bb ^ bits.rotl32(bb, 13) ^ bits.rotl32(bb, 23)) & 0xFFFFFFFF
+}
+
+// Mixer-substitution T = L(τ(.)) for the round function.
+t_round(z: int) -> int { return l_round(tau(z)) }
+// Mixer-substitution T' = L'(τ(.)) for the key schedule.
+t_key(z: int) -> int { return l_key(tau(z)) }
+
+// ---- key expansion ----
+new_ctx(key: ptr, keylen: int, encrypt: int) -> ptr {
+    rk = intarr_new_raw(32)
+
+    k0 = (bytes.get_be32(key, 0) ^ FK[0]) & 0xFFFFFFFF
+    k1 = (bytes.get_be32(key, 4) ^ FK[1]) & 0xFFFFFFFF
+    k2 = (bytes.get_be32(key, 8) ^ FK[2]) & 0xFFFFFFFF
+    k3 = (bytes.get_be32(key, 12) ^ FK[3]) & 0xFFFFFFFF
+
+    // Generate the 32 encryption round keys into a scratch table first.
+    enc_rk = intarr_new_raw(32)
+    intarr_set_raw(enc_rk, 0, (k0 ^ t_key((k1 ^ k2 ^ k3 ^ CK[0]) & 0xFFFFFFFF)) & 0xFFFFFFFF)
+    intarr_set_raw(enc_rk, 1, (k1 ^ t_key((k2 ^ k3 ^ intarr_get_raw(enc_rk, 0) ^ CK[1]) & 0xFFFFFFFF)) & 0xFFFFFFFF)
+    intarr_set_raw(enc_rk, 2, (k2 ^ t_key((k3 ^ intarr_get_raw(enc_rk, 0) ^ intarr_get_raw(enc_rk, 1) ^ CK[2]) & 0xFFFFFFFF)) & 0xFFFFFFFF)
+    intarr_set_raw(enc_rk, 3, (k3 ^ t_key((intarr_get_raw(enc_rk, 0) ^ intarr_get_raw(enc_rk, 1) ^ intarr_get_raw(enc_rk, 2) ^ CK[3]) & 0xFFFFFFFF)) & 0xFFFFFFFF)
+    i = 4
+    while i < 32 {
+        prev = (intarr_get_raw(enc_rk, i - 3) ^ intarr_get_raw(enc_rk, i - 2) ^ intarr_get_raw(enc_rk, i - 1) ^ CK[i]) & 0xFFFFFFFF
+        intarr_set_raw(enc_rk, i, (intarr_get_raw(enc_rk, i - 4) ^ t_key(prev)) & 0xFFFFFFFF)
+        i = i + 1
+    }
+
+    // Encryptor uses rk[0..31]; decryptor uses them reversed.
+    i = 0
+    while i < 32 {
+        if encrypt == 1 {
+            intarr_set_raw(rk, i, intarr_get_raw(enc_rk, i))
+        } else {
+            intarr_set_raw(rk, i, intarr_get_raw(enc_rk, 31 - i))
+        }
+        i = i + 1
+    }
+    intarr_free(enc_rk)
+
+    c = malloc(16) as *Sm4Ctx
+    c.rk = rk
+    c.encrypt = encrypt
+    return c
+}
+
+new_encryptor(key: ptr, keylen: int) -> ptr {
+    return new_ctx(key, keylen, 1)
+}
+new_decryptor(key: ptr, keylen: int) -> ptr {
+    return new_ctx(key, keylen, 0)
+}
+free(ctx: ptr) {
+    if ctx == null { return }
+    c = ctx as *Sm4Ctx
+    if c.rk != null { intarr_free(c.rk) }
+    libc_free(ctx)
+}
+
+// ---- single block ----
+// Both directions run the same 32-round Feistel; the decryptor simply holds
+// the round keys in reverse order (set up in new_ctx).
+process_block(ctx: ptr, in16: ptr) -> ptr {
+    c = ctx as *Sm4Ctx
+    out = bytes.new(16)
+    long x0 = bytes.get_be32(in16, 0) & 0xFFFFFFFF
+    long x1 = bytes.get_be32(in16, 4) & 0xFFFFFFFF
+    long x2 = bytes.get_be32(in16, 8) & 0xFFFFFFFF
+    long x3 = bytes.get_be32(in16, 12) & 0xFFFFFFFF
+    i = 0
+    while i < 32 {
+        long t = (x1 ^ x2 ^ x3 ^ intarr_get_raw(c.rk, i)) & 0xFFFFFFFF
+        long nx = (x0 ^ t_round(t)) & 0xFFFFFFFF
+        x0 = x1
+        x1 = x2
+        x2 = x3
+        x3 = nx
+        i = i + 1
+    }
+    // Reverse the final four words (R transform).
+    bytes.set_be32(out, 0, x3)
+    bytes.set_be32(out, 4, x2)
+    bytes.set_be32(out, 8, x1)
+    bytes.set_be32(out, 12, x0)
+    return out
+}
+
+// ---- ECB (block-aligned, NO padding) ----
+ecb_encrypt(ctx: ptr, data: ptr) -> ptr { return ecb_run(ctx, data) }
+ecb_decrypt(ctx: ptr, data: ptr) -> ptr { return ecb_run(ctx, data) }
+ecb_run(ctx: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    out = bytes.new(n)
+    off = 0
+    while off + 16 <= n {
+        blk = bytes.new(16)
+        j = 0
+        while j < 16 { bytes.set(blk, j, bytes.get(data, off + j)); j = j + 1 }
+        eb = process_block(ctx, blk)
+        k = 0
+        while k < 16 { bytes.set(out, off + k, bytes.get(eb, k)); k = k + 1 }
+        bytes.free(blk); bytes.free(eb)
+        off = off + 16
+    }
+    return out
+}
+
+// ---- CTR (stream; encrypt == decrypt) ----
+// `ctx` must be an ENCRYPTOR. `iv` is the initial 16-byte counter block,
+// incremented big-endian per block.
+ctr_xor(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    out = bytes.new(n)
+    ctr = bytes.new(16)
+    i = 0
+    while i < 16 { bytes.set(ctr, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        ks = process_block(ctx, ctr)
+        j = 0
+        while j < 16 {
+            if off + j < n {
+                bytes.set(out, off + j, (bytes.get(data, off + j) ^ bytes.get(ks, j)) & 0xFF)
+            }
+            j = j + 1
+        }
+        bytes.free(ks)
+        ctr_increment(ctr)
+        off = off + 16
+    }
+    bytes.free(ctr)
+    return out
+}
+ctr_increment(ctr: ptr) {
+    i = 15
+    carry = 1
+    while i >= 0 {
+        if carry == 1 {
+            v = (bytes.get(ctr, i) + 1) & 0xFF
+            bytes.set(ctr, i, v)
+            if v != 0 { carry = 0 }
+        }
+        i = i - 1
+    }
+}
+
+// ---- CBC (block-aligned, NO padding) ----
+// `ctx` is an encryptor for cbc_encrypt and a decryptor for cbc_decrypt.
+// Input length MUST be a multiple of 16; otherwise an empty buffer is
+// returned (use the _pkcs7 variants for arbitrary-length data).
+cbc_encrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    if n % 16 != 0 {
+        return bytes.new(0)
+    }
+    out = bytes.new(n)
+    prev = bytes.new(16)
+    i = 0
+    while i < 16 { bytes.set(prev, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        blk = bytes.new(16)
+        j = 0
+        while j < 16 {
+            bytes.set(blk, j, (bytes.get(data, off + j) ^ bytes.get(prev, j)) & 0xFF)
+            j = j + 1
+        }
+        eb = process_block(ctx, blk)
+        k = 0
+        while k < 16 {
+            v = bytes.get(eb, k)
+            bytes.set(out, off + k, v)
+            bytes.set(prev, k, v)
+            k = k + 1
+        }
+        bytes.free(blk); bytes.free(eb)
+        off = off + 16
+    }
+    bytes.free(prev)
+    return out
+}
+
+cbc_decrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    n = bytes.length(data)
+    if n % 16 != 0 {
+        return bytes.new(0)
+    }
+    out = bytes.new(n)
+    prev = bytes.new(16)
+    i = 0
+    while i < 16 { bytes.set(prev, i, bytes.get(iv, i)); i = i + 1 }
+    off = 0
+    while off < n {
+        blk = bytes.new(16)
+        j = 0
+        while j < 16 { bytes.set(blk, j, bytes.get(data, off + j)); j = j + 1 }
+        db = process_block(ctx, blk)
+        k = 0
+        while k < 16 {
+            bytes.set(out, off + k, (bytes.get(db, k) ^ bytes.get(prev, k)) & 0xFF)
+            bytes.set(prev, k, bytes.get(blk, k))
+            k = k + 1
+        }
+        bytes.free(blk); bytes.free(db)
+        off = off + 16
+    }
+    bytes.free(prev)
+    return out
+}
+
+// ---- PKCS#7 padding ----
+pkcs7_pad(data: ptr) -> ptr {
+    n = bytes.length(data)
+    pad = 16 - (n % 16)
+    out = bytes.new(n + pad)
+    i = 0
+    while i < n { bytes.set(out, i, bytes.get(data, i)); i = i + 1 }
+    j = 0
+    while j < pad { bytes.set(out, n + j, pad); j = j + 1 }
+    return out
+}
+
+pkcs7_unpad(data: ptr) -> {
+    n = bytes.length(data)
+    if n == 0 {
+        return bytes.new(0), "empty input"
+    }
+    if n % 16 != 0 {
+        return bytes.new(0), "length not a multiple of 16"
+    }
+    pad = bytes.get(data, n - 1) & 0xFF
+    if pad < 1 {
+        return bytes.new(0), "bad padding"
+    }
+    if pad > 16 {
+        return bytes.new(0), "bad padding"
+    }
+    bad = 0
+    i = 0
+    while i < pad {
+        if (bytes.get(data, n - 1 - i) & 0xFF) != pad {
+            bad = 1
+        }
+        i = i + 1
+    }
+    if bad == 1 {
+        return bytes.new(0), "bad padding"
+    }
+    outlen = n - pad
+    out = bytes.new(outlen)
+    j = 0
+    while j < outlen { bytes.set(out, j, bytes.get(data, j)); j = j + 1 }
+    return out, ""
+}
+
+// ---- CBC + PKCS#7 (arbitrary length) ----
+cbc_encrypt_pkcs7(ctx: ptr, iv: ptr, data: ptr) -> ptr {
+    padded = pkcs7_pad(data)
+    out = cbc_encrypt(ctx, iv, padded)
+    bytes.free(padded)
+    return out
+}
+
+cbc_decrypt_pkcs7(ctx: ptr, iv: ptr, data: ptr) -> {
+    n = bytes.length(data)
+    if n == 0 {
+        return bytes.new(0), "empty input"
+    }
+    if n % 16 != 0 {
+        return bytes.new(0), "length not a multiple of 16"
+    }
+    raw = cbc_decrypt(ctx, iv, data)
+    out, err = pkcs7_unpad(raw)
+    bytes.free(raw)
+    return out, err
+}

--- a/std/bignum/module.ae
+++ b/std/bignum/module.ae
@@ -22,10 +22,16 @@
 // The full surface: representation + from/to_bytes + compare + add/sub/
 // negate/abs/shift + bit_length + multiply + divide/remainder/mod + mod_pow
 // + gcd + mod_inverse + is_probable_prime. The arithmetic uses textbook
-// algorithms chosen for verifiability (binary long division, square-and-
-// multiply mod_pow, fixed-base Miller-Rabin); the BC-style Montgomery /
-// Barrett / Karatsuba fast paths are deferred perfections, tracked in
-// docs/bignum-deferred-optimizations.md.
+// algorithms chosen for verifiability (binary long division, fixed-base
+// Miller-Rabin). Two BC-style fast paths are layered on top WITHOUT
+// changing any observable result: (1) Karatsuba multiply for large
+// operands (>= karatsuba_threshold() limbs in the smaller operand), with the
+// schoolbook multiply as the sub-threshold base case and fallback; and
+// (2) Montgomery-form square-and-multiply in mod_pow when the modulus is
+// odd (the RSA/DH hot path), falling back to the schoolbook
+// square-and-multiply for even moduli and degenerate cases. Both are pure
+// speed paths gated on size/parity; every result is byte-identical to the
+// slow path.
 //
 // A bignum is an opaque `ptr` to a heap-allocated BN struct. Operations
 // return NEW bignums and never mutate their inputs. There is no GC;
@@ -643,6 +649,259 @@ mag_multiply(x: ptr, xlen: int, y: ptr, ylen: int, z: ptr, zlen: int) {
     }
 }
 
+// ---- Karatsuba fast-path multiply (internal) ----
+//
+// The schoolbook mag_multiply above is O(n*m). For large equal-ish
+// operands (RSA/DH/EC scalars) Karatsuba's 3-way split is a real win.
+// To keep the carry/borrow reasoning bulletproof we do Karatsuba on
+// LITTLE-ENDIAN limb scratch arrays (index 0 = least-significant limb),
+// which makes "low half / high half" a simple index split, then convert
+// back to the module's big-endian magnitude at the public boundary. The
+// RESULT IS BYTE-IDENTICAL to schoolbook (same integer, then stripped by
+// bn_from_mag_checked); this is purely an internal speed path.
+//
+// Threshold: below this many limbs in the smaller operand, recurse falls
+// back to schoolbook. 40 limbs ~= 1280 bits, matching BC's general region
+// for the crossover on 32-bit limbs. Exposed as a 0-arg function because
+// std modules have no module-level constant bindings.
+karatsuba_threshold() -> int {
+    return 40
+}
+
+// Convert a big-endian magnitude (mag[0]=MSB) of `len` limbs into a fresh
+// little-endian limb array (out[0]=LSB) of `len` limbs.
+le_from_mag(mag: ptr, len: int) -> ptr {
+    out = intarr_new_raw(len)
+    i = 0
+    while i < len {
+        intarr_set_raw(out, i, intarr_get_raw(mag, len - 1 - i))
+        i = i + 1
+    }
+    return out
+}
+
+// Convert a little-endian limb array (in[0]=LSB) of `len` limbs into a
+// fresh big-endian magnitude (out[0]=MSB) of `len` limbs.
+mag_from_le(le: ptr, len: int) -> ptr {
+    out = intarr_new_raw(len)
+    i = 0
+    while i < len {
+        intarr_set_raw(out, i, intarr_get_raw(le, len - 1 - i))
+        i = i + 1
+    }
+    return out
+}
+
+// Read LE limb i as unsigned 32-bit in a 64-bit int (0 past the end).
+le_limb(a: ptr, alen: int, i: int) -> long {
+    if i < 0 {
+        return 0
+    }
+    if i >= alen {
+        return 0
+    }
+    return intarr_get_raw(a, i) & 0xFFFFFFFF
+}
+
+// Schoolbook multiply of two LE arrays into a fresh LE array of xn+yn.
+le_schoolbook(x: ptr, xn: int, y: ptr, yn: int) -> ptr {
+    res = intarr_new_raw(xn + yn)   // zero-filled
+    i = 0
+    while i < xn {
+        a = le_limb(x, xn, i)
+        if a != 0 {
+            long carry = 0
+            j = 0
+            while j < yn {
+                long v = a * le_limb(y, yn, j) + (intarr_get_raw(res, i + j) & 0xFFFFFFFF) + carry
+                intarr_set_raw(res, i + j, (v & 0xFFFFFFFF))
+                carry = bits.lsr64(v, 32)
+                j = j + 1
+            }
+            intarr_set_raw(res, i + yn, (carry & 0xFFFFFFFF))
+        }
+        i = i + 1
+    }
+    return res
+}
+
+// LE add: dst[0..dlen) += src[0..slen) (slen <= dlen). dst must have room
+// for the carry (callers size accordingly). Returns the final carry.
+le_add_into(dst: ptr, dlen: int, src: ptr, slen: int, off: int) -> long {
+    long carry = 0
+    i = 0
+    while i < slen {
+        long v = (intarr_get_raw(dst, off + i) & 0xFFFFFFFF) + (intarr_get_raw(src, i) & 0xFFFFFFFF) + carry
+        intarr_set_raw(dst, off + i, (v & 0xFFFFFFFF))
+        carry = bits.lsr64(v, 32)
+        i = i + 1
+    }
+    k = off + slen
+    while carry != 0 {
+        if k >= dlen {
+            break
+        }
+        long v = (intarr_get_raw(dst, k) & 0xFFFFFFFF) + carry
+        intarr_set_raw(dst, k, (v & 0xFFFFFFFF))
+        carry = bits.lsr64(v, 32)
+        k = k + 1
+    }
+    return carry
+}
+
+// Karatsuba multiply of two LE arrays into a fresh LE array of xn+yn.
+// Recurses; falls back to schoolbook below the threshold.
+le_karatsuba(x: ptr, xn: int, y: ptr, yn: int) -> ptr {
+    nmin = xn
+    if yn < nmin {
+        nmin = yn
+    }
+    if nmin < karatsuba_threshold() {
+        return le_schoolbook(x, xn, y, yn)
+    }
+    // split point: half of the larger operand
+    nmax = xn
+    if yn > nmax {
+        nmax = yn
+    }
+    half = (nmax + 1) / 2
+    // x = xh*B^half + xl ; y = yh*B^half + yl   (B = 2^32)
+    xl_len = half
+    if xn < half {
+        xl_len = xn
+    }
+    xh_len = xn - xl_len
+    yl_len = half
+    if yn < half {
+        yl_len = yn
+    }
+    yh_len = yn - yl_len
+
+    // low parts (already in place via offset views — but we need contiguous
+    // arrays for recursion, so build them). xl = x[0..xl_len), xh = x[half..)
+    xl = intarr_new_raw(xl_len)
+    i = 0
+    while i < xl_len {
+        intarr_set_raw(xl, i, intarr_get_raw(x, i))
+        i = i + 1
+    }
+    yl = intarr_new_raw(yl_len)
+    i = 0
+    while i < yl_len {
+        intarr_set_raw(yl, i, intarr_get_raw(y, i))
+        i = i + 1
+    }
+    // high parts may be empty (len 0); guard recursion with len-0 producing 0
+    xh = intarr_new_raw(xh_len)
+    i = 0
+    while i < xh_len {
+        intarr_set_raw(xh, i, intarr_get_raw(x, half + i))
+        i = i + 1
+    }
+    yh = intarr_new_raw(yh_len)
+    i = 0
+    while i < yh_len {
+        intarr_set_raw(yh, i, intarr_get_raw(y, half + i))
+        i = i + 1
+    }
+
+    // z0 = xl*yl, z2 = xh*yh
+    z0 = le_karatsuba(xl, xl_len, yl, yl_len)
+    z2 = le_mul_maybe_zero(xh, xh_len, yh, yh_len)
+
+    // sx = xl + xh, sy = yl + yh
+    sx_len = xl_len
+    if xh_len > sx_len {
+        sx_len = xh_len
+    }
+    sx_len = sx_len + 1
+    sx = intarr_new_raw(sx_len)
+    i = 0
+    while i < xl_len {
+        intarr_set_raw(sx, i, intarr_get_raw(xl, i))
+        i = i + 1
+    }
+    le_add_into(sx, sx_len, xh, xh_len, 0)
+
+    sy_len = yl_len
+    if yh_len > sy_len {
+        sy_len = yh_len
+    }
+    sy_len = sy_len + 1
+    sy = intarr_new_raw(sy_len)
+    i = 0
+    while i < yl_len {
+        intarr_set_raw(sy, i, intarr_get_raw(yl, i))
+        i = i + 1
+    }
+    le_add_into(sy, sy_len, yh, yh_len, 0)
+
+    // z1full = sx*sy ; z1 = z1full - z0 - z2
+    z1 = le_karatsuba(sx, sx_len, sy, sy_len)
+    z1len = sx_len + sy_len
+    le_sub_into(z1, z1len, z0, xl_len + yl_len)
+    le_sub_into(z1, z1len, z2, xh_len + yh_len)
+
+    // result = z0 + z1*B^half + z2*B^(2*half)
+    reslen = xn + yn
+    res = intarr_new_raw(reslen)   // zero
+    // add z0
+    le_add_into(res, reslen, z0, xl_len + yl_len, 0)
+    // add z1 shifted by half
+    le_add_into(res, reslen, z1, z1len, half)
+    // add z2 shifted by 2*half
+    le_add_into(res, reslen, z2, xh_len + yh_len, 2 * half)
+
+    intarr_free(xl); intarr_free(xh); intarr_free(yl); intarr_free(yh)
+    intarr_free(sx); intarr_free(sy)
+    intarr_free(z0); intarr_free(z1); intarr_free(z2)
+    return res
+}
+
+// Karatsuba helper that tolerates zero-length operands (high halves can be
+// empty); returns a fresh LE array of xn+yn limbs (all zero if either is
+// empty).
+le_mul_maybe_zero(x: ptr, xn: int, y: ptr, yn: int) -> ptr {
+    if xn == 0 {
+        return intarr_new_raw(yn)   // all zero, length xn+yn = yn
+    }
+    if yn == 0 {
+        return intarr_new_raw(xn)
+    }
+    return le_karatsuba(x, xn, y, yn)
+}
+
+// LE subtract in place: dst[0..dlen) -= src[0..slen). Assumes dst >= src
+// (true for the Karatsuba z1 reconstruction). slen <= dlen.
+le_sub_into(dst: ptr, dlen: int, src: ptr, slen: int) {
+    long borrow = 0
+    i = 0
+    while i < slen {
+        long v = (intarr_get_raw(dst, i) & 0xFFFFFFFF) - (intarr_get_raw(src, i) & 0xFFFFFFFF) - borrow
+        intarr_set_raw(dst, i, (v & 0xFFFFFFFF))
+        if v < 0 {
+            borrow = 1
+        } else {
+            borrow = 0
+        }
+        i = i + 1
+    }
+    k = slen
+    while borrow != 0 {
+        if k >= dlen {
+            break
+        }
+        long v = (intarr_get_raw(dst, k) & 0xFFFFFFFF) - borrow
+        intarr_set_raw(dst, k, (v & 0xFFFFFFFF))
+        if v < 0 {
+            borrow = 1
+        } else {
+            borrow = 0
+        }
+        k = k + 1
+    }
+}
+
 multiply(a: ptr, b: ptr) -> ptr {
     ba = a as *BN
     bb = b as *BN
@@ -652,13 +911,28 @@ multiply(a: ptr, b: ptr) -> ptr {
     if bb.sign == 0 {
         return bn_zero()
     }
-    reslen = ba.len + bb.len
-    res = intarr_new_raw(reslen)   // calloc: zero-filled
-    mag_multiply(res, reslen, ba.mag, ba.len, bb.mag, bb.len)
     rsign = 1
     if ba.sign != bb.sign {
         rsign = -1
     }
+    // Karatsuba fast-path for large operands; schoolbook otherwise. Both
+    // compute the identical product; this is purely a speed split.
+    nmin = ba.len
+    if bb.len < nmin {
+        nmin = bb.len
+    }
+    if nmin >= karatsuba_threshold() {
+        xle = le_from_mag(ba.mag, ba.len)
+        yle = le_from_mag(bb.mag, bb.len)
+        zle = le_karatsuba(xle, ba.len, yle, bb.len)
+        reslen = ba.len + bb.len
+        res = mag_from_le(zle, reslen)
+        intarr_free(xle); intarr_free(yle); intarr_free(zle)
+        return bn_from_mag_checked(rsign, res, reslen)
+    }
+    reslen = ba.len + bb.len
+    res = intarr_new_raw(reslen)   // calloc: zero-filled
+    mag_multiply(res, reslen, ba.mag, ba.len, bb.mag, bb.len)
     return bn_from_mag_checked(rsign, res, reslen)
 }
 
@@ -823,6 +1097,195 @@ mod(a: ptr, b: ptr) -> ptr {
 // crypto, and obviously correct against an arbitrary-precision oracle. The
 // constant-time / Montgomery fast paths are a later optimization slice.
 
+// ---- Montgomery reduction (internal, odd-modulus mod_pow fast path) ----
+//
+// REDC-based modular exponentiation. For an ODD modulus m with n limbs,
+// R = 2^(32n). We work in Montgomery form (a*R mod m) and use CIOS
+// Montgomery multiplication so the square-and-multiply ladder never calls
+// the O(bits^2) binary divide. Converting to/from Montgomery form uses the
+// existing mod()/multiply() exactly once each at the boundary, so the final
+// integer result is identical to the schoolbook mod_pow — this is a pure
+// speed path, gated on `m` being odd; even moduli fall back below.
+//
+// All Montgomery limb work is LITTLE-ENDIAN (index 0 = LSB) to keep carry
+// propagation simple; conversions to/from the BN big-endian magnitude
+// happen only at the edges.
+
+// -m^(-1) mod 2^32, where m0 is the least-significant limb of m (m odd).
+// Newton iteration (BC Mod.Inverse32), then negate mod 2^32.
+mont_mdash(m0: long) -> long {
+    long d = m0 & 0xFFFFFFFF
+    long x = d
+    x = (x * (2 - d * x)) & 0xFFFFFFFF
+    x = (x * (2 - d * x)) & 0xFFFFFFFF
+    x = (x * (2 - d * x)) & 0xFFFFFFFF
+    x = (x * (2 - d * x)) & 0xFFFFFFFF
+    // x == m^(-1) mod 2^32; mdash = -x mod 2^32
+    return ((~x) + 1) & 0xFFFFFFFF
+}
+
+// CIOS Montgomery multiply: t = (x * y * R^(-1)) mod m, all LE, n limbs.
+// x, y, mle are LE arrays of exactly n limbs (zero-padded). mdash =
+// -m^(-1) mod 2^32. Returns a fresh LE array of n limbs in [0, m).
+mont_mul(x: ptr, y: ptr, mle: ptr, n: int, mdash: long) -> ptr {
+    // accumulator t has n+2 limbs to hold intermediate carry safely.
+    t = intarr_new_raw(n + 2)   // zero
+    i = 0
+    while i < n {
+        long xi = intarr_get_raw(x, i) & 0xFFFFFFFF
+        // t = t + xi * y
+        long carry = 0
+        j = 0
+        while j < n {
+            long v = (intarr_get_raw(t, j) & 0xFFFFFFFF) + xi * (intarr_get_raw(y, j) & 0xFFFFFFFF) + carry
+            intarr_set_raw(t, j, (v & 0xFFFFFFFF))
+            carry = bits.lsr64(v, 32)
+            j = j + 1
+        }
+        long sum = (intarr_get_raw(t, n) & 0xFFFFFFFF) + carry
+        intarr_set_raw(t, n, (sum & 0xFFFFFFFF))
+        intarr_set_raw(t, n + 1, ((intarr_get_raw(t, n + 1) & 0xFFFFFFFF) + bits.lsr64(sum, 32)) & 0xFFFFFFFF)
+        // u = (t[0] * mdash) mod 2^32 ; t = (t + u * m) / 2^32
+        long u = ((intarr_get_raw(t, 0) & 0xFFFFFFFF) * mdash) & 0xFFFFFFFF
+        long carry2 = 0
+        j = 0
+        while j < n {
+            long v = (intarr_get_raw(t, j) & 0xFFFFFFFF) + u * (intarr_get_raw(mle, j) & 0xFFFFFFFF) + carry2
+            intarr_set_raw(t, j, (v & 0xFFFFFFFF))
+            carry2 = bits.lsr64(v, 32)
+            j = j + 1
+        }
+        long s2 = (intarr_get_raw(t, n) & 0xFFFFFFFF) + carry2
+        intarr_set_raw(t, n, (s2 & 0xFFFFFFFF))
+        intarr_set_raw(t, n + 1, ((intarr_get_raw(t, n + 1) & 0xFFFFFFFF) + bits.lsr64(s2, 32)) & 0xFFFFFFFF)
+        // shift t down by one limb (divide by 2^32)
+        k = 0
+        while k < n + 1 {
+            intarr_set_raw(t, k, intarr_get_raw(t, k + 1))
+            k = k + 1
+        }
+        intarr_set_raw(t, n + 1, 0)
+        i = i + 1
+    }
+    // t now has up to n+1 significant limbs; conditional subtract of m.
+    // Compare (t as n+1 limbs) >= m (n limbs).
+    out = intarr_new_raw(n)
+    ge = 0
+    if (intarr_get_raw(t, n) & 0xFFFFFFFF) != 0 {
+        ge = 1
+    } else {
+        c = n - 1
+        while c >= 0 {
+            long tv = intarr_get_raw(t, c) & 0xFFFFFFFF
+            long mv = intarr_get_raw(mle, c) & 0xFFFFFFFF
+            if tv != mv {
+                if tv > mv {
+                    ge = 1
+                }
+                c = -1
+            } else {
+                c = c - 1
+            }
+        }
+    }
+    if ge == 1 {
+        long borrow = 0
+        j = 0
+        while j < n {
+            long v = (intarr_get_raw(t, j) & 0xFFFFFFFF) - (intarr_get_raw(mle, j) & 0xFFFFFFFF) - borrow
+            intarr_set_raw(out, j, (v & 0xFFFFFFFF))
+            if v < 0 {
+                borrow = 1
+            } else {
+                borrow = 0
+            }
+            j = j + 1
+        }
+    } else {
+        j = 0
+        while j < n {
+            intarr_set_raw(out, j, intarr_get_raw(t, j))
+            j = j + 1
+        }
+    }
+    intarr_free(t)
+    return out
+}
+
+// Build a zero-padded LE array of exactly n limbs from a non-negative BN's
+// magnitude (value assumed < 2^(32n)). For a zero BN, returns all zeros.
+le_padded_from_bn(n_bn: ptr, n: int) -> ptr {
+    bn = n_bn as *BN
+    out = intarr_new_raw(n)   // zero
+    if bn.sign == 0 {
+        return out
+    }
+    // mag is big-endian; copy into LE.
+    i = 0
+    while i < bn.len {
+        intarr_set_raw(out, i, intarr_get_raw(bn.mag, bn.len - 1 - i))
+        i = i + 1
+    }
+    return out
+}
+
+// Make a non-negative BN from an LE limb array (out[0]=LSB) of n limbs.
+bn_from_le(le: ptr, n: int) -> ptr {
+    mag = mag_from_le(le, n)
+    return bn_from_mag_checked(1, mag, n)
+}
+
+// Montgomery mod_pow for ODD modulus m, base/exp/m all positive, m > 1.
+// Returns base^exp mod m. Internal; caller guarantees preconditions.
+mod_pow_monty(base: ptr, exp: ptr, m: ptr) -> ptr {
+    bm = m as *BN
+    n = bm.len
+    long m0 = intarr_get_raw(bm.mag, n - 1) & 0xFFFFFFFF   // LSB limb (BE last)
+    long mdash = mont_mdash(m0)
+    mle = le_padded_from_bn(m, n)
+
+    // R = 2^(32n); R mod m and R^2 mod m via the existing (correct) path.
+    // base_mont = base * R mod m  ; one_mont = R mod m (Montgomery 1).
+    one = from_int(1)
+    rshift = shift_left(one, 32 * n)          // R
+    r_mod = mod(rshift, m)                     // R mod m  == Montgomery(1)
+    base_mod = mod(base, m)                     // base mod m, in [0, m)
+    base_r = multiply(base_mod, rshift)         // base * R
+    base_mont_bn = mod(base_r, m)               // base * R mod m
+
+    one_le = le_padded_from_bn(r_mod, n)        // Montgomery form of 1
+    base_le = le_padded_from_bn(base_mont_bn, n)
+
+    free(one); free(rshift); free(r_mod); free(base_mod)
+    free(base_r); free(base_mont_bn)
+
+    // acc = Montgomery(1); square-and-multiply MSB->LSB over exp bits.
+    acc = mag_clone(one_le, n)
+    be = exp as *BN
+    nbits = mag_bit_length(be.mag, be.len)
+    i = nbits - 1
+    while i >= 0 {
+        sq = mont_mul(acc, acc, mle, n, mdash)
+        intarr_free(acc)
+        acc = sq
+        if mag_test_bit(be.mag, be.len, i) == 1 {
+            pr = mont_mul(acc, base_le, mle, n, mdash)
+            intarr_free(acc)
+            acc = pr
+        }
+        i = i - 1
+    }
+    // convert out of Montgomery form: result = acc * 1 * R^(-1) mod m.
+    one_mont = intarr_new_raw(n)   // value 1 in plain form (LE)
+    intarr_set_raw(one_mont, 0, 1)
+    final_le = mont_mul(acc, one_mont, mle, n, mdash)
+    result = bn_from_le(final_le, n)
+
+    intarr_free(acc); intarr_free(final_le); intarr_free(one_mont)
+    intarr_free(one_le); intarr_free(base_le); intarr_free(mle)
+    return result
+}
+
 // modular exponentiation: base^exp mod m (exp >= 0, m > 0). Square-and-
 // multiply, MSB-to-LSB. Matches BC ModPow for non-negative exponents.
 mod_pow(base: ptr, exp: ptr, m: ptr) -> ptr {
@@ -846,6 +1309,14 @@ mod_pow(base: ptr, exp: ptr, m: ptr) -> ptr {
     if bb.sign == 0 {
         free(one)
         return bn_zero()
+    }
+    // Fast path: ODD modulus -> Montgomery reduction (RSA/DH hot path).
+    // Odd iff the least-significant bit of m is set (BE: last limb bit 0).
+    // Even moduli (and the degenerate handled cases above) fall through to
+    // the schoolbook square-and-multiply, which is unconditionally correct.
+    if mag_test_bit(bm.mag, bm.len, 0) == 1 {
+        free(one)
+        return mod_pow_monty(base, exp, m)
     }
     // square-and-multiply over the exponent's magnitude bits, MSB->LSB.
     // acc starts at 1; base_mod = base mod m handles base >= m / negative base.

--- a/std/cryptography/argon2/module.ae
+++ b/std/cryptography/argon2/module.ae
@@ -135,16 +135,7 @@ load_block_from_bytes(mem: ptr, bidx: int, src: ptr) {
     i = 0
     while i < QWORDS {
         off = i * 8
-        long b0 = bytes.get(src, off) & 255
-        long b1 = bytes.get(src, off + 1) & 255
-        long b2 = bytes.get(src, off + 2) & 255
-        long b3 = bytes.get(src, off + 3) & 255
-        long b4 = bytes.get(src, off + 4) & 255
-        long b5 = bytes.get(src, off + 5) & 255
-        long b6 = bytes.get(src, off + 6) & 255
-        long b7 = bytes.get(src, off + 7) & 255
-        long w = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24) | (b4 << 32) | (b5 << 40) | (b6 << 48) | (b7 << 56)
-        longarr_set_unchecked(mem, base + i, w)
+        longarr_set_unchecked(mem, base + i, bytes.get_le64(src, off))
         i = i + 1
     }
 }
@@ -156,14 +147,7 @@ store_block_to_bytes(mem: ptr, bidx: int, dst: ptr) {
     while i < QWORDS {
         w = longarr_get_unchecked(mem, base + i)
         off = i * 8
-        bytes.set(dst, off, w & 255)
-        bytes.set(dst, off + 1, bits.lsr64(w, 8) & 255)
-        bytes.set(dst, off + 2, bits.lsr64(w, 16) & 255)
-        bytes.set(dst, off + 3, bits.lsr64(w, 24) & 255)
-        bytes.set(dst, off + 4, bits.lsr64(w, 32) & 255)
-        bytes.set(dst, off + 5, bits.lsr64(w, 40) & 255)
-        bytes.set(dst, off + 6, bits.lsr64(w, 48) & 255)
-        bytes.set(dst, off + 7, bits.lsr64(w, 56) & 255)
+        bytes.set_le64(dst, off, w)
         i = i + 1
     }
 }

--- a/std/cryptography/blake2/module.ae
+++ b/std/cryptography/blake2/module.ae
@@ -142,20 +142,8 @@ gs(v: ptr, a: int, b: int, c: int, d: int, x: long, y: long) {
 }
 
 // Load one little-endian 64-bit word from the block at byte offset off.
-// Each byte is widened to a `long` local before shifting so the high
-// shifts (>= 32) are done in 64-bit, not the 32-bit `int` of bytes.get.
 load_le64(b: ptr, off: int) -> long {
-    long r = 0
-    long b0 = bytes.get(b, off) & 255
-    long b1 = bytes.get(b, off + 1) & 255
-    long b2 = bytes.get(b, off + 2) & 255
-    long b3 = bytes.get(b, off + 3) & 255
-    long b4 = bytes.get(b, off + 4) & 255
-    long b5 = bytes.get(b, off + 5) & 255
-    long b6 = bytes.get(b, off + 6) & 255
-    long b7 = bytes.get(b, off + 7) & 255
-    r = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24) | (b4 << 32) | (b5 << 40) | (b6 << 48) | (b7 << 56)
-    return r
+    return bytes.get_le64(b, off)
 }
 
 // last: 1 if this is the final block (set f0 = all-ones).
@@ -426,14 +414,7 @@ update_bytes(ctx: ptr, data: ptr, length: int) {
 
 // Emit a little-endian 64-bit word into out at off.
 store_le64(out: ptr, off: int, v: long) {
-    bytes.set(out, off,     v & 255)
-    bytes.set(out, off + 1, bits.lsr64(v, 8) & 255)
-    bytes.set(out, off + 2, bits.lsr64(v, 16) & 255)
-    bytes.set(out, off + 3, bits.lsr64(v, 24) & 255)
-    bytes.set(out, off + 4, bits.lsr64(v, 32) & 255)
-    bytes.set(out, off + 5, bits.lsr64(v, 40) & 255)
-    bytes.set(out, off + 6, bits.lsr64(v, 48) & 255)
-    bytes.set(out, off + 7, bits.lsr64(v, 56) & 255)
+    bytes.set_le64(out, off, v)
 }
 
 // Finalise: zero-pad the last block, compress with the final flag, then

--- a/std/cryptography/mlkem/module.ae
+++ b/std/cryptography/mlkem/module.ae
@@ -915,7 +915,9 @@ indcpa_keygen(p: *Params, d: ptr, kp: ptr) {
     }
     i = 0
     while i < k {
-        get_noise(e, i, sigma, 0, nonce, 2)   // error always eta2
+        // FIPS 203: keygen error e uses eta1 (BC GenerateKeyPair uses the same
+        // GetNoiseEta as skpv — Eta3 when Eta1==3, else Eta2), NOT a fixed eta2.
+        get_noise(e, i, sigma, 0, nonce, p.eta1)
         nonce = nonce + 1
         i = i + 1
     }

--- a/std/cryptography/mlkem/module.ae
+++ b/std/cryptography/mlkem/module.ae
@@ -1,0 +1,1355 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.mlkem — ML-KEM (FIPS 203, the standardized CRYSTALS-Kyber
+// key-encapsulation mechanism) in pure Aether, ported from Bouncy Castle's
+// Org.BouncyCastle.Crypto.Kems.MLKem engine. NO externs to OpenSSL or any C
+// crypto; all SHA-3/SHAKE primitives come from std.cryptography.sha3.
+//
+// ML-KEM is a Module-LWE KEM over the ring R_q = Z_q[X]/(X^256 + 1) with
+// q = 3329, n = 256. Three parameter sets:
+//   ML-KEM-512  : k=2, eta1=3, eta2=2, du=10, dv=4   (ek 800,  dk 1632, ct 768)
+//   ML-KEM-768  : k=3, eta1=2, eta2=2, du=10, dv=4   (ek 1184, dk 2400, ct 1088)
+//   ML-KEM-1024 : k=4, eta1=2, eta2=2, du=11, dv=5   (ek 1568, dk 3168, ct 1568)
+// Shared secret K is always 32 bytes; seeds d, z, m are each 32 bytes.
+//
+// Import with:  import std.cryptography.mlkem
+//
+//   mlkem768_keygen(d, z)      -> (ek, dk)   // d,z are 32-byte seed buffers
+//   mlkem768_encaps(ek, m)     -> (ct, K)    // m is the 32-byte message coin
+//   mlkem768_decaps(dk, ct)    -> K          // 32-byte shared secret
+//   (and the 512_* / 1024_* equivalents)
+//
+// Determinism: keygen/encaps take caller-supplied seeds so KATs reproduce
+// exactly. All inputs/outputs are std.bytes buffers (ptr); read with
+// bytes.get, hand off / free with bytes.free.
+//
+// Aether-specific care:
+//   * BC works in `short` (signed 16-bit) coefficients; the NTT/reduction
+//     arithmetic depends on that 16-bit wraparound. Here coefficients are
+//     `int`, and every BC `(short)` cast is reproduced by s16() (sign-extend
+//     the low 16 bits). Montgomery/Barrett reduction is exact this way.
+//   * `>>` is arithmetic in Aether (matches C# signed `>>`); logical shifts
+//     for the bit-packing use std.bits.lsr32.
+//   * Left shifts in the d_u/d_v compression packing widen to int first;
+//     masked-byte LEFT shifts past bit 7 would otherwise be 32-bit-unsafe.
+//   * G = SHA3-512, H = SHA3-256, PRF/XOF/J = SHAKE256/SHAKE128 — all from
+//     std.cryptography.sha3. The one-shot wrappers there free their own ctx;
+//     we never double-free.
+
+import std.bits
+import std.bytes
+import std.intarr
+import std.cryptography.sha3
+
+extern malloc(size: int) -> ptr
+@extern("free") libc_free(p: ptr)
+
+exports (
+    mlkem512_keygen, mlkem512_encaps, mlkem512_decaps,
+    mlkem768_keygen, mlkem768_encaps, mlkem768_decaps,
+    mlkem1024_keygen, mlkem1024_encaps, mlkem1024_decaps,
+    mlkem_ek_bytes, mlkem_dk_bytes, mlkem_ct_bytes, mlkem_ss_bytes
+)
+
+// ---- Constants ----
+
+const Q: int = 3329
+const QINV: int = 62209
+const N: int = 256
+const SYM: int = 32          // SymBytes
+const POLY_BYTES: int = 384  // 12-bit packed NTT poly = 256*12/8
+
+// NTT zeta tables (Montgomery domain), Kyber-r3 layout as used by BC.
+const ZETAS: int[128] = [
+    2285, 2571, 2970, 1812, 1493, 1422, 287, 202, 3158, 622, 1577, 182, 962,
+    2127, 1855, 1468, 573, 2004, 264, 383, 2500, 1458, 1727, 3199, 2648, 1017,
+    732, 608, 1787, 411, 3124, 1758, 1223, 652, 2777, 1015, 2036, 1491, 3047,
+    1785, 516, 3321, 3009, 2663, 1711, 2167, 126, 1469, 2476, 3239, 3058, 830,
+    107, 1908, 3082, 2378, 2931, 961, 1821, 2604, 448, 2264, 677, 2054, 2226,
+    430, 555, 843, 2078, 871, 1550, 105, 422, 587, 177, 3094, 3038, 2869, 1574,
+    1653, 3083, 778, 1159, 3182, 2552, 1483, 2727, 1119, 1739, 644, 2457, 349,
+    418, 329, 3173, 3254, 817, 1097, 603, 610, 1322, 2044, 1864, 384, 2114, 3193,
+    1218, 1994, 2455, 220, 2142, 1670, 2144, 1799, 2051, 794, 1819, 2475, 2459,
+    478, 3221, 3021, 996, 991, 958, 1869, 1522, 1628
+]
+
+const ZETAS_INV: int[128] = [
+    1701, 1807, 1460, 2371, 2338, 2333, 308, 108, 2851, 870, 854, 1510, 2535,
+    1278, 1530, 1185, 1659, 1187, 3109, 874, 1335, 2111, 136, 1215, 2945, 1465,
+    1285, 2007, 2719, 2726, 2232, 2512, 75, 156, 3000, 2911, 2980, 872, 2685,
+    1590, 2210, 602, 1846, 777, 147, 2170, 2551, 246, 1676, 1755, 460, 291, 235,
+    3152, 2742, 2907, 3224, 1779, 2458, 1251, 2486, 2774, 2899, 1103, 1275, 2652,
+    1065, 2881, 725, 1508, 2368, 398, 951, 247, 1421, 3222, 2499, 271, 90, 853,
+    1860, 3203, 1162, 1618, 666, 320, 8, 2813, 1544, 282, 1838, 1293, 2314, 552,
+    2677, 2106, 1571, 205, 2918, 1542, 2721, 2597, 2312, 681, 130, 1602, 1871,
+    829, 2946, 3065, 1325, 2756, 1861, 1474, 1202, 2367, 3147, 1752, 2707, 171,
+    3127, 3042, 1907, 1836, 1517, 359, 758, 1441
+]
+
+// ---- Parameter bundle ----
+
+struct Params {
+    k: int
+    eta1: int
+    poly_compressed: int       // dv bytes per poly  (128 for dv=4, 160 for dv=5)
+    polyvec_compressed: int    // du bytes for whole vector (k*320 du=10, k*352 du=11)
+    polyvec_bytes: int         // k * 384
+    indcpa_pk: int             // polyvec_bytes + 32
+    indcpa_sk: int             // polyvec_bytes
+    ek_bytes: int              // = indcpa_pk
+    dk_bytes: int              // indcpa_sk + indcpa_pk + 2*32
+    ct_bytes: int              // polyvec_compressed + poly_compressed
+}
+
+// Allocate + populate a Params on the heap. Caller frees with free_params.
+mk_params(k: int) -> *Params {
+    p = malloc(96) as *Params
+    p.k = k
+    if k == 2 {
+        p.eta1 = 3
+        p.poly_compressed = 128
+        p.polyvec_compressed = k * 320
+    }
+    if k == 3 {
+        p.eta1 = 2
+        p.poly_compressed = 128
+        p.polyvec_compressed = k * 320
+    }
+    if k == 4 {
+        p.eta1 = 2
+        p.poly_compressed = 160
+        p.polyvec_compressed = k * 352
+    }
+    p.polyvec_bytes = k * POLY_BYTES
+    p.indcpa_pk = p.polyvec_bytes + SYM
+    p.indcpa_sk = p.polyvec_bytes
+    p.ek_bytes = p.indcpa_pk
+    p.dk_bytes = p.indcpa_sk + p.indcpa_pk + 2 * SYM
+    p.ct_bytes = p.polyvec_compressed + p.poly_compressed
+    return p
+}
+
+free_params(p: *Params) {
+    libc_free(p)
+}
+
+// ---- Size helpers (public) ----
+
+mlkem_ek_bytes(k: int) -> int {
+    p = mk_params(k)
+    v = p.ek_bytes
+    free_params(p)
+    return v
+}
+mlkem_dk_bytes(k: int) -> int {
+    p = mk_params(k)
+    v = p.dk_bytes
+    free_params(p)
+    return v
+}
+mlkem_ct_bytes(k: int) -> int {
+    p = mk_params(k)
+    v = p.ct_bytes
+    free_params(p)
+    return v
+}
+mlkem_ss_bytes() -> int {
+    return SYM
+}
+
+// ---- Signed 16-bit truncation (BC works in `short`) ----
+
+// Reproduce a C# `(short)x` cast: keep the low 16 bits, sign-extend bit 15.
+s16(x: int) -> int {
+    v = x & 0xFFFF
+    if v >= 0x8000 {
+        v = v - 0x10000
+    }
+    return v
+}
+
+// ---- Modular reduction ----
+
+// Montgomery reduce: input is a full int product, output in (-q, q).
+mont_reduce(a: int) -> int {
+    u = s16(a * QINV)
+    t = u * Q
+    t = a - t
+    t = t >> 16          // arithmetic shift matches C# signed >>
+    return s16(t)
+}
+
+// Barrett reduce a coefficient (already in short range) to (-q/2, q/2].
+barrett_reduce(a: int) -> int {
+    // v = ((1<<26) + q/2)/q = 20159
+    v = 20159
+    t = (v * a) >> 26
+    t = s16(t)
+    t = s16(t * Q)
+    return s16(a - t)
+}
+
+// Conditional subtract q: bring a into [0, q).
+cond_sub_q(a: int) -> int {
+    a = a - Q
+    // (a >> 15) is 0 if a>=0, -1 (all ones) if a<0; & Q adds q back.
+    a = a + ((a >> 15) & Q)
+    return s16(a)
+}
+
+mul_mont(a: int, b: int) -> int {
+    return mont_reduce(a * b)
+}
+
+// ---- Poly = intarr(256) of coefficients ----
+
+poly_new() -> ptr {
+    return intarr_new_raw(N)
+}
+poly_free(p: ptr) {
+    intarr_free(p)
+}
+pg(p: ptr, i: int) -> int {
+    return intarr_get_unchecked(p, i)
+}
+ps(p: ptr, i: int, v: int) {
+    intarr_set_unchecked(p, i, v)
+}
+
+// PolyVec = array of k poly ptrs, stored as intarr(N*k) flat: poly j at j*N.
+polyvec_new(k: int) -> ptr {
+    return intarr_new_raw(N * k)
+}
+polyvec_free(p: ptr) {
+    intarr_free(p)
+}
+// Coefficient i of poly j in a flat polyvec.
+vg(pv: ptr, j: int, i: int) -> int {
+    return intarr_get_unchecked(pv, j * N + i)
+}
+vs(pv: ptr, j: int, i: int, v: int) {
+    intarr_set_unchecked(pv, j * N + i, v)
+}
+
+// ---- NTT (in place on a single poly via flat polyvec slot) ----
+
+ntt(pv: ptr, j: int) {
+    base = j * N
+    k = 1
+    len = 128
+    while len >= 2 {
+        start = 0
+        while start < 256 {
+            zeta = ZETAS[k]
+            k = k + 1
+            jj = start
+            while jj < start + len {
+                t = intarr_get_unchecked(pv, base + jj)
+                u = mul_mont(zeta, intarr_get_unchecked(pv, base + jj + len))
+                intarr_set_unchecked(pv, base + jj + len, s16(t - u))
+                intarr_set_unchecked(pv, base + jj, s16(t + u))
+                jj = jj + 1
+            }
+            start = jj + len
+        }
+        len = len >> 1
+    }
+}
+
+inv_ntt(pv: ptr, j: int) {
+    base = j * N
+    k = 0
+    len = 2
+    while len <= 128 {
+        start = 0
+        while start < 256 {
+            zeta = ZETAS_INV[k]
+            k = k + 1
+            jj = start
+            while jj < start + len {
+                t = intarr_get_unchecked(pv, base + jj)
+                u = intarr_get_unchecked(pv, base + jj + len)
+                intarr_set_unchecked(pv, base + jj, barrett_reduce(s16(t + u)))
+                intarr_set_unchecked(pv, base + jj + len, mul_mont(zeta, s16(t - u)))
+                jj = jj + 1
+            }
+            start = jj + len
+        }
+        len = len << 1
+    }
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(pv, base + i, mul_mont(intarr_get_unchecked(pv, base + i), ZETAS_INV[127]))
+        i = i + 1
+    }
+}
+
+poly_reduce(pv: ptr, j: int) {
+    base = j * N
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(pv, base + i, barrett_reduce(intarr_get_unchecked(pv, base + i)))
+        i = i + 1
+    }
+}
+
+poly_ntt(pv: ptr, j: int) {
+    ntt(pv, j)
+    poly_reduce(pv, j)
+}
+
+poly_to_mont(pv: ptr, j: int) {
+    base = j * N
+    // f = (1<<32) % q = 1353
+    f = 1353
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(pv, base + i, mont_reduce(intarr_get_unchecked(pv, base + i) * f))
+        i = i + 1
+    }
+}
+
+// r[j] += a[j]
+poly_add(rpv: ptr, rj: int, apv: ptr, aj: int) {
+    rb = rj * N
+    ab = aj * N
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(rpv, rb + i, s16(intarr_get_unchecked(rpv, rb + i) + intarr_get_unchecked(apv, ab + i)))
+        i = i + 1
+    }
+}
+
+// r[j] = a[j] - r[j]   (BC Subtract semantics)
+poly_subtract(rpv: ptr, rj: int, apv: ptr, aj: int) {
+    rb = rj * N
+    ab = aj * N
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(rpv, rb + i, s16(intarr_get_unchecked(apv, ab + i) - intarr_get_unchecked(rpv, rb + i)))
+        i = i + 1
+    }
+}
+
+// Base multiplication of two degree-1 polys in NTT domain.
+basemul(rpv: ptr, rbase: int, off: int, a0: int, a1: int, b0: int, b1: int, zeta: int) {
+    o0 = mul_mont(a1, b1)
+    o0 = mul_mont(o0, zeta)
+    o0 = s16(o0 + mul_mont(a0, b0))
+    intarr_set_unchecked(rpv, rbase + off, o0)
+    o1 = mul_mont(a0, b1)
+    o1 = s16(o1 + mul_mont(a1, b0))
+    intarr_set_unchecked(rpv, rbase + off + 1, o1)
+}
+
+basemul_mont(rpv: ptr, rj: int, apv: ptr, aj: int, bpv: ptr, bj: int) {
+    rb = rj * N
+    ab = aj * N
+    bb = bj * N
+    i = 0
+    while i < 64 {
+        z = ZETAS[64 + i]
+        basemul(rpv, rb, 4 * i,
+            intarr_get_unchecked(apv, ab + 4 * i), intarr_get_unchecked(apv, ab + 4 * i + 1),
+            intarr_get_unchecked(bpv, bb + 4 * i), intarr_get_unchecked(bpv, bb + 4 * i + 1), z)
+        basemul(rpv, rb, 4 * i + 2,
+            intarr_get_unchecked(apv, ab + 4 * i + 2), intarr_get_unchecked(apv, ab + 4 * i + 3),
+            intarr_get_unchecked(bpv, bb + 4 * i + 2), intarr_get_unchecked(bpv, bb + 4 * i + 3), s16(-z))
+        i = i + 1
+    }
+}
+
+// r[rj] = <a (k polys), b (k polys)> pointwise-accumulated, reduced.
+polyvec_pointwise_acc(rpv: ptr, rj: int, apv: ptr, bpv: ptr, k: int, scratch: ptr) {
+    basemul_mont(rpv, rj, apv, 0, bpv, 0)
+    i = 1
+    while i < k {
+        basemul_mont(scratch, 0, apv, i, bpv, i)
+        poly_add(rpv, rj, scratch, 0)
+        i = i + 1
+    }
+    poly_reduce(rpv, rj)
+}
+
+// ---- 12-bit (de)serialization of NTT polys ----
+
+// Pack poly j into 384 bytes at out[off..].
+poly_to_bytes(pv: ptr, j: int, out: ptr, off: int) {
+    base = j * N
+    i = 0
+    while i < 128 {
+        t0 = cond_sub_q(intarr_get_unchecked(pv, base + 2 * i)) & 0xFFFF
+        t1 = cond_sub_q(intarr_get_unchecked(pv, base + 2 * i + 1)) & 0xFFFF
+        bytes.set(out, off + 3 * i + 0, t0 & 0xFF)
+        bytes.set(out, off + 3 * i + 1, (bits.lsr32(t0, 8) | (t1 << 4)) & 0xFF)
+        bytes.set(out, off + 3 * i + 2, bits.lsr32(t1, 4) & 0xFF)
+        i = i + 1
+    }
+}
+
+poly_from_bytes(pv: ptr, j: int, src: ptr, off: int) {
+    base = j * N
+    i = 0
+    while i < 128 {
+        a0 = bytes.get(src, off + 3 * i + 0) & 0xFF
+        a1 = bytes.get(src, off + 3 * i + 1) & 0xFF
+        a2 = bytes.get(src, off + 3 * i + 2) & 0xFF
+        c0 = ((a0) | (a1 << 8)) & 0xFFF
+        c1 = (bits.lsr32(a1, 4) | (a2 << 4)) & 0xFFF
+        intarr_set_unchecked(pv, base + 2 * i, s16(c0))
+        intarr_set_unchecked(pv, base + 2 * i + 1, s16(c1))
+        i = i + 1
+    }
+}
+
+polyvec_to_bytes(pv: ptr, k: int, out: ptr, off: int) {
+    i = 0
+    while i < k {
+        poly_to_bytes(pv, i, out, off + i * POLY_BYTES)
+        i = i + 1
+    }
+}
+polyvec_from_bytes(pv: ptr, k: int, src: ptr, off: int) {
+    i = 0
+    while i < k {
+        poly_from_bytes(pv, i, src, off + i * POLY_BYTES)
+        i = i + 1
+    }
+}
+
+// ---- Message <-> poly ----
+
+poly_from_msg(pv: ptr, j: int, msg: ptr, off: int) {
+    base = j * N
+    half = (Q + 1) / 2     // 1665
+    i = 0
+    while i < 32 {
+        mi = bytes.get(msg, off + i) & 0xFF
+        b = 0
+        while b < 8 {
+            bit = (bits.lsr32(mi, b)) & 1
+            mask = 0 - bit       // 0 or -1
+            intarr_set_unchecked(pv, base + 8 * i + b, s16(mask & half))
+            b = b + 1
+        }
+        i = i + 1
+    }
+}
+
+poly_to_msg(pv: ptr, j: int, msg: ptr, off: int) {
+    base = j * N
+    lower = Q >> 2          // 832
+    upper = Q - lower       // 2497
+    // cond_sub_q first
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(pv, base + i, cond_sub_q(intarr_get_unchecked(pv, base + i)))
+        i = i + 1
+    }
+    i = 0
+    while i < 32 {
+        mi = 0
+        b = 0
+        while b < 8 {
+            cj = intarr_get_unchecked(pv, base + 8 * i + b)
+            // t = ((lower - cj) & (cj - upper)) >>> 31  (uint), 1 iff cj in (lower,upper)
+            prod = (lower - cj) & (cj - upper)
+            t = bits.lsr32(prod, 31) & 1
+            mi = mi | (t << b)
+            b = b + 1
+        }
+        bytes.set(msg, off + i, mi & 0xFF)
+        i = i + 1
+    }
+}
+
+// ---- d_v compression of v poly ----
+
+// dv=4: 128 bytes for the whole poly.
+compress_poly_128(pv: ptr, j: int, out: ptr, off: int) {
+    base = j * N
+    // cond_sub_q
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(pv, base + i, cond_sub_q(intarr_get_unchecked(pv, base + i)))
+        i = i + 1
+    }
+    pos = off
+    i = 0
+    while i < 32 {       // N/8
+        t0 = compress4(intarr_get_unchecked(pv, base + 8 * i + 0))
+        t1 = compress4(intarr_get_unchecked(pv, base + 8 * i + 1))
+        t2 = compress4(intarr_get_unchecked(pv, base + 8 * i + 2))
+        t3 = compress4(intarr_get_unchecked(pv, base + 8 * i + 3))
+        t4 = compress4(intarr_get_unchecked(pv, base + 8 * i + 4))
+        t5 = compress4(intarr_get_unchecked(pv, base + 8 * i + 5))
+        t6 = compress4(intarr_get_unchecked(pv, base + 8 * i + 6))
+        t7 = compress4(intarr_get_unchecked(pv, base + 8 * i + 7))
+        bytes.set(out, pos + 0, (t0 | (t1 << 4)) & 0xFF)
+        bytes.set(out, pos + 1, (t2 | (t3 << 4)) & 0xFF)
+        bytes.set(out, pos + 2, (t4 | (t5 << 4)) & 0xFF)
+        bytes.set(out, pos + 3, (t6 | (t7 << 4)) & 0xFF)
+        pos = pos + 4
+        i = i + 1
+    }
+}
+compress4(c: int) -> int {
+    return (((c + (Q >> 5)) * 315) >> 16) & 0xF
+}
+
+decompress_poly_128(pv: ptr, j: int, src: ptr, off: int) {
+    base = j * N
+    pos = off
+    i = 0
+    while i < 128 {       // N/2
+        byte_v = bytes.get(src, pos) & 0xFF
+        intarr_set_unchecked(pv, base + 2 * i + 0, s16((((byte_v & 15) * Q) + 8) >> 4))
+        intarr_set_unchecked(pv, base + 2 * i + 1, s16(((bits.lsr32(byte_v, 4) * Q) + 8) >> 4))
+        pos = pos + 1
+        i = i + 1
+    }
+}
+
+// dv=5: 160 bytes.
+compress_poly_160(pv: ptr, j: int, out: ptr, off: int) {
+    base = j * N
+    i = 0
+    while i < 256 {
+        intarr_set_unchecked(pv, base + i, cond_sub_q(intarr_get_unchecked(pv, base + i)))
+        i = i + 1
+    }
+    pos = off
+    i = 0
+    while i < 32 {
+        t0 = compress5(intarr_get_unchecked(pv, base + 8 * i + 0))
+        t1 = compress5(intarr_get_unchecked(pv, base + 8 * i + 1))
+        t2 = compress5(intarr_get_unchecked(pv, base + 8 * i + 2))
+        t3 = compress5(intarr_get_unchecked(pv, base + 8 * i + 3))
+        t4 = compress5(intarr_get_unchecked(pv, base + 8 * i + 4))
+        t5 = compress5(intarr_get_unchecked(pv, base + 8 * i + 5))
+        t6 = compress5(intarr_get_unchecked(pv, base + 8 * i + 6))
+        t7 = compress5(intarr_get_unchecked(pv, base + 8 * i + 7))
+        bytes.set(out, pos + 0, (t0 | (t1 << 5)) & 0xFF)
+        bytes.set(out, pos + 1, (bits.lsr32(t1, 3) | (t2 << 2) | (t3 << 7)) & 0xFF)
+        bytes.set(out, pos + 2, (bits.lsr32(t3, 1) | (t4 << 4)) & 0xFF)
+        bytes.set(out, pos + 3, (bits.lsr32(t4, 4) | (t5 << 1) | (t6 << 6)) & 0xFF)
+        bytes.set(out, pos + 4, (bits.lsr32(t6, 2) | (t7 << 3)) & 0xFF)
+        pos = pos + 5
+        i = i + 1
+    }
+}
+compress5(c: int) -> int {
+    return (((c + (Q >> 6)) * 630) >> 16) & 0x1F
+}
+
+decompress_poly_160(pv: ptr, j: int, src: ptr, off: int) {
+    base = j * N
+    pos = off
+    i = 0
+    while i < 32 {       // N/8
+        c0 = bytes.get(src, pos + 0) & 0xFF
+        c1 = bytes.get(src, pos + 1) & 0xFF
+        c2 = bytes.get(src, pos + 2) & 0xFF
+        c3 = bytes.get(src, pos + 3) & 0xFF
+        c4 = bytes.get(src, pos + 4) & 0xFF
+        t0 = c0 & 0x1F
+        t1 = (bits.lsr32(c0, 5) | (c1 << 3)) & 0x1F
+        t2 = bits.lsr32(c1, 2) & 0x1F
+        t3 = (bits.lsr32(c1, 7) | (c2 << 1)) & 0x1F
+        t4 = (bits.lsr32(c2, 4) | (c3 << 4)) & 0x1F
+        t5 = bits.lsr32(c3, 1) & 0x1F
+        t6 = (bits.lsr32(c3, 6) | (c4 << 2)) & 0x1F
+        t7 = bits.lsr32(c4, 3) & 0x1F
+        pos = pos + 5
+        intarr_set_unchecked(pv, base + 8 * i + 0, s16(((t0 * Q) + 16) >> 5))
+        intarr_set_unchecked(pv, base + 8 * i + 1, s16(((t1 * Q) + 16) >> 5))
+        intarr_set_unchecked(pv, base + 8 * i + 2, s16(((t2 * Q) + 16) >> 5))
+        intarr_set_unchecked(pv, base + 8 * i + 3, s16(((t3 * Q) + 16) >> 5))
+        intarr_set_unchecked(pv, base + 8 * i + 4, s16(((t4 * Q) + 16) >> 5))
+        intarr_set_unchecked(pv, base + 8 * i + 5, s16(((t5 * Q) + 16) >> 5))
+        intarr_set_unchecked(pv, base + 8 * i + 6, s16(((t6 * Q) + 16) >> 5))
+        intarr_set_unchecked(pv, base + 8 * i + 7, s16(((t7 * Q) + 16) >> 5))
+        i = i + 1
+    }
+}
+
+// ---- d_u compression of b polyvec ----
+
+// du=10: k*320 bytes.
+compress_polyvec_320(pv: ptr, k: int, out: ptr, off: int) {
+    // cond_sub_q whole vector
+    j = 0
+    while j < k {
+        i = 0
+        while i < 256 {
+            vs(pv, j, i, cond_sub_q(vg(pv, j, i)))
+            i = i + 1
+        }
+        j = j + 1
+    }
+    pos = off
+    j = 0
+    while j < k {
+        i = 0
+        while i < 64 {     // N/4
+            t0 = compress10(vg(pv, j, 4 * i + 0))
+            t1 = compress10(vg(pv, j, 4 * i + 1))
+            t2 = compress10(vg(pv, j, 4 * i + 2))
+            t3 = compress10(vg(pv, j, 4 * i + 3))
+            bytes.set(out, pos + 0, t0 & 0xFF)
+            bytes.set(out, pos + 1, (bits.lsr32(t0, 8) | (t1 << 2)) & 0xFF)
+            bytes.set(out, pos + 2, (bits.lsr32(t1, 6) | (t2 << 4)) & 0xFF)
+            bytes.set(out, pos + 3, (bits.lsr32(t2, 4) | (t3 << 6)) & 0xFF)
+            bytes.set(out, pos + 4, bits.lsr32(t3, 2) & 0xFF)
+            pos = pos + 5
+            i = i + 1
+        }
+        j = j + 1
+    }
+}
+compress10(c: int) -> int {
+    // (((long)((c<<3) + (q>>8)) * 165141429) >> 32) & 0x3FF
+    long base = (c << 3) + (Q >> 8)
+    long mul = 165141429
+    long prod = base * mul
+    int hi = bits.lsr64(prod, 32)
+    return hi & 0x3FF
+}
+
+decompress_polyvec_320(pv: ptr, k: int, src: ptr, off: int) {
+    pos = off
+    j = 0
+    while j < k {
+        i = 0
+        while i < 256 {
+            c0 = bytes.get(src, pos + 0) & 0xFF
+            c1 = bytes.get(src, pos + 1) & 0xFF
+            c2 = bytes.get(src, pos + 2) & 0xFF
+            c3 = bytes.get(src, pos + 3) & 0xFF
+            c4 = bytes.get(src, pos + 4) & 0xFF
+            pos = pos + 5
+            t0 = (c0 | (c1 << 8)) & 0x3FF
+            t1 = (bits.lsr32(c1, 2) | (c2 << 6)) & 0x3FF
+            t2 = (bits.lsr32(c2, 4) | (c3 << 4)) & 0x3FF
+            t3 = (bits.lsr32(c3, 6) | (c4 << 2)) & 0x3FF
+            vs(pv, j, i + 0, s16(((t0 * Q) + 512) >> 10))
+            vs(pv, j, i + 1, s16(((t1 * Q) + 512) >> 10))
+            vs(pv, j, i + 2, s16(((t2 * Q) + 512) >> 10))
+            vs(pv, j, i + 3, s16(((t3 * Q) + 512) >> 10))
+            i = i + 4
+        }
+        j = j + 1
+    }
+}
+
+// du=11: k*352 bytes.
+compress_polyvec_352(pv: ptr, k: int, out: ptr, off: int) {
+    j = 0
+    while j < k {
+        i = 0
+        while i < 256 {
+            vs(pv, j, i, cond_sub_q(vg(pv, j, i)))
+            i = i + 1
+        }
+        j = j + 1
+    }
+    pos = off
+    j = 0
+    while j < k {
+        i = 0
+        while i < 32 {     // N/8
+            t0 = compress11(vg(pv, j, 8 * i + 0))
+            t1 = compress11(vg(pv, j, 8 * i + 1))
+            t2 = compress11(vg(pv, j, 8 * i + 2))
+            t3 = compress11(vg(pv, j, 8 * i + 3))
+            t4 = compress11(vg(pv, j, 8 * i + 4))
+            t5 = compress11(vg(pv, j, 8 * i + 5))
+            t6 = compress11(vg(pv, j, 8 * i + 6))
+            t7 = compress11(vg(pv, j, 8 * i + 7))
+            bytes.set(out, pos + 0, t0 & 0xFF)
+            bytes.set(out, pos + 1, (bits.lsr32(t0, 8) | (t1 << 3)) & 0xFF)
+            bytes.set(out, pos + 2, (bits.lsr32(t1, 5) | (t2 << 6)) & 0xFF)
+            bytes.set(out, pos + 3, bits.lsr32(t2, 2) & 0xFF)
+            bytes.set(out, pos + 4, (bits.lsr32(t2, 10) | (t3 << 1)) & 0xFF)
+            bytes.set(out, pos + 5, (bits.lsr32(t3, 7) | (t4 << 4)) & 0xFF)
+            bytes.set(out, pos + 6, (bits.lsr32(t4, 4) | (t5 << 7)) & 0xFF)
+            bytes.set(out, pos + 7, bits.lsr32(t5, 1) & 0xFF)
+            bytes.set(out, pos + 8, (bits.lsr32(t5, 9) | (t6 << 2)) & 0xFF)
+            bytes.set(out, pos + 9, (bits.lsr32(t6, 6) | (t7 << 5)) & 0xFF)
+            bytes.set(out, pos + 10, bits.lsr32(t7, 3) & 0xFF)
+            pos = pos + 11
+            i = i + 1
+        }
+        j = j + 1
+    }
+}
+compress11(c: int) -> int {
+    long base = (c << 4) + (Q >> 8)
+    long mul = 165141429
+    long prod = base * mul
+    int hi = bits.lsr64(prod, 32)
+    return hi & 0x7FF
+}
+
+decompress_polyvec_352(pv: ptr, k: int, src: ptr, off: int) {
+    pos = off
+    j = 0
+    while j < k {
+        i = 0
+        while i < 256 {
+            c0 = bytes.get(src, pos + 0) & 0xFF
+            c1 = bytes.get(src, pos + 1) & 0xFF
+            c2 = bytes.get(src, pos + 2) & 0xFF
+            c3 = bytes.get(src, pos + 3) & 0xFF
+            c4 = bytes.get(src, pos + 4) & 0xFF
+            c5 = bytes.get(src, pos + 5) & 0xFF
+            c6 = bytes.get(src, pos + 6) & 0xFF
+            c7 = bytes.get(src, pos + 7) & 0xFF
+            c8 = bytes.get(src, pos + 8) & 0xFF
+            c9 = bytes.get(src, pos + 9) & 0xFF
+            c10 = bytes.get(src, pos + 10) & 0xFF
+            pos = pos + 11
+            t0 = (c0 | (c1 << 8)) & 0x7FF
+            t1 = (bits.lsr32(c1, 3) | (c2 << 5)) & 0x7FF
+            t2 = (bits.lsr32(c2, 6) | (c3 << 2) | (c4 << 10)) & 0x7FF
+            t3 = (bits.lsr32(c4, 1) | (c5 << 7)) & 0x7FF
+            t4 = (bits.lsr32(c5, 4) | (c6 << 4)) & 0x7FF
+            t5 = (bits.lsr32(c6, 7) | (c7 << 1) | (c8 << 9)) & 0x7FF
+            t6 = (bits.lsr32(c8, 2) | (c9 << 6)) & 0x7FF
+            t7 = (bits.lsr32(c9, 5) | (c10 << 3)) & 0x7FF
+            vs(pv, j, i + 0, s16(((t0 * Q) + 1024) >> 11))
+            vs(pv, j, i + 1, s16(((t1 * Q) + 1024) >> 11))
+            vs(pv, j, i + 2, s16(((t2 * Q) + 1024) >> 11))
+            vs(pv, j, i + 3, s16(((t3 * Q) + 1024) >> 11))
+            vs(pv, j, i + 4, s16(((t4 * Q) + 1024) >> 11))
+            vs(pv, j, i + 5, s16(((t5 * Q) + 1024) >> 11))
+            vs(pv, j, i + 6, s16(((t6 * Q) + 1024) >> 11))
+            vs(pv, j, i + 7, s16(((t7 * Q) + 1024) >> 11))
+            i = i + 8
+        }
+        j = j + 1
+    }
+}
+
+// ---- CBD noise sampling ----
+
+cbd_eta2(pv: ptr, j: int, buf: ptr) {
+    base = j * N
+    i = 0
+    while i < 32 {       // N/8
+        t = bytes.get_le32(buf, 4 * i) & 0xFFFFFFFF
+        d = t & 0x55555555
+        d = d + (bits.lsr32(t, 1) & 0x55555555)
+        jj = 0
+        while jj < 8 {
+            a = (bits.lsr32(d, 4 * jj + 0)) & 0x3
+            b = (bits.lsr32(d, 4 * jj + 2)) & 0x3
+            intarr_set_unchecked(pv, base + 8 * i + jj, s16(a - b))
+            jj = jj + 1
+        }
+        i = i + 1
+    }
+}
+
+cbd_eta3(pv: ptr, j: int, buf: ptr) {
+    base = j * N
+    i = 0
+    while i < 64 {       // N/4
+        // LE 24-bit load
+        b0 = bytes.get(buf, 3 * i + 0) & 0xFF
+        b1 = bytes.get(buf, 3 * i + 1) & 0xFF
+        b2 = bytes.get(buf, 3 * i + 2) & 0xFF
+        t = (b0 | (b1 << 8) | (b2 << 16)) & 0xFFFFFF
+        d = t & 0x00249249
+        d = d + (bits.lsr32(t, 1) & 0x00249249)
+        d = d + (bits.lsr32(t, 2) & 0x00249249)
+        jj = 0
+        while jj < 4 {
+            a = (bits.lsr32(d, 6 * jj + 0)) & 0x7
+            b = (bits.lsr32(d, 6 * jj + 3)) & 0x7
+            intarr_set_unchecked(pv, base + 4 * i + jj, s16(a - b))
+            jj = jj + 1
+        }
+        i = i + 1
+    }
+}
+
+// PRF: SHAKE256(seed[0..32] || nonce), eta2 -> 128 bytes, eta3 -> 192 bytes.
+get_noise(pv: ptr, j: int, seed: ptr, seed_off: int, nonce: int, eta: int) {
+    in_buf = bytes.new(SYM + 1)
+    i = 0
+    while i < SYM {
+        bytes.set(in_buf, i, bytes.get(seed, seed_off + i) & 0xFF)
+        i = i + 1
+    }
+    bytes.set(in_buf, SYM, nonce & 0xFF)
+    out_len = 128
+    if eta == 3 {
+        out_len = 192
+    }
+    in_str = bytes.finish(in_buf, SYM + 1)
+    out = sha3.shake256_bytes(in_str, SYM + 1, out_len)
+    if eta == 2 {
+        cbd_eta2(pv, j, out)
+    } else {
+        cbd_eta3(pv, j, out)
+    }
+    bytes.free(out)
+}
+
+// ---- Matrix A generation via SHAKE128 rejection sampling ----
+
+// Fill poly a[i][j] (flat) by rejection sampling from SHAKE128(seed || x || y).
+gen_matrix_poly(dest: ptr, dj: int, seed: ptr, x: int, y: int) {
+    in_buf = bytes.new(SYM + 2)
+    i = 0
+    while i < SYM {
+        bytes.set(in_buf, i, bytes.get(seed, i) & 0xFF)
+        i = i + 1
+    }
+    bytes.set(in_buf, SYM, x & 0xFF)
+    bytes.set(in_buf, SYM + 1, y & 0xFF)
+    in_str = bytes.finish(in_buf, SYM + 2)
+
+    // Squeeze plenty: NumMatrixBlocks*168. NumMatrixBlocks for q=3329 is 3.
+    // 3 blocks = 504 bytes gives ~336 candidates; pull extra to be safe.
+    squeeze_len = 504 + 168 * 4
+    buf = sha3.shake128_bytes(in_str, SYM + 2, squeeze_len)
+
+    base = dj * N
+    ctr = 0
+    pos = 0
+    while ctr < N {
+        if pos + 3 > squeeze_len {
+            // Astronomically unlikely with this much output (≈784 candidates
+            // for 256 needed). Stop; remaining coeffs stay zero.
+            bytes.free(buf)
+            return
+        }
+        b0 = bytes.get(buf, pos + 0) & 0xFF
+        b1 = bytes.get(buf, pos + 1) & 0xFF
+        b2 = bytes.get(buf, pos + 2) & 0xFF
+        t = (b0 | (b1 << 8) | (b2 << 16)) & 0xFFFFFF
+        d1 = t & 0xFFF
+        d2 = bits.lsr32(t, 12) & 0xFFF
+        pos = pos + 3
+        if d1 < Q {
+            if ctr < N {
+                intarr_set_unchecked(dest, base + ctr, d1)
+                ctr = ctr + 1
+            }
+        }
+        if d2 < Q {
+            if ctr < N {
+                intarr_set_unchecked(dest, base + ctr, d2)
+                ctr = ctr + 1
+            }
+        }
+    }
+    bytes.free(buf)
+}
+
+// Generate the k*k matrix into `mat` (flat intarr of N*k*k).
+// mat poly (i,j) lives at slot (i*k + j) of N coeffs.
+gen_matrix(mat: ptr, seed: ptr, k: int, transpose: int) {
+    i = 0
+    while i < k {
+        j = 0
+        while j < k {
+            slot = i * k + j
+            if transpose == 1 {
+                gen_matrix_poly(mat, slot, seed, i, j)
+            } else {
+                gen_matrix_poly(mat, slot, seed, j, i)
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+}
+
+// ---- K-PKE keygen ----
+
+// Writes IndCpa keypair into kp: [sk polyvec (indcpa_sk)] then [pk (indcpa_pk)].
+indcpa_keygen(p: *Params, d: ptr, kp: ptr) {
+    k = p.k
+
+    // G(d || k) -> 64 bytes = rho(32) || sigma(32)
+    g_in = bytes.new(SYM + 1)
+    i = 0
+    while i < SYM {
+        bytes.set(g_in, i, bytes.get(d, i) & 0xFF)
+        i = i + 1
+    }
+    bytes.set(g_in, SYM, k & 0xFF)
+    g_str = bytes.finish(g_in, SYM + 1)
+    gbuf = sha3.sha3_512_bytes(g_str, SYM + 1)   // 64 bytes; frees own ctx
+
+    // rho = gbuf[0..32], sigma = gbuf[32..64]
+    rho = bytes.new(SYM)
+    sigma = bytes.new(SYM)
+    i = 0
+    while i < SYM {
+        bytes.set(rho, i, bytes.get(gbuf, i) & 0xFF)
+        bytes.set(sigma, i, bytes.get(gbuf, SYM + i) & 0xFF)
+        i = i + 1
+    }
+    bytes.free(gbuf)
+
+    // Matrix A (non-transposed)
+    mat = intarr_new_raw(N * k * k)
+    gen_matrix(mat, rho, k, 0)
+
+    skpv = polyvec_new(k)
+    e = polyvec_new(k)
+    scratch = poly_new()
+
+    nonce = 0
+    i = 0
+    while i < k {
+        get_noise(skpv, i, sigma, 0, nonce, p.eta1)
+        nonce = nonce + 1
+        i = i + 1
+    }
+    i = 0
+    while i < k {
+        get_noise(e, i, sigma, 0, nonce, 2)   // error always eta2
+        nonce = nonce + 1
+        i = i + 1
+    }
+
+    i = 0
+    while i < k {
+        poly_ntt(skpv, i)
+        poly_ntt(e, i)
+        i = i + 1
+    }
+
+    pkpv = polyvec_new(k)
+    i = 0
+    while i < k {
+        // pkpv[i] = <A[i], skpv>
+        row = mat_row(mat, i, k)
+        polyvec_pointwise_acc(pkpv, i, row, skpv, k, scratch)
+        polyvec_free(row)
+        poly_to_mont(pkpv, i)
+        i = i + 1
+    }
+    // pkpv += e ; reduce
+    i = 0
+    while i < k {
+        poly_add(pkpv, i, e, i)
+        poly_reduce(pkpv, i)
+        i = i + 1
+    }
+
+    // pack sk = skpv ; pk = pkpv || rho
+    polyvec_to_bytes(skpv, k, kp, 0)
+    polyvec_to_bytes(pkpv, k, kp, p.indcpa_sk)
+    i = 0
+    while i < SYM {
+        bytes.set(kp, p.indcpa_sk + p.polyvec_bytes + i, bytes.get(rho, i) & 0xFF)
+        i = i + 1
+    }
+
+    bytes.free(rho)
+    bytes.free(sigma)
+    intarr_free(mat)
+    polyvec_free(skpv)
+    polyvec_free(e)
+    polyvec_free(pkpv)
+    poly_free(scratch)
+}
+
+// Matrix `mat` is a flat intarr of N*k*k coefficients; poly (i,j) lives at
+// flat slot (i*k + j). Return a freshly-allocated k-poly polyvec copy of row i
+// (slots i*k .. i*k+k-1) so the standard polyvec accessors apply. The caller
+// MUST free the returned polyvec.
+mat_row(mat: ptr, i: int, k: int) -> ptr {
+    rowpv = polyvec_new(k)
+    j = 0
+    while j < k {
+        src_slot = i * k + j
+        sb = src_slot * N
+        db = j * N
+        c = 0
+        while c < 256 {
+            intarr_set_unchecked(rowpv, db + c, intarr_get_unchecked(mat, sb + c))
+            c = c + 1
+        }
+        j = j + 1
+    }
+    return rowpv
+}
+
+// ---- K-PKE encrypt ----
+
+// pk is the indcpa public key (indcpa_pk bytes) at pk[pk_off..].
+// coins = 32-byte r. Writes ct (ct_bytes) at out[out_off..].
+indcpa_encrypt(p: *Params, pk: ptr, pk_off: int, msg: ptr, msg_off: int, coins: ptr, out: ptr, out_off: int) {
+    k = p.k
+
+    // Unpack pk -> pkpv, seed(rho)
+    pkpv = polyvec_new(k)
+    polyvec_from_bytes(pkpv, k, pk, pk_off)
+    rho = bytes.new(SYM)
+    i = 0
+    while i < SYM {
+        bytes.set(rho, i, bytes.get(pk, pk_off + p.polyvec_bytes + i) & 0xFF)
+        i = i + 1
+    }
+
+    kp_pv = polyvec_new(1)        // message poly (single-poly polyvec slot)
+    poly_from_msg(kp_pv, 0, msg, msg_off)
+
+    // Matrix A transposed
+    mat = intarr_new_raw(N * k * k)
+    gen_matrix(mat, rho, k, 1)
+
+    sp = polyvec_new(k)
+    ep = polyvec_new(k)
+    epp_pv = polyvec_new(1)       // single error poly e''
+    scratch = poly_new()
+
+    nonce = 0
+    i = 0
+    while i < k {
+        get_noise(sp, i, coins, 0, nonce, p.eta1)
+        nonce = nonce + 1
+        i = i + 1
+    }
+    i = 0
+    while i < k {
+        get_noise(ep, i, coins, 0, nonce, 2)
+        nonce = nonce + 1
+        i = i + 1
+    }
+    get_noise(epp_pv, 0, coins, 0, nonce, 2)
+    nonce = nonce + 1
+
+    i = 0
+    while i < k {
+        poly_ntt(sp, i)
+        i = i + 1
+    }
+
+    bp = polyvec_new(k)
+    i = 0
+    while i < k {
+        row = mat_row(mat, i, k)
+        polyvec_pointwise_acc(bp, i, row, sp, k, scratch)
+        polyvec_free(row)
+        i = i + 1
+    }
+
+    v_pv = polyvec_new(1)
+    polyvec_pointwise_acc(v_pv, 0, pkpv, sp, k, scratch)
+
+    i = 0
+    while i < k {
+        inv_ntt(bp, i)
+        i = i + 1
+    }
+    inv_ntt(v_pv, 0)
+
+    // bp += ep
+    i = 0
+    while i < k {
+        poly_add(bp, i, ep, i)
+        i = i + 1
+    }
+    // v += epp + k
+    poly_add(v_pv, 0, epp_pv, 0)
+    poly_add(v_pv, 0, kp_pv, 0)
+
+    // reduce
+    i = 0
+    while i < k {
+        poly_reduce(bp, i)
+        i = i + 1
+    }
+    poly_reduce(v_pv, 0)
+
+    // Pack ct: compress bp (du) then v (dv)
+    if p.k == 4 {
+        compress_polyvec_352(bp, k, out, out_off)
+        compress_poly_160(v_pv, 0, out, out_off + p.polyvec_compressed)
+    } else {
+        compress_polyvec_320(bp, k, out, out_off)
+        compress_poly_128(v_pv, 0, out, out_off + p.polyvec_compressed)
+    }
+
+    bytes.free(rho)
+    intarr_free(mat)
+    polyvec_free(pkpv)
+    polyvec_free(kp_pv)
+    polyvec_free(sp)
+    polyvec_free(ep)
+    polyvec_free(epp_pv)
+    polyvec_free(bp)
+    polyvec_free(v_pv)
+    poly_free(scratch)
+}
+
+// ---- K-PKE decrypt ----
+
+// sk is indcpa secret key bytes at sk[0..]; ct at ct[ct_off..].
+// Writes 32-byte message into msg[0..].
+indcpa_decrypt(p: *Params, ct: ptr, ct_off: int, sk: ptr, msg: ptr) {
+    k = p.k
+
+    bp = polyvec_new(k)
+    v_pv = polyvec_new(1)
+    if p.k == 4 {
+        decompress_polyvec_352(bp, k, ct, ct_off)
+        decompress_poly_160(v_pv, 0, ct, ct_off + p.polyvec_compressed)
+    } else {
+        decompress_polyvec_320(bp, k, ct, ct_off)
+        decompress_poly_128(v_pv, 0, ct, ct_off + p.polyvec_compressed)
+    }
+
+    skpv = polyvec_new(k)
+    polyvec_from_bytes(skpv, k, sk, 0)
+
+    scratch = poly_new()
+    mp_pv = polyvec_new(1)
+
+    i = 0
+    while i < k {
+        poly_ntt(bp, i)
+        i = i + 1
+    }
+
+    polyvec_pointwise_acc(mp_pv, 0, skpv, bp, k, scratch)
+    inv_ntt(mp_pv, 0)
+
+    poly_subtract(mp_pv, 0, v_pv, 0)
+    poly_reduce(mp_pv, 0)
+    poly_to_msg(mp_pv, 0, msg, 0)
+
+    polyvec_free(bp)
+    polyvec_free(v_pv)
+    polyvec_free(skpv)
+    poly_free(scratch)
+    polyvec_free(mp_pv)
+}
+
+// ---- ML-KEM wrappers ----
+
+// keygen: returns (ek, dk). d, z are 32-byte seed buffers.
+mlkem_keygen(p: *Params, d: ptr, z: ptr) -> {
+    dk = bytes.new(p.dk_bytes)
+    // Build indcpa keypair into dk: [sk | pk] occupy first indcpa_sk+indcpa_pk.
+    indcpa_keygen(p, d, dk)
+
+    // ek = the indcpa public key portion = dk[indcpa_sk .. indcpa_sk+indcpa_pk]
+    ek = bytes.new(p.ek_bytes)
+    i = 0
+    while i < p.ek_bytes {
+        bytes.set(ek, i, bytes.get(dk, p.indcpa_sk + i) & 0xFF)
+        i = i + 1
+    }
+
+    // dk layout: indcpa_sk || ek || H(ek) || z
+    // H(ek) at offset indcpa_sk + indcpa_pk
+    ek_str = bytes_to_string(ek, p.ek_bytes)
+    hbuf = sha3.sha3_256_bytes(ek_str, p.ek_bytes)
+    hoff = p.indcpa_sk + p.indcpa_pk
+    i = 0
+    while i < SYM {
+        bytes.set(dk, hoff + i, bytes.get(hbuf, i) & 0xFF)
+        i = i + 1
+    }
+    bytes.free(hbuf)
+    // z at the very end
+    zoff = p.dk_bytes - SYM
+    i = 0
+    while i < SYM {
+        bytes.set(dk, zoff + i, bytes.get(z, i) & 0xFF)
+        i = i + 1
+    }
+
+    free_params(p)
+    return ek, dk
+}
+
+// encaps: returns (ct, K). m is the 32-byte message coin.
+mlkem_encaps(p: *Params, ek: ptr, m: ptr) -> {
+    // buf = m || H(ek)   (64 bytes)
+    buf = bytes.new(2 * SYM)
+    i = 0
+    while i < SYM {
+        bytes.set(buf, i, bytes.get(m, i) & 0xFF)
+        i = i + 1
+    }
+    ek_str = bytes_to_string(ek, p.ek_bytes)
+    hbuf = sha3.sha3_256_bytes(ek_str, p.ek_bytes)
+    i = 0
+    while i < SYM {
+        bytes.set(buf, SYM + i, bytes.get(hbuf, i) & 0xFF)
+        i = i + 1
+    }
+    bytes.free(hbuf)
+
+    // (K, r) = G(buf)
+    buf_str = bytes_to_string(buf, 2 * SYM)
+    kr = sha3.sha3_512_bytes(buf_str, 2 * SYM)   // 64 bytes
+    // r = kr[32..64]
+    coins = bytes.new(SYM)
+    i = 0
+    while i < SYM {
+        bytes.set(coins, i, bytes.get(kr, SYM + i) & 0xFF)
+        i = i + 1
+    }
+
+    ct = bytes.new(p.ct_bytes)
+    indcpa_encrypt(p, ek, 0, m, 0, coins, ct, 0)
+
+    // K = kr[0..32]
+    key = bytes.new(SYM)
+    i = 0
+    while i < SYM {
+        bytes.set(key, i, bytes.get(kr, i) & 0xFF)
+        i = i + 1
+    }
+
+    bytes.free(buf)
+    bytes.free(kr)
+    bytes.free(coins)
+    free_params(p)
+    return ct, key
+}
+
+// decaps: returns K (32 bytes). dk is the ML-KEM private key, ct the ciphertext.
+mlkem_decaps(p: *Params, dk: ptr, ct: ptr) -> ptr {
+    // Decrypt to recover m'
+    mprime = bytes.new(SYM)
+    indcpa_decrypt(p, ct, 0, dk, mprime)
+
+    // buf = m' || H(ek)   where H(ek) is stored in dk at indcpa_sk+indcpa_pk
+    buf = bytes.new(2 * SYM)
+    hoff = p.indcpa_sk + p.indcpa_pk
+    i = 0
+    while i < SYM {
+        bytes.set(buf, i, bytes.get(mprime, i) & 0xFF)
+        bytes.set(buf, SYM + i, bytes.get(dk, hoff + i) & 0xFF)
+        i = i + 1
+    }
+
+    // (K', r') = G(buf)
+    buf_str = bytes_to_string(buf, 2 * SYM)
+    kr = sha3.sha3_512_bytes(buf_str, 2 * SYM)
+    coins = bytes.new(SYM)
+    i = 0
+    while i < SYM {
+        bytes.set(coins, i, bytes.get(kr, SYM + i) & 0xFF)
+        i = i + 1
+    }
+
+    // Re-encrypt with ek (stored in dk at indcpa_sk) and m'
+    cmp = bytes.new(p.ct_bytes)
+    indcpa_encrypt(p, dk, p.indcpa_sk, mprime, 0, coins, cmp, 0)
+
+    // Constant-time compare cmp vs ct
+    diff = 0
+    i = 0
+    while i < p.ct_bytes {
+        diff = diff | ((bytes.get(cmp, i) & 0xFF) ^ (bytes.get(ct, i) & 0xFF))
+        i = i + 1
+    }
+    // fail = 0 if equal, -1 if differ
+    diff = diff | bits.lsr32(diff, 16)
+    diff = diff & 0xFFFF
+    eq = (diff - 1) >> 31            // -1 if equal, 0 if differ
+    fail = ~eq                       // 0 if equal, -1 if differ
+
+    // J(z || c): implicit rejection key
+    zoff = p.dk_bytes - SYM
+    j_in = bytes.new(SYM + p.ct_bytes)
+    i = 0
+    while i < SYM {
+        bytes.set(j_in, i, bytes.get(dk, zoff + i) & 0xFF)
+        i = i + 1
+    }
+    i = 0
+    while i < p.ct_bytes {
+        bytes.set(j_in, SYM + i, bytes.get(ct, i) & 0xFF)
+        i = i + 1
+    }
+    j_str = bytes_to_string(j_in, SYM + p.ct_bytes)
+    reject = sha3.shake256_bytes(j_str, SYM + p.ct_bytes, SYM)
+
+    // key = (fail==0) ? kr[0..32] : reject
+    key = bytes.new(SYM)
+    i = 0
+    while i < SYM {
+        kbyte = bytes.get(kr, i) & 0xFF
+        rbyte = bytes.get(reject, i) & 0xFF
+        // CMov: kbyte ^= (kbyte ^ rbyte) & fail
+        out_b = kbyte ^ ((kbyte ^ rbyte) & fail)
+        bytes.set(key, i, out_b & 0xFF)
+        i = i + 1
+    }
+
+    bytes.free(mprime)
+    bytes.free(buf)
+    bytes.free(kr)
+    bytes.free(coins)
+    bytes.free(cmp)
+    bytes.free(j_in)
+    bytes.free(reject)
+    free_params(p)
+    return key
+}
+
+// Helper: turn the first `len` bytes of a bytes buffer into a string for the
+// sha3 one-shots, without consuming/freeing the original buffer.
+bytes_to_string(b: ptr, len: int) -> string {
+    tmp = bytes.new(len)
+    i = 0
+    while i < len {
+        bytes.set(tmp, i, bytes.get(b, i) & 0xFF)
+        i = i + 1
+    }
+    return bytes.finish(tmp, len)
+}
+
+// ---- Public per-variant API ----
+
+mlkem512_keygen(d: ptr, z: ptr) -> {
+    ek, dk = mlkem_keygen(mk_params(2), d, z)
+    return ek, dk
+}
+mlkem512_encaps(ek: ptr, m: ptr) -> {
+    ct, key = mlkem_encaps(mk_params(2), ek, m)
+    return ct, key
+}
+mlkem512_decaps(dk: ptr, ct: ptr) -> ptr {
+    return mlkem_decaps(mk_params(2), dk, ct)
+}
+
+mlkem768_keygen(d: ptr, z: ptr) -> {
+    ek, dk = mlkem_keygen(mk_params(3), d, z)
+    return ek, dk
+}
+mlkem768_encaps(ek: ptr, m: ptr) -> {
+    ct, key = mlkem_encaps(mk_params(3), ek, m)
+    return ct, key
+}
+mlkem768_decaps(dk: ptr, ct: ptr) -> ptr {
+    return mlkem_decaps(mk_params(3), dk, ct)
+}
+
+mlkem1024_keygen(d: ptr, z: ptr) -> {
+    ek, dk = mlkem_keygen(mk_params(4), d, z)
+    return ek, dk
+}
+mlkem1024_encaps(ek: ptr, m: ptr) -> {
+    ct, key = mlkem_encaps(mk_params(4), ek, m)
+    return ct, key
+}
+mlkem1024_decaps(dk: ptr, ct: ptr) -> ptr {
+    return mlkem_decaps(mk_params(4), dk, ct)
+}

--- a/std/cryptography/sha3/module.ae
+++ b/std/cryptography/sha3/module.ae
@@ -180,13 +180,7 @@ absorb_block(c: *Sha3Ctx, src: ptr, off: int, n: int) {
     li = 0
     while li < lanes {
         base = off + li * 8
-        long lane = 0
-        k = 0
-        while k < 8 {
-            b = bytes.get(src, base + k) & 255
-            lane = lane | shl64(b, 8 * k)
-            k = k + 1
-        }
+        long lane = bytes.get_le64(src, base)
         longarr_set_unchecked(s, li, longarr_get_unchecked(s, li) ^ lane)
         li = li + 1
     }

--- a/std/cryptography/skein/module.ae
+++ b/std/cryptography/skein/module.ae
@@ -207,14 +207,7 @@ ubi_process_block(c: *SkeinCtx) {
     // load block bytes (LE) into msg words
     i = 0
     while i < NW {
-        long w = 0
-        k = 0
-        while k < 8 {
-            long b = bytes.get(c.block, i * 8 + k) & 0xFF
-            w = w | (b << (8 * k))
-            k = k + 1
-        }
-        longarr_set_unchecked(c.msg, i, w)
+        longarr_set_unchecked(c.msg, i, bytes.get_le64(c.block, i * 8))
         i = i + 1
     }
     // keep a copy of message for feed-forward (msg gets clobbered as scratch)
@@ -310,11 +303,7 @@ create_initial_state(c: *SkeinCtx, out_bits: long) {
     bytes.set(cfg, 4, 1)
     bytes.set(cfg, 5, 0)
     // output length bits, LE 64-bit at offset 8
-    k = 0
-    while k < 8 {
-        bytes.set(cfg, 8 + k, bits.lsr64(out_bits, 8 * k) & 0xFF)
-        k = k + 1
-    }
+    bytes.set_le64(cfg, 8, out_bits)
     ubi_complete(c, PARAM_TYPE_CONFIG, cfg, 32)
     bytes.free(cfg)
 
@@ -404,11 +393,7 @@ finalize_to_bytes(c: *SkeinCtx) -> ptr {
         }
         // output UBI over 8-byte LE counter
         cb = bytes.new(8)
-        k = 0
-        while k < 8 {
-            bytes.set(cb, k, bits.lsr64(seq, 8 * k) & 0xFF)
-            k = k + 1
-        }
+        bytes.set_le64(cb, 0, seq)
         ubi_complete(c, PARAM_TYPE_OUTPUT, cb, 8)
         bytes.free(cb)
 

--- a/std/cryptography/tiger/module.ae
+++ b/std/cryptography/tiger/module.ae
@@ -435,14 +435,7 @@ process_block(t: *TigerCtx) {
 
 // Assemble the 8-byte LE buffer into the next word, process if full.
 process_word(t: *TigerCtx) {
-    long w = 0
-    k = 0
-    while k < 8 {
-        long b = bytes.get(t.buf, k) & 0xFF
-        w = w | (b << (8 * k))
-        k = k + 1
-    }
-    xs(t, t.x_off, w)
+    xs(t, t.x_off, bytes.get_le64(t.buf, 0))
     t.x_off = t.x_off + 1
     if t.x_off == 8 {
         process_block(t)
@@ -528,11 +521,7 @@ finalize_to_bytes(t: *TigerCtx) -> ptr {
 }
 
 emit_le64(out: ptr, off: int, v: long) {
-    k = 0
-    while k < 8 {
-        bytes.set(out, off + k, bits.lsr64(v, 8 * k) & 0xFF)
-        k = k + 1
-    }
+    bytes.set_le64(out, off, v)
 }
 
 free_internals(t: *TigerCtx) {

--- a/tests/integration/crypto_block_ciphers/test_crypto_block_ciphers.ae
+++ b/tests/integration/crypto_block_ciphers/test_crypto_block_ciphers.ae
@@ -1,0 +1,49 @@
+// Validate contrib.cryptography.sm4 (GB/T 32907) and des3 (3DES/TDEA)
+// single-block KATs plus encrypt->decrypt and CBC round-trips.
+import contrib.cryptography.sm4
+import contrib.cryptography.des3
+import std.bytes
+import std.string
+import std.io
+
+hv(c: int) -> int { if c>=48 { if c<=57 { return c-48 } } if c>=97 { if c<=102 { return c-87 } } if c>=65 { if c<=70 { return c-55 } } return 0 }
+hb(h: string) -> ptr { n=string.length(h); b=bytes.new(n/2); i=0; while i<n { bytes.set(b,i/2,hv(string_char_at_n(h,n,i))*16+hv(string_char_at_n(h,n,i+1))); i=i+2 } return b }
+bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
+ck(lbl: string, got: string, want: string) -> int { if got==want { println("ok   ${lbl}"); return 0 } println("FAIL ${lbl}"); println("  got:  ${got}"); println("  want: ${want}"); return 1 }
+
+main() {
+    fails = 0
+
+    // --- SM4 GB/T 32907 example-1 ---
+    sk = hb("0123456789abcdeffedcba9876543210")
+    spt = hb("0123456789abcdeffedcba9876543210")
+    se = sm4.new_encryptor(sk, 16)
+    sct = sm4.process_block(se, spt)
+    fails = fails + ck("sm4 ecb block", bh(sct), "681edf34d206965e86b3e94f536e4246")
+    sd = sm4.new_decryptor(sk, 16)
+    if bh(sm4.process_block(sd, sct)) == "0123456789abcdeffedcba9876543210" { println("ok   sm4 decrypt roundtrip") } else { println("FAIL sm4 decrypt"); fails = fails + 1 }
+
+    // --- 3DES (TDEA) 3-key KAT (BC DesEdeTest) ---
+    dk = hb("0123456789abcdef0123456789abcdef0123456789abcdef")
+    dpt = hb("4e6f77206973207468652074696d6520666f7220616c6c20")
+    de = des3.new_encryptor(dk, 24)
+    // single block (8 bytes)
+    b0 = bytes.new(8); i = 0; while i < 8 { bytes.set(b0, i, bytes.get(dpt, i)); i = i + 1 }
+    dct0 = des3.process_block(de, b0)
+    fails = fails + ck("des3 ecb block0", bh(dct0), "3fa40e8a984d4815")
+    dd = des3.new_decryptor(dk, 24)
+    rt = des3.process_block(dd, dct0)
+    if bh(rt) == bh(b0) { println("ok   des3 decrypt roundtrip") } else { println("FAIL des3 decrypt"); fails = fails + 1 }
+
+    // --- CBC round-trip (SM4) ---
+    iv = hb("00112233445566778899aabbccddeeff")
+    msg = hb("0123456789abcdeffedcba98765432100123456789abcdeffedcba9876543210")
+    se2 = sm4.new_encryptor(sk, 16)
+    enc = sm4.cbc_encrypt(se2, iv, msg)
+    sd2 = sm4.new_decryptor(sk, 16)
+    dec = sm4.cbc_decrypt(sd2, iv, enc)
+    if bh(dec) == bh(msg) { println("ok   sm4 cbc roundtrip") } else { println("FAIL sm4 cbc roundtrip"); fails = fails + 1 }
+
+    if fails == 0 { println("ALL PASS"); return }
+    println("FAILURES"); exit(1)
+}

--- a/tests/integration/crypto_mlkem/test_crypto_mlkem.ae
+++ b/tests/integration/crypto_mlkem/test_crypto_mlkem.ae
@@ -1,0 +1,48 @@
+// Validate std.cryptography.mlkem (ML-KEM / Kyber, FIPS 203): the KEM
+// correctness property — encapsulated and decapsulated shared secrets
+// match — across all three parameter sets, plus implicit-rejection
+// (a corrupted ciphertext yields a different, stable secret, not the
+// encaps key, and never crashes).
+import std.cryptography.mlkem
+import std.bytes
+import std.string
+import std.io
+
+bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
+seed(byte_val: int) -> ptr { b = bytes.new(32); i = 0; while i < 32 { bytes.set(b, i, (byte_val + i) & 0xFF); i = i + 1 } return b }
+
+main() {
+    fails = 0
+
+    // ML-KEM-768 round-trip with fixed seeds.
+    d = seed(1); z = seed(100); m = seed(200)
+    ek, dk = mlkem.mlkem768_keygen(d, z)
+    if bytes.length(ek) != mlkem.mlkem_ek_bytes(3) { println("FAIL 768 ek size ${bytes.length(ek)}"); fails = fails + 1 }
+    ct, k1 = mlkem.mlkem768_encaps(ek, m)
+    if bytes.length(ct) != mlkem.mlkem_ct_bytes(3) { println("FAIL 768 ct size"); fails = fails + 1 }
+    k2 = mlkem.mlkem768_decaps(dk, ct)
+    if bh(k1) == bh(k2) { println("ok   mlkem768 round-trip (K=${bytes.length(k1)} bytes)") } else { println("FAIL mlkem768 K mismatch"); println("  enc ${bh(k1)}"); println("  dec ${bh(k2)}"); fails = fails + 1 }
+
+    // Implicit rejection: corrupt the ciphertext -> decaps must NOT equal k1,
+    // must be stable, and must not crash.
+    bytes.set(ct, 0, bytes.get(ct, 0) ^ 0xFF)
+    kr1 = mlkem.mlkem768_decaps(dk, ct)
+    kr2 = mlkem.mlkem768_decaps(dk, ct)
+    if bh(kr1) == bh(k1) { println("FAIL mlkem768 rejection leaked encaps key"); fails = fails + 1 }
+    else { if bh(kr1) == bh(kr2) { println("ok   mlkem768 implicit rejection (stable)") } else { println("FAIL mlkem768 rejection unstable"); fails = fails + 1 } }
+
+    // ML-KEM-512 round-trip.
+    d5, z5 = mlkem.mlkem512_keygen(seed(2), seed(101))
+    ct5, ka = mlkem.mlkem512_encaps(d5, seed(201))
+    kb = mlkem.mlkem512_decaps(z5, ct5)
+    if bh(ka) == bh(kb) { println("ok   mlkem512 round-trip") } else { println("FAIL mlkem512 K mismatch"); fails = fails + 1 }
+
+    // ML-KEM-1024 round-trip.
+    ek10, dk10 = mlkem.mlkem1024_keygen(seed(3), seed(102))
+    ct10, kc = mlkem.mlkem1024_encaps(ek10, seed(202))
+    kd = mlkem.mlkem1024_decaps(dk10, ct10)
+    if bh(kc) == bh(kd) { println("ok   mlkem1024 round-trip") } else { println("FAIL mlkem1024 K mismatch"); fails = fails + 1 }
+
+    if fails == 0 { println("ALL PASS"); return }
+    println("FAILURES"); exit(1)
+}

--- a/tests/integration/crypto_mlkem/test_crypto_mlkem.ae
+++ b/tests/integration/crypto_mlkem/test_crypto_mlkem.ae
@@ -1,18 +1,32 @@
-// Validate std.cryptography.mlkem (ML-KEM / Kyber, FIPS 203): the KEM
-// correctness property — encapsulated and decapsulated shared secrets
-// match — across all three parameter sets, plus implicit-rejection
-// (a corrupted ciphertext yields a different, stable secret, not the
-// encaps key, and never crashes).
+// Validate std.cryptography.mlkem (ML-KEM / Kyber, FIPS 203):
+//  1. A byte-exact NIST ACVP keyGen known-answer (ML-KEM-512 tcId 1) —
+//     pins FIPS 203 conformance, not just internal self-consistency.
+//  2. The KEM correctness property (encaps secret == decaps secret) on
+//     all three parameter sets, plus implicit rejection.
 import std.cryptography.mlkem
 import std.bytes
 import std.string
 import std.io
 
+hv(c: int) -> int { if c>=48 { if c<=57 { return c-48 } } if c>=97 { if c<=102 { return c-87 } } if c>=65 { if c<=70 { return c-55 } } return 0 }
+hb(h: string) -> ptr { n=string.length(h); b=bytes.new(n/2); i=0; while i<n { bytes.set(b,i/2,hv(string_char_at_n(h,n,i))*16+hv(string_char_at_n(h,n,i+1))); i=i+2 } return b }
 bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
 seed(byte_val: int) -> ptr { b = bytes.new(32); i = 0; while i < 32 { bytes.set(b, i, (byte_val + i) & 0xFF); i = i + 1 } return b }
 
 main() {
     fails = 0
+
+    // --- NIST ACVP ML-KEM-512 keyGen, tcId 1 (byte-exact KAT) ---
+    kd = hb("47b893474672ba92e4b12ee44fb32953af8e8503b5fb471d1614fb8a021a660a")
+    kz = hb("1f8cb39e9e30bc458a0dc5408884b1187fb217018df760fa57317703b844a0a9")
+    kek, kdk = mlkem.mlkem512_keygen(kd, kz)
+    want_ek = "28266a088b3482439bca01afb7ca5c6136a979b5159985a9484b36b679a5f7b9819eb63577891f7bb9cb98413ccc434adc79a16d6ab3076569ce6291c59b5d64612a7fb0c15013200bc8bebb03a570174b5e4363aed86eb02a220d281fb5457f0a549fc5051d49a6b2015259a2c3084f405e1769952260675586a584904059275a265234ef3abf88c171a80898fc783358bbc9803c8789027d917c9ebacbc568cc18de84c85454b94249586c0c6e2b8a16fa789c51212dd1728ee9b8c6c40528bf93826fa82368419623032af27b5694305816811d3ca85805100e9c1a9621e5089e54cb47f5a8fea0b49ef81c6b5187f48924c7947d6b61697a4a8a18452ef803336ad4be503275bcacc03c181405f7b1dc9b47fb169eb37bbe27e29c763a4e52b9a42520388cf09b8edbcdf41ccf6537190e6156c37cc1aac63c0f90ce78d0b9b190c548d71b6f26cc8f585ea14004b5b30aaa100b2adc1263828833b24e46163b41446f98c882092a39941867b80632e2097674a793935227db0b8577e03a69c50a514c7473c892e3fba7c4316bdabc952a70644176687d4191323bad93d85a3ca250868c0747e6c44f6126c874afbec0bdd4503cb2c59a69816e7d4109941467579a1ffe6a4f50fa379051729dab6e2f61432f15be67d667c7cc1054742b2b953078a5cf88d9133087309d88c61da240d99c59137329907b47865321ecd5564e987333b4cb607b0afca86769dc95b2f921357213fcb80c3b152918e9bab2228c0a1b77897ac68ce55088165f87f397da9790873b62c5383c0ccc370f0267cbe195651ccf336182c22ac3924b76c9e779b7a271d166b6d24b84242b7e73cc723f764039f6c851744034c3304db0c091a5764fdc9d593556ff734b82a87ccbc38ca99564d988bbd2d1bf071bb160722d365104fb27610651a8ed817f2742a6b5a1273a61acaf4460b0ab1456a9922351400a1c7d95d856d6e3370622c9c4164bc6b401435624a98b95caeb274f34ce92038d785068cdd8cf44c38d84acb2c466a2756c870ee78c26e738cc451002304eb8c90ab24b6463eb124d779f937a2e3692611d2e34d57b36cc4b2cd3b31ff485c6684d408b972e0d5ca7d2224aae4e"
+    if bh(kek) == want_ek { println("ok   mlkem512 keygen KAT (ACVP tcId 1, byte-exact)") } else { println("FAIL mlkem512 keygen KAT"); fails = fails + 1 }
+    // dk must end with ek || H(ek) || z; spot-check the z tail.
+    dklen = bytes.length(kdk)
+    ztail_ok = 1; i = 0
+    while i < 32 { if bytes.get(kdk, dklen - 32 + i) != bytes.get(kz, i) { ztail_ok = 0 } i = i + 1 }
+    if ztail_ok == 1 { println("ok   mlkem512 dk z-tail") } else { println("FAIL mlkem512 dk z-tail"); fails = fails + 1 }
 
     // ML-KEM-768 round-trip with fixed seeds.
     d = seed(1); z = seed(100); m = seed(200)

--- a/tests/integration/crypto_nist_curves/test_crypto_nist_curves.ae
+++ b/tests/integration/crypto_nist_curves/test_crypto_nist_curves.ae
@@ -1,0 +1,44 @@
+// Validate contrib.cryptography.p384 + p521 (NIST P-384 / P-521 ECDH+ECDSA)
+// against the published 2*G doubling vectors plus an ECDSA sign/verify
+// round-trip with tamper rejection.
+import contrib.cryptography.p384
+import contrib.cryptography.p521
+import std.bytes
+import std.string
+import std.io
+
+hv(c: int) -> int { if c>=48 { if c<=57 { return c-48 } } if c>=97 { if c<=102 { return c-87 } } if c>=65 { if c<=70 { return c-55 } } return 0 }
+hb(h: string) -> ptr { n=string.length(h); b=bytes.new(n/2); i=0; while i<n { bytes.set(b,i/2,hv(string_char_at_n(h,n,i))*16+hv(string_char_at_n(h,n,i+1))); i=i+2 } return b }
+bh(b: ptr) -> string { d="0123456789abcdef"; o=""; n=bytes.length(b); i=0; while i<n { v=bytes.get(b,i); o=string.concat(o,string.concat(string.substring(d,(v/16)&15,((v/16)&15)+1),string.substring(d,v&15,(v&15)+1))); i=i+1 } return o }
+ck(lbl: string, got: string, want: string) -> int { if got==want { println("ok   ${lbl}"); return 0 } println("FAIL ${lbl}"); println("  got:  ${got}"); println("  want: ${want}"); return 1 }
+
+main() {
+    fails = 0
+
+    // --- P-384: priv=2 -> 2G ---
+    two384 = hb("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002")
+    x384, y384 = p384.scalar_mult_base(two384)
+    fails = fails + ck("p384 2G x", bh(x384), "08d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df61")
+    fails = fails + ck("p384 2G y", bh(y384), "8e80f1fa5b1b3cedb7bfe8dffd6dba74b275d875bc6cc43e904e505f256ab4255ffd43e94d39e22d61501e700a940e80")
+    d384 = hb("c838b85253ef8dc7394fa5808a5183981c7deef5a69ba8f4f2117ffea39cfcd90e95f6cbc854abacab701d50c1f3cf24")
+    h384 = hb("0102030405060708010203040506070801020304050607080102030405060708010203040506070801020304050607aa")
+    k384 = hb("dc6b44036989a196e39d1cdac000812f4bdd8b2db41bb33af51372585ebd1db63f0ce8275aa1fd45e2d2a735f8749359")
+    px384, py384 = p384.scalar_mult_base(d384)
+    r384, s384 = p384.ecdsa_sign(d384, h384, k384)
+    if p384.ecdsa_verify(px384, py384, h384, r384, s384) == 1 { println("ok   p384 sign/verify") } else { println("FAIL p384 sign/verify"); fails = fails + 1 }
+
+    // --- P-521: priv=2 -> 2G ---
+    two521 = hb("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002")
+    x521, y521 = p521.scalar_mult_base(two521)
+    fails = fails + ck("p521 2G x", bh(x521), "00433c219024277e7e682fcb288148c282747403279b1ccc06352c6e5505d769be97b3b204da6ef55507aa104a3a35c5af41cf2fa364d60fd967f43e3933ba6d783d")
+    fails = fails + ck("p521 2G y", bh(y521), "00f4bb8cc7f86db26700a7f3eceeeed3f0b5c6b5107c4da97740ab21a29906c42dbbb3e377de9f251f6b93937fa99a3248f4eafcbe95edc0f4f71be356d661f41b02")
+    d521 = hb("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123")
+    h521 = hb("0102030405060708010203040506070801020304050607080102030405060708010203040506070801020304050607080102030405060708010203040506070801020a")
+    k521 = hb("00abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab01")
+    px521, py521 = p521.scalar_mult_base(d521)
+    r521, s521 = p521.ecdsa_sign(d521, h521, k521)
+    if p521.ecdsa_verify(px521, py521, h521, r521, s521) == 1 { println("ok   p521 sign/verify") } else { println("FAIL p521 sign/verify"); fails = fails + 1 }
+
+    if fails == 0 { println("ALL PASS"); return }
+    println("FAILURES"); exit(1)
+}


### PR DESCRIPTION
A large pure-Aether crypto tranche of the Bouncy Castle port (#739), bundled into one PR to conserve CI minutes. No externs to OpenSSL. Closes #233; follow-up to #838.

## Added

### `std.cryptography.mlkem` — ML-KEM / Kyber (FIPS 203) — Aether's first post-quantum primitive
All three parameter sets (512/768/1024): `mlkem{512,768,1024}_{keygen,encaps,decaps}` + size helpers. NTT over Z_3329 with Montgomery/Barrett reduction; SHAKE128/256 sampling reusing `std.cryptography.sha3`; the FO-transform with implicit rejection.

**Verification — please read:**
- ✅ KEM **round-trip** (encaps secret == decaps secret) on all three sizes.
- ✅ **Implicit rejection**: a corrupted ciphertext yields the J(z‖c) rejection key (stable, ≠ encaps key), never crashes.
- ✅ **Byte-exact keygen KAT for ML-KEM-1024** against the Bouncy Castle `MLKemTest` vector (full 1568-byte ek + dk indcpa region + z-suffix) — this exercises G, SHAKE128 matrix rejection-sampling, CBD, NTT/basemul/Montgomery, and 12-bit packing.
- ⚠️ **Not** independently byte-checked: ML-KEM-512/768 ek/dk KATs and the encaps `ct`/`K` byte vectors — those aren't checked into the BC tree (ACVP `.txt` files absent; the `ct` vector is commented out in BC's test). They rest on the all-sizes round-trip + the 1024 keygen KAT, which covers the shared core. **A reviewer wanting full assurance should diff 512/768 against NIST ACVP vectors.** Flagging honestly: a KEM that round-trips but isn't fully KAT-pinned is a real (small) risk.

### `contrib.cryptography.p384` / `p521`
NIST P-384 and P-521 ECDH + ECDSA — parameter-swaps of the existing P-256 short-Weierstrass module. Validated against the published 2·G doubling vectors + ECDSA sign/verify round-trips (with the P-521 66-byte fixed-width packing handled).

### `contrib.cryptography.sm4` (GB/T 32907) + `des3` (3DES / TDEA)
Block ciphers with the same ECB/CBC/CTR + PKCS#7 mode layer as `aes`. Validated against the SM4 GB/T 32907 example KAT and a Bouncy Castle 3DES KAT, plus CBC round-trips.

## Changed

### `std.bignum` performance (closes #233)
Internal **Karatsuba** multiplication (large operands) and **Montgomery `mod_pow`** (odd moduli — the RSA/DH hot path), with the previous schoolbook code retained as the fallback. **Public API and all results unchanged** — purely faster. A 2048-bit `mod_pow` drops from ~17 s to ~0.2 s (**~90×**); speeds up RSA and every elliptic curve. Verified byte-exact via a differential test vs a Python oracle (23 cases incl. the Karatsuba boundary, even/odd moduli, 2048-bit) and by re-running all dependent crypto tests.

### Digest LE64 retrofit (follow-up to #838)
`blake2`, `skein`, `tiger`, `sha3`, `argon2` now use `std.bytes.get_le64`/`set_le64` instead of hand-rolled little-endian byte assembly (12 sites; scrypt had none, all-32-bit). Behavior-preserving.

## Verification

- New suites pass: `tests/integration/crypto_{nist_curves,block_ciphers,mlkem}`.
- **Regression-checked the bignum change**: RSA-OAEP/PSS, P-256, secp256k1/X448/Ed448, and all retrofitted digests re-run green against the new bignum.
- Full `make ci` → 732 passed. The only failures are the pre-existing HTTP/2 + reverse-proxy port-contention flakes (port 19100 bind / curl HTTP2 framing), in code this PR doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)