### PR TITLE
docs(crypto): document digest ctx ownership contract across all modules (#837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ renamed, so it drifts from the tags and can cause the next release's
 notes to be skipped or clobbered (the failure modes documented in
 `changelog-release-drift-note.md`).
 
+## [current]
+
+### Documentation
+
+- **Crypto digest context-ownership contract (#837) is now documented
+  consistently across every streaming hash module.** `final_hex` /
+  `final_bytes` free the context; `free_ctx` is only for abandoning a
+  context *before* finalizing — calling `free_ctx` after a successful
+  `final_*` is a double-free. Previously only `std.cryptography.sha2`
+  stated this. The rule is now on the `final_*` / `free_ctx` doc-comments
+  and in the header usage example of `sha3`, `sm3`, `blake2`,
+  `ripemd128` / `ripemd160` / `ripemd256` / `ripemd320`, `whirlpool`,
+  `tiger`, and `skein`, and the streaming examples that previously invited
+  the broken pattern now carry an explicit `ownership:` note. Comment-only;
+  no behavior change.
+
 ## [0.302.0]
 
 ### Changed

--- a/std/cryptography/blake2/module.ae
+++ b/std/cryptography/blake2/module.ae
@@ -20,6 +20,8 @@
 //   variable:   blake2b_hex_n(data, len, out_len)
 //   keyed:      blake2b_keyed_hex(data, len, key, key_len, out_len)
 //   streaming:  ctx = new_b(64); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care:
 //   * int/long are both 64-bit; `>>` is ARITHMETIC. BLAKE2s is 32-bit
@@ -487,6 +489,8 @@ free_internals(c: *Blake2Ctx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     c = ctx as *Blake2Ctx
     n = c.out_len
@@ -499,6 +503,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     c = ctx as *Blake2Ctx
     n = c.out_len
@@ -528,6 +534,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/ripemd128/module.ae
+++ b/std/cryptography/ripemd128/module.ae
@@ -14,6 +14,8 @@
 //
 //   one-shot:   ripemd128_hex(data, len) / ripemd128_bytes(data, len)
 //   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care matches std.cryptography.ripemd160: every 32-bit add
 // masked with & 0xFFFFFFFF; rotates are LEFT via std.bits.rotl32 on a
@@ -385,6 +387,8 @@ free_internals(c: *Rmd128Ctx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     c = ctx as *Rmd128Ctx
     out = finalize_to_bytes(c)
@@ -396,6 +400,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     c = ctx as *Rmd128Ctx
     out = finalize_to_bytes(c)
@@ -424,6 +430,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/ripemd160/module.ae
+++ b/std/cryptography/ripemd160/module.ae
@@ -16,6 +16,8 @@
 // Two shapes are exposed:
 //   one-shot:   ripemd160_hex(data, len) / ripemd160_bytes(data, len)
 //   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care (this is where digest bugs live):
 //   * RIPEMD works on 32-bit words but Aether int/long are wider, so every
@@ -481,6 +483,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/ripemd256/module.ae
+++ b/std/cryptography/ripemd256/module.ae
@@ -16,6 +16,8 @@
 // Import with:  import std.cryptography.ripemd256
 //   one-shot:   ripemd256_hex(data, len) / ripemd256_bytes(data, len)
 //   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Little-endian word load/store/length; 32-bit adds masked; left rotates.
 
@@ -399,6 +401,8 @@ free_internals(c: *Rmd256Ctx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     c = ctx as *Rmd256Ctx
     out = finalize_to_bytes(c)
@@ -410,6 +414,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     c = ctx as *Rmd256Ctx
     out = finalize_to_bytes(c)
@@ -438,6 +444,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/ripemd320/module.ae
+++ b/std/cryptography/ripemd320/module.ae
@@ -15,6 +15,8 @@
 // Import with:  import std.cryptography.ripemd320
 //   one-shot:   ripemd320_hex(data, len) / ripemd320_bytes(data, len)
 //   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Little-endian word load/store/length; 32-bit adds masked; left rotates.
 
@@ -434,6 +436,8 @@ free_internals(c: *Rmd320Ctx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     c = ctx as *Rmd320Ctx
     out = finalize_to_bytes(c)
@@ -445,6 +449,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     c = ctx as *Rmd320Ctx
     out = finalize_to_bytes(c)
@@ -473,6 +479,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/sha3/module.ae
+++ b/std/cryptography/sha3/module.ae
@@ -19,6 +19,8 @@
 //   streaming:      ctx,_ = new("sha3-256"); update(ctx, data, len)
 //                   final_hex(ctx, 0)        // out_len ignored for fixed
 //                   final_hex(ctx, out_len)  // out_len required for shake
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care:
 //   * Lanes are full 64-bit; a `long` holds an entire uint64 lane.
@@ -383,6 +385,9 @@ free_internals(c: *Sha3Ctx) {
     }
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return
@@ -394,6 +399,7 @@ free_ctx(ctx: ptr) {
 
 // `out_len` is ignored for fixed digests (uses the variant's length) and
 // required (>0) for SHAKE.
+// FREES the ctx; do NOT call free_ctx after a successful finalize.
 final_bytes(ctx: ptr, out_len: int) -> ptr {
     c = ctx as *Sha3Ctx
     n = c.out_len
@@ -410,6 +416,8 @@ final_bytes(ctx: ptr, out_len: int) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr, out_len: int) -> string {
     c = ctx as *Sha3Ctx
     n = c.out_len

--- a/std/cryptography/skein/module.ae
+++ b/std/cryptography/skein/module.ae
@@ -19,6 +19,8 @@
 //   one-shot:   skein512_hex(data, len)  / skein512_bytes(data, len)   -> 64 bytes
 //   sized:      skein512_n_hex(data, len, out_bytes) / ..._bytes(...)
 //   streaming:  ctx,_ = new(out_bits); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care:
 //   * Words are full 64-bit `long`; Threefish add/sub wrap in two's complement.
@@ -466,6 +468,8 @@ free_internals(c: *SkeinCtx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     c = ctx as *SkeinCtx
     n = c.out_bytes
@@ -478,6 +482,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     c = ctx as *SkeinCtx
     n = c.out_bytes
@@ -507,6 +513,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/sm3/module.ae
+++ b/std/cryptography/sm3/module.ae
@@ -14,6 +14,8 @@
 //
 //   one-shot:   sm3_hex(data, len) / sm3_bytes(data, len)
 //   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care:
 //   * 32-bit words, so every add is masked with & 0xFFFFFFFF (m32).
@@ -316,6 +318,8 @@ free_internals(c: *Sm3Ctx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     c = ctx as *Sm3Ctx
     out = finalize_to_bytes(c)
@@ -327,6 +331,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     c = ctx as *Sm3Ctx
     out = finalize_to_bytes(c)
@@ -355,6 +361,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/tiger/module.ae
+++ b/std/cryptography/tiger/module.ae
@@ -17,6 +17,8 @@
 //
 //   one-shot:   tiger_hex(data, len) / tiger_bytes(data, len)
 //   streaming:  ctx,_ = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care:
 //   * Words are full 64-bit; a `long` holds an entire uint64 word.
@@ -544,6 +546,8 @@ free_internals(t: *TigerCtx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     t = ctx as *TigerCtx
     out = finalize_to_bytes(t)
@@ -555,6 +559,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     t = ctx as *TigerCtx
     out = finalize_to_bytes(t)
@@ -583,6 +589,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return

--- a/std/cryptography/whirlpool/module.ae
+++ b/std/cryptography/whirlpool/module.ae
@@ -20,6 +20,8 @@
 //
 //   one-shot:   whirlpool_hex(data, len) / whirlpool_bytes(data, len)
 //   streaming:  ctx,_ = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
 //
 // Aether-specific care:
 //   * Lanes are full 64-bit; a `long` holds an entire uint64 lane.
@@ -405,6 +407,8 @@ free_internals(c: *WpCtx) {
     }
 }
 
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
 final_bytes(ctx: ptr) -> ptr {
     c = ctx as *WpCtx
     out = finalize_to_bytes(c)
@@ -416,6 +420,8 @@ final_bytes(ctx: ptr) -> ptr {
     return res
 }
 
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
 final_hex(ctx: ptr) -> string {
     c = ctx as *WpCtx
     out = finalize_to_bytes(c)
@@ -444,6 +450,9 @@ final_hex(ctx: ptr) -> string {
     return s
 }
 
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
 free_ctx(ctx: ptr) {
     if ctx == null {
         return


### PR DESCRIPTION
## Summary

Fixes #837 — the `std.cryptography` streaming digest modules document their context-ownership contract inconsistently, which invites a double-free.

The contract (correct and intentional, per the issue): `final_hex` / `final_bytes` **free the context** internally; `free_ctx` is **only** for abandoning a context *before* finalizing. So `new → update → final_* → free_ctx` is a double-free. Only `std.cryptography.sha2` documented this; the other ten modules left it implicit, and their header `streaming:` examples showed `final_*` with no note that it frees and no warning against a following `free_ctx`.

This PR makes the contract **explicit and consistent** across all modules — a comment-only change, no behavior change.

## What changed

For `sha3`, `sm3`, `blake2`, `ripemd128` / `ripemd160` / `ripemd256` / `ripemd320`, `whirlpool`, `tiger`, `skein`:

- Doc-comments on `final_bytes` / `final_hex` now state **"FREES the ctx; do NOT call `free_ctx` after a successful finalize (double-free)."**
- A doc-comment on `free_ctx` states it is the **abandon-without-finalizing** bail-out path, NULL-safe, and that `final_*` already frees the ctx.
- The header usage block gains an explicit `ownership:` note next to the `streaming:` example.

`ripemd160` already documented "FREES the ctx" on its finalizers (left as-is); it only needed the `free_ctx` doc + header note. `sha2` was already complete and is the model this matches.

## Why documentation rather than a behavior change

The ownership rule itself is intentional and matches `sha2`. Changing `final_*` to *not* free the ctx would be a public-API behavior change and would break in-flight consumers of these digests (e.g. the open ML-KEM/curves work, which uses SHAKE) by leaking every finalized context. The reported defect is the missing/inconsistent documentation, so that is what this fixes.

## Verification

- `make compiler ae stdlib` — clean, zero warnings.
- Comment-only: 101 insertions, **zero deletions, zero non-comment changes** (the `.ae` lexer strips comments, so no behavior change is possible).
- Existing crypto integration tests pass: `crypto_classic_hashes` (whirlpool/tiger/skein), `crypto_sm3`, `crypto_ripemd160`.
- Smoke covering the documented paths: one-shot vectors for ripemd128/256/320 + blake2b + sha3-256; streaming `final_hex` equals the one-shot digest (confirms it frees + returns the correct value); and the abandon path (`new → update → free_ctx` without finalizing) runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)