### PR TITLE
fix(std.net): silence -Wunused-variable for _ae_pipe_read_fd on Windows

### DIFF
--- a/std/net/aether_actor_bridge.c
+++ b/std/net/aether_actor_bridge.c
@@ -84,7 +84,15 @@ void ae_io_cancel(int fd) {
 // ae_pipe_write_fd(). Single-pipe scope is sufficient for the one
 // caller that needs it (the await_io end-to-end test); production code
 // that needs multiple pipes should use its own syscall wrapper.
+/* `_ae_pipe_read_fd` is consumed only on the POSIX path (ae_pipe_open
+ * returns it directly), so guard it out on Windows — there's no pipe()
+ * and no read-fd accessor, and an always-declared static would warn as
+ * unused (-Wunused-variable). `_ae_pipe_write_fd` stays declared on every
+ * platform because ae_pipe_write_fd() reads it unconditionally (it just
+ * returns -1 on Windows). */
+#ifndef _WIN32
 static int _ae_pipe_read_fd = -1;
+#endif
 static int _ae_pipe_write_fd = -1;
 
 int ae_pipe_open(void) {


### PR DESCRIPTION
Cleans up the `-Wunused-variable` warning surfaced in the Windows (MINGW64) CI stdlib build:

```
std/net/aether_actor_bridge.c:87:12: warning: '_ae_pipe_read_fd' defined but not used [-Wunused-variable]
```

`_ae_pipe_read_fd` is assigned and returned only inside `ae_pipe_open`'s POSIX `#else` branch; on Windows `ae_pipe_open` returns `-1` without touching it and there's no read-fd accessor, so the always-declared file-scope static is genuinely unused there. Guarded its declaration with `#ifndef _WIN32` (exactly the platform where it's used). `_ae_pipe_write_fd` stays declared on all platforms because `ae_pipe_write_fd()` reads it unconditionally (returns `-1` on Windows).

Pre-existing (not -Werror-gated in the stdlib step, so it didn't fail CI — but it's noise). POSIX build unchanged; `-Werror` compiler build + stdlib build clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
