### PR TITLE
docs(api): generate stdlib API docs from .ae exports, not C headers

### DIFF
--- a/docs/api/actors.html
+++ b/docs/api/actors.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>actors - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search actors..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_actor_register">aether_actor_register</a></li>
+    <li><a href="#aether_actor_whereis">aether_actor_whereis</a></li>
+    <li><a href="#aether_actor_unregister">aether_actor_unregister</a></li>
+    <li><a href="#aether_actor_is_registered">aether_actor_is_registered</a></li>
+    <li><a href="#aether_actor_registry_size">aether_actor_registry_size</a></li>
+    <li><a href="#aether_actor_registry_clear">aether_actor_registry_clear</a></li>
+    <li><a href="#register">register</a></li>
+    <li><a href="#whereis">whereis</a></li>
+    <li><a href="#unregister">unregister</a></li>
+    <li><a href="#is_registered">is_registered</a></li>
+    <li><a href="#registry_size">registry_size</a></li>
+    <li><a href="#registry_clear">registry_clear</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li class="active"><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>actors</h1>
+    <p class="module-desc">std.actors — process-global name → actor_ref registry.</p>
+    <p class="import-line"><code>import std.actors</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_actor_register" data-name="aether_actor_register">
+      <h3 class="function-name">aether_actor_register <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_actor_register(name, ref)</code></pre>
+      <p class="signature"><span class="sig-params">name: string, ref: actor_ref</span></p>
+      <p class="doc">---- Raw externs ---- `actor_ref` lowers to `void*` at the C level, so the registry's `void* ref` slot accepts and returns the same shape Aether code passes / receives.</p>
+    </div>
+    <div class="function" id="aether_actor_whereis" data-name="aether_actor_whereis">
+      <h3 class="function-name">aether_actor_whereis <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_actor_whereis(name) <span class="arrow">-&gt;</span> actor_ref</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+    </div>
+    <div class="function" id="aether_actor_unregister" data-name="aether_actor_unregister">
+      <h3 class="function-name">aether_actor_unregister <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_actor_unregister(name) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+    </div>
+    <div class="function" id="aether_actor_is_registered" data-name="aether_actor_is_registered">
+      <h3 class="function-name">aether_actor_is_registered <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_actor_is_registered(name) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+    </div>
+    <div class="function" id="aether_actor_registry_size" data-name="aether_actor_registry_size">
+      <h3 class="function-name">aether_actor_registry_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_actor_registry_size() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="aether_actor_registry_clear" data-name="aether_actor_registry_clear">
+      <h3 class="function-name">aether_actor_registry_clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_actor_registry_clear()</code></pre>
+    </div>
+    <div class="function" id="register" data-name="register">
+      <h3 class="function-name">register <span class="kind">fn</span></h3>
+      <pre class="usage"><code>register(name, ref)</code></pre>
+      <p class="signature"><span class="sig-params">name: string, ref: actor_ref</span></p>
+      <p class="doc">Bind `name` → `ref`. Overwrites any prior binding of the same name (no error). The name is duplicated internally; the actor_ref is stored as-is.</p>
+    </div>
+    <div class="function" id="whereis" data-name="whereis">
+      <h3 class="function-name">whereis <span class="kind">fn</span></h3>
+      <pre class="usage"><code>whereis(name) <span class="arrow">-&gt;</span> actor_ref</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">Look up by name. Returns the registered actor_ref, or null (when cast to actor_ref) if no binding exists. Pattern: spawn at startup, register with a stable name, look up from any context (including from inside C-callback handlers that can't take an Aether-typed parameter).</p>
+    </div>
+    <div class="function" id="unregister" data-name="unregister">
+      <h3 class="function-name">unregister <span class="kind">fn</span></h3>
+      <pre class="usage"><code>unregister(name) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">Remove a binding. Returns 1 if a binding was removed, 0 if `name` wasn't registered.</p>
+    </div>
+    <div class="function" id="is_registered" data-name="is_registered">
+      <h3 class="function-name">is_registered <span class="kind">fn</span></h3>
+      <pre class="usage"><code>is_registered(name) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">1 if `name` is bound, 0 otherwise.</p>
+    </div>
+    <div class="function" id="registry_size" data-name="registry_size">
+      <h3 class="function-name">registry_size <span class="kind">fn</span></h3>
+      <pre class="usage"><code>registry_size() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Number of currently-registered names. Mostly for tests / debug.</p>
+    </div>
+    <div class="function" id="registry_clear" data-name="registry_clear">
+      <h3 class="function-name">registry_clear <span class="kind">fn</span></h3>
+      <pre class="usage"><code>registry_clear()</code></pre>
+      <p class="doc">Wipe all bindings. Tests use this for isolation.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/arena.html
+++ b/docs/api/arena.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>arena - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search arena..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#create">create</a></li>
+    <li><a href="#alloc">alloc</a></li>
+    <li><a href="#alloc_aligned">alloc_aligned</a></li>
+    <li><a href="#reset">reset</a></li>
+    <li><a href="#destroy">destroy</a></li>
+    <li><a href="#get_used">get_used</a></li>
+    <li><a href="#get_size">get_size</a></li>
+    <li><a href="#used">used</a></li>
+    <li><a href="#size">size</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li class="active"><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>arena</h1>
+    <p class="module-desc">std.arena - Arena (bulk) allocator An arena owns a growable block of memory that it hands out via arena.alloc().</p>
+    <p class="import-line"><code>import std.arena</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="create" data-name="create">
+      <h3 class="function-name">create <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create(size) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">C-style externs (the escape hatch).</p>
+    </div>
+    <div class="function" id="alloc" data-name="alloc">
+      <h3 class="function-name">alloc <span class="kind">extern</span></h3>
+      <pre class="usage"><code>alloc(arena, bytes) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr, bytes: int</span></p>
+    </div>
+    <div class="function" id="alloc_aligned" data-name="alloc_aligned">
+      <h3 class="function-name">alloc_aligned <span class="kind">extern</span></h3>
+      <pre class="usage"><code>alloc_aligned(arena, bytes, alignment) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr, bytes: int, alignment: int</span></p>
+    </div>
+    <div class="function" id="reset" data-name="reset">
+      <h3 class="function-name">reset <span class="kind">extern</span></h3>
+      <pre class="usage"><code>reset(arena)</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr</span></p>
+    </div>
+    <div class="function" id="destroy" data-name="destroy">
+      <h3 class="function-name">destroy <span class="kind">extern</span></h3>
+      <pre class="usage"><code>destroy(arena)</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr</span></p>
+    </div>
+    <div class="function" id="get_used" data-name="get_used">
+      <h3 class="function-name">get_used <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_used(arena) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr</span></p>
+    </div>
+    <div class="function" id="get_size" data-name="get_size">
+      <h3 class="function-name">get_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_size(arena) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr</span></p>
+    </div>
+    <div class="function" id="used" data-name="used">
+      <h3 class="function-name">used <span class="kind">fn</span></h3>
+      <pre class="usage"><code>used(arena) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr</span></p>
+      <p class="doc">Bytes currently allocated from the arena (sum across overflow blocks).</p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">fn</span></h3>
+      <pre class="usage"><code>size(arena) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arena: ptr</span></p>
+      <p class="doc">Total capacity (sum across overflow blocks).</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/audit.html
+++ b/docs/api/audit.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>audit - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search audit..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_audit_count">aether_audit_count</a></li>
+    <li><a href="#aether_audit_entry_category">aether_audit_entry_category</a></li>
+    <li><a href="#aether_audit_entry_resource">aether_audit_entry_resource</a></li>
+    <li><a href="#aether_audit_entry_allowed">aether_audit_entry_allowed</a></li>
+    <li><a href="#aether_audit_clear">aether_audit_clear</a></li>
+    <li><a href="#count">count</a></li>
+    <li><a href="#entry">entry</a></li>
+    <li><a href="#clear">clear</a></li>
+    <li><a href="#denied_count">denied_count</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li class="active"><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>audit</h1>
+    <p class="module-desc">std.audit — query the sandbox audit trail.</p>
+    <p class="import-line"><code>import std.audit</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_audit_count" data-name="aether_audit_count">
+      <h3 class="function-name">aether_audit_count <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_audit_count() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Number of checks currently in the ring buffer.</p>
+    </div>
+    <div class="function" id="aether_audit_entry_category" data-name="aether_audit_entry_category">
+      <h3 class="function-name">aether_audit_entry_category <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_audit_entry_category(i) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">i: int</span></p>
+      <p class="doc">Field accessors for buffered entry `i` (0-based, oldest first). The category/resource strings are borrowed — copy before the slot is overwritten. The `entry()` wrapper below does that for you.</p>
+    </div>
+    <div class="function" id="aether_audit_entry_resource" data-name="aether_audit_entry_resource">
+      <h3 class="function-name">aether_audit_entry_resource <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_audit_entry_resource(i) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">i: int</span></p>
+    </div>
+    <div class="function" id="aether_audit_entry_allowed" data-name="aether_audit_entry_allowed">
+      <h3 class="function-name">aether_audit_entry_allowed <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_audit_entry_allowed(i) <span class="arrow">-&gt;</span> int // 1 allowed, 0 denied, -1 out of range</code></pre>
+      <p class="signature"><span class="sig-params">i: int</span></p>
+    </div>
+    <div class="function" id="aether_audit_clear" data-name="aether_audit_clear">
+      <h3 class="function-name">aether_audit_clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_audit_clear()</code></pre>
+      <p class="doc">Drop all buffered entries.</p>
+    </div>
+    <div class="function" id="count" data-name="count">
+      <h3 class="function-name">count <span class="kind">fn</span></h3>
+      <pre class="usage"><code>count() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">How many permission checks are currently buffered.</p>
+    </div>
+    <div class="function" id="entry" data-name="entry">
+      <h3 class="function-name">entry <span class="kind">fn</span></h3>
+      <pre class="usage"><code>entry(i) <span class="arrow">-&gt;</span> (_0, _1, _2)</code></pre>
+      <p class="signature"><span class="sig-params">i: int</span></p>
+      <p class="doc">Buffered check `i` as a tuple (category, resource, allowed). `allowed` is 1 (passed) or 0 (denied); for an out-of-range index the tuple is (&quot;&quot;, &quot;&quot;, -1). The strings are Aether-owned copies, safe to keep after further audit activity.</p>
+    </div>
+    <div class="function" id="clear" data-name="clear">
+      <h3 class="function-name">clear <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clear()</code></pre>
+      <p class="doc">Empty the audit buffer. Scope a later query to just the work that follows by clearing first.</p>
+    </div>
+    <div class="function" id="denied_count" data-name="denied_count">
+      <h3 class="function-name">denied_count <span class="kind">fn</span></h3>
+      <pre class="usage"><code>denied_count() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Convenience: how many of the buffered checks were denials.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/bignum.html
+++ b/docs/api/bignum.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>bignum - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search bignum..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#from_bytes">from_bytes</a></li>
+    <li><a href="#from_bytes_unsigned">from_bytes_unsigned</a></li>
+    <li><a href="#to_bytes">to_bytes</a></li>
+    <li><a href="#to_bytes_unsigned">to_bytes_unsigned</a></li>
+    <li><a href="#from_int">from_int</a></li>
+    <li><a href="#compare">compare</a></li>
+    <li><a href="#is_zero">is_zero</a></li>
+    <li><a href="#sign">sign</a></li>
+    <li><a href="#bit_length">bit_length</a></li>
+    <li><a href="#add">add</a></li>
+    <li><a href="#subtract">subtract</a></li>
+    <li><a href="#negate">negate</a></li>
+    <li><a href="#abs">abs</a></li>
+    <li><a href="#multiply">multiply</a></li>
+    <li><a href="#divide">divide</a></li>
+    <li><a href="#remainder">remainder</a></li>
+    <li><a href="#mod">mod</a></li>
+    <li><a href="#mod_pow">mod_pow</a></li>
+    <li><a href="#gcd">gcd</a></li>
+    <li><a href="#mod_inverse">mod_inverse</a></li>
+    <li><a href="#is_probable_prime">is_probable_prime</a></li>
+    <li><a href="#shift_left">shift_left</a></li>
+    <li><a href="#shift_right">shift_right</a></li>
+    <li><a href="#to_hex">to_hex</a></li>
+    <li><a href="#free">free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li class="active"><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>bignum</h1>
+    <p class="module-desc">MIT License (https://opensource.org/licenses/MIT) Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc.</p>
+    <p class="import-line"><code>import std.bignum</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="from_bytes" data-name="from_bytes">
+      <h3 class="function-name">from_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>from_bytes(b, length) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, length: int</span></p>
+      <p class="doc">Big-endian, two's-complement SIGNED decode (BC BigInteger(byte[])).</p>
+    </div>
+    <div class="function" id="from_bytes_unsigned" data-name="from_bytes_unsigned">
+      <h3 class="function-name">from_bytes_unsigned <span class="kind">fn</span></h3>
+      <pre class="usage"><code>from_bytes_unsigned(b, length) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, length: int</span></p>
+      <p class="doc">Big-endian, always-non-negative magnitude decode (BC ToByteArrayUnsigned inverse — magnitude only).</p>
+    </div>
+    <div class="function" id="to_bytes" data-name="to_bytes">
+      <h3 class="function-name">to_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_bytes(n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+      <p class="doc">Signed two's-complement big-endian. Returns a std.intarr where slot i holds byte i (0..255); the byte count is the intarr's size. Callers read with intarr_get_raw and mask &amp; 0xFF. NOTE: returns the bytes in an intarr-of-bytes; the test harness reads them back through bignum.* helpers. To keep the public surface a plain `ptr` of raw bytes, we copy into a malloc'd byte buffer.</p>
+    </div>
+    <div class="function" id="to_bytes_unsigned" data-name="to_bytes_unsigned">
+      <h3 class="function-name">to_bytes_unsigned <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_bytes_unsigned(n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+    </div>
+    <div class="function" id="from_int" data-name="from_int">
+      <h3 class="function-name">from_int <span class="kind">fn</span></h3>
+      <pre class="usage"><code>from_int(v) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">v: long</span></p>
+      <p class="doc">Convenience: from a signed 64-bit value, full range including the most negative value.</p>
+    </div>
+    <div class="function" id="compare" data-name="compare">
+      <h3 class="function-name">compare <span class="kind">fn</span></h3>
+      <pre class="usage"><code>compare(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+    </div>
+    <div class="function" id="is_zero" data-name="is_zero">
+      <h3 class="function-name">is_zero <span class="kind">fn</span></h3>
+      <pre class="usage"><code>is_zero(n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+    </div>
+    <div class="function" id="sign" data-name="sign">
+      <h3 class="function-name">sign <span class="kind">fn</span></h3>
+      <pre class="usage"><code>sign(n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+    </div>
+    <div class="function" id="bit_length" data-name="bit_length">
+      <h3 class="function-name">bit_length <span class="kind">fn</span></h3>
+      <pre class="usage"><code>bit_length(n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+      <p class="doc">BC CalcBitLength, including the negative power-of-two adjustment.</p>
+    </div>
+    <div class="function" id="add" data-name="add">
+      <h3 class="function-name">add <span class="kind">fn</span></h3>
+      <pre class="usage"><code>add(a, b) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+    </div>
+    <div class="function" id="subtract" data-name="subtract">
+      <h3 class="function-name">subtract <span class="kind">fn</span></h3>
+      <pre class="usage"><code>subtract(a, b) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+    </div>
+    <div class="function" id="negate" data-name="negate">
+      <h3 class="function-name">negate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>negate(n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+    </div>
+    <div class="function" id="abs" data-name="abs">
+      <h3 class="function-name">abs <span class="kind">fn</span></h3>
+      <pre class="usage"><code>abs(n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+    </div>
+    <div class="function" id="multiply" data-name="multiply">
+      <h3 class="function-name">multiply <span class="kind">fn</span></h3>
+      <pre class="usage"><code>multiply(a, b) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+    </div>
+    <div class="function" id="divide" data-name="divide">
+      <h3 class="function-name">divide <span class="kind">fn</span></h3>
+      <pre class="usage"><code>divide(a, b) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+    </div>
+    <div class="function" id="remainder" data-name="remainder">
+      <h3 class="function-name">remainder <span class="kind">fn</span></h3>
+      <pre class="usage"><code>remainder(a, b) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+    </div>
+    <div class="function" id="mod" data-name="mod">
+      <h3 class="function-name">mod <span class="kind">fn</span></h3>
+      <pre class="usage"><code>mod(a, b) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+      <p class="doc">Mathematical modulus: always in [0, |b|) (BC Mod).</p>
+    </div>
+    <div class="function" id="mod_pow" data-name="mod_pow">
+      <h3 class="function-name">mod_pow <span class="kind">fn</span></h3>
+      <pre class="usage"><code>mod_pow(base, exp, m) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">base: ptr, exp: ptr, m: ptr</span></p>
+      <p class="doc">modular exponentiation: base^exp mod m (exp &gt;= 0, m &gt; 0). Square-and- multiply, MSB-to-LSB. Matches BC ModPow for non-negative exponents.</p>
+    </div>
+    <div class="function" id="gcd" data-name="gcd">
+      <h3 class="function-name">gcd <span class="kind">fn</span></h3>
+      <pre class="usage"><code>gcd(a, b) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr</span></p>
+      <p class="doc">gcd(|a|, |b|) via Euclid (BC Gcd). Always non-negative.</p>
+    </div>
+    <div class="function" id="mod_inverse" data-name="mod_inverse">
+      <h3 class="function-name">mod_inverse <span class="kind">fn</span></h3>
+      <pre class="usage"><code>mod_inverse(a, m) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, m: ptr</span></p>
+      <p class="doc">modular inverse: a^(-1) mod m, in [0, m). Iterative extended Euclid. Returns null if gcd(a, m) != 1 (no inverse exists). m must be &gt; 0.</p>
+    </div>
+    <div class="function" id="is_probable_prime" data-name="is_probable_prime">
+      <h3 class="function-name">is_probable_prime <span class="kind">fn</span></h3>
+      <pre class="usage"><code>is_probable_prime(n, rounds) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr, rounds: int</span></p>
+      <p class="doc">Miller-Rabin primality test with a fixed set of small witness bases. `rounds` caps how many bases to try (the fixed list is deterministic for all n &lt; 3.317e24 with the first 13 primes; beyond that it is a strong probable-prime test). Returns 1 for probable prime, 0 for composite.</p>
+    </div>
+    <div class="function" id="shift_left" data-name="shift_left">
+      <h3 class="function-name">shift_left <span class="kind">fn</span></h3>
+      <pre class="usage"><code>shift_left(n, bits_to) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr, bits_to: int</span></p>
+    </div>
+    <div class="function" id="shift_right" data-name="shift_right">
+      <h3 class="function-name">shift_right <span class="kind">fn</span></h3>
+      <pre class="usage"><code>shift_right(n, bits_to) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr, bits_to: int</span></p>
+    </div>
+    <div class="function" id="to_hex" data-name="to_hex">
+      <h3 class="function-name">to_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_hex(n) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">n: ptr</span></p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>free(r)</code></pre>
+      <p class="signature"><span class="sig-params">r</span></p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/bits.html
+++ b/docs/api/bits.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>bits - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search bits..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#lsr32">lsr32</a></li>
+    <li><a href="#lsr64">lsr64</a></li>
+    <li><a href="#rotr32">rotr32</a></li>
+    <li><a href="#rotl32">rotl32</a></li>
+    <li><a href="#rotr64">rotr64</a></li>
+    <li><a href="#rotl64">rotl64</a></li>
+    <li><a href="#popcount32">popcount32</a></li>
+    <li><a href="#popcount64">popcount64</a></li>
+    <li><a href="#clz32">clz32</a></li>
+    <li><a href="#clz64">clz64</a></li>
+    <li><a href="#udiv32">udiv32</a></li>
+    <li><a href="#urem32">urem32</a></li>
+    <li><a href="#udiv64">udiv64</a></li>
+    <li><a href="#urem64">urem64</a></li>
+    <li><a href="#ucmp64">ucmp64</a></li>
+    <li><a href="#aether_bits_lsr32">aether_bits_lsr32</a></li>
+    <li><a href="#aether_bits_lsr64">aether_bits_lsr64</a></li>
+    <li><a href="#aether_bits_rotr32">aether_bits_rotr32</a></li>
+    <li><a href="#aether_bits_rotl32">aether_bits_rotl32</a></li>
+    <li><a href="#aether_bits_rotr64">aether_bits_rotr64</a></li>
+    <li><a href="#aether_bits_rotl64">aether_bits_rotl64</a></li>
+    <li><a href="#aether_bits_popcount32">aether_bits_popcount32</a></li>
+    <li><a href="#aether_bits_popcount64">aether_bits_popcount64</a></li>
+    <li><a href="#aether_bits_clz32">aether_bits_clz32</a></li>
+    <li><a href="#aether_bits_clz64">aether_bits_clz64</a></li>
+    <li><a href="#aether_bits_udiv32">aether_bits_udiv32</a></li>
+    <li><a href="#aether_bits_urem32">aether_bits_urem32</a></li>
+    <li><a href="#aether_bits_udiv64">aether_bits_udiv64</a></li>
+    <li><a href="#aether_bits_urem64">aether_bits_urem64</a></li>
+    <li><a href="#aether_bits_ucmp64">aether_bits_ucmp64</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li class="active"><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>bits</h1>
+    <p class="module-desc">MIT License (https://opensource.org/licenses/MIT) Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc.</p>
+    <p class="import-line"><code>import std.bits</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="lsr32" data-name="lsr32">
+      <h3 class="function-name">lsr32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>lsr32(x, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int, n: int</span></p>
+      <p class="doc">Logical (unsigned) right shift of `x` by `n` bits. The shift count is masked by (W-1), so n is taken mod 32 (lsr32) / mod 64 (lsr64).</p>
+    </div>
+    <div class="function" id="lsr64" data-name="lsr64">
+      <h3 class="function-name">lsr64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>lsr64(x, n) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">x: long, n: int</span></p>
+    </div>
+    <div class="function" id="rotr32" data-name="rotr32">
+      <h3 class="function-name">rotr32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>rotr32(x, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int, n: int</span></p>
+      <p class="doc">Bit rotates. Count masked by (W-1); a count of 0 returns x unchanged.</p>
+    </div>
+    <div class="function" id="rotl32" data-name="rotl32">
+      <h3 class="function-name">rotl32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>rotl32(x, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int, n: int</span></p>
+    </div>
+    <div class="function" id="rotr64" data-name="rotr64">
+      <h3 class="function-name">rotr64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>rotr64(x, n) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">x: long, n: int</span></p>
+    </div>
+    <div class="function" id="rotl64" data-name="rotl64">
+      <h3 class="function-name">rotl64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>rotl64(x, n) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">x: long, n: int</span></p>
+    </div>
+    <div class="function" id="popcount32" data-name="popcount32">
+      <h3 class="function-name">popcount32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>popcount32(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int</span></p>
+      <p class="doc">Count of set bits over the unsigned value.</p>
+    </div>
+    <div class="function" id="popcount64" data-name="popcount64">
+      <h3 class="function-name">popcount64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>popcount64(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: long</span></p>
+    </div>
+    <div class="function" id="clz32" data-name="clz32">
+      <h3 class="function-name">clz32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clz32(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int</span></p>
+      <p class="doc">Count leading zeros over the unsigned value, MSB-first. Returns the width (32 / 64) for a zero input.</p>
+    </div>
+    <div class="function" id="clz64" data-name="clz64">
+      <h3 class="function-name">clz64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clz64(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: long</span></p>
+    </div>
+    <div class="function" id="udiv32" data-name="udiv32">
+      <h3 class="function-name">udiv32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>udiv32(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: int, b: int</span></p>
+      <p class="doc">Unsigned division / remainder. Returns 0 if the divisor is 0.</p>
+    </div>
+    <div class="function" id="urem32" data-name="urem32">
+      <h3 class="function-name">urem32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>urem32(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: int, b: int</span></p>
+    </div>
+    <div class="function" id="udiv64" data-name="udiv64">
+      <h3 class="function-name">udiv64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>udiv64(a, b) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">a: long, b: long</span></p>
+    </div>
+    <div class="function" id="urem64" data-name="urem64">
+      <h3 class="function-name">urem64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>urem64(a, b) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">a: long, b: long</span></p>
+    </div>
+    <div class="function" id="ucmp64" data-name="ucmp64">
+      <h3 class="function-name">ucmp64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>ucmp64(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: long, b: long</span></p>
+      <p class="doc">Unsigned compare of two 64-bit values. Returns -1 / 0 / 1.</p>
+    </div>
+    <div class="function" id="aether_bits_lsr32" data-name="aether_bits_lsr32">
+      <h3 class="function-name">aether_bits_lsr32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_lsr32(x, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int, n: int</span></p>
+      <p class="doc">---- Raw externs ----</p>
+    </div>
+    <div class="function" id="aether_bits_lsr64" data-name="aether_bits_lsr64">
+      <h3 class="function-name">aether_bits_lsr64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_lsr64(x, n) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">x: long, n: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_rotr32" data-name="aether_bits_rotr32">
+      <h3 class="function-name">aether_bits_rotr32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_rotr32(x, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int, n: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_rotl32" data-name="aether_bits_rotl32">
+      <h3 class="function-name">aether_bits_rotl32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_rotl32(x, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int, n: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_rotr64" data-name="aether_bits_rotr64">
+      <h3 class="function-name">aether_bits_rotr64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_rotr64(x, n) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">x: long, n: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_rotl64" data-name="aether_bits_rotl64">
+      <h3 class="function-name">aether_bits_rotl64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_rotl64(x, n) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">x: long, n: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_popcount32" data-name="aether_bits_popcount32">
+      <h3 class="function-name">aether_bits_popcount32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_popcount32(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_popcount64" data-name="aether_bits_popcount64">
+      <h3 class="function-name">aether_bits_popcount64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_popcount64(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: long</span></p>
+    </div>
+    <div class="function" id="aether_bits_clz32" data-name="aether_bits_clz32">
+      <h3 class="function-name">aether_bits_clz32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_clz32(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_clz64" data-name="aether_bits_clz64">
+      <h3 class="function-name">aether_bits_clz64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_clz64(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: long</span></p>
+    </div>
+    <div class="function" id="aether_bits_udiv32" data-name="aether_bits_udiv32">
+      <h3 class="function-name">aether_bits_udiv32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_udiv32(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: int, b: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_urem32" data-name="aether_bits_urem32">
+      <h3 class="function-name">aether_bits_urem32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_urem32(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: int, b: int</span></p>
+    </div>
+    <div class="function" id="aether_bits_udiv64" data-name="aether_bits_udiv64">
+      <h3 class="function-name">aether_bits_udiv64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_udiv64(a, b) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">a: long, b: long</span></p>
+    </div>
+    <div class="function" id="aether_bits_urem64" data-name="aether_bits_urem64">
+      <h3 class="function-name">aether_bits_urem64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_urem64(a, b) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">a: long, b: long</span></p>
+    </div>
+    <div class="function" id="aether_bits_ucmp64" data-name="aether_bits_ucmp64">
+      <h3 class="function-name">aether_bits_ucmp64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bits_ucmp64(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: long, b: long</span></p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/bytes.html
+++ b/docs/api/bytes.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>bytes - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search bytes..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_bytes_new">aether_bytes_new</a></li>
+    <li><a href="#aether_bytes_set">aether_bytes_set</a></li>
+    <li><a href="#aether_bytes_get">aether_bytes_get</a></li>
+    <li><a href="#aether_bytes_length">aether_bytes_length</a></li>
+    <li><a href="#aether_bytes_set_le16">aether_bytes_set_le16</a></li>
+    <li><a href="#aether_bytes_get_le16">aether_bytes_get_le16</a></li>
+    <li><a href="#aether_bytes_set_le32">aether_bytes_set_le32</a></li>
+    <li><a href="#aether_bytes_get_le32">aether_bytes_get_le32</a></li>
+    <li><a href="#aether_bytes_set_le64">aether_bytes_set_le64</a></li>
+    <li><a href="#aether_bytes_get_le64">aether_bytes_get_le64</a></li>
+    <li><a href="#aether_bytes_set_be16">aether_bytes_set_be16</a></li>
+    <li><a href="#aether_bytes_get_be16">aether_bytes_get_be16</a></li>
+    <li><a href="#aether_bytes_set_be32">aether_bytes_set_be32</a></li>
+    <li><a href="#aether_bytes_get_be32">aether_bytes_get_be32</a></li>
+    <li><a href="#aether_bytes_set_be64">aether_bytes_set_be64</a></li>
+    <li><a href="#aether_bytes_get_be64">aether_bytes_get_be64</a></li>
+    <li><a href="#aether_bytes_copy_from_string">aether_bytes_copy_from_string</a></li>
+    <li><a href="#aether_bytes_copy_from_bytes">aether_bytes_copy_from_bytes</a></li>
+    <li><a href="#aether_bytes_copy_within">aether_bytes_copy_within</a></li>
+    <li><a href="#aether_bytes_finish">aether_bytes_finish</a></li>
+    <li><a href="#aether_bytes_free">aether_bytes_free</a></li>
+    <li><a href="#new">new</a></li>
+    <li><a href="#set">set</a></li>
+    <li><a href="#get">get</a></li>
+    <li><a href="#length">length</a></li>
+    <li><a href="#set_le16">set_le16</a></li>
+    <li><a href="#get_le16">get_le16</a></li>
+    <li><a href="#set_le32">set_le32</a></li>
+    <li><a href="#get_le32">get_le32</a></li>
+    <li><a href="#set_le64">set_le64</a></li>
+    <li><a href="#get_le64">get_le64</a></li>
+    <li><a href="#set_be16">set_be16</a></li>
+    <li><a href="#get_be16">get_be16</a></li>
+    <li><a href="#set_be32">set_be32</a></li>
+    <li><a href="#get_be32">get_be32</a></li>
+    <li><a href="#set_be64">set_be64</a></li>
+    <li><a href="#get_be64">get_be64</a></li>
+    <li><a href="#copy_from_string">copy_from_string</a></li>
+    <li><a href="#copy_from_bytes">copy_from_bytes</a></li>
+    <li><a href="#copy_within">copy_within</a></li>
+    <li><a href="#finish">finish</a></li>
+    <li><a href="#free">free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li class="active"><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>bytes</h1>
+    <p class="module-desc">std.bytes — mutable byte buffer with random-access write and overlap-safe forward copy_within.</p>
+    <p class="import-line"><code>import std.bytes</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_bytes_new" data-name="aether_bytes_new">
+      <h3 class="function-name">aether_bytes_new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_new(initial_capacity) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">initial_capacity: int</span></p>
+      <p class="doc">---- Raw externs ----</p>
+    </div>
+    <div class="function" id="aether_bytes_set" data-name="aether_bytes_set">
+      <h3 class="function-name">aether_bytes_set <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_set(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_get" data-name="aether_bytes_get">
+      <h3 class="function-name">aether_bytes_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_get(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_length" data-name="aether_bytes_length">
+      <h3 class="function-name">aether_bytes_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_length(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="aether_bytes_set_le16" data-name="aether_bytes_set_le16">
+      <h3 class="function-name">aether_bytes_set_le16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_set_le16(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_get_le16" data-name="aether_bytes_get_le16">
+      <h3 class="function-name">aether_bytes_get_le16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_get_le16(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_set_le32" data-name="aether_bytes_set_le32">
+      <h3 class="function-name">aether_bytes_set_le32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_set_le32(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_get_le32" data-name="aether_bytes_get_le32">
+      <h3 class="function-name">aether_bytes_get_le32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_get_le32(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_set_le64" data-name="aether_bytes_set_le64">
+      <h3 class="function-name">aether_bytes_set_le64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_set_le64(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: long</span></p>
+    </div>
+    <div class="function" id="aether_bytes_get_le64" data-name="aether_bytes_get_le64">
+      <h3 class="function-name">aether_bytes_get_le64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_get_le64(b, index) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_set_be16" data-name="aether_bytes_set_be16">
+      <h3 class="function-name">aether_bytes_set_be16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_set_be16(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_get_be16" data-name="aether_bytes_get_be16">
+      <h3 class="function-name">aether_bytes_get_be16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_get_be16(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_set_be32" data-name="aether_bytes_set_be32">
+      <h3 class="function-name">aether_bytes_set_be32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_set_be32(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_get_be32" data-name="aether_bytes_get_be32">
+      <h3 class="function-name">aether_bytes_get_be32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_get_be32(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_set_be64" data-name="aether_bytes_set_be64">
+      <h3 class="function-name">aether_bytes_set_be64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_set_be64(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: long</span></p>
+    </div>
+    <div class="function" id="aether_bytes_get_be64" data-name="aether_bytes_get_be64">
+      <h3 class="function-name">aether_bytes_get_be64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_get_be64(b, index) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_copy_from_string" data-name="aether_bytes_copy_from_string">
+      <h3 class="function-name">aether_bytes_copy_from_string <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_copy_from_string(b, dst, src, src_len) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, dst: int, src: string, src_len: int</span></p>
+    </div>
+    <div class="function" id="aether_bytes_copy_from_bytes" data-name="aether_bytes_copy_from_bytes">
+      <h3 class="function-name">aether_bytes_copy_from_bytes <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_copy_from_bytes(dst, dst_off, src, src_off, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, dst_off: int, src: ptr, src_off: int, length: int</span></p>
+      <p class="doc">Two-buffer copy. `dst` and `src` are distinct AetherBytes pointers; `length` is the count of bytes to copy from `src` at offset `src_off` into `dst` at offset `dst_off`. Grows `dst` if needed. For an in-place copy (same buffer) use `copy_within` — it has the deliberate RLE forward-overlap semantics that memmove() lacks.</p>
+    </div>
+    <div class="function" id="aether_bytes_copy_within" data-name="aether_bytes_copy_within">
+      <h3 class="function-name">aether_bytes_copy_within <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_copy_within(b, dst, src, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, dst: int, src: int, length: int</span></p>
+      <p class="doc">`length` here is the count of bytes to copy, not a buffer length.</p>
+    </div>
+    <div class="function" id="aether_bytes_finish" data-name="aether_bytes_finish">
+      <h3 class="function-name">aether_bytes_finish <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_finish(b, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, length: int</span></p>
+      <p class="doc">`aether_bytes_finish` returns a freshly heap-owned AetherString (`string_new_with_length` — see std/bytes/aether_bytes.c). The `string @heap` return tells the heap-string tracker the caller owns the result, so `x = bytes.finish(...)` gets a `_heap_x = 1` slot and any function returning a `bytes.finish` value is itself classified heap-returning. Mirrors `aether_strbuilder_finish`.</p>
+    </div>
+    <div class="function" id="aether_bytes_free" data-name="aether_bytes_free">
+      <h3 class="function-name">aether_bytes_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_bytes_free(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new(initial_capacity) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">initial_capacity: int</span></p>
+      <p class="doc">---- Aether-side wrappers ---- Allocate a new mutable byte buffer with at least `initial_capacity` bytes reserved. Returns null on allocation failure or negative capacity. Initial logical length is 0.</p>
+    </div>
+    <div class="function" id="set" data-name="set">
+      <h3 class="function-name">set <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+      <p class="doc">Write a single byte at `index`. The buffer grows if needed; gaps between the previous tail and `index` are zero-filled. Returns 1 on success, 0 on failure. The parameter is named `value` (not `byte`) because `byte` became a reserved keyword for the new primitive type. The third arg's runtime semantics are unchanged — it stores the low 8 bits at `index`.</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+      <p class="doc">Read the byte previously written at `index`, returned as 0..255. Returns -1 if `b` is null, `index` is negative, or `index` is past the buffer's logical length. Pairs with `set` so a caller can build then walk a buffer in-place — the canonical binary-codec encoder pattern (svndiff and similar).</p>
+    </div>
+    <div class="function" id="length" data-name="length">
+      <h3 class="function-name">length <span class="kind">fn</span></h3>
+      <pre class="usage"><code>length(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Number of bytes the buffer logically contains. Returns -1 if `b` is null.</p>
+    </div>
+    <div class="function" id="set_le16" data-name="set_le16">
+      <h3 class="function-name">set_le16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_le16(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+      <p class="doc">Little-endian 16-bit write at `index..index+1`. Grows the buffer if needed. Returns 1 on success, 0 on failure (NULL buffer or negative index).</p>
+    </div>
+    <div class="function" id="get_le16" data-name="get_le16">
+      <h3 class="function-name">get_le16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_le16(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+      <p class="doc">Little-endian 16-bit read at `index..index+1`. Returns the unsigned 16-bit value as an int, or -1 on failure (NULL buffer, negative index, or range past current length).</p>
+    </div>
+    <div class="function" id="set_le32" data-name="set_le32">
+      <h3 class="function-name">set_le32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_le32(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+      <p class="doc">Little-endian 32-bit write at `index..index+3`. Grows the buffer if needed. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="get_le32" data-name="get_le32">
+      <h3 class="function-name">get_le32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_le32(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+      <p class="doc">Little-endian 32-bit read at `index..index+3`. Returns the value as an int (host-endian after reassembly), or -1 on failure. Round-trips losslessly with set_le32 for any int input.</p>
+    </div>
+    <div class="function" id="set_le64" data-name="set_le64">
+      <h3 class="function-name">set_le64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_le64(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: long</span></p>
+      <p class="doc">Little-endian 64-bit write at `index..index+7` (least-significant byte first). Grows the buffer if needed. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="get_le64" data-name="get_le64">
+      <h3 class="function-name">get_le64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_le64(b, index) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+      <p class="doc">Little-endian 64-bit read at `index..index+7`. Returns the value as a long, or -1 on failure. Round-trips losslessly with set_le64 for any long input.</p>
+    </div>
+    <div class="function" id="set_be16" data-name="set_be16">
+      <h3 class="function-name">set_be16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_be16(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+      <p class="doc">Big-endian 16-bit write at `index..index+1` (most-significant byte first). Grows the buffer if needed. Returns 1 on success, 0 on failure (NULL buffer or negative index).</p>
+    </div>
+    <div class="function" id="get_be16" data-name="get_be16">
+      <h3 class="function-name">get_be16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_be16(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+      <p class="doc">Big-endian 16-bit read at `index..index+1`. Returns the unsigned 16-bit value as an int, or -1 on failure (NULL buffer, negative index, or range past current length).</p>
+    </div>
+    <div class="function" id="set_be32" data-name="set_be32">
+      <h3 class="function-name">set_be32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_be32(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: int</span></p>
+      <p class="doc">Big-endian 32-bit write at `index..index+3` (most-significant byte first). Grows the buffer if needed. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="get_be32" data-name="get_be32">
+      <h3 class="function-name">get_be32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_be32(b, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+      <p class="doc">Big-endian 32-bit read at `index..index+3`. Returns the value as an int (top bit reads back as the sign bit), or -1 on failure. Round-trips losslessly with set_be32 for any int input.</p>
+    </div>
+    <div class="function" id="set_be64" data-name="set_be64">
+      <h3 class="function-name">set_be64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_be64(b, index, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int, value: long</span></p>
+      <p class="doc">Big-endian 64-bit write at `index..index+7` (most-significant byte first). Grows the buffer if needed. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="get_be64" data-name="get_be64">
+      <h3 class="function-name">get_be64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_be64(b, index) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, index: int</span></p>
+      <p class="doc">Big-endian 64-bit read at `index..index+7`. Returns the value as a long, or -1 on failure. Round-trips losslessly with set_be64.</p>
+    </div>
+    <div class="function" id="copy_from_string" data-name="copy_from_string">
+      <h3 class="function-name">copy_from_string <span class="kind">fn</span></h3>
+      <pre class="usage"><code>copy_from_string(b, dst, src, src_len) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, dst: int, src: string, src_len: int</span></p>
+      <p class="doc">Copy `src_len` bytes from `src` into the buffer starting at offset `dst`. `src` may be either a plain `string` literal or an AetherString-bearing value (binary-safe via aether_string_data on the C side). Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="copy_from_bytes" data-name="copy_from_bytes">
+      <h3 class="function-name">copy_from_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>copy_from_bytes(dst, dst_off, src, src_off, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, dst_off: int, src: ptr, src_off: int, length: int</span></p>
+      <p class="doc">Copy `length` bytes from `src` buffer at offset `src_off` into `dst` buffer at offset `dst_off`. The buffers must be distinct; for an in-place copy use `copy_within`. Grows the destination buffer if needed. Returns 1 on success, 0 on failure (NULL buffer, negative offsets/length, source range past src's logical length, or destination grow OOM). Canonical use: two-pass separable Gaussian blur (pixels → temp → pixels).</p>
+    </div>
+    <div class="function" id="copy_within" data-name="copy_within">
+      <h3 class="function-name">copy_within <span class="kind">fn</span></h3>
+      <pre class="usage"><code>copy_within(b, dst, src, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, dst: int, src: int, length: int</span></p>
+      <p class="doc">Copy `length` bytes from offset `src` to offset `dst` *within the same buffer*, forward byte-by-byte. Bytes written earlier in the same call are visible to later reads — the RLE-overlap behaviour. Returns 1 on success, 0 on failure (NULL buffer, negative offsets, or src + length &gt; current buffer length).</p>
+    </div>
+    <div class="function" id="finish" data-name="finish">
+      <h3 class="function-name">finish <span class="kind">fn</span></h3>
+      <pre class="usage"><code>finish(b, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, length: int</span></p>
+      <p class="doc">Hand the buffer off to a refcounted AetherString and destroy the AetherBytes wrapper. After this call, `b` is invalid. The string carries the explicit length so embedded NULs survive end-to-end. Pass the prefix you actually want to keep (use bytes.length(b) to take the whole buffer).</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>free(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Discard the buffer without converting to a string. Idempotent on null. Use this for error paths that mid-way decide the buffer isn't needed.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/capsicum.html
+++ b/docs/api/capsicum.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>capsicum - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search capsicum..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#CAP_OK">CAP_OK</a></li>
+    <li><a href="#CAP_ERR">CAP_ERR</a></li>
+    <li><a href="#CAP_UNSUPPORTED">CAP_UNSUPPORTED</a></li>
+    <li><a href="#aether_capsicum_available">aether_capsicum_available</a></li>
+    <li><a href="#aether_capsicum_enter">aether_capsicum_enter</a></li>
+    <li><a href="#aether_capsicum_in_mode">aether_capsicum_in_mode</a></li>
+    <li><a href="#aether_capsicum_rights_limit">aether_capsicum_rights_limit</a></li>
+    <li><a href="#aether_capsicum_fcntls_limit">aether_capsicum_fcntls_limit</a></li>
+    <li><a href="#available">available</a></li>
+    <li><a href="#enter">enter</a></li>
+    <li><a href="#in_mode">in_mode</a></li>
+    <li><a href="#rights_limit">rights_limit</a></li>
+    <li><a href="#fcntls_limit">fcntls_limit</a></li>
+    <li><a href="#R_READ">R_READ</a></li>
+    <li><a href="#R_WRITE">R_WRITE</a></li>
+    <li><a href="#R_SEEK">R_SEEK</a></li>
+    <li><a href="#R_FSTAT">R_FSTAT</a></li>
+    <li><a href="#R_FTRUNCATE">R_FTRUNCATE</a></li>
+    <li><a href="#R_FSYNC">R_FSYNC</a></li>
+    <li><a href="#R_MMAP">R_MMAP</a></li>
+    <li><a href="#R_ACCEPT">R_ACCEPT</a></li>
+    <li><a href="#R_CONNECT">R_CONNECT</a></li>
+    <li><a href="#R_BIND">R_BIND</a></li>
+    <li><a href="#R_LISTEN">R_LISTEN</a></li>
+    <li><a href="#R_RECV">R_RECV</a></li>
+    <li><a href="#R_SEND">R_SEND</a></li>
+    <li><a href="#R_EVENT">R_EVENT</a></li>
+    <li><a href="#R_IOCTL">R_IOCTL</a></li>
+    <li><a href="#R_FCNTL">R_FCNTL</a></li>
+    <li><a href="#F_GETFL">F_GETFL</a></li>
+    <li><a href="#F_SETFL">F_SETFL</a></li>
+    <li><a href="#F_GETOWN">F_GETOWN</a></li>
+    <li><a href="#F_SETOWN">F_SETOWN</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li class="active"><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>capsicum</h1>
+    <p class="module-desc">std.capsicum — FreeBSD Capsicum capability-mode bindings.</p>
+    <p class="import-line"><code>import std.capsicum</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="CAP_OK" data-name="CAP_OK">
+      <h3 class="function-name">CAP_OK <span class="kind">const</span></h3>
+      <pre class="usage"><code>CAP_OK = 0</code></pre>
+    </div>
+    <div class="function" id="CAP_ERR" data-name="CAP_ERR">
+      <h3 class="function-name">CAP_ERR <span class="kind">const</span></h3>
+      <pre class="usage"><code>CAP_ERR = -1</code></pre>
+    </div>
+    <div class="function" id="CAP_UNSUPPORTED" data-name="CAP_UNSUPPORTED">
+      <h3 class="function-name">CAP_UNSUPPORTED <span class="kind">const</span></h3>
+      <pre class="usage"><code>CAP_UNSUPPORTED = -2</code></pre>
+    </div>
+    <div class="function" id="aether_capsicum_available" data-name="aether_capsicum_available">
+      <h3 class="function-name">aether_capsicum_available <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_capsicum_available() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">1 if Capsicum is usable in this process, 0 otherwise.</p>
+    </div>
+    <div class="function" id="aether_capsicum_enter" data-name="aether_capsicum_enter">
+      <h3 class="function-name">aether_capsicum_enter <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_capsicum_enter() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Enter capability mode. Irreversible. Returns CAP_OK / CAP_ERR / CAP_UNSUPPORTED.</p>
+    </div>
+    <div class="function" id="aether_capsicum_in_mode" data-name="aether_capsicum_in_mode">
+      <h3 class="function-name">aether_capsicum_in_mode <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_capsicum_in_mode() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">1 if already in capability mode, 0 if not, CAP_UNSUPPORTED off FreeBSD.</p>
+    </div>
+    <div class="function" id="aether_capsicum_rights_limit" data-name="aether_capsicum_rights_limit">
+      <h3 class="function-name">aether_capsicum_rights_limit <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_capsicum_rights_limit(fd, rights_mask) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, rights_mask: int</span></p>
+      <p class="doc">Limit `fd` to the rights in `rights_mask` (OR of R_* values). Rights only ever narrow. Returns CAP_OK / CAP_ERR / CAP_UNSUPPORTED.</p>
+    </div>
+    <div class="function" id="aether_capsicum_fcntls_limit" data-name="aether_capsicum_fcntls_limit">
+      <h3 class="function-name">aether_capsicum_fcntls_limit <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_capsicum_fcntls_limit(fd, fcntl_mask) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, fcntl_mask: int</span></p>
+      <p class="doc">Limit which fcntl(2) commands `fd` permits (OR of F_* values).</p>
+    </div>
+    <div class="function" id="available" data-name="available">
+      <h3 class="function-name">available <span class="kind">fn</span></h3>
+      <pre class="usage"><code>available() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Is Capsicum enforcement available right now?</p>
+    </div>
+    <div class="function" id="enter" data-name="enter">
+      <h3 class="function-name">enter <span class="kind">fn</span></h3>
+      <pre class="usage"><code>enter() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Enter capability mode — irreversible, inherited by children.</p>
+    </div>
+    <div class="function" id="in_mode" data-name="in_mode">
+      <h3 class="function-name">in_mode <span class="kind">fn</span></h3>
+      <pre class="usage"><code>in_mode() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Is the current process already sandboxed by Capsicum?</p>
+    </div>
+    <div class="function" id="rights_limit" data-name="rights_limit">
+      <h3 class="function-name">rights_limit <span class="kind">fn</span></h3>
+      <pre class="usage"><code>rights_limit(fd, rights_mask) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, rights_mask: int</span></p>
+      <p class="doc">Narrow an fd to `rights_mask`.</p>
+    </div>
+    <div class="function" id="fcntls_limit" data-name="fcntls_limit">
+      <h3 class="function-name">fcntls_limit <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fcntls_limit(fd, fcntl_mask) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, fcntl_mask: int</span></p>
+      <p class="doc">Narrow the fcntl commands allowed on an fd.</p>
+    </div>
+    <div class="function" id="R_READ" data-name="R_READ">
+      <h3 class="function-name">R_READ <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_READ = 0x0001</code></pre>
+    </div>
+    <div class="function" id="R_WRITE" data-name="R_WRITE">
+      <h3 class="function-name">R_WRITE <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_WRITE = 0x0002</code></pre>
+    </div>
+    <div class="function" id="R_SEEK" data-name="R_SEEK">
+      <h3 class="function-name">R_SEEK <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_SEEK = 0x0004</code></pre>
+    </div>
+    <div class="function" id="R_FSTAT" data-name="R_FSTAT">
+      <h3 class="function-name">R_FSTAT <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_FSTAT = 0x0008</code></pre>
+    </div>
+    <div class="function" id="R_FTRUNCATE" data-name="R_FTRUNCATE">
+      <h3 class="function-name">R_FTRUNCATE <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_FTRUNCATE = 0x0010</code></pre>
+    </div>
+    <div class="function" id="R_FSYNC" data-name="R_FSYNC">
+      <h3 class="function-name">R_FSYNC <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_FSYNC = 0x0020</code></pre>
+    </div>
+    <div class="function" id="R_MMAP" data-name="R_MMAP">
+      <h3 class="function-name">R_MMAP <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_MMAP = 0x0040</code></pre>
+    </div>
+    <div class="function" id="R_ACCEPT" data-name="R_ACCEPT">
+      <h3 class="function-name">R_ACCEPT <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_ACCEPT = 0x0080</code></pre>
+    </div>
+    <div class="function" id="R_CONNECT" data-name="R_CONNECT">
+      <h3 class="function-name">R_CONNECT <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_CONNECT = 0x0100</code></pre>
+    </div>
+    <div class="function" id="R_BIND" data-name="R_BIND">
+      <h3 class="function-name">R_BIND <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_BIND = 0x0200</code></pre>
+    </div>
+    <div class="function" id="R_LISTEN" data-name="R_LISTEN">
+      <h3 class="function-name">R_LISTEN <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_LISTEN = 0x0400</code></pre>
+    </div>
+    <div class="function" id="R_RECV" data-name="R_RECV">
+      <h3 class="function-name">R_RECV <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_RECV = 0x0800</code></pre>
+    </div>
+    <div class="function" id="R_SEND" data-name="R_SEND">
+      <h3 class="function-name">R_SEND <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_SEND = 0x1000</code></pre>
+    </div>
+    <div class="function" id="R_EVENT" data-name="R_EVENT">
+      <h3 class="function-name">R_EVENT <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_EVENT = 0x2000</code></pre>
+    </div>
+    <div class="function" id="R_IOCTL" data-name="R_IOCTL">
+      <h3 class="function-name">R_IOCTL <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_IOCTL = 0x4000</code></pre>
+    </div>
+    <div class="function" id="R_FCNTL" data-name="R_FCNTL">
+      <h3 class="function-name">R_FCNTL <span class="kind">const</span></h3>
+      <pre class="usage"><code>R_FCNTL = 0x8000</code></pre>
+    </div>
+    <div class="function" id="F_GETFL" data-name="F_GETFL">
+      <h3 class="function-name">F_GETFL <span class="kind">const</span></h3>
+      <pre class="usage"><code>F_GETFL = 0x01</code></pre>
+    </div>
+    <div class="function" id="F_SETFL" data-name="F_SETFL">
+      <h3 class="function-name">F_SETFL <span class="kind">const</span></h3>
+      <pre class="usage"><code>F_SETFL = 0x02</code></pre>
+    </div>
+    <div class="function" id="F_GETOWN" data-name="F_GETOWN">
+      <h3 class="function-name">F_GETOWN <span class="kind">const</span></h3>
+      <pre class="usage"><code>F_GETOWN = 0x04</code></pre>
+    </div>
+    <div class="function" id="F_SETOWN" data-name="F_SETOWN">
+      <h3 class="function-name">F_SETOWN <span class="kind">const</span></h3>
+      <pre class="usage"><code>F_SETOWN = 0x08</code></pre>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/cas.html
+++ b/docs/api/cas.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>cas - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search cas..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#root">root</a></li>
+    <li><a href="#path">path</a></li>
+    <li><a href="#has">has</a></li>
+    <li><a href="#put">put</a></li>
+    <li><a href="#get">get</a></li>
+    <li><a href="#root_raw">root_raw</a></li>
+    <li><a href="#path_raw">path_raw</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li class="active"><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>cas</h1>
+    <p class="module-desc">std.cas - Content-addressed artifact store A small content-addressed store (CAS) for sharing built artifacts (`.so` files from `--emit=lib`, eventually anything content- addressable).</p>
+    <p class="import-line"><code>import std.cas</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="root" data-name="root">
+      <h3 class="function-name">root <span class="kind">fn</span></h3>
+      <pre class="usage"><code>root() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="path" data-name="path">
+      <h3 class="function-name">path <span class="kind">fn</span></h3>
+      <pre class="usage"><code>path(digest) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">digest: string</span></p>
+    </div>
+    <div class="function" id="has" data-name="has">
+      <h3 class="function-name">has <span class="kind">fn</span></h3>
+      <pre class="usage"><code>has(digest) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">digest: string</span></p>
+      <p class="doc">Test whether a digest is present in the local store. Pure existence check on `&lt;root&gt;/&lt;digest&gt;`. NULL-safe — passing an empty or NULL digest returns 0.</p>
+    </div>
+    <div class="function" id="put" data-name="put">
+      <h3 class="function-name">put <span class="kind">fn</span></h3>
+      <pre class="usage"><code>put(file_path) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">file_path: string</span></p>
+      <p class="doc">Insert a file into the store. Reads the file's content, computes the hex sha256, and atomically renames into place at `&lt;root&gt;/&lt;digest&gt;`. Returns `(digest, &quot;&quot;)` on success, `(&quot;&quot;, err)` on any failure (file missing, OOM, mkdir failure, write failure). Idempotent: putting a file whose contents already exist in the store re-writes the entry (the content is the same — the store stays well-formed) and returns the same digest. Callers comparing digests to detect &quot;is this the same artifact?&quot; never need to special-case &quot;already present.&quot;</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(digest, dest_path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">digest: string, dest_path: string</span></p>
+      <p class="doc">Copy an entry out of the store to `dest_path`, verifying that the bytes hash back to `digest` before declaring success. The re-hash protects callers from a corrupted store entry quietly handing back the wrong content (filesystem bit-rot, an out-of-band tool that wrote something with a wrong name, etc.). `dest_path` is overwritten via atomic rename. Returns &quot;&quot; on success, error string on: - digest not in store - read failure - dest write failure - digest mismatch (corrupted entry)</p>
+    </div>
+    <div class="function" id="root_raw" data-name="root_raw">
+      <h3 class="function-name">root_raw <span class="kind">fn</span></h3>
+      <pre class="usage"><code>root_raw() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">Resolve the CAS root directory. Reads AETHER_CAS first; falls back to $HOME/.aether/cas. Always returns a non-empty string — callers don't have to handle a NULL root. Note that the directory may not yet exist; ensure_root_exists below creates it on demand.</p>
+    </div>
+    <div class="function" id="path_raw" data-name="path_raw">
+      <h3 class="function-name">path_raw <span class="kind">fn</span></h3>
+      <pre class="usage"><code>path_raw(digest) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">digest: string</span></p>
+      <p class="doc">Compose the CAS file path for a digest: &lt;root&gt;/&lt;digest&gt;. Pure function — does not touch the filesystem.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/casper.html
+++ b/docs/api/casper.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>casper - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search casper..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_casper_init">aether_casper_init</a></li>
+    <li><a href="#aether_casper_service_open">aether_casper_service_open</a></li>
+    <li><a href="#aether_casper_close">aether_casper_close</a></li>
+    <li><a href="#aether_casper_available">aether_casper_available</a></li>
+    <li><a href="#aether_casper_resolve">aether_casper_resolve</a></li>
+    <li><a href="#aether_casper_pwd_uid">aether_casper_pwd_uid</a></li>
+    <li><a href="#aether_casper_pwd_home">aether_casper_pwd_home</a></li>
+    <li><a href="#aether_casper_sysctl_str">aether_casper_sysctl_str</a></li>
+    <li><a href="#available">available</a></li>
+    <li><a href="#init">init</a></li>
+    <li><a href="#service">service</a></li>
+    <li><a href="#close">close</a></li>
+    <li><a href="#dns_resolve">dns_resolve</a></li>
+    <li><a href="#pwd_uid">pwd_uid</a></li>
+    <li><a href="#pwd_home">pwd_home</a></li>
+    <li><a href="#sysctl">sysctl</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li class="active"><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>casper</h1>
+    <p class="module-desc">std.casper — FreeBSD Casper service delegation.</p>
+    <p class="import-line"><code>import std.casper</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_casper_init" data-name="aether_casper_init">
+      <h3 class="function-name">aether_casper_init <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_init() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">Connect to the casper daemon. Returns an opaque channel, or null. Must be called BEFORE capsicum.enter().</p>
+    </div>
+    <div class="function" id="aether_casper_service_open" data-name="aether_casper_service_open">
+      <h3 class="function-name">aether_casper_service_open <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_service_open(casper, service) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">casper: ptr, service: string</span></p>
+      <p class="doc">Open a named service channel (&quot;system.net&quot; / &quot;system.pwd&quot; / &quot;system.sysctl&quot;) from the casper handle. Returns a channel or null. Must be called BEFORE capsicum.enter().</p>
+    </div>
+    <div class="function" id="aether_casper_close" data-name="aether_casper_close">
+      <h3 class="function-name">aether_casper_close <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_close(chan)</code></pre>
+      <p class="signature"><span class="sig-params">chan: ptr</span></p>
+      <p class="doc">Close a channel (casper handle or service handle). Safe on null.</p>
+    </div>
+    <div class="function" id="aether_casper_available" data-name="aether_casper_available">
+      <h3 class="function-name">aether_casper_available <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_available() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">1 if Casper is usable (FreeBSD with the casper daemon reachable).</p>
+    </div>
+    <div class="function" id="aether_casper_resolve" data-name="aether_casper_resolve">
+      <h3 class="function-name">aether_casper_resolve <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_resolve(netchan, hostname) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">netchan: ptr, hostname: string</span></p>
+      <p class="doc">Resolve a hostname to its first IP via a &quot;system.net&quot; channel. Returns the address string, or null on failure.</p>
+    </div>
+    <div class="function" id="aether_casper_pwd_uid" data-name="aether_casper_pwd_uid">
+      <h3 class="function-name">aether_casper_pwd_uid <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_pwd_uid(pwdchan, username) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">pwdchan: ptr, username: string</span></p>
+      <p class="doc">Look up a username's uid via a &quot;system.pwd&quot; channel. -1 if absent.</p>
+    </div>
+    <div class="function" id="aether_casper_pwd_home" data-name="aether_casper_pwd_home">
+      <h3 class="function-name">aether_casper_pwd_home <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_pwd_home(pwdchan, username) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">pwdchan: ptr, username: string</span></p>
+      <p class="doc">Look up a username's home directory via a &quot;system.pwd&quot; channel. Returns the path, or null on failure.</p>
+    </div>
+    <div class="function" id="aether_casper_sysctl_str" data-name="aether_casper_sysctl_str">
+      <h3 class="function-name">aether_casper_sysctl_str <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_casper_sysctl_str(sysctlchan, name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">sysctlchan: ptr, name: string</span></p>
+      <p class="doc">Read a string-valued sysctl via a &quot;system.sysctl&quot; channel. Returns the value, or null on failure.</p>
+    </div>
+    <div class="function" id="available" data-name="available">
+      <h3 class="function-name">available <span class="kind">fn</span></h3>
+      <pre class="usage"><code>available() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Is Casper service delegation available?</p>
+    </div>
+    <div class="function" id="init" data-name="init">
+      <h3 class="function-name">init <span class="kind">fn</span></h3>
+      <pre class="usage"><code>init() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">Connect to the casper daemon. Call before capsicum.enter().</p>
+    </div>
+    <div class="function" id="service" data-name="service">
+      <h3 class="function-name">service <span class="kind">fn</span></h3>
+      <pre class="usage"><code>service(casper, name) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">casper: ptr, name: string</span></p>
+      <p class="doc">Open a service channel. Call before capsicum.enter().</p>
+    </div>
+    <div class="function" id="close" data-name="close">
+      <h3 class="function-name">close <span class="kind">fn</span></h3>
+      <pre class="usage"><code>close(chan)</code></pre>
+      <p class="signature"><span class="sig-params">chan: ptr</span></p>
+      <p class="doc">Close a channel.</p>
+    </div>
+    <div class="function" id="dns_resolve" data-name="dns_resolve">
+      <h3 class="function-name">dns_resolve <span class="kind">fn</span></h3>
+      <pre class="usage"><code>dns_resolve(netchan, hostname) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">netchan: ptr, hostname: string</span></p>
+      <p class="doc">Resolve `hostname` via a &quot;system.net&quot; channel. Returns (ip, &quot;&quot;) on success, (&quot;&quot;, error) on failure. Works inside capability mode.</p>
+    </div>
+    <div class="function" id="pwd_uid" data-name="pwd_uid">
+      <h3 class="function-name">pwd_uid <span class="kind">fn</span></h3>
+      <pre class="usage"><code>pwd_uid(pwdchan, username) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">pwdchan: ptr, username: string</span></p>
+      <p class="doc">Look up `username`'s uid via a &quot;system.pwd&quot; channel. -1 if absent.</p>
+    </div>
+    <div class="function" id="pwd_home" data-name="pwd_home">
+      <h3 class="function-name">pwd_home <span class="kind">fn</span></h3>
+      <pre class="usage"><code>pwd_home(pwdchan, username) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">pwdchan: ptr, username: string</span></p>
+      <p class="doc">Look up `username`'s home directory via a &quot;system.pwd&quot; channel. Returns (home, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="sysctl" data-name="sysctl">
+      <h3 class="function-name">sysctl <span class="kind">fn</span></h3>
+      <pre class="usage"><code>sysctl(sysctlchan, name) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">sysctlchan: ptr, name: string</span></p>
+      <p class="doc">Read a string-valued sysctl via a &quot;system.sysctl&quot; channel. Returns (value, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/collections.html
+++ b/docs/api/collections.html
@@ -13,10 +13,11 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search collections..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
+    <li><a href="#list_new">list_new</a></li>
     <li><a href="#list_add_raw">list_add_raw</a></li>
-    <li><a href="#list_get">list_get</a></li>
+    <li><a href="#list_get_raw">list_get_raw</a></li>
     <li><a href="#list_set">list_set</a></li>
     <li><a href="#list_size">list_size</a></li>
     <li><a href="#list_remove">list_remove</a></li>
@@ -24,525 +25,304 @@
     <li><a href="#list_free">list_free</a></li>
     <li><a href="#map_new">map_new</a></li>
     <li><a href="#map_put_raw">map_put_raw</a></li>
-    <li><a href="#map_get">map_get</a></li>
+    <li><a href="#map_get_raw">map_get_raw</a></li>
     <li><a href="#map_has">map_has</a></li>
     <li><a href="#map_remove">map_remove</a></li>
     <li><a href="#map_size">map_size</a></li>
     <li><a href="#map_clear">map_clear</a></li>
     <li><a href="#map_free">map_free</a></li>
-    <li><a href="#map_keys">map_keys</a></li>
+    <li><a href="#map_keys_raw">map_keys_raw</a></li>
     <li><a href="#map_keys_free">map_keys_free</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#set_free">set_free</a></li>
-    <li><a href="#set_add">set_add</a></li>
-    <li><a href="#set_remove">set_remove</a></li>
-    <li><a href="#set_contains">set_contains</a></li>
-    <li><a href="#set_clear">set_clear</a></li>
-    <li><a href="#set_size">set_size</a></li>
-    <li><a href="#set_is_empty">set_is_empty</a></li>
-    <li><a href="#set_union">set_union</a></li>
-    <li><a href="#set_intersection">set_intersection</a></li>
-    <li><a href="#set_difference">set_difference</a></li>
-    <li><a href="#set_is_subset">set_is_subset</a></li>
-    <li><a href="#set_is_superset">set_is_superset</a></li>
-    <li><a href="#set_iterator">set_iterator</a></li>
-    <li><a href="#set_iterator_next">set_iterator_next</a></li>
-    <li><a href="#set_create_string">set_create_string</a></li>
-    <li><a href="#set_create_int">set_create_int</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#uint64_t">uint64_t</a></li>
-    <li><a href="#bool">bool</a></li>
-    <li><a href="#void">void</a></li>
-    <li><a href="#void">void</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#hashmap_free">hashmap_free</a></li>
-    <li><a href="#hashmap_insert">hashmap_insert</a></li>
-    <li><a href="#hashmap_get">hashmap_get</a></li>
-    <li><a href="#hashmap_remove">hashmap_remove</a></li>
-    <li><a href="#hashmap_contains">hashmap_contains</a></li>
-    <li><a href="#hashmap_clear">hashmap_clear</a></li>
-    <li><a href="#hashmap_size">hashmap_size</a></li>
-    <li><a href="#hashmap_is_empty">hashmap_is_empty</a></li>
-    <li><a href="#hashmap_iterator">hashmap_iterator</a></li>
-    <li><a href="#hashmap_iterator_next">hashmap_iterator_next</a></li>
-    <li><a href="#hashmap_hash_string">hashmap_hash_string</a></li>
-    <li><a href="#hashmap_equals_string">hashmap_equals_string</a></li>
-    <li><a href="#hashmap_free_string">hashmap_free_string</a></li>
-    <li><a href="#hashmap_clone_string">hashmap_clone_string</a></li>
-    <li><a href="#hashmap_hash_int">hashmap_hash_int</a></li>
-    <li><a href="#hashmap_equals_int">hashmap_equals_int</a></li>
-    <li><a href="#hashmap_free_int">hashmap_free_int</a></li>
-    <li><a href="#hashmap_clone_int">hashmap_clone_int</a></li>
-    <li><a href="#hashmap_create_string_to_int">hashmap_create_string_to_int</a></li>
-    <li><a href="#hashmap_create_string_to_string">hashmap_create_string_to_string</a></li>
-    <li><a href="#hashmap_create_int_to_int">hashmap_create_int_to_int</a></li>
-    <li><a href="#int">int</a></li>
-    <li><a href="#void">void</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#pqueue_free">pqueue_free</a></li>
-    <li><a href="#pqueue_insert">pqueue_insert</a></li>
-    <li><a href="#pqueue_extract">pqueue_extract</a></li>
-    <li><a href="#pqueue_peek">pqueue_peek</a></li>
-    <li><a href="#pqueue_size">pqueue_size</a></li>
-    <li><a href="#pqueue_is_empty">pqueue_is_empty</a></li>
-    <li><a href="#pqueue_clear">pqueue_clear</a></li>
-    <li><a href="#bool">bool</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#pqueue_compare_int_min">pqueue_compare_int_min</a></li>
-    <li><a href="#pqueue_compare_int_max">pqueue_compare_int_max</a></li>
-    <li><a href="#void">void</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#vector_free">vector_free</a></li>
-    <li><a href="#vector_push">vector_push</a></li>
-    <li><a href="#vector_pop">vector_pop</a></li>
-    <li><a href="#vector_get">vector_get</a></li>
-    <li><a href="#vector_set">vector_set</a></li>
-    <li><a href="#vector_insert">vector_insert</a></li>
-    <li><a href="#vector_remove">vector_remove</a></li>
-    <li><a href="#vector_clear">vector_clear</a></li>
-    <li><a href="#vector_size">vector_size</a></li>
-    <li><a href="#vector_is_empty">vector_is_empty</a></li>
-    <li><a href="#vector_capacity">vector_capacity</a></li>
-    <li><a href="#vector_reserve">vector_reserve</a></li>
-    <li><a href="#vector_shrink_to_fit">vector_shrink_to_fit</a></li>
-    <li><a href="#vector_find">vector_find</a></li>
-    <li><a href="#vector_contains">vector_contains</a></li>
-    <li><a href="#vector_reverse">vector_reverse</a></li>
-    <li><a href="#vector_sort">vector_sort</a></li>
+    <li><a href="#intarr_new_raw">intarr_new_raw</a></li>
+    <li><a href="#intarr_new_filled_raw">intarr_new_filled_raw</a></li>
+    <li><a href="#intarr_size">intarr_size</a></li>
+    <li><a href="#intarr_get_raw">intarr_get_raw</a></li>
+    <li><a href="#intarr_set_raw">intarr_set_raw</a></li>
+    <li><a href="#intarr_get_unchecked">intarr_get_unchecked</a></li>
+    <li><a href="#intarr_set_unchecked">intarr_set_unchecked</a></li>
+    <li><a href="#intarr_fill">intarr_fill</a></li>
+    <li><a href="#intarr_free">intarr_free</a></li>
+    <li><a href="#string_list_new">string_list_new</a></li>
+    <li><a href="#string_list_add">string_list_add</a></li>
+    <li><a href="#string_list_get">string_list_get</a></li>
+    <li><a href="#string_list_set">string_list_set</a></li>
+    <li><a href="#string_list_size">string_list_size</a></li>
+    <li><a href="#string_list_remove">string_list_remove</a></li>
+    <li><a href="#string_list_clear">string_list_clear</a></li>
+    <li><a href="#string_list_free">string_list_free</a></li>
+    <li><a href="#list_add">list_add</a></li>
+    <li><a href="#list_get">list_get</a></li>
+    <li><a href="#map_put">map_put</a></li>
+    <li><a href="#map_get">map_get</a></li>
+    <li><a href="#map_keys">map_keys</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li class="active"><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>collections</h1>
-    <p class="module-desc">Lists, maps, sets, and data structures</p>
+    <p class="module-desc">std.collections - Collections Module Import with: import std.collections API shape: - Raw externs end in `_raw` and return ptr/int in the old C-style convention.</p>
+    <p class="import-line"><code>import std.collections</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="list_add_raw" data-name="list_add_raw">
-      <h3 class="function-name">list_add_raw</h3>
-      <pre class="usage"><code>list_add_raw(list, item)</code></pre>
+    <div class="function" id="list_new" data-name="list_new">
+      <h3 class="function-name">list_new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>list_new() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">---- ArrayList raw externs ----</p>
     </div>
-    <div class="function" id="list_get" data-name="list_get">
-      <h3 class="function-name">list_get</h3>
-      <pre class="usage"><code>list_get(list, index)</code></pre>
+    <div class="function" id="list_add_raw" data-name="list_add_raw">
+      <h3 class="function-name">list_add_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>list_add_raw(list, item) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, item: ptr</span></p>
+    </div>
+    <div class="function" id="list_get_raw" data-name="list_get_raw">
+      <h3 class="function-name">list_get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>list_get_raw(list, index) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
     </div>
     <div class="function" id="list_set" data-name="list_set">
-      <h3 class="function-name">list_set</h3>
+      <h3 class="function-name">list_set <span class="kind">extern</span></h3>
       <pre class="usage"><code>list_set(list, index, item)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int, item: ptr</span></p>
     </div>
     <div class="function" id="list_size" data-name="list_size">
-      <h3 class="function-name">list_size</h3>
-      <pre class="usage"><code>list_size(list)</code></pre>
+      <h3 class="function-name">list_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>list_size(list) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
     </div>
     <div class="function" id="list_remove" data-name="list_remove">
-      <h3 class="function-name">list_remove</h3>
+      <h3 class="function-name">list_remove <span class="kind">extern</span></h3>
       <pre class="usage"><code>list_remove(list, index)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
     </div>
     <div class="function" id="list_clear" data-name="list_clear">
-      <h3 class="function-name">list_clear</h3>
+      <h3 class="function-name">list_clear <span class="kind">extern</span></h3>
       <pre class="usage"><code>list_clear(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
     </div>
     <div class="function" id="list_free" data-name="list_free">
-      <h3 class="function-name">list_free</h3>
+      <h3 class="function-name">list_free <span class="kind">extern</span></h3>
       <pre class="usage"><code>list_free(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
     </div>
     <div class="function" id="map_new" data-name="map_new">
-      <h3 class="function-name">map_new</h3>
-      <pre class="usage"><code>map_new()</code></pre>
+      <h3 class="function-name">map_new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>map_new() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">---- HashMap raw externs ----</p>
     </div>
     <div class="function" id="map_put_raw" data-name="map_put_raw">
-      <h3 class="function-name">map_put_raw</h3>
-      <pre class="usage"><code>map_put_raw(map, key, value)</code></pre>
+      <h3 class="function-name">map_put_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>map_put_raw(map, key, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string, value: ptr</span></p>
+      <p class="doc">`key` is BORROWED: map_put_raw copies the key into the map's own AetherString (string_new at put time, released at map_free), so it never holds a reference to the caller's key bytes after the call. A heap-string `key` argument is therefore the caller's to reclaim — it must NOT be @retain-marked, or the caller's key leaks (the map only ever owns its copy). The map_clear/map_free path releases the COPY, not the caller's original.</p>
     </div>
-    <div class="function" id="map_get" data-name="map_get">
-      <h3 class="function-name">map_get</h3>
-      <pre class="usage"><code>map_get(map, key)</code></pre>
+    <div class="function" id="map_get_raw" data-name="map_get_raw">
+      <h3 class="function-name">map_get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>map_get_raw(map, key) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
     </div>
     <div class="function" id="map_has" data-name="map_has">
-      <h3 class="function-name">map_has</h3>
-      <pre class="usage"><code>map_has(map, key)</code></pre>
+      <h3 class="function-name">map_has <span class="kind">extern</span></h3>
+      <pre class="usage"><code>map_has(map, key) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
     </div>
     <div class="function" id="map_remove" data-name="map_remove">
-      <h3 class="function-name">map_remove</h3>
+      <h3 class="function-name">map_remove <span class="kind">extern</span></h3>
       <pre class="usage"><code>map_remove(map, key)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
     </div>
     <div class="function" id="map_size" data-name="map_size">
-      <h3 class="function-name">map_size</h3>
-      <pre class="usage"><code>map_size(map)</code></pre>
+      <h3 class="function-name">map_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>map_size(map) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
     </div>
     <div class="function" id="map_clear" data-name="map_clear">
-      <h3 class="function-name">map_clear</h3>
+      <h3 class="function-name">map_clear <span class="kind">extern</span></h3>
       <pre class="usage"><code>map_clear(map)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
     </div>
     <div class="function" id="map_free" data-name="map_free">
-      <h3 class="function-name">map_free</h3>
+      <h3 class="function-name">map_free <span class="kind">extern</span></h3>
       <pre class="usage"><code>map_free(map)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
     </div>
-    <div class="function" id="map_keys" data-name="map_keys">
-      <h3 class="function-name">map_keys</h3>
-      <pre class="usage"><code>map_keys(map)</code></pre>
+    <div class="function" id="map_keys_raw" data-name="map_keys_raw">
+      <h3 class="function-name">map_keys_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>map_keys_raw(map) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
+      <p class="doc">---- Key iteration ----</p>
     </div>
     <div class="function" id="map_keys_free" data-name="map_keys_free">
-      <h3 class="function-name">map_keys_free</h3>
+      <h3 class="function-name">map_keys_free <span class="kind">extern</span></h3>
       <pre class="usage"><code>map_keys_free(keys)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(key_clone)</code></pre>
-    </div>
-    <div class="function" id="set_free" data-name="set_free">
-      <h3 class="function-name">set_free</h3>
-      <pre class="usage"><code>set_free(set)</code></pre>
-    </div>
-    <div class="function" id="set_add" data-name="set_add">
-      <h3 class="function-name">set_add</h3>
-      <pre class="usage"><code>set_add(set, element)</code></pre>
-      <p class="doc">Core operations</p>
-    </div>
-    <div class="function" id="set_remove" data-name="set_remove">
-      <h3 class="function-name">set_remove</h3>
-      <pre class="usage"><code>set_remove(set, element)</code></pre>
-    </div>
-    <div class="function" id="set_contains" data-name="set_contains">
-      <h3 class="function-name">set_contains</h3>
-      <pre class="usage"><code>set_contains(set, element)</code></pre>
-    </div>
-    <div class="function" id="set_clear" data-name="set_clear">
-      <h3 class="function-name">set_clear</h3>
-      <pre class="usage"><code>set_clear(set)</code></pre>
-    </div>
-    <div class="function" id="set_size" data-name="set_size">
-      <h3 class="function-name">set_size</h3>
-      <pre class="usage"><code>set_size(set)</code></pre>
-      <p class="doc">Size operations</p>
-    </div>
-    <div class="function" id="set_is_empty" data-name="set_is_empty">
-      <h3 class="function-name">set_is_empty</h3>
-      <pre class="usage"><code>set_is_empty(set)</code></pre>
-    </div>
-    <div class="function" id="set_union" data-name="set_union">
-      <h3 class="function-name">set_union</h3>
-      <pre class="usage"><code>set_union(a, b)</code></pre>
-      <p class="doc">Set operations</p>
-    </div>
-    <div class="function" id="set_intersection" data-name="set_intersection">
-      <h3 class="function-name">set_intersection</h3>
-      <pre class="usage"><code>set_intersection(a, b)</code></pre>
-    </div>
-    <div class="function" id="set_difference" data-name="set_difference">
-      <h3 class="function-name">set_difference</h3>
-      <pre class="usage"><code>set_difference(a, b)</code></pre>
-    </div>
-    <div class="function" id="set_is_subset" data-name="set_is_subset">
-      <h3 class="function-name">set_is_subset</h3>
-      <pre class="usage"><code>set_is_subset(a, b)</code></pre>
-    </div>
-    <div class="function" id="set_is_superset" data-name="set_is_superset">
-      <h3 class="function-name">set_is_superset</h3>
-      <pre class="usage"><code>set_is_superset(a, b)</code></pre>
-    </div>
-    <div class="function" id="set_iterator" data-name="set_iterator">
-      <h3 class="function-name">set_iterator</h3>
-      <pre class="usage"><code>set_iterator(set)</code></pre>
-    </div>
-    <div class="function" id="set_iterator_next" data-name="set_iterator_next">
-      <h3 class="function-name">set_iterator_next</h3>
-      <pre class="usage"><code>set_iterator_next(iter, element)</code></pre>
-    </div>
-    <div class="function" id="set_create_string" data-name="set_create_string">
-      <h3 class="function-name">set_create_string</h3>
-      <pre class="usage"><code>set_create_string(initial_capacity)</code></pre>
-      <p class="doc">Convenience constructors</p>
-    </div>
-    <div class="function" id="set_create_int" data-name="set_create_int">
-      <h3 class="function-name">set_create_int</h3>
-      <pre class="usage"><code>set_create_int(initial_capacity)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-    </div>
-    <div class="function" id="uint64_t" data-name="uint64_t">
-      <h3 class="function-name">uint64_t</h3>
-      <pre class="usage"><code>uint64_t(hash_func)</code></pre>
-      <p class="doc">Function pointers for generic key/value operations</p>
-    </div>
-    <div class="function" id="bool" data-name="bool">
-      <h3 class="function-name">bool</h3>
-      <pre class="usage"><code>bool(key_equals)</code></pre>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(key_free)</code></pre>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(value_free)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(key_clone)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(value_clone)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(value_clone)</code></pre>
-    </div>
-    <div class="function" id="hashmap_free" data-name="hashmap_free">
-      <h3 class="function-name">hashmap_free</h3>
-      <pre class="usage"><code>hashmap_free(map)</code></pre>
-    </div>
-    <div class="function" id="hashmap_insert" data-name="hashmap_insert">
-      <h3 class="function-name">hashmap_insert</h3>
-      <pre class="usage"><code>hashmap_insert(map, key, value)</code></pre>
-      <p class="doc">Core operations</p>
-    </div>
-    <div class="function" id="hashmap_get" data-name="hashmap_get">
-      <h3 class="function-name">hashmap_get</h3>
-      <pre class="usage"><code>hashmap_get(map, key)</code></pre>
-    </div>
-    <div class="function" id="hashmap_remove" data-name="hashmap_remove">
-      <h3 class="function-name">hashmap_remove</h3>
-      <pre class="usage"><code>hashmap_remove(map, key)</code></pre>
-    </div>
-    <div class="function" id="hashmap_contains" data-name="hashmap_contains">
-      <h3 class="function-name">hashmap_contains</h3>
-      <pre class="usage"><code>hashmap_contains(map, key)</code></pre>
-    </div>
-    <div class="function" id="hashmap_clear" data-name="hashmap_clear">
-      <h3 class="function-name">hashmap_clear</h3>
-      <pre class="usage"><code>hashmap_clear(map)</code></pre>
-    </div>
-    <div class="function" id="hashmap_size" data-name="hashmap_size">
-      <h3 class="function-name">hashmap_size</h3>
-      <pre class="usage"><code>hashmap_size(map)</code></pre>
-      <p class="doc">Size operations</p>
-    </div>
-    <div class="function" id="hashmap_is_empty" data-name="hashmap_is_empty">
-      <h3 class="function-name">hashmap_is_empty</h3>
-      <pre class="usage"><code>hashmap_is_empty(map)</code></pre>
-    </div>
-    <div class="function" id="hashmap_iterator" data-name="hashmap_iterator">
-      <h3 class="function-name">hashmap_iterator</h3>
-      <pre class="usage"><code>hashmap_iterator(map)</code></pre>
-      <p class="doc">Iterator operations</p>
-    </div>
-    <div class="function" id="hashmap_iterator_next" data-name="hashmap_iterator_next">
-      <h3 class="function-name">hashmap_iterator_next</h3>
-      <pre class="usage"><code>hashmap_iterator_next(iter, key, value)</code></pre>
-    </div>
-    <div class="function" id="hashmap_hash_string" data-name="hashmap_hash_string">
-      <h3 class="function-name">hashmap_hash_string</h3>
-      <pre class="usage"><code>hashmap_hash_string(key)</code></pre>
-      <p class="doc">Utility functions for common types</p>
-    </div>
-    <div class="function" id="hashmap_equals_string" data-name="hashmap_equals_string">
-      <h3 class="function-name">hashmap_equals_string</h3>
-      <pre class="usage"><code>hashmap_equals_string(a, b)</code></pre>
-    </div>
-    <div class="function" id="hashmap_free_string" data-name="hashmap_free_string">
-      <h3 class="function-name">hashmap_free_string</h3>
-      <pre class="usage"><code>hashmap_free_string(str)</code></pre>
-    </div>
-    <div class="function" id="hashmap_clone_string" data-name="hashmap_clone_string">
-      <h3 class="function-name">hashmap_clone_string</h3>
-      <pre class="usage"><code>hashmap_clone_string(str)</code></pre>
-    </div>
-    <div class="function" id="hashmap_hash_int" data-name="hashmap_hash_int">
-      <h3 class="function-name">hashmap_hash_int</h3>
-      <pre class="usage"><code>hashmap_hash_int(key)</code></pre>
-    </div>
-    <div class="function" id="hashmap_equals_int" data-name="hashmap_equals_int">
-      <h3 class="function-name">hashmap_equals_int</h3>
-      <pre class="usage"><code>hashmap_equals_int(a, b)</code></pre>
-    </div>
-    <div class="function" id="hashmap_free_int" data-name="hashmap_free_int">
-      <h3 class="function-name">hashmap_free_int</h3>
-      <pre class="usage"><code>hashmap_free_int(ptr)</code></pre>
-    </div>
-    <div class="function" id="hashmap_clone_int" data-name="hashmap_clone_int">
-      <h3 class="function-name">hashmap_clone_int</h3>
-      <pre class="usage"><code>hashmap_clone_int(ptr)</code></pre>
-    </div>
-    <div class="function" id="hashmap_create_string_to_int" data-name="hashmap_create_string_to_int">
-      <h3 class="function-name">hashmap_create_string_to_int</h3>
-      <pre class="usage"><code>hashmap_create_string_to_int(initial_capacity)</code></pre>
-      <p class="doc">Convenience constructors</p>
-    </div>
-    <div class="function" id="hashmap_create_string_to_string" data-name="hashmap_create_string_to_string">
-      <h3 class="function-name">hashmap_create_string_to_string</h3>
-      <pre class="usage"><code>hashmap_create_string_to_string(initial_capacity)</code></pre>
-    </div>
-    <div class="function" id="hashmap_create_int_to_int" data-name="hashmap_create_int_to_int">
-      <h3 class="function-name">hashmap_create_int_to_int</h3>
-      <pre class="usage"><code>hashmap_create_int_to_int(initial_capacity)</code></pre>
-    </div>
-    <div class="function" id="int" data-name="int">
-      <h3 class="function-name">int</h3>
-      <pre class="usage"><code>int(compare)</code></pre>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(element_free)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(element_clone)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(element_clone)</code></pre>
-    </div>
-    <div class="function" id="pqueue_free" data-name="pqueue_free">
-      <h3 class="function-name">pqueue_free</h3>
-      <pre class="usage"><code>pqueue_free(pq)</code></pre>
-    </div>
-    <div class="function" id="pqueue_insert" data-name="pqueue_insert">
-      <h3 class="function-name">pqueue_insert</h3>
-      <pre class="usage"><code>pqueue_insert(pq, element)</code></pre>
-      <p class="doc">Core operations - O(log n)</p>
-    </div>
-    <div class="function" id="pqueue_extract" data-name="pqueue_extract">
-      <h3 class="function-name">pqueue_extract</h3>
-      <pre class="usage"><code>pqueue_extract(pq)</code></pre>
-    </div>
-    <div class="function" id="pqueue_peek" data-name="pqueue_peek">
-      <h3 class="function-name">pqueue_peek</h3>
-      <pre class="usage"><code>pqueue_peek(pq)</code></pre>
-      <p class="doc">Query operations - O(1)</p>
-    </div>
-    <div class="function" id="pqueue_size" data-name="pqueue_size">
-      <h3 class="function-name">pqueue_size</h3>
-      <pre class="usage"><code>pqueue_size(pq)</code></pre>
-    </div>
-    <div class="function" id="pqueue_is_empty" data-name="pqueue_is_empty">
-      <h3 class="function-name">pqueue_is_empty</h3>
-      <pre class="usage"><code>pqueue_is_empty(pq)</code></pre>
-    </div>
-    <div class="function" id="pqueue_clear" data-name="pqueue_clear">
-      <h3 class="function-name">pqueue_clear</h3>
-      <pre class="usage"><code>pqueue_clear(pq)</code></pre>
-      <p class="doc">Utility</p>
-    </div>
-    <div class="function" id="bool" data-name="bool">
-      <h3 class="function-name">bool</h3>
-      <pre class="usage"><code>bool(equals)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(element_clone)</code></pre>
-    </div>
-    <div class="function" id="pqueue_compare_int_min" data-name="pqueue_compare_int_min">
-      <h3 class="function-name">pqueue_compare_int_min</h3>
-      <pre class="usage"><code>pqueue_compare_int_min(a, b)</code></pre>
-      <p class="doc">Common comparators</p>
-    </div>
-    <div class="function" id="pqueue_compare_int_max" data-name="pqueue_compare_int_max">
-      <h3 class="function-name">pqueue_compare_int_max</h3>
-      <pre class="usage"><code>pqueue_compare_int_max(a, b)</code></pre>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(element_free)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(element_clone)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(element_clone)</code></pre>
-    </div>
-    <div class="function" id="vector_free" data-name="vector_free">
-      <h3 class="function-name">vector_free</h3>
-      <pre class="usage"><code>vector_free(vec)</code></pre>
-    </div>
-    <div class="function" id="vector_push" data-name="vector_push">
-      <h3 class="function-name">vector_push</h3>
-      <pre class="usage"><code>vector_push(vec, element)</code></pre>
-      <p class="doc">Core operations (amortized O(1) for push)</p>
-    </div>
-    <div class="function" id="vector_pop" data-name="vector_pop">
-      <h3 class="function-name">vector_pop</h3>
-      <pre class="usage"><code>vector_pop(vec)</code></pre>
-    </div>
-    <div class="function" id="vector_get" data-name="vector_get">
-      <h3 class="function-name">vector_get</h3>
-      <pre class="usage"><code>vector_get(vec, index)</code></pre>
-    </div>
-    <div class="function" id="vector_set" data-name="vector_set">
-      <h3 class="function-name">vector_set</h3>
-      <pre class="usage"><code>vector_set(vec, index, element)</code></pre>
-    </div>
-    <div class="function" id="vector_insert" data-name="vector_insert">
-      <h3 class="function-name">vector_insert</h3>
-      <pre class="usage"><code>vector_insert(vec, index, element)</code></pre>
-    </div>
-    <div class="function" id="vector_remove" data-name="vector_remove">
-      <h3 class="function-name">vector_remove</h3>
-      <pre class="usage"><code>vector_remove(vec, index)</code></pre>
-    </div>
-    <div class="function" id="vector_clear" data-name="vector_clear">
-      <h3 class="function-name">vector_clear</h3>
-      <pre class="usage"><code>vector_clear(vec)</code></pre>
-    </div>
-    <div class="function" id="vector_size" data-name="vector_size">
-      <h3 class="function-name">vector_size</h3>
-      <pre class="usage"><code>vector_size(vec)</code></pre>
-      <p class="doc">Size operations</p>
-    </div>
-    <div class="function" id="vector_is_empty" data-name="vector_is_empty">
-      <h3 class="function-name">vector_is_empty</h3>
-      <pre class="usage"><code>vector_is_empty(vec)</code></pre>
-    </div>
-    <div class="function" id="vector_capacity" data-name="vector_capacity">
-      <h3 class="function-name">vector_capacity</h3>
-      <pre class="usage"><code>vector_capacity(vec)</code></pre>
-    </div>
-    <div class="function" id="vector_reserve" data-name="vector_reserve">
-      <h3 class="function-name">vector_reserve</h3>
-      <pre class="usage"><code>vector_reserve(vec, new_capacity)</code></pre>
-    </div>
-    <div class="function" id="vector_shrink_to_fit" data-name="vector_shrink_to_fit">
-      <h3 class="function-name">vector_shrink_to_fit</h3>
-      <pre class="usage"><code>vector_shrink_to_fit(vec)</code></pre>
-    </div>
-    <div class="function" id="vector_find" data-name="vector_find">
-      <h3 class="function-name">vector_find</h3>
-      <pre class="usage"><code>vector_find(vec, element, equals)</code></pre>
-      <p class="doc">Search operations</p>
-    </div>
-    <div class="function" id="vector_contains" data-name="vector_contains">
-      <h3 class="function-name">vector_contains</h3>
-      <pre class="usage"><code>vector_contains(vec, element, equals)</code></pre>
-    </div>
-    <div class="function" id="vector_reverse" data-name="vector_reverse">
-      <h3 class="function-name">vector_reverse</h3>
-      <pre class="usage"><code>vector_reverse(vec)</code></pre>
-      <p class="doc">Utility operations</p>
-    </div>
-    <div class="function" id="vector_sort" data-name="vector_sort">
-      <h3 class="function-name">vector_sort</h3>
-      <pre class="usage"><code>vector_sort(vec, compare)</code></pre>
+      <p class="signature"><span class="sig-params">keys: ptr</span></p>
+    </div>
+    <div class="function" id="intarr_new_raw" data-name="intarr_new_raw">
+      <h3 class="function-name">intarr_new_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_new_raw(size) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">---- IntArray raw externs ---- Fixed-size packed int buffer with O(1) random access. For DP tables and other hot loops where std.list's void*-boxed items would cost an allocation per entry. Go-style wrappers live in std.intarr — import that module for `intarr.new(size)` / etc.</p>
+    </div>
+    <div class="function" id="intarr_new_filled_raw" data-name="intarr_new_filled_raw">
+      <h3 class="function-name">intarr_new_filled_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_new_filled_raw(size, init) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int, init: int</span></p>
+    </div>
+    <div class="function" id="intarr_size" data-name="intarr_size">
+      <h3 class="function-name">intarr_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_size(arr) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+    </div>
+    <div class="function" id="intarr_get_raw" data-name="intarr_get_raw">
+      <h3 class="function-name">intarr_get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_get_raw(arr, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+    </div>
+    <div class="function" id="intarr_set_raw" data-name="intarr_set_raw">
+      <h3 class="function-name">intarr_set_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_set_raw(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: int</span></p>
+    </div>
+    <div class="function" id="intarr_get_unchecked" data-name="intarr_get_unchecked">
+      <h3 class="function-name">intarr_get_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_get_unchecked(arr, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+    </div>
+    <div class="function" id="intarr_set_unchecked" data-name="intarr_set_unchecked">
+      <h3 class="function-name">intarr_set_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_set_unchecked(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: int</span></p>
+    </div>
+    <div class="function" id="intarr_fill" data-name="intarr_fill">
+      <h3 class="function-name">intarr_fill <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_fill(arr, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, value: int</span></p>
+    </div>
+    <div class="function" id="intarr_free" data-name="intarr_free">
+      <h3 class="function-name">intarr_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>intarr_free(arr)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+    </div>
+    <div class="function" id="string_list_new" data-name="string_list_new">
+      <h3 class="function-name">string_list_new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_new() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">---- StringList: refcount-aware list for AetherString values ---- The plain ArrayList stores items as raw `void*` and doesn't retain on insert / release on remove. That works for caller-managed lifetimes but silently dangles when the list is asked to hold AetherString-bearing values whose refcount drops to zero before the list itself is freed (the original variable goes out of scope, the string frees, the list is left with a stale pointer). StringList wraps the same backing storage but takes a strong reference on every insert and releases on remove / clear / free. Plain `string` literals pass through unchanged — string_retain is a no-op on values that don't bear the AetherString magic header. Issue #274.</p>
+    </div>
+    <div class="function" id="string_list_add" data-name="string_list_add">
+      <h3 class="function-name">string_list_add <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_add(list, s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, s: string</span></p>
+      <p class="doc">`s` is COPIED, not retained: the list owns an independent NUL- terminated copy of the string's bytes and frees it itself (in remove / clear / free / overwriting set). The caller therefore keeps ownership of its argument — a `string`-typed param is read-only to the escape walker, so the caller's heap value is reclaimed normally at its own scope exit. This is why there is no `@retain` here: an earlier version stored the caller's pointer (needing `@retain` to suppress the caller's free and avoid a UAF), but that leaked every plain `char*` element — `string_retain`/`string_release` are no-ops on non-magic `char*`, so the list could never reclaim a `string.concat`/`split` result. Copy-on-add owns the bytes outright, fixing the leak with no UAF. (#420 / leak-tail follow-up.)</p>
+    </div>
+    <div class="function" id="string_list_get" data-name="string_list_get">
+      <h3 class="function-name">string_list_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_get(list, index) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="string_list_set" data-name="string_list_set">
+      <h3 class="function-name">string_list_set <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_set(list, index, s)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int, s: string</span></p>
+      <p class="doc">`s` is copied, same as string_list_add; the overwritten element is freed.</p>
+    </div>
+    <div class="function" id="string_list_size" data-name="string_list_size">
+      <h3 class="function-name">string_list_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_size(list) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="string_list_remove" data-name="string_list_remove">
+      <h3 class="function-name">string_list_remove <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_remove(list, index)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="string_list_clear" data-name="string_list_clear">
+      <h3 class="function-name">string_list_clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_clear(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="string_list_free" data-name="string_list_free">
+      <h3 class="function-name">string_list_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>string_list_free(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="list_add" data-name="list_add">
+      <h3 class="function-name">list_add <span class="kind">fn</span></h3>
+      <pre class="usage"><code>list_add(list, item) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, item: ptr</span></p>
+      <p class="doc">Append an item to a list. Returns &quot;&quot; on success, error on failure (OOM during resize, null list).</p>
+    </div>
+    <div class="function" id="list_get" data-name="list_get">
+      <h3 class="function-name">list_get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>list_get(list, index) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
+      <p class="doc">Index into a list. - (item, &quot;&quot;)            : index in range - (null, &quot;&quot;)            : index out of range (not an error) - (null, &quot;null list&quot;)   : `list` is null</p>
+    </div>
+    <div class="function" id="map_put" data-name="map_put">
+      <h3 class="function-name">map_put <span class="kind">fn</span></h3>
+      <pre class="usage"><code>map_put(map, key, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string, value: ptr</span></p>
+      <p class="doc">Insert or update a key-value pair. Returns &quot;&quot; on success, error on failure (OOM during resize, null map, null key).</p>
+    </div>
+    <div class="function" id="map_get" data-name="map_get">
+      <h3 class="function-name">map_get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>map_get(map, key) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
+      <p class="doc">Look up a key. - (value, &quot;&quot;)          : key present - (null, &quot;&quot;)           : key absent (not an error — use map.has to disambiguate) - (null, &quot;null map&quot;)   : `map` is null</p>
+    </div>
+    <div class="function" id="map_keys" data-name="map_keys">
+      <h3 class="function-name">map_keys <span class="kind">fn</span></h3>
+      <pre class="usage"><code>map_keys(map) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
+      <p class="doc">Snapshot a map's keys. Returns (MapKeys ptr, &quot;&quot;) on success, (null, error) on allocation failure. Caller must free the returned ptr with map.keys_free.</p>
     </div>
   </div>
 </main>

--- a/docs/api/config.html
+++ b/docs/api/config.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>config - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search config..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_config_put">aether_config_put</a></li>
+    <li><a href="#aether_config_get">aether_config_get</a></li>
+    <li><a href="#aether_config_get_or">aether_config_get_or</a></li>
+    <li><a href="#aether_config_has">aether_config_has</a></li>
+    <li><a href="#aether_config_size">aether_config_size</a></li>
+    <li><a href="#aether_config_clear">aether_config_clear</a></li>
+    <li><a href="#put">put</a></li>
+    <li><a href="#get">get</a></li>
+    <li><a href="#get_or">get_or</a></li>
+    <li><a href="#has">has</a></li>
+    <li><a href="#size">size</a></li>
+    <li><a href="#clear">clear</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li class="active"><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>config</h1>
+    <p class="module-desc">std.config — process-global immutable string→string KV store.</p>
+    <p class="import-line"><code>import std.config</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_config_put" data-name="aether_config_put">
+      <h3 class="function-name">aether_config_put <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_config_put(key, value)</code></pre>
+      <p class="signature"><span class="sig-params">key: string, value: string</span></p>
+      <p class="doc">---- Raw externs ----</p>
+    </div>
+    <div class="function" id="aether_config_get" data-name="aether_config_get">
+      <h3 class="function-name">aether_config_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_config_get(key) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">key: string</span></p>
+    </div>
+    <div class="function" id="aether_config_get_or" data-name="aether_config_get_or">
+      <h3 class="function-name">aether_config_get_or <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_config_get_or(key, default_value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">key: string, default_value: string</span></p>
+    </div>
+    <div class="function" id="aether_config_has" data-name="aether_config_has">
+      <h3 class="function-name">aether_config_has <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_config_has(key) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">key: string</span></p>
+    </div>
+    <div class="function" id="aether_config_size" data-name="aether_config_size">
+      <h3 class="function-name">aether_config_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_config_size() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="aether_config_clear" data-name="aether_config_clear">
+      <h3 class="function-name">aether_config_clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_config_clear()</code></pre>
+    </div>
+    <div class="function" id="put" data-name="put">
+      <h3 class="function-name">put <span class="kind">fn</span></h3>
+      <pre class="usage"><code>put(key, value)</code></pre>
+      <p class="signature"><span class="sig-params">key: string, value: string</span></p>
+      <p class="doc">Insert / overwrite. Both `key` and `value` are duplicated internally; the caller's string lifetimes don't matter.</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(key) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">key: string</span></p>
+      <p class="doc">Retrieve. Returns &quot;&quot; if the key isn't set (matches Aether's Go-style &quot;&quot; = absent convention).</p>
+    </div>
+    <div class="function" id="get_or" data-name="get_or">
+      <h3 class="function-name">get_or <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_or(key, default_value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">key: string, default_value: string</span></p>
+      <p class="doc">Retrieve with a fallback. Returns the registered value if set, otherwise `default_value`.</p>
+    </div>
+    <div class="function" id="has" data-name="has">
+      <h3 class="function-name">has <span class="kind">fn</span></h3>
+      <pre class="usage"><code>has(key) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">key: string</span></p>
+      <p class="doc">1 if `key` has been put, 0 otherwise.</p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">fn</span></h3>
+      <pre class="usage"><code>size() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Number of keys currently registered. Mostly for tests / debug.</p>
+    </div>
+    <div class="function" id="clear" data-name="clear">
+      <h3 class="function-name">clear <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clear()</code></pre>
+      <p class="doc">Wipe all keys. Tests use this for isolation; production code almost never needs it.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/cryptography.html
+++ b/docs/api/cryptography.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>cryptography - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search cryptography..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#sha1_hex_raw">sha1_hex_raw</a></li>
+    <li><a href="#sha256_hex_raw">sha256_hex_raw</a></li>
+    <li><a href="#hash_hex_raw">hash_hex_raw</a></li>
+    <li><a href="#hash_supported">hash_supported</a></li>
+    <li><a href="#base64_encode_raw">base64_encode_raw</a></li>
+    <li><a href="#base64_encode_padded_raw">base64_encode_padded_raw</a></li>
+    <li><a href="#base64_decode_raw">base64_decode_raw</a></li>
+    <li><a href="#get_base64_decode">get_base64_decode</a></li>
+    <li><a href="#get_base64_decode_length">get_base64_decode_length</a></li>
+    <li><a href="#release_base64_decode">release_base64_decode</a></li>
+    <li><a href="#md4_hex_raw">md4_hex_raw</a></li>
+    <li><a href="#md5_hex_raw">md5_hex_raw</a></li>
+    <li><a href="#hmac_sha256_hex_raw">hmac_sha256_hex_raw</a></li>
+    <li><a href="#hmac_sha256_bytes_raw">hmac_sha256_bytes_raw</a></li>
+    <li><a href="#md4_bytes_raw">md4_bytes_raw</a></li>
+    <li><a href="#md5_bytes_raw">md5_bytes_raw</a></li>
+    <li><a href="#sha1_bytes_raw">sha1_bytes_raw</a></li>
+    <li><a href="#sha256_bytes_raw">sha256_bytes_raw</a></li>
+    <li><a href="#hash_bytes_raw">hash_bytes_raw</a></li>
+    <li><a href="#get_binary_digest">get_binary_digest</a></li>
+    <li><a href="#get_binary_digest_length">get_binary_digest_length</a></li>
+    <li><a href="#release_binary_digest">release_binary_digest</a></li>
+    <li><a href="#random_bytes_raw">random_bytes_raw</a></li>
+    <li><a href="#get_random_bytes">get_random_bytes</a></li>
+    <li><a href="#get_random_bytes_length">get_random_bytes_length</a></li>
+    <li><a href="#release_random_bytes">release_random_bytes</a></li>
+    <li><a href="#digest_new_raw">digest_new_raw</a></li>
+    <li><a href="#digest_update_raw">digest_update_raw</a></li>
+    <li><a href="#digest_final_hex_raw">digest_final_hex_raw</a></li>
+    <li><a href="#digest_final_bytes_raw">digest_final_bytes_raw</a></li>
+    <li><a href="#digest_free_raw">digest_free_raw</a></li>
+    <li><a href="#sha1_hex">sha1_hex</a></li>
+    <li><a href="#sha256_hex">sha256_hex</a></li>
+    <li><a href="#hash_hex">hash_hex</a></li>
+    <li><a href="#base64_encode">base64_encode</a></li>
+    <li><a href="#base64_encode_padded">base64_encode_padded</a></li>
+    <li><a href="#base64_decode">base64_decode</a></li>
+    <li><a href="#md4_hex">md4_hex</a></li>
+    <li><a href="#md5_hex">md5_hex</a></li>
+    <li><a href="#hmac_sha256_hex">hmac_sha256_hex</a></li>
+    <li><a href="#hmac_sha256_bytes">hmac_sha256_bytes</a></li>
+    <li><a href="#md4_bytes">md4_bytes</a></li>
+    <li><a href="#md5_bytes">md5_bytes</a></li>
+    <li><a href="#sha1_bytes">sha1_bytes</a></li>
+    <li><a href="#sha256_bytes">sha256_bytes</a></li>
+    <li><a href="#hash_bytes">hash_bytes</a></li>
+    <li><a href="#random_bytes">random_bytes</a></li>
+    <li><a href="#random_hex">random_hex</a></li>
+    <li><a href="#random_base64">random_base64</a></li>
+    <li><a href="#digest_new">digest_new</a></li>
+    <li><a href="#digest_update">digest_update</a></li>
+    <li><a href="#digest_final_hex">digest_final_hex</a></li>
+    <li><a href="#digest_final_bytes">digest_final_bytes</a></li>
+    <li><a href="#digest_free">digest_free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li class="active"><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>cryptography</h1>
+    <p class="module-desc">std.cryptography - Cryptographic hash primitives + Base64 codec Import with: import std.cryptography Pure functions: bytes in, hex digest or Base64 string out.</p>
+    <p class="import-line"><code>import std.cryptography</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="sha1_hex_raw" data-name="sha1_hex_raw">
+      <h3 class="function-name">sha1_hex_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>sha1_hex_raw(data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="sha256_hex_raw" data-name="sha256_hex_raw">
+      <h3 class="function-name">sha256_hex_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>sha256_hex_raw(data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="hash_hex_raw" data-name="hash_hex_raw">
+      <h3 class="function-name">hash_hex_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>hash_hex_raw(algo, data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">algo: string, data: string, length: int</span></p>
+    </div>
+    <div class="function" id="hash_supported" data-name="hash_supported">
+      <h3 class="function-name">hash_supported <span class="kind">extern</span></h3>
+      <pre class="usage"><code>hash_supported(algo) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">algo: string</span></p>
+    </div>
+    <div class="function" id="base64_encode_raw" data-name="base64_encode_raw">
+      <h3 class="function-name">base64_encode_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>base64_encode_raw(data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="base64_encode_padded_raw" data-name="base64_encode_padded_raw">
+      <h3 class="function-name">base64_encode_padded_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>base64_encode_padded_raw(data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="base64_decode_raw" data-name="base64_decode_raw">
+      <h3 class="function-name">base64_decode_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>base64_decode_raw(b64) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b64: string</span></p>
+    </div>
+    <div class="function" id="get_base64_decode" data-name="get_base64_decode">
+      <h3 class="function-name">get_base64_decode <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_base64_decode() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_base64_decode_length" data-name="get_base64_decode_length">
+      <h3 class="function-name">get_base64_decode_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_base64_decode_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_base64_decode" data-name="release_base64_decode">
+      <h3 class="function-name">release_base64_decode <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_base64_decode()</code></pre>
+    </div>
+    <div class="function" id="md4_hex_raw" data-name="md4_hex_raw">
+      <h3 class="function-name">md4_hex_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>md4_hex_raw(data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="md5_hex_raw" data-name="md5_hex_raw">
+      <h3 class="function-name">md5_hex_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>md5_hex_raw(data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="hmac_sha256_hex_raw" data-name="hmac_sha256_hex_raw">
+      <h3 class="function-name">hmac_sha256_hex_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>hmac_sha256_hex_raw(key, key_len, msg, msg_len) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">key: string, key_len: int, msg: string, msg_len: int</span></p>
+    </div>
+    <div class="function" id="hmac_sha256_bytes_raw" data-name="hmac_sha256_bytes_raw">
+      <h3 class="function-name">hmac_sha256_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>hmac_sha256_bytes_raw(key, key_len, msg, msg_len) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">key: string, key_len: int, msg: string, msg_len: int</span></p>
+    </div>
+    <div class="function" id="md4_bytes_raw" data-name="md4_bytes_raw">
+      <h3 class="function-name">md4_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>md4_bytes_raw(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="md5_bytes_raw" data-name="md5_bytes_raw">
+      <h3 class="function-name">md5_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>md5_bytes_raw(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="sha1_bytes_raw" data-name="sha1_bytes_raw">
+      <h3 class="function-name">sha1_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>sha1_bytes_raw(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="sha256_bytes_raw" data-name="sha256_bytes_raw">
+      <h3 class="function-name">sha256_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>sha256_bytes_raw(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="hash_bytes_raw" data-name="hash_bytes_raw">
+      <h3 class="function-name">hash_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>hash_bytes_raw(algo, data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">algo: string, data: string, length: int</span></p>
+    </div>
+    <div class="function" id="get_binary_digest" data-name="get_binary_digest">
+      <h3 class="function-name">get_binary_digest <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_binary_digest() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_binary_digest_length" data-name="get_binary_digest_length">
+      <h3 class="function-name">get_binary_digest_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_binary_digest_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_binary_digest" data-name="release_binary_digest">
+      <h3 class="function-name">release_binary_digest <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_binary_digest()</code></pre>
+    </div>
+    <div class="function" id="random_bytes_raw" data-name="random_bytes_raw">
+      <h3 class="function-name">random_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>random_bytes_raw(n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">n: int</span></p>
+    </div>
+    <div class="function" id="get_random_bytes" data-name="get_random_bytes">
+      <h3 class="function-name">get_random_bytes <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_random_bytes() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_random_bytes_length" data-name="get_random_bytes_length">
+      <h3 class="function-name">get_random_bytes_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_random_bytes_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_random_bytes" data-name="release_random_bytes">
+      <h3 class="function-name">release_random_bytes <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_random_bytes()</code></pre>
+    </div>
+    <div class="function" id="digest_new_raw" data-name="digest_new_raw">
+      <h3 class="function-name">digest_new_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>digest_new_raw(algo) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">algo: string</span></p>
+    </div>
+    <div class="function" id="digest_update_raw" data-name="digest_update_raw">
+      <h3 class="function-name">digest_update_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>digest_update_raw(handle, data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr, data: string, length: int</span></p>
+    </div>
+    <div class="function" id="digest_final_hex_raw" data-name="digest_final_hex_raw">
+      <h3 class="function-name">digest_final_hex_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>digest_final_hex_raw(handle) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr</span></p>
+    </div>
+    <div class="function" id="digest_final_bytes_raw" data-name="digest_final_bytes_raw">
+      <h3 class="function-name">digest_final_bytes_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>digest_final_bytes_raw(handle) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr</span></p>
+    </div>
+    <div class="function" id="digest_free_raw" data-name="digest_free_raw">
+      <h3 class="function-name">digest_free_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>digest_free_raw(handle)</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr</span></p>
+    </div>
+    <div class="function" id="sha1_hex" data-name="sha1_hex">
+      <h3 class="function-name">sha1_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>sha1_hex(data, length) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">Compute the SHA-1 hex digest of the first `length` bytes of `data`. Returns (digest, &quot;&quot;) on success, (&quot;&quot;, error) when OpenSSL is unavailable or the hash context could not be created. SHA-1 is included for interop with legacy formats (Git object IDs, Subversion rep-stores, HMAC-SHA1 fixtures). Prefer SHA-256 for new work.</p>
+    </div>
+    <div class="function" id="sha256_hex" data-name="sha256_hex">
+      <h3 class="function-name">sha256_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>sha256_hex(data, length) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">Compute the SHA-256 hex digest of the first `length` bytes of `data`. Returns (digest, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="hash_hex" data-name="hash_hex">
+      <h3 class="function-name">hash_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>hash_hex(algo, data, length) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">algo: string, data: string, length: int</span></p>
+      <p class="doc">Algorithm-by-name digest dispatch. `algo` is a string like &quot;sha1&quot; or &quot;sha256&quot; — useful when the algorithm is config-driven rather than compile-time. Returns the same lowercase-hex shape as sha1_hex / sha256_hex, or (&quot;&quot;, error) when: - OpenSSL isn't linked - the algorithm name is unknown (&quot;unknown algorithm&quot;) - the digest computation itself fails Whatever names libcrypto recognizes work here (&quot;sha384&quot;, &quot;sha512&quot;, &quot;sha3-256&quot;, ...), but the supported set may vary by OpenSSL build. Use hash_supported() to check before passing user-supplied names.</p>
+    </div>
+    <div class="function" id="base64_encode" data-name="base64_encode">
+      <h3 class="function-name">base64_encode <span class="kind">fn</span></h3>
+      <pre class="usage"><code>base64_encode(data, length) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">Encode `length` bytes of `data` as Base64 (RFC 4648 §4 standard alphabet, unpadded for compactness). Callers that need `=` padding to make the output length a multiple of 4 can append it themselves; the unpadded length is `((n + 2) / 3) * 4` for an n-byte input. Returns (b64_string, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="base64_encode_padded" data-name="base64_encode_padded">
+      <h3 class="function-name">base64_encode_padded <span class="kind">fn</span></h3>
+      <pre class="usage"><code>base64_encode_padded(data, length) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">Padded sibling of base64_encode — RFC 4648 §4 standard alphabet WITH `=` padding to a multiple of 4 bytes. Reach for this when the wire format on the other end expects padded base64 — most non-strict decoders accept either, but some auth headers and JSON-encoded blob formats explicitly require padding. Returns (b64_string, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="base64_decode" data-name="base64_decode">
+      <h3 class="function-name">base64_decode <span class="kind">fn</span></h3>
+      <pre class="usage"><code>base64_decode(b64) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">b64: string</span></p>
+      <p class="doc">Decode a Base64 string back into raw bytes. Accepts both padded and unpadded RFC 4648 §4 input. Returns (bytes, length, &quot;&quot;) on success — `bytes` is an AetherString preserving any embedded NULs in the decoded payload. Returns (&quot;&quot;, 0, error) on: - malformed Base64 input - OpenSSL unavailable - allocation failure Same shape as fs.read_binary so callers can chain through the same destructure pattern.</p>
+    </div>
+    <div class="function" id="md4_hex" data-name="md4_hex">
+      <h3 class="function-name">md4_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>md4_hex(data, length) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">MD4 hex digest. Legacy — included for interop with formats that bake it into the wire shape (zsync's per-block strong checksum, some pre-2000 packet captures). NOT collision-resistant; do not use for security. Bound to EVP_md4() directly so it works on stock OpenSSL 3 (whose by-name dispatcher skips the legacy provider). Returns (&quot;&quot;, &quot;md4 unavailable&quot;) on builds whose OpenSSL was compiled without MD4 at all.</p>
+    </div>
+    <div class="function" id="md5_hex" data-name="md5_hex">
+      <h3 class="function-name">md5_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>md5_hex(data, length) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">MD5 hex digest. Legacy — Content-MD5, ETag, and various pre-SHA1 fixtures. NOT collision-resistant; do not use for security.</p>
+    </div>
+    <div class="function" id="hmac_sha256_hex" data-name="hmac_sha256_hex">
+      <h3 class="function-name">hmac_sha256_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>hmac_sha256_hex(key, key_len, msg, msg_len) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">key: string, key_len: int, msg: string, msg_len: int</span></p>
+      <p class="doc">HMAC-SHA256 hex digest (RFC 2104 + FIPS 198-1, RFC 4231 test vectors). The hex form is the natural shape for opaque token signing and bearer-token derivation; for SigV4-style chained key derivation (each round's output keys the next), use the raw bytes form `hmac_sha256_bytes` so intermediate steps don't round-trip through hex.</p>
+    </div>
+    <div class="function" id="hmac_sha256_bytes" data-name="hmac_sha256_bytes">
+      <h3 class="function-name">hmac_sha256_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>hmac_sha256_bytes(key, key_len, msg, msg_len) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">key: string, key_len: int, msg: string, msg_len: int</span></p>
+      <p class="doc">HMAC-SHA256 raw 32-byte digest. Returns (bytes, length, &quot;&quot;) on success — `bytes` is an owned AetherString preserving every digest byte including embedded NULs. Use this for chained key derivation (SigV4, HKDF-shaped flows) where each round's output keys the next.</p>
+    </div>
+    <div class="function" id="md4_bytes" data-name="md4_bytes">
+      <h3 class="function-name">md4_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>md4_bytes(data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">Raw-bytes digest accessors. Same tuple shape as base64_decode and the HMAC-bytes form above. Use when the wire format expects a fixed-width digest (zsync's truncated 3–16 byte MD4 per block, binary git object IDs, etc.) — hex would double the size and lose the embedded-NUL semantics.</p>
+    </div>
+    <div class="function" id="md5_bytes" data-name="md5_bytes">
+      <h3 class="function-name">md5_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>md5_bytes(data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="sha1_bytes" data-name="sha1_bytes">
+      <h3 class="function-name">sha1_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>sha1_bytes(data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="sha256_bytes" data-name="sha256_bytes">
+      <h3 class="function-name">sha256_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>sha256_bytes(data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="hash_bytes" data-name="hash_bytes">
+      <h3 class="function-name">hash_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>hash_bytes(algo, data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">algo: string, data: string, length: int</span></p>
+      <p class="doc">Algorithm-by-name binary digest. Same dispatcher rules as hash_hex — useful when the algorithm is config-driven. Returns (&quot;&quot;, 0, error) when: - OpenSSL isn't linked - the algorithm name is unknown (&quot;unknown algorithm&quot;) - the digest computation fails</p>
+    </div>
+    <div class="function" id="random_bytes" data-name="random_bytes">
+      <h3 class="function-name">random_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>random_bytes(n) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">n: int</span></p>
+      <p class="doc">Draw `n` cryptographically-secure random bytes from the OS CSPRNG. Returns (bytes, length, &quot;&quot;) on success — `bytes` is an owned AetherString preserving every byte including embedded NULs. Returns (&quot;&quot;, 0, error) on failure (n &lt; 0, allocation failure, syscall failure). The OS sources are: - Linux:    getrandom(2) → /dev/urandom fallback - macOS/BSD: arc4random_buf(3) - Windows:  BCryptGenRandom (CNG) std.math.random_int / random_float are SEEDABLE PRNGs (fine for sampling, NOT for secrets). When the value is unpredictability — bearer tokens, session keys, opaque storage filenames — this is the right primitive. n == 0 succeeds with a length-0 result.</p>
+    </div>
+    <div class="function" id="random_hex" data-name="random_hex">
+      <h3 class="function-name">random_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>random_hex(n) <span class="arrow">-&gt;</span> (string, _1)</code></pre>
+      <p class="signature"><span class="sig-params">n: int</span></p>
+      <p class="doc">Draw `n` cryptographically-secure random bytes and return them as a lowercase-hex string (2*`n` chars). Returns (&quot;&quot;, err) on failure. Composes random_bytes + per-byte hex emission; same OS-CSPRNG source and same caveat: NOT std.math. The motivating shape is opaque-bearer- token / API-key minting, where callers want a printable secret and don't want to hand-roll the byte→hex loop.</p>
+    </div>
+    <div class="function" id="random_base64" data-name="random_base64">
+      <h3 class="function-name">random_base64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>random_base64(n) <span class="arrow">-&gt;</span> (string, _1)</code></pre>
+      <p class="signature"><span class="sig-params">n: int</span></p>
+      <p class="doc">Draw `n` cryptographically-secure random bytes and return them as RFC 4648 §4 standard-alphabet Base64 (unpadded — same shape as base64_encode). Returns (&quot;&quot;, err) on failure. Useful when the wire format prefers a denser printable encoding than hex (~33% shorter). n == 0 yields &quot;&quot;.</p>
+    </div>
+    <div class="function" id="digest_new" data-name="digest_new">
+      <h3 class="function-name">digest_new <span class="kind">fn</span></h3>
+      <pre class="usage"><code>digest_new(algo) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">algo: string</span></p>
+      <p class="doc">Create a streaming digest context for `algo` (&quot;md5&quot;, &quot;sha256&quot;, &quot;sha1&quot;, &quot;md4&quot;, or any name OpenSSL's by-name lookup recognizes — same rules as hash_hex). Returns (ctx, &quot;&quot;) on success, (null, error) on unknown algorithm / OOM / no OpenSSL. The returned handle is opaque; thread it through digest_update / digest_final_*.</p>
+    </div>
+    <div class="function" id="digest_update" data-name="digest_update">
+      <h3 class="function-name">digest_update <span class="kind">fn</span></h3>
+      <pre class="usage"><code>digest_update(ctx, data, length) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">ctx: ptr, data: string, length: int</span></p>
+      <p class="doc">Feed `length` bytes of `data` into the context. Binary-safe (`data` may be an owned AetherString from fs.pread / a window buffer; embedded NULs survive). Returns (1, &quot;&quot;) on success, (0, error) on failure. Feeding 0 bytes is a no-op success. Does NOT free the context.</p>
+    </div>
+    <div class="function" id="digest_final_hex" data-name="digest_final_hex">
+      <h3 class="function-name">digest_final_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>digest_final_hex(ctx) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">ctx: ptr</span></p>
+      <p class="doc">Finalize the context and return the digest as lowercase hex (32 chars for md5/md4, 40 for sha1, 64 for sha256). The context is FREED by this call — do not reuse or free it again. Returns (hex, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="digest_final_bytes" data-name="digest_final_bytes">
+      <h3 class="function-name">digest_final_bytes <span class="kind">fn</span></h3>
+      <pre class="usage"><code>digest_final_bytes(ctx) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">ctx: ptr</span></p>
+      <p class="doc">Finalize the context and return the raw digest bytes as an owned AetherString (16 bytes for md5/md4, 20 for sha1, 32 for sha256). The context is FREED by this call. Use this when the raw bytes key a subsequent step (SigV4 payload hashing). Returns (bytes, length, &quot;&quot;) on success, (&quot;&quot;, 0, error) on failure.</p>
+    </div>
+    <div class="function" id="digest_free" data-name="digest_free">
+      <h3 class="function-name">digest_free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>digest_free(ctx)</code></pre>
+      <p class="signature"><span class="sig-params">ctx: ptr</span></p>
+      <p class="doc">Abandon a context without finalizing — the cleanup path for an aborted operation. NULL-safe; a no-op on a null handle. After a successful digest_final_* the context is already freed, so this is only for the bail-out-before-final case.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/dir.html
+++ b/docs/api/dir.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dir - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search dir..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#exists">exists</a></li>
+    <li><a href="#create_raw">create_raw</a></li>
+    <li><a href="#delete_raw">delete_raw</a></li>
+    <li><a href="#list_raw">list_raw</a></li>
+    <li><a href="#list_free">list_free</a></li>
+    <li><a href="#create">create</a></li>
+    <li><a href="#delete">delete</a></li>
+    <li><a href="#list">list</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li class="active"><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>dir</h1>
+    <p class="module-desc">std.dir - Directory Operations (alias for std.fs) Raw externs end in `_raw`.</p>
+    <p class="import-line"><code>import std.dir</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="exists" data-name="exists">
+      <h3 class="function-name">exists <span class="kind">extern</span></h3>
+      <pre class="usage"><code>exists(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="create_raw" data-name="create_raw">
+      <h3 class="function-name">create_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="delete_raw" data-name="delete_raw">
+      <h3 class="function-name">delete_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>delete_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="list_raw" data-name="list_raw">
+      <h3 class="function-name">list_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>list_raw(path) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="list_free" data-name="list_free">
+      <h3 class="function-name">list_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>list_free(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="create" data-name="create">
+      <h3 class="function-name">create <span class="kind">fn</span></h3>
+      <pre class="usage"><code>create(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Create a directory. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="delete" data-name="delete">
+      <h3 class="function-name">delete <span class="kind">fn</span></h3>
+      <pre class="usage"><code>delete(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Delete a directory. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="list" data-name="list">
+      <h3 class="function-name">list <span class="kind">fn</span></h3>
+      <pre class="usage"><code>list(path) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">List directory contents. Returns (DirList ptr, &quot;&quot;) on success, (null, error) on failure. Caller must free the returned ptr with dir.list_free.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/dl.html
+++ b/docs/api/dl.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dl - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search dl..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#open_raw">open_raw</a></li>
+    <li><a href="#symbol_raw">symbol_raw</a></li>
+    <li><a href="#close_raw">close_raw</a></li>
+    <li><a href="#last_error_raw">last_error_raw</a></li>
+    <li><a href="#open">open</a></li>
+    <li><a href="#symbol">symbol</a></li>
+    <li><a href="#close">close</a></li>
+    <li><a href="#last_error">last_error</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li class="active"><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>dl</h1>
+    <p class="module-desc">std.dl - cross-platform dynamic library loader.</p>
+    <p class="import-line"><code>import std.dl</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="open_raw" data-name="open_raw">
+      <h3 class="function-name">open_raw <span class="kind">fn</span></h3>
+      <pre class="usage"><code>open_raw(path) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Aether-side aliases under the dl.* namespace. Keeping the C symbol names verbose preserves header-grep friendliness; the short aliases below are what user code calls.</p>
+    </div>
+    <div class="function" id="symbol_raw" data-name="symbol_raw">
+      <h3 class="function-name">symbol_raw <span class="kind">fn</span></h3>
+      <pre class="usage"><code>symbol_raw(handle, name) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr, name: string</span></p>
+    </div>
+    <div class="function" id="close_raw" data-name="close_raw">
+      <h3 class="function-name">close_raw <span class="kind">fn</span></h3>
+      <pre class="usage"><code>close_raw(handle) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr</span></p>
+    </div>
+    <div class="function" id="last_error_raw" data-name="last_error_raw">
+      <h3 class="function-name">last_error_raw <span class="kind">fn</span></h3>
+      <pre class="usage"><code>last_error_raw() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="open" data-name="open">
+      <h3 class="function-name">open <span class="kind">fn</span></h3>
+      <pre class="usage"><code>open(path) <span class="arrow">-&gt;</span> (ptr, _1)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Open a shared library. Returns (handle, &quot;&quot;) on success, (null, error) on failure.</p>
+    </div>
+    <div class="function" id="symbol" data-name="symbol">
+      <h3 class="function-name">symbol <span class="kind">fn</span></h3>
+      <pre class="usage"><code>symbol(handle, name) <span class="arrow">-&gt;</span> (ptr, _1)</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr, name: string</span></p>
+      <p class="doc">Resolve a symbol in a previously opened handle. Returns (ptr, &quot;&quot;) on success, (null, error) on failure.</p>
+    </div>
+    <div class="function" id="close" data-name="close">
+      <h3 class="function-name">close <span class="kind">fn</span></h3>
+      <pre class="usage"><code>close(handle) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">handle: ptr</span></p>
+      <p class="doc">Close a handle. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="last_error" data-name="last_error">
+      <h3 class="function-name">last_error <span class="kind">fn</span></h3>
+      <pre class="usage"><code>last_error() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">Last error string for the calling thread, or &quot;&quot; if none.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/file.html
+++ b/docs/api/file.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>file - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search file..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#below">below</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li class="active"><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>file</h1>
+    <p class="module-desc">std.file - File Operations (alias for std.fs) This is a convenience module that re-exports file functions from std.fs.</p>
+    <p class="import-line"><code>import std.file</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="below" data-name="below">
+      <h3 class="function-name">below <span class="kind">fn</span></h3>
+      <pre class="usage"><code>below()</code></pre>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/floatarr.html
+++ b/docs/api/floatarr.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>floatarr - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search floatarr..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#new">new</a></li>
+    <li><a href="#new_filled">new_filled</a></li>
+    <li><a href="#get">get</a></li>
+    <li><a href="#set">set</a></li>
+    <li><a href="#new_raw">new_raw</a></li>
+    <li><a href="#new_filled_raw">new_filled_raw</a></li>
+    <li><a href="#size">size</a></li>
+    <li><a href="#get_raw">get_raw</a></li>
+    <li><a href="#set_raw">set_raw</a></li>
+    <li><a href="#get_unchecked">get_unchecked</a></li>
+    <li><a href="#set_unchecked">set_unchecked</a></li>
+    <li><a href="#fill">fill</a></li>
+    <li><a href="#free">free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li class="active"><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>floatarr</h1>
+    <p class="module-desc">std.floatarr - Fixed-size packed-double buffer (float twin of std.intarr) For SVG path-command args, rasterizer edge tables, bbox accumulators, blur kernel coefficients, and other hot paths where std.list's void*-boxed items cost an allocation per entry.</p>
+    <p class="import-line"><code>import std.floatarr</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new(size) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">Allocate a FloatArray of `size` elements, zero-initialised. Returns (ptr, &quot;&quot;) on success, (null, error) on failure.</p>
+    </div>
+    <div class="function" id="new_filled" data-name="new_filled">
+      <h3 class="function-name">new_filled <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new_filled(size, init) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">size: int, init: float</span></p>
+      <p class="doc">Allocate and fill with `init` at every index.</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(arr, i) <span class="arrow">-&gt;</span> (float, string)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Bounds-checked read. Returns (value, &quot;&quot;) on success, (0.0, error) for null array or OOB index. Use the raw `floatarr_get_raw` directly (imported above) when you don't need to tell absent apart from stored-zero — it's one fewer function call and one fewer branch.</p>
+    </div>
+    <div class="function" id="set" data-name="set">
+      <h3 class="function-name">set <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set(arr, i, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: float</span></p>
+      <p class="doc">Bounds-checked write. Returns &quot;&quot; on success, error for null array or OOB index. Use the raw `floatarr_set_raw` directly in hot paths where a no-op-on-OOB is acceptable.</p>
+    </div>
+    <div class="function" id="new_raw" data-name="new_raw">
+      <h3 class="function-name">new_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new_raw(size) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">Allocate a FloatArray of `size` doubles, zero-initialised. Returns null if `size` is negative or allocation fails.</p>
+    </div>
+    <div class="function" id="new_filled_raw" data-name="new_filled_raw">
+      <h3 class="function-name">new_filled_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new_filled_raw(size, init) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int, init: float</span></p>
+      <p class="doc">Allocate and fill every index with `init`.</p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>size(arr) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+      <p class="doc">Number of elements. -1 if `arr` is null.</p>
+    </div>
+    <div class="function" id="get_raw" data-name="get_raw">
+      <h3 class="function-name">get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_raw(arr, i) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Read at `i`. Returns 0.0 if `arr` is null or `i` is out-of-range. Use `floatarr.get` (below) to distinguish stored-zero from OOB.</p>
+    </div>
+    <div class="function" id="set_raw" data-name="set_raw">
+      <h3 class="function-name">set_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_raw(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: float</span></p>
+      <p class="doc">Write `value` at `i`. No-op if `arr` is null or `i` is out-of-range. Use `floatarr.set` (below) if you need an error on OOB.</p>
+    </div>
+    <div class="function" id="get_unchecked" data-name="get_unchecked">
+      <h3 class="function-name">get_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_unchecked(arr, i) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Hot-path variants — caller guarantees index is in [0, size). OOB access is undefined behaviour. Don't use from outside a tight loop.</p>
+    </div>
+    <div class="function" id="set_unchecked" data-name="set_unchecked">
+      <h3 class="function-name">set_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_unchecked(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: float</span></p>
+    </div>
+    <div class="function" id="fill" data-name="fill">
+      <h3 class="function-name">fill <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fill(arr, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, value: float</span></p>
+      <p class="doc">Fill every element with `value`.</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>free(arr)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+      <p class="doc">Release. Idempotent on null.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/fs.html
+++ b/docs/api/fs.html
@@ -13,147 +13,712 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search fs..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
+    <li><a href="#file_open_raw">file_open_raw</a></li>
+    <li><a href="#file_close">file_close</a></li>
     <li><a href="#file_read_all_raw">file_read_all_raw</a></li>
     <li><a href="#file_write_raw">file_write_raw</a></li>
-    <li><a href="#file_close">file_close</a></li>
     <li><a href="#file_exists">file_exists</a></li>
+    <li><a href="#path_exists">path_exists</a></li>
     <li><a href="#file_delete_raw">file_delete_raw</a></li>
     <li><a href="#file_size_raw">file_size_raw</a></li>
     <li><a href="#file_mtime">file_mtime</a></li>
     <li><a href="#dir_exists">dir_exists</a></li>
     <li><a href="#dir_create_raw">dir_create_raw</a></li>
     <li><a href="#dir_delete_raw">dir_delete_raw</a></li>
-    <li><a href="#fs_mkdir_p_raw">fs_mkdir_p_raw</a></li>
-    <li><a href="#fs_symlink_raw">fs_symlink_raw</a></li>
-    <li><a href="#fs_readlink_raw">fs_readlink_raw</a></li>
-    <li><a href="#fs_is_symlink">fs_is_symlink</a></li>
-    <li><a href="#fs_unlink_raw">fs_unlink_raw</a></li>
+    <li><a href="#dir_list_raw">dir_list_raw</a></li>
+    <li><a href="#mkdir_p_raw">mkdir_p_raw</a></li>
+    <li><a href="#symlink_raw">symlink_raw</a></li>
+    <li><a href="#readlink_raw">readlink_raw</a></li>
+    <li><a href="#is_symlink">is_symlink</a></li>
+    <li><a href="#unlink_raw">unlink_raw</a></li>
+    <li><a href="#write_binary_raw">write_binary_raw</a></li>
+    <li><a href="#write_atomic_raw">write_atomic_raw</a></li>
+    <li><a href="#rename_raw">rename_raw</a></li>
+    <li><a href="#try_stat">try_stat</a></li>
+    <li><a href="#get_stat_kind">get_stat_kind</a></li>
+    <li><a href="#get_stat_size">get_stat_size</a></li>
+    <li><a href="#get_stat_mtime">get_stat_mtime</a></li>
+    <li><a href="#try_read_binary">try_read_binary</a></li>
+    <li><a href="#get_read_binary">get_read_binary</a></li>
+    <li><a href="#get_read_binary_length">get_read_binary_length</a></li>
+    <li><a href="#release_read_binary">release_read_binary</a></li>
+    <li><a href="#read_binary_tuple">read_binary_tuple</a></li>
+    <li><a href="#dir_list_count">dir_list_count</a></li>
+    <li><a href="#dir_list_get">dir_list_get</a></li>
+    <li><a href="#dir_list_free">dir_list_free</a></li>
     <li><a href="#path_join">path_join</a></li>
     <li><a href="#path_dirname">path_dirname</a></li>
     <li><a href="#path_basename">path_basename</a></li>
     <li><a href="#path_extension">path_extension</a></li>
     <li><a href="#path_is_absolute">path_is_absolute</a></li>
-    <li><a href="#dir_list_count">dir_list_count</a></li>
-    <li><a href="#dir_list_get">dir_list_get</a></li>
-    <li><a href="#dir_list_free">dir_list_free</a></li>
+    <li><a href="#path_clean">path_clean</a></li>
+    <li><a href="#path_is_within_base">path_is_within_base</a></li>
+    <li><a href="#path_rel">path_rel</a></li>
+    <li><a href="#clean">clean</a></li>
+    <li><a href="#is_within_base">is_within_base</a></li>
+    <li><a href="#rel">rel</a></li>
+    <li><a href="#join_clean">join_clean</a></li>
+    <li><a href="#first_element">first_element</a></li>
+    <li><a href="#pwrite_raw">pwrite_raw</a></li>
+    <li><a href="#pread_raw">pread_raw</a></li>
+    <li><a href="#get_pread">get_pread</a></li>
+    <li><a href="#get_pread_length">get_pread_length</a></li>
+    <li><a href="#release_pread">release_pread</a></li>
+    <li><a href="#ftruncate_raw">ftruncate_raw</a></li>
+    <li><a href="#fsync_raw">fsync_raw</a></li>
+    <li><a href="#pwrite">pwrite</a></li>
+    <li><a href="#pread">pread</a></li>
+    <li><a href="#ftruncate">ftruncate</a></li>
+    <li><a href="#fsync">fsync</a></li>
+    <li><a href="#glob_raw">glob_raw</a></li>
+    <li><a href="#glob_multi_raw">glob_multi_raw</a></li>
+    <li><a href="#open">open</a></li>
+    <li><a href="#read">read</a></li>
+    <li><a href="#write">write</a></li>
+    <li><a href="#delete">delete</a></li>
+    <li><a href="#size">size</a></li>
+    <li><a href="#mtime">mtime</a></li>
+    <li><a href="#exists">exists</a></li>
+    <li><a href="#create_dir">create_dir</a></li>
+    <li><a href="#create_dir_with_mode">create_dir_with_mode</a></li>
+    <li><a href="#delete_dir">delete_dir</a></li>
+    <li><a href="#mkdir_p">mkdir_p</a></li>
+    <li><a href="#symlink">symlink</a></li>
+    <li><a href="#readlink">readlink</a></li>
+    <li><a href="#unlink">unlink</a></li>
+    <li><a href="#list_dir">list_dir</a></li>
+    <li><a href="#glob">glob</a></li>
+    <li><a href="#glob_multi">glob_multi</a></li>
+    <li><a href="#write_binary">write_binary</a></li>
+    <li><a href="#write_atomic">write_atomic</a></li>
+    <li><a href="#rename">rename</a></li>
+    <li><a href="#file_stat">file_stat</a></li>
+    <li><a href="#read_binary">read_binary</a></li>
+    <li><a href="#copy_raw">copy_raw</a></li>
+    <li><a href="#move_raw">move_raw</a></li>
+    <li><a href="#realpath_raw">realpath_raw</a></li>
+    <li><a href="#chmod_raw">chmod_raw</a></li>
+    <li><a href="#copy">copy</a></li>
+    <li><a href="#move">move</a></li>
+    <li><a href="#realpath">realpath</a></li>
+    <li><a href="#chmod">chmod</a></li>
+    <li><a href="#KIND_OK">KIND_OK</a></li>
+    <li><a href="#KIND_NOT_FOUND">KIND_NOT_FOUND</a></li>
+    <li><a href="#KIND_PERMISSION_DENIED">KIND_PERMISSION_DENIED</a></li>
+    <li><a href="#KIND_EXISTS">KIND_EXISTS</a></li>
+    <li><a href="#KIND_CROSS_DEVICE">KIND_CROSS_DEVICE</a></li>
+    <li><a href="#KIND_IO">KIND_IO</a></li>
+    <li><a href="#KIND_INVALID">KIND_INVALID</a></li>
+    <li><a href="#KIND_LOOP">KIND_LOOP</a></li>
+    <li><a href="#KIND_NAME_TOO_LONG">KIND_NAME_TOO_LONG</a></li>
+    <li><a href="#KIND_NO_SPACE">KIND_NO_SPACE</a></li>
+    <li><a href="#KIND_IS_DIR">KIND_IS_DIR</a></li>
+    <li><a href="#KIND_NOT_DIR">KIND_NOT_DIR</a></li>
+    <li><a href="#KIND_UNAVAILABLE">KIND_UNAVAILABLE</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li class="active"><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>fs</h1>
-    <p class="module-desc">File system operations</p>
+    <p class="module-desc">std.fs - File System Module Import with: import std.fs Provides file, directory, path, glob, and copy/move/realpath/chmod operations.</p>
+    <p class="import-line"><code>import std.fs</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="file_read_all_raw" data-name="file_read_all_raw">
-      <h3 class="function-name">file_read_all_raw</h3>
-      <pre class="usage"><code>file_read_all_raw(file)</code></pre>
-    </div>
-    <div class="function" id="file_write_raw" data-name="file_write_raw">
-      <h3 class="function-name">file_write_raw</h3>
-      <pre class="usage"><code>file_write_raw(file, data, length)</code></pre>
+    <div class="function" id="file_open_raw" data-name="file_open_raw">
+      <h3 class="function-name">file_open_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_open_raw(path, mode) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">path: string, mode: string</span></p>
+      <p class="doc">File operations - raw externs</p>
     </div>
     <div class="function" id="file_close" data-name="file_close">
-      <h3 class="function-name">file_close</h3>
-      <pre class="usage"><code>file_close(file)</code></pre>
+      <h3 class="function-name">file_close <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_close(file) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr</span></p>
+    </div>
+    <div class="function" id="file_read_all_raw" data-name="file_read_all_raw">
+      <h3 class="function-name">file_read_all_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_read_all_raw(file) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr</span></p>
+    </div>
+    <div class="function" id="file_write_raw" data-name="file_write_raw">
+      <h3 class="function-name">file_write_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_write_raw(file, data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr, data: string, length: int</span></p>
     </div>
     <div class="function" id="file_exists" data-name="file_exists">
-      <h3 class="function-name">file_exists</h3>
-      <pre class="usage"><code>file_exists(path)</code></pre>
+      <h3 class="function-name">file_exists <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_exists(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="path_exists" data-name="path_exists">
+      <h3 class="function-name">path_exists <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_exists(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Path-agnostic existence check: 1 if anything is at `path` (regular file, directory, symlink, fifo, ...), 0 otherwise. Distinct from `file_exists` (regular-file-only) and `dir_exists` (directory-only). Use this when the caller doesn't care what kind of thing is there — only whether the path is bound. Matches POSIX `test -e`.</p>
     </div>
     <div class="function" id="file_delete_raw" data-name="file_delete_raw">
-      <h3 class="function-name">file_delete_raw</h3>
-      <pre class="usage"><code>file_delete_raw(path)</code></pre>
+      <h3 class="function-name">file_delete_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_delete_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
     <div class="function" id="file_size_raw" data-name="file_size_raw">
-      <h3 class="function-name">file_size_raw</h3>
-      <pre class="usage"><code>file_size_raw(path)</code></pre>
+      <h3 class="function-name">file_size_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_size_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
     <div class="function" id="file_mtime" data-name="file_mtime">
-      <h3 class="function-name">file_mtime</h3>
-      <pre class="usage"><code>file_mtime(path)</code></pre>
+      <h3 class="function-name">file_mtime <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_mtime(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Get file modification time as a Unix timestamp. Infallible — returns 0 for missing files, null paths, or stat failure. Kept as a raw extern with no Go-style wrapper because callers already use the 0 sentinel for &quot;no mtime&quot;.</p>
     </div>
     <div class="function" id="dir_exists" data-name="dir_exists">
-      <h3 class="function-name">dir_exists</h3>
-      <pre class="usage"><code>dir_exists(path)</code></pre>
-      <p class="doc">Directory operations</p>
+      <h3 class="function-name">dir_exists <span class="kind">extern</span></h3>
+      <pre class="usage"><code>dir_exists(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Directory operations - raw externs</p>
     </div>
     <div class="function" id="dir_create_raw" data-name="dir_create_raw">
-      <h3 class="function-name">dir_create_raw</h3>
-      <pre class="usage"><code>dir_create_raw(path)</code></pre>
+      <h3 class="function-name">dir_create_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>dir_create_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
     <div class="function" id="dir_delete_raw" data-name="dir_delete_raw">
-      <h3 class="function-name">dir_delete_raw</h3>
-      <pre class="usage"><code>dir_delete_raw(path)</code></pre>
+      <h3 class="function-name">dir_delete_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>dir_delete_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
-    <div class="function" id="fs_mkdir_p_raw" data-name="fs_mkdir_p_raw">
-      <h3 class="function-name">fs_mkdir_p_raw</h3>
-      <pre class="usage"><code>fs_mkdir_p_raw(path)</code></pre>
-      <p class="doc">`mkdir -p` semantics: create `path` and any missing parent directories. Treats already-existing directories as success. Returns 1 on success, 0 on failure. Raw extern — use the `mkdir_p` Go-style wrapper in std/fs/module.ae from most code.</p>
+    <div class="function" id="dir_list_raw" data-name="dir_list_raw">
+      <h3 class="function-name">dir_list_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>dir_list_raw(path) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
-    <div class="function" id="fs_symlink_raw" data-name="fs_symlink_raw">
-      <h3 class="function-name">fs_symlink_raw</h3>
-      <pre class="usage"><code>fs_symlink_raw(target, link_path)</code></pre>
-      <p class="doc">Symbolic-link operations. The *_raw functions are the low-level externs; idiomatic callers use the Go-style `symlink` / `readlink` / `unlink` wrappers in std/fs/module.ae which return `(value, err)`.  fs_symlink_raw: create a symlink at `link_path` pointing to `target`. Returns 1 on success, 0 on failure (e.g. link already exists). `target` is recorded verbatim — NOT resolved at create time, so a relative target stays relative.  fs_readlink_raw: read a symlink. Returns a heap-allocated string containing the link target, or NULL if `path` is not a symlink (or cannot be read). Caller frees.  fs_is_symlink: returns 1 if `path` is itself a symlink (does not follow), 0 otherwise. Pure boolean query — no wrapper needed, matches file_exists / dir_exists shape.  fs_unlink_raw: remove a file or symlink. Will NOT remove a directory — use dir_delete_raw for that. Returns 1 on success, 0 on failure.</p>
+    <div class="function" id="mkdir_p_raw" data-name="mkdir_p_raw">
+      <h3 class="function-name">mkdir_p_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>mkdir_p_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">`mkdir -p` semantics: create `path` and any missing parent directories. Treats already-existing directories as success. Raw extern — use the `mkdir_p` wrapper below in most code.</p>
     </div>
-    <div class="function" id="fs_readlink_raw" data-name="fs_readlink_raw">
-      <h3 class="function-name">fs_readlink_raw</h3>
-      <pre class="usage"><code>fs_readlink_raw(path)</code></pre>
+    <div class="function" id="symlink_raw" data-name="symlink_raw">
+      <h3 class="function-name">symlink_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>symlink_raw(target, link_path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">target: string, link_path: string</span></p>
+      <p class="doc">Symbolic-link operations (raw externs). fs_symlink_raw   — create a symlink at `link_path` pointing to `target`. `target` is recorded verbatim (relative stays relative). fs_readlink_raw  — read a symlink's target. Returns null if not a symlink. fs_is_symlink    — does NOT follow; returns 1 only for the link itself. Pure boolean query, no wrapper (matches file_exists). fs_unlink_raw    — remove a file or symlink (NOT a directory).</p>
     </div>
-    <div class="function" id="fs_is_symlink" data-name="fs_is_symlink">
-      <h3 class="function-name">fs_is_symlink</h3>
-      <pre class="usage"><code>fs_is_symlink(path)</code></pre>
+    <div class="function" id="readlink_raw" data-name="readlink_raw">
+      <h3 class="function-name">readlink_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>readlink_raw(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
-    <div class="function" id="fs_unlink_raw" data-name="fs_unlink_raw">
-      <h3 class="function-name">fs_unlink_raw</h3>
-      <pre class="usage"><code>fs_unlink_raw(path)</code></pre>
+    <div class="function" id="is_symlink" data-name="is_symlink">
+      <h3 class="function-name">is_symlink <span class="kind">extern</span></h3>
+      <pre class="usage"><code>is_symlink(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
-    <div class="function" id="path_join" data-name="path_join">
-      <h3 class="function-name">path_join</h3>
-      <pre class="usage"><code>path_join(path1, path2)</code></pre>
-      <p class="doc">Path operations</p>
+    <div class="function" id="unlink_raw" data-name="unlink_raw">
+      <h3 class="function-name">unlink_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>unlink_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
-    <div class="function" id="path_dirname" data-name="path_dirname">
-      <h3 class="function-name">path_dirname</h3>
-      <pre class="usage"><code>path_dirname(path)</code></pre>
+    <div class="function" id="write_binary_raw" data-name="write_binary_raw">
+      <h3 class="function-name">write_binary_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>write_binary_raw(path, data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string, data: string, length: int</span></p>
+      <p class="doc">Non-atomic binary write: fopen(&quot;wb&quot;) + fwrite(len bytes) + fclose. Binary-safe because length is explicit. Cheaper than fs_write_atomic_raw when a partial file on crash is acceptable — scratch writes, caches, and anywhere the destination isn't load-bearing for another process.</p>
     </div>
-    <div class="function" id="path_basename" data-name="path_basename">
-      <h3 class="function-name">path_basename</h3>
-      <pre class="usage"><code>path_basename(path)</code></pre>
+    <div class="function" id="write_atomic_raw" data-name="write_atomic_raw">
+      <h3 class="function-name">write_atomic_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>write_atomic_raw(path, data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string, data: string, length: int</span></p>
+      <p class="doc">Durable write: write-to-tmp + fsync + rename over destination. Binary-safe — takes an explicit length so embedded NULs survive.</p>
     </div>
-    <div class="function" id="path_extension" data-name="path_extension">
-      <h3 class="function-name">path_extension</h3>
-      <pre class="usage"><code>path_extension(path)</code></pre>
+    <div class="function" id="rename_raw" data-name="rename_raw">
+      <h3 class="function-name">rename_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>rename_raw(from, to) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">from: string, to: string</span></p>
+      <p class="doc">POSIX rename(2). Callers pairing with write_atomic should keep `from` on the same filesystem as `to` for atomicity.</p>
     </div>
-    <div class="function" id="path_is_absolute" data-name="path_is_absolute">
-      <h3 class="function-name">path_is_absolute</h3>
-      <pre class="usage"><code>path_is_absolute(path)</code></pre>
+    <div class="function" id="try_stat" data-name="try_stat">
+      <h3 class="function-name">try_stat <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_stat(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Split-accessor stat: call fs_try_stat first, then read the getters. kind encoding: 1=file, 2=dir, 3=symlink, 4=other. Pair is thread-local so back-to-back calls on one thread are safe.</p>
+    </div>
+    <div class="function" id="get_stat_kind" data-name="get_stat_kind">
+      <h3 class="function-name">get_stat_kind <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_stat_kind() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="get_stat_size" data-name="get_stat_size">
+      <h3 class="function-name">get_stat_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_stat_size() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="get_stat_mtime" data-name="get_stat_mtime">
+      <h3 class="function-name">get_stat_mtime <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_stat_mtime() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="try_read_binary" data-name="try_read_binary">
+      <h3 class="function-name">try_read_binary <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_read_binary(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Split-accessor binary read: fs_try_read_binary reads the file into a TLS-owned buffer; fs_get_read_binary / fs_get_read_binary_length read that buffer borrowed. fs_release_read_binary frees early (otherwise it's released on the next fs_try_read_binary call).</p>
+    </div>
+    <div class="function" id="get_read_binary" data-name="get_read_binary">
+      <h3 class="function-name">get_read_binary <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_read_binary() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_read_binary_length" data-name="get_read_binary_length">
+      <h3 class="function-name">get_read_binary_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_read_binary_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_read_binary" data-name="release_read_binary">
+      <h3 class="function-name">release_read_binary <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_read_binary()</code></pre>
+    </div>
+    <div class="function" id="read_binary_tuple" data-name="read_binary_tuple">
+      <h3 class="function-name">read_binary_tuple <span class="kind">extern</span></h3>
+      <pre class="usage"><code>read_binary_tuple(path) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Unified tuple-return shape (#271 + #273) — the canonical entry point that fs.read_binary wraps. Returns (bytes, length, err): (AetherString*, int, &quot;&quot;) on success, (empty, 0, &quot;&lt;reason&gt;&quot;) on failure. Position 0 (bytes) is `@heap`: the C side allocates a fresh AetherString via `string_new_with_length`. The destructured LHS owns the buffer; the heap-string-tracker frees it at function exit (or on reassignment) — same machinery `fs_realpath_raw` below relies on. Position 2 (err) stays default-borrow — the error message is a static C string literal. Earlier shape used `(ptr, int, string)` for position 0, which suppressed heap classification at every tuple-destructure site and silently leaked the bytes buffer at scope exit. Reported by the avn port (tuple-destructure-heap-classification.md) where it drove O(N²) RSS retention in avnserver.</p>
     </div>
     <div class="function" id="dir_list_count" data-name="dir_list_count">
-      <h3 class="function-name">dir_list_count</h3>
-      <pre class="usage"><code>dir_list_count(list)</code></pre>
+      <h3 class="function-name">dir_list_count <span class="kind">extern</span></h3>
+      <pre class="usage"><code>dir_list_count(list) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
     </div>
     <div class="function" id="dir_list_get" data-name="dir_list_get">
-      <h3 class="function-name">dir_list_get</h3>
-      <pre class="usage"><code>dir_list_get(list, index)</code></pre>
+      <h3 class="function-name">dir_list_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>dir_list_get(list, index) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
     </div>
     <div class="function" id="dir_list_free" data-name="dir_list_free">
-      <h3 class="function-name">dir_list_free</h3>
+      <h3 class="function-name">dir_list_free <span class="kind">extern</span></h3>
       <pre class="usage"><code>dir_list_free(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="path_join" data-name="path_join">
+      <h3 class="function-name">path_join <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_join(path1, path2) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path1: string, path2: string</span></p>
+      <p class="doc">Path utilities - pure functions, never fail</p>
+    </div>
+    <div class="function" id="path_dirname" data-name="path_dirname">
+      <h3 class="function-name">path_dirname <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_dirname(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="path_basename" data-name="path_basename">
+      <h3 class="function-name">path_basename <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_basename(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="path_extension" data-name="path_extension">
+      <h3 class="function-name">path_extension <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_extension(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="path_is_absolute" data-name="path_is_absolute">
+      <h3 class="function-name">path_is_absolute <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_is_absolute(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="path_clean" data-name="path_clean">
+      <h3 class="function-name">path_clean <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_clean(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Lexical path ops (#632). Pure-string; never touch the filesystem.</p>
+    </div>
+    <div class="function" id="path_is_within_base" data-name="path_is_within_base">
+      <h3 class="function-name">path_is_within_base <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_is_within_base(base, target) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">base: string, target: string</span></p>
+    </div>
+    <div class="function" id="path_rel" data-name="path_rel">
+      <h3 class="function-name">path_rel <span class="kind">extern</span></h3>
+      <pre class="usage"><code>path_rel(base, target) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">base: string, target: string</span></p>
+    </div>
+    <div class="function" id="clean" data-name="clean">
+      <h3 class="function-name">clean <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clean(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Lexically clean `path` per POSIX filepath.Clean semantics — collapse `//` and `./`, resolve `..` against a segment stack (drop the parent), preserve a leading `/`, preserve unresolved leading `..` on relative paths. Empty input → &quot;.&quot;. Pure-string, no filesystem access. Examples: fs.clean(&quot;/a//b/./c/../d&quot;) → &quot;/a/b/d&quot; fs.clean(&quot;../../x&quot;)        → &quot;../../x&quot;   (relative, unresolved) fs.clean(&quot;/..&quot;)            → &quot;/&quot;         (rooted) fs.clean(&quot;&quot;)               → &quot;.&quot;</p>
+    </div>
+    <div class="function" id="is_within_base" data-name="is_within_base">
+      <h3 class="function-name">is_within_base <span class="kind">fn</span></h3>
+      <pre class="usage"><code>is_within_base(base, target) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">base: string, target: string</span></p>
+      <p class="doc">Lexical containment: does cleaned `target` lie under cleaned `base`? Returns 1 yes, 0 no. SECURITY-CRITICAL primitive for any code that resolves a user-supplied path against a data dir / static-asset root / archive extraction prefix — call this BEFORE open(2) to reject `../../etc/passwd` at the door. Pure-string: does NOT follow symlinks. A symlink under `base` pointing outside is an open-time concern this function does not address. For symlink-aware containment, use realpath on both sides first (one extra syscall per request) then call this. Examples: fs.is_within_base(&quot;/data&quot;, &quot;/data/x/y&quot;)    → 1 fs.is_within_base(&quot;/data&quot;, &quot;/data&quot;)        → 1   (identical) fs.is_within_base(&quot;/data&quot;, &quot;/data/../x&quot;)   → 0   (cleans to /x) fs.is_within_base(&quot;/data&quot;, &quot;/datax/y&quot;)     → 0   (prefix but not subdir)</p>
+    </div>
+    <div class="function" id="rel" data-name="rel">
+      <h3 class="function-name">rel <span class="kind">fn</span></h3>
+      <pre class="usage"><code>rel(base, target) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">base: string, target: string</span></p>
+      <p class="doc">Relative path from cleaned `base` to cleaned `target` (Go filepath.Rel). Returns the relative path on success, &quot;&quot; when one is absolute and the other relative (no relative path exists). `base == target` returns &quot;.&quot;. Useful for showing paths relative to a project root in logs / UI. Less security-critical than is_within_base — same lexical computation in a different shape.</p>
+    </div>
+    <div class="function" id="join_clean" data-name="join_clean">
+      <h3 class="function-name">join_clean <span class="kind">fn</span></h3>
+      <pre class="usage"><code>join_clean(a, b) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">a: string, b: string</span></p>
+      <p class="doc">Lexically-cleaned join. `path_join(a, b)` followed by `clean` in one call — the path that actually hits the filesystem after a user- supplied segment is appended. Use this (not bare `path_join`) wherever `b` may contain `..` or `.` — object keys, archive entry names, any caller-controlled tail — so `join_clean(&quot;bucket&quot;, &quot;a/../b&quot;)` collapses to &quot;bucket/b&quot; rather than leaving the traversal in place. Pair with `is_within_base` for the containment check. Empty-segment handling mirrors path_join's identity behaviour: an empty `a` or `b` cleans the other side alone (so the result is never a spurious &quot;./x&quot; or &quot;x/.&quot;). Examples: fs.join_clean(&quot;bucket&quot;, &quot;a/../b&quot;) → &quot;bucket/b&quot; fs.join_clean(&quot;/data&quot;, &quot;x/./y&quot;)   → &quot;/data/x/y&quot; fs.join_clean(&quot;&quot;, &quot;a/../b&quot;)       → &quot;b&quot; fs.join_clean(&quot;bucket&quot;, &quot;&quot;)       → &quot;bucket&quot;</p>
+    </div>
+    <div class="function" id="first_element" data-name="first_element">
+      <h3 class="function-name">first_element <span class="kind">fn</span></h3>
+      <pre class="usage"><code>first_element(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">First cleaned path segment. Cleans `path` then returns the leading component up to (but not including) the first &quot;/&quot;. For a rooted path the leading &quot;/&quot; is dropped first, so `first_element(&quot;/a/b&quot;)` is &quot;a&quot;. A path that cleans to &quot;.&quot; or &quot;/&quot; yields &quot;&quot;. Useful for splitting an object key into its top-level bucket/prefix after traversal has been neutralised. Examples: fs.first_element(&quot;a/b/c&quot;)     → &quot;a&quot; fs.first_element(&quot;/a/b&quot;)      → &quot;a&quot; fs.first_element(&quot;x/../y/z&quot;)  → &quot;y&quot; fs.first_element(&quot;only&quot;)      → &quot;only&quot; fs.first_element(&quot;/&quot;)         → &quot;&quot;</p>
+    </div>
+    <div class="function" id="pwrite_raw" data-name="pwrite_raw">
+      <h3 class="function-name">pwrite_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>pwrite_raw(file, data, length, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr, data: string, length: int, offset: long</span></p>
+      <p class="doc">Positional I/O (#640).</p>
+    </div>
+    <div class="function" id="pread_raw" data-name="pread_raw">
+      <h3 class="function-name">pread_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>pread_raw(file, length, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr, length: int, offset: long</span></p>
+    </div>
+    <div class="function" id="get_pread" data-name="get_pread">
+      <h3 class="function-name">get_pread <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_pread() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_pread_length" data-name="get_pread_length">
+      <h3 class="function-name">get_pread_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_pread_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_pread" data-name="release_pread">
+      <h3 class="function-name">release_pread <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_pread()</code></pre>
+    </div>
+    <div class="function" id="ftruncate_raw" data-name="ftruncate_raw">
+      <h3 class="function-name">ftruncate_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ftruncate_raw(file, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr, length: long</span></p>
+    </div>
+    <div class="function" id="fsync_raw" data-name="fsync_raw">
+      <h3 class="function-name">fsync_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fsync_raw(file) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr</span></p>
+    </div>
+    <div class="function" id="pwrite" data-name="pwrite">
+      <h3 class="function-name">pwrite <span class="kind">fn</span></h3>
+      <pre class="usage"><code>pwrite(file, data, length, offset) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr, data: string, length: int, offset: long</span></p>
+      <p class="doc">Positional binary-safe write. Writes `length` bytes from `data` at `offset` bytes from the start of the file. Returns (written, &quot;&quot;) on success, (-1, error) on failure. Loops on short writes (POSIX permits returning fewer bytes than asked). The file must be opened in a mode admitting writes — &quot;r+&quot;, &quot;w+&quot;, &quot;w&quot;, &quot;a+&quot;, &quot;wb+&quot;, etc. — via `fs.open(path, mode)`. This is the &quot;scatter-write&quot; primitive — reconstructing a file from blocks fetched out of order (rsync, zsync, parallel downloads, sparse-file build). For sequential append, `fs.write` is simpler.</p>
+    </div>
+    <div class="function" id="pread" data-name="pread">
+      <h3 class="function-name">pread <span class="kind">fn</span></h3>
+      <pre class="usage"><code>pread(file, length, offset) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr, length: int, offset: long</span></p>
+      <p class="doc">Positional binary-safe read. Reads up to `length` bytes from `offset` into an owned AetherString. Returns (bytes, n, &quot;&quot;) on success — `n` may be less than `length` if EOF was reached (short reads are NOT an error per the POSIX convention for sparse-file I/O). Returns (&quot;&quot;, 0, error) on failure. Same tuple shape as fs.read_binary so destructuring stays consistent.</p>
+    </div>
+    <div class="function" id="ftruncate" data-name="ftruncate">
+      <h3 class="function-name">ftruncate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>ftruncate(file, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr, length: long</span></p>
+      <p class="doc">Set the file length to `length` bytes. Extends with zero bytes if the new length is greater than the current size. Returns &quot;&quot; on success, an error message on failure. Required at the end of an out-of-order reconstruction to clip trailing padding.</p>
+    </div>
+    <div class="function" id="fsync" data-name="fsync">
+      <h3 class="function-name">fsync <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fsync(file) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">file: ptr</span></p>
+      <p class="doc">Flush kernel buffers for `file` to durable storage (POSIX fsync / Windows _commit). Required AFTER pwrite for the data-survives-crash guarantee — pwrite alone makes the bytes visible to other handles on the same machine but doesn't promise they reach the disk. Returns &quot;&quot; on success.</p>
+    </div>
+    <div class="function" id="glob_raw" data-name="glob_raw">
+      <h3 class="function-name">glob_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>glob_raw(pattern) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string</span></p>
+      <p class="doc">Glob: match files by pattern. Raw externs return ptr, NULL on failure.</p>
+    </div>
+    <div class="function" id="glob_multi_raw" data-name="glob_multi_raw">
+      <h3 class="function-name">glob_multi_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>glob_multi_raw(patterns) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">patterns: ptr</span></p>
+    </div>
+    <div class="function" id="open" data-name="open">
+      <h3 class="function-name">open <span class="kind">fn</span></h3>
+      <pre class="usage"><code>open(path, mode) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string, mode: string</span></p>
+      <p class="doc">Open a file. Returns (handle, &quot;&quot;) on success, (null, error) on failure.</p>
+    </div>
+    <div class="function" id="read" data-name="read">
+      <h3 class="function-name">read <span class="kind">fn</span></h3>
+      <pre class="usage"><code>read(path) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Read the entire contents of a file at `path`. Opens, reads, closes. Returns (content, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="write" data-name="write">
+      <h3 class="function-name">write <span class="kind">fn</span></h3>
+      <pre class="usage"><code>write(path, content) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string, content: string</span></p>
+      <p class="doc">Write `content` to a file at `path`. Opens in write mode, writes, closes. Returns &quot;&quot; on success, error string on failure.</p>
+    </div>
+    <div class="function" id="delete" data-name="delete">
+      <h3 class="function-name">delete <span class="kind">fn</span></h3>
+      <pre class="usage"><code>delete(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Delete the file at `path`. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">fn</span></h3>
+      <pre class="usage"><code>size(path) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Return the size of the file at `path` in bytes. Returns (size, &quot;&quot;) on success, (0, error) on failure.</p>
+    </div>
+    <div class="function" id="mtime" data-name="mtime">
+      <h3 class="function-name">mtime <span class="kind">fn</span></h3>
+      <pre class="usage"><code>mtime(path) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Return the file's mtime as Unix epoch seconds. Returns (mtime, &quot;&quot;) on success, (0, error) on failure. Distinguishes &quot;stat failed&quot; from &quot;file's mtime is 0&quot; (which the older `file_mtime` extern collapses into a single sentinel). Prefer this wrapper for new code; `file_mtime` stays for back-compat.</p>
+    </div>
+    <div class="function" id="exists" data-name="exists">
+      <h3 class="function-name">exists <span class="kind">fn</span></h3>
+      <pre class="usage"><code>exists(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Does anything exist at `path`? Returns 1 for any kind of filesystem entry (regular file, directory, symlink, fifo, ...), 0 if nothing is there or `path` is empty. Use this when you don't care whether the target is a file or a directory — for type- specific checks reach for `file.exists` (regular-file-only) or `dir.exists` (directory-only). Matches POSIX `test -e`.</p>
+    </div>
+    <div class="function" id="create_dir" data-name="create_dir">
+      <h3 class="function-name">create_dir <span class="kind">fn</span></h3>
+      <pre class="usage"><code>create_dir(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Create a directory. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="create_dir_with_mode" data-name="create_dir_with_mode">
+      <h3 class="function-name">create_dir_with_mode <span class="kind">fn</span></h3>
+      <pre class="usage"><code>create_dir_with_mode(path, mode) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string, mode: int</span></p>
+      <p class="doc">Like `create_dir` but with an explicit POSIX-style mode (0777-masked). Use this when the directory needs to be private — e.g. `fs.create_dir_with_mode(&quot;/run/myapp/keys&quot;, 448)` for 0o700 — without the mkdir-then-chmod race the &quot;always 0755 + shell out to chmod&quot; workaround would open. Windows ignores the mode at the directory layer; the parameter is accepted for API portability.</p>
+    </div>
+    <div class="function" id="delete_dir" data-name="delete_dir">
+      <h3 class="function-name">delete_dir <span class="kind">fn</span></h3>
+      <pre class="usage"><code>delete_dir(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Delete a directory. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="mkdir_p" data-name="mkdir_p">
+      <h3 class="function-name">mkdir_p <span class="kind">fn</span></h3>
+      <pre class="usage"><code>mkdir_p(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">`mkdir -p`: create `path` and any missing parent directories. Treats already-existing directories as success. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="symlink" data-name="symlink">
+      <h3 class="function-name">symlink <span class="kind">fn</span></h3>
+      <pre class="usage"><code>symlink(target, link_path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">target: string, link_path: string</span></p>
+      <p class="doc">Create a symbolic link at `link_path` pointing to `target`. The target is recorded verbatim — relative targets stay relative. Returns &quot;&quot; on success, error on failure (e.g. `link_path` already exists).</p>
+    </div>
+    <div class="function" id="readlink" data-name="readlink">
+      <h3 class="function-name">readlink <span class="kind">fn</span></h3>
+      <pre class="usage"><code>readlink(path) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Read a symbolic link. Returns (target, &quot;&quot;) on success, (&quot;&quot;, error) if `path` is not a symlink or can't be read.</p>
+    </div>
+    <div class="function" id="unlink" data-name="unlink">
+      <h3 class="function-name">unlink <span class="kind">fn</span></h3>
+      <pre class="usage"><code>unlink(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Remove a file or symlink. Refuses to remove a directory — use `delete_dir` for that. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="list_dir" data-name="list_dir">
+      <h3 class="function-name">list_dir <span class="kind">fn</span></h3>
+      <pre class="usage"><code>list_dir(path) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">List directory contents. Returns (DirList ptr, &quot;&quot;) on success, (null, error) on failure. Caller must free the returned ptr with dir_list_free.</p>
+    </div>
+    <div class="function" id="glob" data-name="glob">
+      <h3 class="function-name">glob <span class="kind">fn</span></h3>
+      <pre class="usage"><code>glob(pattern) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string</span></p>
+      <p class="doc">Glob for files matching a pattern. Returns (DirList ptr, &quot;&quot;) on success, (null, error) on failure.</p>
+    </div>
+    <div class="function" id="glob_multi" data-name="glob_multi">
+      <h3 class="function-name">glob_multi <span class="kind">fn</span></h3>
+      <pre class="usage"><code>glob_multi(patterns) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">patterns: ptr</span></p>
+      <p class="doc">Multi-pattern glob.</p>
+    </div>
+    <div class="function" id="write_binary" data-name="write_binary">
+      <h3 class="function-name">write_binary <span class="kind">fn</span></h3>
+      <pre class="usage"><code>write_binary(path, data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string, data: string, length: int</span></p>
+      <p class="doc">Non-atomic binary write: open, write exactly `length` bytes, close. Binary-safe — embedded NULs in `data` survive because the length is explicit (unlike `fs.write` which also works for AetherString inputs but trusts `string.length(content)` to report the right count). When you want the write to be crash-safe, use `fs.write_atomic` instead (stage + fsync + rename). `write_binary` skips that machinery for cheaper writes to scratch paths, caches, or any destination where a partial file on crash is acceptable. Returns &quot;&quot; on success, error on failure (open / write / close). On failure, whatever bytes were written stay on disk — caller removes the partial file if needed.</p>
+    </div>
+    <div class="function" id="write_atomic" data-name="write_atomic">
+      <h3 class="function-name">write_atomic <span class="kind">fn</span></h3>
+      <pre class="usage"><code>write_atomic(path, data, length) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string, data: string, length: int</span></p>
+      <p class="doc">Durable write: stage `data` into a sibling tmp file, fsync, then rename(2) over `path`. On crash between write and rename, the destination is either the old contents or the new — never a partial write. Binary-safe: pass the explicit byte length so embedded NULs survive (the Aether string's own length is used at the call site, so callers normally just pass string.length(data)). Returns &quot;&quot; on success, error on failure (tmp create, write, fsync, rename — the tmp is removed if any step fails so the filesystem isn't littered with aborted writes).</p>
+    </div>
+    <div class="function" id="rename" data-name="rename">
+      <h3 class="function-name">rename <span class="kind">fn</span></h3>
+      <pre class="usage"><code>rename(from, to) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">from: string, to: string</span></p>
+      <p class="doc">Rename `from` to `to` — thin POSIX rename(2) wrapper. Atomic when both sides are on the same filesystem. Returns &quot;&quot; on success, error on failure (e.g. cross-filesystem rename, destination dir not writable, source missing).</p>
+    </div>
+    <div class="function" id="file_stat" data-name="file_stat">
+      <h3 class="function-name">file_stat <span class="kind">fn</span></h3>
+      <pre class="usage"><code>file_stat(path) <span class="arrow">-&gt;</span> (int, int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Single-stat accessor. Returns (kind, size, mtime, &quot;&quot;) on success, (0, 0, 0, error) on failure. `kind` is one of: 1 = file, 2 = directory, 3 = symlink, 4 = other (FIFO, socket, device, ...). `mtime` is a Unix timestamp, `size` is in bytes. Uses lstat(2) — symlinks report kind 3, the target is NOT followed. Cheaper than the existing file_exists + fs_is_symlink + size + file_mtime quartet when callers need more than one field.</p>
+    </div>
+    <div class="function" id="read_binary" data-name="read_binary">
+      <h3 class="function-name">read_binary <span class="kind">fn</span></h3>
+      <pre class="usage"><code>read_binary(path) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Binary-safe file read. Preserves embedded NULs and reports the exact byte length. Returns (content, length, &quot;&quot;) on success, (&quot;&quot;, 0, error) on failure. The returned string is a length-aware copy: `string.length(content)` equals the returned `length` even when the payload contains NULs. Under the hood the copy goes through `string_new_with_length` rather than `string_concat`, which is strlen-based and would silently truncate at the first embedded NUL. The TLS buffer inside the runtime is released after the copy completes, so the caller doesn't have to manage lifetime.</p>
+    </div>
+    <div class="function" id="copy_raw" data-name="copy_raw">
+      <h3 class="function-name">copy_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>copy_raw(src, dst) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">src: string, dst: string</span></p>
+      <p class="doc">Structured-error pilot (issue #392) — these externs return (value, kind, message) where kind is one of the KIND_* constants at the top of this module. fs_copy_raw zero-copies via the platform's best primitive (copy_file_range / sendfile / fcopyfile / CopyFileExW); falls back to an 8 MiB read/write loop on filesystems that reject the kernel primitives. See aether_fs.c for the full performance hierarchy.</p>
+    </div>
+    <div class="function" id="move_raw" data-name="move_raw">
+      <h3 class="function-name">move_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>move_raw(src, dst) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">src: string, dst: string</span></p>
+      <p class="doc">fs_move_raw — atomic rename(2) when same-fs, transparent copy + unlink fallback on EXDEV. Returns (1, KIND_OK, &quot;&quot;) on success, (0, KIND_*, msg) on failure.</p>
+    </div>
+    <div class="function" id="realpath_raw" data-name="realpath_raw">
+      <h3 class="function-name">realpath_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>realpath_raw(path) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">fs_realpath_raw — OS-canonicalise the path (deref every symlink, remove ./.. components). Returns (resolved_path, KIND_OK, &quot;&quot;) on success, (&quot;&quot;, KIND_*, msg) on failure. Position 0 (resolved_path) is `@heap`: realpath(3) on POSIX allocates a fresh buffer (POSIX.1-2008 extension); on Windows the GetFinalPathNameByHandleW result is converted to UTF-8 via a fresh malloc. The destructured LHS owns the buffer; the heap-string-tracker frees it at function exit (or on reassignment). Position 2 (msg) stays default-borrow — error message is a static string literal in the C source. Audited callers: only `fs.realpath` (the Aether wrapper below) passes the tuple through; no manual string.release on the resolved path anywhere in stdlib, tests/, examples/, tools/, or contrib/. See #420 follow-up.</p>
+    </div>
+    <div class="function" id="chmod_raw" data-name="chmod_raw">
+      <h3 class="function-name">chmod_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>chmod_raw(path, mode) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string, mode: int</span></p>
+      <p class="doc">fs_chmod_raw — POSIX chmod(2). On Windows only the user-write bit (0o200) is honoured (matches Python's os.chmod docs). Returns (1, KIND_OK, &quot;&quot;) or (0, KIND_*, msg).</p>
+    </div>
+    <div class="function" id="copy" data-name="copy">
+      <h3 class="function-name">copy <span class="kind">fn</span></h3>
+      <pre class="usage"><code>copy(src, dst) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">src: string, dst: string</span></p>
+      <p class="doc">Copy file contents from `src` to `dst`, preserving source mode bits (file owner is NOT changed). Returns (bytes_copied, kind, message): on success: (n, KIND_OK, &quot;&quot;) on failure: (bytes_so_far, KIND_*, &quot;&lt;reason&gt;&quot;) Symlinks in `src` are followed (matches POSIX `cp` without -P). `dst` is overwritten if it exists; if `dst` is an existing directory the call returns KIND_IS_DIR — we do not nest into it. `src` and `dst` must differ lexically; the call returns KIND_INVALID otherwise. Performance: zero-copy primitives are tried in order (copy_file_range → sendfile on Linux; fcopyfile on macOS; CopyFileExW on Windows). An 8 MiB read/write loop is the portable fallback for filesystems that reject the kernel primitives. The reported byte count saturates at INT_MAX for files larger than 2^31 bytes — the data is still copied correctly; only the count is truncated.</p>
+    </div>
+    <div class="function" id="move" data-name="move">
+      <h3 class="function-name">move <span class="kind">fn</span></h3>
+      <pre class="usage"><code>move(src, dst) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">src: string, dst: string</span></p>
+      <p class="doc">Move file from `src` to `dst`. Atomic on the same filesystem; transparently falls back to copy + unlink across filesystems (EXDEV). Returns (1, KIND_OK, &quot;&quot;) on success, (0, KIND_*, msg) on failure. Cross-device directory moves surface as KIND_IS_DIR (the underlying copy refuses to recurse into directories — that needs a higher-level walker).</p>
+    </div>
+    <div class="function" id="realpath" data-name="realpath">
+      <h3 class="function-name">realpath <span class="kind">fn</span></h3>
+      <pre class="usage"><code>realpath(path) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">OS-canonicalise the path: deref every symlink, fold . and .. components. Returns (resolved_path, KIND_OK, &quot;&quot;) on success, (&quot;&quot;, KIND_*, msg) on failure (KIND_NOT_FOUND if a component is missing, KIND_LOOP for symlink cycles, KIND_NAME_TOO_LONG if the resolved form exceeds the OS limit). The returned path is owned by the runtime; the caller does not need to free it.</p>
+    </div>
+    <div class="function" id="chmod" data-name="chmod">
+      <h3 class="function-name">chmod <span class="kind">fn</span></h3>
+      <pre class="usage"><code>chmod(path, mode) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string, mode: int</span></p>
+      <p class="doc">Change the permission bits at `path`. POSIX chmod(2) — follows symlinks. On Windows only the user-write bit (0o200) is honoured; every other bit is silently ignored (matches Python's os.chmod docs). `mode` is masked with 07777 internally. Returns (1, KIND_OK, &quot;&quot;) or (0, KIND_*, msg).</p>
+    </div>
+    <div class="function" id="KIND_OK" data-name="KIND_OK">
+      <h3 class="function-name">KIND_OK <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_OK = 0</code></pre>
+      <p class="doc">---- Structured-error kinds (pilot — issue #392) ---- Returned as the second element of the (value, kind, message) tuple from `copy`, `move`, `realpath`, and `chmod`. Switch on these to programmatically discriminate between common failure modes without parsing the human-readable message. Non-fs callers should treat any non-zero kind as &quot;an error happened&quot; — the message remains the authoritative human-readable diagnostic. Values are stable; new kinds may be appended (always with a fresh integer above the existing range) but existing values are part of the surface contract. Mirror these in std/fs/aether_fs.h as AETHER_FS_KIND_* macros so the C side and the Aether surface remain in lock-step.</p>
+    </div>
+    <div class="function" id="KIND_NOT_FOUND" data-name="KIND_NOT_FOUND">
+      <h3 class="function-name">KIND_NOT_FOUND <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_NOT_FOUND = 1</code></pre>
+    </div>
+    <div class="function" id="KIND_PERMISSION_DENIED" data-name="KIND_PERMISSION_DENIED">
+      <h3 class="function-name">KIND_PERMISSION_DENIED <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_PERMISSION_DENIED = 2</code></pre>
+    </div>
+    <div class="function" id="KIND_EXISTS" data-name="KIND_EXISTS">
+      <h3 class="function-name">KIND_EXISTS <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_EXISTS = 3</code></pre>
+    </div>
+    <div class="function" id="KIND_CROSS_DEVICE" data-name="KIND_CROSS_DEVICE">
+      <h3 class="function-name">KIND_CROSS_DEVICE <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_CROSS_DEVICE = 4</code></pre>
+    </div>
+    <div class="function" id="KIND_IO" data-name="KIND_IO">
+      <h3 class="function-name">KIND_IO <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_IO = 5</code></pre>
+    </div>
+    <div class="function" id="KIND_INVALID" data-name="KIND_INVALID">
+      <h3 class="function-name">KIND_INVALID <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_INVALID = 6</code></pre>
+    </div>
+    <div class="function" id="KIND_LOOP" data-name="KIND_LOOP">
+      <h3 class="function-name">KIND_LOOP <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_LOOP = 7</code></pre>
+    </div>
+    <div class="function" id="KIND_NAME_TOO_LONG" data-name="KIND_NAME_TOO_LONG">
+      <h3 class="function-name">KIND_NAME_TOO_LONG <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_NAME_TOO_LONG = 8</code></pre>
+    </div>
+    <div class="function" id="KIND_NO_SPACE" data-name="KIND_NO_SPACE">
+      <h3 class="function-name">KIND_NO_SPACE <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_NO_SPACE = 9</code></pre>
+    </div>
+    <div class="function" id="KIND_IS_DIR" data-name="KIND_IS_DIR">
+      <h3 class="function-name">KIND_IS_DIR <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_IS_DIR = 10</code></pre>
+    </div>
+    <div class="function" id="KIND_NOT_DIR" data-name="KIND_NOT_DIR">
+      <h3 class="function-name">KIND_NOT_DIR <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_NOT_DIR = 11</code></pre>
+    </div>
+    <div class="function" id="KIND_UNAVAILABLE" data-name="KIND_UNAVAILABLE">
+      <h3 class="function-name">KIND_UNAVAILABLE <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_UNAVAILABLE = 99</code></pre>
     </div>
   </div>
 </main>

--- a/docs/api/host.html
+++ b/docs/api/host.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>host - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search host..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#notify">notify</a></li>
+    <li><a href="#describe">describe</a></li>
+    <li><a href="#input">input</a></li>
+    <li><a href="#event">event</a></li>
+    <li><a href="#bindings">bindings</a></li>
+    <li><a href="#java">java</a></li>
+    <li><a href="#python">python</a></li>
+    <li><a href="#ruby">ruby</a></li>
+    <li><a href="#go">go</a></li>
+    <li><a href="#manifest_get">manifest_get</a></li>
+    <li><a href="#manifest_clear">manifest_clear</a></li>
+    <li><a href="#aether_caller_identity">aether_caller_identity</a></li>
+    <li><a href="#aether_caller_attribute">aether_caller_attribute</a></li>
+    <li><a href="#aether_caller_deadline_ms">aether_caller_deadline_ms</a></li>
+    <li><a href="#caller_identity">caller_identity</a></li>
+    <li><a href="#caller_attribute">caller_attribute</a></li>
+    <li><a href="#caller_deadline_ms">caller_deadline_ms</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li class="active"><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>host</h1>
+    <p class="module-desc">std.host — primitives for Aether scripts embedded in a host application.</p>
+    <p class="import-line"><code>import std.host</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="notify" data-name="notify">
+      <h3 class="function-name">notify <span class="kind">extern</span></h3>
+      <pre class="usage"><code>notify(event, id) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">event: string, id: long</span></p>
+      <p class="doc">Emit an event to the host process. Returns 1 if a handler was found and invoked, 0 if no listener is registered for this event name. `long` is Aether's 64-bit integer (TOKEN_INT64); the C-side ABI is int64_t per the public host header (runtime/aether_host.h).</p>
+    </div>
+    <div class="function" id="describe" data-name="describe">
+      <h3 class="function-name">describe <span class="kind">extern</span></h3>
+      <pre class="usage"><code>describe(_ctx, name)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr, name: string</span></p>
+      <p class="doc">Begin a namespace declaration. The trailing block contains input(), event(), and bindings() calls.</p>
+    </div>
+    <div class="function" id="input" data-name="input">
+      <h3 class="function-name">input <span class="kind">extern</span></h3>
+      <pre class="usage"><code>input(_ctx, name, type_signature)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr, name: string, type_signature: string</span></p>
+      <p class="doc">Inside a `describe() { }` block.</p>
+    </div>
+    <div class="function" id="event" data-name="event">
+      <h3 class="function-name">event <span class="kind">extern</span></h3>
+      <pre class="usage"><code>event(_ctx, name, carries_type)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr, name: string, carries_type: string</span></p>
+    </div>
+    <div class="function" id="bindings" data-name="bindings">
+      <h3 class="function-name">bindings <span class="kind">extern</span></h3>
+      <pre class="usage"><code>bindings(_ctx)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr</span></p>
+      <p class="doc">Bindings — visual grouping for the per-language binding builders. Each binding extern appends to its slot in the manifest.</p>
+    </div>
+    <div class="function" id="java" data-name="java">
+      <h3 class="function-name">java <span class="kind">extern</span></h3>
+      <pre class="usage"><code>java(_ctx, package_name, class_name)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr, package_name: string, class_name: string</span></p>
+    </div>
+    <div class="function" id="python" data-name="python">
+      <h3 class="function-name">python <span class="kind">extern</span></h3>
+      <pre class="usage"><code>python(_ctx, module_name)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr, module_name: string</span></p>
+    </div>
+    <div class="function" id="ruby" data-name="ruby">
+      <h3 class="function-name">ruby <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ruby(_ctx, module_name)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr, module_name: string</span></p>
+    </div>
+    <div class="function" id="go" data-name="go">
+      <h3 class="function-name">go <span class="kind">extern</span></h3>
+      <pre class="usage"><code>go(_ctx, package_name)</code></pre>
+      <p class="signature"><span class="sig-params">_ctx: ptr, package_name: string</span></p>
+    </div>
+    <div class="function" id="manifest_get" data-name="manifest_get">
+      <h3 class="function-name">manifest_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>manifest_get() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">Read the captured manifest. Returns a ptr to an opaque AetherManifest struct (see runtime/aether_host.h). Used by tests and the dlopen pipeline; user code rarely calls this.</p>
+    </div>
+    <div class="function" id="manifest_clear" data-name="manifest_clear">
+      <h3 class="function-name">manifest_clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>manifest_clear()</code></pre>
+      <p class="doc">Reset the captured manifest. Intended for tests and for the pipeline to start each compilation from a clean slate.</p>
+    </div>
+    <div class="function" id="aether_caller_identity" data-name="aether_caller_identity">
+      <h3 class="function-name">aether_caller_identity <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_caller_identity() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="aether_caller_attribute" data-name="aether_caller_attribute">
+      <h3 class="function-name">aether_caller_attribute <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_caller_attribute(key) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">key: string</span></p>
+    </div>
+    <div class="function" id="aether_caller_deadline_ms" data-name="aether_caller_deadline_ms">
+      <h3 class="function-name">aether_caller_deadline_ms <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_caller_deadline_ms() <span class="arrow">-&gt;</span> long</code></pre>
+    </div>
+    <div class="function" id="caller_identity" data-name="caller_identity">
+      <h3 class="function-name">caller_identity <span class="kind">fn</span></h3>
+      <pre class="usage"><code>caller_identity() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="caller_attribute" data-name="caller_attribute">
+      <h3 class="function-name">caller_attribute <span class="kind">fn</span></h3>
+      <pre class="usage"><code>caller_attribute(key) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">key: string</span></p>
+    </div>
+    <div class="function" id="caller_deadline_ms" data-name="caller_deadline_ms">
+      <h3 class="function-name">caller_deadline_ms <span class="kind">fn</span></h3>
+      <pre class="usage"><code>caller_deadline_ms() <span class="arrow">-&gt;</span> long</code></pre>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/http.html
+++ b/docs/api/http.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>http - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search http..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#this">this</a></li>
+    <li><a href="#module">module</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li class="active"><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>http</h1>
+    <p class="module-desc">std.http - HTTP Client &amp; Server (alias for std.net) This is a convenience module that re-exports HTTP functions from std.net.</p>
+    <p class="import-line"><code>import std.http</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="this" data-name="this">
+      <h3 class="function-name">this <span class="kind">fn</span></h3>
+      <pre class="usage"><code>this()</code></pre>
+    </div>
+    <div class="function" id="module" data-name="module">
+      <h3 class="function-name">module <span class="kind">fn</span></h3>
+      <pre class="usage"><code>module()</code></pre>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -15,75 +15,1053 @@
   <input type="text" id="search" placeholder="Search functions..." onkeyup="search()">
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="hero">
     <h1>Standard Library</h1>
-    <p>Built-in functions for strings, collections, networking, file I/O, and more.</p>
+    <p>The public <code>.ae</code> API: import a module with <code>import std.&lt;name&gt;</code> and call its exports as <code>&lt;name&gt;.&lt;function&gt;</code>.</p>
   </div>
   <div class="module-grid">
-    <a href="net.html" class="module-card">
-      <h3>net</h3>
-      <p>HTTP client, server, and networking</p>
+    <a href="actors.html" class="module-card">
+      <h3>actors</h3>
+      <p>std.actors — process-global name → actor_ref registry.</p>
+      <span class="count">12 exports</span>
     </a>
-    <a href="io.html" class="module-card">
-      <h3>io</h3>
-      <p>Input/output and console</p>
+    <a href="arena.html" class="module-card">
+      <h3>arena</h3>
+      <p>std.arena - Arena (bulk) allocator An arena owns a growable block of memory that it hands out via arena.alloc().</p>
+      <span class="count">9 exports</span>
     </a>
-    <a href="math.html" class="module-card">
-      <h3>math</h3>
-      <p>Mathematical functions</p>
+    <a href="audit.html" class="module-card">
+      <h3>audit</h3>
+      <p>std.audit — query the sandbox audit trail.</p>
+      <span class="count">9 exports</span>
     </a>
-    <a href="json.html" class="module-card">
-      <h3>json</h3>
-      <p>JSON parsing and serialization</p>
+    <a href="bignum.html" class="module-card">
+      <h3>bignum</h3>
+      <p>MIT License (https://opensource.org/licenses/MIT) Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc.</p>
+      <span class="count">25 exports</span>
     </a>
-    <a href="log.html" class="module-card">
-      <h3>log</h3>
-      <p>Logging and diagnostics</p>
+    <a href="bits.html" class="module-card">
+      <h3>bits</h3>
+      <p>MIT License (https://opensource.org/licenses/MIT) Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc.</p>
+      <span class="count">30 exports</span>
     </a>
-    <a href="os.html" class="module-card">
-      <h3>os</h3>
-      <p></p>
+    <a href="bytes.html" class="module-card">
+      <h3>bytes</h3>
+      <p>std.bytes — mutable byte buffer with random-access write and overlap-safe forward copy_within.</p>
+      <span class="count">42 exports</span>
     </a>
-    <a href="string.html" class="module-card">
-      <h3>string</h3>
-      <p>String manipulation and formatting</p>
+    <a href="capsicum.html" class="module-card">
+      <h3>capsicum</h3>
+      <p>std.capsicum — FreeBSD Capsicum capability-mode bindings.</p>
+      <span class="count">33 exports</span>
+    </a>
+    <a href="cas.html" class="module-card">
+      <h3>cas</h3>
+      <p>std.cas - Content-addressed artifact store A small content-addressed store (CAS) for sharing built artifacts (`.so` files from `--emit=lib`, eventually anything content- addressable).</p>
+      <span class="count">7 exports</span>
+    </a>
+    <a href="casper.html" class="module-card">
+      <h3>casper</h3>
+      <p>std.casper — FreeBSD Casper service delegation.</p>
+      <span class="count">16 exports</span>
     </a>
     <a href="collections.html" class="module-card">
       <h3>collections</h3>
-      <p>Lists, maps, sets, and data structures</p>
+      <p>std.collections - Collections Module Import with: import std.collections API shape: - Raw externs end in `_raw` and return ptr/int in the old C-style convention.</p>
+      <span class="count">40 exports</span>
+    </a>
+    <a href="config.html" class="module-card">
+      <h3>config</h3>
+      <p>std.config — process-global immutable string→string KV store.</p>
+      <span class="count">12 exports</span>
+    </a>
+    <a href="cryptography.html" class="module-card">
+      <h3>cryptography</h3>
+      <p>std.cryptography - Cryptographic hash primitives + Base64 codec Import with: import std.cryptography Pure functions: bytes in, hex digest or Base64 string out.</p>
+      <span class="count">54 exports</span>
+    </a>
+    <a href="dir.html" class="module-card">
+      <h3>dir</h3>
+      <p>std.dir - Directory Operations (alias for std.fs) Raw externs end in `_raw`.</p>
+      <span class="count">8 exports</span>
+    </a>
+    <a href="dl.html" class="module-card">
+      <h3>dl</h3>
+      <p>std.dl - cross-platform dynamic library loader.</p>
+      <span class="count">8 exports</span>
+    </a>
+    <a href="file.html" class="module-card">
+      <h3>file</h3>
+      <p>std.file - File Operations (alias for std.fs) This is a convenience module that re-exports file functions from std.fs.</p>
+      <span class="count">1 exports</span>
+    </a>
+    <a href="floatarr.html" class="module-card">
+      <h3>floatarr</h3>
+      <p>std.floatarr - Fixed-size packed-double buffer (float twin of std.intarr) For SVG path-command args, rasterizer edge tables, bbox accumulators, blur kernel coefficients, and other hot paths where std.list's void*-boxed items cost an allocation per entry.</p>
+      <span class="count">13 exports</span>
     </a>
     <a href="fs.html" class="module-card">
       <h3>fs</h3>
-      <p>File system operations</p>
+      <p>std.fs - File System Module Import with: import std.fs Provides file, directory, path, glob, and copy/move/realpath/chmod operations.</p>
+      <span class="count">102 exports</span>
+    </a>
+    <a href="host.html" class="module-card">
+      <h3>host</h3>
+      <p>std.host — primitives for Aether scripts embedded in a host application.</p>
+      <span class="count">17 exports</span>
+    </a>
+    <a href="http.html" class="module-card">
+      <h3>http</h3>
+      <p>std.http - HTTP Client &amp; Server (alias for std.net) This is a convenience module that re-exports HTTP functions from std.net.</p>
+      <span class="count">2 exports</span>
+    </a>
+    <a href="intarr.html" class="module-card">
+      <h3>intarr</h3>
+      <p>std.intarr - Fixed-size packed-int buffer (alias for std.collections) For DP tables, flat int-keyed lookup, and other hot paths where std.list's void*-boxed items cost an allocation per entry.</p>
+      <span class="count">13 exports</span>
+    </a>
+    <a href="io.html" class="module-card">
+      <h3>io</h3>
+      <p>std.io - Input/Output Module Import with: import std.io Raw externs end in `_raw` and return the C-style NULL/0/1 convention.</p>
+      <span class="count">40 exports</span>
+    </a>
+    <a href="ipc.html" class="module-card">
+      <h3>ipc</h3>
+      <p>std.ipc — child-to-parent back-channel IPC.</p>
+      <span class="count">4 exports</span>
+    </a>
+    <a href="json.html" class="module-card">
+      <h3>json</h3>
+      <p>std.json - JSON Module Import with: import std.json Parses and serializes JSON per RFC 8259.</p>
+      <span class="count">53 exports</span>
+    </a>
+    <a href="ksuid.html" class="module-card">
+      <h3>ksuid</h3>
+      <p>std.ksuid — KSUID (https://github.com/segmentio/ksuid).</p>
+      <span class="count">1 exports</span>
+    </a>
+    <a href="list.html" class="module-card">
+      <h3>list</h3>
+      <p>std.list - ArrayList Operations (alias for std.collections) API shape: - Raw externs end in `_raw` and return ptr/int in the old C-style convention.</p>
+      <span class="count">11 exports</span>
+    </a>
+    <a href="log.html" class="module-card">
+      <h3>log</h3>
+      <p>std.log - Logging Module Import with: import std.log Log level constants LOG_LEVEL_DEBUG = 0, LOG_LEVEL_INFO = 1, LOG_LEVEL_WARN = 2 LOG_LEVEL_ERROR = 3, LOG_LEVEL_FATAL = 4</p>
+      <span class="count">9 exports</span>
+    </a>
+    <a href="longarr.html" class="module-card">
+      <h3>longarr</h3>
+      <p>Copyright (c) 2026 Aether Developers.</p>
+      <span class="count">13 exports</span>
+    </a>
+    <a href="lzf.html" class="module-card">
+      <h3>lzf</h3>
+      <p>std.lzf - One-shot LZF compression/decompression.</p>
+      <span class="count">11 exports</span>
+    </a>
+    <a href="map.html" class="module-card">
+      <h3>map</h3>
+      <p>std.map - HashMap Operations (alias for std.collections) API shape: - Raw externs end in `_raw` and return ptr/int in the old C-style convention.</p>
+      <span class="count">14 exports</span>
+    </a>
+    <a href="math.html" class="module-card">
+      <h3>math</h3>
+      <p>std.math - Math Module Import with: import std.math</p>
+      <span class="count">31 exports</span>
+    </a>
+    <a href="mem.html" class="module-card">
+      <h3>mem</h3>
+      <p>std.mem — byte-level access to caller-allocated raw pointers.</p>
+      <span class="count">94 exports</span>
+    </a>
+    <a href="nanoid.html" class="module-card">
+      <h3>nanoid</h3>
+      <p>std.nanoid — NanoID (https://github.com/ai/nanoid).</p>
+      <span class="count">2 exports</span>
+    </a>
+    <a href="net.html" class="module-card">
+      <h3>net</h3>
+      <p>std.net - Networking Module Import with: import std.net Naming convention: category_action - tcp_* : TCP client/server operations - http_* : HTTP client operations - http_server_* : HTTP server operations</p>
+      <span class="count">63 exports</span>
+    </a>
+    <a href="os.html" class="module-card">
+      <h3>os</h3>
+      <p>std.os - Shell &amp; Process Execution Import with: import std.os</p>
+      <span class="count">63 exports</span>
+    </a>
+    <a href="path.html" class="module-card">
+      <h3>path</h3>
+      <p>std.path - Path Utilities (alias for std.fs) This is a convenience module that re-exports path functions from std.fs.</p>
+      <span class="count">2 exports</span>
+    </a>
+    <a href="regex.html" class="module-card">
+      <h3>regex</h3>
+      <p>std.regex — Perl-compatible regular expressions (PCRE2-backed).</p>
+      <span class="count">45 exports</span>
+    </a>
+    <a href="signal.html" class="module-card">
+      <h3>signal</h3>
+      <p>std.signal — POSIX signal-number constants.</p>
+      <span class="count">11 exports</span>
+    </a>
+    <a href="strbuilder.html" class="module-card">
+      <h3>strbuilder</h3>
+      <p>std.strbuilder — amortised-O(1) string append.</p>
+      <span class="count">33 exports</span>
+    </a>
+    <a href="string.html" class="module-card">
+      <h3>string</h3>
+      <p>std.string - String Module Import with: import std.string</p>
+      <span class="count">81 exports</span>
+    </a>
+    <a href="tcp.html" class="module-card">
+      <h3>tcp</h3>
+      <p>std.tcp - TCP Socket Operations (alias for std.net) Raw externs end in `_raw` and return NULL/int in C-style.</p>
+      <span class="count">12 exports</span>
+    </a>
+    <a href="tsid.html" class="module-card">
+      <h3>tsid</h3>
+      <p>std.tsid — TSID (Twitter Snowflake family / Discord-shaped).</p>
+      <span class="count">1 exports</span>
+    </a>
+    <a href="ulid.html" class="module-card">
+      <h3>ulid</h3>
+      <p>std.ulid — ULID (https://github.com/ulid/spec).</p>
+      <span class="count">1 exports</span>
+    </a>
+    <a href="url.html" class="module-card">
+      <h3>url</h3>
+      <p>std.url — RFC 3986 percent-encoding + query-string parsing (#629).</p>
+      <span class="count">7 exports</span>
+    </a>
+    <a href="uuid.html" class="module-card">
+      <h3>uuid</h3>
+      <p>std.uuid — UUID v4 and v7 (RFC 9562).</p>
+      <span class="count">2 exports</span>
+    </a>
+    <a href="xml.html" class="module-card">
+      <h3>xml</h3>
+      <p>std.xml - XML Module Import with: import std.xml A deliberately small XML surface (issue #627): a pull/SAX reader and an escaping element builder.</p>
+      <span class="count">43 exports</span>
+    </a>
+    <a href="zlib.html" class="module-card">
+      <h3>zlib</h3>
+      <p>std.zlib - One-shot zlib and gzip deflate/inflate.</p>
+      <span class="count">16 exports</span>
     </a>
   </div>
   <div id="search-results" class="search-results hidden">
     <h2>Search Results</h2>
     <ul class="function-list" id="all-functions">
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="void"><a href="net.html#void"><span class="fn-name">void</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="void"><a href="net.html#void"><span class="fn-name">void</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="void"><a href="net.html#void"><span class="fn-name">void</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name=""><a href="net.html#"><span class="fn-name"></span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="aether_actor_register"><a href="actors.html#aether_actor_register"><span class="fn-name">aether_actor_register</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="aether_actor_whereis"><a href="actors.html#aether_actor_whereis"><span class="fn-name">aether_actor_whereis</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="aether_actor_unregister"><a href="actors.html#aether_actor_unregister"><span class="fn-name">aether_actor_unregister</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="aether_actor_is_registered"><a href="actors.html#aether_actor_is_registered"><span class="fn-name">aether_actor_is_registered</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="aether_actor_registry_size"><a href="actors.html#aether_actor_registry_size"><span class="fn-name">aether_actor_registry_size</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="aether_actor_registry_clear"><a href="actors.html#aether_actor_registry_clear"><span class="fn-name">aether_actor_registry_clear</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="register"><a href="actors.html#register"><span class="fn-name">register</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="whereis"><a href="actors.html#whereis"><span class="fn-name">whereis</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="unregister"><a href="actors.html#unregister"><span class="fn-name">unregister</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="is_registered"><a href="actors.html#is_registered"><span class="fn-name">is_registered</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="registry_size"><a href="actors.html#registry_size"><span class="fn-name">registry_size</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="registry_clear"><a href="actors.html#registry_clear"><span class="fn-name">registry_clear</span><span class="fn-module">actors</span></a></li>
+      <li class="function-item" data-name="create"><a href="arena.html#create"><span class="fn-name">create</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="alloc"><a href="arena.html#alloc"><span class="fn-name">alloc</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="alloc_aligned"><a href="arena.html#alloc_aligned"><span class="fn-name">alloc_aligned</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="reset"><a href="arena.html#reset"><span class="fn-name">reset</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="destroy"><a href="arena.html#destroy"><span class="fn-name">destroy</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="get_used"><a href="arena.html#get_used"><span class="fn-name">get_used</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="get_size"><a href="arena.html#get_size"><span class="fn-name">get_size</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="used"><a href="arena.html#used"><span class="fn-name">used</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="size"><a href="arena.html#size"><span class="fn-name">size</span><span class="fn-module">arena</span></a></li>
+      <li class="function-item" data-name="aether_audit_count"><a href="audit.html#aether_audit_count"><span class="fn-name">aether_audit_count</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="aether_audit_entry_category"><a href="audit.html#aether_audit_entry_category"><span class="fn-name">aether_audit_entry_category</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="aether_audit_entry_resource"><a href="audit.html#aether_audit_entry_resource"><span class="fn-name">aether_audit_entry_resource</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="aether_audit_entry_allowed"><a href="audit.html#aether_audit_entry_allowed"><span class="fn-name">aether_audit_entry_allowed</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="aether_audit_clear"><a href="audit.html#aether_audit_clear"><span class="fn-name">aether_audit_clear</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="count"><a href="audit.html#count"><span class="fn-name">count</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="entry"><a href="audit.html#entry"><span class="fn-name">entry</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="clear"><a href="audit.html#clear"><span class="fn-name">clear</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="denied_count"><a href="audit.html#denied_count"><span class="fn-name">denied_count</span><span class="fn-module">audit</span></a></li>
+      <li class="function-item" data-name="from_bytes"><a href="bignum.html#from_bytes"><span class="fn-name">from_bytes</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="from_bytes_unsigned"><a href="bignum.html#from_bytes_unsigned"><span class="fn-name">from_bytes_unsigned</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="to_bytes"><a href="bignum.html#to_bytes"><span class="fn-name">to_bytes</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="to_bytes_unsigned"><a href="bignum.html#to_bytes_unsigned"><span class="fn-name">to_bytes_unsigned</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="from_int"><a href="bignum.html#from_int"><span class="fn-name">from_int</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="compare"><a href="bignum.html#compare"><span class="fn-name">compare</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="is_zero"><a href="bignum.html#is_zero"><span class="fn-name">is_zero</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="sign"><a href="bignum.html#sign"><span class="fn-name">sign</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="bit_length"><a href="bignum.html#bit_length"><span class="fn-name">bit_length</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="add"><a href="bignum.html#add"><span class="fn-name">add</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="subtract"><a href="bignum.html#subtract"><span class="fn-name">subtract</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="negate"><a href="bignum.html#negate"><span class="fn-name">negate</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="abs"><a href="bignum.html#abs"><span class="fn-name">abs</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="multiply"><a href="bignum.html#multiply"><span class="fn-name">multiply</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="divide"><a href="bignum.html#divide"><span class="fn-name">divide</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="remainder"><a href="bignum.html#remainder"><span class="fn-name">remainder</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="mod"><a href="bignum.html#mod"><span class="fn-name">mod</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="mod_pow"><a href="bignum.html#mod_pow"><span class="fn-name">mod_pow</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="gcd"><a href="bignum.html#gcd"><span class="fn-name">gcd</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="mod_inverse"><a href="bignum.html#mod_inverse"><span class="fn-name">mod_inverse</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="is_probable_prime"><a href="bignum.html#is_probable_prime"><span class="fn-name">is_probable_prime</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="shift_left"><a href="bignum.html#shift_left"><span class="fn-name">shift_left</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="shift_right"><a href="bignum.html#shift_right"><span class="fn-name">shift_right</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="to_hex"><a href="bignum.html#to_hex"><span class="fn-name">to_hex</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="free"><a href="bignum.html#free"><span class="fn-name">free</span><span class="fn-module">bignum</span></a></li>
+      <li class="function-item" data-name="lsr32"><a href="bits.html#lsr32"><span class="fn-name">lsr32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="lsr64"><a href="bits.html#lsr64"><span class="fn-name">lsr64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="rotr32"><a href="bits.html#rotr32"><span class="fn-name">rotr32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="rotl32"><a href="bits.html#rotl32"><span class="fn-name">rotl32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="rotr64"><a href="bits.html#rotr64"><span class="fn-name">rotr64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="rotl64"><a href="bits.html#rotl64"><span class="fn-name">rotl64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="popcount32"><a href="bits.html#popcount32"><span class="fn-name">popcount32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="popcount64"><a href="bits.html#popcount64"><span class="fn-name">popcount64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="clz32"><a href="bits.html#clz32"><span class="fn-name">clz32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="clz64"><a href="bits.html#clz64"><span class="fn-name">clz64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="udiv32"><a href="bits.html#udiv32"><span class="fn-name">udiv32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="urem32"><a href="bits.html#urem32"><span class="fn-name">urem32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="udiv64"><a href="bits.html#udiv64"><span class="fn-name">udiv64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="urem64"><a href="bits.html#urem64"><span class="fn-name">urem64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="ucmp64"><a href="bits.html#ucmp64"><span class="fn-name">ucmp64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_lsr32"><a href="bits.html#aether_bits_lsr32"><span class="fn-name">aether_bits_lsr32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_lsr64"><a href="bits.html#aether_bits_lsr64"><span class="fn-name">aether_bits_lsr64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_rotr32"><a href="bits.html#aether_bits_rotr32"><span class="fn-name">aether_bits_rotr32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_rotl32"><a href="bits.html#aether_bits_rotl32"><span class="fn-name">aether_bits_rotl32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_rotr64"><a href="bits.html#aether_bits_rotr64"><span class="fn-name">aether_bits_rotr64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_rotl64"><a href="bits.html#aether_bits_rotl64"><span class="fn-name">aether_bits_rotl64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_popcount32"><a href="bits.html#aether_bits_popcount32"><span class="fn-name">aether_bits_popcount32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_popcount64"><a href="bits.html#aether_bits_popcount64"><span class="fn-name">aether_bits_popcount64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_clz32"><a href="bits.html#aether_bits_clz32"><span class="fn-name">aether_bits_clz32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_clz64"><a href="bits.html#aether_bits_clz64"><span class="fn-name">aether_bits_clz64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_udiv32"><a href="bits.html#aether_bits_udiv32"><span class="fn-name">aether_bits_udiv32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_urem32"><a href="bits.html#aether_bits_urem32"><span class="fn-name">aether_bits_urem32</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_udiv64"><a href="bits.html#aether_bits_udiv64"><span class="fn-name">aether_bits_udiv64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_urem64"><a href="bits.html#aether_bits_urem64"><span class="fn-name">aether_bits_urem64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bits_ucmp64"><a href="bits.html#aether_bits_ucmp64"><span class="fn-name">aether_bits_ucmp64</span><span class="fn-module">bits</span></a></li>
+      <li class="function-item" data-name="aether_bytes_new"><a href="bytes.html#aether_bytes_new"><span class="fn-name">aether_bytes_new</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_set"><a href="bytes.html#aether_bytes_set"><span class="fn-name">aether_bytes_set</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_get"><a href="bytes.html#aether_bytes_get"><span class="fn-name">aether_bytes_get</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_length"><a href="bytes.html#aether_bytes_length"><span class="fn-name">aether_bytes_length</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_set_le16"><a href="bytes.html#aether_bytes_set_le16"><span class="fn-name">aether_bytes_set_le16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_get_le16"><a href="bytes.html#aether_bytes_get_le16"><span class="fn-name">aether_bytes_get_le16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_set_le32"><a href="bytes.html#aether_bytes_set_le32"><span class="fn-name">aether_bytes_set_le32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_get_le32"><a href="bytes.html#aether_bytes_get_le32"><span class="fn-name">aether_bytes_get_le32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_set_le64"><a href="bytes.html#aether_bytes_set_le64"><span class="fn-name">aether_bytes_set_le64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_get_le64"><a href="bytes.html#aether_bytes_get_le64"><span class="fn-name">aether_bytes_get_le64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_set_be16"><a href="bytes.html#aether_bytes_set_be16"><span class="fn-name">aether_bytes_set_be16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_get_be16"><a href="bytes.html#aether_bytes_get_be16"><span class="fn-name">aether_bytes_get_be16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_set_be32"><a href="bytes.html#aether_bytes_set_be32"><span class="fn-name">aether_bytes_set_be32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_get_be32"><a href="bytes.html#aether_bytes_get_be32"><span class="fn-name">aether_bytes_get_be32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_set_be64"><a href="bytes.html#aether_bytes_set_be64"><span class="fn-name">aether_bytes_set_be64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_get_be64"><a href="bytes.html#aether_bytes_get_be64"><span class="fn-name">aether_bytes_get_be64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_copy_from_string"><a href="bytes.html#aether_bytes_copy_from_string"><span class="fn-name">aether_bytes_copy_from_string</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_copy_from_bytes"><a href="bytes.html#aether_bytes_copy_from_bytes"><span class="fn-name">aether_bytes_copy_from_bytes</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_copy_within"><a href="bytes.html#aether_bytes_copy_within"><span class="fn-name">aether_bytes_copy_within</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_finish"><a href="bytes.html#aether_bytes_finish"><span class="fn-name">aether_bytes_finish</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="aether_bytes_free"><a href="bytes.html#aether_bytes_free"><span class="fn-name">aether_bytes_free</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="new"><a href="bytes.html#new"><span class="fn-name">new</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="set"><a href="bytes.html#set"><span class="fn-name">set</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="get"><a href="bytes.html#get"><span class="fn-name">get</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="length"><a href="bytes.html#length"><span class="fn-name">length</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="set_le16"><a href="bytes.html#set_le16"><span class="fn-name">set_le16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="get_le16"><a href="bytes.html#get_le16"><span class="fn-name">get_le16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="set_le32"><a href="bytes.html#set_le32"><span class="fn-name">set_le32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="get_le32"><a href="bytes.html#get_le32"><span class="fn-name">get_le32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="set_le64"><a href="bytes.html#set_le64"><span class="fn-name">set_le64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="get_le64"><a href="bytes.html#get_le64"><span class="fn-name">get_le64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="set_be16"><a href="bytes.html#set_be16"><span class="fn-name">set_be16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="get_be16"><a href="bytes.html#get_be16"><span class="fn-name">get_be16</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="set_be32"><a href="bytes.html#set_be32"><span class="fn-name">set_be32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="get_be32"><a href="bytes.html#get_be32"><span class="fn-name">get_be32</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="set_be64"><a href="bytes.html#set_be64"><span class="fn-name">set_be64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="get_be64"><a href="bytes.html#get_be64"><span class="fn-name">get_be64</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="copy_from_string"><a href="bytes.html#copy_from_string"><span class="fn-name">copy_from_string</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="copy_from_bytes"><a href="bytes.html#copy_from_bytes"><span class="fn-name">copy_from_bytes</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="copy_within"><a href="bytes.html#copy_within"><span class="fn-name">copy_within</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="finish"><a href="bytes.html#finish"><span class="fn-name">finish</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="free"><a href="bytes.html#free"><span class="fn-name">free</span><span class="fn-module">bytes</span></a></li>
+      <li class="function-item" data-name="CAP_OK"><a href="capsicum.html#CAP_OK"><span class="fn-name">CAP_OK</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="CAP_ERR"><a href="capsicum.html#CAP_ERR"><span class="fn-name">CAP_ERR</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="CAP_UNSUPPORTED"><a href="capsicum.html#CAP_UNSUPPORTED"><span class="fn-name">CAP_UNSUPPORTED</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="aether_capsicum_available"><a href="capsicum.html#aether_capsicum_available"><span class="fn-name">aether_capsicum_available</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="aether_capsicum_enter"><a href="capsicum.html#aether_capsicum_enter"><span class="fn-name">aether_capsicum_enter</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="aether_capsicum_in_mode"><a href="capsicum.html#aether_capsicum_in_mode"><span class="fn-name">aether_capsicum_in_mode</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="aether_capsicum_rights_limit"><a href="capsicum.html#aether_capsicum_rights_limit"><span class="fn-name">aether_capsicum_rights_limit</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="aether_capsicum_fcntls_limit"><a href="capsicum.html#aether_capsicum_fcntls_limit"><span class="fn-name">aether_capsicum_fcntls_limit</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="available"><a href="capsicum.html#available"><span class="fn-name">available</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="enter"><a href="capsicum.html#enter"><span class="fn-name">enter</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="in_mode"><a href="capsicum.html#in_mode"><span class="fn-name">in_mode</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="rights_limit"><a href="capsicum.html#rights_limit"><span class="fn-name">rights_limit</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="fcntls_limit"><a href="capsicum.html#fcntls_limit"><span class="fn-name">fcntls_limit</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_READ"><a href="capsicum.html#R_READ"><span class="fn-name">R_READ</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_WRITE"><a href="capsicum.html#R_WRITE"><span class="fn-name">R_WRITE</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_SEEK"><a href="capsicum.html#R_SEEK"><span class="fn-name">R_SEEK</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_FSTAT"><a href="capsicum.html#R_FSTAT"><span class="fn-name">R_FSTAT</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_FTRUNCATE"><a href="capsicum.html#R_FTRUNCATE"><span class="fn-name">R_FTRUNCATE</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_FSYNC"><a href="capsicum.html#R_FSYNC"><span class="fn-name">R_FSYNC</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_MMAP"><a href="capsicum.html#R_MMAP"><span class="fn-name">R_MMAP</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_ACCEPT"><a href="capsicum.html#R_ACCEPT"><span class="fn-name">R_ACCEPT</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_CONNECT"><a href="capsicum.html#R_CONNECT"><span class="fn-name">R_CONNECT</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_BIND"><a href="capsicum.html#R_BIND"><span class="fn-name">R_BIND</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_LISTEN"><a href="capsicum.html#R_LISTEN"><span class="fn-name">R_LISTEN</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_RECV"><a href="capsicum.html#R_RECV"><span class="fn-name">R_RECV</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_SEND"><a href="capsicum.html#R_SEND"><span class="fn-name">R_SEND</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_EVENT"><a href="capsicum.html#R_EVENT"><span class="fn-name">R_EVENT</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_IOCTL"><a href="capsicum.html#R_IOCTL"><span class="fn-name">R_IOCTL</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="R_FCNTL"><a href="capsicum.html#R_FCNTL"><span class="fn-name">R_FCNTL</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="F_GETFL"><a href="capsicum.html#F_GETFL"><span class="fn-name">F_GETFL</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="F_SETFL"><a href="capsicum.html#F_SETFL"><span class="fn-name">F_SETFL</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="F_GETOWN"><a href="capsicum.html#F_GETOWN"><span class="fn-name">F_GETOWN</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="F_SETOWN"><a href="capsicum.html#F_SETOWN"><span class="fn-name">F_SETOWN</span><span class="fn-module">capsicum</span></a></li>
+      <li class="function-item" data-name="root"><a href="cas.html#root"><span class="fn-name">root</span><span class="fn-module">cas</span></a></li>
+      <li class="function-item" data-name="path"><a href="cas.html#path"><span class="fn-name">path</span><span class="fn-module">cas</span></a></li>
+      <li class="function-item" data-name="has"><a href="cas.html#has"><span class="fn-name">has</span><span class="fn-module">cas</span></a></li>
+      <li class="function-item" data-name="put"><a href="cas.html#put"><span class="fn-name">put</span><span class="fn-module">cas</span></a></li>
+      <li class="function-item" data-name="get"><a href="cas.html#get"><span class="fn-name">get</span><span class="fn-module">cas</span></a></li>
+      <li class="function-item" data-name="root_raw"><a href="cas.html#root_raw"><span class="fn-name">root_raw</span><span class="fn-module">cas</span></a></li>
+      <li class="function-item" data-name="path_raw"><a href="cas.html#path_raw"><span class="fn-name">path_raw</span><span class="fn-module">cas</span></a></li>
+      <li class="function-item" data-name="aether_casper_init"><a href="casper.html#aether_casper_init"><span class="fn-name">aether_casper_init</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="aether_casper_service_open"><a href="casper.html#aether_casper_service_open"><span class="fn-name">aether_casper_service_open</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="aether_casper_close"><a href="casper.html#aether_casper_close"><span class="fn-name">aether_casper_close</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="aether_casper_available"><a href="casper.html#aether_casper_available"><span class="fn-name">aether_casper_available</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="aether_casper_resolve"><a href="casper.html#aether_casper_resolve"><span class="fn-name">aether_casper_resolve</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="aether_casper_pwd_uid"><a href="casper.html#aether_casper_pwd_uid"><span class="fn-name">aether_casper_pwd_uid</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="aether_casper_pwd_home"><a href="casper.html#aether_casper_pwd_home"><span class="fn-name">aether_casper_pwd_home</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="aether_casper_sysctl_str"><a href="casper.html#aether_casper_sysctl_str"><span class="fn-name">aether_casper_sysctl_str</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="available"><a href="casper.html#available"><span class="fn-name">available</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="init"><a href="casper.html#init"><span class="fn-name">init</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="service"><a href="casper.html#service"><span class="fn-name">service</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="close"><a href="casper.html#close"><span class="fn-name">close</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="dns_resolve"><a href="casper.html#dns_resolve"><span class="fn-name">dns_resolve</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="pwd_uid"><a href="casper.html#pwd_uid"><span class="fn-name">pwd_uid</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="pwd_home"><a href="casper.html#pwd_home"><span class="fn-name">pwd_home</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="sysctl"><a href="casper.html#sysctl"><span class="fn-name">sysctl</span><span class="fn-module">casper</span></a></li>
+      <li class="function-item" data-name="list_new"><a href="collections.html#list_new"><span class="fn-name">list_new</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_add_raw"><a href="collections.html#list_add_raw"><span class="fn-name">list_add_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_get_raw"><a href="collections.html#list_get_raw"><span class="fn-name">list_get_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_set"><a href="collections.html#list_set"><span class="fn-name">list_set</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_size"><a href="collections.html#list_size"><span class="fn-name">list_size</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_remove"><a href="collections.html#list_remove"><span class="fn-name">list_remove</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_clear"><a href="collections.html#list_clear"><span class="fn-name">list_clear</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_free"><a href="collections.html#list_free"><span class="fn-name">list_free</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_new"><a href="collections.html#map_new"><span class="fn-name">map_new</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_put_raw"><a href="collections.html#map_put_raw"><span class="fn-name">map_put_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_get_raw"><a href="collections.html#map_get_raw"><span class="fn-name">map_get_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_has"><a href="collections.html#map_has"><span class="fn-name">map_has</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_remove"><a href="collections.html#map_remove"><span class="fn-name">map_remove</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_size"><a href="collections.html#map_size"><span class="fn-name">map_size</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_clear"><a href="collections.html#map_clear"><span class="fn-name">map_clear</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_free"><a href="collections.html#map_free"><span class="fn-name">map_free</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_keys_raw"><a href="collections.html#map_keys_raw"><span class="fn-name">map_keys_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_keys_free"><a href="collections.html#map_keys_free"><span class="fn-name">map_keys_free</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_new_raw"><a href="collections.html#intarr_new_raw"><span class="fn-name">intarr_new_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_new_filled_raw"><a href="collections.html#intarr_new_filled_raw"><span class="fn-name">intarr_new_filled_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_size"><a href="collections.html#intarr_size"><span class="fn-name">intarr_size</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_get_raw"><a href="collections.html#intarr_get_raw"><span class="fn-name">intarr_get_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_set_raw"><a href="collections.html#intarr_set_raw"><span class="fn-name">intarr_set_raw</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_get_unchecked"><a href="collections.html#intarr_get_unchecked"><span class="fn-name">intarr_get_unchecked</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_set_unchecked"><a href="collections.html#intarr_set_unchecked"><span class="fn-name">intarr_set_unchecked</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_fill"><a href="collections.html#intarr_fill"><span class="fn-name">intarr_fill</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="intarr_free"><a href="collections.html#intarr_free"><span class="fn-name">intarr_free</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_new"><a href="collections.html#string_list_new"><span class="fn-name">string_list_new</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_add"><a href="collections.html#string_list_add"><span class="fn-name">string_list_add</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_get"><a href="collections.html#string_list_get"><span class="fn-name">string_list_get</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_set"><a href="collections.html#string_list_set"><span class="fn-name">string_list_set</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_size"><a href="collections.html#string_list_size"><span class="fn-name">string_list_size</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_remove"><a href="collections.html#string_list_remove"><span class="fn-name">string_list_remove</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_clear"><a href="collections.html#string_list_clear"><span class="fn-name">string_list_clear</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="string_list_free"><a href="collections.html#string_list_free"><span class="fn-name">string_list_free</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_add"><a href="collections.html#list_add"><span class="fn-name">list_add</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="list_get"><a href="collections.html#list_get"><span class="fn-name">list_get</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_put"><a href="collections.html#map_put"><span class="fn-name">map_put</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_get"><a href="collections.html#map_get"><span class="fn-name">map_get</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="map_keys"><a href="collections.html#map_keys"><span class="fn-name">map_keys</span><span class="fn-module">collections</span></a></li>
+      <li class="function-item" data-name="aether_config_put"><a href="config.html#aether_config_put"><span class="fn-name">aether_config_put</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="aether_config_get"><a href="config.html#aether_config_get"><span class="fn-name">aether_config_get</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="aether_config_get_or"><a href="config.html#aether_config_get_or"><span class="fn-name">aether_config_get_or</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="aether_config_has"><a href="config.html#aether_config_has"><span class="fn-name">aether_config_has</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="aether_config_size"><a href="config.html#aether_config_size"><span class="fn-name">aether_config_size</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="aether_config_clear"><a href="config.html#aether_config_clear"><span class="fn-name">aether_config_clear</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="put"><a href="config.html#put"><span class="fn-name">put</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="get"><a href="config.html#get"><span class="fn-name">get</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="get_or"><a href="config.html#get_or"><span class="fn-name">get_or</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="has"><a href="config.html#has"><span class="fn-name">has</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="size"><a href="config.html#size"><span class="fn-name">size</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="clear"><a href="config.html#clear"><span class="fn-name">clear</span><span class="fn-module">config</span></a></li>
+      <li class="function-item" data-name="sha1_hex_raw"><a href="cryptography.html#sha1_hex_raw"><span class="fn-name">sha1_hex_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="sha256_hex_raw"><a href="cryptography.html#sha256_hex_raw"><span class="fn-name">sha256_hex_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hash_hex_raw"><a href="cryptography.html#hash_hex_raw"><span class="fn-name">hash_hex_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hash_supported"><a href="cryptography.html#hash_supported"><span class="fn-name">hash_supported</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="base64_encode_raw"><a href="cryptography.html#base64_encode_raw"><span class="fn-name">base64_encode_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="base64_encode_padded_raw"><a href="cryptography.html#base64_encode_padded_raw"><span class="fn-name">base64_encode_padded_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="base64_decode_raw"><a href="cryptography.html#base64_decode_raw"><span class="fn-name">base64_decode_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="get_base64_decode"><a href="cryptography.html#get_base64_decode"><span class="fn-name">get_base64_decode</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="get_base64_decode_length"><a href="cryptography.html#get_base64_decode_length"><span class="fn-name">get_base64_decode_length</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="release_base64_decode"><a href="cryptography.html#release_base64_decode"><span class="fn-name">release_base64_decode</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md4_hex_raw"><a href="cryptography.html#md4_hex_raw"><span class="fn-name">md4_hex_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md5_hex_raw"><a href="cryptography.html#md5_hex_raw"><span class="fn-name">md5_hex_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hmac_sha256_hex_raw"><a href="cryptography.html#hmac_sha256_hex_raw"><span class="fn-name">hmac_sha256_hex_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hmac_sha256_bytes_raw"><a href="cryptography.html#hmac_sha256_bytes_raw"><span class="fn-name">hmac_sha256_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md4_bytes_raw"><a href="cryptography.html#md4_bytes_raw"><span class="fn-name">md4_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md5_bytes_raw"><a href="cryptography.html#md5_bytes_raw"><span class="fn-name">md5_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="sha1_bytes_raw"><a href="cryptography.html#sha1_bytes_raw"><span class="fn-name">sha1_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="sha256_bytes_raw"><a href="cryptography.html#sha256_bytes_raw"><span class="fn-name">sha256_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hash_bytes_raw"><a href="cryptography.html#hash_bytes_raw"><span class="fn-name">hash_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="get_binary_digest"><a href="cryptography.html#get_binary_digest"><span class="fn-name">get_binary_digest</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="get_binary_digest_length"><a href="cryptography.html#get_binary_digest_length"><span class="fn-name">get_binary_digest_length</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="release_binary_digest"><a href="cryptography.html#release_binary_digest"><span class="fn-name">release_binary_digest</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="random_bytes_raw"><a href="cryptography.html#random_bytes_raw"><span class="fn-name">random_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="get_random_bytes"><a href="cryptography.html#get_random_bytes"><span class="fn-name">get_random_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="get_random_bytes_length"><a href="cryptography.html#get_random_bytes_length"><span class="fn-name">get_random_bytes_length</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="release_random_bytes"><a href="cryptography.html#release_random_bytes"><span class="fn-name">release_random_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_new_raw"><a href="cryptography.html#digest_new_raw"><span class="fn-name">digest_new_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_update_raw"><a href="cryptography.html#digest_update_raw"><span class="fn-name">digest_update_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_final_hex_raw"><a href="cryptography.html#digest_final_hex_raw"><span class="fn-name">digest_final_hex_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_final_bytes_raw"><a href="cryptography.html#digest_final_bytes_raw"><span class="fn-name">digest_final_bytes_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_free_raw"><a href="cryptography.html#digest_free_raw"><span class="fn-name">digest_free_raw</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="sha1_hex"><a href="cryptography.html#sha1_hex"><span class="fn-name">sha1_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="sha256_hex"><a href="cryptography.html#sha256_hex"><span class="fn-name">sha256_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hash_hex"><a href="cryptography.html#hash_hex"><span class="fn-name">hash_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="base64_encode"><a href="cryptography.html#base64_encode"><span class="fn-name">base64_encode</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="base64_encode_padded"><a href="cryptography.html#base64_encode_padded"><span class="fn-name">base64_encode_padded</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="base64_decode"><a href="cryptography.html#base64_decode"><span class="fn-name">base64_decode</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md4_hex"><a href="cryptography.html#md4_hex"><span class="fn-name">md4_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md5_hex"><a href="cryptography.html#md5_hex"><span class="fn-name">md5_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hmac_sha256_hex"><a href="cryptography.html#hmac_sha256_hex"><span class="fn-name">hmac_sha256_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hmac_sha256_bytes"><a href="cryptography.html#hmac_sha256_bytes"><span class="fn-name">hmac_sha256_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md4_bytes"><a href="cryptography.html#md4_bytes"><span class="fn-name">md4_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="md5_bytes"><a href="cryptography.html#md5_bytes"><span class="fn-name">md5_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="sha1_bytes"><a href="cryptography.html#sha1_bytes"><span class="fn-name">sha1_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="sha256_bytes"><a href="cryptography.html#sha256_bytes"><span class="fn-name">sha256_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="hash_bytes"><a href="cryptography.html#hash_bytes"><span class="fn-name">hash_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="random_bytes"><a href="cryptography.html#random_bytes"><span class="fn-name">random_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="random_hex"><a href="cryptography.html#random_hex"><span class="fn-name">random_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="random_base64"><a href="cryptography.html#random_base64"><span class="fn-name">random_base64</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_new"><a href="cryptography.html#digest_new"><span class="fn-name">digest_new</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_update"><a href="cryptography.html#digest_update"><span class="fn-name">digest_update</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_final_hex"><a href="cryptography.html#digest_final_hex"><span class="fn-name">digest_final_hex</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_final_bytes"><a href="cryptography.html#digest_final_bytes"><span class="fn-name">digest_final_bytes</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="digest_free"><a href="cryptography.html#digest_free"><span class="fn-name">digest_free</span><span class="fn-module">cryptography</span></a></li>
+      <li class="function-item" data-name="exists"><a href="dir.html#exists"><span class="fn-name">exists</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="create_raw"><a href="dir.html#create_raw"><span class="fn-name">create_raw</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="delete_raw"><a href="dir.html#delete_raw"><span class="fn-name">delete_raw</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="list_raw"><a href="dir.html#list_raw"><span class="fn-name">list_raw</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="list_free"><a href="dir.html#list_free"><span class="fn-name">list_free</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="create"><a href="dir.html#create"><span class="fn-name">create</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="delete"><a href="dir.html#delete"><span class="fn-name">delete</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="list"><a href="dir.html#list"><span class="fn-name">list</span><span class="fn-module">dir</span></a></li>
+      <li class="function-item" data-name="open_raw"><a href="dl.html#open_raw"><span class="fn-name">open_raw</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="symbol_raw"><a href="dl.html#symbol_raw"><span class="fn-name">symbol_raw</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="close_raw"><a href="dl.html#close_raw"><span class="fn-name">close_raw</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="last_error_raw"><a href="dl.html#last_error_raw"><span class="fn-name">last_error_raw</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="open"><a href="dl.html#open"><span class="fn-name">open</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="symbol"><a href="dl.html#symbol"><span class="fn-name">symbol</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="close"><a href="dl.html#close"><span class="fn-name">close</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="last_error"><a href="dl.html#last_error"><span class="fn-name">last_error</span><span class="fn-module">dl</span></a></li>
+      <li class="function-item" data-name="below"><a href="file.html#below"><span class="fn-name">below</span><span class="fn-module">file</span></a></li>
+      <li class="function-item" data-name="new"><a href="floatarr.html#new"><span class="fn-name">new</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="new_filled"><a href="floatarr.html#new_filled"><span class="fn-name">new_filled</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="get"><a href="floatarr.html#get"><span class="fn-name">get</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="set"><a href="floatarr.html#set"><span class="fn-name">set</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="new_raw"><a href="floatarr.html#new_raw"><span class="fn-name">new_raw</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="new_filled_raw"><a href="floatarr.html#new_filled_raw"><span class="fn-name">new_filled_raw</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="size"><a href="floatarr.html#size"><span class="fn-name">size</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="get_raw"><a href="floatarr.html#get_raw"><span class="fn-name">get_raw</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="set_raw"><a href="floatarr.html#set_raw"><span class="fn-name">set_raw</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="get_unchecked"><a href="floatarr.html#get_unchecked"><span class="fn-name">get_unchecked</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="set_unchecked"><a href="floatarr.html#set_unchecked"><span class="fn-name">set_unchecked</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="fill"><a href="floatarr.html#fill"><span class="fn-name">fill</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="free"><a href="floatarr.html#free"><span class="fn-name">free</span><span class="fn-module">floatarr</span></a></li>
+      <li class="function-item" data-name="file_open_raw"><a href="fs.html#file_open_raw"><span class="fn-name">file_open_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_close"><a href="fs.html#file_close"><span class="fn-name">file_close</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_read_all_raw"><a href="fs.html#file_read_all_raw"><span class="fn-name">file_read_all_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_write_raw"><a href="fs.html#file_write_raw"><span class="fn-name">file_write_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_exists"><a href="fs.html#file_exists"><span class="fn-name">file_exists</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_exists"><a href="fs.html#path_exists"><span class="fn-name">path_exists</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_delete_raw"><a href="fs.html#file_delete_raw"><span class="fn-name">file_delete_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_size_raw"><a href="fs.html#file_size_raw"><span class="fn-name">file_size_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_mtime"><a href="fs.html#file_mtime"><span class="fn-name">file_mtime</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="dir_exists"><a href="fs.html#dir_exists"><span class="fn-name">dir_exists</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="dir_create_raw"><a href="fs.html#dir_create_raw"><span class="fn-name">dir_create_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="dir_delete_raw"><a href="fs.html#dir_delete_raw"><span class="fn-name">dir_delete_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="dir_list_raw"><a href="fs.html#dir_list_raw"><span class="fn-name">dir_list_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="mkdir_p_raw"><a href="fs.html#mkdir_p_raw"><span class="fn-name">mkdir_p_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="symlink_raw"><a href="fs.html#symlink_raw"><span class="fn-name">symlink_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="readlink_raw"><a href="fs.html#readlink_raw"><span class="fn-name">readlink_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="is_symlink"><a href="fs.html#is_symlink"><span class="fn-name">is_symlink</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="unlink_raw"><a href="fs.html#unlink_raw"><span class="fn-name">unlink_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="write_binary_raw"><a href="fs.html#write_binary_raw"><span class="fn-name">write_binary_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="write_atomic_raw"><a href="fs.html#write_atomic_raw"><span class="fn-name">write_atomic_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="rename_raw"><a href="fs.html#rename_raw"><span class="fn-name">rename_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="try_stat"><a href="fs.html#try_stat"><span class="fn-name">try_stat</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="get_stat_kind"><a href="fs.html#get_stat_kind"><span class="fn-name">get_stat_kind</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="get_stat_size"><a href="fs.html#get_stat_size"><span class="fn-name">get_stat_size</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="get_stat_mtime"><a href="fs.html#get_stat_mtime"><span class="fn-name">get_stat_mtime</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="try_read_binary"><a href="fs.html#try_read_binary"><span class="fn-name">try_read_binary</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="get_read_binary"><a href="fs.html#get_read_binary"><span class="fn-name">get_read_binary</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="get_read_binary_length"><a href="fs.html#get_read_binary_length"><span class="fn-name">get_read_binary_length</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="release_read_binary"><a href="fs.html#release_read_binary"><span class="fn-name">release_read_binary</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="read_binary_tuple"><a href="fs.html#read_binary_tuple"><span class="fn-name">read_binary_tuple</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="dir_list_count"><a href="fs.html#dir_list_count"><span class="fn-name">dir_list_count</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="dir_list_get"><a href="fs.html#dir_list_get"><span class="fn-name">dir_list_get</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="dir_list_free"><a href="fs.html#dir_list_free"><span class="fn-name">dir_list_free</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_join"><a href="fs.html#path_join"><span class="fn-name">path_join</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_dirname"><a href="fs.html#path_dirname"><span class="fn-name">path_dirname</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_basename"><a href="fs.html#path_basename"><span class="fn-name">path_basename</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_extension"><a href="fs.html#path_extension"><span class="fn-name">path_extension</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_is_absolute"><a href="fs.html#path_is_absolute"><span class="fn-name">path_is_absolute</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_clean"><a href="fs.html#path_clean"><span class="fn-name">path_clean</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_is_within_base"><a href="fs.html#path_is_within_base"><span class="fn-name">path_is_within_base</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="path_rel"><a href="fs.html#path_rel"><span class="fn-name">path_rel</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="clean"><a href="fs.html#clean"><span class="fn-name">clean</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="is_within_base"><a href="fs.html#is_within_base"><span class="fn-name">is_within_base</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="rel"><a href="fs.html#rel"><span class="fn-name">rel</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="join_clean"><a href="fs.html#join_clean"><span class="fn-name">join_clean</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="first_element"><a href="fs.html#first_element"><span class="fn-name">first_element</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="pwrite_raw"><a href="fs.html#pwrite_raw"><span class="fn-name">pwrite_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="pread_raw"><a href="fs.html#pread_raw"><span class="fn-name">pread_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="get_pread"><a href="fs.html#get_pread"><span class="fn-name">get_pread</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="get_pread_length"><a href="fs.html#get_pread_length"><span class="fn-name">get_pread_length</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="release_pread"><a href="fs.html#release_pread"><span class="fn-name">release_pread</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="ftruncate_raw"><a href="fs.html#ftruncate_raw"><span class="fn-name">ftruncate_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="fsync_raw"><a href="fs.html#fsync_raw"><span class="fn-name">fsync_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="pwrite"><a href="fs.html#pwrite"><span class="fn-name">pwrite</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="pread"><a href="fs.html#pread"><span class="fn-name">pread</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="ftruncate"><a href="fs.html#ftruncate"><span class="fn-name">ftruncate</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="fsync"><a href="fs.html#fsync"><span class="fn-name">fsync</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="glob_raw"><a href="fs.html#glob_raw"><span class="fn-name">glob_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="glob_multi_raw"><a href="fs.html#glob_multi_raw"><span class="fn-name">glob_multi_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="open"><a href="fs.html#open"><span class="fn-name">open</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="read"><a href="fs.html#read"><span class="fn-name">read</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="write"><a href="fs.html#write"><span class="fn-name">write</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="delete"><a href="fs.html#delete"><span class="fn-name">delete</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="size"><a href="fs.html#size"><span class="fn-name">size</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="mtime"><a href="fs.html#mtime"><span class="fn-name">mtime</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="exists"><a href="fs.html#exists"><span class="fn-name">exists</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="create_dir"><a href="fs.html#create_dir"><span class="fn-name">create_dir</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="create_dir_with_mode"><a href="fs.html#create_dir_with_mode"><span class="fn-name">create_dir_with_mode</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="delete_dir"><a href="fs.html#delete_dir"><span class="fn-name">delete_dir</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="mkdir_p"><a href="fs.html#mkdir_p"><span class="fn-name">mkdir_p</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="symlink"><a href="fs.html#symlink"><span class="fn-name">symlink</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="readlink"><a href="fs.html#readlink"><span class="fn-name">readlink</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="unlink"><a href="fs.html#unlink"><span class="fn-name">unlink</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="list_dir"><a href="fs.html#list_dir"><span class="fn-name">list_dir</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="glob"><a href="fs.html#glob"><span class="fn-name">glob</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="glob_multi"><a href="fs.html#glob_multi"><span class="fn-name">glob_multi</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="write_binary"><a href="fs.html#write_binary"><span class="fn-name">write_binary</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="write_atomic"><a href="fs.html#write_atomic"><span class="fn-name">write_atomic</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="rename"><a href="fs.html#rename"><span class="fn-name">rename</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="file_stat"><a href="fs.html#file_stat"><span class="fn-name">file_stat</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="read_binary"><a href="fs.html#read_binary"><span class="fn-name">read_binary</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="copy_raw"><a href="fs.html#copy_raw"><span class="fn-name">copy_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="move_raw"><a href="fs.html#move_raw"><span class="fn-name">move_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="realpath_raw"><a href="fs.html#realpath_raw"><span class="fn-name">realpath_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="chmod_raw"><a href="fs.html#chmod_raw"><span class="fn-name">chmod_raw</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="copy"><a href="fs.html#copy"><span class="fn-name">copy</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="move"><a href="fs.html#move"><span class="fn-name">move</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="realpath"><a href="fs.html#realpath"><span class="fn-name">realpath</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="chmod"><a href="fs.html#chmod"><span class="fn-name">chmod</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_OK"><a href="fs.html#KIND_OK"><span class="fn-name">KIND_OK</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_NOT_FOUND"><a href="fs.html#KIND_NOT_FOUND"><span class="fn-name">KIND_NOT_FOUND</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_PERMISSION_DENIED"><a href="fs.html#KIND_PERMISSION_DENIED"><span class="fn-name">KIND_PERMISSION_DENIED</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_EXISTS"><a href="fs.html#KIND_EXISTS"><span class="fn-name">KIND_EXISTS</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_CROSS_DEVICE"><a href="fs.html#KIND_CROSS_DEVICE"><span class="fn-name">KIND_CROSS_DEVICE</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_IO"><a href="fs.html#KIND_IO"><span class="fn-name">KIND_IO</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_INVALID"><a href="fs.html#KIND_INVALID"><span class="fn-name">KIND_INVALID</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_LOOP"><a href="fs.html#KIND_LOOP"><span class="fn-name">KIND_LOOP</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_NAME_TOO_LONG"><a href="fs.html#KIND_NAME_TOO_LONG"><span class="fn-name">KIND_NAME_TOO_LONG</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_NO_SPACE"><a href="fs.html#KIND_NO_SPACE"><span class="fn-name">KIND_NO_SPACE</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_IS_DIR"><a href="fs.html#KIND_IS_DIR"><span class="fn-name">KIND_IS_DIR</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_NOT_DIR"><a href="fs.html#KIND_NOT_DIR"><span class="fn-name">KIND_NOT_DIR</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="KIND_UNAVAILABLE"><a href="fs.html#KIND_UNAVAILABLE"><span class="fn-name">KIND_UNAVAILABLE</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="notify"><a href="host.html#notify"><span class="fn-name">notify</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="describe"><a href="host.html#describe"><span class="fn-name">describe</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="input"><a href="host.html#input"><span class="fn-name">input</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="event"><a href="host.html#event"><span class="fn-name">event</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="bindings"><a href="host.html#bindings"><span class="fn-name">bindings</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="java"><a href="host.html#java"><span class="fn-name">java</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="python"><a href="host.html#python"><span class="fn-name">python</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="ruby"><a href="host.html#ruby"><span class="fn-name">ruby</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="go"><a href="host.html#go"><span class="fn-name">go</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="manifest_get"><a href="host.html#manifest_get"><span class="fn-name">manifest_get</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="manifest_clear"><a href="host.html#manifest_clear"><span class="fn-name">manifest_clear</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="aether_caller_identity"><a href="host.html#aether_caller_identity"><span class="fn-name">aether_caller_identity</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="aether_caller_attribute"><a href="host.html#aether_caller_attribute"><span class="fn-name">aether_caller_attribute</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="aether_caller_deadline_ms"><a href="host.html#aether_caller_deadline_ms"><span class="fn-name">aether_caller_deadline_ms</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="caller_identity"><a href="host.html#caller_identity"><span class="fn-name">caller_identity</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="caller_attribute"><a href="host.html#caller_attribute"><span class="fn-name">caller_attribute</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="caller_deadline_ms"><a href="host.html#caller_deadline_ms"><span class="fn-name">caller_deadline_ms</span><span class="fn-module">host</span></a></li>
+      <li class="function-item" data-name="this"><a href="http.html#this"><span class="fn-name">this</span><span class="fn-module">http</span></a></li>
+      <li class="function-item" data-name="module"><a href="http.html#module"><span class="fn-name">module</span><span class="fn-module">http</span></a></li>
+      <li class="function-item" data-name="new"><a href="intarr.html#new"><span class="fn-name">new</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="new_filled"><a href="intarr.html#new_filled"><span class="fn-name">new_filled</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="get"><a href="intarr.html#get"><span class="fn-name">get</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="set"><a href="intarr.html#set"><span class="fn-name">set</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="new_raw"><a href="intarr.html#new_raw"><span class="fn-name">new_raw</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="new_filled_raw"><a href="intarr.html#new_filled_raw"><span class="fn-name">new_filled_raw</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="size"><a href="intarr.html#size"><span class="fn-name">size</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="get_raw"><a href="intarr.html#get_raw"><span class="fn-name">get_raw</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="set_raw"><a href="intarr.html#set_raw"><span class="fn-name">set_raw</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="get_unchecked"><a href="intarr.html#get_unchecked"><span class="fn-name">get_unchecked</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="set_unchecked"><a href="intarr.html#set_unchecked"><span class="fn-name">set_unchecked</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="fill"><a href="intarr.html#fill"><span class="fn-name">fill</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="free"><a href="intarr.html#free"><span class="fn-name">free</span><span class="fn-module">intarr</span></a></li>
+      <li class="function-item" data-name="print"><a href="io.html#print"><span class="fn-name">print</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="print_line"><a href="io.html#print_line"><span class="fn-name">print_line</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="print_int"><a href="io.html#print_int"><span class="fn-name">print_int</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="print_float"><a href="io.html#print_float"><span class="fn-name">print_float</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="read_file_raw"><a href="io.html#read_file_raw"><span class="fn-name">read_file_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="write_file_raw"><a href="io.html#write_file_raw"><span class="fn-name">write_file_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="append_file_raw"><a href="io.html#append_file_raw"><span class="fn-name">append_file_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="file_exists"><a href="io.html#file_exists"><span class="fn-name">file_exists</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="delete_file_raw"><a href="io.html#delete_file_raw"><span class="fn-name">delete_file_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="file_info_raw"><a href="io.html#file_info_raw"><span class="fn-name">file_info_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="file_info_free"><a href="io.html#file_info_free"><span class="fn-name">file_info_free</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="getenv"><a href="io.html#getenv"><span class="fn-name">getenv</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="setenv_raw"><a href="io.html#setenv_raw"><span class="fn-name">setenv_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="unsetenv_raw"><a href="io.html#unsetenv_raw"><span class="fn-name">unsetenv_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="stderr_write_raw"><a href="io.html#stderr_write_raw"><span class="fn-name">stderr_write_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="stdout_write_raw"><a href="io.html#stdout_write_raw"><span class="fn-name">stdout_write_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="perror_raw"><a href="io.html#perror_raw"><span class="fn-name">perror_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="errno_message_raw"><a href="io.html#errno_message_raw"><span class="fn-name">errno_message_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_open_read_tuple"><a href="io.html#fd_open_read_tuple"><span class="fn-name">fd_open_read_tuple</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_open_write_tuple"><a href="io.html#fd_open_write_tuple"><span class="fn-name">fd_open_write_tuple</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_close_raw"><a href="io.html#fd_close_raw"><span class="fn-name">fd_close_raw</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_write_n"><a href="io.html#fd_write_n"><span class="fn-name">fd_write_n</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_read_n_tuple"><a href="io.html#fd_read_n_tuple"><span class="fn-name">fd_read_n_tuple</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_read_line_tuple"><a href="io.html#fd_read_line_tuple"><span class="fn-name">fd_read_line_tuple</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="read_file"><a href="io.html#read_file"><span class="fn-name">read_file</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="write_file"><a href="io.html#write_file"><span class="fn-name">write_file</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="append_file"><a href="io.html#append_file"><span class="fn-name">append_file</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="delete_file"><a href="io.html#delete_file"><span class="fn-name">delete_file</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="file_info"><a href="io.html#file_info"><span class="fn-name">file_info</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="setenv"><a href="io.html#setenv"><span class="fn-name">setenv</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="unsetenv"><a href="io.html#unsetenv"><span class="fn-name">unsetenv</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="stderr_write"><a href="io.html#stderr_write"><span class="fn-name">stderr_write</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="stdout_write"><a href="io.html#stdout_write"><span class="fn-name">stdout_write</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="perror"><a href="io.html#perror"><span class="fn-name">perror</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="errno_message"><a href="io.html#errno_message"><span class="fn-name">errno_message</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_open_read"><a href="io.html#fd_open_read"><span class="fn-name">fd_open_read</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_open_write"><a href="io.html#fd_open_write"><span class="fn-name">fd_open_write</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_close"><a href="io.html#fd_close"><span class="fn-name">fd_close</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_read_n"><a href="io.html#fd_read_n"><span class="fn-name">fd_read_n</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="fd_read_line"><a href="io.html#fd_read_line"><span class="fn-name">fd_read_line</span><span class="fn-module">io</span></a></li>
+      <li class="function-item" data-name="parent_channel_raw"><a href="ipc.html#parent_channel_raw"><span class="fn-name">parent_channel_raw</span><span class="fn-module">ipc</span></a></li>
+      <li class="function-item" data-name="parent_channel"><a href="ipc.html#parent_channel"><span class="fn-name">parent_channel</span><span class="fn-module">ipc</span></a></li>
+      <li class="function-item" data-name="write"><a href="ipc.html#write"><span class="fn-name">write</span><span class="fn-module">ipc</span></a></li>
+      <li class="function-item" data-name="write_close"><a href="ipc.html#write_close"><span class="fn-name">write_close</span><span class="fn-module">ipc</span></a></li>
+      <li class="function-item" data-name="parse_raw"><a href="json.html#parse_raw"><span class="fn-name">parse_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="last_error"><a href="json.html#last_error"><span class="fn-name">last_error</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="stringify_raw"><a href="json.html#stringify_raw"><span class="fn-name">stringify_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="free"><a href="json.html#free"><span class="fn-name">free</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="type"><a href="json.html#type"><span class="fn-name">type</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="is_null"><a href="json.html#is_null"><span class="fn-name">is_null</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="get_bool"><a href="json.html#get_bool"><span class="fn-name">get_bool</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="get_number"><a href="json.html#get_number"><span class="fn-name">get_number</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="get_int"><a href="json.html#get_int"><span class="fn-name">get_int</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="get_string_raw"><a href="json.html#get_string_raw"><span class="fn-name">get_string_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_get_raw"><a href="json.html#object_get_raw"><span class="fn-name">object_get_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_set_raw"><a href="json.html#object_set_raw"><span class="fn-name">object_set_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_has"><a href="json.html#object_has"><span class="fn-name">object_has</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_size_raw"><a href="json.html#object_size_raw"><span class="fn-name">object_size_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_key_at"><a href="json.html#object_key_at"><span class="fn-name">object_key_at</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_value_at"><a href="json.html#object_value_at"><span class="fn-name">object_value_at</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="array_get_raw"><a href="json.html#array_get_raw"><span class="fn-name">array_get_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="array_add_raw"><a href="json.html#array_add_raw"><span class="fn-name">array_add_raw</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="array_size"><a href="json.html#array_size"><span class="fn-name">array_size</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="create_null"><a href="json.html#create_null"><span class="fn-name">create_null</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="create_bool"><a href="json.html#create_bool"><span class="fn-name">create_bool</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="create_number"><a href="json.html#create_number"><span class="fn-name">create_number</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="create_int"><a href="json.html#create_int"><span class="fn-name">create_int</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="create_string"><a href="json.html#create_string"><span class="fn-name">create_string</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="create_array"><a href="json.html#create_array"><span class="fn-name">create_array</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="create_object"><a href="json.html#create_object"><span class="fn-name">create_object</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="parse"><a href="json.html#parse"><span class="fn-name">parse</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="stringify"><a href="json.html#stringify"><span class="fn-name">stringify</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="get_string"><a href="json.html#get_string"><span class="fn-name">get_string</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_get"><a href="json.html#object_get"><span class="fn-name">object_get</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_set"><a href="json.html#object_set"><span class="fn-name">object_set</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_size"><a href="json.html#object_size"><span class="fn-name">object_size</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="object_entry"><a href="json.html#object_entry"><span class="fn-name">object_entry</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="array_get"><a href="json.html#array_get"><span class="fn-name">array_get</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="array_add"><a href="json.html#array_add"><span class="fn-name">array_add</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="obj"><a href="json.html#obj"><span class="fn-name">obj</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="arr"><a href="json.html#arr"><span class="fn-name">arr</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="str"><a href="json.html#str"><span class="fn-name">str</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="num"><a href="json.html#num"><span class="fn-name">num</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="from_int"><a href="json.html#from_int"><span class="fn-name">from_int</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="boolean"><a href="json.html#boolean"><span class="fn-name">boolean</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="null_value"><a href="json.html#null_value"><span class="fn-name">null_value</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="set"><a href="json.html#set"><span class="fn-name">set</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="push"><a href="json.html#push"><span class="fn-name">push</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="encode"><a href="json.html#encode"><span class="fn-name">encode</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="parse_strict"><a href="json.html#parse_strict"><span class="fn-name">parse_strict</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="last_error_kind"><a href="json.html#last_error_kind"><span class="fn-name">last_error_kind</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="last_error_line"><a href="json.html#last_error_line"><span class="fn-name">last_error_line</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="last_error_col"><a href="json.html#last_error_col"><span class="fn-name">last_error_col</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="KIND_OK"><a href="json.html#KIND_OK"><span class="fn-name">KIND_OK</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="KIND_PARSE_ERROR"><a href="json.html#KIND_PARSE_ERROR"><span class="fn-name">KIND_PARSE_ERROR</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="KIND_OUT_OF_MEMORY"><a href="json.html#KIND_OUT_OF_MEMORY"><span class="fn-name">KIND_OUT_OF_MEMORY</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="KIND_INVALID_INPUT"><a href="json.html#KIND_INVALID_INPUT"><span class="fn-name">KIND_INVALID_INPUT</span><span class="fn-module">json</span></a></li>
+      <li class="function-item" data-name="generate"><a href="ksuid.html#generate"><span class="fn-name">generate</span><span class="fn-module">ksuid</span></a></li>
+      <li class="function-item" data-name="new"><a href="list.html#new"><span class="fn-name">new</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="add_raw"><a href="list.html#add_raw"><span class="fn-name">add_raw</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="add_string_owned"><a href="list.html#add_string_owned"><span class="fn-name">add_string_owned</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="get_raw"><a href="list.html#get_raw"><span class="fn-name">get_raw</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="set"><a href="list.html#set"><span class="fn-name">set</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="size"><a href="list.html#size"><span class="fn-name">size</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="remove"><a href="list.html#remove"><span class="fn-name">remove</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="clear"><a href="list.html#clear"><span class="fn-name">clear</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="free"><a href="list.html#free"><span class="fn-name">free</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="add"><a href="list.html#add"><span class="fn-name">add</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="get"><a href="list.html#get"><span class="fn-name">get</span><span class="fn-module">list</span></a></li>
+      <li class="function-item" data-name="init_raw"><a href="log.html#init_raw"><span class="fn-name">init_raw</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="shutdown"><a href="log.html#shutdown"><span class="fn-name">shutdown</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="write"><a href="log.html#write"><span class="fn-name">write</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="set_level"><a href="log.html#set_level"><span class="fn-name">set_level</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="set_colors"><a href="log.html#set_colors"><span class="fn-name">set_colors</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="set_timestamps"><a href="log.html#set_timestamps"><span class="fn-name">set_timestamps</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="get_stats"><a href="log.html#get_stats"><span class="fn-name">get_stats</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="print_stats"><a href="log.html#print_stats"><span class="fn-name">print_stats</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="init"><a href="log.html#init"><span class="fn-name">init</span><span class="fn-module">log</span></a></li>
+      <li class="function-item" data-name="new"><a href="longarr.html#new"><span class="fn-name">new</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="new_filled"><a href="longarr.html#new_filled"><span class="fn-name">new_filled</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="get"><a href="longarr.html#get"><span class="fn-name">get</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="set"><a href="longarr.html#set"><span class="fn-name">set</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="new_raw"><a href="longarr.html#new_raw"><span class="fn-name">new_raw</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="new_filled_raw"><a href="longarr.html#new_filled_raw"><span class="fn-name">new_filled_raw</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="size"><a href="longarr.html#size"><span class="fn-name">size</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="get_raw"><a href="longarr.html#get_raw"><span class="fn-name">get_raw</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="set_raw"><a href="longarr.html#set_raw"><span class="fn-name">set_raw</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="get_unchecked"><a href="longarr.html#get_unchecked"><span class="fn-name">get_unchecked</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="set_unchecked"><a href="longarr.html#set_unchecked"><span class="fn-name">set_unchecked</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="fill"><a href="longarr.html#fill"><span class="fn-name">fill</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="free"><a href="longarr.html#free"><span class="fn-name">free</span><span class="fn-module">longarr</span></a></li>
+      <li class="function-item" data-name="max_compressed_size"><a href="lzf.html#max_compressed_size"><span class="fn-name">max_compressed_size</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="try_compress"><a href="lzf.html#try_compress"><span class="fn-name">try_compress</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="get_compress_bytes"><a href="lzf.html#get_compress_bytes"><span class="fn-name">get_compress_bytes</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="get_compress_length"><a href="lzf.html#get_compress_length"><span class="fn-name">get_compress_length</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="release_compress"><a href="lzf.html#release_compress"><span class="fn-name">release_compress</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="try_decompress"><a href="lzf.html#try_decompress"><span class="fn-name">try_decompress</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="get_decompress_bytes"><a href="lzf.html#get_decompress_bytes"><span class="fn-name">get_decompress_bytes</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="get_decompress_length"><a href="lzf.html#get_decompress_length"><span class="fn-name">get_decompress_length</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="release_decompress"><a href="lzf.html#release_decompress"><span class="fn-name">release_decompress</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="compress"><a href="lzf.html#compress"><span class="fn-name">compress</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="decompress"><a href="lzf.html#decompress"><span class="fn-name">decompress</span><span class="fn-module">lzf</span></a></li>
+      <li class="function-item" data-name="new"><a href="map.html#new"><span class="fn-name">new</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="put_raw"><a href="map.html#put_raw"><span class="fn-name">put_raw</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="put_string_owned"><a href="map.html#put_string_owned"><span class="fn-name">put_string_owned</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="get_raw"><a href="map.html#get_raw"><span class="fn-name">get_raw</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="has"><a href="map.html#has"><span class="fn-name">has</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="remove"><a href="map.html#remove"><span class="fn-name">remove</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="size"><a href="map.html#size"><span class="fn-name">size</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="clear"><a href="map.html#clear"><span class="fn-name">clear</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="free"><a href="map.html#free"><span class="fn-name">free</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="keys_raw"><a href="map.html#keys_raw"><span class="fn-name">keys_raw</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="keys_free"><a href="map.html#keys_free"><span class="fn-name">keys_free</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="put"><a href="map.html#put"><span class="fn-name">put</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="get"><a href="map.html#get"><span class="fn-name">get</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="keys"><a href="map.html#keys"><span class="fn-name">keys</span><span class="fn-module">map</span></a></li>
+      <li class="function-item" data-name="abs_int"><a href="math.html#abs_int"><span class="fn-name">abs_int</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="abs_float"><a href="math.html#abs_float"><span class="fn-name">abs_float</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="min_int"><a href="math.html#min_int"><span class="fn-name">min_int</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="max_int"><a href="math.html#max_int"><span class="fn-name">max_int</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="min_float"><a href="math.html#min_float"><span class="fn-name">min_float</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="max_float"><a href="math.html#max_float"><span class="fn-name">max_float</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="clamp_int"><a href="math.html#clamp_int"><span class="fn-name">clamp_int</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="clamp_float"><a href="math.html#clamp_float"><span class="fn-name">clamp_float</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="sqrt"><a href="math.html#sqrt"><span class="fn-name">sqrt</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="pow"><a href="math.html#pow"><span class="fn-name">pow</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="sin"><a href="math.html#sin"><span class="fn-name">sin</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="cos"><a href="math.html#cos"><span class="fn-name">cos</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="tan"><a href="math.html#tan"><span class="fn-name">tan</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="asin"><a href="math.html#asin"><span class="fn-name">asin</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="acos"><a href="math.html#acos"><span class="fn-name">acos</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="atan"><a href="math.html#atan"><span class="fn-name">atan</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="atan2"><a href="math.html#atan2"><span class="fn-name">atan2</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="floor"><a href="math.html#floor"><span class="fn-name">floor</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="ceil"><a href="math.html#ceil"><span class="fn-name">ceil</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="round"><a href="math.html#round"><span class="fn-name">round</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="log"><a href="math.html#log"><span class="fn-name">log</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="log10"><a href="math.html#log10"><span class="fn-name">log10</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="exp"><a href="math.html#exp"><span class="fn-name">exp</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="random_seed"><a href="math.html#random_seed"><span class="fn-name">random_seed</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="random_int"><a href="math.html#random_int"><span class="fn-name">random_int</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="random_float"><a href="math.html#random_float"><span class="fn-name">random_float</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="pi"><a href="math.html#pi"><span class="fn-name">pi</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="tau"><a href="math.html#tau"><span class="fn-name">tau</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="e"><a href="math.html#e"><span class="fn-name">e</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="deg_to_rad"><a href="math.html#deg_to_rad"><span class="fn-name">deg_to_rad</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="rad_to_deg"><a href="math.html#rad_to_deg"><span class="fn-name">rad_to_deg</span><span class="fn-module">math</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_byte"><a href="mem.html#aether_mem_get_byte"><span class="fn-name">aether_mem_get_byte</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_byte"><a href="mem.html#aether_mem_set_byte"><span class="fn-name">aether_mem_set_byte</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_byte_sz"><a href="mem.html#aether_mem_get_byte_sz"><span class="fn-name">aether_mem_get_byte_sz</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_byte_sz"><a href="mem.html#aether_mem_set_byte_sz"><span class="fn-name">aether_mem_set_byte_sz</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_ptr"><a href="mem.html#aether_mem_get_ptr"><span class="fn-name">aether_mem_get_ptr</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_ptr"><a href="mem.html#aether_mem_set_ptr"><span class="fn-name">aether_mem_set_ptr</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_int"><a href="mem.html#aether_mem_get_int"><span class="fn-name">aether_mem_get_int</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_int"><a href="mem.html#aether_mem_set_int"><span class="fn-name">aether_mem_set_int</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_long"><a href="mem.html#aether_mem_get_long"><span class="fn-name">aether_mem_get_long</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_long"><a href="mem.html#aether_mem_set_long"><span class="fn-name">aether_mem_set_long</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_int8"><a href="mem.html#aether_mem_get_int8"><span class="fn-name">aether_mem_get_int8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_int8"><a href="mem.html#aether_mem_set_int8"><span class="fn-name">aether_mem_set_int8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_uint8"><a href="mem.html#aether_mem_get_uint8"><span class="fn-name">aether_mem_get_uint8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_uint8"><a href="mem.html#aether_mem_set_uint8"><span class="fn-name">aether_mem_set_uint8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_int16"><a href="mem.html#aether_mem_get_int16"><span class="fn-name">aether_mem_get_int16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_int16"><a href="mem.html#aether_mem_set_int16"><span class="fn-name">aether_mem_set_int16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_uint16"><a href="mem.html#aether_mem_get_uint16"><span class="fn-name">aether_mem_get_uint16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_uint16"><a href="mem.html#aether_mem_set_uint16"><span class="fn-name">aether_mem_set_uint16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_uint32"><a href="mem.html#aether_mem_get_uint32"><span class="fn-name">aether_mem_get_uint32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_uint32"><a href="mem.html#aether_mem_set_uint32"><span class="fn-name">aether_mem_set_uint32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_float32"><a href="mem.html#aether_mem_get_float32"><span class="fn-name">aether_mem_get_float32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_float32"><a href="mem.html#aether_mem_set_float32"><span class="fn-name">aether_mem_set_float32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_float64"><a href="mem.html#aether_mem_get_float64"><span class="fn-name">aether_mem_get_float64</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_float64"><a href="mem.html#aether_mem_set_float64"><span class="fn-name">aether_mem_set_float64</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_bits_of_float"><a href="mem.html#aether_mem_bits_of_float"><span class="fn-name">aether_mem_bits_of_float</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_float_from_bits"><a href="mem.html#aether_mem_float_from_bits"><span class="fn-name">aether_mem_float_from_bits</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_clz32"><a href="mem.html#aether_mem_clz32"><span class="fn-name">aether_mem_clz32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_clz64"><a href="mem.html#aether_mem_clz64"><span class="fn-name">aether_mem_clz64</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_udiv64_32"><a href="mem.html#aether_mem_udiv64_32"><span class="fn-name">aether_mem_udiv64_32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_call_fn3_int"><a href="mem.html#aether_mem_call_fn3_int"><span class="fn-name">aether_mem_call_fn3_int</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_call_fn3_void"><a href="mem.html#aether_mem_call_fn3_void"><span class="fn-name">aether_mem_call_fn3_void</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_copy"><a href="mem.html#aether_mem_copy"><span class="fn-name">aether_mem_copy</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_move"><a href="mem.html#aether_mem_move"><span class="fn-name">aether_mem_move</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_compare"><a href="mem.html#aether_mem_compare"><span class="fn-name">aether_mem_compare</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_bulk"><a href="mem.html#aether_mem_set_bulk"><span class="fn-name">aether_mem_set_bulk</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_u16_le"><a href="mem.html#aether_mem_get_u16_le"><span class="fn-name">aether_mem_get_u16_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_u16_be"><a href="mem.html#aether_mem_get_u16_be"><span class="fn-name">aether_mem_get_u16_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_u16_le"><a href="mem.html#aether_mem_set_u16_le"><span class="fn-name">aether_mem_set_u16_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_u16_be"><a href="mem.html#aether_mem_set_u16_be"><span class="fn-name">aether_mem_set_u16_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_u32_le"><a href="mem.html#aether_mem_get_u32_le"><span class="fn-name">aether_mem_get_u32_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_u32_be"><a href="mem.html#aether_mem_get_u32_be"><span class="fn-name">aether_mem_get_u32_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_u32_le"><a href="mem.html#aether_mem_set_u32_le"><span class="fn-name">aether_mem_set_u32_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_u32_be"><a href="mem.html#aether_mem_set_u32_be"><span class="fn-name">aether_mem_set_u32_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_u64_le"><a href="mem.html#aether_mem_get_u64_le"><span class="fn-name">aether_mem_get_u64_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_get_u64_be"><a href="mem.html#aether_mem_get_u64_be"><span class="fn-name">aether_mem_get_u64_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_u64_le"><a href="mem.html#aether_mem_set_u64_le"><span class="fn-name">aether_mem_set_u64_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="aether_mem_set_u64_be"><a href="mem.html#aether_mem_set_u64_be"><span class="fn-name">aether_mem_set_u64_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_byte"><a href="mem.html#get_byte"><span class="fn-name">get_byte</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_byte"><a href="mem.html#set_byte"><span class="fn-name">set_byte</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_byte_sz"><a href="mem.html#get_byte_sz"><span class="fn-name">get_byte_sz</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_byte_sz"><a href="mem.html#set_byte_sz"><span class="fn-name">set_byte_sz</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_ptr"><a href="mem.html#get_ptr"><span class="fn-name">get_ptr</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_ptr"><a href="mem.html#set_ptr"><span class="fn-name">set_ptr</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_int"><a href="mem.html#get_int"><span class="fn-name">get_int</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_int"><a href="mem.html#set_int"><span class="fn-name">set_int</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_long"><a href="mem.html#get_long"><span class="fn-name">get_long</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_long"><a href="mem.html#set_long"><span class="fn-name">set_long</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_int8"><a href="mem.html#get_int8"><span class="fn-name">get_int8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_int8"><a href="mem.html#set_int8"><span class="fn-name">set_int8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_uint8"><a href="mem.html#get_uint8"><span class="fn-name">get_uint8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_uint8"><a href="mem.html#set_uint8"><span class="fn-name">set_uint8</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_int16"><a href="mem.html#get_int16"><span class="fn-name">get_int16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_int16"><a href="mem.html#set_int16"><span class="fn-name">set_int16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_uint16"><a href="mem.html#get_uint16"><span class="fn-name">get_uint16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_uint16"><a href="mem.html#set_uint16"><span class="fn-name">set_uint16</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_uint32"><a href="mem.html#get_uint32"><span class="fn-name">get_uint32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_uint32"><a href="mem.html#set_uint32"><span class="fn-name">set_uint32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_float32"><a href="mem.html#get_float32"><span class="fn-name">get_float32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_float32"><a href="mem.html#set_float32"><span class="fn-name">set_float32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_float64"><a href="mem.html#get_float64"><span class="fn-name">get_float64</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_float64"><a href="mem.html#set_float64"><span class="fn-name">set_float64</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="bits_of_float"><a href="mem.html#bits_of_float"><span class="fn-name">bits_of_float</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="float_from_bits"><a href="mem.html#float_from_bits"><span class="fn-name">float_from_bits</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="clz32"><a href="mem.html#clz32"><span class="fn-name">clz32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="clz64"><a href="mem.html#clz64"><span class="fn-name">clz64</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="udiv64_32"><a href="mem.html#udiv64_32"><span class="fn-name">udiv64_32</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="call_fn3_int"><a href="mem.html#call_fn3_int"><span class="fn-name">call_fn3_int</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="call_fn3_void"><a href="mem.html#call_fn3_void"><span class="fn-name">call_fn3_void</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="copy"><a href="mem.html#copy"><span class="fn-name">copy</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="move"><a href="mem.html#move"><span class="fn-name">move</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="compare"><a href="mem.html#compare"><span class="fn-name">compare</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set"><a href="mem.html#set"><span class="fn-name">set</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_u16_le"><a href="mem.html#get_u16_le"><span class="fn-name">get_u16_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_u16_be"><a href="mem.html#get_u16_be"><span class="fn-name">get_u16_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_u16_le"><a href="mem.html#set_u16_le"><span class="fn-name">set_u16_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_u16_be"><a href="mem.html#set_u16_be"><span class="fn-name">set_u16_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_u32_le"><a href="mem.html#get_u32_le"><span class="fn-name">get_u32_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_u32_be"><a href="mem.html#get_u32_be"><span class="fn-name">get_u32_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_u32_le"><a href="mem.html#set_u32_le"><span class="fn-name">set_u32_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_u32_be"><a href="mem.html#set_u32_be"><span class="fn-name">set_u32_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_u64_le"><a href="mem.html#get_u64_le"><span class="fn-name">get_u64_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="get_u64_be"><a href="mem.html#get_u64_be"><span class="fn-name">get_u64_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_u64_le"><a href="mem.html#set_u64_le"><span class="fn-name">set_u64_le</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="set_u64_be"><a href="mem.html#set_u64_be"><span class="fn-name">set_u64_be</span><span class="fn-module">mem</span></a></li>
+      <li class="function-item" data-name="generate"><a href="nanoid.html#generate"><span class="fn-name">generate</span><span class="fn-module">nanoid</span></a></li>
+      <li class="function-item" data-name="generate_n"><a href="nanoid.html#generate_n"><span class="fn-name">generate_n</span><span class="fn-module">nanoid</span></a></li>
+      <li class="function-item" data-name="tcp_connect_raw"><a href="net.html#tcp_connect_raw"><span class="fn-name">tcp_connect_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="tcp_send_raw"><a href="net.html#tcp_send_raw"><span class="fn-name">tcp_send_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="tcp_receive_raw"><a href="net.html#tcp_receive_raw"><span class="fn-name">tcp_receive_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="tcp_close"><a href="net.html#tcp_close"><span class="fn-name">tcp_close</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="tcp_listen_raw"><a href="net.html#tcp_listen_raw"><span class="fn-name">tcp_listen_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="tcp_accept_raw"><a href="net.html#tcp_accept_raw"><span class="fn-name">tcp_accept_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="tcp_server_close"><a href="net.html#tcp_server_close"><span class="fn-name">tcp_server_close</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_get_raw"><a href="net.html#http_get_raw"><span class="fn-name">http_get_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_post_raw"><a href="net.html#http_post_raw"><span class="fn-name">http_post_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_put_raw"><a href="net.html#http_put_raw"><span class="fn-name">http_put_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_delete_raw"><a href="net.html#http_delete_raw"><span class="fn-name">http_delete_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_free"><a href="net.html#http_response_free"><span class="fn-name">http_response_free</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_status_code"><a href="net.html#http_response_status_code"><span class="fn-name">http_response_status_code</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_body_str"><a href="net.html#http_response_body_str"><span class="fn-name">http_response_body_str</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_headers_str"><a href="net.html#http_response_headers_str"><span class="fn-name">http_response_headers_str</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_status"><a href="net.html#http_response_status"><span class="fn-name">http_response_status</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_body"><a href="net.html#http_response_body"><span class="fn-name">http_response_body</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_headers"><a href="net.html#http_response_headers"><span class="fn-name">http_response_headers</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_error"><a href="net.html#http_response_error"><span class="fn-name">http_response_error</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_ok"><a href="net.html#http_response_ok"><span class="fn-name">http_response_ok</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_server_create"><a href="net.html#http_server_create"><span class="fn-name">http_server_create</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_server_bind_raw"><a href="net.html#http_server_bind_raw"><span class="fn-name">http_server_bind_raw</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_server_port"><a href="net.html#http_server_port"><span class="fn-name">http_server_port</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_server_start_raw"><a href="net.html#http_server_start_raw"><span class="fn-name">http_server_start_raw</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_server_stop"><a href="net.html#http_server_stop"><span class="fn-name">http_server_stop</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_server_free"><a href="net.html#http_server_free"><span class="fn-name">http_server_free</span><span class="fn-module">net</span></a></li>
@@ -97,273 +1075,350 @@
       <li class="function-item" data-name="http_get_query_param"><a href="net.html#http_get_query_param"><span class="fn-name">http_get_query_param</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_get_path_param"><a href="net.html#http_get_path_param"><span class="fn-name">http_get_path_param</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_request_free"><a href="net.html#http_request_free"><span class="fn-name">http_request_free</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_create"><a href="net.html#http_response_create"><span class="fn-name">http_response_create</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_response_set_status"><a href="net.html#http_response_set_status"><span class="fn-name">http_response_set_status</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_response_set_header"><a href="net.html#http_response_set_header"><span class="fn-name">http_response_set_header</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_response_set_body"><a href="net.html#http_response_set_body"><span class="fn-name">http_response_set_body</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_response_set_body_n"><a href="net.html#http_response_set_body_n"><span class="fn-name">http_response_set_body_n</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_response_json"><a href="net.html#http_response_json"><span class="fn-name">http_response_json</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_serialize"><a href="net.html#http_response_serialize"><span class="fn-name">http_response_serialize</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_server_response_free"><a href="net.html#http_server_response_free"><span class="fn-name">http_server_response_free</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_route_matches"><a href="net.html#http_route_matches"><span class="fn-name">http_route_matches</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_status_text"><a href="net.html#http_status_text"><span class="fn-name">http_status_text</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_mime_type"><a href="net.html#http_mime_type"><span class="fn-name">http_mime_type</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_serve_file"><a href="net.html#http_serve_file"><span class="fn-name">http_serve_file</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_serve_static"><a href="net.html#http_serve_static"><span class="fn-name">http_serve_static</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="void"><a href="net.html#void"><span class="fn-name">void</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_server_set_actor_handler"><a href="net.html#http_server_set_actor_handler"><span class="fn-name">http_server_set_actor_handler</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_request_method"><a href="net.html#http_request_method"><span class="fn-name">http_request_method</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_request_path"><a href="net.html#http_request_path"><span class="fn-name">http_request_path</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_request_body"><a href="net.html#http_request_body"><span class="fn-name">http_request_body</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_request_body_length"><a href="net.html#http_request_body_length"><span class="fn-name">http_request_body_length</span><span class="fn-module">net</span></a></li>
       <li class="function-item" data-name="http_request_query"><a href="net.html#http_request_query"><span class="fn-name">http_request_query</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_free"><a href="net.html#http_response_free"><span class="fn-name">http_response_free</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_status"><a href="net.html#http_response_status"><span class="fn-name">http_response_status</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_body"><a href="net.html#http_response_body"><span class="fn-name">http_response_body</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_headers"><a href="net.html#http_response_headers"><span class="fn-name">http_response_headers</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_error"><a href="net.html#http_response_error"><span class="fn-name">http_response_error</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_ok"><a href="net.html#http_response_ok"><span class="fn-name">http_response_ok</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_status_code"><a href="net.html#http_response_status_code"><span class="fn-name">http_response_status_code</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_body_str"><a href="net.html#http_response_body_str"><span class="fn-name">http_response_body_str</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="http_response_headers_str"><a href="net.html#http_response_headers_str"><span class="fn-name">http_response_headers_str</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="tcp_send_raw"><a href="net.html#tcp_send_raw"><span class="fn-name">tcp_send_raw</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="tcp_receive_raw"><a href="net.html#tcp_receive_raw"><span class="fn-name">tcp_receive_raw</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="tcp_close"><a href="net.html#tcp_close"><span class="fn-name">tcp_close</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="tcp_server_close"><a href="net.html#tcp_server_close"><span class="fn-name">tcp_server_close</span><span class="fn-module">net</span></a></li>
-      <li class="function-item" data-name="io_print"><a href="io.html#io_print"><span class="fn-name">io_print</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_print_line"><a href="io.html#io_print_line"><span class="fn-name">io_print_line</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_print_int"><a href="io.html#io_print_int"><span class="fn-name">io_print_int</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_print_float"><a href="io.html#io_print_float"><span class="fn-name">io_print_float</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_read_file_raw"><a href="io.html#io_read_file_raw"><span class="fn-name">io_read_file_raw</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_write_file_raw"><a href="io.html#io_write_file_raw"><span class="fn-name">io_write_file_raw</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_append_file_raw"><a href="io.html#io_append_file_raw"><span class="fn-name">io_append_file_raw</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_file_exists"><a href="io.html#io_file_exists"><span class="fn-name">io_file_exists</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_delete_file_raw"><a href="io.html#io_delete_file_raw"><span class="fn-name">io_delete_file_raw</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_file_info_free"><a href="io.html#io_file_info_free"><span class="fn-name">io_file_info_free</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_getenv"><a href="io.html#io_getenv"><span class="fn-name">io_getenv</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_setenv_raw"><a href="io.html#io_setenv_raw"><span class="fn-name">io_setenv_raw</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="io_unsetenv_raw"><a href="io.html#io_unsetenv_raw"><span class="fn-name">io_unsetenv_raw</span><span class="fn-module">io</span></a></li>
-      <li class="function-item" data-name="math_abs_int"><a href="math.html#math_abs_int"><span class="fn-name">math_abs_int</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_abs_float"><a href="math.html#math_abs_float"><span class="fn-name">math_abs_float</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_min_int"><a href="math.html#math_min_int"><span class="fn-name">math_min_int</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_max_int"><a href="math.html#math_max_int"><span class="fn-name">math_max_int</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_min_float"><a href="math.html#math_min_float"><span class="fn-name">math_min_float</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_max_float"><a href="math.html#math_max_float"><span class="fn-name">math_max_float</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_clamp_int"><a href="math.html#math_clamp_int"><span class="fn-name">math_clamp_int</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_clamp_float"><a href="math.html#math_clamp_float"><span class="fn-name">math_clamp_float</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_sqrt"><a href="math.html#math_sqrt"><span class="fn-name">math_sqrt</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_pow"><a href="math.html#math_pow"><span class="fn-name">math_pow</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_sin"><a href="math.html#math_sin"><span class="fn-name">math_sin</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_cos"><a href="math.html#math_cos"><span class="fn-name">math_cos</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_tan"><a href="math.html#math_tan"><span class="fn-name">math_tan</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_asin"><a href="math.html#math_asin"><span class="fn-name">math_asin</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_acos"><a href="math.html#math_acos"><span class="fn-name">math_acos</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_atan"><a href="math.html#math_atan"><span class="fn-name">math_atan</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_atan2"><a href="math.html#math_atan2"><span class="fn-name">math_atan2</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_floor"><a href="math.html#math_floor"><span class="fn-name">math_floor</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_ceil"><a href="math.html#math_ceil"><span class="fn-name">math_ceil</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_round"><a href="math.html#math_round"><span class="fn-name">math_round</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_log"><a href="math.html#math_log"><span class="fn-name">math_log</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_log10"><a href="math.html#math_log10"><span class="fn-name">math_log10</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_exp"><a href="math.html#math_exp"><span class="fn-name">math_exp</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_random_seed"><a href="math.html#math_random_seed"><span class="fn-name">math_random_seed</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_random_int"><a href="math.html#math_random_int"><span class="fn-name">math_random_int</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="math_random_float"><a href="math.html#math_random_float"><span class="fn-name">math_random_float</span><span class="fn-module">math</span></a></li>
-      <li class="function-item" data-name="json_parse_raw"><a href="json.html#json_parse_raw"><span class="fn-name">json_parse_raw</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_stringify"><a href="json.html#json_stringify"><span class="fn-name">json_stringify</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_free"><a href="json.html#json_free"><span class="fn-name">json_free</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_type"><a href="json.html#json_type"><span class="fn-name">json_type</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_is_null"><a href="json.html#json_is_null"><span class="fn-name">json_is_null</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_get_bool"><a href="json.html#json_get_bool"><span class="fn-name">json_get_bool</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_get_number"><a href="json.html#json_get_number"><span class="fn-name">json_get_number</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_get_int"><a href="json.html#json_get_int"><span class="fn-name">json_get_int</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_get_string"><a href="json.html#json_get_string"><span class="fn-name">json_get_string</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_object_get"><a href="json.html#json_object_get"><span class="fn-name">json_object_get</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_object_set"><a href="json.html#json_object_set"><span class="fn-name">json_object_set</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_object_has"><a href="json.html#json_object_has"><span class="fn-name">json_object_has</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_array_get"><a href="json.html#json_array_get"><span class="fn-name">json_array_get</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_array_add"><a href="json.html#json_array_add"><span class="fn-name">json_array_add</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_array_size"><a href="json.html#json_array_size"><span class="fn-name">json_array_size</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_create_null"><a href="json.html#json_create_null"><span class="fn-name">json_create_null</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_create_bool"><a href="json.html#json_create_bool"><span class="fn-name">json_create_bool</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_create_number"><a href="json.html#json_create_number"><span class="fn-name">json_create_number</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_create_string"><a href="json.html#json_create_string"><span class="fn-name">json_create_string</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_create_array"><a href="json.html#json_create_array"><span class="fn-name">json_create_array</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="json_create_object"><a href="json.html#json_create_object"><span class="fn-name">json_create_object</span><span class="fn-module">json</span></a></li>
-      <li class="function-item" data-name="log_init_raw"><a href="log.html#log_init_raw"><span class="fn-name">log_init_raw</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_init_with_config"><a href="log.html#log_init_with_config"><span class="fn-name">log_init_with_config</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_shutdown"><a href="log.html#log_shutdown"><span class="fn-name">log_shutdown</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_write"><a href="log.html#log_write"><span class="fn-name">log_write</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_set_level"><a href="log.html#log_set_level"><span class="fn-name">log_set_level</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_set_colors"><a href="log.html#log_set_colors"><span class="fn-name">log_set_colors</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_set_timestamps"><a href="log.html#log_set_timestamps"><span class="fn-name">log_set_timestamps</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_set_format"><a href="log.html#log_set_format"><span class="fn-name">log_set_format</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="log_print_stats"><a href="log.html#log_print_stats"><span class="fn-name">log_print_stats</span><span class="fn-module">log</span></a></li>
-      <li class="function-item" data-name="os_system"><a href="os.html#os_system"><span class="fn-name">os_system</span><span class="fn-module">os</span></a></li>
-      <li class="function-item" data-name="os_exec_raw"><a href="os.html#os_exec_raw"><span class="fn-name">os_exec_raw</span><span class="fn-module">os</span></a></li>
-      <li class="function-item" data-name="os_getenv"><a href="os.html#os_getenv"><span class="fn-name">os_getenv</span><span class="fn-module">os</span></a></li>
-      <li class="function-item" data-name="os_execv"><a href="os.html#os_execv"><span class="fn-name">os_execv</span><span class="fn-module">os</span></a></li>
-      <li class="function-item" data-name="os_which"><a href="os.html#os_which"><span class="fn-name">os_which</span><span class="fn-module">os</span></a></li>
-      <li class="function-item" data-name="os_run"><a href="os.html#os_run"><span class="fn-name">os_run</span><span class="fn-module">os</span></a></li>
-      <li class="function-item" data-name="os_run_capture_raw"><a href="os.html#os_run_capture_raw"><span class="fn-name">os_run_capture_raw</span><span class="fn-module">os</span></a></li>
-      <li class="function-item" data-name="="><a href="string.html#="><span class="fn-name">=</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_new"><a href="string.html#string_new"><span class="fn-name">string_new</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_from_cstr"><a href="string.html#string_from_cstr"><span class="fn-name">string_from_cstr</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_from_literal"><a href="string.html#string_from_literal"><span class="fn-name">string_from_literal</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_new_with_length"><a href="string.html#string_new_with_length"><span class="fn-name">string_new_with_length</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_empty"><a href="string.html#string_empty"><span class="fn-name">string_empty</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_retain"><a href="string.html#string_retain"><span class="fn-name">string_retain</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_release"><a href="string.html#string_release"><span class="fn-name">string_release</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_free"><a href="string.html#string_free"><span class="fn-name">string_free</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_concat"><a href="string.html#string_concat"><span class="fn-name">string_concat</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_length"><a href="string.html#string_length"><span class="fn-name">string_length</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_char_at"><a href="string.html#string_char_at"><span class="fn-name">string_char_at</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_equals"><a href="string.html#string_equals"><span class="fn-name">string_equals</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_compare"><a href="string.html#string_compare"><span class="fn-name">string_compare</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_starts_with"><a href="string.html#string_starts_with"><span class="fn-name">string_starts_with</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_ends_with"><a href="string.html#string_ends_with"><span class="fn-name">string_ends_with</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_contains"><a href="string.html#string_contains"><span class="fn-name">string_contains</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_index_of"><a href="string.html#string_index_of"><span class="fn-name">string_index_of</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_substring"><a href="string.html#string_substring"><span class="fn-name">string_substring</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_to_upper"><a href="string.html#string_to_upper"><span class="fn-name">string_to_upper</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_to_lower"><a href="string.html#string_to_lower"><span class="fn-name">string_to_lower</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_trim"><a href="string.html#string_trim"><span class="fn-name">string_trim</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_split"><a href="string.html#string_split"><span class="fn-name">string_split</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_array_size"><a href="string.html#string_array_size"><span class="fn-name">string_array_size</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_array_get"><a href="string.html#string_array_get"><span class="fn-name">string_array_get</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_array_free"><a href="string.html#string_array_free"><span class="fn-name">string_array_free</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_to_cstr"><a href="string.html#string_to_cstr"><span class="fn-name">string_to_cstr</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_from_int"><a href="string.html#string_from_int"><span class="fn-name">string_from_int</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_from_float"><a href="string.html#string_from_float"><span class="fn-name">string_from_float</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_to_int_raw"><a href="string.html#string_to_int_raw"><span class="fn-name">string_to_int_raw</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_to_long_raw"><a href="string.html#string_to_long_raw"><span class="fn-name">string_to_long_raw</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_to_float_raw"><a href="string.html#string_to_float_raw"><span class="fn-name">string_to_float_raw</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_to_double_raw"><a href="string.html#string_to_double_raw"><span class="fn-name">string_to_double_raw</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_try_int"><a href="string.html#string_try_int"><span class="fn-name">string_try_int</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_get_int"><a href="string.html#string_get_int"><span class="fn-name">string_get_int</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_try_long"><a href="string.html#string_try_long"><span class="fn-name">string_try_long</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_try_float"><a href="string.html#string_try_float"><span class="fn-name">string_try_float</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_get_float"><a href="string.html#string_get_float"><span class="fn-name">string_get_float</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_try_double"><a href="string.html#string_try_double"><span class="fn-name">string_try_double</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_get_double"><a href="string.html#string_get_double"><span class="fn-name">string_get_double</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="string_format"><a href="string.html#string_format"><span class="fn-name">string_format</span><span class="fn-module">string</span></a></li>
-      <li class="function-item" data-name="list_add_raw"><a href="collections.html#list_add_raw"><span class="fn-name">list_add_raw</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="list_get"><a href="collections.html#list_get"><span class="fn-name">list_get</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="list_set"><a href="collections.html#list_set"><span class="fn-name">list_set</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="list_size"><a href="collections.html#list_size"><span class="fn-name">list_size</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="list_remove"><a href="collections.html#list_remove"><span class="fn-name">list_remove</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="list_clear"><a href="collections.html#list_clear"><span class="fn-name">list_clear</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="list_free"><a href="collections.html#list_free"><span class="fn-name">list_free</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_new"><a href="collections.html#map_new"><span class="fn-name">map_new</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_put_raw"><a href="collections.html#map_put_raw"><span class="fn-name">map_put_raw</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_get"><a href="collections.html#map_get"><span class="fn-name">map_get</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_has"><a href="collections.html#map_has"><span class="fn-name">map_has</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_remove"><a href="collections.html#map_remove"><span class="fn-name">map_remove</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_size"><a href="collections.html#map_size"><span class="fn-name">map_size</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_clear"><a href="collections.html#map_clear"><span class="fn-name">map_clear</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_free"><a href="collections.html#map_free"><span class="fn-name">map_free</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_keys"><a href="collections.html#map_keys"><span class="fn-name">map_keys</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="map_keys_free"><a href="collections.html#map_keys_free"><span class="fn-name">map_keys_free</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_free"><a href="collections.html#set_free"><span class="fn-name">set_free</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_add"><a href="collections.html#set_add"><span class="fn-name">set_add</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_remove"><a href="collections.html#set_remove"><span class="fn-name">set_remove</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_contains"><a href="collections.html#set_contains"><span class="fn-name">set_contains</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_clear"><a href="collections.html#set_clear"><span class="fn-name">set_clear</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_size"><a href="collections.html#set_size"><span class="fn-name">set_size</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_is_empty"><a href="collections.html#set_is_empty"><span class="fn-name">set_is_empty</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_union"><a href="collections.html#set_union"><span class="fn-name">set_union</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_intersection"><a href="collections.html#set_intersection"><span class="fn-name">set_intersection</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_difference"><a href="collections.html#set_difference"><span class="fn-name">set_difference</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_is_subset"><a href="collections.html#set_is_subset"><span class="fn-name">set_is_subset</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_is_superset"><a href="collections.html#set_is_superset"><span class="fn-name">set_is_superset</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_iterator"><a href="collections.html#set_iterator"><span class="fn-name">set_iterator</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_iterator_next"><a href="collections.html#set_iterator_next"><span class="fn-name">set_iterator_next</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_create_string"><a href="collections.html#set_create_string"><span class="fn-name">set_create_string</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="set_create_int"><a href="collections.html#set_create_int"><span class="fn-name">set_create_int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="uint64_t"><a href="collections.html#uint64_t"><span class="fn-name">uint64_t</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="bool"><a href="collections.html#bool"><span class="fn-name">bool</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="void"><a href="collections.html#void"><span class="fn-name">void</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="void"><a href="collections.html#void"><span class="fn-name">void</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_free"><a href="collections.html#hashmap_free"><span class="fn-name">hashmap_free</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_insert"><a href="collections.html#hashmap_insert"><span class="fn-name">hashmap_insert</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_get"><a href="collections.html#hashmap_get"><span class="fn-name">hashmap_get</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_remove"><a href="collections.html#hashmap_remove"><span class="fn-name">hashmap_remove</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_contains"><a href="collections.html#hashmap_contains"><span class="fn-name">hashmap_contains</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_clear"><a href="collections.html#hashmap_clear"><span class="fn-name">hashmap_clear</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_size"><a href="collections.html#hashmap_size"><span class="fn-name">hashmap_size</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_is_empty"><a href="collections.html#hashmap_is_empty"><span class="fn-name">hashmap_is_empty</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_iterator"><a href="collections.html#hashmap_iterator"><span class="fn-name">hashmap_iterator</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_iterator_next"><a href="collections.html#hashmap_iterator_next"><span class="fn-name">hashmap_iterator_next</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_hash_string"><a href="collections.html#hashmap_hash_string"><span class="fn-name">hashmap_hash_string</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_equals_string"><a href="collections.html#hashmap_equals_string"><span class="fn-name">hashmap_equals_string</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_free_string"><a href="collections.html#hashmap_free_string"><span class="fn-name">hashmap_free_string</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_clone_string"><a href="collections.html#hashmap_clone_string"><span class="fn-name">hashmap_clone_string</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_hash_int"><a href="collections.html#hashmap_hash_int"><span class="fn-name">hashmap_hash_int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_equals_int"><a href="collections.html#hashmap_equals_int"><span class="fn-name">hashmap_equals_int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_free_int"><a href="collections.html#hashmap_free_int"><span class="fn-name">hashmap_free_int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_clone_int"><a href="collections.html#hashmap_clone_int"><span class="fn-name">hashmap_clone_int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_create_string_to_int"><a href="collections.html#hashmap_create_string_to_int"><span class="fn-name">hashmap_create_string_to_int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_create_string_to_string"><a href="collections.html#hashmap_create_string_to_string"><span class="fn-name">hashmap_create_string_to_string</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="hashmap_create_int_to_int"><a href="collections.html#hashmap_create_int_to_int"><span class="fn-name">hashmap_create_int_to_int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="int"><a href="collections.html#int"><span class="fn-name">int</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="void"><a href="collections.html#void"><span class="fn-name">void</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_free"><a href="collections.html#pqueue_free"><span class="fn-name">pqueue_free</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_insert"><a href="collections.html#pqueue_insert"><span class="fn-name">pqueue_insert</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_extract"><a href="collections.html#pqueue_extract"><span class="fn-name">pqueue_extract</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_peek"><a href="collections.html#pqueue_peek"><span class="fn-name">pqueue_peek</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_size"><a href="collections.html#pqueue_size"><span class="fn-name">pqueue_size</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_is_empty"><a href="collections.html#pqueue_is_empty"><span class="fn-name">pqueue_is_empty</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_clear"><a href="collections.html#pqueue_clear"><span class="fn-name">pqueue_clear</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="bool"><a href="collections.html#bool"><span class="fn-name">bool</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_compare_int_min"><a href="collections.html#pqueue_compare_int_min"><span class="fn-name">pqueue_compare_int_min</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="pqueue_compare_int_max"><a href="collections.html#pqueue_compare_int_max"><span class="fn-name">pqueue_compare_int_max</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="void"><a href="collections.html#void"><span class="fn-name">void</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name=""><a href="collections.html#"><span class="fn-name"></span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_free"><a href="collections.html#vector_free"><span class="fn-name">vector_free</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_push"><a href="collections.html#vector_push"><span class="fn-name">vector_push</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_pop"><a href="collections.html#vector_pop"><span class="fn-name">vector_pop</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_get"><a href="collections.html#vector_get"><span class="fn-name">vector_get</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_set"><a href="collections.html#vector_set"><span class="fn-name">vector_set</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_insert"><a href="collections.html#vector_insert"><span class="fn-name">vector_insert</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_remove"><a href="collections.html#vector_remove"><span class="fn-name">vector_remove</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_clear"><a href="collections.html#vector_clear"><span class="fn-name">vector_clear</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_size"><a href="collections.html#vector_size"><span class="fn-name">vector_size</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_is_empty"><a href="collections.html#vector_is_empty"><span class="fn-name">vector_is_empty</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_capacity"><a href="collections.html#vector_capacity"><span class="fn-name">vector_capacity</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_reserve"><a href="collections.html#vector_reserve"><span class="fn-name">vector_reserve</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_shrink_to_fit"><a href="collections.html#vector_shrink_to_fit"><span class="fn-name">vector_shrink_to_fit</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_find"><a href="collections.html#vector_find"><span class="fn-name">vector_find</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_contains"><a href="collections.html#vector_contains"><span class="fn-name">vector_contains</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_reverse"><a href="collections.html#vector_reverse"><span class="fn-name">vector_reverse</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="vector_sort"><a href="collections.html#vector_sort"><span class="fn-name">vector_sort</span><span class="fn-module">collections</span></a></li>
-      <li class="function-item" data-name="file_read_all_raw"><a href="fs.html#file_read_all_raw"><span class="fn-name">file_read_all_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="file_write_raw"><a href="fs.html#file_write_raw"><span class="fn-name">file_write_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="file_close"><a href="fs.html#file_close"><span class="fn-name">file_close</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="file_exists"><a href="fs.html#file_exists"><span class="fn-name">file_exists</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="file_delete_raw"><a href="fs.html#file_delete_raw"><span class="fn-name">file_delete_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="file_size_raw"><a href="fs.html#file_size_raw"><span class="fn-name">file_size_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="file_mtime"><a href="fs.html#file_mtime"><span class="fn-name">file_mtime</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="dir_exists"><a href="fs.html#dir_exists"><span class="fn-name">dir_exists</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="dir_create_raw"><a href="fs.html#dir_create_raw"><span class="fn-name">dir_create_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="dir_delete_raw"><a href="fs.html#dir_delete_raw"><span class="fn-name">dir_delete_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="fs_mkdir_p_raw"><a href="fs.html#fs_mkdir_p_raw"><span class="fn-name">fs_mkdir_p_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="fs_symlink_raw"><a href="fs.html#fs_symlink_raw"><span class="fn-name">fs_symlink_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="fs_readlink_raw"><a href="fs.html#fs_readlink_raw"><span class="fn-name">fs_readlink_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="fs_is_symlink"><a href="fs.html#fs_is_symlink"><span class="fn-name">fs_is_symlink</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="fs_unlink_raw"><a href="fs.html#fs_unlink_raw"><span class="fn-name">fs_unlink_raw</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="path_join"><a href="fs.html#path_join"><span class="fn-name">path_join</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="path_dirname"><a href="fs.html#path_dirname"><span class="fn-name">path_dirname</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="path_basename"><a href="fs.html#path_basename"><span class="fn-name">path_basename</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="path_extension"><a href="fs.html#path_extension"><span class="fn-name">path_extension</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="path_is_absolute"><a href="fs.html#path_is_absolute"><span class="fn-name">path_is_absolute</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="dir_list_count"><a href="fs.html#dir_list_count"><span class="fn-name">dir_list_count</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="dir_list_get"><a href="fs.html#dir_list_get"><span class="fn-name">dir_list_get</span><span class="fn-module">fs</span></a></li>
-      <li class="function-item" data-name="dir_list_free"><a href="fs.html#dir_list_free"><span class="fn-name">dir_list_free</span><span class="fn-module">fs</span></a></li>
+      <li class="function-item" data-name="http_serve_static"><a href="net.html#http_serve_static"><span class="fn-name">http_serve_static</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_serve_file"><a href="net.html#http_serve_file"><span class="fn-name">http_serve_file</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="http_mime_type"><a href="net.html#http_mime_type"><span class="fn-name">http_mime_type</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="ae_io_await"><a href="net.html#ae_io_await"><span class="fn-name">ae_io_await</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="ae_io_cancel"><a href="net.html#ae_io_cancel"><span class="fn-name">ae_io_cancel</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="ae_pipe_open"><a href="net.html#ae_pipe_open"><span class="fn-name">ae_pipe_open</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="ae_pipe_write_fd"><a href="net.html#ae_pipe_write_fd"><span class="fn-name">ae_pipe_write_fd</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="ae_fd_write"><a href="net.html#ae_fd_write"><span class="fn-name">ae_fd_write</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="ae_fd_close"><a href="net.html#ae_fd_close"><span class="fn-name">ae_fd_close</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="await_io"><a href="net.html#await_io"><span class="fn-name">await_io</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="pipe_open"><a href="net.html#pipe_open"><span class="fn-name">pipe_open</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="pipe_write_fd"><a href="net.html#pipe_write_fd"><span class="fn-name">pipe_write_fd</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="fd_write"><a href="net.html#fd_write"><span class="fn-name">fd_write</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="fd_close"><a href="net.html#fd_close"><span class="fn-name">fd_close</span><span class="fn-module">net</span></a></li>
+      <li class="function-item" data-name="system"><a href="os.html#system"><span class="fn-name">system</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="exec_raw"><a href="os.html#exec_raw"><span class="fn-name">exec_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run"><a href="os.html#run"><span class="fn-name">run</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_capture_raw"><a href="os.html#run_capture_raw"><span class="fn-name">run_capture_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_capture_status_raw"><a href="os.html#run_capture_status_raw"><span class="fn-name">run_capture_status_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_pipe_raw"><a href="os.html#run_pipe_raw"><span class="fn-name">run_pipe_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wait_pid_raw"><a href="os.html#wait_pid_raw"><span class="fn-name">wait_pid_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_pipe_drain_and_wait_raw"><a href="os.html#run_pipe_drain_and_wait_raw"><span class="fn-name">run_pipe_drain_and_wait_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="getenv"><a href="os.html#getenv"><span class="fn-name">getenv</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="which"><a href="os.html#which"><span class="fn-name">which</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="aether_args_count"><a href="os.html#aether_args_count"><span class="fn-name">aether_args_count</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="aether_args_get"><a href="os.html#aether_args_get"><span class="fn-name">aether_args_get</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="aether_argv0"><a href="os.html#aether_argv0"><span class="fn-name">aether_argv0</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="aether_argv_raw"><a href="os.html#aether_argv_raw"><span class="fn-name">aether_argv_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="aether_args_seal"><a href="os.html#aether_args_seal"><span class="fn-name">aether_args_seal</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="aether_args_sealed"><a href="os.html#aether_args_sealed"><span class="fn-name">aether_args_sealed</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="args_seal"><a href="os.html#args_seal"><span class="fn-name">args_seal</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="args_sealed"><a href="os.html#args_sealed"><span class="fn-name">args_sealed</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="execv"><a href="os.html#execv"><span class="fn-name">execv</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_utc_iso8601_raw"><a href="os.html#now_utc_iso8601_raw"><span class="fn-name">now_utc_iso8601_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="getpid_raw"><a href="os.html#getpid_raw"><span class="fn-name">getpid_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="exit"><a href="os.html#exit"><span class="fn-name">exit</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wall_seconds_raw"><a href="os.html#wall_seconds_raw"><span class="fn-name">wall_seconds_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wall_micros_raw"><a href="os.html#wall_micros_raw"><span class="fn-name">wall_micros_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_monotonic_ms_raw"><a href="os.html#now_monotonic_ms_raw"><span class="fn-name">now_monotonic_ms_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_monotonic_ns_raw"><a href="os.html#now_monotonic_ns_raw"><span class="fn-name">now_monotonic_ns_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_unix_ms_raw"><a href="os.html#now_unix_ms_raw"><span class="fn-name">now_unix_ms_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_local_fill_raw"><a href="os.html#now_local_fill_raw"><span class="fn-name">now_local_fill_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_local_iso8601_raw"><a href="os.html#now_local_iso8601_raw"><span class="fn-name">now_local_iso8601_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="platform_raw"><a href="os.html#platform_raw"><span class="fn-name">platform_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="io_setenv_raw"><a href="os.html#io_setenv_raw"><span class="fn-name">io_setenv_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="io_unsetenv_raw"><a href="os.html#io_unsetenv_raw"><span class="fn-name">io_unsetenv_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="exec"><a href="os.html#exec"><span class="fn-name">exec</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_capture"><a href="os.html#run_capture"><span class="fn-name">run_capture</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="argv0"><a href="os.html#argv0"><span class="fn-name">argv0</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_utc_iso8601"><a href="os.html#now_utc_iso8601"><span class="fn-name">now_utc_iso8601</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="getpid"><a href="os.html#getpid"><span class="fn-name">getpid</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wall_seconds"><a href="os.html#wall_seconds"><span class="fn-name">wall_seconds</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wall_micros"><a href="os.html#wall_micros"><span class="fn-name">wall_micros</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_monotonic_ms"><a href="os.html#now_monotonic_ms"><span class="fn-name">now_monotonic_ms</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_monotonic_ns"><a href="os.html#now_monotonic_ns"><span class="fn-name">now_monotonic_ns</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_unix_ms"><a href="os.html#now_unix_ms"><span class="fn-name">now_unix_ms</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_local"><a href="os.html#now_local"><span class="fn-name">now_local</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="now_local_iso8601"><a href="os.html#now_local_iso8601"><span class="fn-name">now_local_iso8601</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="LocalTime"><a href="os.html#LocalTime"><span class="fn-name">LocalTime</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="platform"><a href="os.html#platform"><span class="fn-name">platform</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="setenv"><a href="os.html#setenv"><span class="fn-name">setenv</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="unsetenv"><a href="os.html#unsetenv"><span class="fn-name">unsetenv</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_pipe"><a href="os.html#run_pipe"><span class="fn-name">run_pipe</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wait_pid"><a href="os.html#wait_pid"><span class="fn-name">wait_pid</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_pipe_drain_and_wait"><a href="os.html#run_pipe_drain_and_wait"><span class="fn-name">run_pipe_drain_and_wait</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="kill_raw"><a href="os.html#kill_raw"><span class="fn-name">kill_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wait_pid_timeout_raw"><a href="os.html#wait_pid_timeout_raw"><span class="fn-name">wait_pid_timeout_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_supervised_raw"><a href="os.html#run_supervised_raw"><span class="fn-name">run_supervised_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="kill"><a href="os.html#kill"><span class="fn-name">kill</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="wait_pid_timeout"><a href="os.html#wait_pid_timeout"><span class="fn-name">wait_pid_timeout</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_supervised"><a href="os.html#run_supervised"><span class="fn-name">run_supervised</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_full_raw"><a href="os.html#run_full_raw"><span class="fn-name">run_full_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="run_full"><a href="os.html#run_full"><span class="fn-name">run_full</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="chdir_raw"><a href="os.html#chdir_raw"><span class="fn-name">chdir_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="getcwd_raw"><a href="os.html#getcwd_raw"><span class="fn-name">getcwd_raw</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="chdir"><a href="os.html#chdir"><span class="fn-name">chdir</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="getcwd"><a href="os.html#getcwd"><span class="fn-name">getcwd</span><span class="fn-module">os</span></a></li>
+      <li class="function-item" data-name="this"><a href="path.html#this"><span class="fn-name">this</span><span class="fn-module">path</span></a></li>
+      <li class="function-item" data-name="module"><a href="path.html#module"><span class="fn-name">module</span><span class="fn-module">path</span></a></li>
+      <li class="function-item" data-name="aether_regex_compile"><a href="regex.html#aether_regex_compile"><span class="fn-name">aether_regex_compile</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_free"><a href="regex.html#aether_regex_free"><span class="fn-name">aether_regex_free</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_matches"><a href="regex.html#aether_regex_matches"><span class="fn-name">aether_regex_matches</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_captures"><a href="regex.html#aether_regex_captures"><span class="fn-name">aether_regex_captures</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_captures_count"><a href="regex.html#aether_regex_captures_count"><span class="fn-name">aether_regex_captures_count</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_captures_get"><a href="regex.html#aether_regex_captures_get"><span class="fn-name">aether_regex_captures_get</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_captures_start"><a href="regex.html#aether_regex_captures_start"><span class="fn-name">aether_regex_captures_start</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_captures_end"><a href="regex.html#aether_regex_captures_end"><span class="fn-name">aether_regex_captures_end</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_captures_free"><a href="regex.html#aether_regex_captures_free"><span class="fn-name">aether_regex_captures_free</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_find_all"><a href="regex.html#aether_regex_find_all"><span class="fn-name">aether_regex_find_all</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_find_all_count"><a href="regex.html#aether_regex_find_all_count"><span class="fn-name">aether_regex_find_all_count</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_find_all_start"><a href="regex.html#aether_regex_find_all_start"><span class="fn-name">aether_regex_find_all_start</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_find_all_end"><a href="regex.html#aether_regex_find_all_end"><span class="fn-name">aether_regex_find_all_end</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_find_all_free"><a href="regex.html#aether_regex_find_all_free"><span class="fn-name">aether_regex_find_all_free</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_replace"><a href="regex.html#aether_regex_replace"><span class="fn-name">aether_regex_replace</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_replace_all"><a href="regex.html#aether_regex_replace_all"><span class="fn-name">aether_regex_replace_all</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_last_error"><a href="regex.html#aether_regex_last_error"><span class="fn-name">aether_regex_last_error</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="aether_regex_clear_last_error"><a href="regex.html#aether_regex_clear_last_error"><span class="fn-name">aether_regex_clear_last_error</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="compile"><a href="regex.html#compile"><span class="fn-name">compile</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="compile_flags"><a href="regex.html#compile_flags"><span class="fn-name">compile_flags</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="free"><a href="regex.html#free"><span class="fn-name">free</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="last_error"><a href="regex.html#last_error"><span class="fn-name">last_error</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="clear_last_error"><a href="regex.html#clear_last_error"><span class="fn-name">clear_last_error</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="matches"><a href="regex.html#matches"><span class="fn-name">matches</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="find"><a href="regex.html#find"><span class="fn-name">find</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="captures"><a href="regex.html#captures"><span class="fn-name">captures</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="capture_count"><a href="regex.html#capture_count"><span class="fn-name">capture_count</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="capture"><a href="regex.html#capture"><span class="fn-name">capture</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="capture_start"><a href="regex.html#capture_start"><span class="fn-name">capture_start</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="capture_end"><a href="regex.html#capture_end"><span class="fn-name">capture_end</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="captures_free"><a href="regex.html#captures_free"><span class="fn-name">captures_free</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="find_all"><a href="regex.html#find_all"><span class="fn-name">find_all</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="find_all_count"><a href="regex.html#find_all_count"><span class="fn-name">find_all_count</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="find_all_start"><a href="regex.html#find_all_start"><span class="fn-name">find_all_start</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="find_all_end"><a href="regex.html#find_all_end"><span class="fn-name">find_all_end</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="find_all_free"><a href="regex.html#find_all_free"><span class="fn-name">find_all_free</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="replace"><a href="regex.html#replace"><span class="fn-name">replace</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="replace_all"><a href="regex.html#replace_all"><span class="fn-name">replace_all</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="matches_lit"><a href="regex.html#matches_lit"><span class="fn-name">matches_lit</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="find_lit"><a href="regex.html#find_lit"><span class="fn-name">find_lit</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="FLAG_CASELESS"><a href="regex.html#FLAG_CASELESS"><span class="fn-name">FLAG_CASELESS</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="FLAG_MULTILINE"><a href="regex.html#FLAG_MULTILINE"><span class="fn-name">FLAG_MULTILINE</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="FLAG_DOTALL"><a href="regex.html#FLAG_DOTALL"><span class="fn-name">FLAG_DOTALL</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="FLAG_EXTENDED"><a href="regex.html#FLAG_EXTENDED"><span class="fn-name">FLAG_EXTENDED</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="FLAG_UNGREEDY"><a href="regex.html#FLAG_UNGREEDY"><span class="fn-name">FLAG_UNGREEDY</span><span class="fn-module">regex</span></a></li>
+      <li class="function-item" data-name="SIGHUP"><a href="signal.html#SIGHUP"><span class="fn-name">SIGHUP</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGINT"><a href="signal.html#SIGINT"><span class="fn-name">SIGINT</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGQUIT"><a href="signal.html#SIGQUIT"><span class="fn-name">SIGQUIT</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGILL"><a href="signal.html#SIGILL"><span class="fn-name">SIGILL</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGABRT"><a href="signal.html#SIGABRT"><span class="fn-name">SIGABRT</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGFPE"><a href="signal.html#SIGFPE"><span class="fn-name">SIGFPE</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGKILL"><a href="signal.html#SIGKILL"><span class="fn-name">SIGKILL</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGSEGV"><a href="signal.html#SIGSEGV"><span class="fn-name">SIGSEGV</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGPIPE"><a href="signal.html#SIGPIPE"><span class="fn-name">SIGPIPE</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGALRM"><a href="signal.html#SIGALRM"><span class="fn-name">SIGALRM</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="SIGTERM"><a href="signal.html#SIGTERM"><span class="fn-name">SIGTERM</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_new"><a href="strbuilder.html#aether_strbuilder_new"><span class="fn-name">aether_strbuilder_new</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_append"><a href="strbuilder.html#aether_strbuilder_append"><span class="fn-name">aether_strbuilder_append</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_append_n"><a href="strbuilder.html#aether_strbuilder_append_n"><span class="fn-name">aether_strbuilder_append_n</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_append_byte"><a href="strbuilder.html#aether_strbuilder_append_byte"><span class="fn-name">aether_strbuilder_append_byte</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_append_int"><a href="strbuilder.html#aether_strbuilder_append_int"><span class="fn-name">aether_strbuilder_append_int</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_append_long"><a href="strbuilder.html#aether_strbuilder_append_long"><span class="fn-name">aether_strbuilder_append_long</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_append_hex"><a href="strbuilder.html#aether_strbuilder_append_hex"><span class="fn-name">aether_strbuilder_append_hex</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_append_codepoint"><a href="strbuilder.html#aether_strbuilder_append_codepoint"><span class="fn-name">aether_strbuilder_append_codepoint</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_length"><a href="strbuilder.html#aether_strbuilder_length"><span class="fn-name">aether_strbuilder_length</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_capacity"><a href="strbuilder.html#aether_strbuilder_capacity"><span class="fn-name">aether_strbuilder_capacity</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_reserve"><a href="strbuilder.html#aether_strbuilder_reserve"><span class="fn-name">aether_strbuilder_reserve</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_truncate"><a href="strbuilder.html#aether_strbuilder_truncate"><span class="fn-name">aether_strbuilder_truncate</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_clear"><a href="strbuilder.html#aether_strbuilder_clear"><span class="fn-name">aether_strbuilder_clear</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_finish"><a href="strbuilder.html#aether_strbuilder_finish"><span class="fn-name">aether_strbuilder_finish</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_finish_with_length"><a href="strbuilder.html#aether_strbuilder_finish_with_length"><span class="fn-name">aether_strbuilder_finish_with_length</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="aether_strbuilder_free"><a href="strbuilder.html#aether_strbuilder_free"><span class="fn-name">aether_strbuilder_free</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="new"><a href="strbuilder.html#new"><span class="fn-name">new</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append"><a href="strbuilder.html#append"><span class="fn-name">append</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append_n"><a href="strbuilder.html#append_n"><span class="fn-name">append_n</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append_byte"><a href="strbuilder.html#append_byte"><span class="fn-name">append_byte</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append_int"><a href="strbuilder.html#append_int"><span class="fn-name">append_int</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append_long"><a href="strbuilder.html#append_long"><span class="fn-name">append_long</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append_hex"><a href="strbuilder.html#append_hex"><span class="fn-name">append_hex</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append_codepoint"><a href="strbuilder.html#append_codepoint"><span class="fn-name">append_codepoint</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="append_format"><a href="strbuilder.html#append_format"><span class="fn-name">append_format</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="length"><a href="strbuilder.html#length"><span class="fn-name">length</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="capacity"><a href="strbuilder.html#capacity"><span class="fn-name">capacity</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="reserve"><a href="strbuilder.html#reserve"><span class="fn-name">reserve</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="truncate"><a href="strbuilder.html#truncate"><span class="fn-name">truncate</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="clear"><a href="strbuilder.html#clear"><span class="fn-name">clear</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="finish"><a href="strbuilder.html#finish"><span class="fn-name">finish</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="finish_with_length"><a href="strbuilder.html#finish_with_length"><span class="fn-name">finish_with_length</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="free"><a href="strbuilder.html#free"><span class="fn-name">free</span><span class="fn-module">strbuilder</span></a></li>
+      <li class="function-item" data-name="new"><a href="string.html#new"><span class="fn-name">new</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="from_cstr"><a href="string.html#from_cstr"><span class="fn-name">from_cstr</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="from_literal"><a href="string.html#from_literal"><span class="fn-name">from_literal</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="new_with_length"><a href="string.html#new_with_length"><span class="fn-name">new_with_length</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="empty"><a href="string.html#empty"><span class="fn-name">empty</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="retain"><a href="string.html#retain"><span class="fn-name">retain</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="release"><a href="string.html#release"><span class="fn-name">release</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="free"><a href="string.html#free"><span class="fn-name">free</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="concat"><a href="string.html#concat"><span class="fn-name">concat</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="concat_wrapped"><a href="string.html#concat_wrapped"><span class="fn-name">concat_wrapped</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="length"><a href="string.html#length"><span class="fn-name">length</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="char_at"><a href="string.html#char_at"><span class="fn-name">char_at</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="equals"><a href="string.html#equals"><span class="fn-name">equals</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="compare"><a href="string.html#compare"><span class="fn-name">compare</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="starts_with"><a href="string.html#starts_with"><span class="fn-name">starts_with</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="ends_with"><a href="string.html#ends_with"><span class="fn-name">ends_with</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="contains"><a href="string.html#contains"><span class="fn-name">contains</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="index_of"><a href="string.html#index_of"><span class="fn-name">index_of</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="index_of_from"><a href="string.html#index_of_from"><span class="fn-name">index_of_from</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="substring"><a href="string.html#substring"><span class="fn-name">substring</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="substring_n"><a href="string.html#substring_n"><span class="fn-name">substring_n</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="length_n"><a href="string.html#length_n"><span class="fn-name">length_n</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="char_at_n"><a href="string.html#char_at_n"><span class="fn-name">char_at_n</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="index_of_from_n"><a href="string.html#index_of_from_n"><span class="fn-name">index_of_from_n</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="from_char"><a href="string.html#from_char"><span class="fn-name">from_char</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_upper"><a href="string.html#to_upper"><span class="fn-name">to_upper</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_lower"><a href="string.html#to_lower"><span class="fn-name">to_lower</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="trim"><a href="string.html#trim"><span class="fn-name">trim</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="split"><a href="string.html#split"><span class="fn-name">split</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="array_size"><a href="string.html#array_size"><span class="fn-name">array_size</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="array_get"><a href="string.html#array_get"><span class="fn-name">array_get</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="array_free"><a href="string.html#array_free"><span class="fn-name">array_free</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="split_to_seq"><a href="string.html#split_to_seq"><span class="fn-name">split_to_seq</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_empty"><a href="string.html#seq_empty"><span class="fn-name">seq_empty</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_cons"><a href="string.html#seq_cons"><span class="fn-name">seq_cons</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_head"><a href="string.html#seq_head"><span class="fn-name">seq_head</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_tail"><a href="string.html#seq_tail"><span class="fn-name">seq_tail</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_is_empty"><a href="string.html#seq_is_empty"><span class="fn-name">seq_is_empty</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_length"><a href="string.html#seq_length"><span class="fn-name">seq_length</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_retain"><a href="string.html#seq_retain"><span class="fn-name">seq_retain</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_free"><a href="string.html#seq_free"><span class="fn-name">seq_free</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_from_array"><a href="string.html#seq_from_array"><span class="fn-name">seq_from_array</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_to_array"><a href="string.html#seq_to_array"><span class="fn-name">seq_to_array</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_reverse"><a href="string.html#seq_reverse"><span class="fn-name">seq_reverse</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_concat"><a href="string.html#seq_concat"><span class="fn-name">seq_concat</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_take"><a href="string.html#seq_take"><span class="fn-name">seq_take</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_drop"><a href="string.html#seq_drop"><span class="fn-name">seq_drop</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_cstr"><a href="string.html#to_cstr"><span class="fn-name">to_cstr</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="from_int"><a href="string.html#from_int"><span class="fn-name">from_int</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="from_long"><a href="string.html#from_long"><span class="fn-name">from_long</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="from_float"><a href="string.html#from_float"><span class="fn-name">from_float</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="from_int_radix"><a href="string.html#from_int_radix"><span class="fn-name">from_int_radix</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="pad_start"><a href="string.html#pad_start"><span class="fn-name">pad_start</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="pad_end"><a href="string.html#pad_end"><span class="fn-name">pad_end</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_int_raw"><a href="string.html#to_int_raw"><span class="fn-name">to_int_raw</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_long_raw"><a href="string.html#to_long_raw"><span class="fn-name">to_long_raw</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_float_raw"><a href="string.html#to_float_raw"><span class="fn-name">to_float_raw</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_double_raw"><a href="string.html#to_double_raw"><span class="fn-name">to_double_raw</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="try_int"><a href="string.html#try_int"><span class="fn-name">try_int</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="get_int"><a href="string.html#get_int"><span class="fn-name">get_int</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="try_long"><a href="string.html#try_long"><span class="fn-name">try_long</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="get_long"><a href="string.html#get_long"><span class="fn-name">get_long</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="try_float"><a href="string.html#try_float"><span class="fn-name">try_float</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="get_float"><a href="string.html#get_float"><span class="fn-name">get_float</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="try_double"><a href="string.html#try_double"><span class="fn-name">try_double</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="get_double"><a href="string.html#get_double"><span class="fn-name">get_double</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_int_radix_raw"><a href="string.html#to_int_radix_raw"><span class="fn-name">to_int_radix_raw</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="try_int_radix"><a href="string.html#try_int_radix"><span class="fn-name">try_int_radix</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="get_int_radix"><a href="string.html#get_int_radix"><span class="fn-name">get_int_radix</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_int"><a href="string.html#to_int"><span class="fn-name">to_int</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_long"><a href="string.html#to_long"><span class="fn-name">to_long</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_float"><a href="string.html#to_float"><span class="fn-name">to_float</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_double"><a href="string.html#to_double"><span class="fn-name">to_double</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="to_int_radix"><a href="string.html#to_int_radix"><span class="fn-name">to_int_radix</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="strip_prefix"><a href="string.html#strip_prefix"><span class="fn-name">strip_prefix</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="copy"><a href="string.html#copy"><span class="fn-name">copy</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="format_list"><a href="string.html#format_list"><span class="fn-name">format_list</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="format"><a href="string.html#format"><span class="fn-name">format</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="glob_match_raw"><a href="string.html#glob_match_raw"><span class="fn-name">glob_match_raw</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="glob_match"><a href="string.html#glob_match"><span class="fn-name">glob_match</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="glob_match_pathname"><a href="string.html#glob_match_pathname"><span class="fn-name">glob_match_pathname</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="connect_raw"><a href="tcp.html#connect_raw"><span class="fn-name">connect_raw</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="send_raw"><a href="tcp.html#send_raw"><span class="fn-name">send_raw</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="receive_raw"><a href="tcp.html#receive_raw"><span class="fn-name">receive_raw</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="close"><a href="tcp.html#close"><span class="fn-name">close</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="listen_raw"><a href="tcp.html#listen_raw"><span class="fn-name">listen_raw</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="accept_raw"><a href="tcp.html#accept_raw"><span class="fn-name">accept_raw</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="server_close"><a href="tcp.html#server_close"><span class="fn-name">server_close</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="connect"><a href="tcp.html#connect"><span class="fn-name">connect</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="write"><a href="tcp.html#write"><span class="fn-name">write</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="read"><a href="tcp.html#read"><span class="fn-name">read</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="listen"><a href="tcp.html#listen"><span class="fn-name">listen</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="accept"><a href="tcp.html#accept"><span class="fn-name">accept</span><span class="fn-module">tcp</span></a></li>
+      <li class="function-item" data-name="generate"><a href="tsid.html#generate"><span class="fn-name">generate</span><span class="fn-module">tsid</span></a></li>
+      <li class="function-item" data-name="generate"><a href="ulid.html#generate"><span class="fn-name">generate</span><span class="fn-module">ulid</span></a></li>
+      <li class="function-item" data-name="encode"><a href="url.html#encode"><span class="fn-name">encode</span><span class="fn-module">url</span></a></li>
+      <li class="function-item" data-name="encode_path"><a href="url.html#encode_path"><span class="fn-name">encode_path</span><span class="fn-module">url</span></a></li>
+      <li class="function-item" data-name="encode_strict"><a href="url.html#encode_strict"><span class="fn-name">encode_strict</span><span class="fn-module">url</span></a></li>
+      <li class="function-item" data-name="decode"><a href="url.html#decode"><span class="fn-name">decode</span><span class="fn-module">url</span></a></li>
+      <li class="function-item" data-name="parse_query"><a href="url.html#parse_query"><span class="fn-name">parse_query</span><span class="fn-module">url</span></a></li>
+      <li class="function-item" data-name="query_get"><a href="url.html#query_get"><span class="fn-name">query_get</span><span class="fn-module">url</span></a></li>
+      <li class="function-item" data-name="query_get_all"><a href="url.html#query_get_all"><span class="fn-name">query_get_all</span><span class="fn-module">url</span></a></li>
+      <li class="function-item" data-name="v4"><a href="uuid.html#v4"><span class="fn-name">v4</span><span class="fn-module">uuid</span></a></li>
+      <li class="function-item" data-name="v7"><a href="uuid.html#v7"><span class="fn-name">v7</span><span class="fn-module">uuid</span></a></li>
+      <li class="function-item" data-name="EVENT_START"><a href="xml.html#EVENT_START"><span class="fn-name">EVENT_START</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="EVENT_END"><a href="xml.html#EVENT_END"><span class="fn-name">EVENT_END</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="EVENT_TEXT"><a href="xml.html#EVENT_TEXT"><span class="fn-name">EVENT_TEXT</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="EVENT_EOF"><a href="xml.html#EVENT_EOF"><span class="fn-name">EVENT_EOF</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="EVENT_ERROR"><a href="xml.html#EVENT_ERROR"><span class="fn-name">EVENT_ERROR</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="parser_new_str"><a href="xml.html#parser_new_str"><span class="fn-name">parser_new_str</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="next"><a href="xml.html#next"><span class="fn-name">next</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="event_name"><a href="xml.html#event_name"><span class="fn-name">event_name</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="event_text"><a href="xml.html#event_text"><span class="fn-name">event_text</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="event_attr_count"><a href="xml.html#event_attr_count"><span class="fn-name">event_attr_count</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="event_attr_name"><a href="xml.html#event_attr_name"><span class="fn-name">event_attr_name</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="event_attr_value"><a href="xml.html#event_attr_value"><span class="fn-name">event_attr_value</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="event_attr_str"><a href="xml.html#event_attr_str"><span class="fn-name">event_attr_str</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="parser_error"><a href="xml.html#parser_error"><span class="fn-name">parser_error</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="parser_free"><a href="xml.html#parser_free"><span class="fn-name">parser_free</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_new"><a href="xml.html#builder_new"><span class="fn-name">builder_new</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_declaration"><a href="xml.html#builder_declaration"><span class="fn-name">builder_declaration</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_start"><a href="xml.html#builder_start"><span class="fn-name">builder_start</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_attr"><a href="xml.html#builder_attr"><span class="fn-name">builder_attr</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_text"><a href="xml.html#builder_text"><span class="fn-name">builder_text</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_end"><a href="xml.html#builder_end"><span class="fn-name">builder_end</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_element"><a href="xml.html#builder_element"><span class="fn-name">builder_element</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_finish"><a href="xml.html#builder_finish"><span class="fn-name">builder_finish</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="builder_free"><a href="xml.html#builder_free"><span class="fn-name">builder_free</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="escape"><a href="xml.html#escape"><span class="fn-name">escape</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="parser"><a href="xml.html#parser"><span class="fn-name">parser</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="name"><a href="xml.html#name"><span class="fn-name">name</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="text"><a href="xml.html#text"><span class="fn-name">text</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="attr"><a href="xml.html#attr"><span class="fn-name">attr</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="attr_count"><a href="xml.html#attr_count"><span class="fn-name">attr_count</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="attr_name"><a href="xml.html#attr_name"><span class="fn-name">attr_name</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="attr_value"><a href="xml.html#attr_value"><span class="fn-name">attr_value</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="error"><a href="xml.html#error"><span class="fn-name">error</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="free"><a href="xml.html#free"><span class="fn-name">free</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="writer"><a href="xml.html#writer"><span class="fn-name">writer</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="declaration"><a href="xml.html#declaration"><span class="fn-name">declaration</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="start"><a href="xml.html#start"><span class="fn-name">start</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="attribute"><a href="xml.html#attribute"><span class="fn-name">attribute</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="text_node"><a href="xml.html#text_node"><span class="fn-name">text_node</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="end"><a href="xml.html#end"><span class="fn-name">end</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="element"><a href="xml.html#element"><span class="fn-name">element</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="finish"><a href="xml.html#finish"><span class="fn-name">finish</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="free_builder"><a href="xml.html#free_builder"><span class="fn-name">free_builder</span><span class="fn-module">xml</span></a></li>
+      <li class="function-item" data-name="backend_available"><a href="zlib.html#backend_available"><span class="fn-name">backend_available</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="try_deflate"><a href="zlib.html#try_deflate"><span class="fn-name">try_deflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="get_deflate_bytes"><a href="zlib.html#get_deflate_bytes"><span class="fn-name">get_deflate_bytes</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="get_deflate_length"><a href="zlib.html#get_deflate_length"><span class="fn-name">get_deflate_length</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="release_deflate"><a href="zlib.html#release_deflate"><span class="fn-name">release_deflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="try_inflate"><a href="zlib.html#try_inflate"><span class="fn-name">try_inflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="get_inflate_bytes"><a href="zlib.html#get_inflate_bytes"><span class="fn-name">get_inflate_bytes</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="get_inflate_length"><a href="zlib.html#get_inflate_length"><span class="fn-name">get_inflate_length</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="release_inflate"><a href="zlib.html#release_inflate"><span class="fn-name">release_inflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="try_gzip_deflate"><a href="zlib.html#try_gzip_deflate"><span class="fn-name">try_gzip_deflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="try_gzip_inflate"><a href="zlib.html#try_gzip_inflate"><span class="fn-name">try_gzip_inflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="available"><a href="zlib.html#available"><span class="fn-name">available</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="deflate"><a href="zlib.html#deflate"><span class="fn-name">deflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="inflate"><a href="zlib.html#inflate"><span class="fn-name">inflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="gzip_deflate"><a href="zlib.html#gzip_deflate"><span class="fn-name">gzip_deflate</span><span class="fn-module">zlib</span></a></li>
+      <li class="function-item" data-name="gzip_inflate"><a href="zlib.html#gzip_inflate"><span class="fn-name">gzip_inflate</span><span class="fn-module">zlib</span></a></li>
     </ul>
   </div>
 </main>

--- a/docs/api/intarr.html
+++ b/docs/api/intarr.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>intarr - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search intarr..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#new">new</a></li>
+    <li><a href="#new_filled">new_filled</a></li>
+    <li><a href="#get">get</a></li>
+    <li><a href="#set">set</a></li>
+    <li><a href="#new_raw">new_raw</a></li>
+    <li><a href="#new_filled_raw">new_filled_raw</a></li>
+    <li><a href="#size">size</a></li>
+    <li><a href="#get_raw">get_raw</a></li>
+    <li><a href="#set_raw">set_raw</a></li>
+    <li><a href="#get_unchecked">get_unchecked</a></li>
+    <li><a href="#set_unchecked">set_unchecked</a></li>
+    <li><a href="#fill">fill</a></li>
+    <li><a href="#free">free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li class="active"><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>intarr</h1>
+    <p class="module-desc">std.intarr - Fixed-size packed-int buffer (alias for std.collections) For DP tables, flat int-keyed lookup, and other hot paths where std.list's void*-boxed items cost an allocation per entry.</p>
+    <p class="import-line"><code>import std.intarr</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new(size) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">Allocate an IntArray of `size` elements, zero-initialised. Returns (ptr, &quot;&quot;) on success, (null, error) on failure.</p>
+    </div>
+    <div class="function" id="new_filled" data-name="new_filled">
+      <h3 class="function-name">new_filled <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new_filled(size, init) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">size: int, init: int</span></p>
+      <p class="doc">Allocate and fill with `init` at every index.</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(arr, i) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Bounds-checked read. Returns (value, &quot;&quot;) on success, (0, error) for null array or OOB index. Use the raw `intarr_get_raw` directly (imported above) when you don't need to tell absent apart from stored-zero — it's one fewer function call and one fewer branch.</p>
+    </div>
+    <div class="function" id="set" data-name="set">
+      <h3 class="function-name">set <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set(arr, i, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: int</span></p>
+      <p class="doc">Bounds-checked write. Returns &quot;&quot; on success, error for null array or OOB index. Use the raw `intarr_set_raw` directly in hot paths where a no-op-on-OOB is acceptable.</p>
+    </div>
+    <div class="function" id="new_raw" data-name="new_raw">
+      <h3 class="function-name">new_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new_raw(size) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">Allocate an IntArray of `size` ints, zero-initialised. Returns null if `size` is negative or allocation fails.</p>
+    </div>
+    <div class="function" id="new_filled_raw" data-name="new_filled_raw">
+      <h3 class="function-name">new_filled_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new_filled_raw(size, init) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int, init: int</span></p>
+      <p class="doc">Allocate and fill every index with `init`.</p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>size(arr) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+      <p class="doc">Number of elements. -1 if `arr` is null.</p>
+    </div>
+    <div class="function" id="get_raw" data-name="get_raw">
+      <h3 class="function-name">get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_raw(arr, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Read at `i`. Returns 0 if `arr` is null or `i` is out-of-range. Use `intarr.get` (below) to distinguish stored-zero from OOB.</p>
+    </div>
+    <div class="function" id="set_raw" data-name="set_raw">
+      <h3 class="function-name">set_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_raw(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: int</span></p>
+      <p class="doc">Write `value` at `i`. No-op if `arr` is null or `i` is out-of-range. Use `intarr.set` (below) if you need an error on OOB.</p>
+    </div>
+    <div class="function" id="get_unchecked" data-name="get_unchecked">
+      <h3 class="function-name">get_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_unchecked(arr, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Hot-path variants — caller guarantees index is in [0, size). OOB access is undefined behaviour. Don't use from outside a tight loop.</p>
+    </div>
+    <div class="function" id="set_unchecked" data-name="set_unchecked">
+      <h3 class="function-name">set_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_unchecked(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: int</span></p>
+    </div>
+    <div class="function" id="fill" data-name="fill">
+      <h3 class="function-name">fill <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fill(arr, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, value: int</span></p>
+      <p class="doc">Fill every element with `value`. Useful for resetting a DP table.</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>free(arr)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+      <p class="doc">Release. Idempotent on null.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/io.html
+++ b/docs/api/io.html
@@ -13,96 +13,328 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search io..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
-    <li><a href="#io_print">io_print</a></li>
-    <li><a href="#io_print_line">io_print_line</a></li>
-    <li><a href="#io_print_int">io_print_int</a></li>
-    <li><a href="#io_print_float">io_print_float</a></li>
-    <li><a href="#io_read_file_raw">io_read_file_raw</a></li>
-    <li><a href="#io_write_file_raw">io_write_file_raw</a></li>
-    <li><a href="#io_append_file_raw">io_append_file_raw</a></li>
-    <li><a href="#io_file_exists">io_file_exists</a></li>
-    <li><a href="#io_delete_file_raw">io_delete_file_raw</a></li>
-    <li><a href="#io_file_info_free">io_file_info_free</a></li>
-    <li><a href="#io_getenv">io_getenv</a></li>
-    <li><a href="#io_setenv_raw">io_setenv_raw</a></li>
-    <li><a href="#io_unsetenv_raw">io_unsetenv_raw</a></li>
+    <li><a href="#print">print</a></li>
+    <li><a href="#print_line">print_line</a></li>
+    <li><a href="#print_int">print_int</a></li>
+    <li><a href="#print_float">print_float</a></li>
+    <li><a href="#read_file_raw">read_file_raw</a></li>
+    <li><a href="#write_file_raw">write_file_raw</a></li>
+    <li><a href="#append_file_raw">append_file_raw</a></li>
+    <li><a href="#file_exists">file_exists</a></li>
+    <li><a href="#delete_file_raw">delete_file_raw</a></li>
+    <li><a href="#file_info_raw">file_info_raw</a></li>
+    <li><a href="#file_info_free">file_info_free</a></li>
+    <li><a href="#getenv">getenv</a></li>
+    <li><a href="#setenv_raw">setenv_raw</a></li>
+    <li><a href="#unsetenv_raw">unsetenv_raw</a></li>
+    <li><a href="#stderr_write_raw">stderr_write_raw</a></li>
+    <li><a href="#stdout_write_raw">stdout_write_raw</a></li>
+    <li><a href="#perror_raw">perror_raw</a></li>
+    <li><a href="#errno_message_raw">errno_message_raw</a></li>
+    <li><a href="#fd_open_read_tuple">fd_open_read_tuple</a></li>
+    <li><a href="#fd_open_write_tuple">fd_open_write_tuple</a></li>
+    <li><a href="#fd_close_raw">fd_close_raw</a></li>
+    <li><a href="#fd_write_n">fd_write_n</a></li>
+    <li><a href="#fd_read_n_tuple">fd_read_n_tuple</a></li>
+    <li><a href="#fd_read_line_tuple">fd_read_line_tuple</a></li>
+    <li><a href="#read_file">read_file</a></li>
+    <li><a href="#write_file">write_file</a></li>
+    <li><a href="#append_file">append_file</a></li>
+    <li><a href="#delete_file">delete_file</a></li>
+    <li><a href="#file_info">file_info</a></li>
+    <li><a href="#setenv">setenv</a></li>
+    <li><a href="#unsetenv">unsetenv</a></li>
+    <li><a href="#stderr_write">stderr_write</a></li>
+    <li><a href="#stdout_write">stdout_write</a></li>
+    <li><a href="#perror">perror</a></li>
+    <li><a href="#errno_message">errno_message</a></li>
+    <li><a href="#fd_open_read">fd_open_read</a></li>
+    <li><a href="#fd_open_write">fd_open_write</a></li>
+    <li><a href="#fd_close">fd_close</a></li>
+    <li><a href="#fd_read_n">fd_read_n</a></li>
+    <li><a href="#fd_read_line">fd_read_line</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li class="active"><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li class="active"><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>io</h1>
-    <p class="module-desc">Input/output and console</p>
+    <p class="module-desc">std.io - Input/Output Module Import with: import std.io Raw externs end in `_raw` and return the C-style NULL/0/1 convention.</p>
+    <p class="import-line"><code>import std.io</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="io_print" data-name="io_print">
-      <h3 class="function-name">io_print</h3>
-      <pre class="usage"><code>io_print(str)</code></pre>
-      <p class="doc">Console I/O</p>
+    <div class="function" id="print" data-name="print">
+      <h3 class="function-name">print <span class="kind">extern</span></h3>
+      <pre class="usage"><code>print(str)</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
+      <p class="doc">Console I/O — infallible in practice</p>
     </div>
-    <div class="function" id="io_print_line" data-name="io_print_line">
-      <h3 class="function-name">io_print_line</h3>
-      <pre class="usage"><code>io_print_line(str)</code></pre>
+    <div class="function" id="print_line" data-name="print_line">
+      <h3 class="function-name">print_line <span class="kind">extern</span></h3>
+      <pre class="usage"><code>print_line(str)</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
     </div>
-    <div class="function" id="io_print_int" data-name="io_print_int">
-      <h3 class="function-name">io_print_int</h3>
-      <pre class="usage"><code>io_print_int(value)</code></pre>
+    <div class="function" id="print_int" data-name="print_int">
+      <h3 class="function-name">print_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>print_int(value)</code></pre>
+      <p class="signature"><span class="sig-params">value: int</span></p>
     </div>
-    <div class="function" id="io_print_float" data-name="io_print_float">
-      <h3 class="function-name">io_print_float</h3>
-      <pre class="usage"><code>io_print_float(value)</code></pre>
+    <div class="function" id="print_float" data-name="print_float">
+      <h3 class="function-name">print_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>print_float(value)</code></pre>
+      <p class="signature"><span class="sig-params">value: float</span></p>
     </div>
-    <div class="function" id="io_read_file_raw" data-name="io_read_file_raw">
-      <h3 class="function-name">io_read_file_raw</h3>
-      <pre class="usage"><code>io_read_file_raw(path)</code></pre>
-      <p class="doc">File I/O (raw)</p>
+    <div class="function" id="read_file_raw" data-name="read_file_raw">
+      <h3 class="function-name">read_file_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>read_file_raw(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">File I/O — raw externs</p>
     </div>
-    <div class="function" id="io_write_file_raw" data-name="io_write_file_raw">
-      <h3 class="function-name">io_write_file_raw</h3>
-      <pre class="usage"><code>io_write_file_raw(path, content)</code></pre>
+    <div class="function" id="write_file_raw" data-name="write_file_raw">
+      <h3 class="function-name">write_file_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>write_file_raw(path, content) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string, content: string</span></p>
     </div>
-    <div class="function" id="io_append_file_raw" data-name="io_append_file_raw">
-      <h3 class="function-name">io_append_file_raw</h3>
-      <pre class="usage"><code>io_append_file_raw(path, content)</code></pre>
+    <div class="function" id="append_file_raw" data-name="append_file_raw">
+      <h3 class="function-name">append_file_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>append_file_raw(path, content) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string, content: string</span></p>
     </div>
-    <div class="function" id="io_file_exists" data-name="io_file_exists">
-      <h3 class="function-name">io_file_exists</h3>
-      <pre class="usage"><code>io_file_exists(path)</code></pre>
+    <div class="function" id="file_exists" data-name="file_exists">
+      <h3 class="function-name">file_exists <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_exists(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
-    <div class="function" id="io_delete_file_raw" data-name="io_delete_file_raw">
-      <h3 class="function-name">io_delete_file_raw</h3>
-      <pre class="usage"><code>io_delete_file_raw(path)</code></pre>
+    <div class="function" id="delete_file_raw" data-name="delete_file_raw">
+      <h3 class="function-name">delete_file_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>delete_file_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
     </div>
-    <div class="function" id="io_file_info_free" data-name="io_file_info_free">
-      <h3 class="function-name">io_file_info_free</h3>
-      <pre class="usage"><code>io_file_info_free(info)</code></pre>
+    <div class="function" id="file_info_raw" data-name="file_info_raw">
+      <h3 class="function-name">file_info_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_info_raw(path) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">File info</p>
     </div>
-    <div class="function" id="io_getenv" data-name="io_getenv">
-      <h3 class="function-name">io_getenv</h3>
-      <pre class="usage"><code>io_getenv(name)</code></pre>
+    <div class="function" id="file_info_free" data-name="file_info_free">
+      <h3 class="function-name">file_info_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>file_info_free(info)</code></pre>
+      <p class="signature"><span class="sig-params">info: ptr</span></p>
+    </div>
+    <div class="function" id="getenv" data-name="getenv">
+      <h3 class="function-name">getenv <span class="kind">extern</span></h3>
+      <pre class="usage"><code>getenv(name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
       <p class="doc">Environment variables</p>
     </div>
-    <div class="function" id="io_setenv_raw" data-name="io_setenv_raw">
-      <h3 class="function-name">io_setenv_raw</h3>
-      <pre class="usage"><code>io_setenv_raw(name, value)</code></pre>
+    <div class="function" id="setenv_raw" data-name="setenv_raw">
+      <h3 class="function-name">setenv_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>setenv_raw(name, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string, value: string</span></p>
     </div>
-    <div class="function" id="io_unsetenv_raw" data-name="io_unsetenv_raw">
-      <h3 class="function-name">io_unsetenv_raw</h3>
-      <pre class="usage"><code>io_unsetenv_raw(name)</code></pre>
+    <div class="function" id="unsetenv_raw" data-name="unsetenv_raw">
+      <h3 class="function-name">unsetenv_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>unsetenv_raw(name) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+    </div>
+    <div class="function" id="stderr_write_raw" data-name="stderr_write_raw">
+      <h3 class="function-name">stderr_write_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>stderr_write_raw(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">Unbuffered fd-1 / fd-2 writes — bypass stdio buffering so output is guaranteed on the wire before the process exits / crashes / aborts. Returns bytes written, -1 on error. Loops on partial writes and retries on EINTR.</p>
+    </div>
+    <div class="function" id="stdout_write_raw" data-name="stdout_write_raw">
+      <h3 class="function-name">stdout_write_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>stdout_write_raw(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="perror_raw" data-name="perror_raw">
+      <h3 class="function-name">perror_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>perror_raw(name)</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">errno-based error reporting — see the perror / errno_message wrappers below.</p>
+    </div>
+    <div class="function" id="errno_message_raw" data-name="errno_message_raw">
+      <h3 class="function-name">errno_message_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>errno_message_raw() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="fd_open_read_tuple" data-name="fd_open_read_tuple">
+      <h3 class="function-name">fd_open_read_tuple <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fd_open_read_tuple(path) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Full fd-level I/O surface. Section 1 of nuther-ask-of-aether-team.md. fd_open_read       → POSIX O_RDONLY  / Win _O_RDONLY | _O_BINARY fd_open_write      → POSIX O_WRONLY|O_CREAT|O_TRUNC, mode 0644 / Win _O_WRONLY|_O_CREAT|_O_TRUNC|_O_BINARY fd_close           → close(fd) or _close(fd) fd_write_n         → looped write, retries EINTR; 0 ok / -1 fail fd_read_n          → looped read of up to `n` bytes; (bytes, count, err); bytes is a refcounted AetherString (binary-safe; embedded NULs survive) fd_read_line       → reads until '\n', stripping trailing CR/LF; (&quot;&quot;, &quot;&quot;) on clean EOF before any byte; partial line returned on EOF mid-line</p>
+    </div>
+    <div class="function" id="fd_open_write_tuple" data-name="fd_open_write_tuple">
+      <h3 class="function-name">fd_open_write_tuple <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fd_open_write_tuple(path) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="fd_close_raw" data-name="fd_close_raw">
+      <h3 class="function-name">fd_close_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fd_close_raw(fd) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+    </div>
+    <div class="function" id="fd_write_n" data-name="fd_write_n">
+      <h3 class="function-name">fd_write_n <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fd_write_n(fd, data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, data: string, length: int</span></p>
+    </div>
+    <div class="function" id="fd_read_n_tuple" data-name="fd_read_n_tuple">
+      <h3 class="function-name">fd_read_n_tuple <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fd_read_n_tuple(fd, n) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, n: int</span></p>
+      <p class="doc">Position 0 (the read buffer) is `@heap`: the C side returns a fresh AetherString (string_new_with_length, &quot;&quot; on EOF/error) that the caller owns and must release — without the annotation the destructured local was never reclaimed, leaking one buffer per read. aether_heap_str_free dispatches on the magic header (string_release here); never a literal.</p>
+    </div>
+    <div class="function" id="fd_read_line_tuple" data-name="fd_read_line_tuple">
+      <h3 class="function-name">fd_read_line_tuple <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fd_read_line_tuple(fd) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+    </div>
+    <div class="function" id="read_file" data-name="read_file">
+      <h3 class="function-name">read_file <span class="kind">fn</span></h3>
+      <pre class="usage"><code>read_file(path) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Read the entire contents of a file at `path`. Returns (content, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="write_file" data-name="write_file">
+      <h3 class="function-name">write_file <span class="kind">fn</span></h3>
+      <pre class="usage"><code>write_file(path, content) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string, content: string</span></p>
+      <p class="doc">Write `content` to a file at `path`. Overwrites if exists. Returns &quot;&quot; on success, error string on failure.</p>
+    </div>
+    <div class="function" id="append_file" data-name="append_file">
+      <h3 class="function-name">append_file <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_file(path, content) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string, content: string</span></p>
+      <p class="doc">Append `content` to a file at `path`. Creates if missing. Returns &quot;&quot; on success, error string on failure.</p>
+    </div>
+    <div class="function" id="delete_file" data-name="delete_file">
+      <h3 class="function-name">delete_file <span class="kind">fn</span></h3>
+      <pre class="usage"><code>delete_file(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Delete the file at `path`. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="file_info" data-name="file_info">
+      <h3 class="function-name">file_info <span class="kind">fn</span></h3>
+      <pre class="usage"><code>file_info(path) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Get file info (FileInfo ptr with size, is_directory, modified_time). Returns (info, &quot;&quot;) on success, (null, error) on failure. Caller must free the returned ptr with io.file_info_free.</p>
+    </div>
+    <div class="function" id="setenv" data-name="setenv">
+      <h3 class="function-name">setenv <span class="kind">fn</span></h3>
+      <pre class="usage"><code>setenv(name, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">name: string, value: string</span></p>
+      <p class="doc">Set an environment variable. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="unsetenv" data-name="unsetenv">
+      <h3 class="function-name">unsetenv <span class="kind">fn</span></h3>
+      <pre class="usage"><code>unsetenv(name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">Unset an environment variable. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="stderr_write" data-name="stderr_write">
+      <h3 class="function-name">stderr_write <span class="kind">fn</span></h3>
+      <pre class="usage"><code>stderr_write(data) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string</span></p>
+      <p class="doc">Unbuffered write to stderr (fd 2). Writes the whole of `data`; the byte count comes from the string itself via string.length — which reads an AetherString's stored length (NUL-safe) or falls back to strlen for a bare C string. Returns bytes written, -1 on error. Reach for this in crash-trace paths where println's buffering would lose output. io.stderr_write(&quot;PANIC: ${msg}\n&quot;) Distinct from `println` (line-buffered, lost on abort) and `eprintln` (block-buffered when stderr is piped). API note: the former two-arg form (data, length) was removed — `string` already carries its own length, so a caller-supplied count was redundant and a source of mismatch bugs.</p>
+    </div>
+    <div class="function" id="stdout_write" data-name="stdout_write">
+      <h3 class="function-name">stdout_write <span class="kind">fn</span></h3>
+      <pre class="usage"><code>stdout_write(data) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string</span></p>
+      <p class="doc">Unbuffered write to stdout (fd 1). Same shape as stderr_write. Useful for shell-pipe-friendly tools that need to flush each record before the next stage reads.</p>
+    </div>
+    <div class="function" id="perror" data-name="perror">
+      <h3 class="function-name">perror <span class="kind">fn</span></h3>
+      <pre class="usage"><code>perror(name)</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">Print &quot;name: &lt;errno message&gt;\n&quot; to stderr — the POSIX perror(3). Call it immediately after a failing libc-backed operation, while errno is still live (same constraint as C's perror). fd, err = io.fd_open_read(path) if fd &lt; 0 { io.perror(&quot;open&quot;) ; exit(1) }</p>
+    </div>
+    <div class="function" id="errno_message" data-name="errno_message">
+      <h3 class="function-name">errno_message <span class="kind">fn</span></h3>
+      <pre class="usage"><code>errno_message() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">The current errno as a human-readable message string — strerror(3) for `errno`. Same &quot;call right after the failure&quot; rule as perror. Use this when you want the message in a string (to wrap in a Go-style error tuple, log it, etc.) rather than printed to stderr.</p>
+    </div>
+    <div class="function" id="fd_open_read" data-name="fd_open_read">
+      <h3 class="function-name">fd_open_read <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fd_open_read(path) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Open `path` for reading. Returns (fd, err): success → (fd &gt;= 0, &quot;&quot;); failure → (-1, &quot;...&quot;). Use with fd_read_n / fd_read_line / fd_close. fd, err = io.fd_open_read(&quot;data.bin&quot;) if err != &quot;&quot; { return err } defer io.fd_close(fd)</p>
+    </div>
+    <div class="function" id="fd_open_write" data-name="fd_open_write">
+      <h3 class="function-name">fd_open_write <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fd_open_write(path) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Open `path` for writing — implicit O_CREAT + O_TRUNC, mode 0644 on POSIX. Returns (fd, err) like fd_open_read. The truncate-on-open matches std.fs.write_binary semantics; if you need O_APPEND or open-without-truncate, file an issue (the porter says no svn-aether site needs them today).</p>
+    </div>
+    <div class="function" id="fd_close" data-name="fd_close">
+      <h3 class="function-name">fd_close <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fd_close(fd) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+      <p class="doc">Close `fd`. Returns &quot;&quot; on success, error string on failure.</p>
+    </div>
+    <div class="function" id="fd_read_n" data-name="fd_read_n">
+      <h3 class="function-name">fd_read_n <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fd_read_n(fd, n) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, n: int</span></p>
+      <p class="doc">Read up to `n` bytes from `fd`. Returns (bytes, count, err): - On success: (bytes, count, &quot;&quot;) with `count` between 1 and `n`. - On clean EOF before any byte: (&quot;&quot;, 0, &quot;&quot;). - On error: (&quot;&quot;, 0, &quot;&lt;reason&gt;&quot;). `bytes` is a refcounted AetherString carrying the explicit byte count, so embedded NULs survive (binary-safe). Inferred return type (`-&gt; {`) so the extern's `@heap` tuple flag on position 0 propagates to callers' destructure sites — an explicit tuple type can't carry the per-position annotation. Mirrors std.fs's read_binary / realpath wrappers.</p>
+    </div>
+    <div class="function" id="fd_read_line" data-name="fd_read_line">
+      <h3 class="function-name">fd_read_line <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fd_read_line(fd) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+      <p class="doc">Read one '\n'-delimited line from `fd`. The trailing '\n' is stripped (and a '\r' before it for CRLF input). Returns (line, err): - Normal line: (content, &quot;&quot;). - Clean EOF before any byte: (&quot;&quot;, &quot;&quot;). - EOF mid-line: returns the partial line and (&quot;&quot;, &quot;&quot;) — server- side dump streams sometimes end without a trailing '\n'. - Read error: (&quot;&quot;, &quot;&lt;reason&gt;&quot;).</p>
     </div>
   </div>
 </main>

--- a/docs/api/ipc.html
+++ b/docs/api/ipc.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ipc - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search ipc..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#parent_channel_raw">parent_channel_raw</a></li>
+    <li><a href="#parent_channel">parent_channel</a></li>
+    <li><a href="#write">write</a></li>
+    <li><a href="#write_close">write_close</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li class="active"><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>ipc</h1>
+    <p class="module-desc">std.ipc — child-to-parent back-channel IPC.</p>
+    <p class="import-line"><code>import std.ipc</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="parent_channel_raw" data-name="parent_channel_raw">
+      <h3 class="function-name">parent_channel_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>parent_channel_raw() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Returns the parent-channel fd if the parent spawned this process via os.run_pipe (i.e. AETHER_IPC_FD is set in env and the named fd is open); -1 otherwise. Children of os.run / os.run_capture see -1 — those don't open a back-channel. On Windows always -1 (v1 stub). The fd value is whatever the parent picked; current parent-side default is 3 but consumers MUST NOT hardcode that.</p>
+    </div>
+    <div class="function" id="parent_channel" data-name="parent_channel">
+      <h3 class="function-name">parent_channel <span class="kind">fn</span></h3>
+      <pre class="usage"><code>parent_channel() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Aether-side wrappers. parent_channel returns the raw int from the extern; -1 sentinel for &quot;no parent channel.&quot;</p>
+    </div>
+    <div class="function" id="write" data-name="write">
+      <h3 class="function-name">write <span class="kind">fn</span></h3>
+      <pre class="usage"><code>write(fd, bytes) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, bytes: string</span></p>
+      <p class="doc">Write `bytes` to the back-channel `fd`. Returns &quot;&quot; on success, non-empty error string on failure. Wraps std.net.fd_write — the underlying transport is an inherited pipe, so the same byte-stream semantics apply (partial writes are possible on interrupted system calls; the wrapped C extern handles EINTR). For the common case where the child writes one payload and exits, prefer write_close so the parent's read_all loop sees EOF promptly.</p>
+    </div>
+    <div class="function" id="write_close" data-name="write_close">
+      <h3 class="function-name">write_close <span class="kind">fn</span></h3>
+      <pre class="usage"><code>write_close(fd, bytes) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, bytes: string</span></p>
+      <p class="doc">Write `bytes` then close the channel. The common case: child produces one structured report at exit and closes the fd so the parent's drain loop sees EOF and stops. Calling close releases the writer's reference on the pipe; the parent sees EOF only after every writer has closed. If the child is itself going to exit immediately after, the kernel will close the fd anyway during process teardown — explicit close is still preferred because it lets the parent's reader unblock before the child exits, useful when the parent's reader runs in the same thread as the child-wait loop.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/json.html
+++ b/docs/api/json.html
@@ -13,133 +13,392 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search json..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
-    <li><a href="#json_parse_raw">json_parse_raw</a></li>
-    <li><a href="#json_stringify">json_stringify</a></li>
-    <li><a href="#json_free">json_free</a></li>
-    <li><a href="#json_type">json_type</a></li>
-    <li><a href="#json_is_null">json_is_null</a></li>
-    <li><a href="#json_get_bool">json_get_bool</a></li>
-    <li><a href="#json_get_number">json_get_number</a></li>
-    <li><a href="#json_get_int">json_get_int</a></li>
-    <li><a href="#json_get_string">json_get_string</a></li>
-    <li><a href="#json_object_get">json_object_get</a></li>
-    <li><a href="#json_object_set">json_object_set</a></li>
-    <li><a href="#json_object_has">json_object_has</a></li>
-    <li><a href="#json_array_get">json_array_get</a></li>
-    <li><a href="#json_array_add">json_array_add</a></li>
-    <li><a href="#json_array_size">json_array_size</a></li>
-    <li><a href="#json_create_null">json_create_null</a></li>
-    <li><a href="#json_create_bool">json_create_bool</a></li>
-    <li><a href="#json_create_number">json_create_number</a></li>
-    <li><a href="#json_create_string">json_create_string</a></li>
-    <li><a href="#json_create_array">json_create_array</a></li>
-    <li><a href="#json_create_object">json_create_object</a></li>
+    <li><a href="#parse_raw">parse_raw</a></li>
+    <li><a href="#last_error">last_error</a></li>
+    <li><a href="#stringify_raw">stringify_raw</a></li>
+    <li><a href="#free">free</a></li>
+    <li><a href="#type">type</a></li>
+    <li><a href="#is_null">is_null</a></li>
+    <li><a href="#get_bool">get_bool</a></li>
+    <li><a href="#get_number">get_number</a></li>
+    <li><a href="#get_int">get_int</a></li>
+    <li><a href="#get_string_raw">get_string_raw</a></li>
+    <li><a href="#object_get_raw">object_get_raw</a></li>
+    <li><a href="#object_set_raw">object_set_raw</a></li>
+    <li><a href="#object_has">object_has</a></li>
+    <li><a href="#object_size_raw">object_size_raw</a></li>
+    <li><a href="#object_key_at">object_key_at</a></li>
+    <li><a href="#object_value_at">object_value_at</a></li>
+    <li><a href="#array_get_raw">array_get_raw</a></li>
+    <li><a href="#array_add_raw">array_add_raw</a></li>
+    <li><a href="#array_size">array_size</a></li>
+    <li><a href="#create_null">create_null</a></li>
+    <li><a href="#create_bool">create_bool</a></li>
+    <li><a href="#create_number">create_number</a></li>
+    <li><a href="#create_int">create_int</a></li>
+    <li><a href="#create_string">create_string</a></li>
+    <li><a href="#create_array">create_array</a></li>
+    <li><a href="#create_object">create_object</a></li>
+    <li><a href="#parse">parse</a></li>
+    <li><a href="#stringify">stringify</a></li>
+    <li><a href="#get_string">get_string</a></li>
+    <li><a href="#object_get">object_get</a></li>
+    <li><a href="#object_set">object_set</a></li>
+    <li><a href="#object_size">object_size</a></li>
+    <li><a href="#object_entry">object_entry</a></li>
+    <li><a href="#array_get">array_get</a></li>
+    <li><a href="#array_add">array_add</a></li>
+    <li><a href="#obj">obj</a></li>
+    <li><a href="#arr">arr</a></li>
+    <li><a href="#str">str</a></li>
+    <li><a href="#num">num</a></li>
+    <li><a href="#from_int">from_int</a></li>
+    <li><a href="#boolean">boolean</a></li>
+    <li><a href="#null_value">null_value</a></li>
+    <li><a href="#set">set</a></li>
+    <li><a href="#push">push</a></li>
+    <li><a href="#encode">encode</a></li>
+    <li><a href="#parse_strict">parse_strict</a></li>
+    <li><a href="#last_error_kind">last_error_kind</a></li>
+    <li><a href="#last_error_line">last_error_line</a></li>
+    <li><a href="#last_error_col">last_error_col</a></li>
+    <li><a href="#KIND_OK">KIND_OK</a></li>
+    <li><a href="#KIND_PARSE_ERROR">KIND_PARSE_ERROR</a></li>
+    <li><a href="#KIND_OUT_OF_MEMORY">KIND_OUT_OF_MEMORY</a></li>
+    <li><a href="#KIND_INVALID_INPUT">KIND_INVALID_INPUT</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li class="active"><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li class="active"><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>json</h1>
-    <p class="module-desc">JSON parsing and serialization</p>
+    <p class="module-desc">std.json - JSON Module Import with: import std.json Parses and serializes JSON per RFC 8259.</p>
+    <p class="import-line"><code>import std.json</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="json_parse_raw" data-name="json_parse_raw">
-      <h3 class="function-name">json_parse_raw</h3>
-      <pre class="usage"><code>json_parse_raw(json_str)</code></pre>
+    <div class="function" id="parse_raw" data-name="parse_raw">
+      <h3 class="function-name">parse_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>parse_raw(json_str) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">json_str: string</span></p>
+      <p class="doc">---- parsing and serialization (raw externs) ----</p>
     </div>
-    <div class="function" id="json_stringify" data-name="json_stringify">
-      <h3 class="function-name">json_stringify</h3>
-      <pre class="usage"><code>json_stringify(value)</code></pre>
+    <div class="function" id="last_error" data-name="last_error">
+      <h3 class="function-name">last_error <span class="kind">extern</span></h3>
+      <pre class="usage"><code>last_error() <span class="arrow">-&gt;</span> string</code></pre>
     </div>
-    <div class="function" id="json_free" data-name="json_free">
-      <h3 class="function-name">json_free</h3>
-      <pre class="usage"><code>json_free(value)</code></pre>
+    <div class="function" id="stringify_raw" data-name="stringify_raw">
+      <h3 class="function-name">stringify_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>stringify_raw(value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
     </div>
-    <div class="function" id="json_type" data-name="json_type">
-      <h3 class="function-name">json_type</h3>
-      <pre class="usage"><code>json_type(value)</code></pre>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>free(value)</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
     </div>
-    <div class="function" id="json_is_null" data-name="json_is_null">
-      <h3 class="function-name">json_is_null</h3>
-      <pre class="usage"><code>json_is_null(value)</code></pre>
+    <div class="function" id="type" data-name="type">
+      <h3 class="function-name">type <span class="kind">extern</span></h3>
+      <pre class="usage"><code>type(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
+      <p class="doc">---- type introspection (infallible, no wrapper needed) ----</p>
     </div>
-    <div class="function" id="json_get_bool" data-name="json_get_bool">
-      <h3 class="function-name">json_get_bool</h3>
-      <pre class="usage"><code>json_get_bool(value)</code></pre>
+    <div class="function" id="is_null" data-name="is_null">
+      <h3 class="function-name">is_null <span class="kind">extern</span></h3>
+      <pre class="usage"><code>is_null(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
     </div>
-    <div class="function" id="json_get_number" data-name="json_get_number">
-      <h3 class="function-name">json_get_number</h3>
-      <pre class="usage"><code>json_get_number(value)</code></pre>
+    <div class="function" id="get_bool" data-name="get_bool">
+      <h3 class="function-name">get_bool <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_bool(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
+      <p class="doc">---- typed getters (infallible — sentinel 0/0.0 on wrong type) ----</p>
     </div>
-    <div class="function" id="json_get_int" data-name="json_get_int">
-      <h3 class="function-name">json_get_int</h3>
-      <pre class="usage"><code>json_get_int(value)</code></pre>
+    <div class="function" id="get_number" data-name="get_number">
+      <h3 class="function-name">get_number <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_number(value) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
     </div>
-    <div class="function" id="json_get_string" data-name="json_get_string">
-      <h3 class="function-name">json_get_string</h3>
-      <pre class="usage"><code>json_get_string(value)</code></pre>
+    <div class="function" id="get_int" data-name="get_int">
+      <h3 class="function-name">get_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_int(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
     </div>
-    <div class="function" id="json_object_get" data-name="json_object_get">
-      <h3 class="function-name">json_object_get</h3>
-      <pre class="usage"><code>json_object_get(obj, key)</code></pre>
+    <div class="function" id="get_string_raw" data-name="get_string_raw">
+      <h3 class="function-name">get_string_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_string_raw(value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
     </div>
-    <div class="function" id="json_object_set" data-name="json_object_set">
-      <h3 class="function-name">json_object_set</h3>
-      <pre class="usage"><code>json_object_set(obj, key, value)</code></pre>
+    <div class="function" id="object_get_raw" data-name="object_get_raw">
+      <h3 class="function-name">object_get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>object_get_raw(obj, key) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, key: string</span></p>
+      <p class="doc">---- object operations (raw externs) ----</p>
     </div>
-    <div class="function" id="json_object_has" data-name="json_object_has">
-      <h3 class="function-name">json_object_has</h3>
-      <pre class="usage"><code>json_object_has(obj, key)</code></pre>
+    <div class="function" id="object_set_raw" data-name="object_set_raw">
+      <h3 class="function-name">object_set_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>object_set_raw(obj, key, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, key: string, value: ptr</span></p>
     </div>
-    <div class="function" id="json_array_get" data-name="json_array_get">
-      <h3 class="function-name">json_array_get</h3>
-      <pre class="usage"><code>json_array_get(arr, index)</code></pre>
+    <div class="function" id="object_has" data-name="object_has">
+      <h3 class="function-name">object_has <span class="kind">extern</span></h3>
+      <pre class="usage"><code>object_has(obj, key) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, key: string</span></p>
     </div>
-    <div class="function" id="json_array_add" data-name="json_array_add">
-      <h3 class="function-name">json_array_add</h3>
-      <pre class="usage"><code>json_array_add(arr, value)</code></pre>
+    <div class="function" id="object_size_raw" data-name="object_size_raw">
+      <h3 class="function-name">object_size_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>object_size_raw(obj) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr</span></p>
     </div>
-    <div class="function" id="json_array_size" data-name="json_array_size">
-      <h3 class="function-name">json_array_size</h3>
-      <pre class="usage"><code>json_array_size(arr)</code></pre>
+    <div class="function" id="object_key_at" data-name="object_key_at">
+      <h3 class="function-name">object_key_at <span class="kind">extern</span></h3>
+      <pre class="usage"><code>object_key_at(obj, i) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, i: int</span></p>
     </div>
-    <div class="function" id="json_create_null" data-name="json_create_null">
-      <h3 class="function-name">json_create_null</h3>
-      <pre class="usage"><code>json_create_null()</code></pre>
+    <div class="function" id="object_value_at" data-name="object_value_at">
+      <h3 class="function-name">object_value_at <span class="kind">extern</span></h3>
+      <pre class="usage"><code>object_value_at(obj, i) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, i: int</span></p>
     </div>
-    <div class="function" id="json_create_bool" data-name="json_create_bool">
-      <h3 class="function-name">json_create_bool</h3>
-      <pre class="usage"><code>json_create_bool(value)</code></pre>
+    <div class="function" id="array_get_raw" data-name="array_get_raw">
+      <h3 class="function-name">array_get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>array_get_raw(arr, index) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, index: int</span></p>
+      <p class="doc">---- array operations (raw externs) ----</p>
     </div>
-    <div class="function" id="json_create_number" data-name="json_create_number">
-      <h3 class="function-name">json_create_number</h3>
-      <pre class="usage"><code>json_create_number(value)</code></pre>
+    <div class="function" id="array_add_raw" data-name="array_add_raw">
+      <h3 class="function-name">array_add_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>array_add_raw(arr, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, value: ptr</span></p>
     </div>
-    <div class="function" id="json_create_string" data-name="json_create_string">
-      <h3 class="function-name">json_create_string</h3>
-      <pre class="usage"><code>json_create_string(value)</code></pre>
+    <div class="function" id="array_size" data-name="array_size">
+      <h3 class="function-name">array_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>array_size(arr) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
     </div>
-    <div class="function" id="json_create_array" data-name="json_create_array">
-      <h3 class="function-name">json_create_array</h3>
-      <pre class="usage"><code>json_create_array()</code></pre>
+    <div class="function" id="create_null" data-name="create_null">
+      <h3 class="function-name">create_null <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_null() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">---- value creation (infallible — OOM treated as crash) ----</p>
     </div>
-    <div class="function" id="json_create_object" data-name="json_create_object">
-      <h3 class="function-name">json_create_object</h3>
-      <pre class="usage"><code>json_create_object()</code></pre>
+    <div class="function" id="create_bool" data-name="create_bool">
+      <h3 class="function-name">create_bool <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_bool(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: int</span></p>
+    </div>
+    <div class="function" id="create_number" data-name="create_number">
+      <h3 class="function-name">create_number <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_number(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: float</span></p>
+    </div>
+    <div class="function" id="create_int" data-name="create_int">
+      <h3 class="function-name">create_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_int(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: long long</span></p>
+    </div>
+    <div class="function" id="create_string" data-name="create_string">
+      <h3 class="function-name">create_string <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_string(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: string</span></p>
+    </div>
+    <div class="function" id="create_array" data-name="create_array">
+      <h3 class="function-name">create_array <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_array() <span class="arrow">-&gt;</span> ptr</code></pre>
+    </div>
+    <div class="function" id="create_object" data-name="create_object">
+      <h3 class="function-name">create_object <span class="kind">extern</span></h3>
+      <pre class="usage"><code>create_object() <span class="arrow">-&gt;</span> ptr</code></pre>
+    </div>
+    <div class="function" id="parse" data-name="parse">
+      <h3 class="function-name">parse <span class="kind">fn</span></h3>
+      <pre class="usage"><code>parse(json_str) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">json_str: string</span></p>
+      <p class="doc">Parse a JSON string. Returns (value, &quot;&quot;) on success, (null, error) on failure. The error is a position-qualified message like &quot;expected ':' at 3:17&quot;. Caller owns the returned value and must free with json.free. Heap-classification shape: position 1 (the error message) is heap on both return paths so the destructure wrapper at the call site fires uniformly. The failure path uses string_concat(json_last_error(), &quot;&quot;) for an owned copy; the success path uses string_concat(&quot;&quot;, &quot;&quot;) for a (tiny) empty heap string. Without both paths returning heap, function_def_returns_heap_at's AND-fold would mark position 1 non-heap and every destructure of `_, err = json.parse(...)` would leak the success-path &quot;&quot; allocation — except the success &quot;&quot; was already a literal so there'd be nothing TO leak, only an over-free risk on the failure path. The uniform-heap shape sidesteps the classifier's mixed-path conservatism. See # further-bug-fix4 for the wider context.</p>
+    </div>
+    <div class="function" id="stringify" data-name="stringify">
+      <h3 class="function-name">stringify <span class="kind">fn</span></h3>
+      <pre class="usage"><code>stringify(value) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
+      <p class="doc">Serialize a JSON value to a compact string. Returns (string, &quot;&quot;) on success, (&quot;&quot;, error) on failure. The returned string is a refcounted Aether string — no manual free required. Uniform-heap shape on both positions: see `parse` for the rationale.</p>
+    </div>
+    <div class="function" id="get_string" data-name="get_string">
+      <h3 class="function-name">get_string <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_string(value) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
+      <p class="doc">Read the string payload out of a JSON value. Returns (string, &quot;&quot;) on success, (&quot;&quot;, error) if `value` is not a JSON_STRING. The returned string is an owned copy — safe to hold past a json.free of the value. Uniform-heap shape on both positions. This is the high-volume avn hot-path identified in `further-bug-fix4.md`: every `b64, _ = json.get_string(jcontent)` in a commit loop is a ~133 KB allocation per call. Pre-refactor the failure-path literal `&quot;&quot;` at position 0 made `function_def_returns_heap_at` AND-fold to non-heap, so the destructure wrapper at the call site never set `_heap_b64 = 1` and the function-exit defer-free never ran. avn's 5000-commit bench retained ~666 MB just from this site.</p>
+    </div>
+    <div class="function" id="object_get" data-name="object_get">
+      <h3 class="function-name">object_get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>object_get(obj, key) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, key: string</span></p>
+      <p class="doc">Look up `key` in a JSON object. - (value, &quot;&quot;)             : key present - (null, &quot;&quot;)              : key absent (not an error — use json.object_has to disambiguate) - (null, &quot;not an object&quot;) : `obj` is not a JSON_OBJECT The returned value is borrowed from `obj` — don't json.free it, and don't use it after `obj` is freed.</p>
+    </div>
+    <div class="function" id="object_set" data-name="object_set">
+      <h3 class="function-name">object_set <span class="kind">fn</span></h3>
+      <pre class="usage"><code>object_set(obj, key, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, key: string, value: ptr</span></p>
+      <p class="doc">Insert or update a key-value pair on a JSON object. Returns &quot;&quot; on success, error if `obj` is not a JSON_OBJECT. The object takes ownership of `value` — don't json.free it separately.</p>
+    </div>
+    <div class="function" id="object_size" data-name="object_size">
+      <h3 class="function-name">object_size <span class="kind">fn</span></h3>
+      <pre class="usage"><code>object_size(obj) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr</span></p>
+      <p class="doc">Number of entries in a JSON object. Returns 0 for an empty object, -1 if `obj` is not a JSON_OBJECT.</p>
+    </div>
+    <div class="function" id="object_entry" data-name="object_entry">
+      <h3 class="function-name">object_entry <span class="kind">fn</span></h3>
+      <pre class="usage"><code>object_entry(obj, i) <span class="arrow">-&gt;</span> (string, ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, i: int</span></p>
+      <p class="doc">Read the (key, value) pair at index `i` in iteration order. Keys are yielded in insertion order — the order they appeared in parsed JSON input, or the order `object_set` was called for a built object. - (key, value, &quot;&quot;)                  : index in range - (&quot;&quot;, null, &quot;index out of range&quot;)  : i &lt; 0 or i &gt;= object_size(obj) - (&quot;&quot;, null, &quot;not an object&quot;)       : `obj` is not a JSON_OBJECT The key is an owned string; the value is borrowed from `obj` and must not be json.free'd separately, nor used after `obj` is freed. Mutating `obj` during iteration is not supported: order becomes unpredictable and entries may be skipped or revisited. Uniform-heap shape on positions 0 (key) and 2 (error message): all return paths use string_concat so the per-position structural analyzer marks both as heap. The success path's `owned_key` is the big one — iterating a large object via object_entry without this would leak a key allocation per iteration. See `parse` for the wider rationale.</p>
+    </div>
+    <div class="function" id="array_get" data-name="array_get">
+      <h3 class="function-name">array_get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>array_get(arr, index) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, index: int</span></p>
+      <p class="doc">Index into a JSON array. - (value, &quot;&quot;)             : index in range - (null, &quot;&quot;)              : index out of range (not an error) - (null, &quot;not an array&quot;)  : `arr` is not a JSON_ARRAY The returned value is borrowed from `arr`.</p>
+    </div>
+    <div class="function" id="array_add" data-name="array_add">
+      <h3 class="function-name">array_add <span class="kind">fn</span></h3>
+      <pre class="usage"><code>array_add(arr, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, value: ptr</span></p>
+      <p class="doc">Append a value to a JSON array. Returns &quot;&quot; on success, error if `arr` is not a JSON_ARRAY. The array takes ownership of `value`.</p>
+    </div>
+    <div class="function" id="obj" data-name="obj">
+      <h3 class="function-name">obj <span class="kind">fn</span></h3>
+      <pre class="usage"><code>obj() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">New empty JSON object / array.</p>
+    </div>
+    <div class="function" id="arr" data-name="arr">
+      <h3 class="function-name">arr <span class="kind">fn</span></h3>
+      <pre class="usage"><code>arr() <span class="arrow">-&gt;</span> ptr</code></pre>
+    </div>
+    <div class="function" id="str" data-name="str">
+      <h3 class="function-name">str <span class="kind">fn</span></h3>
+      <pre class="usage"><code>str(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: string</span></p>
+      <p class="doc">Scalar value constructors. `num` takes a float (JSON has one numeric type); pass `1.0` etc. `from_int` is the integer-flavoured sibling — serialised as a bare integer (no decimal point, no scientific notation, full int64 range), the right shape for byte-counts / IDs / totals where the consumer expects a plain integer. `boolean` takes 0/1; `null_value` is JSON null.</p>
+    </div>
+    <div class="function" id="num" data-name="num">
+      <h3 class="function-name">num <span class="kind">fn</span></h3>
+      <pre class="usage"><code>num(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: float</span></p>
+    </div>
+    <div class="function" id="from_int" data-name="from_int">
+      <h3 class="function-name">from_int <span class="kind">fn</span></h3>
+      <pre class="usage"><code>from_int(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: long</span></p>
+    </div>
+    <div class="function" id="boolean" data-name="boolean">
+      <h3 class="function-name">boolean <span class="kind">fn</span></h3>
+      <pre class="usage"><code>boolean(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: int</span></p>
+    </div>
+    <div class="function" id="null_value" data-name="null_value">
+      <h3 class="function-name">null_value <span class="kind">fn</span></h3>
+      <pre class="usage"><code>null_value() <span class="arrow">-&gt;</span> ptr</code></pre>
+    </div>
+    <div class="function" id="set" data-name="set">
+      <h3 class="function-name">set <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set(obj, key, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">obj: ptr, key: string, value: ptr</span></p>
+      <p class="doc">Set a key on an object / append to an array. Aliases for `object_set` / `array_add` (same ownership + error contract): &quot;&quot; on success, an error string if the target is the wrong kind (and the orphaned value is reclaimed so it can't leak).</p>
+    </div>
+    <div class="function" id="push" data-name="push">
+      <h3 class="function-name">push <span class="kind">fn</span></h3>
+      <pre class="usage"><code>push(arr, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, value: ptr</span></p>
+    </div>
+    <div class="function" id="encode" data-name="encode">
+      <h3 class="function-name">encode <span class="kind">fn</span></h3>
+      <pre class="usage"><code>encode(value) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">value: ptr</span></p>
+      <p class="doc">Encode a JSON value tree to a compact string with all escaping handled internally. Returns (string, &quot;&quot;) on success, (&quot;&quot;, error) on failure — an alias for `stringify`.</p>
+    </div>
+    <div class="function" id="parse_strict" data-name="parse_strict">
+      <h3 class="function-name">parse_strict <span class="kind">fn</span></h3>
+      <pre class="usage"><code>parse_strict(json_str) <span class="arrow">-&gt;</span> (ptr, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">json_str: string</span></p>
+      <p class="doc">Issue #392 — structured-error variant of `parse`. Returns the canonical (value, kind, message) tuple: on success: (value, KIND_OK, &quot;&quot;) on failure: (null,  KIND_*, &quot;&lt;reason&gt; at &lt;line&gt;:&lt;col&gt;&quot;) `kind` is one of the KIND_* constants exported from this module — switch on it to discriminate between syntax errors, OOM, and invalid-input failures without parsing the human-readable message. Use `last_error_line` / `last_error_col` to pull the position programmatically (the message also carries it as text, but the accessors avoid a regex).</p>
+    </div>
+    <div class="function" id="last_error_kind" data-name="last_error_kind">
+      <h3 class="function-name">last_error_kind <span class="kind">fn</span></h3>
+      <pre class="usage"><code>last_error_kind() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Programmatic accessors for the most recent parse failure on this thread (issue #392). Read these AFTER a `parse` / `parse_strict` call returned a failure; they're undefined after a successful parse. The line/col are 1-based and match the values embedded in the error message.</p>
+    </div>
+    <div class="function" id="last_error_line" data-name="last_error_line">
+      <h3 class="function-name">last_error_line <span class="kind">fn</span></h3>
+      <pre class="usage"><code>last_error_line() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="last_error_col" data-name="last_error_col">
+      <h3 class="function-name">last_error_col <span class="kind">fn</span></h3>
+      <pre class="usage"><code>last_error_col() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="KIND_OK" data-name="KIND_OK">
+      <h3 class="function-name">KIND_OK <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_OK = 0</code></pre>
+      <p class="doc">---- Structured-error pilot (issue #392) ---- A non-breaking extension of `json.parse` that returns the canonical (value, kind, message) tuple from the std.fs pilot. Existing `parse` callers (with the (value, err) shape) keep working unchanged; new callers that want to switch on the failure reason without parsing English use `parse_strict`. Kinds match std.fs's where applicable so callers can mix the two surfaces in the same switch.</p>
+    </div>
+    <div class="function" id="KIND_PARSE_ERROR" data-name="KIND_PARSE_ERROR">
+      <h3 class="function-name">KIND_PARSE_ERROR <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_PARSE_ERROR = 1</code></pre>
+    </div>
+    <div class="function" id="KIND_OUT_OF_MEMORY" data-name="KIND_OUT_OF_MEMORY">
+      <h3 class="function-name">KIND_OUT_OF_MEMORY <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_OUT_OF_MEMORY = 2</code></pre>
+    </div>
+    <div class="function" id="KIND_INVALID_INPUT" data-name="KIND_INVALID_INPUT">
+      <h3 class="function-name">KIND_INVALID_INPUT <span class="kind">const</span></h3>
+      <pre class="usage"><code>KIND_INVALID_INPUT = 3</code></pre>
     </div>
   </div>
 </main>

--- a/docs/api/ksuid.html
+++ b/docs/api/ksuid.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ksuid - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search ksuid..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#generate">generate</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li class="active"><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>ksuid</h1>
+    <p class="module-desc">std.ksuid — KSUID (https://github.com/segmentio/ksuid).</p>
+    <p class="import-line"><code>import std.ksuid</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="generate" data-name="generate">
+      <h3 class="function-name">generate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>generate() <span class="arrow">-&gt;</span> (string, _1)</code></pre>
+      <p class="doc">Generate a 27-char KSUID. Returns (ksuid, &quot;&quot;) on success, (&quot;&quot;, error) on CSPRNG failure.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/list.html
+++ b/docs/api/list.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>list - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search list..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#new">new</a></li>
+    <li><a href="#add_raw">add_raw</a></li>
+    <li><a href="#add_string_owned">add_string_owned</a></li>
+    <li><a href="#get_raw">get_raw</a></li>
+    <li><a href="#set">set</a></li>
+    <li><a href="#size">size</a></li>
+    <li><a href="#remove">remove</a></li>
+    <li><a href="#clear">clear</a></li>
+    <li><a href="#free">free</a></li>
+    <li><a href="#add">add</a></li>
+    <li><a href="#get">get</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li class="active"><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>list</h1>
+    <p class="module-desc">std.list - ArrayList Operations (alias for std.collections) API shape: - Raw externs end in `_raw` and return ptr/int in the old C-style convention.</p>
+    <p class="import-line"><code>import std.list</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new() <span class="arrow">-&gt;</span> ptr</code></pre>
+    </div>
+    <div class="function" id="add_raw" data-name="add_raw">
+      <h3 class="function-name">add_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>add_raw(list, item) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, item: ptr</span></p>
+    </div>
+    <div class="function" id="add_string_owned" data-name="add_string_owned">
+      <h3 class="function-name">add_string_owned <span class="kind">extern</span></h3>
+      <pre class="usage"><code>add_string_owned(list, item) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, item: ptr</span></p>
+      <p class="doc">Heap-string-aware add (#467). Retains the value and tags the list so list_free releases each string element before freeing the backing array. Codegen auto-routes `list.add(l, heap_string_expr)` here when the value is heap-classified.</p>
+    </div>
+    <div class="function" id="get_raw" data-name="get_raw">
+      <h3 class="function-name">get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_raw(list, index) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="set" data-name="set">
+      <h3 class="function-name">set <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set(list, index, item)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int, item: ptr</span></p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>size(list) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="remove" data-name="remove">
+      <h3 class="function-name">remove <span class="kind">extern</span></h3>
+      <pre class="usage"><code>remove(list, index)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="clear" data-name="clear">
+      <h3 class="function-name">clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>clear(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>free(list)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr</span></p>
+    </div>
+    <div class="function" id="add" data-name="add">
+      <h3 class="function-name">add <span class="kind">fn</span></h3>
+      <pre class="usage"><code>add(list, item) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, item: ptr</span></p>
+      <p class="doc">Append an item to a list. Returns &quot;&quot; on success, error on failure.</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(list, index) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, index: int</span></p>
+      <p class="doc">Index into a list. - (item, &quot;&quot;)           : index in range - (null, &quot;&quot;)           : index out of range (not an error) - (null, &quot;null list&quot;)  : `list` is null</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/log.html
+++ b/docs/api/log.html
@@ -13,76 +13,122 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search log..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
-    <li><a href="#log_init_raw">log_init_raw</a></li>
-    <li><a href="#log_init_with_config">log_init_with_config</a></li>
-    <li><a href="#log_shutdown">log_shutdown</a></li>
-    <li><a href="#log_write">log_write</a></li>
-    <li><a href="#log_set_level">log_set_level</a></li>
-    <li><a href="#log_set_colors">log_set_colors</a></li>
-    <li><a href="#log_set_timestamps">log_set_timestamps</a></li>
-    <li><a href="#log_set_format">log_set_format</a></li>
-    <li><a href="#log_print_stats">log_print_stats</a></li>
+    <li><a href="#init_raw">init_raw</a></li>
+    <li><a href="#shutdown">shutdown</a></li>
+    <li><a href="#write">write</a></li>
+    <li><a href="#set_level">set_level</a></li>
+    <li><a href="#set_colors">set_colors</a></li>
+    <li><a href="#set_timestamps">set_timestamps</a></li>
+    <li><a href="#get_stats">get_stats</a></li>
+    <li><a href="#print_stats">print_stats</a></li>
+    <li><a href="#init">init</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li class="active"><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li class="active"><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>log</h1>
-    <p class="module-desc">Logging and diagnostics</p>
+    <p class="module-desc">std.log - Logging Module Import with: import std.log Log level constants LOG_LEVEL_DEBUG = 0, LOG_LEVEL_INFO = 1, LOG_LEVEL_WARN = 2 LOG_LEVEL_ERROR = 3, LOG_LEVEL_FATAL = 4</p>
+    <p class="import-line"><code>import std.log</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="log_init_raw" data-name="log_init_raw">
-      <h3 class="function-name">log_init_raw</h3>
-      <pre class="usage"><code>log_init_raw(filename, min_level)</code></pre>
-      <p class="doc">Initialize logging system. Returns 1 on success, 0 if the requested log file could not be opened (logging still works via stderr).</p>
+    <div class="function" id="init_raw" data-name="init_raw">
+      <h3 class="function-name">init_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>init_raw(filename, min_level) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">filename: string, min_level: int</span></p>
+      <p class="doc">Initialize and shutdown. Raw init returns 1/0 for ok/file-open-failed.</p>
     </div>
-    <div class="function" id="log_init_with_config" data-name="log_init_with_config">
-      <h3 class="function-name">log_init_with_config</h3>
-      <pre class="usage"><code>log_init_with_config(config)</code></pre>
+    <div class="function" id="shutdown" data-name="shutdown">
+      <h3 class="function-name">shutdown <span class="kind">extern</span></h3>
+      <pre class="usage"><code>shutdown()</code></pre>
     </div>
-    <div class="function" id="log_shutdown" data-name="log_shutdown">
-      <h3 class="function-name">log_shutdown</h3>
-      <pre class="usage"><code>log_shutdown()</code></pre>
+    <div class="function" id="write" data-name="write">
+      <h3 class="function-name">write <span class="kind">extern</span></h3>
+      <pre class="usage"><code>write(level, msg)</code></pre>
+      <p class="signature"><span class="sig-params">level: int, msg: string</span></p>
+      <p class="doc">Core logging (variadic not fully supported, use with format string)</p>
     </div>
-    <div class="function" id="log_write" data-name="log_write">
-      <h3 class="function-name">log_write</h3>
-      <pre class="usage"><code>log_write(level, fmt)</code></pre>
-      <p class="doc">Core logging functions</p>
-    </div>
-    <div class="function" id="log_set_level" data-name="log_set_level">
-      <h3 class="function-name">log_set_level</h3>
-      <pre class="usage"><code>log_set_level(level)</code></pre>
+    <div class="function" id="set_level" data-name="set_level">
+      <h3 class="function-name">set_level <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_level(level)</code></pre>
+      <p class="signature"><span class="sig-params">level: int</span></p>
       <p class="doc">Configuration</p>
     </div>
-    <div class="function" id="log_set_colors" data-name="log_set_colors">
-      <h3 class="function-name">log_set_colors</h3>
-      <pre class="usage"><code>log_set_colors(enabled)</code></pre>
+    <div class="function" id="set_colors" data-name="set_colors">
+      <h3 class="function-name">set_colors <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_colors(enabled)</code></pre>
+      <p class="signature"><span class="sig-params">enabled: int</span></p>
     </div>
-    <div class="function" id="log_set_timestamps" data-name="log_set_timestamps">
-      <h3 class="function-name">log_set_timestamps</h3>
-      <pre class="usage"><code>log_set_timestamps(enabled)</code></pre>
+    <div class="function" id="set_timestamps" data-name="set_timestamps">
+      <h3 class="function-name">set_timestamps <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_timestamps(enabled)</code></pre>
+      <p class="signature"><span class="sig-params">enabled: int</span></p>
     </div>
-    <div class="function" id="log_set_format" data-name="log_set_format">
-      <h3 class="function-name">log_set_format</h3>
-      <pre class="usage"><code>log_set_format(format)</code></pre>
+    <div class="function" id="get_stats" data-name="get_stats">
+      <h3 class="function-name">get_stats <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_stats() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">Statistics</p>
     </div>
-    <div class="function" id="log_print_stats" data-name="log_print_stats">
-      <h3 class="function-name">log_print_stats</h3>
-      <pre class="usage"><code>log_print_stats()</code></pre>
+    <div class="function" id="print_stats" data-name="print_stats">
+      <h3 class="function-name">print_stats <span class="kind">extern</span></h3>
+      <pre class="usage"><code>print_stats()</code></pre>
+    </div>
+    <div class="function" id="init" data-name="init">
+      <h3 class="function-name">init <span class="kind">fn</span></h3>
+      <pre class="usage"><code>init(filename, min_level) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">filename: string, min_level: int</span></p>
+      <p class="doc">Initialize logging. Returns &quot;&quot; on success, error string if the requested log file could not be opened (in which case logging still works via stderr as a fallback).</p>
     </div>
   </div>
 </main>

--- a/docs/api/longarr.html
+++ b/docs/api/longarr.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>longarr - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search longarr..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#new">new</a></li>
+    <li><a href="#new_filled">new_filled</a></li>
+    <li><a href="#get">get</a></li>
+    <li><a href="#set">set</a></li>
+    <li><a href="#new_raw">new_raw</a></li>
+    <li><a href="#new_filled_raw">new_filled_raw</a></li>
+    <li><a href="#size">size</a></li>
+    <li><a href="#get_raw">get_raw</a></li>
+    <li><a href="#set_raw">set_raw</a></li>
+    <li><a href="#get_unchecked">get_unchecked</a></li>
+    <li><a href="#set_unchecked">set_unchecked</a></li>
+    <li><a href="#fill">fill</a></li>
+    <li><a href="#free">free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li class="active"><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>longarr</h1>
+    <p class="module-desc">Copyright (c) 2026 Aether Developers.</p>
+    <p class="import-line"><code>import std.longarr</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new(size) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">Allocate a LongArray of `size` elements, zero-initialised. Returns (ptr, &quot;&quot;) on success, (null, error) on failure.</p>
+    </div>
+    <div class="function" id="new_filled" data-name="new_filled">
+      <h3 class="function-name">new_filled <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new_filled(size, init) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">size: int, init: long</span></p>
+      <p class="doc">Allocate and fill with `init` at every index.</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(arr, i) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Bounds-checked read. Returns (value, &quot;&quot;) on success, (0, error) for null array or OOB index. Use the raw `longarr_get_raw` directly (imported above) when you don't need to tell absent apart from stored-zero — it's one fewer function call and one fewer branch.</p>
+    </div>
+    <div class="function" id="set" data-name="set">
+      <h3 class="function-name">set <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set(arr, i, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: long</span></p>
+      <p class="doc">Bounds-checked write. Returns &quot;&quot; on success, error for null array or OOB index. Use the raw `longarr_set_raw` directly in hot paths where a no-op-on-OOB is acceptable.</p>
+    </div>
+    <div class="function" id="new_raw" data-name="new_raw">
+      <h3 class="function-name">new_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new_raw(size) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int</span></p>
+      <p class="doc">Allocate a LongArray of `size` longs, zero-initialised. Returns null if `size` is negative or allocation fails.</p>
+    </div>
+    <div class="function" id="new_filled_raw" data-name="new_filled_raw">
+      <h3 class="function-name">new_filled_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new_filled_raw(size, init) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">size: int, init: long</span></p>
+      <p class="doc">Allocate and fill every index with `init`.</p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>size(arr) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+      <p class="doc">Number of elements. -1 if `arr` is null.</p>
+    </div>
+    <div class="function" id="get_raw" data-name="get_raw">
+      <h3 class="function-name">get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_raw(arr, i) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Read at `i`. Returns 0 if `arr` is null or `i` is out-of-range. Use `longarr.get` (below) to distinguish stored-zero from OOB.</p>
+    </div>
+    <div class="function" id="set_raw" data-name="set_raw">
+      <h3 class="function-name">set_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_raw(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: long</span></p>
+      <p class="doc">Write `value` at `i`. No-op if `arr` is null or `i` is out-of-range. Use `longarr.set` (below) if you need an error on OOB.</p>
+    </div>
+    <div class="function" id="get_unchecked" data-name="get_unchecked">
+      <h3 class="function-name">get_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_unchecked(arr, i) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int</span></p>
+      <p class="doc">Hot-path variants — caller guarantees index is in [0, size). OOB access is undefined behaviour. Don't use from outside a tight loop.</p>
+    </div>
+    <div class="function" id="set_unchecked" data-name="set_unchecked">
+      <h3 class="function-name">set_unchecked <span class="kind">extern</span></h3>
+      <pre class="usage"><code>set_unchecked(arr, i, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, i: int, value: long</span></p>
+    </div>
+    <div class="function" id="fill" data-name="fill">
+      <h3 class="function-name">fill <span class="kind">extern</span></h3>
+      <pre class="usage"><code>fill(arr, value)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, value: long</span></p>
+      <p class="doc">Fill every element with `value`.</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>free(arr)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+      <p class="doc">Release. Idempotent on null.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/lzf.html
+++ b/docs/api/lzf.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>lzf - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search lzf..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#max_compressed_size">max_compressed_size</a></li>
+    <li><a href="#try_compress">try_compress</a></li>
+    <li><a href="#get_compress_bytes">get_compress_bytes</a></li>
+    <li><a href="#get_compress_length">get_compress_length</a></li>
+    <li><a href="#release_compress">release_compress</a></li>
+    <li><a href="#try_decompress">try_decompress</a></li>
+    <li><a href="#get_decompress_bytes">get_decompress_bytes</a></li>
+    <li><a href="#get_decompress_length">get_decompress_length</a></li>
+    <li><a href="#release_decompress">release_decompress</a></li>
+    <li><a href="#compress">compress</a></li>
+    <li><a href="#decompress">decompress</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li class="active"><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>lzf</h1>
+    <p class="module-desc">std.lzf - One-shot LZF compression/decompression.</p>
+    <p class="import-line"><code>import std.lzf</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="max_compressed_size" data-name="max_compressed_size">
+      <h3 class="function-name">max_compressed_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>max_compressed_size(length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">length: int</span></p>
+    </div>
+    <div class="function" id="try_compress" data-name="try_compress">
+      <h3 class="function-name">try_compress <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_compress(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="get_compress_bytes" data-name="get_compress_bytes">
+      <h3 class="function-name">get_compress_bytes <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_compress_bytes() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_compress_length" data-name="get_compress_length">
+      <h3 class="function-name">get_compress_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_compress_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_compress" data-name="release_compress">
+      <h3 class="function-name">release_compress <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_compress()</code></pre>
+    </div>
+    <div class="function" id="try_decompress" data-name="try_decompress">
+      <h3 class="function-name">try_decompress <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_decompress(data, length, output_length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int, output_length: int</span></p>
+    </div>
+    <div class="function" id="get_decompress_bytes" data-name="get_decompress_bytes">
+      <h3 class="function-name">get_decompress_bytes <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_decompress_bytes() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_decompress_length" data-name="get_decompress_length">
+      <h3 class="function-name">get_decompress_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_decompress_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_decompress" data-name="release_decompress">
+      <h3 class="function-name">release_decompress <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_decompress()</code></pre>
+    </div>
+    <div class="function" id="compress" data-name="compress">
+      <h3 class="function-name">compress <span class="kind">fn</span></h3>
+      <pre class="usage"><code>compress(data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="decompress" data-name="decompress">
+      <h3 class="function-name">decompress <span class="kind">fn</span></h3>
+      <pre class="usage"><code>decompress(data, length, output_length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int, output_length: int</span></p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/map.html
+++ b/docs/api/map.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>map - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search map..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#new">new</a></li>
+    <li><a href="#put_raw">put_raw</a></li>
+    <li><a href="#put_string_owned">put_string_owned</a></li>
+    <li><a href="#get_raw">get_raw</a></li>
+    <li><a href="#has">has</a></li>
+    <li><a href="#remove">remove</a></li>
+    <li><a href="#size">size</a></li>
+    <li><a href="#clear">clear</a></li>
+    <li><a href="#free">free</a></li>
+    <li><a href="#keys_raw">keys_raw</a></li>
+    <li><a href="#keys_free">keys_free</a></li>
+    <li><a href="#put">put</a></li>
+    <li><a href="#get">get</a></li>
+    <li><a href="#keys">keys</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li class="active"><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>map</h1>
+    <p class="module-desc">std.map - HashMap Operations (alias for std.collections) API shape: - Raw externs end in `_raw` and return ptr/int in the old C-style convention.</p>
+    <p class="import-line"><code>import std.map</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new() <span class="arrow">-&gt;</span> ptr</code></pre>
+    </div>
+    <div class="function" id="put_raw" data-name="put_raw">
+      <h3 class="function-name">put_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>put_raw(map, key, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string, value: ptr</span></p>
+    </div>
+    <div class="function" id="put_string_owned" data-name="put_string_owned">
+      <h3 class="function-name">put_string_owned <span class="kind">extern</span></h3>
+      <pre class="usage"><code>put_string_owned(map, key, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string, value: ptr</span></p>
+      <p class="doc">Heap-string-aware put (#467). Retains the value and tags the map so map_free releases each string value before freeing. Codegen auto-routes `map.put(m, k, heap_string_expr)` here.</p>
+    </div>
+    <div class="function" id="get_raw" data-name="get_raw">
+      <h3 class="function-name">get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_raw(map, key) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
+    </div>
+    <div class="function" id="has" data-name="has">
+      <h3 class="function-name">has <span class="kind">extern</span></h3>
+      <pre class="usage"><code>has(map, key) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
+    </div>
+    <div class="function" id="remove" data-name="remove">
+      <h3 class="function-name">remove <span class="kind">extern</span></h3>
+      <pre class="usage"><code>remove(map, key)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
+    </div>
+    <div class="function" id="size" data-name="size">
+      <h3 class="function-name">size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>size(map) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
+    </div>
+    <div class="function" id="clear" data-name="clear">
+      <h3 class="function-name">clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>clear(map)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>free(map)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
+    </div>
+    <div class="function" id="keys_raw" data-name="keys_raw">
+      <h3 class="function-name">keys_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>keys_raw(map) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
+    </div>
+    <div class="function" id="keys_free" data-name="keys_free">
+      <h3 class="function-name">keys_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>keys_free(keys)</code></pre>
+      <p class="signature"><span class="sig-params">keys: ptr</span></p>
+    </div>
+    <div class="function" id="put" data-name="put">
+      <h3 class="function-name">put <span class="kind">fn</span></h3>
+      <pre class="usage"><code>put(map, key, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string, value: ptr</span></p>
+      <p class="doc">Insert or update a key-value pair. Returns &quot;&quot; on success, error on failure (null map/key or OOM).</p>
+    </div>
+    <div class="function" id="get" data-name="get">
+      <h3 class="function-name">get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get(map, key) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr, key: string</span></p>
+      <p class="doc">Look up a key. - (value, &quot;&quot;)          : key present - (null, &quot;&quot;)           : key absent (not an error — use map.has) - (null, &quot;null map&quot;)   : `map` is null</p>
+    </div>
+    <div class="function" id="keys" data-name="keys">
+      <h3 class="function-name">keys <span class="kind">fn</span></h3>
+      <pre class="usage"><code>keys(map) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">map: ptr</span></p>
+      <p class="doc">Snapshot a map's keys. Returns (MapKeys ptr, &quot;&quot;) on success, (null, error) on allocation failure. Caller must free with map.keys_free.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/math.html
+++ b/docs/api/math.html
@@ -13,161 +13,250 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search math..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
-    <li><a href="#math_abs_int">math_abs_int</a></li>
-    <li><a href="#math_abs_float">math_abs_float</a></li>
-    <li><a href="#math_min_int">math_min_int</a></li>
-    <li><a href="#math_max_int">math_max_int</a></li>
-    <li><a href="#math_min_float">math_min_float</a></li>
-    <li><a href="#math_max_float">math_max_float</a></li>
-    <li><a href="#math_clamp_int">math_clamp_int</a></li>
-    <li><a href="#math_clamp_float">math_clamp_float</a></li>
-    <li><a href="#math_sqrt">math_sqrt</a></li>
-    <li><a href="#math_pow">math_pow</a></li>
-    <li><a href="#math_sin">math_sin</a></li>
-    <li><a href="#math_cos">math_cos</a></li>
-    <li><a href="#math_tan">math_tan</a></li>
-    <li><a href="#math_asin">math_asin</a></li>
-    <li><a href="#math_acos">math_acos</a></li>
-    <li><a href="#math_atan">math_atan</a></li>
-    <li><a href="#math_atan2">math_atan2</a></li>
-    <li><a href="#math_floor">math_floor</a></li>
-    <li><a href="#math_ceil">math_ceil</a></li>
-    <li><a href="#math_round">math_round</a></li>
-    <li><a href="#math_log">math_log</a></li>
-    <li><a href="#math_log10">math_log10</a></li>
-    <li><a href="#math_exp">math_exp</a></li>
-    <li><a href="#math_random_seed">math_random_seed</a></li>
-    <li><a href="#math_random_int">math_random_int</a></li>
-    <li><a href="#math_random_float">math_random_float</a></li>
+    <li><a href="#abs_int">abs_int</a></li>
+    <li><a href="#abs_float">abs_float</a></li>
+    <li><a href="#min_int">min_int</a></li>
+    <li><a href="#max_int">max_int</a></li>
+    <li><a href="#min_float">min_float</a></li>
+    <li><a href="#max_float">max_float</a></li>
+    <li><a href="#clamp_int">clamp_int</a></li>
+    <li><a href="#clamp_float">clamp_float</a></li>
+    <li><a href="#sqrt">sqrt</a></li>
+    <li><a href="#pow">pow</a></li>
+    <li><a href="#sin">sin</a></li>
+    <li><a href="#cos">cos</a></li>
+    <li><a href="#tan">tan</a></li>
+    <li><a href="#asin">asin</a></li>
+    <li><a href="#acos">acos</a></li>
+    <li><a href="#atan">atan</a></li>
+    <li><a href="#atan2">atan2</a></li>
+    <li><a href="#floor">floor</a></li>
+    <li><a href="#ceil">ceil</a></li>
+    <li><a href="#round">round</a></li>
+    <li><a href="#log">log</a></li>
+    <li><a href="#log10">log10</a></li>
+    <li><a href="#exp">exp</a></li>
+    <li><a href="#random_seed">random_seed</a></li>
+    <li><a href="#random_int">random_int</a></li>
+    <li><a href="#random_float">random_float</a></li>
+    <li><a href="#pi">pi</a></li>
+    <li><a href="#tau">tau</a></li>
+    <li><a href="#e">e</a></li>
+    <li><a href="#deg_to_rad">deg_to_rad</a></li>
+    <li><a href="#rad_to_deg">rad_to_deg</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li class="active"><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li class="active"><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>math</h1>
-    <p class="module-desc">Mathematical functions</p>
+    <p class="module-desc">std.math - Math Module Import with: import std.math</p>
+    <p class="import-line"><code>import std.math</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="math_abs_int" data-name="math_abs_int">
-      <h3 class="function-name">math_abs_int</h3>
-      <pre class="usage"><code>math_abs_int(x)</code></pre>
-      <p class="doc">Basic math operations</p>
+    <div class="function" id="abs_int" data-name="abs_int">
+      <h3 class="function-name">abs_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>abs_int(x) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int</span></p>
+      <p class="doc">Basic operations (int/float variants)</p>
     </div>
-    <div class="function" id="math_abs_float" data-name="math_abs_float">
-      <h3 class="function-name">math_abs_float</h3>
-      <pre class="usage"><code>math_abs_float(x)</code></pre>
+    <div class="function" id="abs_float" data-name="abs_float">
+      <h3 class="function-name">abs_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>abs_float(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_min_int" data-name="math_min_int">
-      <h3 class="function-name">math_min_int</h3>
-      <pre class="usage"><code>math_min_int(a, b)</code></pre>
+    <div class="function" id="min_int" data-name="min_int">
+      <h3 class="function-name">min_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>min_int(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: int, b: int</span></p>
     </div>
-    <div class="function" id="math_max_int" data-name="math_max_int">
-      <h3 class="function-name">math_max_int</h3>
-      <pre class="usage"><code>math_max_int(a, b)</code></pre>
+    <div class="function" id="max_int" data-name="max_int">
+      <h3 class="function-name">max_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>max_int(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: int, b: int</span></p>
     </div>
-    <div class="function" id="math_min_float" data-name="math_min_float">
-      <h3 class="function-name">math_min_float</h3>
-      <pre class="usage"><code>math_min_float(a, b)</code></pre>
+    <div class="function" id="min_float" data-name="min_float">
+      <h3 class="function-name">min_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>min_float(a, b) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">a: float, b: float</span></p>
     </div>
-    <div class="function" id="math_max_float" data-name="math_max_float">
-      <h3 class="function-name">math_max_float</h3>
-      <pre class="usage"><code>math_max_float(a, b)</code></pre>
+    <div class="function" id="max_float" data-name="max_float">
+      <h3 class="function-name">max_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>max_float(a, b) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">a: float, b: float</span></p>
     </div>
-    <div class="function" id="math_clamp_int" data-name="math_clamp_int">
-      <h3 class="function-name">math_clamp_int</h3>
-      <pre class="usage"><code>math_clamp_int(x, min, max)</code></pre>
+    <div class="function" id="clamp_int" data-name="clamp_int">
+      <h3 class="function-name">clamp_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>clamp_int(x, min, max) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">x: int, min: int, max: int</span></p>
     </div>
-    <div class="function" id="math_clamp_float" data-name="math_clamp_float">
-      <h3 class="function-name">math_clamp_float</h3>
-      <pre class="usage"><code>math_clamp_float(x, min, max)</code></pre>
+    <div class="function" id="clamp_float" data-name="clamp_float">
+      <h3 class="function-name">clamp_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>clamp_float(x, min, max) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float, min: float, max: float</span></p>
     </div>
-    <div class="function" id="math_sqrt" data-name="math_sqrt">
-      <h3 class="function-name">math_sqrt</h3>
-      <pre class="usage"><code>math_sqrt(x)</code></pre>
+    <div class="function" id="sqrt" data-name="sqrt">
+      <h3 class="function-name">sqrt <span class="kind">extern</span></h3>
+      <pre class="usage"><code>sqrt(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
       <p class="doc">Advanced math</p>
     </div>
-    <div class="function" id="math_pow" data-name="math_pow">
-      <h3 class="function-name">math_pow</h3>
-      <pre class="usage"><code>math_pow(base, exp)</code></pre>
+    <div class="function" id="pow" data-name="pow">
+      <h3 class="function-name">pow <span class="kind">extern</span></h3>
+      <pre class="usage"><code>pow(base, exp) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">base: float, exp: float</span></p>
     </div>
-    <div class="function" id="math_sin" data-name="math_sin">
-      <h3 class="function-name">math_sin</h3>
-      <pre class="usage"><code>math_sin(x)</code></pre>
+    <div class="function" id="sin" data-name="sin">
+      <h3 class="function-name">sin <span class="kind">extern</span></h3>
+      <pre class="usage"><code>sin(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_cos" data-name="math_cos">
-      <h3 class="function-name">math_cos</h3>
-      <pre class="usage"><code>math_cos(x)</code></pre>
+    <div class="function" id="cos" data-name="cos">
+      <h3 class="function-name">cos <span class="kind">extern</span></h3>
+      <pre class="usage"><code>cos(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_tan" data-name="math_tan">
-      <h3 class="function-name">math_tan</h3>
-      <pre class="usage"><code>math_tan(x)</code></pre>
+    <div class="function" id="tan" data-name="tan">
+      <h3 class="function-name">tan <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tan(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_asin" data-name="math_asin">
-      <h3 class="function-name">math_asin</h3>
-      <pre class="usage"><code>math_asin(x)</code></pre>
+    <div class="function" id="asin" data-name="asin">
+      <h3 class="function-name">asin <span class="kind">extern</span></h3>
+      <pre class="usage"><code>asin(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_acos" data-name="math_acos">
-      <h3 class="function-name">math_acos</h3>
-      <pre class="usage"><code>math_acos(x)</code></pre>
+    <div class="function" id="acos" data-name="acos">
+      <h3 class="function-name">acos <span class="kind">extern</span></h3>
+      <pre class="usage"><code>acos(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_atan" data-name="math_atan">
-      <h3 class="function-name">math_atan</h3>
-      <pre class="usage"><code>math_atan(x)</code></pre>
+    <div class="function" id="atan" data-name="atan">
+      <h3 class="function-name">atan <span class="kind">extern</span></h3>
+      <pre class="usage"><code>atan(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_atan2" data-name="math_atan2">
-      <h3 class="function-name">math_atan2</h3>
-      <pre class="usage"><code>math_atan2(y, x)</code></pre>
+    <div class="function" id="atan2" data-name="atan2">
+      <h3 class="function-name">atan2 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>atan2(y, x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">y: float, x: float</span></p>
     </div>
-    <div class="function" id="math_floor" data-name="math_floor">
-      <h3 class="function-name">math_floor</h3>
-      <pre class="usage"><code>math_floor(x)</code></pre>
+    <div class="function" id="floor" data-name="floor">
+      <h3 class="function-name">floor <span class="kind">extern</span></h3>
+      <pre class="usage"><code>floor(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_ceil" data-name="math_ceil">
-      <h3 class="function-name">math_ceil</h3>
-      <pre class="usage"><code>math_ceil(x)</code></pre>
+    <div class="function" id="ceil" data-name="ceil">
+      <h3 class="function-name">ceil <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ceil(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_round" data-name="math_round">
-      <h3 class="function-name">math_round</h3>
-      <pre class="usage"><code>math_round(x)</code></pre>
+    <div class="function" id="round" data-name="round">
+      <h3 class="function-name">round <span class="kind">extern</span></h3>
+      <pre class="usage"><code>round(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_log" data-name="math_log">
-      <h3 class="function-name">math_log</h3>
-      <pre class="usage"><code>math_log(x)</code></pre>
+    <div class="function" id="log" data-name="log">
+      <h3 class="function-name">log <span class="kind">extern</span></h3>
+      <pre class="usage"><code>log(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_log10" data-name="math_log10">
-      <h3 class="function-name">math_log10</h3>
-      <pre class="usage"><code>math_log10(x)</code></pre>
+    <div class="function" id="log10" data-name="log10">
+      <h3 class="function-name">log10 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>log10(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_exp" data-name="math_exp">
-      <h3 class="function-name">math_exp</h3>
-      <pre class="usage"><code>math_exp(x)</code></pre>
+    <div class="function" id="exp" data-name="exp">
+      <h3 class="function-name">exp <span class="kind">extern</span></h3>
+      <pre class="usage"><code>exp(x) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">x: float</span></p>
     </div>
-    <div class="function" id="math_random_seed" data-name="math_random_seed">
-      <h3 class="function-name">math_random_seed</h3>
-      <pre class="usage"><code>math_random_seed(seed)</code></pre>
+    <div class="function" id="random_seed" data-name="random_seed">
+      <h3 class="function-name">random_seed <span class="kind">extern</span></h3>
+      <pre class="usage"><code>random_seed(seed)</code></pre>
+      <p class="signature"><span class="sig-params">seed: int</span></p>
       <p class="doc">Random numbers</p>
     </div>
-    <div class="function" id="math_random_int" data-name="math_random_int">
-      <h3 class="function-name">math_random_int</h3>
-      <pre class="usage"><code>math_random_int(min, max)</code></pre>
+    <div class="function" id="random_int" data-name="random_int">
+      <h3 class="function-name">random_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>random_int(min, max) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">min: int, max: int</span></p>
     </div>
-    <div class="function" id="math_random_float" data-name="math_random_float">
-      <h3 class="function-name">math_random_float</h3>
-      <pre class="usage"><code>math_random_float()</code></pre>
+    <div class="function" id="random_float" data-name="random_float">
+      <h3 class="function-name">random_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>random_float() <span class="arrow">-&gt;</span> float</code></pre>
+    </div>
+    <div class="function" id="pi" data-name="pi">
+      <h3 class="function-name">pi <span class="kind">extern</span></h3>
+      <pre class="usage"><code>pi() <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="doc">Function-constants. Aether has no const-expression evaluator at the call site, so trigonometric / radian-conversion constants are zero-arg functions. The C lowering is `return &lt;literal&gt;`; any reasonable C compiler inlines it. Keeps the `math.*` namespace uniform with the trig / pow / sqrt functions above.</p>
+    </div>
+    <div class="function" id="tau" data-name="tau">
+      <h3 class="function-name">tau <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tau() <span class="arrow">-&gt;</span> float</code></pre>
+    </div>
+    <div class="function" id="e" data-name="e">
+      <h3 class="function-name">e <span class="kind">extern</span></h3>
+      <pre class="usage"><code>e() <span class="arrow">-&gt;</span> float</code></pre>
+    </div>
+    <div class="function" id="deg_to_rad" data-name="deg_to_rad">
+      <h3 class="function-name">deg_to_rad <span class="kind">extern</span></h3>
+      <pre class="usage"><code>deg_to_rad() <span class="arrow">-&gt;</span> float</code></pre>
+    </div>
+    <div class="function" id="rad_to_deg" data-name="rad_to_deg">
+      <h3 class="function-name">rad_to_deg <span class="kind">extern</span></h3>
+      <pre class="usage"><code>rad_to_deg() <span class="arrow">-&gt;</span> float</code></pre>
     </div>
   </div>
 </main>

--- a/docs/api/mem.html
+++ b/docs/api/mem.html
@@ -1,0 +1,667 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>mem - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search mem..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_mem_get_byte">aether_mem_get_byte</a></li>
+    <li><a href="#aether_mem_set_byte">aether_mem_set_byte</a></li>
+    <li><a href="#aether_mem_get_byte_sz">aether_mem_get_byte_sz</a></li>
+    <li><a href="#aether_mem_set_byte_sz">aether_mem_set_byte_sz</a></li>
+    <li><a href="#aether_mem_get_ptr">aether_mem_get_ptr</a></li>
+    <li><a href="#aether_mem_set_ptr">aether_mem_set_ptr</a></li>
+    <li><a href="#aether_mem_get_int">aether_mem_get_int</a></li>
+    <li><a href="#aether_mem_set_int">aether_mem_set_int</a></li>
+    <li><a href="#aether_mem_get_long">aether_mem_get_long</a></li>
+    <li><a href="#aether_mem_set_long">aether_mem_set_long</a></li>
+    <li><a href="#aether_mem_get_int8">aether_mem_get_int8</a></li>
+    <li><a href="#aether_mem_set_int8">aether_mem_set_int8</a></li>
+    <li><a href="#aether_mem_get_uint8">aether_mem_get_uint8</a></li>
+    <li><a href="#aether_mem_set_uint8">aether_mem_set_uint8</a></li>
+    <li><a href="#aether_mem_get_int16">aether_mem_get_int16</a></li>
+    <li><a href="#aether_mem_set_int16">aether_mem_set_int16</a></li>
+    <li><a href="#aether_mem_get_uint16">aether_mem_get_uint16</a></li>
+    <li><a href="#aether_mem_set_uint16">aether_mem_set_uint16</a></li>
+    <li><a href="#aether_mem_get_uint32">aether_mem_get_uint32</a></li>
+    <li><a href="#aether_mem_set_uint32">aether_mem_set_uint32</a></li>
+    <li><a href="#aether_mem_get_float32">aether_mem_get_float32</a></li>
+    <li><a href="#aether_mem_set_float32">aether_mem_set_float32</a></li>
+    <li><a href="#aether_mem_get_float64">aether_mem_get_float64</a></li>
+    <li><a href="#aether_mem_set_float64">aether_mem_set_float64</a></li>
+    <li><a href="#aether_mem_bits_of_float">aether_mem_bits_of_float</a></li>
+    <li><a href="#aether_mem_float_from_bits">aether_mem_float_from_bits</a></li>
+    <li><a href="#aether_mem_clz32">aether_mem_clz32</a></li>
+    <li><a href="#aether_mem_clz64">aether_mem_clz64</a></li>
+    <li><a href="#aether_mem_udiv64_32">aether_mem_udiv64_32</a></li>
+    <li><a href="#aether_mem_call_fn3_int">aether_mem_call_fn3_int</a></li>
+    <li><a href="#aether_mem_call_fn3_void">aether_mem_call_fn3_void</a></li>
+    <li><a href="#aether_mem_copy">aether_mem_copy</a></li>
+    <li><a href="#aether_mem_move">aether_mem_move</a></li>
+    <li><a href="#aether_mem_compare">aether_mem_compare</a></li>
+    <li><a href="#aether_mem_set_bulk">aether_mem_set_bulk</a></li>
+    <li><a href="#aether_mem_get_u16_le">aether_mem_get_u16_le</a></li>
+    <li><a href="#aether_mem_get_u16_be">aether_mem_get_u16_be</a></li>
+    <li><a href="#aether_mem_set_u16_le">aether_mem_set_u16_le</a></li>
+    <li><a href="#aether_mem_set_u16_be">aether_mem_set_u16_be</a></li>
+    <li><a href="#aether_mem_get_u32_le">aether_mem_get_u32_le</a></li>
+    <li><a href="#aether_mem_get_u32_be">aether_mem_get_u32_be</a></li>
+    <li><a href="#aether_mem_set_u32_le">aether_mem_set_u32_le</a></li>
+    <li><a href="#aether_mem_set_u32_be">aether_mem_set_u32_be</a></li>
+    <li><a href="#aether_mem_get_u64_le">aether_mem_get_u64_le</a></li>
+    <li><a href="#aether_mem_get_u64_be">aether_mem_get_u64_be</a></li>
+    <li><a href="#aether_mem_set_u64_le">aether_mem_set_u64_le</a></li>
+    <li><a href="#aether_mem_set_u64_be">aether_mem_set_u64_be</a></li>
+    <li><a href="#get_byte">get_byte</a></li>
+    <li><a href="#set_byte">set_byte</a></li>
+    <li><a href="#get_byte_sz">get_byte_sz</a></li>
+    <li><a href="#set_byte_sz">set_byte_sz</a></li>
+    <li><a href="#get_ptr">get_ptr</a></li>
+    <li><a href="#set_ptr">set_ptr</a></li>
+    <li><a href="#get_int">get_int</a></li>
+    <li><a href="#set_int">set_int</a></li>
+    <li><a href="#get_long">get_long</a></li>
+    <li><a href="#set_long">set_long</a></li>
+    <li><a href="#get_int8">get_int8</a></li>
+    <li><a href="#set_int8">set_int8</a></li>
+    <li><a href="#get_uint8">get_uint8</a></li>
+    <li><a href="#set_uint8">set_uint8</a></li>
+    <li><a href="#get_int16">get_int16</a></li>
+    <li><a href="#set_int16">set_int16</a></li>
+    <li><a href="#get_uint16">get_uint16</a></li>
+    <li><a href="#set_uint16">set_uint16</a></li>
+    <li><a href="#get_uint32">get_uint32</a></li>
+    <li><a href="#set_uint32">set_uint32</a></li>
+    <li><a href="#get_float32">get_float32</a></li>
+    <li><a href="#set_float32">set_float32</a></li>
+    <li><a href="#get_float64">get_float64</a></li>
+    <li><a href="#set_float64">set_float64</a></li>
+    <li><a href="#bits_of_float">bits_of_float</a></li>
+    <li><a href="#float_from_bits">float_from_bits</a></li>
+    <li><a href="#clz32">clz32</a></li>
+    <li><a href="#clz64">clz64</a></li>
+    <li><a href="#udiv64_32">udiv64_32</a></li>
+    <li><a href="#call_fn3_int">call_fn3_int</a></li>
+    <li><a href="#call_fn3_void">call_fn3_void</a></li>
+    <li><a href="#copy">copy</a></li>
+    <li><a href="#move">move</a></li>
+    <li><a href="#compare">compare</a></li>
+    <li><a href="#set">set</a></li>
+    <li><a href="#get_u16_le">get_u16_le</a></li>
+    <li><a href="#get_u16_be">get_u16_be</a></li>
+    <li><a href="#set_u16_le">set_u16_le</a></li>
+    <li><a href="#set_u16_be">set_u16_be</a></li>
+    <li><a href="#get_u32_le">get_u32_le</a></li>
+    <li><a href="#get_u32_be">get_u32_be</a></li>
+    <li><a href="#set_u32_le">set_u32_le</a></li>
+    <li><a href="#set_u32_be">set_u32_be</a></li>
+    <li><a href="#get_u64_le">get_u64_le</a></li>
+    <li><a href="#get_u64_be">get_u64_be</a></li>
+    <li><a href="#set_u64_le">set_u64_le</a></li>
+    <li><a href="#set_u64_be">set_u64_be</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li class="active"><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>mem</h1>
+    <p class="module-desc">std.mem — byte-level access to caller-allocated raw pointers.</p>
+    <p class="import-line"><code>import std.mem</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_mem_get_byte" data-name="aether_mem_get_byte">
+      <h3 class="function-name">aether_mem_get_byte <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_byte(p, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int</span></p>
+      <p class="doc">Read unsigned byte at offset `i` from raw pointer `p`. Returns 0..255 on success, -1 if `p` is null. Negative or out-of-range `i` is undefined behaviour (the caller owns the buffer and knows its size; same contract as POSIX read into a char*).</p>
+    </div>
+    <div class="function" id="aether_mem_set_byte" data-name="aether_mem_set_byte">
+      <h3 class="function-name">aether_mem_set_byte <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_byte(p, i, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int, value: int</span></p>
+      <p class="doc">Write the low 8 bits of `value` at offset `i` of `p`. Returns 1 on success, 0 if `p` is null. As with get_byte, out-of-range `i` is undefined behaviour.</p>
+    </div>
+    <div class="function" id="aether_mem_get_byte_sz" data-name="aether_mem_get_byte_sz">
+      <h3 class="function-name">aether_mem_get_byte_sz <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_byte_sz(p, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: size_t</span></p>
+      <p class="doc">size_t-indexed companions. The int variants top out at 2 GiB; codebases whose natural index width is size_t (Redis SDS, lzf, siphash, syncio, large mmap walkers) need the wider form. Aether has no primitive narrowing via `as` so callers cannot convert size_t to int at the call site — that's the gap these fill. Same null defence; same out-of-range UB contract.</p>
+    </div>
+    <div class="function" id="aether_mem_set_byte_sz" data-name="aether_mem_set_byte_sz">
+      <h3 class="function-name">aether_mem_set_byte_sz <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_byte_sz(p, i, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: size_t, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_ptr" data-name="aether_mem_get_ptr">
+      <h3 class="function-name">aether_mem_get_ptr <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_ptr(p, offset) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+      <p class="doc">Read a pointer-sized value at byte offset `offset` from `p`. Returns null if `p` is null OR the loaded value is null — callers needing to distinguish should null-check `p` themselves. `offset` must be pointer-aligned and the slot must be at least `sizeof(void*)` bytes. Use for the C-side `*(void**)slot` read pattern — e.g. when a C library hands back an out-parameter through a `T**` argument the Aether caller filled with a malloc-d slot.</p>
+    </div>
+    <div class="function" id="aether_mem_set_ptr" data-name="aether_mem_set_ptr">
+      <h3 class="function-name">aether_mem_set_ptr <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_ptr(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: ptr</span></p>
+      <p class="doc">Write a pointer `value` into the slot at byte offset `offset` of `p`. Returns 1 on success, 0 if `p` is null. Drives the `*(void**)out_pp = value` pattern for out-parameter writes across the FFI boundary.</p>
+    </div>
+    <div class="function" id="aether_mem_get_int" data-name="aether_mem_get_int">
+      <h3 class="function-name">aether_mem_get_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_int(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+      <p class="doc">Read int32 at byte offset `offset` of `p`. Returns 0 if `p` is null (conflated with stored 0). Slot must be 4-byte aligned. Driver case: C functions with `int *out` out-parameters (mquickjs's get_pc2line et al, write line/col deltas).</p>
+    </div>
+    <div class="function" id="aether_mem_set_int" data-name="aether_mem_set_int">
+      <h3 class="function-name">aether_mem_set_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_int(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+      <p class="doc">Write int32 `value` at byte offset `offset` of `p`. Returns 1 on success, 0 if `p` is null.</p>
+    </div>
+    <div class="function" id="aether_mem_get_long" data-name="aether_mem_get_long">
+      <h3 class="function-name">aether_mem_get_long <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_long(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+      <p class="doc">Read int64-sized value at byte offset `offset` of `p`. Returns 0 if `p` is null (conflated with &quot;stored value is 0&quot; — null-check `p` first if you need to distinguish). Slot must be 8-byte aligned. Driver case: C functions taking `size_t *out` parameters — mquickjs's __unicode_from_utf8 writes the consumed-byte count to a size_t* slot. On 64-bit Linux/macOS (mquickjs targets) size_t is 8 bytes, matching int64_t.</p>
+    </div>
+    <div class="function" id="aether_mem_set_long" data-name="aether_mem_set_long">
+      <h3 class="function-name">aether_mem_set_long <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_long(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+      <p class="doc">Write int64-sized `value` at byte offset `offset` of `p`. Returns 1 on success, 0 if `p` is null. Slot must be 8-byte aligned and at least 8 bytes.</p>
+    </div>
+    <div class="function" id="aether_mem_get_int8" data-name="aether_mem_get_int8">
+      <h3 class="function-name">aether_mem_get_int8 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_int8(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+      <p class="doc">Sized typed-array accessors. Reads/writes at a byte offset with a known C type. Driver case: porting C codebases (mquickjs's TypedArray load/store paths) that walk packed numeric buffers — every port that didn't have these added bespoke C helpers. `get_byte` already exists for unsigned-byte reads; `get_uint8` is the parallel name for type-driven code (so the caller doesn't have to mentally translate &quot;byte&quot; to &quot;uint8&quot;). `get_int8` is the sign-extending variant returning -128..127. 16- and 32-bit accesses use memcpy internally so the offset doesn't need to be naturally aligned (matters on strict-alignment ARM / MIPS; a no-op on x86/x64). Modern compilers fold the memcpy into a single load/store. Float reads widen to Aether `float` (= C `double`); float writes narrow on store with IEEE-754 round-to-nearest. NULL `p` returns 0 (or 0.0); same conflation caveat as get_int / get_long (&quot;p is null&quot; vs. &quot;stored value is 0&quot;). Out-of-range offset is the caller's problem.</p>
+    </div>
+    <div class="function" id="aether_mem_set_int8" data-name="aether_mem_set_int8">
+      <h3 class="function-name">aether_mem_set_int8 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_int8(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_uint8" data-name="aether_mem_get_uint8">
+      <h3 class="function-name">aether_mem_get_uint8 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_uint8(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_uint8" data-name="aether_mem_set_uint8">
+      <h3 class="function-name">aether_mem_set_uint8 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_uint8(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_int16" data-name="aether_mem_get_int16">
+      <h3 class="function-name">aether_mem_get_int16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_int16(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_int16" data-name="aether_mem_set_int16">
+      <h3 class="function-name">aether_mem_set_int16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_int16(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_uint16" data-name="aether_mem_get_uint16">
+      <h3 class="function-name">aether_mem_get_uint16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_uint16(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_uint16" data-name="aether_mem_set_uint16">
+      <h3 class="function-name">aether_mem_set_uint16 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_uint16(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_uint32" data-name="aether_mem_get_uint32">
+      <h3 class="function-name">aether_mem_get_uint32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_uint32(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_uint32" data-name="aether_mem_set_uint32">
+      <h3 class="function-name">aether_mem_set_uint32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_uint32(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_float32" data-name="aether_mem_get_float32">
+      <h3 class="function-name">aether_mem_get_float32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_float32(p, offset) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_float32" data-name="aether_mem_set_float32">
+      <h3 class="function-name">aether_mem_set_float32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_float32(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: float</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_float64" data-name="aether_mem_get_float64">
+      <h3 class="function-name">aether_mem_get_float64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_float64(p, offset) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_float64" data-name="aether_mem_set_float64">
+      <h3 class="function-name">aether_mem_set_float64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_float64(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: float</span></p>
+    </div>
+    <div class="function" id="aether_mem_bits_of_float" data-name="aether_mem_bits_of_float">
+      <h3 class="function-name">aether_mem_bits_of_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_bits_of_float(value) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">value: float</span></p>
+      <p class="doc">Reinterpret an IEEE-754 double's bit pattern as a 64-bit integer. Bitwise type-pun (no value conversion) — preserves NaN payloads, signed-zero, infinities exactly. Aether `float` lowers to C `double` (binary64), so this is the standard 64-bit reinterpret. Driver case: porting C softfloat / IEEE-754 manipulation code (mquickjs libm.c) which uses `float64_as_uint64(d)` everywhere to access exponent/mantissa/sign bits.</p>
+    </div>
+    <div class="function" id="aether_mem_float_from_bits" data-name="aether_mem_float_from_bits">
+      <h3 class="function-name">aether_mem_float_from_bits <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_float_from_bits(bits) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">bits: long</span></p>
+      <p class="doc">Inverse of bits_of_float — reconstitute a double from its 64-bit bit pattern. Same byte-level reinterpret. Used for the `uint64_as_float64` direction in libm.c after softfloat ops.</p>
+    </div>
+    <div class="function" id="aether_mem_clz32" data-name="aether_mem_clz32">
+      <h3 class="function-name">aether_mem_clz32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_clz32(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: int</span></p>
+      <p class="doc">Count leading zeros in a 32-bit value. Wraps __builtin_clz. Undefined behavior if `value` is 0 — caller must guard. Driver case: bit-twiddling code in mquickjs's prop hash sizing, dtoa's pow_ui, regexp range count rounding-up to log2.</p>
+    </div>
+    <div class="function" id="aether_mem_clz64" data-name="aether_mem_clz64">
+      <h3 class="function-name">aether_mem_clz64 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_clz64(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: long</span></p>
+      <p class="doc">Count leading zeros in a 64-bit value. Wraps __builtin_clzll. Same UB-on-zero contract as clz32.</p>
+    </div>
+    <div class="function" id="aether_mem_udiv64_32" data-name="aether_mem_udiv64_32">
+      <h3 class="function-name">aether_mem_udiv64_32 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_udiv64_32(dividend, divisor, premainder) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">dividend: long, divisor: int, premainder: ptr</span></p>
+      <p class="doc">Unsigned 64-by-32-bit division. Returns the uint32 quotient and writes the uint32 remainder to *premainder. Aether's `long` is signed int64; `long / int` sign-extends the dividend, producing wrong results for values with bit 63 set. This primitive does the division as true unsigned at the C boundary. Returns 0 if `premainder` is null or `divisor` is 0 (defensive — caller is expected to provide both). Quotient sign-extends to int return value but the bit pattern matches uint32 since the result fits in 32 bits. Driver: dtoa.c's mp_div1 needs uint64 / uint32 in its inner loop, where the dividend is `(remainder &lt;&lt; 32) | next_limb`.</p>
+    </div>
+    <div class="function" id="aether_mem_call_fn3_int" data-name="aether_mem_call_fn3_int">
+      <h3 class="function-name">aether_mem_call_fn3_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_call_fn3_int(fn, a, b, opaque) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fn: ptr, a: long, b: long, opaque: ptr</span></p>
+      <p class="doc">Invoke a C bare function pointer with a (size_t, size_t, void*) signature, int return. Aether's `fn` lowers to a closure struct (`{ fn, env }`) — incompatible with C's bare fnptr ABI. This shim bridges: Aether receives the C fnptr as `ptr` (raw address) and calls through this extern, which casts and invokes. Driver: porting C functions like rqsort_idx that take a comparator + swap callback from C.</p>
+    </div>
+    <div class="function" id="aether_mem_call_fn3_void" data-name="aether_mem_call_fn3_void">
+      <h3 class="function-name">aether_mem_call_fn3_void <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_call_fn3_void(fn, a, b, opaque)</code></pre>
+      <p class="signature"><span class="sig-params">fn: ptr, a: long, b: long, opaque: ptr</span></p>
+      <p class="doc">Same shape, void return (e.g. swap callbacks).</p>
+    </div>
+    <div class="function" id="aether_mem_copy" data-name="aether_mem_copy">
+      <h3 class="function-name">aether_mem_copy <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_copy(dst, src, n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, src: ptr, n: long</span></p>
+      <p class="doc">Bulk operations — `mem.copy` / `mem.move` / `mem.compare` / `mem.set`. These map directly onto libc memcpy / memmove / memcmp / memset; length is a long (lowered to size_t on the C side). Added per docs/redis-porting-language-gaps.md §P2; the Redis port had to hand-roll byte loops or reach for libc shims for every bulk move/compare.</p>
+    </div>
+    <div class="function" id="aether_mem_move" data-name="aether_mem_move">
+      <h3 class="function-name">aether_mem_move <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_move(dst, src, n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, src: ptr, n: long</span></p>
+    </div>
+    <div class="function" id="aether_mem_compare" data-name="aether_mem_compare">
+      <h3 class="function-name">aether_mem_compare <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_compare(a, b, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr, n: long</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_bulk" data-name="aether_mem_set_bulk">
+      <h3 class="function-name">aether_mem_set_bulk <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_bulk(dst, value, n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, value: int, n: long</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_u16_le" data-name="aether_mem_get_u16_le">
+      <h3 class="function-name">aether_mem_get_u16_le <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_u16_le(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+      <p class="doc">Endian-aware 16/32/64 load/store at a byte offset. Unaligned-safe (each access uses byte-by-byte composition). `_le` is little- endian (low byte first); `_be` is big-endian. 32-bit and 64-bit loads return `long` so the full unsigned range is representable — narrowing to Aether `int` truncates the same way C `(int32_t)u32` does.</p>
+    </div>
+    <div class="function" id="aether_mem_get_u16_be" data-name="aether_mem_get_u16_be">
+      <h3 class="function-name">aether_mem_get_u16_be <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_u16_be(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_u16_le" data-name="aether_mem_set_u16_le">
+      <h3 class="function-name">aether_mem_set_u16_le <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_u16_le(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_u16_be" data-name="aether_mem_set_u16_be">
+      <h3 class="function-name">aether_mem_set_u16_be <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_u16_be(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_u32_le" data-name="aether_mem_get_u32_le">
+      <h3 class="function-name">aether_mem_get_u32_le <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_u32_le(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_u32_be" data-name="aether_mem_get_u32_be">
+      <h3 class="function-name">aether_mem_get_u32_be <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_u32_be(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_u32_le" data-name="aether_mem_set_u32_le">
+      <h3 class="function-name">aether_mem_set_u32_le <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_u32_le(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_u32_be" data-name="aether_mem_set_u32_be">
+      <h3 class="function-name">aether_mem_set_u32_be <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_u32_be(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_u64_le" data-name="aether_mem_get_u64_le">
+      <h3 class="function-name">aether_mem_get_u64_le <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_u64_le(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_get_u64_be" data-name="aether_mem_get_u64_be">
+      <h3 class="function-name">aether_mem_get_u64_be <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_get_u64_be(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_u64_le" data-name="aether_mem_set_u64_le">
+      <h3 class="function-name">aether_mem_set_u64_le <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_u64_le(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="aether_mem_set_u64_be" data-name="aether_mem_set_u64_be">
+      <h3 class="function-name">aether_mem_set_u64_be <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_mem_set_u64_be(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="get_byte" data-name="get_byte">
+      <h3 class="function-name">get_byte <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_byte(p, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int</span></p>
+      <p class="doc">Aether-side wrappers — call shape consistent with the rest of std.* (`mem.get_byte(p, 0)`, `mem.set_byte(p, 0, 0xff)`).</p>
+    </div>
+    <div class="function" id="set_byte" data-name="set_byte">
+      <h3 class="function-name">set_byte <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_byte(p, i, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_byte_sz" data-name="get_byte_sz">
+      <h3 class="function-name">get_byte_sz <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_byte_sz(p, i) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: size_t</span></p>
+    </div>
+    <div class="function" id="set_byte_sz" data-name="set_byte_sz">
+      <h3 class="function-name">set_byte_sz <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_byte_sz(p, i, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: size_t, value: int</span></p>
+    </div>
+    <div class="function" id="get_ptr" data-name="get_ptr">
+      <h3 class="function-name">get_ptr <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_ptr(p, offset) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_ptr" data-name="set_ptr">
+      <h3 class="function-name">set_ptr <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_ptr(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: ptr</span></p>
+    </div>
+    <div class="function" id="get_int" data-name="get_int">
+      <h3 class="function-name">get_int <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_int(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_int" data-name="set_int">
+      <h3 class="function-name">set_int <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_int(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_long" data-name="get_long">
+      <h3 class="function-name">get_long <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_long(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_long" data-name="set_long">
+      <h3 class="function-name">set_long <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_long(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="get_int8" data-name="get_int8">
+      <h3 class="function-name">get_int8 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_int8(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_int8" data-name="set_int8">
+      <h3 class="function-name">set_int8 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_int8(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_uint8" data-name="get_uint8">
+      <h3 class="function-name">get_uint8 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_uint8(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_uint8" data-name="set_uint8">
+      <h3 class="function-name">set_uint8 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_uint8(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_int16" data-name="get_int16">
+      <h3 class="function-name">get_int16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_int16(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_int16" data-name="set_int16">
+      <h3 class="function-name">set_int16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_int16(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_uint16" data-name="get_uint16">
+      <h3 class="function-name">get_uint16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_uint16(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_uint16" data-name="set_uint16">
+      <h3 class="function-name">set_uint16 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_uint16(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_uint32" data-name="get_uint32">
+      <h3 class="function-name">get_uint32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_uint32(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_uint32" data-name="set_uint32">
+      <h3 class="function-name">set_uint32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_uint32(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_float32" data-name="get_float32">
+      <h3 class="function-name">get_float32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_float32(p, offset) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_float32" data-name="set_float32">
+      <h3 class="function-name">set_float32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_float32(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: float</span></p>
+    </div>
+    <div class="function" id="get_float64" data-name="get_float64">
+      <h3 class="function-name">get_float64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_float64(p, offset) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_float64" data-name="set_float64">
+      <h3 class="function-name">set_float64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_float64(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: float</span></p>
+    </div>
+    <div class="function" id="bits_of_float" data-name="bits_of_float">
+      <h3 class="function-name">bits_of_float <span class="kind">fn</span></h3>
+      <pre class="usage"><code>bits_of_float(value) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">value: float</span></p>
+    </div>
+    <div class="function" id="float_from_bits" data-name="float_from_bits">
+      <h3 class="function-name">float_from_bits <span class="kind">fn</span></h3>
+      <pre class="usage"><code>float_from_bits(bits) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">bits: long</span></p>
+    </div>
+    <div class="function" id="clz32" data-name="clz32">
+      <h3 class="function-name">clz32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clz32(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: int</span></p>
+    </div>
+    <div class="function" id="clz64" data-name="clz64">
+      <h3 class="function-name">clz64 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clz64(value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">value: long</span></p>
+    </div>
+    <div class="function" id="udiv64_32" data-name="udiv64_32">
+      <h3 class="function-name">udiv64_32 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>udiv64_32(dividend, divisor, premainder) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">dividend: long, divisor: int, premainder: ptr</span></p>
+    </div>
+    <div class="function" id="call_fn3_int" data-name="call_fn3_int">
+      <h3 class="function-name">call_fn3_int <span class="kind">fn</span></h3>
+      <pre class="usage"><code>call_fn3_int(fn, a, b, opaque) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fn: ptr, a: long, b: long, opaque: ptr</span></p>
+    </div>
+    <div class="function" id="call_fn3_void" data-name="call_fn3_void">
+      <h3 class="function-name">call_fn3_void <span class="kind">fn</span></h3>
+      <pre class="usage"><code>call_fn3_void(fn, a, b, opaque)</code></pre>
+      <p class="signature"><span class="sig-params">fn: ptr, a: long, b: long, opaque: ptr</span></p>
+    </div>
+    <div class="function" id="copy" data-name="copy">
+      <h3 class="function-name">copy <span class="kind">fn</span></h3>
+      <pre class="usage"><code>copy(dst, src, n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, src: ptr, n: long</span></p>
+      <p class="doc">Bulk wrappers — call shape `mem.copy(dst, src, n)`, etc. `set` mirrors libc memset (NOT to be confused with `set_byte` / `set_int` etc, which write a single value at an offset).</p>
+    </div>
+    <div class="function" id="move" data-name="move">
+      <h3 class="function-name">move <span class="kind">fn</span></h3>
+      <pre class="usage"><code>move(dst, src, n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, src: ptr, n: long</span></p>
+    </div>
+    <div class="function" id="compare" data-name="compare">
+      <h3 class="function-name">compare <span class="kind">fn</span></h3>
+      <pre class="usage"><code>compare(a, b, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: ptr, b: ptr, n: long</span></p>
+    </div>
+    <div class="function" id="set" data-name="set">
+      <h3 class="function-name">set <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set(dst, value, n) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">dst: ptr, value: int, n: long</span></p>
+    </div>
+    <div class="function" id="get_u16_le" data-name="get_u16_le">
+      <h3 class="function-name">get_u16_le <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_u16_le(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+      <p class="doc">Endian-aware wrappers.</p>
+    </div>
+    <div class="function" id="get_u16_be" data-name="get_u16_be">
+      <h3 class="function-name">get_u16_be <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_u16_be(p, offset) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_u16_le" data-name="set_u16_le">
+      <h3 class="function-name">set_u16_le <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_u16_le(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="set_u16_be" data-name="set_u16_be">
+      <h3 class="function-name">set_u16_be <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_u16_be(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: int</span></p>
+    </div>
+    <div class="function" id="get_u32_le" data-name="get_u32_le">
+      <h3 class="function-name">get_u32_le <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_u32_le(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="get_u32_be" data-name="get_u32_be">
+      <h3 class="function-name">get_u32_be <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_u32_be(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_u32_le" data-name="set_u32_le">
+      <h3 class="function-name">set_u32_le <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_u32_le(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="set_u32_be" data-name="set_u32_be">
+      <h3 class="function-name">set_u32_be <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_u32_be(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="get_u64_le" data-name="get_u64_le">
+      <h3 class="function-name">get_u64_le <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_u64_le(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="get_u64_be" data-name="get_u64_be">
+      <h3 class="function-name">get_u64_be <span class="kind">fn</span></h3>
+      <pre class="usage"><code>get_u64_be(p, offset) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int</span></p>
+    </div>
+    <div class="function" id="set_u64_le" data-name="set_u64_le">
+      <h3 class="function-name">set_u64_le <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_u64_le(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+    <div class="function" id="set_u64_be" data-name="set_u64_be">
+      <h3 class="function-name">set_u64_be <span class="kind">fn</span></h3>
+      <pre class="usage"><code>set_u64_be(p, offset, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, offset: int, value: long</span></p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/nanoid.html
+++ b/docs/api/nanoid.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nanoid - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search nanoid..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#generate">generate</a></li>
+    <li><a href="#generate_n">generate_n</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li class="active"><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>nanoid</h1>
+    <p class="module-desc">std.nanoid — NanoID (https://github.com/ai/nanoid).</p>
+    <p class="import-line"><code>import std.nanoid</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="generate" data-name="generate">
+      <h3 class="function-name">generate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>generate()</code></pre>
+      <p class="doc">Generate a 21-char NanoID. Returns (id, &quot;&quot;) on success, (&quot;&quot;, error) on CSPRNG failure.</p>
+    </div>
+    <div class="function" id="generate_n" data-name="generate_n">
+      <h3 class="function-name">generate_n <span class="kind">fn</span></h3>
+      <pre class="usage"><code>generate_n(n) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">n: int</span></p>
+      <p class="doc">Generate an `n`-char NanoID with the standard URL-safe alphabet. `n` must be &gt;= 1. For collision math: ~2.7 million IDs/sec for ~1000 years to have a 1% collision probability at n=21. Cut `n` only if you understand the birthday-bound implication.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/net.html
+++ b/docs/api/net.html
@@ -13,20 +13,31 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search net..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
-    <li><a href="#"></a></li>
-    <li><a href="#void">void</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#void">void</a></li>
-    <li><a href="#void">void</a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
-    <li><a href="#"></a></li>
+    <li><a href="#tcp_connect_raw">tcp_connect_raw</a></li>
+    <li><a href="#tcp_send_raw">tcp_send_raw</a></li>
+    <li><a href="#tcp_receive_raw">tcp_receive_raw</a></li>
+    <li><a href="#tcp_close">tcp_close</a></li>
+    <li><a href="#tcp_listen_raw">tcp_listen_raw</a></li>
+    <li><a href="#tcp_accept_raw">tcp_accept_raw</a></li>
+    <li><a href="#tcp_server_close">tcp_server_close</a></li>
+    <li><a href="#http_get_raw">http_get_raw</a></li>
+    <li><a href="#http_post_raw">http_post_raw</a></li>
+    <li><a href="#http_put_raw">http_put_raw</a></li>
+    <li><a href="#http_delete_raw">http_delete_raw</a></li>
+    <li><a href="#http_response_free">http_response_free</a></li>
+    <li><a href="#http_response_status_code">http_response_status_code</a></li>
+    <li><a href="#http_response_body_str">http_response_body_str</a></li>
+    <li><a href="#http_response_headers_str">http_response_headers_str</a></li>
+    <li><a href="#http_response_status">http_response_status</a></li>
+    <li><a href="#http_response_body">http_response_body</a></li>
+    <li><a href="#http_response_headers">http_response_headers</a></li>
+    <li><a href="#http_response_error">http_response_error</a></li>
+    <li><a href="#http_response_ok">http_response_ok</a></li>
+    <li><a href="#http_server_create">http_server_create</a></li>
     <li><a href="#http_server_bind_raw">http_server_bind_raw</a></li>
+    <li><a href="#http_server_port">http_server_port</a></li>
     <li><a href="#http_server_start_raw">http_server_start_raw</a></li>
     <li><a href="#http_server_stop">http_server_stop</a></li>
     <li><a href="#http_server_free">http_server_free</a></li>
@@ -40,283 +51,420 @@
     <li><a href="#http_get_query_param">http_get_query_param</a></li>
     <li><a href="#http_get_path_param">http_get_path_param</a></li>
     <li><a href="#http_request_free">http_request_free</a></li>
+    <li><a href="#http_response_create">http_response_create</a></li>
     <li><a href="#http_response_set_status">http_response_set_status</a></li>
     <li><a href="#http_response_set_header">http_response_set_header</a></li>
     <li><a href="#http_response_set_body">http_response_set_body</a></li>
+    <li><a href="#http_response_set_body_n">http_response_set_body_n</a></li>
     <li><a href="#http_response_json">http_response_json</a></li>
-    <li><a href="#http_response_serialize">http_response_serialize</a></li>
     <li><a href="#http_server_response_free">http_server_response_free</a></li>
-    <li><a href="#http_route_matches">http_route_matches</a></li>
-    <li><a href="#http_status_text">http_status_text</a></li>
-    <li><a href="#http_mime_type">http_mime_type</a></li>
-    <li><a href="#http_serve_file">http_serve_file</a></li>
-    <li><a href="#http_serve_static">http_serve_static</a></li>
-    <li><a href="#void">void</a></li>
+    <li><a href="#http_server_set_actor_handler">http_server_set_actor_handler</a></li>
     <li><a href="#http_request_method">http_request_method</a></li>
     <li><a href="#http_request_path">http_request_path</a></li>
     <li><a href="#http_request_body">http_request_body</a></li>
+    <li><a href="#http_request_body_length">http_request_body_length</a></li>
     <li><a href="#http_request_query">http_request_query</a></li>
-    <li><a href="#http_response_free">http_response_free</a></li>
-    <li><a href="#http_response_status">http_response_status</a></li>
-    <li><a href="#http_response_body">http_response_body</a></li>
-    <li><a href="#http_response_headers">http_response_headers</a></li>
-    <li><a href="#http_response_error">http_response_error</a></li>
-    <li><a href="#http_response_ok">http_response_ok</a></li>
-    <li><a href="#http_response_status_code">http_response_status_code</a></li>
-    <li><a href="#http_response_body_str">http_response_body_str</a></li>
-    <li><a href="#http_response_headers_str">http_response_headers_str</a></li>
-    <li><a href="#tcp_send_raw">tcp_send_raw</a></li>
-    <li><a href="#tcp_receive_raw">tcp_receive_raw</a></li>
-    <li><a href="#tcp_close">tcp_close</a></li>
-    <li><a href="#tcp_server_close">tcp_server_close</a></li>
+    <li><a href="#http_serve_static">http_serve_static</a></li>
+    <li><a href="#http_serve_file">http_serve_file</a></li>
+    <li><a href="#http_mime_type">http_mime_type</a></li>
+    <li><a href="#ae_io_await">ae_io_await</a></li>
+    <li><a href="#ae_io_cancel">ae_io_cancel</a></li>
+    <li><a href="#ae_pipe_open">ae_pipe_open</a></li>
+    <li><a href="#ae_pipe_write_fd">ae_pipe_write_fd</a></li>
+    <li><a href="#ae_fd_write">ae_fd_write</a></li>
+    <li><a href="#ae_fd_close">ae_fd_close</a></li>
+    <li><a href="#await_io">await_io</a></li>
+    <li><a href="#pipe_open">pipe_open</a></li>
+    <li><a href="#pipe_write_fd">pipe_write_fd</a></li>
+    <li><a href="#fd_write">fd_write</a></li>
+    <li><a href="#fd_close">fd_close</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li class="active"><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li class="active"><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>net</h1>
-    <p class="module-desc">HTTP client, server, and networking</p>
+    <p class="module-desc">std.net - Networking Module Import with: import std.net Naming convention: category_action - tcp_* : TCP client/server operations - http_* : HTTP client operations - http_server_* : HTTP server operations</p>
+    <p class="import-line"><code>import std.net</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-      <p class="doc">Actor dispatch mode (opt-in: set via http_server_set_actor_handler)</p>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(send_fn)</code></pre>
-      <p class="doc">Fire-and-forget: spawn one actor per request</p>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>(spawn_fn)</code></pre>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(release_fn)</code></pre>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(step_fn)</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-      <p class="doc">Multi-accept: one accept thread per core with SO_REUSEPORT (opt-in)</p>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-    </div>
-    <div class="function" id="" data-name="">
-      <h3 class="function-name"></h3>
-      <pre class="usage"><code>()</code></pre>
-    </div>
-    <div class="function" id="http_server_bind_raw" data-name="http_server_bind_raw">
-      <h3 class="function-name">http_server_bind_raw</h3>
-      <pre class="usage"><code>http_server_bind_raw(server, host, port)</code></pre>
-    </div>
-    <div class="function" id="http_server_start_raw" data-name="http_server_start_raw">
-      <h3 class="function-name">http_server_start_raw</h3>
-      <pre class="usage"><code>http_server_start_raw(server)</code></pre>
-    </div>
-    <div class="function" id="http_server_stop" data-name="http_server_stop">
-      <h3 class="function-name">http_server_stop</h3>
-      <pre class="usage"><code>http_server_stop(server)</code></pre>
-    </div>
-    <div class="function" id="http_server_free" data-name="http_server_free">
-      <h3 class="function-name">http_server_free</h3>
-      <pre class="usage"><code>http_server_free(server)</code></pre>
-    </div>
-    <div class="function" id="http_server_add_route" data-name="http_server_add_route">
-      <h3 class="function-name">http_server_add_route</h3>
-      <pre class="usage"><code>http_server_add_route(server, method, path, handler, user_data)</code></pre>
-      <p class="doc">Routing</p>
-    </div>
-    <div class="function" id="http_server_get" data-name="http_server_get">
-      <h3 class="function-name">http_server_get</h3>
-      <pre class="usage"><code>http_server_get(server, path, handler, user_data)</code></pre>
-    </div>
-    <div class="function" id="http_server_post" data-name="http_server_post">
-      <h3 class="function-name">http_server_post</h3>
-      <pre class="usage"><code>http_server_post(server, path, handler, user_data)</code></pre>
-    </div>
-    <div class="function" id="http_server_put" data-name="http_server_put">
-      <h3 class="function-name">http_server_put</h3>
-      <pre class="usage"><code>http_server_put(server, path, handler, user_data)</code></pre>
-    </div>
-    <div class="function" id="http_server_delete" data-name="http_server_delete">
-      <h3 class="function-name">http_server_delete</h3>
-      <pre class="usage"><code>http_server_delete(server, path, handler, user_data)</code></pre>
-    </div>
-    <div class="function" id="http_server_use_middleware" data-name="http_server_use_middleware">
-      <h3 class="function-name">http_server_use_middleware</h3>
-      <pre class="usage"><code>http_server_use_middleware(server, middleware, user_data)</code></pre>
-      <p class="doc">Middleware</p>
-    </div>
-    <div class="function" id="http_get_header" data-name="http_get_header">
-      <h3 class="function-name">http_get_header</h3>
-      <pre class="usage"><code>http_get_header(req, key)</code></pre>
-    </div>
-    <div class="function" id="http_get_query_param" data-name="http_get_query_param">
-      <h3 class="function-name">http_get_query_param</h3>
-      <pre class="usage"><code>http_get_query_param(req, key)</code></pre>
-    </div>
-    <div class="function" id="http_get_path_param" data-name="http_get_path_param">
-      <h3 class="function-name">http_get_path_param</h3>
-      <pre class="usage"><code>http_get_path_param(req, key)</code></pre>
-    </div>
-    <div class="function" id="http_request_free" data-name="http_request_free">
-      <h3 class="function-name">http_request_free</h3>
-      <pre class="usage"><code>http_request_free(req)</code></pre>
-    </div>
-    <div class="function" id="http_response_set_status" data-name="http_response_set_status">
-      <h3 class="function-name">http_response_set_status</h3>
-      <pre class="usage"><code>http_response_set_status(res, code)</code></pre>
-    </div>
-    <div class="function" id="http_response_set_header" data-name="http_response_set_header">
-      <h3 class="function-name">http_response_set_header</h3>
-      <pre class="usage"><code>http_response_set_header(res, key, value)</code></pre>
-    </div>
-    <div class="function" id="http_response_set_body" data-name="http_response_set_body">
-      <h3 class="function-name">http_response_set_body</h3>
-      <pre class="usage"><code>http_response_set_body(res, body)</code></pre>
-    </div>
-    <div class="function" id="http_response_json" data-name="http_response_json">
-      <h3 class="function-name">http_response_json</h3>
-      <pre class="usage"><code>http_response_json(res, json)</code></pre>
-    </div>
-    <div class="function" id="http_response_serialize" data-name="http_response_serialize">
-      <h3 class="function-name">http_response_serialize</h3>
-      <pre class="usage"><code>http_response_serialize(res)</code></pre>
-    </div>
-    <div class="function" id="http_server_response_free" data-name="http_server_response_free">
-      <h3 class="function-name">http_server_response_free</h3>
-      <pre class="usage"><code>http_server_response_free(res)</code></pre>
-    </div>
-    <div class="function" id="http_route_matches" data-name="http_route_matches">
-      <h3 class="function-name">http_route_matches</h3>
-      <pre class="usage"><code>http_route_matches(pattern, path, req)</code></pre>
-      <p class="doc">Helpers</p>
-    </div>
-    <div class="function" id="http_status_text" data-name="http_status_text">
-      <h3 class="function-name">http_status_text</h3>
-      <pre class="usage"><code>http_status_text(code)</code></pre>
-    </div>
-    <div class="function" id="http_mime_type" data-name="http_mime_type">
-      <h3 class="function-name">http_mime_type</h3>
-      <pre class="usage"><code>http_mime_type(path)</code></pre>
-      <p class="doc">MIME type detection</p>
-    </div>
-    <div class="function" id="http_serve_file" data-name="http_serve_file">
-      <h3 class="function-name">http_serve_file</h3>
-      <pre class="usage"><code>http_serve_file(res, filepath)</code></pre>
-      <p class="doc">Static file serving</p>
-    </div>
-    <div class="function" id="http_serve_static" data-name="http_serve_static">
-      <h3 class="function-name">http_serve_static</h3>
-      <pre class="usage"><code>http_serve_static(req, res, base_dir)</code></pre>
-    </div>
-    <div class="function" id="void" data-name="void">
-      <h3 class="function-name">void</h3>
-      <pre class="usage"><code>void(release_fn)</code></pre>
-    </div>
-    <div class="function" id="http_request_method" data-name="http_request_method">
-      <h3 class="function-name">http_request_method</h3>
-      <pre class="usage"><code>http_request_method(req)</code></pre>
-      <p class="doc">Request accessors (for use from Aether .ae code via opaque ptr)</p>
-    </div>
-    <div class="function" id="http_request_path" data-name="http_request_path">
-      <h3 class="function-name">http_request_path</h3>
-      <pre class="usage"><code>http_request_path(req)</code></pre>
-    </div>
-    <div class="function" id="http_request_body" data-name="http_request_body">
-      <h3 class="function-name">http_request_body</h3>
-      <pre class="usage"><code>http_request_body(req)</code></pre>
-    </div>
-    <div class="function" id="http_request_query" data-name="http_request_query">
-      <h3 class="function-name">http_request_query</h3>
-      <pre class="usage"><code>http_request_query(req)</code></pre>
-    </div>
-    <div class="function" id="http_response_free" data-name="http_response_free">
-      <h3 class="function-name">http_response_free</h3>
-      <pre class="usage"><code>http_response_free(response)</code></pre>
-    </div>
-    <div class="function" id="http_response_status" data-name="http_response_status">
-      <h3 class="function-name">http_response_status</h3>
-      <pre class="usage"><code>http_response_status(response)</code></pre>
-      <p class="doc">Response field accessors. All are NULL-safe: passing NULL or a freed response returns a sensible default (0 or &quot;&quot;) rather than crashing. Returned const char* pointers are owned by the response struct and valid until http_response_free() is called.</p>
-    </div>
-    <div class="function" id="http_response_body" data-name="http_response_body">
-      <h3 class="function-name">http_response_body</h3>
-      <pre class="usage"><code>http_response_body(response)</code></pre>
-    </div>
-    <div class="function" id="http_response_headers" data-name="http_response_headers">
-      <h3 class="function-name">http_response_headers</h3>
-      <pre class="usage"><code>http_response_headers(response)</code></pre>
-    </div>
-    <div class="function" id="http_response_error" data-name="http_response_error">
-      <h3 class="function-name">http_response_error</h3>
-      <pre class="usage"><code>http_response_error(response)</code></pre>
-    </div>
-    <div class="function" id="http_response_ok" data-name="http_response_ok">
-      <h3 class="function-name">http_response_ok</h3>
-      <pre class="usage"><code>http_response_ok(response)</code></pre>
-      <p class="doc">Convenience: returns 1 if the request succeeded (no transport error AND HTTP status is in the 2xx range), 0 otherwise. Use this for the common &quot;did it work?&quot; check instead of chaining error/status calls.</p>
-    </div>
-    <div class="function" id="http_response_status_code" data-name="http_response_status_code">
-      <h3 class="function-name">http_response_status_code</h3>
-      <pre class="usage"><code>http_response_status_code(response)</code></pre>
-      <p class="doc">Legacy accessor aliases kept for callers that used the older `_code` / `_str` names. Prefer the short names above.</p>
-    </div>
-    <div class="function" id="http_response_body_str" data-name="http_response_body_str">
-      <h3 class="function-name">http_response_body_str</h3>
-      <pre class="usage"><code>http_response_body_str(response)</code></pre>
-    </div>
-    <div class="function" id="http_response_headers_str" data-name="http_response_headers_str">
-      <h3 class="function-name">http_response_headers_str</h3>
-      <pre class="usage"><code>http_response_headers_str(response)</code></pre>
+    <div class="function" id="tcp_connect_raw" data-name="tcp_connect_raw">
+      <h3 class="function-name">tcp_connect_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tcp_connect_raw(host, port) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">host: string, port: int</span></p>
+      <p class="doc">TCP Client - raw externs (escape hatch)</p>
     </div>
     <div class="function" id="tcp_send_raw" data-name="tcp_send_raw">
-      <h3 class="function-name">tcp_send_raw</h3>
-      <pre class="usage"><code>tcp_send_raw(sock, data)</code></pre>
+      <h3 class="function-name">tcp_send_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tcp_send_raw(sock, data) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr, data: string</span></p>
     </div>
     <div class="function" id="tcp_receive_raw" data-name="tcp_receive_raw">
-      <h3 class="function-name">tcp_receive_raw</h3>
-      <pre class="usage"><code>tcp_receive_raw(sock, max_bytes)</code></pre>
+      <h3 class="function-name">tcp_receive_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tcp_receive_raw(sock, max_bytes) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr, max_bytes: int</span></p>
     </div>
     <div class="function" id="tcp_close" data-name="tcp_close">
-      <h3 class="function-name">tcp_close</h3>
-      <pre class="usage"><code>tcp_close(sock)</code></pre>
+      <h3 class="function-name">tcp_close <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tcp_close(sock) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr</span></p>
+    </div>
+    <div class="function" id="tcp_listen_raw" data-name="tcp_listen_raw">
+      <h3 class="function-name">tcp_listen_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tcp_listen_raw(port) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">port: int</span></p>
+      <p class="doc">TCP Server - raw externs</p>
+    </div>
+    <div class="function" id="tcp_accept_raw" data-name="tcp_accept_raw">
+      <h3 class="function-name">tcp_accept_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tcp_accept_raw(server) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
     </div>
     <div class="function" id="tcp_server_close" data-name="tcp_server_close">
-      <h3 class="function-name">tcp_server_close</h3>
-      <pre class="usage"><code>tcp_server_close(server)</code></pre>
+      <h3 class="function-name">tcp_server_close <span class="kind">extern</span></h3>
+      <pre class="usage"><code>tcp_server_close(server) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+    </div>
+    <div class="function" id="http_get_raw" data-name="http_get_raw">
+      <h3 class="function-name">http_get_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_get_raw(url) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">url: string</span></p>
+      <p class="doc">HTTP Client — raw ptr-returning externs (escape hatch). Most callers should use the Go-style wrappers in std.http which provide (body, err) tuple returns and auto-free the response.</p>
+    </div>
+    <div class="function" id="http_post_raw" data-name="http_post_raw">
+      <h3 class="function-name">http_post_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_post_raw(url, body, content_type) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">url: string, body: string, content_type: string</span></p>
+    </div>
+    <div class="function" id="http_put_raw" data-name="http_put_raw">
+      <h3 class="function-name">http_put_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_put_raw(url, body, content_type) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">url: string, body: string, content_type: string</span></p>
+    </div>
+    <div class="function" id="http_delete_raw" data-name="http_delete_raw">
+      <h3 class="function-name">http_delete_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_delete_raw(url) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">url: string</span></p>
+    </div>
+    <div class="function" id="http_response_free" data-name="http_response_free">
+      <h3 class="function-name">http_response_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_free(response)</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_status_code" data-name="http_response_status_code">
+      <h3 class="function-name">http_response_status_code <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_status_code(response) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_body_str" data-name="http_response_body_str">
+      <h3 class="function-name">http_response_body_str <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_body_str(response) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_headers_str" data-name="http_response_headers_str">
+      <h3 class="function-name">http_response_headers_str <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_headers_str(response) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_status" data-name="http_response_status">
+      <h3 class="function-name">http_response_status <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_status(response) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+      <p class="doc">HTTP Client - response accessors Use these to read fields out of the response returned by http_get/post/etc. http_get always returns a non-null response (unless out of memory); inspect the error accessor or use http_response_ok to check for success.</p>
+    </div>
+    <div class="function" id="http_response_body" data-name="http_response_body">
+      <h3 class="function-name">http_response_body <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_body(response) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_headers" data-name="http_response_headers">
+      <h3 class="function-name">http_response_headers <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_headers(response) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_error" data-name="http_response_error">
+      <h3 class="function-name">http_response_error <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_error(response) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_ok" data-name="http_response_ok">
+      <h3 class="function-name">http_response_ok <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_ok(response) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">response: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_create" data-name="http_server_create">
+      <h3 class="function-name">http_server_create <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_create(port) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">port: int</span></p>
+      <p class="doc">HTTP Server - lifecycle</p>
+    </div>
+    <div class="function" id="http_server_bind_raw" data-name="http_server_bind_raw">
+      <h3 class="function-name">http_server_bind_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_bind_raw(server, host, port) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, host: string, port: int</span></p>
+    </div>
+    <div class="function" id="http_server_port" data-name="http_server_port">
+      <h3 class="function-name">http_server_port <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_port(server) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_start_raw" data-name="http_server_start_raw">
+      <h3 class="function-name">http_server_start_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_start_raw(server) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_stop" data-name="http_server_stop">
+      <h3 class="function-name">http_server_stop <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_stop(server)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_free" data-name="http_server_free">
+      <h3 class="function-name">http_server_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_free(server)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_add_route" data-name="http_server_add_route">
+      <h3 class="function-name">http_server_add_route <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_add_route(server, method, path, handler, user_data)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, method: string, path: string, handler: ptr, user_data: ptr</span></p>
+      <p class="doc">HTTP Server - routing</p>
+    </div>
+    <div class="function" id="http_server_get" data-name="http_server_get">
+      <h3 class="function-name">http_server_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_get(server, path, handler, user_data)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, path: string, handler: ptr, user_data: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_post" data-name="http_server_post">
+      <h3 class="function-name">http_server_post <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_post(server, path, handler, user_data)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, path: string, handler: ptr, user_data: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_put" data-name="http_server_put">
+      <h3 class="function-name">http_server_put <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_put(server, path, handler, user_data)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, path: string, handler: ptr, user_data: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_delete" data-name="http_server_delete">
+      <h3 class="function-name">http_server_delete <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_delete(server, path, handler, user_data)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, path: string, handler: ptr, user_data: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_use_middleware" data-name="http_server_use_middleware">
+      <h3 class="function-name">http_server_use_middleware <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_use_middleware(server, middleware, user_data)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, middleware: ptr, user_data: ptr</span></p>
+      <p class="doc">HTTP Server - middleware</p>
+    </div>
+    <div class="function" id="http_get_header" data-name="http_get_header">
+      <h3 class="function-name">http_get_header <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_get_header(req, name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr, name: string</span></p>
+      <p class="doc">HTTP Request - accessors</p>
+    </div>
+    <div class="function" id="http_get_query_param" data-name="http_get_query_param">
+      <h3 class="function-name">http_get_query_param <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_get_query_param(req, name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr, name: string</span></p>
+    </div>
+    <div class="function" id="http_get_path_param" data-name="http_get_path_param">
+      <h3 class="function-name">http_get_path_param <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_get_path_param(req, name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr, name: string</span></p>
+    </div>
+    <div class="function" id="http_request_free" data-name="http_request_free">
+      <h3 class="function-name">http_request_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_request_free(req)</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr</span></p>
+    </div>
+    <div class="function" id="http_response_create" data-name="http_response_create">
+      <h3 class="function-name">http_response_create <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_create() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">HTTP Response - building</p>
+    </div>
+    <div class="function" id="http_response_set_status" data-name="http_response_set_status">
+      <h3 class="function-name">http_response_set_status <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_set_status(res, code)</code></pre>
+      <p class="signature"><span class="sig-params">res: ptr, code: int</span></p>
+    </div>
+    <div class="function" id="http_response_set_header" data-name="http_response_set_header">
+      <h3 class="function-name">http_response_set_header <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_set_header(res, name, value)</code></pre>
+      <p class="signature"><span class="sig-params">res: ptr, name: string, value: string</span></p>
+    </div>
+    <div class="function" id="http_response_set_body" data-name="http_response_set_body">
+      <h3 class="function-name">http_response_set_body <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_set_body(res, body)</code></pre>
+      <p class="signature"><span class="sig-params">res: ptr, body: string</span></p>
+    </div>
+    <div class="function" id="http_response_set_body_n" data-name="http_response_set_body_n">
+      <h3 class="function-name">http_response_set_body_n <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_set_body_n(res, body, length)</code></pre>
+      <p class="signature"><span class="sig-params">res: ptr, body: string, length: int</span></p>
+      <p class="doc">Length-aware sibling — binary-safe set_body. Use when the body may contain embedded NULs (binary content, gzip, packed binary); plain http_response_set_body uses strlen and truncates at the first NUL.</p>
+    </div>
+    <div class="function" id="http_response_json" data-name="http_response_json">
+      <h3 class="function-name">http_response_json <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_response_json(res, json)</code></pre>
+      <p class="signature"><span class="sig-params">res: ptr, json: string</span></p>
+    </div>
+    <div class="function" id="http_server_response_free" data-name="http_server_response_free">
+      <h3 class="function-name">http_server_response_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_response_free(res)</code></pre>
+      <p class="signature"><span class="sig-params">res: ptr</span></p>
+    </div>
+    <div class="function" id="http_server_set_actor_handler" data-name="http_server_set_actor_handler">
+      <h3 class="function-name">http_server_set_actor_handler <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_server_set_actor_handler(server, step_fn, send_fn, spawn_fn, release_fn)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr, step_fn: ptr, send_fn: ptr, spawn_fn: ptr, release_fn: ptr</span></p>
+      <p class="doc">HTTP Server - actor dispatch mode</p>
+    </div>
+    <div class="function" id="http_request_method" data-name="http_request_method">
+      <h3 class="function-name">http_request_method <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_request_method(req) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr</span></p>
+      <p class="doc">HTTP Request - field accessors (for actor dispatch mode)</p>
+    </div>
+    <div class="function" id="http_request_path" data-name="http_request_path">
+      <h3 class="function-name">http_request_path <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_request_path(req) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr</span></p>
+    </div>
+    <div class="function" id="http_request_body" data-name="http_request_body">
+      <h3 class="function-name">http_request_body <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_request_body(req) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr</span></p>
+    </div>
+    <div class="function" id="http_request_body_length" data-name="http_request_body_length">
+      <h3 class="function-name">http_request_body_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_request_body_length(req) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr</span></p>
+      <p class="doc">See std/http/module.ae for the rationale; body_length avoids strlen-truncation on binary bodies.</p>
+    </div>
+    <div class="function" id="http_request_query" data-name="http_request_query">
+      <h3 class="function-name">http_request_query <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_request_query(req) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr</span></p>
+    </div>
+    <div class="function" id="http_serve_static" data-name="http_serve_static">
+      <h3 class="function-name">http_serve_static <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_serve_static(req, res, base_dir)</code></pre>
+      <p class="signature"><span class="sig-params">req: ptr, res: ptr, base_dir: string</span></p>
+      <p class="doc">Static file serving</p>
+    </div>
+    <div class="function" id="http_serve_file" data-name="http_serve_file">
+      <h3 class="function-name">http_serve_file <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_serve_file(res, filepath)</code></pre>
+      <p class="signature"><span class="sig-params">res: ptr, filepath: string</span></p>
+    </div>
+    <div class="function" id="http_mime_type" data-name="http_mime_type">
+      <h3 class="function-name">http_mime_type <span class="kind">extern</span></h3>
+      <pre class="usage"><code>http_mime_type(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="ae_io_await" data-name="ae_io_await">
+      <h3 class="function-name">ae_io_await <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ae_io_await(fd) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+      <p class="doc">Reactor-pattern async I/O — suspends the current actor until the fd becomes readable, without blocking any scheduler thread. Returns 0 on success, -1 on failure (called outside an actor context, or the runtime refused the fd). When the fd becomes ready, the scheduler delivers an `IoReady { fd: int, events: int }` message to the actor's mailbox, which the actor handles in a `receive` arm. The user's program must define the message shape: message IoReady { fd: int, events: int } The message registry reserves an ID for this name so the generated dispatch table routes runtime-delivered notifications to the user-written handler.</p>
+    </div>
+    <div class="function" id="ae_io_cancel" data-name="ae_io_cancel">
+      <h3 class="function-name">ae_io_cancel <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ae_io_cancel(fd)</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+    </div>
+    <div class="function" id="ae_pipe_open" data-name="ae_pipe_open">
+      <h3 class="function-name">ae_pipe_open <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ae_pipe_open() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Minimal fd primitives used by the await_io end-to-end test and any integration code that needs to produce a plain readable fd without going through the TCP/HTTP layers. Pipe support is POSIX-only.</p>
+    </div>
+    <div class="function" id="ae_pipe_write_fd" data-name="ae_pipe_write_fd">
+      <h3 class="function-name">ae_pipe_write_fd <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ae_pipe_write_fd() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="ae_fd_write" data-name="ae_fd_write">
+      <h3 class="function-name">ae_fd_write <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ae_fd_write(fd, data) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, data: string</span></p>
+    </div>
+    <div class="function" id="ae_fd_close" data-name="ae_fd_close">
+      <h3 class="function-name">ae_fd_close <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ae_fd_close(fd)</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+    </div>
+    <div class="function" id="await_io" data-name="await_io">
+      <h3 class="function-name">await_io <span class="kind">fn</span></h3>
+      <pre class="usage"><code>await_io(fd) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+      <p class="doc">Go-style wrapper: returns &quot;&quot; on success, error string on failure. Most callers should use this rather than the raw extern.</p>
+    </div>
+    <div class="function" id="pipe_open" data-name="pipe_open">
+      <h3 class="function-name">pipe_open <span class="kind">fn</span></h3>
+      <pre class="usage"><code>pipe_open() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Aether-level aliases so user code can reach the fd helpers via the namespace prefix (e.g. `net.pipe_open`, `net.fd_write`). Aether wrappers are cloned into the user's program with the namespace prefix applied; bare externs keep their C names and only resolve through unqualified matching.</p>
+    </div>
+    <div class="function" id="pipe_write_fd" data-name="pipe_write_fd">
+      <h3 class="function-name">pipe_write_fd <span class="kind">fn</span></h3>
+      <pre class="usage"><code>pipe_write_fd() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="fd_write" data-name="fd_write">
+      <h3 class="function-name">fd_write <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fd_write(fd, data) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int, data: string</span></p>
+    </div>
+    <div class="function" id="fd_close" data-name="fd_close">
+      <h3 class="function-name">fd_close <span class="kind">fn</span></h3>
+      <pre class="usage"><code>fd_close(fd) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fd: int</span></p>
+      <p class="doc">Close an fd. Wraps the void extern as an int wrapper returning 0 so the generated C has a concrete return type; callers can ignore it.</p>
     </div>
   </div>
 </main>

--- a/docs/api/os.html
+++ b/docs/api/os.html
@@ -13,70 +13,458 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search os..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
-    <li><a href="#os_system">os_system</a></li>
-    <li><a href="#os_exec_raw">os_exec_raw</a></li>
-    <li><a href="#os_getenv">os_getenv</a></li>
-    <li><a href="#os_execv">os_execv</a></li>
-    <li><a href="#os_which">os_which</a></li>
-    <li><a href="#os_run">os_run</a></li>
-    <li><a href="#os_run_capture_raw">os_run_capture_raw</a></li>
+    <li><a href="#system">system</a></li>
+    <li><a href="#exec_raw">exec_raw</a></li>
+    <li><a href="#run">run</a></li>
+    <li><a href="#run_capture_raw">run_capture_raw</a></li>
+    <li><a href="#run_capture_status_raw">run_capture_status_raw</a></li>
+    <li><a href="#run_pipe_raw">run_pipe_raw</a></li>
+    <li><a href="#wait_pid_raw">wait_pid_raw</a></li>
+    <li><a href="#run_pipe_drain_and_wait_raw">run_pipe_drain_and_wait_raw</a></li>
+    <li><a href="#getenv">getenv</a></li>
+    <li><a href="#which">which</a></li>
+    <li><a href="#aether_args_count">aether_args_count</a></li>
+    <li><a href="#aether_args_get">aether_args_get</a></li>
+    <li><a href="#aether_argv0">aether_argv0</a></li>
+    <li><a href="#aether_argv_raw">aether_argv_raw</a></li>
+    <li><a href="#aether_args_seal">aether_args_seal</a></li>
+    <li><a href="#aether_args_sealed">aether_args_sealed</a></li>
+    <li><a href="#args_seal">args_seal</a></li>
+    <li><a href="#args_sealed">args_sealed</a></li>
+    <li><a href="#execv">execv</a></li>
+    <li><a href="#now_utc_iso8601_raw">now_utc_iso8601_raw</a></li>
+    <li><a href="#getpid_raw">getpid_raw</a></li>
+    <li><a href="#exit">exit</a></li>
+    <li><a href="#wall_seconds_raw">wall_seconds_raw</a></li>
+    <li><a href="#wall_micros_raw">wall_micros_raw</a></li>
+    <li><a href="#now_monotonic_ms_raw">now_monotonic_ms_raw</a></li>
+    <li><a href="#now_monotonic_ns_raw">now_monotonic_ns_raw</a></li>
+    <li><a href="#now_unix_ms_raw">now_unix_ms_raw</a></li>
+    <li><a href="#now_local_fill_raw">now_local_fill_raw</a></li>
+    <li><a href="#now_local_iso8601_raw">now_local_iso8601_raw</a></li>
+    <li><a href="#platform_raw">platform_raw</a></li>
+    <li><a href="#io_setenv_raw">io_setenv_raw</a></li>
+    <li><a href="#io_unsetenv_raw">io_unsetenv_raw</a></li>
+    <li><a href="#exec">exec</a></li>
+    <li><a href="#run_capture">run_capture</a></li>
+    <li><a href="#argv0">argv0</a></li>
+    <li><a href="#now_utc_iso8601">now_utc_iso8601</a></li>
+    <li><a href="#getpid">getpid</a></li>
+    <li><a href="#wall_seconds">wall_seconds</a></li>
+    <li><a href="#wall_micros">wall_micros</a></li>
+    <li><a href="#now_monotonic_ms">now_monotonic_ms</a></li>
+    <li><a href="#now_monotonic_ns">now_monotonic_ns</a></li>
+    <li><a href="#now_unix_ms">now_unix_ms</a></li>
+    <li><a href="#now_local">now_local</a></li>
+    <li><a href="#now_local_iso8601">now_local_iso8601</a></li>
+    <li><a href="#LocalTime">LocalTime</a></li>
+    <li><a href="#platform">platform</a></li>
+    <li><a href="#setenv">setenv</a></li>
+    <li><a href="#unsetenv">unsetenv</a></li>
+    <li><a href="#run_pipe">run_pipe</a></li>
+    <li><a href="#wait_pid">wait_pid</a></li>
+    <li><a href="#run_pipe_drain_and_wait">run_pipe_drain_and_wait</a></li>
+    <li><a href="#kill_raw">kill_raw</a></li>
+    <li><a href="#wait_pid_timeout_raw">wait_pid_timeout_raw</a></li>
+    <li><a href="#run_supervised_raw">run_supervised_raw</a></li>
+    <li><a href="#kill">kill</a></li>
+    <li><a href="#wait_pid_timeout">wait_pid_timeout</a></li>
+    <li><a href="#run_supervised">run_supervised</a></li>
+    <li><a href="#run_full_raw">run_full_raw</a></li>
+    <li><a href="#run_full">run_full</a></li>
+    <li><a href="#chdir_raw">chdir_raw</a></li>
+    <li><a href="#getcwd_raw">getcwd_raw</a></li>
+    <li><a href="#chdir">chdir</a></li>
+    <li><a href="#getcwd">getcwd</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li class="active"><a href="os.html">os</a></li>
-    <li><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li class="active"><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>os</h1>
-    <p class="module-desc"></p>
+    <p class="module-desc">std.os - Shell &amp; Process Execution Import with: import std.os</p>
+    <p class="import-line"><code>import std.os</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="os_system" data-name="os_system">
-      <h3 class="function-name">os_system</h3>
-      <pre class="usage"><code>os_system(cmd)</code></pre>
-      <p class="doc">Run a shell command, return exit code</p>
+    <div class="function" id="system" data-name="system">
+      <h3 class="function-name">system <span class="kind">extern</span></h3>
+      <pre class="usage"><code>system(cmd) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">cmd: string</span></p>
+      <p class="doc">Run a shell command, returns exit code (0 = success)</p>
     </div>
-    <div class="function" id="os_exec_raw" data-name="os_exec_raw">
-      <h3 class="function-name">os_exec_raw</h3>
-      <pre class="usage"><code>os_exec_raw(cmd)</code></pre>
-      <p class="doc">Run a command and capture stdout as a string Returns heap-allocated string (caller must free), or NULL on failure</p>
+    <div class="function" id="exec_raw" data-name="exec_raw">
+      <h3 class="function-name">exec_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>exec_raw(cmd) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">cmd: string</span></p>
+      <p class="doc">Run a command and capture stdout as a string. Raw extern returns NULL on failure. Use the Go-style wrapper `os.exec` below in most code.</p>
     </div>
-    <div class="function" id="os_getenv" data-name="os_getenv">
-      <h3 class="function-name">os_getenv</h3>
-      <pre class="usage"><code>os_getenv(name)</code></pre>
+    <div class="function" id="run" data-name="run">
+      <h3 class="function-name">run <span class="kind">extern</span></h3>
+      <pre class="usage"><code>run(prog, argv, env) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">Run a child process directly via fork+execvp+waitpid (POSIX). NO SHELL is interpreted: argv items are passed verbatim, so paths-with-spaces, $variables, |, ;, *, and other shell metacharacters in arguments are not metachars. Returns the child's exit code, or -1 on spawn failure. prog  — program to execute (resolved via PATH if it has no '/') argv  — list of strings to pass as arguments AFTER argv[0]=prog, or null/empty list for no arguments env   — list of &quot;KEY=VALUE&quot; strings to pass as the child's environment, or null to inherit the parent's environment</p>
+    </div>
+    <div class="function" id="run_capture_raw" data-name="run_capture_raw">
+      <h3 class="function-name">run_capture_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>run_capture_raw(prog, argv, env) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">Same as os_run but captures the child's stdout. Raw extern returns null on spawn failure. Use the Go-style wrapper `os.run_capture` in most code. The child's exit code is discarded — use os_run, or the tuple-returning `os_run_capture_status_raw` below, if you need both.</p>
+    </div>
+    <div class="function" id="run_capture_status_raw" data-name="run_capture_status_raw">
+      <h3 class="function-name">run_capture_status_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>run_capture_status_raw(prog, argv, env) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">Tuple sibling that exposes the child's exit code. Returns (stdout, status, err) — see the Aether-side `run_capture` wrapper for the per-slot semantics. Issue #289. Position 0 (stdout) is `@heap`: the C side accumulates the child's output into a malloc'd buffer that grows via realloc as bytes arrive. The destructured LHS owns it; the heap-string-tracker frees it on reassignment / at function exit. Position 2 (err) stays default-borrow — error messages are static string literals in aether_os.c. Audited callers: only the Aether wrapper `run_capture` at line ~150 passes the tuple through; no manual string.release on the captured stdout anywhere in stdlib, tests/, examples/, tools/, or contrib/. See #420 follow-up.</p>
+    </div>
+    <div class="function" id="run_pipe_raw" data-name="run_pipe_raw">
+      <h3 class="function-name">run_pipe_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>run_pipe_raw(prog, argv, env) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">std.ipc back-channel spawn. Spawns a child with an inherited pipe at fd 3 (write end, child side). Sets AETHER_IPC_FD=3 in the child's environment so the child can locate the fd via std.ipc.parent_channel(). Returns (parent_read_fd, child_pid, err). Caller MUST call os.wait_pid(child_pid) to reap, or use the os.run_pipe_drain_and_wait convenience. Pipe-buffer deadlock window: if the child writes more than the OS pipe buffer (~16K macOS, ~64K Linux) without the parent reading concurrently, the child blocks on its write call and never exits. For payload-at-exit usage with small reports (e.g. Aeocha test summaries), this is fine; for larger or streaming payloads, prefer run_pipe_drain_and_wait. On Windows, returns (-1, -1, &quot;unsupported on Windows&quot;) — fall back to the file-marker pattern there.</p>
+    </div>
+    <div class="function" id="wait_pid_raw" data-name="wait_pid_raw">
+      <h3 class="function-name">wait_pid_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>wait_pid_raw(pid) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">pid: int</span></p>
+      <p class="doc">Wait for a child to exit and reap it. Companion to os_run_pipe_raw. Returns (exit_code, err). Calling this once per spawn is required to avoid zombies; the run_pipe_drain_and_wait convenience does it internally for callers who don't need the read-fd loop. On Windows, returns (-1, &quot;unsupported on Windows&quot;).</p>
+    </div>
+    <div class="function" id="run_pipe_drain_and_wait_raw" data-name="run_pipe_drain_and_wait_raw">
+      <h3 class="function-name">run_pipe_drain_and_wait_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>run_pipe_drain_and_wait_raw(prog, argv, env) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">Convenience: spawn child with back-channel pipe, drain pipe to EOF concurrently with the child running, wait for child, reap. Returns (channel_payload, exit_code, err). No deadlock regardless of payload size — the read loop drains continuously so the pipe buffer never fills. This is the recommended entry point for the common case &quot;child writes a structured report at exit, parent reads it after.&quot; Streaming consumers (parent reading mid-run) should use the lower-level os_run_pipe_raw + os_wait_pid_raw pair instead. On Windows, returns (&quot;&quot;, -1, &quot;unsupported on Windows&quot;). Position 0 (channel_payload) is `@heap`: the C side accumulates the drained pipe contents into a malloc'd buffer that grows via realloc. The destructured LHS owns it; the heap-string-tracker frees it on reassignment / at function exit. Position 2 (err) stays default-borrow — every error path returns a static string literal. Audited callers: no manual string.release on the channel payload anywhere in stdlib, tests/, examples/, tools/, or contrib/. See #420 follow-up.</p>
+    </div>
+    <div class="function" id="getenv" data-name="getenv">
+      <h3 class="function-name">getenv <span class="kind">extern</span></h3>
+      <pre class="usage"><code>getenv(name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
       <p class="doc">Get environment variable, returns string or NULL if not set</p>
     </div>
-    <div class="function" id="os_execv" data-name="os_execv">
-      <h3 class="function-name">os_execv</h3>
-      <pre class="usage"><code>os_execv(prog, argv_list)</code></pre>
-      <p class="doc">Replace the current process image with `prog`, passing each element of `argv_list` as an argv entry. `argv_list` is an Aether `list&lt;ptr&gt;` whose entries must be C strings; element 0 is argv[0] for the new program and need not match `prog`. Does NOT return on success — on failure returns -1 and leaves the current process running. `prog` is looked up on PATH if it does not contain a slash (POSIX `execvp`). Not available on Windows (returns -1).</p>
+    <div class="function" id="which" data-name="which">
+      <h3 class="function-name">which <span class="kind">extern</span></h3>
+      <pre class="usage"><code>which(name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">Search PATH for an executable. Returns the absolute path to the first hit, or &quot;&quot; if not found. If `name` already contains '/', it's returned as-is when it's executable.</p>
     </div>
-    <div class="function" id="os_which" data-name="os_which">
-      <h3 class="function-name">os_which</h3>
-      <pre class="usage"><code>os_which(name)</code></pre>
-      <p class="doc">Search PATH for an executable named `name`. Returns the absolute path to the first executable hit, or NULL if not found. If `name` already contains '/', it's returned as-is when it's executable (matches POSIX `command -v` semantics for absolute/relative paths). Caller owns the returned string.</p>
+    <div class="function" id="aether_args_count" data-name="aether_args_count">
+      <h3 class="function-name">aether_args_count <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_args_count() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Command-line arguments</p>
     </div>
-    <div class="function" id="os_run" data-name="os_run">
-      <h3 class="function-name">os_run</h3>
-      <pre class="usage"><code>os_run(prog, argv, env)</code></pre>
-      <p class="doc">Run a child process directly via fork+execvp+waitpid (POSIX) or CreateProcessW (Windows — TODO). NO SHELL is interpreted: argv items are passed verbatim, so paths-with-spaces, $vars, |, ;, *, etc. in arguments are not metachars. Returns the child's exit code, or -1 on failure to spawn (program not found, etc.).  prog    — program to execute. Resolved via PATH if it has no '/'. argv    — Aether list (ArrayList*) of strings; argv[0] should be the program name itself. May be NULL (treated as empty list). env     — Aether list (ArrayList*) of &quot;KEY=VALUE&quot; strings, or NULL to inherit the parent's environment.</p>
+    <div class="function" id="aether_args_get" data-name="aether_args_get">
+      <h3 class="function-name">aether_args_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_args_get(index) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">index: int</span></p>
     </div>
-    <div class="function" id="os_run_capture_raw" data-name="os_run_capture_raw">
-      <h3 class="function-name">os_run_capture_raw</h3>
-      <pre class="usage"><code>os_run_capture_raw(prog, argv, env)</code></pre>
-      <p class="doc">Same as os_run but captures the child's stdout into a heap-allocated string the caller must free. Returns NULL on spawn failure. The child's exit code is discarded — if you need it, use os_run instead (or a future os_run_capture_with_status() if demand arises).</p>
+    <div class="function" id="aether_argv0" data-name="aether_argv0">
+      <h3 class="function-name">aether_argv0 <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_argv0() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">argv[0] — the path the OS launched the current process with. Returns null when aether_args_init has not been called (e.g. unit tests that bypass `main`). The return value is a borrowed pointer into the OS argv storage; do not free. Idiomatic Aether callers should use `os.argv0()` which returns &quot;&quot; instead of null for convenience.</p>
+    </div>
+    <div class="function" id="aether_argv_raw" data-name="aether_argv_raw">
+      <h3 class="function-name">aether_argv_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_argv_raw() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">Raw argv vector captured by the generated process entrypoint. This is for C interop with APIs that need argc/argv exactly as the OS supplied them. Borrowed pointer; do not free.</p>
+    </div>
+    <div class="function" id="aether_args_seal" data-name="aether_args_seal">
+      <h3 class="function-name">aether_args_seal <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_args_seal()</code></pre>
+      <p class="doc">One-shot runtime seal of the argv accessors. After this returns, `os.aether_args_count()` reports 0, `os.aether_args_get(i)` returns null, `os.argv0()` returns &quot;&quot;, and `os.aether_argv_raw()` returns null — as if argv had never been initialised. Idempotent (calling twice is a no-op); there is no unseal. Intended use: once `main()` has parsed command-line flags into its own config state, call `os.args_seal()` to prevent any later code in the process (imported libraries, plugin callbacks, untrusted Aether modules) from reading the original argv. Complements the compile-time `hide` / `seal except` scope directives: those deny LEXICAL access; this denies RUNTIME access. Caveat: this is a co-operative Aether-side gate, not a kernel boundary. The OS still has the original argv in process memory (Linux /proc/self/cmdline, macOS sysctl) and code that goes around the Aether accessors can still read it. The seal defends against accidental late-stage Aether code touching argv, not against an attacker with arbitrary execution. Pair with the LD_PRELOAD libc sandbox if the threat model demands true inaccessibility.</p>
+    </div>
+    <div class="function" id="aether_args_sealed" data-name="aether_args_sealed">
+      <h3 class="function-name">aether_args_sealed <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_args_sealed() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="args_seal" data-name="args_seal">
+      <h3 class="function-name">args_seal <span class="kind">fn</span></h3>
+      <pre class="usage"><code>args_seal()</code></pre>
+      <p class="doc">Aether-side convenience wrappers — short names for the canonical &quot;consumed argv; seal it now&quot; pattern.</p>
+    </div>
+    <div class="function" id="args_sealed" data-name="args_sealed">
+      <h3 class="function-name">args_sealed <span class="kind">fn</span></h3>
+      <pre class="usage"><code>args_sealed() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="execv" data-name="execv">
+      <h3 class="function-name">execv <span class="kind">extern</span></h3>
+      <pre class="usage"><code>execv(prog, argv_list) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv_list: ptr</span></p>
+      <p class="doc">Replace the current process image with `prog`. `argv_list` is a list&lt;ptr&gt; of C strings (element 0 is argv[0] for the new program and does NOT need to match `prog`). On success this call never returns; on failure it returns -1 with the current process still running. `prog` is looked up on PATH if it does not contain a slash. Not available on Windows — returns -1 there.</p>
+    </div>
+    <div class="function" id="now_utc_iso8601_raw" data-name="now_utc_iso8601_raw">
+      <h3 class="function-name">now_utc_iso8601_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>now_utc_iso8601_raw() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">Current UTC time as an ISO-8601 timestamp: &quot;YYYY-MM-DDThh:mm:ssZ&quot; (20 chars). Thread-safe (gmtime_r on POSIX, gmtime_s on Windows). On clock / format failure returns an empty string — never null. Typical use: &quot;when did this event happen&quot; fields where a sortable, human-readable UTC timestamp is wanted (rev-blob date fields, JSON response timestamps, log-line prefixes). Sub-second precision and timezone offsets are out of scope; additive variants can land later.</p>
+    </div>
+    <div class="function" id="getpid_raw" data-name="getpid_raw">
+      <h3 class="function-name">getpid_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>getpid_raw() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Process identifier of the current process. Useful for tmpfile names (`/tmp/myprog.${os.getpid()}.tmp`), per-process locks, log prefixes, and stable tagging across forked children. POSIX `getpid(2)`; Windows `_getpid()`. Returns 0 on platforms compiled without filesystem support (no-op stub).</p>
+    </div>
+    <div class="function" id="exit" data-name="exit">
+      <h3 class="function-name">exit <span class="kind">extern</span></h3>
+      <pre class="usage"><code>exit(code)</code></pre>
+      <p class="signature"><span class="sig-params">code: int</span></p>
+      <p class="doc">Terminate the current process with `code`.</p>
+    </div>
+    <div class="function" id="wall_seconds_raw" data-name="wall_seconds_raw">
+      <h3 class="function-name">wall_seconds_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>wall_seconds_raw() <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="doc">Wall-clock time, split into whole seconds since the Unix epoch and the sub-second microsecond fraction (0..999999) — the two fields of POSIX `struct timeval`.  Kept as two plain-integer accessors so the `struct timeval` layout never has to cross into Aether (it is platform-dependent; raw int64/int do not).  POSIX `gettimeofday(2)`; Windows uses `GetSystemTimeAsFileTime`.  Both return 0 on platforms compiled without filesystem support (no-op stub). Typical uses: a wall-clock millisecond timestamp (`wall_seconds()*1000 + wall_micros()/1000`), or seeding a PRNG (`(wall_seconds() &lt;&lt; 32) ^ wall_micros()`).</p>
+    </div>
+    <div class="function" id="wall_micros_raw" data-name="wall_micros_raw">
+      <h3 class="function-name">wall_micros_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>wall_micros_raw() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="now_monotonic_ms_raw" data-name="now_monotonic_ms_raw">
+      <h3 class="function-name">now_monotonic_ms_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>now_monotonic_ms_raw() <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="doc">Monotonic-clock primitives.  Unlike wall_seconds / wall_micros (UTC, NTP-jumpable, useful for &quot;when did this event happen&quot; timestamps), these are tied to a monotonic per-platform counter whose value-domain is opaque — only *deltas* are meaningful.  Use them for animation tick loops, frame-time budgets, microbenchmarks, and elapsed-time measurements that must survive a wall-clock jump. ms — milliseconds since some fixed epoch (boot / process start / arbitrary).  Wraparound at ~292 million years; no concern. ns — nanoseconds since the same epoch.  Useful for sub-millisecond timing (animation t-curves, microbenchmarks). Implementation: clock_gettime(CLOCK_MONOTONIC) on POSIX, QueryPerformanceCounter on Windows.  Returns 0 on no-filesystem builds (the same stub-policy as wall_seconds / wall_micros). Return type is `long` (Aether's 64-bit on every platform); the C signature is int64_t, not C `long`, to avoid the LLP64 / 32-bit-long truncation hazard PR #562 caught for string_to_long_raw.</p>
+    </div>
+    <div class="function" id="now_monotonic_ns_raw" data-name="now_monotonic_ns_raw">
+      <h3 class="function-name">now_monotonic_ns_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>now_monotonic_ns_raw() <span class="arrow">-&gt;</span> long</code></pre>
+    </div>
+    <div class="function" id="now_unix_ms_raw" data-name="now_unix_ms_raw">
+      <h3 class="function-name">now_unix_ms_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>now_unix_ms_raw() <span class="arrow">-&gt;</span> long</code></pre>
+    </div>
+    <div class="function" id="now_local_fill_raw" data-name="now_local_fill_raw">
+      <h3 class="function-name">now_local_fill_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>now_local_fill_raw(out)</code></pre>
+      <p class="signature"><span class="sig-params">out: ptr</span></p>
+    </div>
+    <div class="function" id="now_local_iso8601_raw" data-name="now_local_iso8601_raw">
+      <h3 class="function-name">now_local_iso8601_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>now_local_iso8601_raw() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="platform_raw" data-name="platform_raw">
+      <h3 class="function-name">platform_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>platform_raw() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">Current OS platform as a flat lowercase string. Picked at compile time from the toolchain's predefined macros. Matches Go's runtime.GOOS and Rust's std::env::consts::OS: &quot;linux&quot;      Linux kernel (any libc) &quot;darwin&quot;     macOS / iOS / any Darwin kernel &quot;windows&quot;    Windows (any toolchain) &quot;freebsd&quot;    FreeBSD &quot;openbsd&quot;    OpenBSD &quot;netbsd&quot;     NetBSD &quot;dragonfly&quot;  DragonFly BSD &quot;solaris&quot;    Solaris / illumos &quot;wasm&quot;       WebAssembly (Emscripten or wasi) &quot;unknown&quot;    None of the above matched at compile time Typical use: if os.platform() == &quot;windows&quot; { // Windows-specific path } For &quot;do I have POSIX features?&quot; the rule of thumb is `os.platform() != &quot;windows&quot; &amp;&amp; os.platform() != &quot;wasm&quot;` — but usually probing the specific capability (e.g. net.pipe_open() &lt; 0) gives a sharper answer than the platform name alone. See CONTRIBUTING.md &quot;Coding for portability&quot; for the broader pattern.</p>
+    </div>
+    <div class="function" id="io_setenv_raw" data-name="io_setenv_raw">
+      <h3 class="function-name">io_setenv_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>io_setenv_raw(name, value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string, value: string</span></p>
+      <p class="doc">Set / unset environment variable. The C-side functions live in std.io for legacy reasons; std.os re-exposes them so callers reaching for `os.setenv` (alongside `os.getenv`) find them where POSIX groups them under &lt;stdlib.h&gt;. Issue #342.</p>
+    </div>
+    <div class="function" id="io_unsetenv_raw" data-name="io_unsetenv_raw">
+      <h3 class="function-name">io_unsetenv_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>io_unsetenv_raw(name) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+    </div>
+    <div class="function" id="exec" data-name="exec">
+      <h3 class="function-name">exec <span class="kind">fn</span></h3>
+      <pre class="usage"><code>exec(cmd) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">cmd: string</span></p>
+      <p class="doc">Execute a shell command and capture stdout. Returns (output, &quot;&quot;) on success, (&quot;&quot;, error) on failure.</p>
+    </div>
+    <div class="function" id="run_capture" data-name="run_capture">
+      <h3 class="function-name">run_capture <span class="kind">fn</span></h3>
+      <pre class="usage"><code>run_capture(prog, argv, env) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">Run a child process and capture its stdout. Returns `(output, status, err)`: - output: child's stdout. Empty string on spawn failure. - status: child's exit code (WEXITSTATUS) on normal exit; -1 when killed by signal or the spawn itself failed. - err:    &quot;&quot; on successful spawn regardless of exit code; non-empty only when the fork/exec couldn't run. Argv-based — no shell, no quoting issues. The status slot lets callers distinguish &quot;ran cleanly&quot; (status == 0) from &quot;ran but exited non-zero&quot; (e.g. `diff3 -m` returning 1 to signal conflicts, `grep` returning 1 for no-match, `gcc` returning non-zero on compile errors). Issue #289.</p>
+    </div>
+    <div class="function" id="argv0" data-name="argv0">
+      <h3 class="function-name">argv0 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>argv0() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">argv[0] — path the OS launched the current process with. Returns &quot;&quot; if aether_args_init has not been called or argv[0] is NULL. The raw form is also accessible as `aether_argv0()` for callers that want explicit null handling (e.g. to distinguish &quot;not initialised&quot; from &quot;empty&quot;).</p>
+    </div>
+    <div class="function" id="now_utc_iso8601" data-name="now_utc_iso8601">
+      <h3 class="function-name">now_utc_iso8601 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>now_utc_iso8601() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="getpid" data-name="getpid">
+      <h3 class="function-name">getpid <span class="kind">fn</span></h3>
+      <pre class="usage"><code>getpid() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="wall_seconds" data-name="wall_seconds">
+      <h3 class="function-name">wall_seconds <span class="kind">fn</span></h3>
+      <pre class="usage"><code>wall_seconds() <span class="arrow">-&gt;</span> long</code></pre>
+    </div>
+    <div class="function" id="wall_micros" data-name="wall_micros">
+      <h3 class="function-name">wall_micros <span class="kind">fn</span></h3>
+      <pre class="usage"><code>wall_micros() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="now_monotonic_ms" data-name="now_monotonic_ms">
+      <h3 class="function-name">now_monotonic_ms <span class="kind">fn</span></h3>
+      <pre class="usage"><code>now_monotonic_ms() <span class="arrow">-&gt;</span> long</code></pre>
+    </div>
+    <div class="function" id="now_monotonic_ns" data-name="now_monotonic_ns">
+      <h3 class="function-name">now_monotonic_ns <span class="kind">fn</span></h3>
+      <pre class="usage"><code>now_monotonic_ns() <span class="arrow">-&gt;</span> long</code></pre>
+    </div>
+    <div class="function" id="now_unix_ms" data-name="now_unix_ms">
+      <h3 class="function-name">now_unix_ms <span class="kind">fn</span></h3>
+      <pre class="usage"><code>now_unix_ms() <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="doc">Wall-clock Unix epoch ms. NTP-sensitive; use this for time-ordered identifiers (UUIDv7, ULID, KSUID, TSID) and for &quot;when did this happen&quot; timestamps, NOT for measuring durations — use now_monotonic_ms / now_monotonic_ns for that.</p>
+    </div>
+    <div class="function" id="now_local" data-name="now_local">
+      <h3 class="function-name">now_local <span class="kind">fn</span></h3>
+      <pre class="usage"><code>now_local() <span class="arrow">-&gt;</span> *LocalTime</code></pre>
+      <p class="doc">Returns a heap-allocated LocalTime populated with the current local wall-clock time. ONE localtime_r call inside the filler, so all eight fields agree with each other. On clock / format failure the struct is zeroed — check `t.year == 0` to detect. Caller-owns; caller must `free()` when done (LocalTime is a plain struct, no nested heap allocations to release).</p>
+    </div>
+    <div class="function" id="now_local_iso8601" data-name="now_local_iso8601">
+      <h3 class="function-name">now_local_iso8601 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>now_local_iso8601() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="LocalTime" data-name="LocalTime">
+      <h3 class="function-name">LocalTime <span class="kind">struct</span></h3>
+      <pre class="usage"><code>struct LocalTime</code></pre>
+      <p class="doc">Current local wall-clock time, broken into integer fields. Use `now_local()` to get a populated `LocalTime` struct in one call; the individual raw getters are exposed for callers that want only one field. Companion: `now_local_iso8601()` returns the same data formatted as an RFC-3339 / ISO-8601 string with explicit timezone offset (&quot;YYYY-MM-DDThh:mm:ss±HH:MM&quot;, or &quot;...Z&quot; when offset is 0). POSIX: `localtime_r` + `tm_gmtoff`. Windows: `localtime_s` + `_get_timezone` with DST correction. Both return zeroes on platforms compiled without filesystem support. LocalTime field ranges: year:                1970.. month:               1..12 day:                 1..31 hour:                0..23 minute:              0..59 second:              0..60 (60 on leap-second-aware systems) nanos:               0..999_999_999 tz_offset_minutes:   -720..+840 from UTC (negative = west)</p>
+    </div>
+    <div class="function" id="platform" data-name="platform">
+      <h3 class="function-name">platform <span class="kind">fn</span></h3>
+      <pre class="usage"><code>platform() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="setenv" data-name="setenv">
+      <h3 class="function-name">setenv <span class="kind">fn</span></h3>
+      <pre class="usage"><code>setenv(name, value) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">name: string, value: string</span></p>
+      <p class="doc">Set an environment variable. Returns &quot;&quot; on success, error on failure. Mirrors std.io.setenv — both modules expose the same C-side function. Issue #342.</p>
+    </div>
+    <div class="function" id="unsetenv" data-name="unsetenv">
+      <h3 class="function-name">unsetenv <span class="kind">fn</span></h3>
+      <pre class="usage"><code>unsetenv(name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">name: string</span></p>
+      <p class="doc">Unset an environment variable. Returns &quot;&quot; on success, error on failure. Mirrors std.io.unsetenv. Issue #342.</p>
+    </div>
+    <div class="function" id="run_pipe" data-name="run_pipe">
+      <h3 class="function-name">run_pipe <span class="kind">fn</span></h3>
+      <pre class="usage"><code>run_pipe(prog, argv, env) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">Spawn child with std.ipc back-channel pipe. Returns (parent_read_fd, child_pid, err). Child sees AETHER_IPC_FD=3 in its env; std.ipc.parent_channel() inside the child resolves to fd 3. Caller MUST call os.wait_pid(child_pid) to reap the child; reading from parent_read_fd is the caller's responsibility. For the common &quot;spawn + read report + wait&quot; case, use os.run_pipe_drain_and_wait — same parent surface but no pipe-buffer deadlock risk and no manual wait_pid call needed. On Windows, returns (-1, -1, &quot;unsupported on Windows&quot;).</p>
+    </div>
+    <div class="function" id="wait_pid" data-name="wait_pid">
+      <h3 class="function-name">wait_pid <span class="kind">fn</span></h3>
+      <pre class="usage"><code>wait_pid(pid) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">pid: int</span></p>
+      <p class="doc">Wait for and reap a child spawned via os.run_pipe. Returns (exit_code, err). Calling this is required after os.run_pipe to avoid leaving the child as a zombie process.</p>
+    </div>
+    <div class="function" id="run_pipe_drain_and_wait" data-name="run_pipe_drain_and_wait">
+      <h3 class="function-name">run_pipe_drain_and_wait <span class="kind">fn</span></h3>
+      <pre class="usage"><code>run_pipe_drain_and_wait(prog, argv, env) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr</span></p>
+      <p class="doc">Convenience: spawn + drain back-channel pipe + wait + reap, all in one call. Returns (channel_payload, exit_code, err). Recommended entry point for &quot;child writes structured report at exit; parent reads it after.&quot; No pipe-buffer deadlock risk regardless of payload size. On Windows, returns (&quot;&quot;, -1, &quot;unsupported on Windows&quot;).</p>
+    </div>
+    <div class="function" id="kill_raw" data-name="kill_raw">
+      <h3 class="function-name">kill_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>kill_raw(pid, sig) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">pid: int, sig: int</span></p>
+      <p class="doc">Send signal `sig` to `pid` — POSIX kill(2). Returns 0 on success, -1 on failure. Two conventions are deliberately exposed: - a NEGATIVE pid signals the whole process group abs(pid), the building block for tearing down a build and all it spawned; - `sig == 0` delivers nothing but still runs the existence / permission checks — the canonical &quot;is this pid/group alive?&quot; probe (0 = alive, -1 = gone). Signal numbers live in `std.signal` (SIGINT / SIGTERM / SIGKILL …) so callers needn't hard-code 2 / 15 / 9. Windows: `sig == 0` probes via OpenProcess; any other signal maps to a forced TerminateProcess (no catchable SIGTERM); a negative pid (group signalling) returns -1 — there is no pgid-by-negative-pid.</p>
+    </div>
+    <div class="function" id="wait_pid_timeout_raw" data-name="wait_pid_timeout_raw">
+      <h3 class="function-name">wait_pid_timeout_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>wait_pid_timeout_raw(pid, secs) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">pid: int, secs: int</span></p>
+      <p class="doc">Bounded wait for one child. Returns (status, timed_out, err): - status:    WEXITSTATUS on normal exit, 128+signo when signalled, -1 on timeout or error. - timed_out: 1 if `secs` elapsed before exit (the child is left RUNNING — caller decides whether to os.kill it), else 0. - err:       &quot;&quot; on a clean reap or clean timeout; non-empty on a waitpid error / invalid pid. `secs &lt;= 0` blocks indefinitely (like os.wait_pid, timed_out always 0). Lets a supervisor bound a wait without a separate watchdog process. Windows: OpenProcess + WaitForSingleObject(secs); status is the process exit code (no signal concept).</p>
+    </div>
+    <div class="function" id="run_supervised_raw" data-name="run_supervised_raw">
+      <h3 class="function-name">run_supervised_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>run_supervised_raw(prog, argv, env, new_process_group, forward_signals, timeout_secs, reap_group) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr, new_process_group: int, forward_signals: int, timeout_secs: int, reap_group: int</span></p>
+      <p class="doc">One-call supervised run — the whole job-control pattern in one primitive. Returns (exit_code, outcome). Options are int flags (1 = on, 0 = off) rather than a stringly-typed map, matching the rest of std.os. - new_process_group: child runs in its own group (POSIX pgid == pid; Windows: its own Job Object + CREATE_NEW_PROCESS_GROUP) so signals and reaping address the whole subtree. - forward_signals:   POSIX — parent SIGINT/SIGTERM forward to the child's group; Windows — a console Ctrl-C/Ctrl-Break handler terminates the job tree. Needs new_process_group; one supervised run at a time. - timeout_secs &gt; 0:  POSIX — TERM the group on deadline, 5s grace, then KILL; Windows — TerminateJobObject. Reports exit_code 124 (GNU `timeout` convention). - reap_group:        after the child exits, clean up anything it leaked into the group (POSIX TERM→grace→KILL + reap; Windows JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE). Needs new_process_group. outcome ∈ {&quot;exited&quot;,&quot;signalled&quot;,&quot;timeout&quot;,&quot;error&quot;}. Windows never reports &quot;signalled&quot; (no signal concept) — a killed child reads as &quot;exited&quot; with its terminate code.</p>
+    </div>
+    <div class="function" id="kill" data-name="kill">
+      <h3 class="function-name">kill <span class="kind">fn</span></h3>
+      <pre class="usage"><code>kill(pid, sig) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">pid: int, sig: int</span></p>
+      <p class="doc">Send `sig` to `pid` (POSIX kill(2)). 0 = success, -1 = failure. Negative pid = whole group; sig 0 = existence probe. See os_kill_raw for the full contract; signal numbers are in std.signal.</p>
+    </div>
+    <div class="function" id="wait_pid_timeout" data-name="wait_pid_timeout">
+      <h3 class="function-name">wait_pid_timeout <span class="kind">fn</span></h3>
+      <pre class="usage"><code>wait_pid_timeout(pid, secs) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">pid: int, secs: int</span></p>
+      <p class="doc">Bounded wait — (status, timed_out, err). See os_wait_pid_timeout_raw.</p>
+    </div>
+    <div class="function" id="run_supervised" data-name="run_supervised">
+      <h3 class="function-name">run_supervised <span class="kind">fn</span></h3>
+      <pre class="usage"><code>run_supervised(prog, argv, env, new_process_group, forward_signals, timeout_secs, reap_group) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr, new_process_group: int, forward_signals: int, timeout_secs: int, reap_group: int</span></p>
+      <p class="doc">Supervised run — (exit_code, outcome). See os_run_supervised_raw for the per-flag semantics. The common build-orchestrator shape is `run_supervised(prog, argv, env, 1, 1, timeout, 1)`: own group, forward Ctrl-C, enforce a timeout, group-reap leaks.</p>
+    </div>
+    <div class="function" id="run_full_raw" data-name="run_full_raw">
+      <h3 class="function-name">run_full_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>run_full_raw(prog, argv, env, stdin_data, stdin_len) <span class="arrow">-&gt;</span> (string, string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr, stdin_data: string, stdin_len: int</span></p>
+      <p class="doc">Full three-way child stdio — the gap os.run_capture leaves open. Feeds `stdin_data` to the child's stdin (binary-safe: exactly its stored length is written, embedded NULs included) and captures stdout and stderr SEPARATELY. Returns (stdout, stderr, exit_code, err): - stdout / stderr: the child's two streams, captured independently (the `2&gt;&amp;1`-merged shape is not this call). &quot;&quot; when empty. Like os.run_capture they are NUL-terminated, so a capture holding an embedded NUL reads as truncated through the string ops — the stdin direction has no such limit. - exit_code: WEXITSTATUS on normal exit, 128+signo if signalled, 127 on exec failure, -1 on spawn/IO error. - err: &quot;&quot; on a successful spawn (regardless of exit code); non-empty only when the fork/exec/pipe itself failed. No pipe-buffer deadlock regardless of stream sizes: POSIX pumps all three fds in one poll(2) loop; Windows drains stdout/stderr on reader threads while the main thread writes stdin (Win32 anonymous pipes aren't pollable). An empty `stdin_data` gives the child an immediately-closed stdin (it can't block on the terminal).</p>
+    </div>
+    <div class="function" id="run_full" data-name="run_full">
+      <h3 class="function-name">run_full <span class="kind">fn</span></h3>
+      <pre class="usage"><code>run_full(prog, argv, env, stdin_data) <span class="arrow">-&gt;</span> (string, string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">prog: string, argv: ptr, env: ptr, stdin_data: string</span></p>
+      <p class="doc">(stdout, stderr, exit_code, err) — feed `stdin_data` and capture both streams. Pass &quot;&quot; for stdin_data when the child reads no input. See os_run_full_raw for the full contract.</p>
+    </div>
+    <div class="function" id="chdir_raw" data-name="chdir_raw">
+      <h3 class="function-name">chdir_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>chdir_raw(path) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+    </div>
+    <div class="function" id="getcwd_raw" data-name="getcwd_raw">
+      <h3 class="function-name">getcwd_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>getcwd_raw() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="chdir" data-name="chdir">
+      <h3 class="function-name">chdir <span class="kind">fn</span></h3>
+      <pre class="usage"><code>chdir(path) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">path: string</span></p>
+      <p class="doc">Change the process working directory. Returns &quot;&quot; on success, an error message on failure (e.g. directory missing or not a directory).</p>
+    </div>
+    <div class="function" id="getcwd" data-name="getcwd">
+      <h3 class="function-name">getcwd <span class="kind">fn</span></h3>
+      <pre class="usage"><code>getcwd() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">Current working directory, or &quot;&quot; on failure. Returns a fresh refcounted string the caller owns (the raw strdup is reclaimed by the heap-string tracker — os_getcwd_raw is classified owned-heap in codegen).</p>
     </div>
   </div>
 </main>

--- a/docs/api/path.html
+++ b/docs/api/path.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>path - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search path..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#this">this</a></li>
+    <li><a href="#module">module</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li class="active"><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>path</h1>
+    <p class="module-desc">std.path - Path Utilities (alias for std.fs) This is a convenience module that re-exports path functions from std.fs.</p>
+    <p class="import-line"><code>import std.path</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="this" data-name="this">
+      <h3 class="function-name">this <span class="kind">fn</span></h3>
+      <pre class="usage"><code>this()</code></pre>
+    </div>
+    <div class="function" id="module" data-name="module">
+      <h3 class="function-name">module <span class="kind">fn</span></h3>
+      <pre class="usage"><code>module()</code></pre>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/regex.html
+++ b/docs/api/regex.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>regex - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search regex..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_regex_compile">aether_regex_compile</a></li>
+    <li><a href="#aether_regex_free">aether_regex_free</a></li>
+    <li><a href="#aether_regex_matches">aether_regex_matches</a></li>
+    <li><a href="#aether_regex_captures">aether_regex_captures</a></li>
+    <li><a href="#aether_regex_captures_count">aether_regex_captures_count</a></li>
+    <li><a href="#aether_regex_captures_get">aether_regex_captures_get</a></li>
+    <li><a href="#aether_regex_captures_start">aether_regex_captures_start</a></li>
+    <li><a href="#aether_regex_captures_end">aether_regex_captures_end</a></li>
+    <li><a href="#aether_regex_captures_free">aether_regex_captures_free</a></li>
+    <li><a href="#aether_regex_find_all">aether_regex_find_all</a></li>
+    <li><a href="#aether_regex_find_all_count">aether_regex_find_all_count</a></li>
+    <li><a href="#aether_regex_find_all_start">aether_regex_find_all_start</a></li>
+    <li><a href="#aether_regex_find_all_end">aether_regex_find_all_end</a></li>
+    <li><a href="#aether_regex_find_all_free">aether_regex_find_all_free</a></li>
+    <li><a href="#aether_regex_replace">aether_regex_replace</a></li>
+    <li><a href="#aether_regex_replace_all">aether_regex_replace_all</a></li>
+    <li><a href="#aether_regex_last_error">aether_regex_last_error</a></li>
+    <li><a href="#aether_regex_clear_last_error">aether_regex_clear_last_error</a></li>
+    <li><a href="#compile">compile</a></li>
+    <li><a href="#compile_flags">compile_flags</a></li>
+    <li><a href="#free">free</a></li>
+    <li><a href="#last_error">last_error</a></li>
+    <li><a href="#clear_last_error">clear_last_error</a></li>
+    <li><a href="#matches">matches</a></li>
+    <li><a href="#find">find</a></li>
+    <li><a href="#captures">captures</a></li>
+    <li><a href="#capture_count">capture_count</a></li>
+    <li><a href="#capture">capture</a></li>
+    <li><a href="#capture_start">capture_start</a></li>
+    <li><a href="#capture_end">capture_end</a></li>
+    <li><a href="#captures_free">captures_free</a></li>
+    <li><a href="#find_all">find_all</a></li>
+    <li><a href="#find_all_count">find_all_count</a></li>
+    <li><a href="#find_all_start">find_all_start</a></li>
+    <li><a href="#find_all_end">find_all_end</a></li>
+    <li><a href="#find_all_free">find_all_free</a></li>
+    <li><a href="#replace">replace</a></li>
+    <li><a href="#replace_all">replace_all</a></li>
+    <li><a href="#matches_lit">matches_lit</a></li>
+    <li><a href="#find_lit">find_lit</a></li>
+    <li><a href="#FLAG_CASELESS">FLAG_CASELESS</a></li>
+    <li><a href="#FLAG_MULTILINE">FLAG_MULTILINE</a></li>
+    <li><a href="#FLAG_DOTALL">FLAG_DOTALL</a></li>
+    <li><a href="#FLAG_EXTENDED">FLAG_EXTENDED</a></li>
+    <li><a href="#FLAG_UNGREEDY">FLAG_UNGREEDY</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li class="active"><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>regex</h1>
+    <p class="module-desc">std.regex — Perl-compatible regular expressions (PCRE2-backed).</p>
+    <p class="import-line"><code>import std.regex</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_regex_compile" data-name="aether_regex_compile">
+      <h3 class="function-name">aether_regex_compile <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_compile(pattern, flags) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string, flags: int</span></p>
+    </div>
+    <div class="function" id="aether_regex_free" data-name="aether_regex_free">
+      <h3 class="function-name">aether_regex_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_free(re)</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr</span></p>
+    </div>
+    <div class="function" id="aether_regex_matches" data-name="aether_regex_matches">
+      <h3 class="function-name">aether_regex_matches <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_matches(re, s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string</span></p>
+    </div>
+    <div class="function" id="aether_regex_captures" data-name="aether_regex_captures">
+      <h3 class="function-name">aether_regex_captures <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_captures(re, s) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string</span></p>
+    </div>
+    <div class="function" id="aether_regex_captures_count" data-name="aether_regex_captures_count">
+      <h3 class="function-name">aether_regex_captures_count <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_captures_count(caps) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr</span></p>
+    </div>
+    <div class="function" id="aether_regex_captures_get" data-name="aether_regex_captures_get">
+      <h3 class="function-name">aether_regex_captures_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_captures_get(caps, index) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_regex_captures_start" data-name="aether_regex_captures_start">
+      <h3 class="function-name">aether_regex_captures_start <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_captures_start(caps, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_regex_captures_end" data-name="aether_regex_captures_end">
+      <h3 class="function-name">aether_regex_captures_end <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_captures_end(caps, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_regex_captures_free" data-name="aether_regex_captures_free">
+      <h3 class="function-name">aether_regex_captures_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_captures_free(caps)</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr</span></p>
+    </div>
+    <div class="function" id="aether_regex_find_all" data-name="aether_regex_find_all">
+      <h3 class="function-name">aether_regex_find_all <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_find_all(re, s) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string</span></p>
+    </div>
+    <div class="function" id="aether_regex_find_all_count" data-name="aether_regex_find_all_count">
+      <h3 class="function-name">aether_regex_find_all_count <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_find_all_count(fa) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr</span></p>
+    </div>
+    <div class="function" id="aether_regex_find_all_start" data-name="aether_regex_find_all_start">
+      <h3 class="function-name">aether_regex_find_all_start <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_find_all_start(fa, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_regex_find_all_end" data-name="aether_regex_find_all_end">
+      <h3 class="function-name">aether_regex_find_all_end <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_find_all_end(fa, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="aether_regex_find_all_free" data-name="aether_regex_find_all_free">
+      <h3 class="function-name">aether_regex_find_all_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_find_all_free(fa)</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr</span></p>
+    </div>
+    <div class="function" id="aether_regex_replace" data-name="aether_regex_replace">
+      <h3 class="function-name">aether_regex_replace <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_replace(re, s, repl) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string, repl: string</span></p>
+    </div>
+    <div class="function" id="aether_regex_replace_all" data-name="aether_regex_replace_all">
+      <h3 class="function-name">aether_regex_replace_all <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_replace_all(re, s, repl) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string, repl: string</span></p>
+    </div>
+    <div class="function" id="aether_regex_last_error" data-name="aether_regex_last_error">
+      <h3 class="function-name">aether_regex_last_error <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_last_error() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="aether_regex_clear_last_error" data-name="aether_regex_clear_last_error">
+      <h3 class="function-name">aether_regex_clear_last_error <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_regex_clear_last_error()</code></pre>
+    </div>
+    <div class="function" id="compile" data-name="compile">
+      <h3 class="function-name">compile <span class="kind">fn</span></h3>
+      <pre class="usage"><code>compile(pattern) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string</span></p>
+      <p class="doc">Compile a pattern. Returns (re, &quot;&quot;) on success; (null, error) on a pattern-syntax error or when the build lacks libpcre2-8.</p>
+    </div>
+    <div class="function" id="compile_flags" data-name="compile_flags">
+      <h3 class="function-name">compile_flags <span class="kind">fn</span></h3>
+      <pre class="usage"><code>compile_flags(pattern, flags) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string, flags: int</span></p>
+      <p class="doc">As compile, with PCRE2 option bits (FLAG_CASELESS | FLAG_MULTILINE …).</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>free(re)</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr</span></p>
+      <p class="doc">Free a compiled regex. Safe to call with null.</p>
+    </div>
+    <div class="function" id="last_error" data-name="last_error">
+      <h3 class="function-name">last_error <span class="kind">fn</span></h3>
+      <pre class="usage"><code>last_error() <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="doc">The last error message set by compile / captures / find_all / replace*. &quot;&quot; if none. Diagnostics for the no-match case are NOT errors — captures returns null with last_error == &quot;&quot; when the pattern simply didn't match.</p>
+    </div>
+    <div class="function" id="clear_last_error" data-name="clear_last_error">
+      <h3 class="function-name">clear_last_error <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clear_last_error()</code></pre>
+    </div>
+    <div class="function" id="matches" data-name="matches">
+      <h3 class="function-name">matches <span class="kind">fn</span></h3>
+      <pre class="usage"><code>matches(re, s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string</span></p>
+      <p class="doc">Does the pattern match anywhere in s? 1 if yes, 0 if no.</p>
+    </div>
+    <div class="function" id="find" data-name="find">
+      <h3 class="function-name">find <span class="kind">fn</span></h3>
+      <pre class="usage"><code>find(re, s) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string</span></p>
+      <p class="doc">First match span: returns (start_byte, end_byte, err). start = -1 when there's no match (err == &quot;&quot;) OR a real error (err != &quot;&quot;).</p>
+    </div>
+    <div class="function" id="captures" data-name="captures">
+      <h3 class="function-name">captures <span class="kind">fn</span></h3>
+      <pre class="usage"><code>captures(re, s) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string</span></p>
+    </div>
+    <div class="function" id="capture_count" data-name="capture_count">
+      <h3 class="function-name">capture_count <span class="kind">fn</span></h3>
+      <pre class="usage"><code>capture_count(caps) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr</span></p>
+    </div>
+    <div class="function" id="capture" data-name="capture">
+      <h3 class="function-name">capture <span class="kind">fn</span></h3>
+      <pre class="usage"><code>capture(caps, index) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="capture_start" data-name="capture_start">
+      <h3 class="function-name">capture_start <span class="kind">fn</span></h3>
+      <pre class="usage"><code>capture_start(caps, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="capture_end" data-name="capture_end">
+      <h3 class="function-name">capture_end <span class="kind">fn</span></h3>
+      <pre class="usage"><code>capture_end(caps, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="captures_free" data-name="captures_free">
+      <h3 class="function-name">captures_free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>captures_free(caps)</code></pre>
+      <p class="signature"><span class="sig-params">caps: ptr</span></p>
+    </div>
+    <div class="function" id="find_all" data-name="find_all">
+      <h3 class="function-name">find_all <span class="kind">fn</span></h3>
+      <pre class="usage"><code>find_all(re, s) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string</span></p>
+    </div>
+    <div class="function" id="find_all_count" data-name="find_all_count">
+      <h3 class="function-name">find_all_count <span class="kind">fn</span></h3>
+      <pre class="usage"><code>find_all_count(fa) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr</span></p>
+    </div>
+    <div class="function" id="find_all_start" data-name="find_all_start">
+      <h3 class="function-name">find_all_start <span class="kind">fn</span></h3>
+      <pre class="usage"><code>find_all_start(fa, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="find_all_end" data-name="find_all_end">
+      <h3 class="function-name">find_all_end <span class="kind">fn</span></h3>
+      <pre class="usage"><code>find_all_end(fa, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="find_all_free" data-name="find_all_free">
+      <h3 class="function-name">find_all_free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>find_all_free(fa)</code></pre>
+      <p class="signature"><span class="sig-params">fa: ptr</span></p>
+    </div>
+    <div class="function" id="replace" data-name="replace">
+      <h3 class="function-name">replace <span class="kind">fn</span></h3>
+      <pre class="usage"><code>replace(re, s, repl) <span class="arrow">-&gt;</span> (_0, _1)</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string, repl: string</span></p>
+      <p class="doc">Inferred return type (`-&gt; {`) so the heap-ownership of `out` (the extern is `-&gt; string @heap`) propagates to the caller's destructured result — an explicit `(string, string)` return marks position 0 as a borrow, so the caller never frees the substituted buffer and it leaks. `e` is the borrowed static last-error buffer (position 1, non-heap).</p>
+    </div>
+    <div class="function" id="replace_all" data-name="replace_all">
+      <h3 class="function-name">replace_all <span class="kind">fn</span></h3>
+      <pre class="usage"><code>replace_all(re, s, repl) <span class="arrow">-&gt;</span> (_0, _1)</code></pre>
+      <p class="signature"><span class="sig-params">re: ptr, s: string, repl: string</span></p>
+    </div>
+    <div class="function" id="matches_lit" data-name="matches_lit">
+      <h3 class="function-name">matches_lit <span class="kind">fn</span></h3>
+      <pre class="usage"><code>matches_lit(pattern, s) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string, s: string</span></p>
+    </div>
+    <div class="function" id="find_lit" data-name="find_lit">
+      <h3 class="function-name">find_lit <span class="kind">fn</span></h3>
+      <pre class="usage"><code>find_lit(pattern, s) <span class="arrow">-&gt;</span> (int, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string, s: string</span></p>
+    </div>
+    <div class="function" id="FLAG_CASELESS" data-name="FLAG_CASELESS">
+      <h3 class="function-name">FLAG_CASELESS <span class="kind">const</span></h3>
+      <pre class="usage"><code>FLAG_CASELESS = 0x00000008</code></pre>
+      <p class="doc">PCRE2 option bits — kept in sync with &lt;pcre2.h&gt;.</p>
+    </div>
+    <div class="function" id="FLAG_MULTILINE" data-name="FLAG_MULTILINE">
+      <h3 class="function-name">FLAG_MULTILINE <span class="kind">const</span></h3>
+      <pre class="usage"><code>FLAG_MULTILINE = 0x00000400</code></pre>
+    </div>
+    <div class="function" id="FLAG_DOTALL" data-name="FLAG_DOTALL">
+      <h3 class="function-name">FLAG_DOTALL <span class="kind">const</span></h3>
+      <pre class="usage"><code>FLAG_DOTALL = 0x00000020</code></pre>
+    </div>
+    <div class="function" id="FLAG_EXTENDED" data-name="FLAG_EXTENDED">
+      <h3 class="function-name">FLAG_EXTENDED <span class="kind">const</span></h3>
+      <pre class="usage"><code>FLAG_EXTENDED = 0x00000080</code></pre>
+    </div>
+    <div class="function" id="FLAG_UNGREEDY" data-name="FLAG_UNGREEDY">
+      <h3 class="function-name">FLAG_UNGREEDY <span class="kind">const</span></h3>
+      <pre class="usage"><code>FLAG_UNGREEDY = 0x00040000</code></pre>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/signal.html
+++ b/docs/api/signal.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>signal - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search signal..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#SIGHUP">SIGHUP</a></li>
+    <li><a href="#SIGINT">SIGINT</a></li>
+    <li><a href="#SIGQUIT">SIGQUIT</a></li>
+    <li><a href="#SIGILL">SIGILL</a></li>
+    <li><a href="#SIGABRT">SIGABRT</a></li>
+    <li><a href="#SIGFPE">SIGFPE</a></li>
+    <li><a href="#SIGKILL">SIGKILL</a></li>
+    <li><a href="#SIGSEGV">SIGSEGV</a></li>
+    <li><a href="#SIGPIPE">SIGPIPE</a></li>
+    <li><a href="#SIGALRM">SIGALRM</a></li>
+    <li><a href="#SIGTERM">SIGTERM</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li class="active"><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>signal</h1>
+    <p class="module-desc">std.signal — POSIX signal-number constants.</p>
+    <p class="import-line"><code>import std.signal</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="SIGHUP" data-name="SIGHUP">
+      <h3 class="function-name">SIGHUP <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGHUP() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Hangup — controlling terminal closed / daemon reload convention.</p>
+    </div>
+    <div class="function" id="SIGINT" data-name="SIGINT">
+      <h3 class="function-name">SIGINT <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGINT() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Interrupt — what Ctrl-C raises. Forwarded to the build group by os.run_supervised when forward_signals is on.</p>
+    </div>
+    <div class="function" id="SIGQUIT" data-name="SIGQUIT">
+      <h3 class="function-name">SIGQUIT <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGQUIT() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Quit — Ctrl-\, like SIGINT but with a core dump.</p>
+    </div>
+    <div class="function" id="SIGILL" data-name="SIGILL">
+      <h3 class="function-name">SIGILL <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGILL() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Illegal instruction.</p>
+    </div>
+    <div class="function" id="SIGABRT" data-name="SIGABRT">
+      <h3 class="function-name">SIGABRT <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGABRT() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Abort — what abort(3) / assert(3) raise.</p>
+    </div>
+    <div class="function" id="SIGFPE" data-name="SIGFPE">
+      <h3 class="function-name">SIGFPE <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGFPE() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Floating-point exception (also integer divide-by-zero).</p>
+    </div>
+    <div class="function" id="SIGKILL" data-name="SIGKILL">
+      <h3 class="function-name">SIGKILL <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGKILL() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Kill — cannot be caught, blocked, or ignored. The &quot;grace expired, take it down now&quot; signal os.run_supervised sends after SIGTERM.</p>
+    </div>
+    <div class="function" id="SIGSEGV" data-name="SIGSEGV">
+      <h3 class="function-name">SIGSEGV <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGSEGV() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Invalid memory reference.</p>
+    </div>
+    <div class="function" id="SIGPIPE" data-name="SIGPIPE">
+      <h3 class="function-name">SIGPIPE <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGPIPE() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Write to a pipe with no reader.</p>
+    </div>
+    <div class="function" id="SIGALRM" data-name="SIGALRM">
+      <h3 class="function-name">SIGALRM <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGALRM() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Timer signal from alarm(2).</p>
+    </div>
+    <div class="function" id="SIGTERM" data-name="SIGTERM">
+      <h3 class="function-name">SIGTERM <span class="kind">fn</span></h3>
+      <pre class="usage"><code>SIGTERM() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Termination — the polite &quot;please shut down&quot; request. The default signal os.run_supervised sends first on timeout / group teardown.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/strbuilder.html
+++ b/docs/api/strbuilder.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>strbuilder - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search strbuilder..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_strbuilder_new">aether_strbuilder_new</a></li>
+    <li><a href="#aether_strbuilder_append">aether_strbuilder_append</a></li>
+    <li><a href="#aether_strbuilder_append_n">aether_strbuilder_append_n</a></li>
+    <li><a href="#aether_strbuilder_append_byte">aether_strbuilder_append_byte</a></li>
+    <li><a href="#aether_strbuilder_append_int">aether_strbuilder_append_int</a></li>
+    <li><a href="#aether_strbuilder_append_long">aether_strbuilder_append_long</a></li>
+    <li><a href="#aether_strbuilder_append_hex">aether_strbuilder_append_hex</a></li>
+    <li><a href="#aether_strbuilder_append_codepoint">aether_strbuilder_append_codepoint</a></li>
+    <li><a href="#aether_strbuilder_length">aether_strbuilder_length</a></li>
+    <li><a href="#aether_strbuilder_capacity">aether_strbuilder_capacity</a></li>
+    <li><a href="#aether_strbuilder_reserve">aether_strbuilder_reserve</a></li>
+    <li><a href="#aether_strbuilder_truncate">aether_strbuilder_truncate</a></li>
+    <li><a href="#aether_strbuilder_clear">aether_strbuilder_clear</a></li>
+    <li><a href="#aether_strbuilder_finish">aether_strbuilder_finish</a></li>
+    <li><a href="#aether_strbuilder_finish_with_length">aether_strbuilder_finish_with_length</a></li>
+    <li><a href="#aether_strbuilder_free">aether_strbuilder_free</a></li>
+    <li><a href="#new">new</a></li>
+    <li><a href="#append">append</a></li>
+    <li><a href="#append_n">append_n</a></li>
+    <li><a href="#append_byte">append_byte</a></li>
+    <li><a href="#append_int">append_int</a></li>
+    <li><a href="#append_long">append_long</a></li>
+    <li><a href="#append_hex">append_hex</a></li>
+    <li><a href="#append_codepoint">append_codepoint</a></li>
+    <li><a href="#append_format">append_format</a></li>
+    <li><a href="#length">length</a></li>
+    <li><a href="#capacity">capacity</a></li>
+    <li><a href="#reserve">reserve</a></li>
+    <li><a href="#truncate">truncate</a></li>
+    <li><a href="#clear">clear</a></li>
+    <li><a href="#finish">finish</a></li>
+    <li><a href="#finish_with_length">finish_with_length</a></li>
+    <li><a href="#free">free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li class="active"><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>strbuilder</h1>
+    <p class="module-desc">std.strbuilder — amortised-O(1) string append.</p>
+    <p class="import-line"><code>import std.strbuilder</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_strbuilder_new" data-name="aether_strbuilder_new">
+      <h3 class="function-name">aether_strbuilder_new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_new(cap_hint) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cap_hint: int</span></p>
+      <p class="doc">---- Raw externs ----</p>
+    </div>
+    <div class="function" id="aether_strbuilder_append" data-name="aether_strbuilder_append">
+      <h3 class="function-name">aether_strbuilder_append <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_append(b, s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, s: string</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_append_n" data-name="aether_strbuilder_append_n">
+      <h3 class="function-name">aether_strbuilder_append_n <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_append_n(b, s, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, s: string, n: int</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_append_byte" data-name="aether_strbuilder_append_byte">
+      <h3 class="function-name">aether_strbuilder_append_byte <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_append_byte(b, c) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, c: int</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_append_int" data-name="aether_strbuilder_append_int">
+      <h3 class="function-name">aether_strbuilder_append_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_append_int(b, v) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, v: int</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_append_long" data-name="aether_strbuilder_append_long">
+      <h3 class="function-name">aether_strbuilder_append_long <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_append_long(b, v) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, v: long</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_append_hex" data-name="aether_strbuilder_append_hex">
+      <h3 class="function-name">aether_strbuilder_append_hex <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_append_hex(b, v, width) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, v: long, width: int</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_append_codepoint" data-name="aether_strbuilder_append_codepoint">
+      <h3 class="function-name">aether_strbuilder_append_codepoint <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_append_codepoint(b, cp) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, cp: int</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_length" data-name="aether_strbuilder_length">
+      <h3 class="function-name">aether_strbuilder_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_length(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_capacity" data-name="aether_strbuilder_capacity">
+      <h3 class="function-name">aether_strbuilder_capacity <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_capacity(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_reserve" data-name="aether_strbuilder_reserve">
+      <h3 class="function-name">aether_strbuilder_reserve <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_reserve(b, additional) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, additional: int</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_truncate" data-name="aether_strbuilder_truncate">
+      <h3 class="function-name">aether_strbuilder_truncate <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_truncate(b, new_length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, new_length: int</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_clear" data-name="aether_strbuilder_clear">
+      <h3 class="function-name">aether_strbuilder_clear <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_clear(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_finish" data-name="aether_strbuilder_finish">
+      <h3 class="function-name">aether_strbuilder_finish <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_finish(b) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_finish_with_length" data-name="aether_strbuilder_finish_with_length">
+      <h3 class="function-name">aether_strbuilder_finish_with_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_finish_with_length(b) <span class="arrow">-&gt;</span> (ptr, int)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="aether_strbuilder_free" data-name="aether_strbuilder_free">
+      <h3 class="function-name">aether_strbuilder_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_strbuilder_free(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new(cap_hint) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cap_hint: int</span></p>
+      <p class="doc">---- Aether-side wrappers ---- Allocate a new builder with at least `cap_hint` bytes reserved. If `cap_hint` is &lt;= 0, a small default is used. Returns null on OOM or cap exceeded. Initial logical length is 0.</p>
+    </div>
+    <div class="function" id="append" data-name="append">
+      <h3 class="function-name">append <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append(b, s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, s: string</span></p>
+      <p class="doc">Append a string. Length is taken from the AetherString header if present, else via strlen — so a plain `const char*` containing embedded NULs truncates at the first NUL. For binary-safe content, use `append_n` with an explicit length. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="append_n" data-name="append_n">
+      <h3 class="function-name">append_n <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_n(b, s, n) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, s: string, n: int</span></p>
+      <p class="doc">Append exactly `n` bytes from `s`. Binary-safe — embedded NULs round-trip cleanly. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="append_byte" data-name="append_byte">
+      <h3 class="function-name">append_byte <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_byte(b, c) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, c: int</span></p>
+      <p class="doc">Append a single byte (low 8 bits of `c`). Useful for separators — '\n' (10), ',' (44), 0x02, etc. — without the round-trip through a 1-byte string. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="append_int" data-name="append_int">
+      <h3 class="function-name">append_int <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_int(b, v) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, v: int</span></p>
+      <p class="doc">Append the decimal representation of `v` (no padding, leading '-' on negatives). Avoids constructing an intermediate AetherString from string.from_int. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="append_long" data-name="append_long">
+      <h3 class="function-name">append_long <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_long(b, v) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, v: long</span></p>
+      <p class="doc">Append the decimal representation of a 64-bit `v`. Use for IDs, timestamps, and offsets that overflow 32 bits. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="append_hex" data-name="append_hex">
+      <h3 class="function-name">append_hex <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_hex(b, v, width) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, v: long, width: int</span></p>
+      <p class="doc">Append `v` as lowercase hexadecimal. `width` is a minimum nibble count — 0 for natural width, &gt;0 to zero-pad; a value wider than `width` grows rather than truncating. Negative `v` is encoded as its unsigned bit pattern. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="append_codepoint" data-name="append_codepoint">
+      <h3 class="function-name">append_codepoint <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_codepoint(b, cp) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, cp: int</span></p>
+      <p class="doc">UTF-8 encode the Unicode code point `cp` and append it (1–4 bytes). Returns 0 — appending nothing — for invalid code points (negative, surrogate halves 0xD800–0xDFFF, or above 0x10FFFF); 1 on success.</p>
+    </div>
+    <div class="function" id="append_format" data-name="append_format">
+      <h3 class="function-name">append_format <span class="kind">fn</span></h3>
+      <pre class="usage"><code>append_format()</code></pre>
+    </div>
+    <div class="function" id="length" data-name="length">
+      <h3 class="function-name">length <span class="kind">fn</span></h3>
+      <pre class="usage"><code>length(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Current accumulated length in bytes. Returns -1 if `b` is null.</p>
+    </div>
+    <div class="function" id="capacity" data-name="capacity">
+      <h3 class="function-name">capacity <span class="kind">fn</span></h3>
+      <pre class="usage"><code>capacity(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Current buffer capacity in bytes. Companion to `length` — useful for confirming a `reserve` hint took or observing growth. Returns -1 if `b` is null.</p>
+    </div>
+    <div class="function" id="reserve" data-name="reserve">
+      <h3 class="function-name">reserve <span class="kind">fn</span></h3>
+      <pre class="usage"><code>reserve(b, additional) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, additional: int</span></p>
+      <p class="doc">Pre-grow the buffer so the next `additional` bytes of appends do not reallocate. A performance hint only — the builder grows on demand regardless. `additional` counts from the current length. Returns 1 on success, 0 on failure.</p>
+    </div>
+    <div class="function" id="truncate" data-name="truncate">
+      <h3 class="function-name">truncate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>truncate(b, new_length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, new_length: int</span></p>
+      <p class="doc">Pop accumulated content back to `new_length` bytes. Only shrinks — a `new_length` past the current length is rejected. The buffer is retained, so a truncate-then-append reuse loop keeps the growth amortisation. Returns 1 on success, 0 on failure (null builder, out-of-range `new_length`).</p>
+    </div>
+    <div class="function" id="clear" data-name="clear">
+      <h3 class="function-name">clear <span class="kind">fn</span></h3>
+      <pre class="usage"><code>clear(b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Reset accumulated content to empty (truncate to 0). The buffer is retained for reuse across loop iterations. Returns 1 on success, 0 if `b` is null.</p>
+    </div>
+    <div class="function" id="finish" data-name="finish">
+      <h3 class="function-name">finish <span class="kind">fn</span></h3>
+      <pre class="usage"><code>finish(b) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Finalise into a refcounted AetherString and destroy the builder. After this call, `b` is invalid — do not call append, length, or free on it. The returned string is heap-owned by the caller; the codegen's heap-string-tracker reclaims the buffer at scope exit.</p>
+    </div>
+    <div class="function" id="finish_with_length" data-name="finish_with_length">
+      <h3 class="function-name">finish_with_length <span class="kind">fn</span></h3>
+      <pre class="usage"><code>finish_with_length(b) <span class="arrow">-&gt;</span> (ptr, int)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Binary-safe finalise: returns the raw data buffer and its exact byte length as `(ptr, int)`, with NO NUL terminator appended — embedded NULs are preserved as content. Use this for binary protocol assembly (CBOR, msgpack, frames, packed records) where the v1 `finish`'s NUL-terminated `string` would be truncated by a strlen-based consumer downstream. The caller owns the returned pointer and MUST free it with a raw libc free (e.g. via `mem`-style handling) — position 0 is `ptr`, so it is not codegen-heap-tracked. An empty builder yields a non-null buffer with length 0. After this call `b` is invalid.</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>free(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Discard the builder without producing a string. Idempotent on null. Use on error paths where the in-progress output is no longer wanted.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/string.html
+++ b/docs/api/string.html
@@ -13,241 +13,580 @@
     <p class="tagline">Standard Library</p>
   </div>
   <input type="text" id="search" placeholder="Search string..." onkeyup="searchModule()">
-  <h2>Functions</h2>
+  <h2>Exports</h2>
   <ul class="function-nav">
-    <li><a href="#=">=</a></li>
-    <li><a href="#string_new">string_new</a></li>
-    <li><a href="#string_from_cstr">string_from_cstr</a></li>
-    <li><a href="#string_from_literal">string_from_literal</a></li>
-    <li><a href="#string_new_with_length">string_new_with_length</a></li>
-    <li><a href="#string_empty">string_empty</a></li>
-    <li><a href="#string_retain">string_retain</a></li>
-    <li><a href="#string_release">string_release</a></li>
-    <li><a href="#string_free">string_free</a></li>
-    <li><a href="#string_concat">string_concat</a></li>
-    <li><a href="#string_length">string_length</a></li>
-    <li><a href="#string_char_at">string_char_at</a></li>
-    <li><a href="#string_equals">string_equals</a></li>
-    <li><a href="#string_compare">string_compare</a></li>
-    <li><a href="#string_starts_with">string_starts_with</a></li>
-    <li><a href="#string_ends_with">string_ends_with</a></li>
-    <li><a href="#string_contains">string_contains</a></li>
-    <li><a href="#string_index_of">string_index_of</a></li>
-    <li><a href="#string_substring">string_substring</a></li>
-    <li><a href="#string_to_upper">string_to_upper</a></li>
-    <li><a href="#string_to_lower">string_to_lower</a></li>
-    <li><a href="#string_trim">string_trim</a></li>
-    <li><a href="#string_split">string_split</a></li>
-    <li><a href="#string_array_size">string_array_size</a></li>
-    <li><a href="#string_array_get">string_array_get</a></li>
-    <li><a href="#string_array_free">string_array_free</a></li>
-    <li><a href="#string_to_cstr">string_to_cstr</a></li>
-    <li><a href="#string_from_int">string_from_int</a></li>
-    <li><a href="#string_from_float">string_from_float</a></li>
-    <li><a href="#string_to_int_raw">string_to_int_raw</a></li>
-    <li><a href="#string_to_long_raw">string_to_long_raw</a></li>
-    <li><a href="#string_to_float_raw">string_to_float_raw</a></li>
-    <li><a href="#string_to_double_raw">string_to_double_raw</a></li>
-    <li><a href="#string_try_int">string_try_int</a></li>
-    <li><a href="#string_get_int">string_get_int</a></li>
-    <li><a href="#string_try_long">string_try_long</a></li>
-    <li><a href="#string_try_float">string_try_float</a></li>
-    <li><a href="#string_get_float">string_get_float</a></li>
-    <li><a href="#string_try_double">string_try_double</a></li>
-    <li><a href="#string_get_double">string_get_double</a></li>
-    <li><a href="#string_format">string_format</a></li>
+    <li><a href="#new">new</a></li>
+    <li><a href="#from_cstr">from_cstr</a></li>
+    <li><a href="#from_literal">from_literal</a></li>
+    <li><a href="#new_with_length">new_with_length</a></li>
+    <li><a href="#empty">empty</a></li>
+    <li><a href="#retain">retain</a></li>
+    <li><a href="#release">release</a></li>
+    <li><a href="#free">free</a></li>
+    <li><a href="#concat">concat</a></li>
+    <li><a href="#concat_wrapped">concat_wrapped</a></li>
+    <li><a href="#length">length</a></li>
+    <li><a href="#char_at">char_at</a></li>
+    <li><a href="#equals">equals</a></li>
+    <li><a href="#compare">compare</a></li>
+    <li><a href="#starts_with">starts_with</a></li>
+    <li><a href="#ends_with">ends_with</a></li>
+    <li><a href="#contains">contains</a></li>
+    <li><a href="#index_of">index_of</a></li>
+    <li><a href="#index_of_from">index_of_from</a></li>
+    <li><a href="#substring">substring</a></li>
+    <li><a href="#substring_n">substring_n</a></li>
+    <li><a href="#length_n">length_n</a></li>
+    <li><a href="#char_at_n">char_at_n</a></li>
+    <li><a href="#index_of_from_n">index_of_from_n</a></li>
+    <li><a href="#from_char">from_char</a></li>
+    <li><a href="#to_upper">to_upper</a></li>
+    <li><a href="#to_lower">to_lower</a></li>
+    <li><a href="#trim">trim</a></li>
+    <li><a href="#split">split</a></li>
+    <li><a href="#array_size">array_size</a></li>
+    <li><a href="#array_get">array_get</a></li>
+    <li><a href="#array_free">array_free</a></li>
+    <li><a href="#split_to_seq">split_to_seq</a></li>
+    <li><a href="#seq_empty">seq_empty</a></li>
+    <li><a href="#seq_cons">seq_cons</a></li>
+    <li><a href="#seq_head">seq_head</a></li>
+    <li><a href="#seq_tail">seq_tail</a></li>
+    <li><a href="#seq_is_empty">seq_is_empty</a></li>
+    <li><a href="#seq_length">seq_length</a></li>
+    <li><a href="#seq_retain">seq_retain</a></li>
+    <li><a href="#seq_free">seq_free</a></li>
+    <li><a href="#seq_from_array">seq_from_array</a></li>
+    <li><a href="#seq_to_array">seq_to_array</a></li>
+    <li><a href="#seq_reverse">seq_reverse</a></li>
+    <li><a href="#seq_concat">seq_concat</a></li>
+    <li><a href="#seq_take">seq_take</a></li>
+    <li><a href="#seq_drop">seq_drop</a></li>
+    <li><a href="#to_cstr">to_cstr</a></li>
+    <li><a href="#from_int">from_int</a></li>
+    <li><a href="#from_long">from_long</a></li>
+    <li><a href="#from_float">from_float</a></li>
+    <li><a href="#from_int_radix">from_int_radix</a></li>
+    <li><a href="#pad_start">pad_start</a></li>
+    <li><a href="#pad_end">pad_end</a></li>
+    <li><a href="#to_int_raw">to_int_raw</a></li>
+    <li><a href="#to_long_raw">to_long_raw</a></li>
+    <li><a href="#to_float_raw">to_float_raw</a></li>
+    <li><a href="#to_double_raw">to_double_raw</a></li>
+    <li><a href="#try_int">try_int</a></li>
+    <li><a href="#get_int">get_int</a></li>
+    <li><a href="#try_long">try_long</a></li>
+    <li><a href="#get_long">get_long</a></li>
+    <li><a href="#try_float">try_float</a></li>
+    <li><a href="#get_float">get_float</a></li>
+    <li><a href="#try_double">try_double</a></li>
+    <li><a href="#get_double">get_double</a></li>
+    <li><a href="#to_int_radix_raw">to_int_radix_raw</a></li>
+    <li><a href="#try_int_radix">try_int_radix</a></li>
+    <li><a href="#get_int_radix">get_int_radix</a></li>
+    <li><a href="#to_int">to_int</a></li>
+    <li><a href="#to_long">to_long</a></li>
+    <li><a href="#to_float">to_float</a></li>
+    <li><a href="#to_double">to_double</a></li>
+    <li><a href="#to_int_radix">to_int_radix</a></li>
+    <li><a href="#strip_prefix">strip_prefix</a></li>
+    <li><a href="#copy">copy</a></li>
+    <li><a href="#format_list">format_list</a></li>
+    <li><a href="#format">format</a></li>
+    <li><a href="#glob_match_raw">glob_match_raw</a></li>
+    <li><a href="#glob_match">glob_match</a></li>
+    <li><a href="#glob_match_pathname">glob_match_pathname</a></li>
   </ul>
   <hr>
   <h2>Modules</h2>
   <ul class="module-list">
-    <li><a href="net.html">net</a></li>
-    <li><a href="io.html">io</a></li>
-    <li><a href="math.html">math</a></li>
-    <li><a href="json.html">json</a></li>
-    <li><a href="log.html">log</a></li>
-    <li><a href="os.html">os</a></li>
-    <li class="active"><a href="string.html">string</a></li>
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
     <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
     <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li class="active"><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
   </ul>
 </nav>
 <main class="content">
   <div class="module-header">
     <h1>string</h1>
-    <p class="module-desc">String manipulation and formatting</p>
+    <p class="module-desc">std.string - String Module Import with: import std.string</p>
+    <p class="import-line"><code>import std.string</code></p>
   </div>
   <div class="functions" id="functions">
-    <div class="function" id="=" data-name="=">
-      <h3 class="function-name">=</h3>
-      <pre class="usage"><code>=()</code></pre>
-    </div>
-    <div class="function" id="string_new" data-name="string_new">
-      <h3 class="function-name">string_new</h3>
-      <pre class="usage"><code>string_new(cstr)</code></pre>
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new(cstr) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cstr: string</span></p>
       <p class="doc">String creation</p>
     </div>
-    <div class="function" id="string_from_cstr" data-name="string_from_cstr">
-      <h3 class="function-name">string_from_cstr</h3>
-      <pre class="usage"><code>string_from_cstr(cstr)</code></pre>
+    <div class="function" id="from_cstr" data-name="from_cstr">
+      <h3 class="function-name">from_cstr <span class="kind">extern</span></h3>
+      <pre class="usage"><code>from_cstr(cstr) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cstr: string</span></p>
     </div>
-    <div class="function" id="string_from_literal" data-name="string_from_literal">
-      <h3 class="function-name">string_from_literal</h3>
-      <pre class="usage"><code>string_from_literal(cstr)</code></pre>
+    <div class="function" id="from_literal" data-name="from_literal">
+      <h3 class="function-name">from_literal <span class="kind">extern</span></h3>
+      <pre class="usage"><code>from_literal(cstr) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cstr: string</span></p>
     </div>
-    <div class="function" id="string_new_with_length" data-name="string_new_with_length">
-      <h3 class="function-name">string_new_with_length</h3>
-      <pre class="usage"><code>string_new_with_length(data, length)</code></pre>
+    <div class="function" id="new_with_length" data-name="new_with_length">
+      <h3 class="function-name">new_with_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>new_with_length(data, length) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
     </div>
-    <div class="function" id="string_empty" data-name="string_empty">
-      <h3 class="function-name">string_empty</h3>
-      <pre class="usage"><code>string_empty()</code></pre>
+    <div class="function" id="empty" data-name="empty">
+      <h3 class="function-name">empty <span class="kind">extern</span></h3>
+      <pre class="usage"><code>empty() <span class="arrow">-&gt;</span> ptr</code></pre>
     </div>
-    <div class="function" id="string_retain" data-name="string_retain">
-      <h3 class="function-name">string_retain</h3>
-      <pre class="usage"><code>string_retain(str)</code></pre>
-      <p class="doc">Reference counting — safe to call with plain char* (no-op)</p>
+    <div class="function" id="retain" data-name="retain">
+      <h3 class="function-name">retain <span class="kind">extern</span></h3>
+      <pre class="usage"><code>retain(str)</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
+      <p class="doc">Reference counting. `str` is `@retain` on every refcount call: each one takes ownership of the lifetime decision (release decrements + frees at refcount 0; retain bumps the refcount; free drops the allocation immediately). The escape walker marks any heap- string variable passed at this slot as escaped, so the function-exit defer-free does not also call free() on the same buffer — without `@retain` here, a `defer string.release(s)` paired with the new auto-cleanup (issue #420 v2) would double-free the underlying allocation. After the call the caller's `_heap_&lt;name&gt;` tracker is conservatively kept at its previous value; the var is treated as dead from the reclamation system's perspective.</p>
     </div>
-    <div class="function" id="string_release" data-name="string_release">
-      <h3 class="function-name">string_release</h3>
-      <pre class="usage"><code>string_release(str)</code></pre>
+    <div class="function" id="release" data-name="release">
+      <h3 class="function-name">release <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release(str)</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
     </div>
-    <div class="function" id="string_free" data-name="string_free">
-      <h3 class="function-name">string_free</h3>
-      <pre class="usage"><code>string_free(str)</code></pre>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>free(str)</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
     </div>
-    <div class="function" id="string_concat" data-name="string_concat">
-      <h3 class="function-name">string_concat</h3>
-      <pre class="usage"><code>string_concat(a, b)</code></pre>
-      <p class="doc">String operations — accept both AetherString* and plain char*</p>
+    <div class="function" id="concat" data-name="concat">
+      <h3 class="function-name">concat <span class="kind">extern</span></h3>
+      <pre class="usage"><code>concat(a, b) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">a: string, b: string</span></p>
+      <p class="doc">String operations</p>
     </div>
-    <div class="function" id="string_length" data-name="string_length">
-      <h3 class="function-name">string_length</h3>
-      <pre class="usage"><code>string_length(str)</code></pre>
+    <div class="function" id="concat_wrapped" data-name="concat_wrapped">
+      <h3 class="function-name">concat_wrapped <span class="kind">extern</span></h3>
+      <pre class="usage"><code>concat_wrapped(a, b) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">a: string, b: string</span></p>
+      <p class="doc">Length-bearing concat. Returns a refcounted AetherString; downstream string.length() honours the stored length rather than falling through to strlen() and silently truncating at the first NUL. Use when joining inputs that may contain binary bytes (base64-decoded payloads, fs.read_binary output, …). Issue #270. Returns `string`: the C function yields an owned, refcounted AetherString*, which is exactly the magic `string` representation. Typing it `string` (not `ptr`) lets the codegen track the result as an owned heap string and release it at scope exit, and unwrap it to its payload bytes at naive-C-extern boundaries (#297). The C ABI is unchanged — the header still declares `AetherString*`.</p>
     </div>
-    <div class="function" id="string_char_at" data-name="string_char_at">
-      <h3 class="function-name">string_char_at</h3>
-      <pre class="usage"><code>string_char_at(str, index)</code></pre>
+    <div class="function" id="length" data-name="length">
+      <h3 class="function-name">length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>length(str) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
     </div>
-    <div class="function" id="string_equals" data-name="string_equals">
-      <h3 class="function-name">string_equals</h3>
-      <pre class="usage"><code>string_equals(a, b)</code></pre>
+    <div class="function" id="char_at" data-name="char_at">
+      <h3 class="function-name">char_at <span class="kind">extern</span></h3>
+      <pre class="usage"><code>char_at(str, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, index: int</span></p>
     </div>
-    <div class="function" id="string_compare" data-name="string_compare">
-      <h3 class="function-name">string_compare</h3>
-      <pre class="usage"><code>string_compare(a, b)</code></pre>
+    <div class="function" id="equals" data-name="equals">
+      <h3 class="function-name">equals <span class="kind">extern</span></h3>
+      <pre class="usage"><code>equals(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: string, b: string</span></p>
     </div>
-    <div class="function" id="string_starts_with" data-name="string_starts_with">
-      <h3 class="function-name">string_starts_with</h3>
-      <pre class="usage"><code>string_starts_with(str, prefix)</code></pre>
-      <p class="doc">String methods — accept both AetherString* and plain char* Return plain char* (caller owns memory, free with free())</p>
+    <div class="function" id="compare" data-name="compare">
+      <h3 class="function-name">compare <span class="kind">extern</span></h3>
+      <pre class="usage"><code>compare(a, b) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">a: string, b: string</span></p>
     </div>
-    <div class="function" id="string_ends_with" data-name="string_ends_with">
-      <h3 class="function-name">string_ends_with</h3>
-      <pre class="usage"><code>string_ends_with(str, suffix)</code></pre>
+    <div class="function" id="starts_with" data-name="starts_with">
+      <h3 class="function-name">starts_with <span class="kind">extern</span></h3>
+      <pre class="usage"><code>starts_with(str, prefix) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, prefix: string</span></p>
+      <p class="doc">String methods</p>
     </div>
-    <div class="function" id="string_contains" data-name="string_contains">
-      <h3 class="function-name">string_contains</h3>
-      <pre class="usage"><code>string_contains(str, substring)</code></pre>
+    <div class="function" id="ends_with" data-name="ends_with">
+      <h3 class="function-name">ends_with <span class="kind">extern</span></h3>
+      <pre class="usage"><code>ends_with(str, suffix) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, suffix: string</span></p>
     </div>
-    <div class="function" id="string_index_of" data-name="string_index_of">
-      <h3 class="function-name">string_index_of</h3>
-      <pre class="usage"><code>string_index_of(str, substring)</code></pre>
+    <div class="function" id="contains" data-name="contains">
+      <h3 class="function-name">contains <span class="kind">extern</span></h3>
+      <pre class="usage"><code>contains(str, substring) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, substring: string</span></p>
     </div>
-    <div class="function" id="string_substring" data-name="string_substring">
-      <h3 class="function-name">string_substring</h3>
-      <pre class="usage"><code>string_substring(str, start, end)</code></pre>
+    <div class="function" id="index_of" data-name="index_of">
+      <h3 class="function-name">index_of <span class="kind">extern</span></h3>
+      <pre class="usage"><code>index_of(str, substring) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, substring: string</span></p>
     </div>
-    <div class="function" id="string_to_upper" data-name="string_to_upper">
-      <h3 class="function-name">string_to_upper</h3>
-      <pre class="usage"><code>string_to_upper(str)</code></pre>
+    <div class="function" id="index_of_from" data-name="index_of_from">
+      <h3 class="function-name">index_of_from <span class="kind">extern</span></h3>
+      <pre class="usage"><code>index_of_from(str, substring, start) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, substring: string, start: int</span></p>
+      <p class="doc">Like index_of but starts scanning at byte offset `start`. Returns the absolute offset of the hit (not relative to `start`), or -1. Saves the substring+index_of allocation dance in hot loops that scan a packed string record-by-record.</p>
     </div>
-    <div class="function" id="string_to_lower" data-name="string_to_lower">
-      <h3 class="function-name">string_to_lower</h3>
-      <pre class="usage"><code>string_to_lower(str)</code></pre>
+    <div class="function" id="substring" data-name="substring">
+      <h3 class="function-name">substring <span class="kind">extern</span></h3>
+      <pre class="usage"><code>substring(str, start, end) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">str: string, start: int, end: int</span></p>
     </div>
-    <div class="function" id="string_trim" data-name="string_trim">
-      <h3 class="function-name">string_trim</h3>
-      <pre class="usage"><code>string_trim(str)</code></pre>
+    <div class="function" id="substring_n" data-name="substring_n">
+      <h3 class="function-name">substring_n <span class="kind">extern</span></h3>
+      <pre class="usage"><code>substring_n(str, str_len_bytes, start, end) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">str: string, str_len_bytes: int, start: int, end: int</span></p>
+      <p class="doc">Length-aware sibling — caller supplies the source length explicitly. Reach for this when `str` arrives as a `string` parameter at a function boundary (where #297's auto-unwrap may have stripped the AetherString header) AND the content may contain embedded NULs. The plain string_substring would call str_len() on the unwrapped data and fall through to strlen, truncating at the first NUL. Trusts the caller's `str_len_bytes` parameter — does NOT consult the AetherString header even if one happens to be present. start / end are clamped to [0, str_len_bytes].</p>
     </div>
-    <div class="function" id="string_split" data-name="string_split">
-      <h3 class="function-name">string_split</h3>
-      <pre class="usage"><code>string_split(str, delimiter)</code></pre>
+    <div class="function" id="length_n" data-name="length_n">
+      <h3 class="function-name">length_n <span class="kind">extern</span></h3>
+      <pre class="usage"><code>length_n(str, known_length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, known_length: int</span></p>
+      <p class="doc">Identity helper documenting intent: in code that receives a `string` parameter plus an explicit length, the explicit length IS the truth — don't consult the AetherString header. This function exists so `n = string.length_n(s, n)` reads as &quot;yes I know my length&quot; at the source level instead of looking like a forgotten `string.length(s)` that would have truncated at NUL. Pure no-op at the C level; clamps negative input to 0.</p>
     </div>
-    <div class="function" id="string_array_size" data-name="string_array_size">
-      <h3 class="function-name">string_array_size</h3>
-      <pre class="usage"><code>string_array_size(arr)</code></pre>
+    <div class="function" id="char_at_n" data-name="char_at_n">
+      <h3 class="function-name">char_at_n <span class="kind">extern</span></h3>
+      <pre class="usage"><code>char_at_n(str, known_length, index) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, known_length: int, index: int</span></p>
+      <p class="doc">Length-aware sibling of string_char_at. Caller supplies the haystack length explicitly so the bounds check skips the per-call strlen that string_char_at pays when `str` arrives as a plain `const char*` (the auto-unwrap at function-parameter boundary strips the AetherString header). Returns the byte at `index` as an int 0..255, or 0 on out-of-range. Reach for this in hot iterator-walk loops over a multi-KB body whose length the caller has already cached. Filed in string-length-aware-accessors.md after avn's bench profile showed __strlen_avx2 dominating CPU.</p>
     </div>
-    <div class="function" id="string_array_get" data-name="string_array_get">
-      <h3 class="function-name">string_array_get</h3>
-      <pre class="usage"><code>string_array_get(arr, index)</code></pre>
+    <div class="function" id="index_of_from_n" data-name="index_of_from_n">
+      <h3 class="function-name">index_of_from_n <span class="kind">extern</span></h3>
+      <pre class="usage"><code>index_of_from_n(str, known_length, substring, start) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, known_length: int, substring: string, start: int</span></p>
+      <p class="doc">Length-aware sibling of string_index_of_from. Same motivation as string_char_at_n — caller has already cached the haystack length. Needle is still strlen'd (small / fixed). Returns the absolute offset of the first match at or after `start`, or -1 on miss. `start` clamped to [0, known_length]; needle longer than the searchable range returns -1.</p>
     </div>
-    <div class="function" id="string_array_free" data-name="string_array_free">
-      <h3 class="function-name">string_array_free</h3>
-      <pre class="usage"><code>string_array_free(arr)</code></pre>
+    <div class="function" id="from_char" data-name="from_char">
+      <h3 class="function-name">from_char <span class="kind">extern</span></h3>
+      <pre class="usage"><code>from_char(code) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">code: int</span></p>
+      <p class="doc">Construct a 1-byte string from a byte code (0..255). Typical use is emitting known single-byte separators (\x01, \x02) into packed formats without routing through a NUL-terminated string literal. Always length 1 — code=0 returns a 1-byte NUL string, not &quot;&quot;.</p>
     </div>
-    <div class="function" id="string_to_cstr" data-name="string_to_cstr">
-      <h3 class="function-name">string_to_cstr</h3>
-      <pre class="usage"><code>string_to_cstr(str)</code></pre>
+    <div class="function" id="to_upper" data-name="to_upper">
+      <h3 class="function-name">to_upper <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_upper(str) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
+    </div>
+    <div class="function" id="to_lower" data-name="to_lower">
+      <h3 class="function-name">to_lower <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_lower(str) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
+    </div>
+    <div class="function" id="trim" data-name="trim">
+      <h3 class="function-name">trim <span class="kind">extern</span></h3>
+      <pre class="usage"><code>trim(str) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
+    </div>
+    <div class="function" id="split" data-name="split">
+      <h3 class="function-name">split <span class="kind">extern</span></h3>
+      <pre class="usage"><code>split(str, delimiter) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">str: string, delimiter: string</span></p>
+      <p class="doc">String array operations. LIFETIME WARNING — `string_array_get` returns a *borrowed* pointer into the array's internal storage, NOT an owned copy. After `string_array_free(arr)` every pointer previously handed out by `string_array_get(arr, ...)` is dangling. The natural-looking pattern below silently use-after-frees: v = string.array_get(parts, idx) string.array_free(parts) return v                 // &lt;- v dangles Symptom is garbage bytes / random crashes downstream — the array's backing storage is gone but the pointer still reads. Safe options when you need a value to outlive the array: 1. Copy first:  v = string.concat(string.array_get(parts, idx), &quot;&quot;) then string.array_free(parts) — the concat made an owned, refcounted copy. 2. Use `string_split_to_seq` (declared further down) — returns a refcounted `*StringSeq` whose cells own their data independently of any backing array, so there's no array-wide free to worry about. This is the RECOMMENDED shape: a `*StringSeq` local is reclaimed DETERMINISTICALLY by the compiler — freed automatically at scope exit via the refcount-decrementing `string_seq_free`, the same way heap strings are. No manual free, and (because the free is a decrement) structurally-shared tails stay safe. A piece you pull from a sequence and let escape transfers ownership cleanly, with no dangling-into-a-backing-array hazard. If your access pattern is &quot;build, walk once, free&quot; within a single scope, the borrowed-pointer form is fine and the cheapest. Reach for option 1/2 only when a piece needs to escape the array's lifetime.</p>
+    </div>
+    <div class="function" id="array_size" data-name="array_size">
+      <h3 class="function-name">array_size <span class="kind">extern</span></h3>
+      <pre class="usage"><code>array_size(arr) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+    </div>
+    <div class="function" id="array_get" data-name="array_get">
+      <h3 class="function-name">array_get <span class="kind">extern</span></h3>
+      <pre class="usage"><code>array_get(arr, index) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, index: int</span></p>
+    </div>
+    <div class="function" id="array_free" data-name="array_free">
+      <h3 class="function-name">array_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>array_free(arr)</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr</span></p>
+    </div>
+    <div class="function" id="split_to_seq" data-name="split_to_seq">
+      <h3 class="function-name">split_to_seq <span class="kind">extern</span></h3>
+      <pre class="usage"><code>split_to_seq(str, delimiter) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">str: string, delimiter: string</span></p>
+      <p class="doc">Producers — sibling of string_split that returns a *StringSeq directly. Same split semantics: empty input → single-cell list with &quot;&quot;, delimiter longer than input → single-cell list with the whole input, trailing/leading delimiters produce empty pieces.</p>
+    </div>
+    <div class="function" id="seq_empty" data-name="seq_empty">
+      <h3 class="function-name">seq_empty <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_empty() <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="doc">Cons-cell construction + destructuring. Names mirror the C runtime symbols; users call them via dot-notation `string.seq_X(...)` (the qualified-name resolver joins `string` + `seq_X` → `string_seq_X`).</p>
+    </div>
+    <div class="function" id="seq_cons" data-name="seq_cons">
+      <h3 class="function-name">seq_cons <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_cons(head, tail) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">head: string, tail: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_head" data-name="seq_head">
+      <h3 class="function-name">seq_head <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_head(s) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_tail" data-name="seq_tail">
+      <h3 class="function-name">seq_tail <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_tail(s) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_is_empty" data-name="seq_is_empty">
+      <h3 class="function-name">seq_is_empty <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_is_empty(s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_length" data-name="seq_length">
+      <h3 class="function-name">seq_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_length(s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_retain" data-name="seq_retain">
+      <h3 class="function-name">seq_retain <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_retain(s) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_free" data-name="seq_free">
+      <h3 class="function-name">seq_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_free(s)</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_from_array" data-name="seq_from_array">
+      <h3 class="function-name">seq_from_array <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_from_array(arr, count) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">arr: ptr, count: int</span></p>
+    </div>
+    <div class="function" id="seq_to_array" data-name="seq_to_array">
+      <h3 class="function-name">seq_to_array <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_to_array(s) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_reverse" data-name="seq_reverse">
+      <h3 class="function-name">seq_reverse <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_reverse(s) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq</span></p>
+      <p class="doc">Closure-free combinators. The shape deliberately avoids passing Aether functions across the FFI — that's its own design question (closure-bearing combinators map / filter / foldl will land in a separate change set once the callback bridge is settled). The four below are pure structural ops over the cons cells, all refcount-correct on shared tails, all O(min(n, length)) or O(length) work with no auxiliary stack.</p>
+    </div>
+    <div class="function" id="seq_concat" data-name="seq_concat">
+      <h3 class="function-name">seq_concat <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_concat(a, b) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">a: *StringSeq, b: *StringSeq</span></p>
+    </div>
+    <div class="function" id="seq_take" data-name="seq_take">
+      <h3 class="function-name">seq_take <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_take(s, n) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq, n: int</span></p>
+    </div>
+    <div class="function" id="seq_drop" data-name="seq_drop">
+      <h3 class="function-name">seq_drop <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_drop(s, n) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq, n: int</span></p>
+    </div>
+    <div class="function" id="to_cstr" data-name="to_cstr">
+      <h3 class="function-name">to_cstr <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_cstr(str) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">str: string</span></p>
       <p class="doc">Conversion</p>
     </div>
-    <div class="function" id="string_from_int" data-name="string_from_int">
-      <h3 class="function-name">string_from_int</h3>
-      <pre class="usage"><code>string_from_int(value)</code></pre>
+    <div class="function" id="from_int" data-name="from_int">
+      <h3 class="function-name">from_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>from_int(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: int</span></p>
     </div>
-    <div class="function" id="string_from_float" data-name="string_from_float">
-      <h3 class="function-name">string_from_float</h3>
-      <pre class="usage"><code>string_from_float(value)</code></pre>
+    <div class="function" id="from_long" data-name="from_long">
+      <h3 class="function-name">from_long <span class="kind">extern</span></h3>
+      <pre class="usage"><code>from_long(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: long</span></p>
     </div>
-    <div class="function" id="string_to_int_raw" data-name="string_to_int_raw">
-      <h3 class="function-name">string_to_int_raw</h3>
-      <pre class="usage"><code>string_to_int_raw(str, out_value)</code></pre>
-      <p class="doc">Parsing (string -&gt; number) — raw form with out-parameter. Returns 1 on success, 0 on failure. Result stored in out_value. Aether code should prefer the Go-style wrappers in std.string (`string.to_int`, etc.) which return `(value, error)` tuples.</p>
+    <div class="function" id="from_float" data-name="from_float">
+      <h3 class="function-name">from_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>from_float(value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: float</span></p>
     </div>
-    <div class="function" id="string_to_long_raw" data-name="string_to_long_raw">
-      <h3 class="function-name">string_to_long_raw</h3>
-      <pre class="usage"><code>string_to_long_raw(str, out_value)</code></pre>
+    <div class="function" id="from_int_radix" data-name="from_int_radix">
+      <h3 class="function-name">from_int_radix <span class="kind">extern</span></h3>
+      <pre class="usage"><code>from_int_radix(value, radix) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">value: long, radix: int</span></p>
+      <p class="doc">Inverse of to_int_radix. Render `value` in base `radix` (2..36). Returns an empty string for radix outside [2, 36]; otherwise the digit string (lowercase a-z for radix 11..36), with a leading '-' for negatives. No &quot;0x&quot; / &quot;0b&quot; prefix. Headline use: hex emit for color round-trips (RGB → #rrggbb). Pair with `string.pad_start(s, 2, 48)` to get the JS `r.toString(16).padStart(2, '0')` shape.</p>
     </div>
-    <div class="function" id="string_to_float_raw" data-name="string_to_float_raw">
-      <h3 class="function-name">string_to_float_raw</h3>
-      <pre class="usage"><code>string_to_float_raw(str, out_value)</code></pre>
+    <div class="function" id="pad_start" data-name="pad_start">
+      <h3 class="function-name">pad_start <span class="kind">extern</span></h3>
+      <pre class="usage"><code>pad_start(s, total_width, pad_char) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">s: string, total_width: int, pad_char: int</span></p>
+      <p class="doc">Pad to a fixed width with `pad_char` (single-byte char code — `48` for '0', `32` for ' '). If `s` is already &gt;= total_width chars, returns a fresh copy (no truncation). total_width &lt;= 0 also returns a fresh copy. pad_start prepends; pad_end appends.</p>
     </div>
-    <div class="function" id="string_to_double_raw" data-name="string_to_double_raw">
-      <h3 class="function-name">string_to_double_raw</h3>
-      <pre class="usage"><code>string_to_double_raw(str, out_value)</code></pre>
+    <div class="function" id="pad_end" data-name="pad_end">
+      <h3 class="function-name">pad_end <span class="kind">extern</span></h3>
+      <pre class="usage"><code>pad_end(s, total_width, pad_char) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">s: string, total_width: int, pad_char: int</span></p>
     </div>
-    <div class="function" id="string_try_int" data-name="string_try_int">
-      <h3 class="function-name">string_try_int</h3>
-      <pre class="usage"><code>string_try_int(s)</code></pre>
-      <p class="doc">Split-return helpers used by the Go-style wrappers. `_try` returns 1 if parseable, 0 otherwise. `_get` returns the parsed value or zero-value on failure.</p>
+    <div class="function" id="to_int_raw" data-name="to_int_raw">
+      <h3 class="function-name">to_int_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_int_raw(str, out_value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, out_value: ptr</span></p>
+      <p class="doc">Parsing — raw externs (escape hatch)</p>
     </div>
-    <div class="function" id="string_get_int" data-name="string_get_int">
-      <h3 class="function-name">string_get_int</h3>
-      <pre class="usage"><code>string_get_int(s)</code></pre>
+    <div class="function" id="to_long_raw" data-name="to_long_raw">
+      <h3 class="function-name">to_long_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_long_raw(str, out_value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, out_value: ptr</span></p>
     </div>
-    <div class="function" id="string_try_long" data-name="string_try_long">
-      <h3 class="function-name">string_try_long</h3>
-      <pre class="usage"><code>string_try_long(s)</code></pre>
+    <div class="function" id="to_float_raw" data-name="to_float_raw">
+      <h3 class="function-name">to_float_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_float_raw(str, out_value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, out_value: ptr</span></p>
     </div>
-    <div class="function" id="string_try_float" data-name="string_try_float">
-      <h3 class="function-name">string_try_float</h3>
-      <pre class="usage"><code>string_try_float(s)</code></pre>
+    <div class="function" id="to_double_raw" data-name="to_double_raw">
+      <h3 class="function-name">to_double_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_double_raw(str, out_value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, out_value: ptr</span></p>
     </div>
-    <div class="function" id="string_get_float" data-name="string_get_float">
-      <h3 class="function-name">string_get_float</h3>
-      <pre class="usage"><code>string_get_float(s)</code></pre>
+    <div class="function" id="try_int" data-name="try_int">
+      <h3 class="function-name">try_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_int(s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Parsing — split-return helpers for the Go-style wrappers.</p>
     </div>
-    <div class="function" id="string_try_double" data-name="string_try_double">
-      <h3 class="function-name">string_try_double</h3>
-      <pre class="usage"><code>string_try_double(s)</code></pre>
+    <div class="function" id="get_int" data-name="get_int">
+      <h3 class="function-name">get_int <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_int(s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
     </div>
-    <div class="function" id="string_get_double" data-name="string_get_double">
-      <h3 class="function-name">string_get_double</h3>
-      <pre class="usage"><code>string_get_double(s)</code></pre>
+    <div class="function" id="try_long" data-name="try_long">
+      <h3 class="function-name">try_long <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_long(s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
     </div>
-    <div class="function" id="string_format" data-name="string_format">
-      <h3 class="function-name">string_format</h3>
-      <pre class="usage"><code>string_format(fmt)</code></pre>
-      <p class="doc">Formatting (printf-style)</p>
+    <div class="function" id="get_long" data-name="get_long">
+      <h3 class="function-name">get_long <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_long(s) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+    </div>
+    <div class="function" id="try_float" data-name="try_float">
+      <h3 class="function-name">try_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_float(s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+    </div>
+    <div class="function" id="get_float" data-name="get_float">
+      <h3 class="function-name">get_float <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_float(s) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+    </div>
+    <div class="function" id="try_double" data-name="try_double">
+      <h3 class="function-name">try_double <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_double(s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+    </div>
+    <div class="function" id="get_double" data-name="get_double">
+      <h3 class="function-name">get_double <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_double(s) <span class="arrow">-&gt;</span> float</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+    </div>
+    <div class="function" id="to_int_radix_raw" data-name="to_int_radix_raw">
+      <h3 class="function-name">to_int_radix_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>to_int_radix_raw(str, radix, out_value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">str: string, radix: int, out_value: ptr</span></p>
+    </div>
+    <div class="function" id="try_int_radix" data-name="try_int_radix">
+      <h3 class="function-name">try_int_radix <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_int_radix(s, radix) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">s: string, radix: int</span></p>
+      <p class="doc">Base-N parse split-return. The value slot is `long` (int64) because radix-36 can exceed int32 quickly and because callers parsing hex often want the full 64-bit width (32-bit ARGB colors, file offsets, flag masks). Callers that only want an int can downcast at the call site.</p>
+    </div>
+    <div class="function" id="get_int_radix" data-name="get_int_radix">
+      <h3 class="function-name">get_int_radix <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_int_radix(s, radix) <span class="arrow">-&gt;</span> long</code></pre>
+      <p class="signature"><span class="sig-params">s: string, radix: int</span></p>
+    </div>
+    <div class="function" id="to_int" data-name="to_int">
+      <h3 class="function-name">to_int <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_int(s) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Parse a string to an integer. Returns (value, &quot;&quot;) on success, (0, error) on invalid input. Handles leading whitespace, sign, base-10 digits. Trailing whitespace is ignored; trailing garbage produces an error.</p>
+    </div>
+    <div class="function" id="to_long" data-name="to_long">
+      <h3 class="function-name">to_long <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_long(s) <span class="arrow">-&gt;</span> (long, string)</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Parse a string to a long (int64). Returns (value, &quot;&quot;) on success, (0, error) on invalid input.</p>
+    </div>
+    <div class="function" id="to_float" data-name="to_float">
+      <h3 class="function-name">to_float <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_float(s) <span class="arrow">-&gt;</span> (float, string)</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Parse a string to a float. Returns (value, &quot;&quot;) on success, (0.0, error) on invalid input.</p>
+    </div>
+    <div class="function" id="to_double" data-name="to_double">
+      <h3 class="function-name">to_double <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_double(s) <span class="arrow">-&gt;</span> (float, string)</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Parse a string to a double. Returns (value, &quot;&quot;) on success, (0.0, error) on invalid input.</p>
+    </div>
+    <div class="function" id="to_int_radix" data-name="to_int_radix">
+      <h3 class="function-name">to_int_radix <span class="kind">fn</span></h3>
+      <pre class="usage"><code>to_int_radix(s, radix) <span class="arrow">-&gt;</span> (long, string)</code></pre>
+      <p class="signature"><span class="sig-params">s: string, radix: int</span></p>
+      <p class="doc">Base-N parse: like `to_long` but accepts a radix in [2, 36]. Headline use cases: hex color decode (`parseInt(hex, 16)` patterns), hex byte fields in config files, binary masks, octal mode bits. Returns (value, &quot;&quot;) on success; (0, error) on: - radix outside [2, 36] - empty string or unparseable digits - overflow (the int64 range) - trailing non-whitespace garbage No &quot;0x&quot; / &quot;0b&quot; prefix recognition — pass the digit-only substring. The value is `long` (int64) because radix-16/36 can exceed int32 quickly and because callers often want the full 64-bit width (32-bit ARGB colors, file offsets, flag masks). Downcast at the call site if you only want an int.</p>
+    </div>
+    <div class="function" id="strip_prefix" data-name="strip_prefix">
+      <h3 class="function-name">strip_prefix <span class="kind">fn</span></h3>
+      <pre class="usage"><code>strip_prefix(s, prefix) <span class="arrow">-&gt;</span> (_0, int, _2, int)</code></pre>
+      <p class="signature"><span class="sig-params">s: string, prefix: string</span></p>
+      <p class="doc">If `s` starts with `prefix`, return (s-after-prefix, 1). Otherwise return (s, 0). An empty prefix is treated as always matching and leaves `s` unchanged — callers can use the 1/0 flag to tell &quot;matched and stripped&quot; from &quot;no match&quot;.</p>
+    </div>
+    <div class="function" id="copy" data-name="copy">
+      <h3 class="function-name">copy <span class="kind">fn</span></h3>
+      <pre class="usage"><code>copy(s) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Return an independently-owned copy of `s`. Useful when `s` is borrowed from a TLS buffer or arena that the next C call will overwrite — calling `copy` guarantees the returned string outlives such a handoff. Equivalent to `string_concat(s, &quot;&quot;)` but with a discoverable name.</p>
+    </div>
+    <div class="function" id="format_list" data-name="format_list">
+      <h3 class="function-name">format_list <span class="kind">extern</span></h3>
+      <pre class="usage"><code>format_list(fmt, args) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">fmt: string, args: ptr</span></p>
+      <p class="doc">Format a string by substituting `{}` placeholders with the corresponding entries of `args` (an `std.list` of strings). `{{` and `}}` are literal braces. Returns a refcounted AetherString. Closes #272. Use this for runtime-built strings of N parts where literal `${...}` interpolation isn't usable (e.g. when the format string itself comes from a config file or message-template lookup): args = list_new() list_add(args, &quot;PUT&quot;) list_add(args, &quot;/foo/bar&quot;) list_add(args, &quot;alice&quot;) msg = string.format(&quot;{} {} by {}&quot;, args)   // &quot;PUT /foo/bar by alice&quot; Non-string values (ints, floats) need explicit conversion via `string.from_int(n)` etc. before being added to the list.</p>
+    </div>
+    <div class="function" id="format" data-name="format">
+      <h3 class="function-name">format <span class="kind">fn</span></h3>
+      <pre class="usage"><code>format(fmt, args) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">fmt: string, args: ptr</span></p>
+    </div>
+    <div class="function" id="glob_match_raw" data-name="glob_match_raw">
+      <h3 class="function-name">glob_match_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>glob_match_raw(pattern, s, flags) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string, s: string, flags: int</span></p>
+      <p class="doc">Glob-pattern matching: does `pattern` match `s`? Aether-side equivalent of POSIX fnmatch(3) — string-pattern matching, distinct from `fs.glob` (which enumerates files on disk). Pattern syntax: `*`      — zero or more characters `?`      — exactly one character `[abc]`  — any of the listed characters (char class) `[a-z]`  — character range `[!abc]` — negated class (also `[^abc]`) `\*` / `\?` — literal `*` / `?` Returns 1 on match, 0 on no-match, -1 on glob-syntax error (unmatched bracket). Section A.2 of aether_changes_needed.md. Use `glob_match` for the plain form (svn:ignore matching, message routing). Use `glob_match_pathname` when `*` and `?` should NOT cross a `/` separator — the right form for matching path patterns like `src/*.c` (matches `src/foo.c` but not `src/sub/foo.c`).</p>
+    </div>
+    <div class="function" id="glob_match" data-name="glob_match">
+      <h3 class="function-name">glob_match <span class="kind">fn</span></h3>
+      <pre class="usage"><code>glob_match(pattern, s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string, s: string</span></p>
+    </div>
+    <div class="function" id="glob_match_pathname" data-name="glob_match_pathname">
+      <h3 class="function-name">glob_match_pathname <span class="kind">fn</span></h3>
+      <pre class="usage"><code>glob_match_pathname(pattern, s) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">pattern: string, s: string</span></p>
     </div>
   </div>
 </main>

--- a/docs/api/style.css
+++ b/docs/api/style.css
@@ -10,6 +10,7 @@ body {
 }
 
 a { color: inherit; text-decoration: none; }
+code { font-family: 'SF Mono', 'Fira Code', monospace; }
 
 .sidebar {
   width: 240px;
@@ -21,17 +22,8 @@ a { color: inherit; text-decoration: none; }
   border-right: 1px solid #222;
 }
 
-.sidebar-header h1 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #fff;
-}
-
-.sidebar-header .tagline {
-  font-size: 0.75rem;
-  color: #666;
-  margin-top: 2px;
-}
+.sidebar-header h1 { font-size: 1.1rem; font-weight: 600; color: #fff; }
+.sidebar-header .tagline { font-size: 0.75rem; color: #666; margin-top: 2px; }
 
 #search {
   width: 100%;
@@ -70,17 +62,13 @@ a { color: inherit; text-decoration: none; }
   font-family: 'SF Mono', 'Fira Code', monospace;
   font-size: 0.8rem;
   padding: 4px 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.module-list li a:hover, .function-nav li a:hover {
-  background: #1a1a1a;
-  color: #fff;
-}
-
-.module-list .active a {
-  background: #1a2a3a;
-  color: #4a9eff;
-}
+.module-list li a:hover, .function-nav li a:hover { background: #1a1a1a; color: #fff; }
+.module-list .active a { background: #1a2a3a; color: #4a9eff; }
 
 hr { border: none; border-top: 1px solid #222; margin: 16px 0; }
 
@@ -93,11 +81,13 @@ hr { border: none; border-top: 1px solid #222; margin: 16px 0; }
 
 .hero { margin-bottom: 40px; }
 .hero h1 { font-size: 1.5rem; font-weight: 600; color: #fff; margin-bottom: 8px; }
-.hero p { color: #666; font-size: 0.95rem; }
+.hero p { color: #888; font-size: 0.95rem; }
+.hero code, .module-desc code, .import-line code { color: #7dd3fc; background: #141414; padding: 1px 5px; border-radius: 4px; font-size: 0.85em; }
 
 .module-header { margin-bottom: 32px; }
 .module-header h1 { font-size: 1.4rem; font-weight: 600; color: #fff; margin-bottom: 4px; }
-.module-desc { color: #666; font-size: 0.9rem; }
+.module-desc { color: #888; font-size: 0.9rem; }
+.import-line { margin-top: 8px; }
 
 .module-grid {
   display: grid;
@@ -116,10 +106,11 @@ hr { border: none; border-top: 1px solid #222; margin: 16px 0; }
 
 .module-card:hover { border-color: #333; background: #181818; }
 .module-card h3 { font-size: 0.95rem; color: #fff; margin-bottom: 4px; }
-.module-card p { font-size: 0.8rem; color: #666; }
+.module-card p { font-size: 0.8rem; color: #888; margin-bottom: 8px; }
+.module-card .count { font-size: 0.7rem; color: #555; }
 
 .search-results { margin-top: 32px; }
-.search-results h2 { font-size: 0.85rem; color: #666; margin-bottom: 16px; }
+.search-results h2 { font-size: 0.85rem; color: #888; margin-bottom: 16px; }
 
 .function-list { list-style: none; }
 .function-item a {
@@ -147,23 +138,43 @@ hr { border: none; border-top: 1px solid #222; margin: 16px 0; }
   font-weight: 500;
   color: #fff;
   margin-bottom: 8px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.function-name .kind {
+  font-family: -apple-system, sans-serif;
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #4a9eff;
+  background: #14202e;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 8px;
+  vertical-align: middle;
 }
 
 .usage {
   background: #0a0a0a;
   padding: 10px 14px;
   border-radius: 6px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   overflow-x: auto;
 }
 
-.usage code {
-  font-family: 'SF Mono', 'Fira Code', monospace;
-  font-size: 0.85rem;
-  color: #7dd3fc;
-}
+.usage code { font-size: 0.85rem; color: #7dd3fc; }
+.usage .arrow { color: #666; }
 
-.doc { color: #888; font-size: 0.9rem; }
+.signature {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.78rem;
+  color: #888;
+  margin-bottom: 8px;
+}
+.signature .sig-params { color: #c0a0e0; }
+
+.doc { color: #999; font-size: 0.9rem; }
 
 .hidden { display: none !important; }
 

--- a/docs/api/tcp.html
+++ b/docs/api/tcp.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tcp - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search tcp..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#connect_raw">connect_raw</a></li>
+    <li><a href="#send_raw">send_raw</a></li>
+    <li><a href="#receive_raw">receive_raw</a></li>
+    <li><a href="#close">close</a></li>
+    <li><a href="#listen_raw">listen_raw</a></li>
+    <li><a href="#accept_raw">accept_raw</a></li>
+    <li><a href="#server_close">server_close</a></li>
+    <li><a href="#connect">connect</a></li>
+    <li><a href="#write">write</a></li>
+    <li><a href="#read">read</a></li>
+    <li><a href="#listen">listen</a></li>
+    <li><a href="#accept">accept</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li class="active"><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>tcp</h1>
+    <p class="module-desc">std.tcp - TCP Socket Operations (alias for std.net) Raw externs end in `_raw` and return NULL/int in C-style.</p>
+    <p class="import-line"><code>import std.tcp</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="connect_raw" data-name="connect_raw">
+      <h3 class="function-name">connect_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>connect_raw(host, port) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">host: string, port: int</span></p>
+      <p class="doc">Raw externs - escape hatch</p>
+    </div>
+    <div class="function" id="send_raw" data-name="send_raw">
+      <h3 class="function-name">send_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>send_raw(sock, data) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr, data: string</span></p>
+    </div>
+    <div class="function" id="receive_raw" data-name="receive_raw">
+      <h3 class="function-name">receive_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>receive_raw(sock, max_bytes) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr, max_bytes: int</span></p>
+    </div>
+    <div class="function" id="close" data-name="close">
+      <h3 class="function-name">close <span class="kind">extern</span></h3>
+      <pre class="usage"><code>close(sock) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr</span></p>
+    </div>
+    <div class="function" id="listen_raw" data-name="listen_raw">
+      <h3 class="function-name">listen_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>listen_raw(port) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">port: int</span></p>
+    </div>
+    <div class="function" id="accept_raw" data-name="accept_raw">
+      <h3 class="function-name">accept_raw <span class="kind">extern</span></h3>
+      <pre class="usage"><code>accept_raw(server) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+    </div>
+    <div class="function" id="server_close" data-name="server_close">
+      <h3 class="function-name">server_close <span class="kind">extern</span></h3>
+      <pre class="usage"><code>server_close(server) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+    </div>
+    <div class="function" id="connect" data-name="connect">
+      <h3 class="function-name">connect <span class="kind">fn</span></h3>
+      <pre class="usage"><code>connect(host, port) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">host: string, port: int</span></p>
+      <p class="doc">Connect to host:port. Returns (socket, &quot;&quot;) on success, (null, error) on failure. Caller must tcp.close the returned socket.</p>
+    </div>
+    <div class="function" id="write" data-name="write">
+      <h3 class="function-name">write <span class="kind">fn</span></h3>
+      <pre class="usage"><code>write(sock, data) <span class="arrow">-&gt;</span> (int, string)</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr, data: string</span></p>
+      <p class="doc">Write data to a socket. Returns (bytes_sent, &quot;&quot;) on success, (0, error) on failure. Note: named `write`/`read` (not `send`/`receive`) because `send` and `receive` are reserved actor keywords in Aether. The `tcp.send_raw` extern is still available under the old name for direct use.</p>
+    </div>
+    <div class="function" id="read" data-name="read">
+      <h3 class="function-name">read <span class="kind">fn</span></h3>
+      <pre class="usage"><code>read(sock, max_bytes) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">sock: ptr, max_bytes: int</span></p>
+      <p class="doc">Read up to max_bytes from a socket. Returns (data, &quot;&quot;) on success, (&quot;&quot;, error) on transport failure or connection close.</p>
+    </div>
+    <div class="function" id="listen" data-name="listen">
+      <h3 class="function-name">listen <span class="kind">fn</span></h3>
+      <pre class="usage"><code>listen(port) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">port: int</span></p>
+      <p class="doc">Listen on a port. Returns (server, &quot;&quot;) on success, (null, error) on failure. Caller must tcp.server_close the returned server.</p>
+    </div>
+    <div class="function" id="accept" data-name="accept">
+      <h3 class="function-name">accept <span class="kind">fn</span></h3>
+      <pre class="usage"><code>accept(server) <span class="arrow">-&gt;</span> (ptr, string)</code></pre>
+      <p class="signature"><span class="sig-params">server: ptr</span></p>
+      <p class="doc">Accept an incoming connection. Returns (socket, &quot;&quot;) on success, (null, error) on failure or shutdown.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/tsid.html
+++ b/docs/api/tsid.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tsid - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search tsid..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#generate">generate</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li class="active"><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>tsid</h1>
+    <p class="module-desc">std.tsid — TSID (Twitter Snowflake family / Discord-shaped).</p>
+    <p class="import-line"><code>import std.tsid</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="generate" data-name="generate">
+      <h3 class="function-name">generate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>generate() <span class="arrow">-&gt;</span> (string, _1)</code></pre>
+      <p class="doc">Generate a 13-char TSID. Returns (tsid, &quot;&quot;) on success, (&quot;&quot;, error) on CSPRNG failure.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/ulid.html
+++ b/docs/api/ulid.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ulid - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search ulid..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#generate">generate</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li class="active"><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>ulid</h1>
+    <p class="module-desc">std.ulid — ULID (https://github.com/ulid/spec).</p>
+    <p class="import-line"><code>import std.ulid</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="generate" data-name="generate">
+      <h3 class="function-name">generate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>generate() <span class="arrow">-&gt;</span> (string, _1)</code></pre>
+      <p class="doc">Generate a new ULID. Returns (ulid_string, &quot;&quot;) on success, (&quot;&quot;, error) on CSPRNG failure.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/url.html
+++ b/docs/api/url.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>url - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search url..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#encode">encode</a></li>
+    <li><a href="#encode_path">encode_path</a></li>
+    <li><a href="#encode_strict">encode_strict</a></li>
+    <li><a href="#decode">decode</a></li>
+    <li><a href="#parse_query">parse_query</a></li>
+    <li><a href="#query_get">query_get</a></li>
+    <li><a href="#query_get_all">query_get_all</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li class="active"><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>url</h1>
+    <p class="module-desc">std.url — RFC 3986 percent-encoding + query-string parsing (#629).</p>
+    <p class="import-line"><code>import std.url</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="encode" data-name="encode">
+      <h3 class="function-name">encode <span class="kind">fn</span></h3>
+      <pre class="usage"><code>encode(s) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">RFC 3986 query-component encoding (Go's url.QueryEscape). Space encoded as '+'.</p>
+    </div>
+    <div class="function" id="encode_path" data-name="encode_path">
+      <h3 class="function-name">encode_path <span class="kind">fn</span></h3>
+      <pre class="usage"><code>encode_path(s) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">RFC 3986 path-segment encoding (Go's url.PathEscape). Keeps unreserved plus $&amp;+:=@; '+' is preserved literally (it is NOT a space in path-context).</p>
+    </div>
+    <div class="function" id="encode_strict" data-name="encode_strict">
+      <h3 class="function-name">encode_strict <span class="kind">fn</span></h3>
+      <pre class="usage"><code>encode_strict(s) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Strict unreserved-only encoding — encodes everything except [A-Za-z0-9-._~]. Required for AWS SigV4 canonical-request signing where any kept-character deviation invalidates the signature.</p>
+    </div>
+    <div class="function" id="decode" data-name="decode">
+      <h3 class="function-name">decode <span class="kind">fn</span></h3>
+      <pre class="usage"><code>decode(s) <span class="arrow">-&gt;</span> (string, string)</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Percent-decode a URL component. '+' is decoded as space (the query-component reading); literal '+' in path components should have been encoded as %2B by a conforming encoder. Returns (&quot;&quot;, &quot;malformed encoding&quot;) on a stray '%' not followed by two hex chars. Otherwise returns (decoded, &quot;&quot;).</p>
+    </div>
+    <div class="function" id="parse_query" data-name="parse_query">
+      <h3 class="function-name">parse_query <span class="kind">fn</span></h3>
+      <pre class="usage"><code>parse_query(s) <span class="arrow">-&gt;</span> (_0, string)</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+      <p class="doc">Parse a query string. Returns (list, &quot;&quot;), where list is a std.collections.string_list of decoded &quot;key=value&quot; entries. Returns (&quot;&quot;, error) on a malformed percent-encoding inside any key or value. Leading '?' is tolerated (stripped before parsing) so callers can pass the raw `request.query_string` or a string they hand-built with `?` retained.</p>
+    </div>
+    <div class="function" id="query_get" data-name="query_get">
+      <h3 class="function-name">query_get <span class="kind">fn</span></h3>
+      <pre class="usage"><code>query_get(list, name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, name: string</span></p>
+      <p class="doc">Get the first value for `name` from a parsed query list. Returns &quot;&quot; if the key is absent.</p>
+    </div>
+    <div class="function" id="query_get_all" data-name="query_get_all">
+      <h3 class="function-name">query_get_all <span class="kind">fn</span></h3>
+      <pre class="usage"><code>query_get_all(list, name) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">list: ptr, name: string</span></p>
+      <p class="doc">Get every value for `name` (for repeated-key queries like `?a=1&amp;a=2`). Returns a fresh string_list. Empty list if absent.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/uuid.html
+++ b/docs/api/uuid.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>uuid - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search uuid..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#v4">v4</a></li>
+    <li><a href="#v7">v7</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li class="active"><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>uuid</h1>
+    <p class="module-desc">std.uuid — UUID v4 and v7 (RFC 9562).</p>
+    <p class="import-line"><code>import std.uuid</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="v4" data-name="v4">
+      <h3 class="function-name">v4 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>v4() <span class="arrow">-&gt;</span> (string, _1)</code></pre>
+      <p class="doc">UUIDv4 — 128 bits with six fixed bits (version=0100, variant=10): xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx   y ∈ {8,9,a,b} Returns (uuid, &quot;&quot;) on success, (&quot;&quot;, error) on CSPRNG failure.</p>
+    </div>
+    <div class="function" id="v7" data-name="v7">
+      <h3 class="function-name">v7 <span class="kind">fn</span></h3>
+      <pre class="usage"><code>v7() <span class="arrow">-&gt;</span> (string, _1)</code></pre>
+      <p class="doc">UUIDv7 (RFC 9562 §5.7) — 48-bit big-endian Unix-ms timestamp in bytes 0..5, then version=0111 in the high nibble of byte 6, variant=10 in the top two bits of byte 8, remaining 74 bits from the CSPRNG. Sortable by issuance time at ms resolution. At very high QPS (&gt;1000 IDs/ms per process) the timestamp can collide with the previous tick; this implementation does NOT add a monotonic counter, so back-to-back same-ms IDs sort arbitrarily within the same millisecond. RFC-allowed and what the fbs-core storage use case wants. Higher-QPS callers should layer a per-process counter on top.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/xml.html
+++ b/docs/api/xml.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>xml - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search xml..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#EVENT_START">EVENT_START</a></li>
+    <li><a href="#EVENT_END">EVENT_END</a></li>
+    <li><a href="#EVENT_TEXT">EVENT_TEXT</a></li>
+    <li><a href="#EVENT_EOF">EVENT_EOF</a></li>
+    <li><a href="#EVENT_ERROR">EVENT_ERROR</a></li>
+    <li><a href="#parser_new_str">parser_new_str</a></li>
+    <li><a href="#next">next</a></li>
+    <li><a href="#event_name">event_name</a></li>
+    <li><a href="#event_text">event_text</a></li>
+    <li><a href="#event_attr_count">event_attr_count</a></li>
+    <li><a href="#event_attr_name">event_attr_name</a></li>
+    <li><a href="#event_attr_value">event_attr_value</a></li>
+    <li><a href="#event_attr_str">event_attr_str</a></li>
+    <li><a href="#parser_error">parser_error</a></li>
+    <li><a href="#parser_free">parser_free</a></li>
+    <li><a href="#builder_new">builder_new</a></li>
+    <li><a href="#builder_declaration">builder_declaration</a></li>
+    <li><a href="#builder_start">builder_start</a></li>
+    <li><a href="#builder_attr">builder_attr</a></li>
+    <li><a href="#builder_text">builder_text</a></li>
+    <li><a href="#builder_end">builder_end</a></li>
+    <li><a href="#builder_element">builder_element</a></li>
+    <li><a href="#builder_finish">builder_finish</a></li>
+    <li><a href="#builder_free">builder_free</a></li>
+    <li><a href="#escape">escape</a></li>
+    <li><a href="#parser">parser</a></li>
+    <li><a href="#name">name</a></li>
+    <li><a href="#text">text</a></li>
+    <li><a href="#attr">attr</a></li>
+    <li><a href="#attr_count">attr_count</a></li>
+    <li><a href="#attr_name">attr_name</a></li>
+    <li><a href="#attr_value">attr_value</a></li>
+    <li><a href="#error">error</a></li>
+    <li><a href="#free">free</a></li>
+    <li><a href="#writer">writer</a></li>
+    <li><a href="#declaration">declaration</a></li>
+    <li><a href="#start">start</a></li>
+    <li><a href="#attribute">attribute</a></li>
+    <li><a href="#text_node">text_node</a></li>
+    <li><a href="#end">end</a></li>
+    <li><a href="#element">element</a></li>
+    <li><a href="#finish">finish</a></li>
+    <li><a href="#free_builder">free_builder</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li class="active"><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>xml</h1>
+    <p class="module-desc">std.xml - XML Module Import with: import std.xml A deliberately small XML surface (issue #627): a pull/SAX reader and an escaping element builder.</p>
+    <p class="import-line"><code>import std.xml</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="EVENT_START" data-name="EVENT_START">
+      <h3 class="function-name">EVENT_START <span class="kind">const</span></h3>
+      <pre class="usage"><code>EVENT_START = 1</code></pre>
+      <p class="doc">Event kinds returned by `next` — match the C `XML_EVENT_*` values.</p>
+    </div>
+    <div class="function" id="EVENT_END" data-name="EVENT_END">
+      <h3 class="function-name">EVENT_END <span class="kind">const</span></h3>
+      <pre class="usage"><code>EVENT_END = 2</code></pre>
+    </div>
+    <div class="function" id="EVENT_TEXT" data-name="EVENT_TEXT">
+      <h3 class="function-name">EVENT_TEXT <span class="kind">const</span></h3>
+      <pre class="usage"><code>EVENT_TEXT = 3</code></pre>
+    </div>
+    <div class="function" id="EVENT_EOF" data-name="EVENT_EOF">
+      <h3 class="function-name">EVENT_EOF <span class="kind">const</span></h3>
+      <pre class="usage"><code>EVENT_EOF = 4</code></pre>
+    </div>
+    <div class="function" id="EVENT_ERROR" data-name="EVENT_ERROR">
+      <h3 class="function-name">EVENT_ERROR <span class="kind">const</span></h3>
+      <pre class="usage"><code>EVENT_ERROR = 5</code></pre>
+    </div>
+    <div class="function" id="parser_new_str" data-name="parser_new_str">
+      <h3 class="function-name">parser_new_str <span class="kind">extern</span></h3>
+      <pre class="usage"><code>parser_new_str(data) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">data: string</span></p>
+      <p class="doc">---- raw externs (C core) ----</p>
+    </div>
+    <div class="function" id="next" data-name="next">
+      <h3 class="function-name">next <span class="kind">extern</span></h3>
+      <pre class="usage"><code>next(p) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+    </div>
+    <div class="function" id="event_name" data-name="event_name">
+      <h3 class="function-name">event_name <span class="kind">extern</span></h3>
+      <pre class="usage"><code>event_name(p) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+    </div>
+    <div class="function" id="event_text" data-name="event_text">
+      <h3 class="function-name">event_text <span class="kind">extern</span></h3>
+      <pre class="usage"><code>event_text(p) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+    </div>
+    <div class="function" id="event_attr_count" data-name="event_attr_count">
+      <h3 class="function-name">event_attr_count <span class="kind">extern</span></h3>
+      <pre class="usage"><code>event_attr_count(p) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+    </div>
+    <div class="function" id="event_attr_name" data-name="event_attr_name">
+      <h3 class="function-name">event_attr_name <span class="kind">extern</span></h3>
+      <pre class="usage"><code>event_attr_name(p, i) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int</span></p>
+    </div>
+    <div class="function" id="event_attr_value" data-name="event_attr_value">
+      <h3 class="function-name">event_attr_value <span class="kind">extern</span></h3>
+      <pre class="usage"><code>event_attr_value(p, i) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int</span></p>
+    </div>
+    <div class="function" id="event_attr_str" data-name="event_attr_str">
+      <h3 class="function-name">event_attr_str <span class="kind">extern</span></h3>
+      <pre class="usage"><code>event_attr_str(p, name) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, name: string</span></p>
+    </div>
+    <div class="function" id="parser_error" data-name="parser_error">
+      <h3 class="function-name">parser_error <span class="kind">extern</span></h3>
+      <pre class="usage"><code>parser_error(p) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+    </div>
+    <div class="function" id="parser_free" data-name="parser_free">
+      <h3 class="function-name">parser_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>parser_free(p)</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+    </div>
+    <div class="function" id="builder_new" data-name="builder_new">
+      <h3 class="function-name">builder_new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_new() <span class="arrow">-&gt;</span> ptr</code></pre>
+    </div>
+    <div class="function" id="builder_declaration" data-name="builder_declaration">
+      <h3 class="function-name">builder_declaration <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_declaration(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="builder_start" data-name="builder_start">
+      <h3 class="function-name">builder_start <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_start(b, name)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string</span></p>
+    </div>
+    <div class="function" id="builder_attr" data-name="builder_attr">
+      <h3 class="function-name">builder_attr <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_attr(b, name, value)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string, value: string</span></p>
+    </div>
+    <div class="function" id="builder_text" data-name="builder_text">
+      <h3 class="function-name">builder_text <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_text(b, text)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, text: string</span></p>
+    </div>
+    <div class="function" id="builder_end" data-name="builder_end">
+      <h3 class="function-name">builder_end <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_end(b, name)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string</span></p>
+    </div>
+    <div class="function" id="builder_element" data-name="builder_element">
+      <h3 class="function-name">builder_element <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_element(b, name, text)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string, text: string</span></p>
+    </div>
+    <div class="function" id="builder_finish" data-name="builder_finish">
+      <h3 class="function-name">builder_finish <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_finish(b) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="builder_free" data-name="builder_free">
+      <h3 class="function-name">builder_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>builder_free(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+    </div>
+    <div class="function" id="escape" data-name="escape">
+      <h3 class="function-name">escape <span class="kind">extern</span></h3>
+      <pre class="usage"><code>escape(s) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">s: string</span></p>
+    </div>
+    <div class="function" id="parser" data-name="parser">
+      <h3 class="function-name">parser <span class="kind">fn</span></h3>
+      <pre class="usage"><code>parser(data) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">data: string</span></p>
+      <p class="doc">Build a pull reader over an XML document. Free with `xml.free`.</p>
+    </div>
+    <div class="function" id="name" data-name="name">
+      <h3 class="function-name">name <span class="kind">fn</span></h3>
+      <pre class="usage"><code>name(p) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+      <p class="doc">Element name for the current START/END event (owned copy; &quot;&quot; otherwise).</p>
+    </div>
+    <div class="function" id="text" data-name="text">
+      <h3 class="function-name">text <span class="kind">fn</span></h3>
+      <pre class="usage"><code>text(p) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+      <p class="doc">Decoded character data for the current TEXT event (owned copy).</p>
+    </div>
+    <div class="function" id="attr" data-name="attr">
+      <h3 class="function-name">attr <span class="kind">fn</span></h3>
+      <pre class="usage"><code>attr(p, key) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, key: string</span></p>
+      <p class="doc">Value of attribute `key` on the current START element, or &quot;&quot; if absent (owned copy). Use `attr_count` + `attr_name`/`attr_value` to iterate.</p>
+    </div>
+    <div class="function" id="attr_count" data-name="attr_count">
+      <h3 class="function-name">attr_count <span class="kind">fn</span></h3>
+      <pre class="usage"><code>attr_count(p) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+      <p class="doc">Number of attributes on the current START element.</p>
+    </div>
+    <div class="function" id="attr_name" data-name="attr_name">
+      <h3 class="function-name">attr_name <span class="kind">fn</span></h3>
+      <pre class="usage"><code>attr_name(p, i) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int</span></p>
+      <p class="doc">Name / value of the i-th attribute on the current START element (owned copies; &quot;&quot; if i is out of range).</p>
+    </div>
+    <div class="function" id="attr_value" data-name="attr_value">
+      <h3 class="function-name">attr_value <span class="kind">fn</span></h3>
+      <pre class="usage"><code>attr_value(p, i) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr, i: int</span></p>
+    </div>
+    <div class="function" id="error" data-name="error">
+      <h3 class="function-name">error <span class="kind">fn</span></h3>
+      <pre class="usage"><code>error(p) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+      <p class="doc">Human-readable message after an EVENT_ERROR (owned copy; &quot;&quot; if none).</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>free(p)</code></pre>
+      <p class="signature"><span class="sig-params">p: ptr</span></p>
+      <p class="doc">Release a reader.</p>
+    </div>
+    <div class="function" id="writer" data-name="writer">
+      <h3 class="function-name">writer <span class="kind">fn</span></h3>
+      <pre class="usage"><code>writer() <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="doc">New XML builder/writer. Free with `xml.free_builder` after `finish`. (Named `writer` because `builder` is a reserved keyword in Aether.)</p>
+    </div>
+    <div class="function" id="declaration" data-name="declaration">
+      <h3 class="function-name">declaration <span class="kind">fn</span></h3>
+      <pre class="usage"><code>declaration(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Emit the `&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;` declaration.</p>
+    </div>
+    <div class="function" id="start" data-name="start">
+      <h3 class="function-name">start <span class="kind">fn</span></h3>
+      <pre class="usage"><code>start(b, name)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string</span></p>
+      <p class="doc">Open a start tag `&lt;name`; follow with `attribute` calls, then `text` / `element` / `start` / `end` (which close the tag's `&gt;` automatically).</p>
+    </div>
+    <div class="function" id="attribute" data-name="attribute">
+      <h3 class="function-name">attribute <span class="kind">fn</span></h3>
+      <pre class="usage"><code>attribute(b, name, value)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string, value: string</span></p>
+      <p class="doc">Add `name=&quot;value&quot;` to the currently-open start tag (value escaped).</p>
+    </div>
+    <div class="function" id="text_node" data-name="text_node">
+      <h3 class="function-name">text_node <span class="kind">fn</span></h3>
+      <pre class="usage"><code>text_node(b, content)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, content: string</span></p>
+      <p class="doc">Append escaped character data.</p>
+    </div>
+    <div class="function" id="end" data-name="end">
+      <h3 class="function-name">end <span class="kind">fn</span></h3>
+      <pre class="usage"><code>end(b, name)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string</span></p>
+      <p class="doc">Close element `name` (`&lt;/name&gt;`).</p>
+    </div>
+    <div class="function" id="element" data-name="element">
+      <h3 class="function-name">element <span class="kind">fn</span></h3>
+      <pre class="usage"><code>element(b, name, content)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr, name: string, content: string</span></p>
+      <p class="doc">`&lt;name&gt;escaped-text&lt;/name&gt;` in one call.</p>
+    </div>
+    <div class="function" id="finish" data-name="finish">
+      <h3 class="function-name">finish <span class="kind">fn</span></h3>
+      <pre class="usage"><code>finish(b) <span class="arrow">-&gt;</span> string</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Finish the document and return it as an owned string (escaping already applied throughout). The builder is still alive — call `free_builder`. The string_concat copies the C buffer into an owned Aether string and lets the codegen reclaim the malloc'd original at scope exit (the same handoff std.json's `stringify` uses).</p>
+    </div>
+    <div class="function" id="free_builder" data-name="free_builder">
+      <h3 class="function-name">free_builder <span class="kind">fn</span></h3>
+      <pre class="usage"><code>free_builder(b)</code></pre>
+      <p class="signature"><span class="sig-params">b: ptr</span></p>
+      <p class="doc">Release a builder.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/zlib.html
+++ b/docs/api/zlib.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>zlib - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search zlib..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#backend_available">backend_available</a></li>
+    <li><a href="#try_deflate">try_deflate</a></li>
+    <li><a href="#get_deflate_bytes">get_deflate_bytes</a></li>
+    <li><a href="#get_deflate_length">get_deflate_length</a></li>
+    <li><a href="#release_deflate">release_deflate</a></li>
+    <li><a href="#try_inflate">try_inflate</a></li>
+    <li><a href="#get_inflate_bytes">get_inflate_bytes</a></li>
+    <li><a href="#get_inflate_length">get_inflate_length</a></li>
+    <li><a href="#release_inflate">release_inflate</a></li>
+    <li><a href="#try_gzip_deflate">try_gzip_deflate</a></li>
+    <li><a href="#try_gzip_inflate">try_gzip_inflate</a></li>
+    <li><a href="#available">available</a></li>
+    <li><a href="#deflate">deflate</a></li>
+    <li><a href="#inflate">inflate</a></li>
+    <li><a href="#gzip_deflate">gzip_deflate</a></li>
+    <li><a href="#gzip_inflate">gzip_inflate</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li class="active"><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>zlib</h1>
+    <p class="module-desc">std.zlib - One-shot zlib and gzip deflate/inflate.</p>
+    <p class="import-line"><code>import std.zlib</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="backend_available" data-name="backend_available">
+      <h3 class="function-name">backend_available <span class="kind">extern</span></h3>
+      <pre class="usage"><code>backend_available() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Probe: returns 1 when the toolchain was built with zlib detected, 0 otherwise. Lets callers / tests distinguish &quot;no backend&quot; from &quot;backend returned an error at runtime&quot;. C-side name is `zlib_backend_available` to avoid colliding with the Aether-side `zlib.available()` wrapper's mangled name.</p>
+    </div>
+    <div class="function" id="try_deflate" data-name="try_deflate">
+      <h3 class="function-name">try_deflate <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_deflate(data, length, level) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int, level: int</span></p>
+      <p class="doc">Split-accessor boundary: try_ performs the op and stashes the result in a TLS buffer; get_ returns a borrowed pointer and length; release_ frees early (otherwise the buffer is freed on the next try_ call on the same thread).</p>
+    </div>
+    <div class="function" id="get_deflate_bytes" data-name="get_deflate_bytes">
+      <h3 class="function-name">get_deflate_bytes <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_deflate_bytes() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_deflate_length" data-name="get_deflate_length">
+      <h3 class="function-name">get_deflate_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_deflate_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_deflate" data-name="release_deflate">
+      <h3 class="function-name">release_deflate <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_deflate()</code></pre>
+    </div>
+    <div class="function" id="try_inflate" data-name="try_inflate">
+      <h3 class="function-name">try_inflate <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_inflate(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="get_inflate_bytes" data-name="get_inflate_bytes">
+      <h3 class="function-name">get_inflate_bytes <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_inflate_bytes() <span class="arrow">-&gt;</span> string</code></pre>
+    </div>
+    <div class="function" id="get_inflate_length" data-name="get_inflate_length">
+      <h3 class="function-name">get_inflate_length <span class="kind">extern</span></h3>
+      <pre class="usage"><code>get_inflate_length() <span class="arrow">-&gt;</span> int</code></pre>
+    </div>
+    <div class="function" id="release_inflate" data-name="release_inflate">
+      <h3 class="function-name">release_inflate <span class="kind">extern</span></h3>
+      <pre class="usage"><code>release_inflate()</code></pre>
+    </div>
+    <div class="function" id="try_gzip_deflate" data-name="try_gzip_deflate">
+      <h3 class="function-name">try_gzip_deflate <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_gzip_deflate(data, length, level) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int, level: int</span></p>
+    </div>
+    <div class="function" id="try_gzip_inflate" data-name="try_gzip_inflate">
+      <h3 class="function-name">try_gzip_inflate <span class="kind">extern</span></h3>
+      <pre class="usage"><code>try_gzip_inflate(data, length) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+    <div class="function" id="available" data-name="available">
+      <h3 class="function-name">available <span class="kind">fn</span></h3>
+      <pre class="usage"><code>available() <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="doc">Compress `length` bytes of `data` at the given level (0..9, or -1 for the library default). Returns (bytes, byte_count, &quot;&quot;) on success, (&quot;&quot;, 0, error) on failure. The returned string is length-aware: string.length(bytes) == byte_count. Alias for the capability probe. Use when skipping a test or choosing a fallback path.</p>
+    </div>
+    <div class="function" id="deflate" data-name="deflate">
+      <h3 class="function-name">deflate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>deflate(data, length, level) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int, level: int</span></p>
+    </div>
+    <div class="function" id="inflate" data-name="inflate">
+      <h3 class="function-name">inflate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>inflate(data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+      <p class="doc">Decompress `length` bytes of `data` (a zlib stream — RFC 1950). Returns (bytes, byte_count, &quot;&quot;) on success, (&quot;&quot;, 0, error) on corruption, truncation, or empty input. The output buffer grows geometrically — callers don't need to know the decompressed size in advance.</p>
+    </div>
+    <div class="function" id="gzip_deflate" data-name="gzip_deflate">
+      <h3 class="function-name">gzip_deflate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>gzip_deflate(data, length, level) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int, level: int</span></p>
+      <p class="doc">gzip-framed siblings (RFC 1952), intended for HTTP Content-Encoding: gzip.</p>
+    </div>
+    <div class="function" id="gzip_inflate" data-name="gzip_inflate">
+      <h3 class="function-name">gzip_inflate <span class="kind">fn</span></h3>
+      <pre class="usage"><code>gzip_inflate(data, length) <span class="arrow">-&gt;</span> (string, int, string)</code></pre>
+      <p class="signature"><span class="sig-params">data: string, length: int</span></p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/tools/docgen/docgen.c
+++ b/tools/docgen/docgen.c
@@ -1,8 +1,20 @@
 /*
  * Aether Documentation Generator
  *
- * Generates searchable HTML documentation from stdlib headers.
- * Similar to Zig's autodoc or Rust's rustdoc.
+ * Generates searchable HTML documentation for the Aether standard library
+ * from the PUBLIC `.ae` API surface.
+ *
+ * For each std/<module>/module.ae the generator parses the `exports (...)`
+ * list and, for every exported name, locates its definition further down the
+ * file — an `extern raw(...) -> T` declaration, an Aether wrapper
+ * `name(params) -> Ret { ... }`, a `const NAME = value`, or a `struct Name`.
+ * The rendered documentation reflects that .ae layer: real parameter
+ * names+types, real return types (including tuple returns like
+ * `(string, string)`), and the `//` doc-comment block immediately above the
+ * definition.
+ *
+ * This documents the layer users actually call (`json.get_string`,
+ * `fs.read`, `os.run_capture`, ...) rather than the underlying C symbols.
  *
  * Usage: docgen <std_dir> <output_dir>
  */
@@ -14,27 +26,33 @@
 #include <sys/stat.h>
 #include <ctype.h>
 
-#define MAX_FUNCTIONS 500
-#define MAX_LINE 2048
-#define MAX_DOC 4096
-#define MAX_MODULES 50
+#define MAX_FUNCTIONS 256
+#define MAX_EXPORTS 256
+#define MAX_LINE 4096
+#define MAX_DOC 6144
+#define MAX_MODULES 64
+#define MAX_FILE_BYTES (1 << 20)   /* 1 MiB per module.ae — generous */
+
+typedef enum {
+    DEF_FUNCTION,   /* Aether wrapper: name(params) -> Ret { ... }            */
+    DEF_EXTERN,     /* extern name(params) -> Ret                             */
+    DEF_CONST,      /* const NAME = value                                     */
+    DEF_STRUCT      /* struct Name { ... }                                    */
+} DefKind;
 
 typedef struct {
-    char name[256];
-    char signature[512];       // Original C signature (for reference)
-    char aether_sig[512];      // Aether extern declaration
-    char return_type[128];     // C return type
-    char aether_return[64];    // Aether return type
-    char params[512];          // C params
-    char aether_params[512];   // Aether params
-    char doc[MAX_DOC];
-    char module[64];
-    int line_number;
+    char name[128];
+    char params[1024];        /* rendered "p1: T1, p2: T2"                    */
+    char return_type[256];    /* rendered return, "" when none / void        */
+    char doc[MAX_DOC];        /* doc-comment block                           */
+    char value[256];          /* const value (DEF_CONST only)                */
+    DefKind kind;
+    int has_def;              /* 1 once a definition was found               */
 } Function;
 
 typedef struct {
     char name[64];
-    char description[512];
+    char description[1024];
     Function functions[MAX_FUNCTIONS];
     int function_count;
 } Module;
@@ -42,7 +60,10 @@ typedef struct {
 static Module modules[MAX_MODULES];
 static int module_count = 0;
 
-// Trim whitespace from string
+/* ---------------------------------------------------------------------- */
+/* Small string helpers                                                    */
+/* ---------------------------------------------------------------------- */
+
 static char* trim(char* str) {
     while (isspace((unsigned char)*str)) str++;
     if (*str == 0) return str;
@@ -52,320 +73,641 @@ static char* trim(char* str) {
     return str;
 }
 
-// Convert C type to Aether type
-static const char* c_type_to_aether(const char* c_type) {
-    // Trim and normalize
-    while (isspace((unsigned char)*c_type)) c_type++;
-
-    // void return type means no return
-    if (strcmp(c_type, "void") == 0) return NULL;
-
-    // String types
-    if (strstr(c_type, "char*") || strstr(c_type, "char *") ||
-        strcmp(c_type, "const char*") == 0 || strcmp(c_type, "const char *") == 0) {
-        return "string";
-    }
-
-    // Integer types
-    if (strcmp(c_type, "int") == 0 || strcmp(c_type, "int32_t") == 0 ||
-        strcmp(c_type, "int64_t") == 0 || strcmp(c_type, "size_t") == 0 ||
-        strcmp(c_type, "bool") == 0 || strcmp(c_type, "ssize_t") == 0 ||
-        strncmp(c_type, "uint", 4) == 0 || strcmp(c_type, "long") == 0) {
-        return "int";
-    }
-
-    // Float types
-    if (strcmp(c_type, "float") == 0 || strcmp(c_type, "double") == 0) {
-        return "float";
-    }
-
-    // Any pointer type -> ptr
-    if (strchr(c_type, '*')) {
-        return "ptr";
-    }
-
-    // Default to ptr for unknown types (structs, etc.)
-    return "ptr";
+static int is_ident_char(int c) {
+    return isalnum(c) || c == '_';
 }
 
-// Parse a single C parameter and convert to Aether
-static void parse_c_param_to_aether(const char* c_param, char* name_out, char* type_out) {
-    char trimmed[256];
-    strncpy(trimmed, c_param, sizeof(trimmed) - 1);
-    trimmed[sizeof(trimmed) - 1] = '\0';
-
-    // Trim whitespace
-    char* p = trimmed;
-    while (isspace((unsigned char)*p)) p++;
-    char* end = p + strlen(p) - 1;
-    while (end > p && isspace((unsigned char)*end)) *end-- = '\0';
-
-    // Handle "void" - no parameters
-    if (strcmp(p, "void") == 0 || strlen(p) == 0) {
-        name_out[0] = '\0';
-        type_out[0] = '\0';
-        return;
-    }
-
-    // Find the parameter name (last word that's not a pointer indicator)
-    // Work backwards from the end
-    char* name_start = NULL;
-    char* scan = p + strlen(p) - 1;
-
-    // Skip trailing whitespace and array brackets
-    while (scan > p && (isspace((unsigned char)*scan) || *scan == ']')) scan--;
-    if (*scan == '[') { // Skip array notation
-        while (scan > p && *scan != ' ') scan--;
-    }
-
-    // The name is the last identifier
-    char* name_end = scan + 1;
-    while (scan > p && (isalnum((unsigned char)*scan) || *scan == '_')) scan--;
-    name_start = scan + 1;
-
-    // Extract name
-    size_t name_len = name_end - name_start;
-    if (name_len >= 128) name_len = 127;
-    strncpy(name_out, name_start, name_len);
-    name_out[name_len] = '\0';
-
-    // Everything before the name is the type
-    size_t type_len = name_start - p;
-    char c_type[256];
-    if (type_len >= sizeof(c_type)) type_len = sizeof(c_type) - 1;
-    strncpy(c_type, p, type_len);
-    c_type[type_len] = '\0';
-
-    // Trim type
-    char* type_trim = c_type;
-    while (isspace((unsigned char)*type_trim)) type_trim++;
-    end = type_trim + strlen(type_trim) - 1;
-    while (end > type_trim && isspace((unsigned char)*end)) *end-- = '\0';
-
-    // Convert to Aether type
-    const char* aether_type = c_type_to_aether(type_trim);
-    if (aether_type) {
-        strncpy(type_out, aether_type, 63);
-        type_out[63] = '\0';
-    } else {
-        type_out[0] = '\0';
-    }
-}
-
-// Check if line is a function declaration
-static int is_function_decl(const char* line) {
-    // Skip typedefs, structs, #define, etc.
-    if (strncmp(line, "typedef", 7) == 0) return 0;
-    if (strncmp(line, "struct", 6) == 0) return 0;
-    if (strncmp(line, "#", 1) == 0) return 0;
-    if (strncmp(line, "//", 2) == 0) return 0;
-    if (strncmp(line, "/*", 2) == 0) return 0;
-    if (strncmp(line, "}", 1) == 0) return 0;
-    if (strncmp(line, "{", 1) == 0) return 0;
-    if (strlen(line) < 5) return 0;
-
-    // Must have parentheses and semicolon
-    if (!strchr(line, '(') || !strchr(line, ')')) return 0;
-    if (!strchr(line, ';')) return 0;
-
-    // Must start with a type
-    if (strncmp(line, "void", 4) == 0 ||
-        strncmp(line, "int", 3) == 0 ||
-        strncmp(line, "char", 4) == 0 ||
-        strncmp(line, "bool", 4) == 0 ||
-        strncmp(line, "size_t", 6) == 0 ||
-        strncmp(line, "float", 5) == 0 ||
-        strncmp(line, "double", 6) == 0 ||
-        strncmp(line, "const", 5) == 0 ||
-        strncmp(line, "uint", 4) == 0 ||
-        strncmp(line, "int64_t", 7) == 0 ||
-        strncmp(line, "int32_t", 7) == 0 ||
-        strstr(line, "Aether") != NULL ||
-        strstr(line, "HashMap") != NULL ||
-        strstr(line, "Vector") != NULL ||
-        strstr(line, "Set") != NULL ||
-        strstr(line, "Json") != NULL ||
-        strstr(line, "HTTP") != NULL) {
-        return 1;
-    }
-    return 0;
-}
-
-// Parse function declaration
-static void parse_function(const char* line, Function* func) {
-    strncpy(func->signature, line, sizeof(func->signature) - 1);
-    func->signature[sizeof(func->signature) - 1] = '\0';
-
-    // Remove trailing semicolon and newline
-    char* semi = strchr(func->signature, ';');
-    if (semi) *semi = '\0';
-
-    // Extract return type (everything before function name)
-    char* paren = strchr(func->signature, '(');
-    if (!paren) return;
-
-    // Find function name (last word before paren)
-    char* name_end = paren;
-    while (name_end > func->signature && *(name_end - 1) == ' ') name_end--;
-    char* name_start = name_end;
-    while (name_start > func->signature && *(name_start - 1) != ' ' && *(name_start - 1) != '*') {
-        name_start--;
-    }
-
-    // Copy function name
-    size_t name_len = name_end - name_start;
-    if (name_len >= sizeof(func->name)) name_len = sizeof(func->name) - 1;
-    strncpy(func->name, name_start, name_len);
-    func->name[name_len] = '\0';
-
-    // Copy return type
-    size_t ret_len = name_start - func->signature;
-    if (ret_len >= sizeof(func->return_type)) ret_len = sizeof(func->return_type) - 1;
-    strncpy(func->return_type, func->signature, ret_len);
-    func->return_type[ret_len] = '\0';
-    trim(func->return_type);
-
-    // Copy parameters
-    char* params_start = paren + 1;
-    char* params_end = strchr(params_start, ')');
-    if (params_end) {
-        size_t params_len = params_end - params_start;
-        if (params_len >= sizeof(func->params)) params_len = sizeof(func->params) - 1;
-        strncpy(func->params, params_start, params_len);
-        func->params[params_len] = '\0';
-        trim(func->params);
-    }
-
-    // === Generate Aether signature ===
-
-    // Convert return type to Aether
-    const char* aether_ret = c_type_to_aether(func->return_type);
-    if (aether_ret) {
-        strncpy(func->aether_return, aether_ret, sizeof(func->aether_return) - 1);
-    } else {
-        func->aether_return[0] = '\0';
-    }
-
-    // Convert parameters to Aether
-    func->aether_params[0] = '\0';
-    if (strlen(func->params) > 0 && strcmp(func->params, "void") != 0) {
-        // Split params by comma
-        char params_copy[512];
-        strncpy(params_copy, func->params, sizeof(params_copy) - 1);
-        params_copy[sizeof(params_copy) - 1] = '\0';
-
-        char* param = strtok(params_copy, ",");
-        int first = 1;
-        while (param) {
-            char param_name[128], param_type[64];
-            parse_c_param_to_aether(param, param_name, param_type);
-
-            if (strlen(param_name) > 0 && strlen(param_type) > 0) {
-                if (!first) {
-                    strncat(func->aether_params, ", ", sizeof(func->aether_params) - strlen(func->aether_params) - 1);
-                }
-                strncat(func->aether_params, param_name, sizeof(func->aether_params) - strlen(func->aether_params) - 1);
-                strncat(func->aether_params, ": ", sizeof(func->aether_params) - strlen(func->aether_params) - 1);
-                strncat(func->aether_params, param_type, sizeof(func->aether_params) - strlen(func->aether_params) - 1);
-                first = 0;
-            }
-            param = strtok(NULL, ",");
+/* Collapse runs of whitespace to single spaces, in place. */
+static void collapse_ws(char* s) {
+    char* w = s;
+    int prev_space = 0;
+    for (char* r = s; *r; r++) {
+        if (isspace((unsigned char)*r)) {
+            if (!prev_space) { *w++ = ' '; prev_space = 1; }
+        } else {
+            *w++ = *r;
+            prev_space = 0;
         }
     }
-
-    // Build full Aether signature
-    snprintf(func->aether_sig, sizeof(func->aether_sig), "extern %s(%s)%s%s",
-             func->name,
-             func->aether_params,
-             strlen(func->aether_return) > 0 ? " -> " : "",
-             func->aether_return);
+    *w = '\0';
+    trim(s);
 }
 
-// Parse a header file
-static void parse_header(const char* filepath, const char* module_name) {
-    FILE* f = fopen(filepath, "r");
-    if (!f) {
-        fprintf(stderr, "Warning: Cannot open %s\n", filepath);
-        return;
-    }
-
-    // Find or create module
-    Module* mod = NULL;
-    for (int i = 0; i < module_count; i++) {
-        if (strcmp(modules[i].name, module_name) == 0) {
-            mod = &modules[i];
-            break;
-        }
-    }
-    if (!mod && module_count < MAX_MODULES) {
-        mod = &modules[module_count++];
-        strncpy(mod->name, module_name, sizeof(mod->name) - 1);
-        mod->function_count = 0;
-    }
-    if (!mod) {
-        fclose(f);
-        return;
-    }
-
-    char line[MAX_LINE];
-    char pending_doc[MAX_DOC] = "";
-    int line_number = 0;
-
-    while (fgets(line, sizeof(line), f)) {
-        line_number++;
-        char* trimmed = trim(line);
-
-        // Collect comments as documentation
-        if (strncmp(trimmed, "//", 2) == 0) {
-            // Skip include guard comments
-            if (strstr(trimmed, "#ifndef") || strstr(trimmed, "#define") || strstr(trimmed, "#endif")) {
-                continue;
-            }
-            const char* comment = trimmed + 2;
-            while (*comment == ' ') comment++;
-            if (strlen(pending_doc) + strlen(comment) + 2 < MAX_DOC) {
-                if (strlen(pending_doc) > 0) strcat(pending_doc, " ");
-                strcat(pending_doc, comment);
-            }
+/* Strip Aether memory annotations (@heap, @retain, @borrow, ...) from a
+ * type/param fragment. They are internal lifetime hints, not part of the
+ * user-facing type. */
+static void strip_annotations(char* s, size_t cap) {
+    char out[1024];
+    size_t j = 0;
+    size_t n = strlen(s);
+    for (size_t i = 0; i < n && j < sizeof(out) - 1; ) {
+        if (s[i] == '@') {
+            i++;
+            while (i < n && is_ident_char((unsigned char)s[i])) i++;  /* skip word */
+            /* skip a single following space so we don't leave doubled spaces */
+            if (i < n && s[i] == ' ') i++;
             continue;
         }
-
-        // Check for function declaration
-        if (is_function_decl(trimmed)) {
-            if (mod->function_count < MAX_FUNCTIONS) {
-                Function* func = &mod->functions[mod->function_count++];
-                parse_function(trimmed, func);
-                strncpy(func->doc, pending_doc, sizeof(func->doc) - 1);
-                strncpy(func->module, module_name, sizeof(func->module) - 1);
-                func->line_number = line_number;
-            }
-            pending_doc[0] = '\0';
-        } else if (strlen(trimmed) > 0 && strncmp(trimmed, "//", 2) != 0) {
-            // Non-comment, non-function line clears pending doc
-            pending_doc[0] = '\0';
-        }
+        out[j++] = s[i++];
     }
-
-    fclose(f);
+    out[j] = '\0';
+    strncpy(s, out, cap - 1);
+    s[cap - 1] = '\0';
+    collapse_ws(s);
+    /* Annotation removal can leave a space before a separator
+     * (`string @heap,` -> `string ,`); drop it. */
+    char* w = s;
+    for (char* r = s; *r; r++) {
+        if (*r == ' ' && (r[1] == ',' || r[1] == ')')) continue;
+        *w++ = *r;
+    }
+    *w = '\0';
 }
 
-// Escape HTML special characters
+/* ---------------------------------------------------------------------- */
+/* HTML escaping                                                           */
+/* ---------------------------------------------------------------------- */
+
 static void html_escape(const char* src, char* dest, size_t dest_size) {
     size_t j = 0;
-    for (size_t i = 0; src[i] && j < dest_size - 6; i++) {
+    for (size_t i = 0; src[i] && j < dest_size - 7; i++) {
         switch (src[i]) {
-            case '<': strcpy(dest + j, "&lt;"); j += 4; break;
-            case '>': strcpy(dest + j, "&gt;"); j += 4; break;
+            case '<': strcpy(dest + j, "&lt;");  j += 4; break;
+            case '>': strcpy(dest + j, "&gt;");  j += 4; break;
             case '&': strcpy(dest + j, "&amp;"); j += 5; break;
             case '"': strcpy(dest + j, "&quot;"); j += 6; break;
-            default: dest[j++] = src[i]; break;
+            default:  dest[j++] = src[i]; break;
         }
     }
     dest[j] = '\0';
 }
 
-// Module descriptions
-static const char* get_module_description(const char* name) {
+/* ---------------------------------------------------------------------- */
+/* Module loading                                                          */
+/* ---------------------------------------------------------------------- */
+
+static Module* find_or_create_module(const char* name) {
+    for (int i = 0; i < module_count; i++) {
+        if (strcmp(modules[i].name, name) == 0) return &modules[i];
+    }
+    if (module_count >= MAX_MODULES) return NULL;
+    Module* m = &modules[module_count++];
+    memset(m, 0, sizeof(*m));
+    strncpy(m->name, name, sizeof(m->name) - 1);
+    return m;
+}
+
+/* Read a whole file into a freshly-malloc'd NUL-terminated buffer. Returns
+ * NULL on failure (caller frees on success). */
+static char* read_file(const char* path) {
+    FILE* f = fopen(path, "rb");
+    if (!f) return NULL;
+    if (fseek(f, 0, SEEK_END) != 0) { fclose(f); return NULL; }
+    long sz = ftell(f);
+    if (sz < 0 || sz > MAX_FILE_BYTES) { fclose(f); return NULL; }
+    if (fseek(f, 0, SEEK_SET) != 0) { fclose(f); return NULL; }
+    char* buf = malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return NULL; }
+    size_t got = fread(buf, 1, (size_t)sz, f);
+    buf[got] = '\0';
+    fclose(f);
+    return buf;
+}
+
+/* ---------------------------------------------------------------------- */
+/* exports (...) list parsing                                              */
+/* ---------------------------------------------------------------------- */
+
+/* Collect comma/whitespace-separated identifiers from the `exports ( ... )`
+ * block into `out`. Returns the export count. Inline `//` comments inside
+ * the block are skipped. */
+static int parse_exports(const char* src, char out[][128], int max) {
+    const char* p = strstr(src, "exports");
+    if (!p) return 0;
+    /* advance to the opening paren */
+    p = strchr(p, '(');
+    if (!p) return 0;
+    p++;
+
+    int count = 0;
+    while (*p && *p != ')') {
+        /* skip line comments inside the export block */
+        if (p[0] == '/' && p[1] == '/') {
+            while (*p && *p != '\n') p++;
+            continue;
+        }
+        if (!is_ident_char((unsigned char)*p)) { p++; continue; }
+        /* read identifier */
+        char ident[128];
+        size_t j = 0;
+        while (*p && is_ident_char((unsigned char)*p) && j < sizeof(ident) - 1) {
+            ident[j++] = *p++;
+        }
+        ident[j] = '\0';
+        if (count < max) {
+            strncpy(out[count], ident, 127);
+            out[count][127] = '\0';
+            count++;
+        }
+    }
+    return count;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Definition extraction                                                   */
+/* ---------------------------------------------------------------------- */
+
+/* Render a parameter list source fragment (text between the outer parens)
+ * into a clean "p1: T1, p2: T2" string with annotations stripped. */
+static void render_params(const char* raw, char* out, size_t out_size) {
+    char work[1024];
+    strncpy(work, raw, sizeof(work) - 1);
+    work[sizeof(work) - 1] = '\0';
+    collapse_ws(work);
+
+    char* t = trim(work);
+    if (*t == '\0' || strcmp(t, "void") == 0) { out[0] = '\0'; return; }
+
+    /* Split on top-level commas (params here never nest parens). */
+    out[0] = '\0';
+    char* save = NULL;
+    char* tok = strtok_r(work, ",", &save);
+    int first = 1;
+    while (tok) {
+        char piece[512];
+        strncpy(piece, tok, sizeof(piece) - 1);
+        piece[sizeof(piece) - 1] = '\0';
+        strip_annotations(piece, sizeof(piece));
+        char* pt = trim(piece);
+        if (*pt) {
+            if (!first) strncat(out, ", ", out_size - strlen(out) - 1);
+            strncat(out, pt, out_size - strlen(out) - 1);
+            first = 0;
+        }
+        tok = strtok_r(NULL, ",", &save);
+    }
+}
+
+/* Given the source position just AFTER the closing paren of a signature,
+ * capture the return type. Handles:
+ *   -> Type
+ *   -> (T1, T2, ...)
+ *   -> *Struct
+ *   (none)                 — extern / void function
+ * The capture stops at `{`, `\n`, or end of source.  Annotations stripped. */
+static void capture_return(const char* after_paren, char* out, size_t out_size) {
+    out[0] = '\0';
+    const char* p = after_paren;
+    while (*p == ' ' || *p == '\t') p++;
+    if (p[0] != '-' || p[1] != '>') return;   /* no return arrow */
+    p += 2;
+    while (*p == ' ' || *p == '\t') p++;
+
+    char buf[256];
+    size_t j = 0;
+    if (*p == '(') {
+        /* tuple return — copy up to and including the matching ')' */
+        int depth = 0;
+        while (*p && j < sizeof(buf) - 1) {
+            if (*p == '(') depth++;
+            else if (*p == ')') { depth--; buf[j++] = *p++; if (depth == 0) break; continue; }
+            buf[j++] = *p++;
+        }
+    } else {
+        /* scalar return — copy until '{', newline, or end */
+        while (*p && *p != '{' && *p != '\n' && j < sizeof(buf) - 1) {
+            buf[j++] = *p++;
+        }
+    }
+    buf[j] = '\0';
+    strip_annotations(buf, sizeof(buf));
+    char* t = trim(buf);
+    /* `void` reads as no return for documentation purposes */
+    if (strcmp(t, "void") == 0) t[0] = '\0';
+    strncpy(out, t, out_size - 1);
+    out[out_size - 1] = '\0';
+}
+
+/* Try to read a `name(params) ...` definition starting at `start` (which
+ * points at the first char of the name). On success fills name/params/return
+ * and returns 1; returns 0 if this is not a callable definition. */
+static int read_callable(const char* start, char* name_out,
+                         char* params_out, char* return_out) {
+    const char* p = start;
+    /* identifier */
+    size_t j = 0;
+    char name[128];
+    while (*p && is_ident_char((unsigned char)*p) && j < sizeof(name) - 1) {
+        name[j++] = *p++;
+    }
+    name[j] = '\0';
+    if (j == 0) return 0;
+
+    /* whitespace then '(' */
+    while (*p == ' ' || *p == '\t') p++;
+    if (*p != '(') return 0;
+    p++;
+
+    /* capture param text up to the matching ')' (params don't nest parens
+     * in the .ae extern/wrapper grammar) */
+    const char* params_start = p;
+    int depth = 1;
+    while (*p && depth > 0) {
+        if (*p == '(') depth++;
+        else if (*p == ')') depth--;
+        if (depth == 0) break;
+        p++;
+    }
+    if (depth != 0) return 0;  /* unterminated */
+    size_t plen = (size_t)(p - params_start);
+    char raw_params[1024];
+    if (plen >= sizeof(raw_params)) plen = sizeof(raw_params) - 1;
+    memcpy(raw_params, params_start, plen);
+    raw_params[plen] = '\0';
+    p++;  /* skip ')' */
+
+    strncpy(name_out, name, 127);
+    name_out[127] = '\0';
+    render_params(raw_params, params_out, 1024);
+    capture_return(p, return_out, 256);
+    return 1;
+}
+
+/* Find or create a function record for `name` in module `mod`. */
+static Function* upsert_function(Module* mod, const char* name) {
+    /* The `<module>.` namespace consumes a leading `<module>_` prefix when a
+     * call is resolved (`string.pad_start` -> export `string_pad_start`), so
+     * the call-site name we document is the suffix. Strip it for display;
+     * exports without the prefix (e.g. json's `get_string`) are shown as-is. */
+    size_t mlen = strlen(mod->name);
+    if (strncmp(name, mod->name, mlen) == 0 && name[mlen] == '_' && name[mlen + 1] != '\0') {
+        name += mlen + 1;
+    }
+    for (int i = 0; i < mod->function_count; i++) {
+        if (strcmp(mod->functions[i].name, name) == 0) return &mod->functions[i];
+    }
+    if (mod->function_count >= MAX_FUNCTIONS) return NULL;
+    Function* fn = &mod->functions[mod->function_count++];
+    memset(fn, 0, sizeof(*fn));
+    strncpy(fn->name, name, sizeof(fn->name) - 1);
+    return fn;
+}
+
+/* Append a doc-comment line (text after `//`) to a pending-doc buffer. */
+static void append_doc_line(char* doc, const char* text) {
+    size_t cur = strlen(doc);
+    size_t add = strlen(text);
+    if (cur + add + 2 >= MAX_DOC) return;
+    if (cur > 0) { doc[cur++] = ' '; doc[cur] = '\0'; }
+    strcat(doc, text);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Inferred-return resolution                                              */
+/* ---------------------------------------------------------------------- */
+
+/* A module-local table mapping EVERY extern (exported or not) to its
+ * declared return type, so thin wrappers written as `name(...) -> { return
+ * some_extern(...) }` can inherit the real return shape the extern documents
+ * (e.g. fs.copy -> fs_copy_raw -> "(int, int, string)"). */
+typedef struct { char name[128]; char ret[256]; } ExternRet;
+static ExternRet extern_rets[MAX_FUNCTIONS];
+static int extern_ret_count = 0;
+
+static void extern_ret_reset(void) { extern_ret_count = 0; }
+
+static void extern_ret_add(const char* name, const char* ret) {
+    if (extern_ret_count >= MAX_FUNCTIONS) return;
+    strncpy(extern_rets[extern_ret_count].name, name, 127);
+    extern_rets[extern_ret_count].name[127] = '\0';
+    strncpy(extern_rets[extern_ret_count].ret, ret, 255);
+    extern_rets[extern_ret_count].ret[255] = '\0';
+    extern_ret_count++;
+}
+
+static const char* extern_ret_lookup(const char* name) {
+    for (int i = 0; i < extern_ret_count; i++) {
+        if (strcmp(extern_rets[i].name, name) == 0) return extern_rets[i].ret;
+    }
+    return NULL;
+}
+
+/* Best-effort type of a single return-expression token. */
+static const char* infer_value_type(const char* expr) {
+    char e[256];
+    strncpy(e, expr, sizeof(e) - 1);
+    e[sizeof(e) - 1] = '\0';
+    char* t = trim(e);
+    if (*t == '\0') return "";
+    if (strcmp(t, "null") == 0) return "ptr";
+    if (t[0] == '"') return "string";                       /* string literal */
+    if (t[0] == '-' || isdigit((unsigned char)t[0])) {      /* numeric literal */
+        return strchr(t, '.') ? "float" : "int";
+    }
+    return "";   /* unknown — left as an unnamed tuple slot */
+}
+
+/* Resolve an inferred (`-> {`) wrapper return by inspecting its body.
+ * `body` points just after the opening brace of the function. Writes a
+ * rendered return type into `out` ("" if nothing could be inferred). */
+static void infer_return_from_body(const char* body, char* out, size_t out_size) {
+    out[0] = '\0';
+    /* find the first `return` keyword at a statement boundary, skipping line
+     * comments and string literals so prose like `// Returns ...` and inline
+     * "return" text never mis-fires */
+    const char* p = body;
+    const char* ret_kw = NULL;
+    while (*p) {
+        if (p[0] == '/' && p[1] == '/') {            /* skip line comment */
+            while (*p && *p != '\n') p++;
+            continue;
+        }
+        if (*p == '"') {                              /* skip string literal */
+            p++;
+            while (*p && *p != '"') { if (*p == '\\' && p[1]) p++; p++; }
+            if (*p) p++;
+            continue;
+        }
+        if (strncmp(p, "return", 6) == 0 &&
+            (p == body || !is_ident_char((unsigned char)p[-1])) &&
+            !is_ident_char((unsigned char)p[6])) {
+            ret_kw = p + 6;
+            break;
+        }
+        if (*p == '}') break;   /* end of this function, no return found */
+        p++;
+    }
+    if (!ret_kw) return;
+
+    /* isolate the return expression up to end-of-line */
+    while (*ret_kw == ' ' || *ret_kw == '\t') ret_kw++;
+    char expr[512];
+    size_t j = 0;
+    int depth = 0;
+    while (*ret_kw && j < sizeof(expr) - 1) {
+        if (*ret_kw == '(') depth++;
+        else if (*ret_kw == ')') depth--;
+        else if (*ret_kw == '\n' && depth <= 0) break;
+        expr[j++] = *ret_kw++;
+    }
+    expr[j] = '\0';
+    char* et = trim(expr);
+    if (*et == '\0') return;
+
+    /* Case 1: `return some_call(args)` — a single function call. Inherit the
+     * callee's declared return type if it's a known extern. */
+    {
+        const char* q = et;
+        char callee[128]; size_t k = 0;
+        while (*q && is_ident_char((unsigned char)*q) && k < sizeof(callee) - 1) callee[k++] = *q++;
+        callee[k] = '\0';
+        while (*q == ' ' || *q == '\t') q++;
+        if (k > 0 && *q == '(') {
+            /* ensure this is the WHOLE expression (no top-level comma after the call) */
+            int d = 0; const char* r = q; int comma_outside = 0;
+            for (; *r; r++) {
+                if (*r == '(') d++;
+                else if (*r == ')') d--;
+                else if (*r == ',' && d == 0) { comma_outside = 1; break; }
+            }
+            if (!comma_outside) {
+                const char* inherited = extern_ret_lookup(callee);
+                if (inherited && inherited[0]) {
+                    strncpy(out, inherited, out_size - 1);
+                    out[out_size - 1] = '\0';
+                    return;
+                }
+            }
+        }
+    }
+
+    /* Case 2: comma-separated tuple of values — render an inferred tuple with
+     * best-effort element types. */
+    {
+        int has_comma = 0, d = 0;
+        for (const char* r = et; *r; r++) {
+            if (*r == '(') d++;
+            else if (*r == ')') d--;
+            else if (*r == ',' && d == 0) { has_comma = 1; break; }
+        }
+        if (!has_comma) {
+            /* single non-call value — infer a scalar type when the literal
+             * makes it obvious (e.g. `return ""` -> string, `return 0` -> int) */
+            const char* ty = infer_value_type(et);
+            if (*ty) {
+                strncpy(out, ty, out_size - 1);
+                out[out_size - 1] = '\0';
+            }
+            return;
+        }
+
+        char work[512];
+        strncpy(work, et, sizeof(work) - 1);
+        work[sizeof(work) - 1] = '\0';
+
+        char tuple[256] = "(";
+        char* save = NULL;
+        char* tok = strtok_r(work, ",", &save);
+        int first = 1, slot = 0;
+        while (tok) {
+            const char* ty = infer_value_type(trim(tok));
+            char label[32];
+            if (*ty) {
+                snprintf(label, sizeof(label), "%s", ty);
+            } else {
+                snprintf(label, sizeof(label), "_%d", slot);   /* unknown slot */
+            }
+            if (!first) strncat(tuple, ", ", sizeof(tuple) - strlen(tuple) - 1);
+            strncat(tuple, label, sizeof(tuple) - strlen(tuple) - 1);
+            first = 0; slot++;
+            tok = strtok_r(NULL, ",", &save);
+        }
+        strncat(tuple, ")", sizeof(tuple) - strlen(tuple) - 1);
+        strncpy(out, tuple, out_size - 1);
+        out[out_size - 1] = '\0';
+    }
+}
+
+/* Record a found definition against an exported name, if `name` is in the
+ * export list and has no definition yet. */
+static void record_def(Module* mod, char exports[][128], int export_count,
+                       const char* name, DefKind kind,
+                       const char* params, const char* return_type,
+                       const char* value, const char* doc) {
+    for (int i = 0; i < export_count; i++) {
+        if (strcmp(exports[i], name) != 0) continue;
+        Function* fn = upsert_function(mod, name);
+        if (fn && !fn->has_def) {
+            fn->kind = kind;
+            if (params)      { strncpy(fn->params, params, sizeof(fn->params) - 1); }
+            if (return_type) { strncpy(fn->return_type, return_type, sizeof(fn->return_type) - 1); }
+            if (value)       { strncpy(fn->value, value, sizeof(fn->value) - 1); }
+            if (doc)         { strncpy(fn->doc, doc, sizeof(fn->doc) - 1); }
+            fn->has_def = 1;
+        }
+        return;
+    }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Parse one module.ae                                                     */
+/* ---------------------------------------------------------------------- */
+
+static void parse_module_ae(const char* filepath, const char* module_name) {
+    char* src = read_file(filepath);
+    if (!src) {
+        fprintf(stderr, "Warning: cannot read %s\n", filepath);
+        return;
+    }
+
+    Module* mod = find_or_create_module(module_name);
+    if (!mod) { free(src); return; }
+
+    /* ---- exported names ---- */
+    static char exports[MAX_EXPORTS][128];
+    int export_count = parse_exports(src, exports, MAX_EXPORTS);
+    if (export_count == 0) { free(src); return; }
+
+    /* Pre-create the function records in export order so the page lists
+     * functions in the same order the module author declared them. */
+    for (int i = 0; i < export_count; i++) {
+        upsert_function(mod, exports[i]);
+    }
+
+    /* Fresh extern-return table for inferred-wrapper resolution. */
+    extern_ret_reset();
+
+    /* ---- walk the file line by line collecting docs + definitions ---- */
+    char module_doc[1024] = "";
+    int seen_exports = 0;
+    char pending_doc[MAX_DOC] = "";
+
+    char* cursor = src;
+    while (*cursor) {
+        /* isolate the current physical line [line, eol) */
+        char* line = cursor;
+        char* eol = strchr(cursor, '\n');
+        size_t line_len = eol ? (size_t)(eol - cursor) : strlen(cursor);
+
+        char buf[MAX_LINE];
+        size_t cp = line_len < sizeof(buf) - 1 ? line_len : sizeof(buf) - 1;
+        memcpy(buf, line, cp);
+        buf[cp] = '\0';
+
+        char* t = trim(buf);
+
+        if (t[0] == '\0') {
+            /* blank line: a doc block ends here */
+            pending_doc[0] = '\0';
+        } else if (t[0] == '/' && t[1] == '/') {
+            const char* comment = t + 2;
+            while (*comment == ' ') comment++;
+            /* skip pure separator lines (----, ===) so the doc stays clean */
+            int only_sep = 1;
+            for (const char* c = comment; *c; c++) {
+                if (*c != '-' && *c != '=' && *c != ' ') { only_sep = 0; break; }
+            }
+            if (!seen_exports) {
+                if (!only_sep && *comment) {
+                    size_t cur = strlen(module_doc);
+                    size_t add = strlen(comment);
+                    if (cur + add + 2 < sizeof(module_doc)) {
+                        if (cur > 0) { module_doc[cur++] = ' '; module_doc[cur] = '\0'; }
+                        strcat(module_doc, comment);
+                    }
+                }
+            } else if (!only_sep && *comment) {
+                append_doc_line(pending_doc, comment);
+            }
+        } else {
+            /* code line */
+            if (strncmp(t, "exports", 7) == 0 && !seen_exports) {
+                seen_exports = 1;
+                pending_doc[0] = '\0';
+            }
+
+            if (strncmp(t, "extern", 6) == 0 && isspace((unsigned char)t[6])) {
+                const char* defstart = t + 6;
+                while (*defstart == ' ' || *defstart == '\t') defstart++;
+                /* resolve against the ORIGINAL source so multi-line param
+                 * lists are captured: compute defstart's offset in `line`. */
+                size_t off = (size_t)(defstart - buf);
+                const char* src_defstart = line + off;
+                char nm[128], pr[1024], rt[256];
+                if (read_callable(src_defstart, nm, pr, rt)) {
+                    /* Register EVERY extern's return so thin wrappers can
+                     * inherit it, even when the extern itself isn't exported. */
+                    extern_ret_add(nm, rt);
+                    record_def(mod, exports, export_count, nm, DEF_EXTERN,
+                               pr, rt, NULL, pending_doc);
+                }
+            } else if (strncmp(t, "const", 5) == 0 && isspace((unsigned char)t[5])) {
+                const char* q = t + 5;
+                while (*q == ' ' || *q == '\t') q++;
+                char nm[128]; size_t j = 0;
+                while (*q && is_ident_char((unsigned char)*q) && j < sizeof(nm) - 1) nm[j++] = *q++;
+                nm[j] = '\0';
+                while (*q == ' ' || *q == '\t') q++;
+                char val[256] = "";
+                if (*q == '=') {
+                    q++;
+                    while (*q == ' ' || *q == '\t') q++;
+                    size_t k = 0;
+                    while (*q && *q != '/' && k < sizeof(val) - 1) val[k++] = *q++;
+                    val[k] = '\0';
+                    char* vt = trim(val);
+                    memmove(val, vt, strlen(vt) + 1);
+                }
+                record_def(mod, exports, export_count, nm, DEF_CONST,
+                           NULL, NULL, val, pending_doc);
+            } else if (strncmp(t, "struct", 6) == 0 && isspace((unsigned char)t[6])) {
+                const char* q = t + 6;
+                while (*q == ' ' || *q == '\t') q++;
+                char nm[128]; size_t j = 0;
+                while (*q && is_ident_char((unsigned char)*q) && j < sizeof(nm) - 1) nm[j++] = *q++;
+                nm[j] = '\0';
+                record_def(mod, exports, export_count, nm, DEF_STRUCT,
+                           NULL, NULL, NULL, pending_doc);
+            } else if (seen_exports && is_ident_char((unsigned char)t[0]) &&
+                       !isdigit((unsigned char)t[0])) {
+                /* Candidate Aether wrapper definition. */
+                size_t lead = (size_t)(t - buf);
+                const char* src_start = line + lead;
+                char nm[128], pr[1024], rt[256];
+                if (read_callable(src_start, nm, pr, rt)) {
+                    /* Wrappers written `name(...) -> { ... }` declare no
+                     * explicit return type; reconstruct it from the body's
+                     * first `return` statement (Go-style (value, err) tuples). */
+                    if (rt[0] == '\0') {
+                        const char* brace = strchr(src_start, '{');
+                        if (brace) infer_return_from_body(brace + 1, rt, sizeof(rt));
+                    }
+                    record_def(mod, exports, export_count, nm, DEF_FUNCTION,
+                               pr, rt, NULL, pending_doc);
+                }
+            }
+
+            pending_doc[0] = '\0';
+        }
+
+        if (!eol) break;
+        cursor = eol + 1;
+    }
+
+    collapse_ws(module_doc);
+    if (module_doc[0]) {
+        strncpy(mod->description, module_doc, sizeof(mod->description) - 1);
+        mod->description[sizeof(mod->description) - 1] = '\0';
+    }
+
+    free(src);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Module descriptions (fallback when the file header has none)            */
+/* ---------------------------------------------------------------------- */
+
+static const char* fallback_description(const char* name) {
     if (strcmp(name, "string") == 0) return "String manipulation and formatting";
     if (strcmp(name, "collections") == 0) return "Lists, maps, sets, and data structures";
     if (strcmp(name, "net") == 0) return "HTTP client, server, and networking";
@@ -374,28 +716,79 @@ static const char* get_module_description(const char* name) {
     if (strcmp(name, "io") == 0) return "Input/output and console";
     if (strcmp(name, "math") == 0) return "Mathematical functions";
     if (strcmp(name, "log") == 0) return "Logging and diagnostics";
+    if (strcmp(name, "os") == 0) return "Shell and process execution";
     return "";
 }
 
-// Generate the main index.html
-static void generate_index(const char* output_dir) {
-    char filepath[512];
-    snprintf(filepath, sizeof(filepath), "%s/index.html", output_dir);
-
-    FILE* f = fopen(filepath, "w");
-    if (!f) {
-        fprintf(stderr, "Error: Cannot create %s\n", filepath);
-        return;
+/* A concise (single-sentence) description suitable for cards/headers. The
+ * module header doc can be long; clip it to the first sentence. */
+static void short_description(const Module* mod, char* out, size_t out_size) {
+    const char* desc = (mod->description[0]) ? mod->description : fallback_description(mod->name);
+    size_t j = 0;
+    for (size_t i = 0; desc[i] && j < out_size - 1; i++) {
+        out[j++] = desc[i];
+        if (desc[i] == '.' && (desc[i + 1] == ' ' || desc[i + 1] == '\0')) break;
     }
+    out[j] = '\0';
+    trim(out);
+}
 
+/* ---------------------------------------------------------------------- */
+/* HTML emitters (templates preserved from the original generator)         */
+/* ---------------------------------------------------------------------- */
+
+/* Build the rendered usage call, e.g. "get_string(value)", from the param
+ * names only. */
+static void build_usage(const Function* fn, char* call_out, size_t call_size) {
+    snprintf(call_out, call_size, "%s(", fn->name);
+    if (fn->params[0]) {
+        char params_copy[1024];
+        strncpy(params_copy, fn->params, sizeof(params_copy) - 1);
+        params_copy[sizeof(params_copy) - 1] = '\0';
+        char* save = NULL;
+        char* tok = strtok_r(params_copy, ",", &save);
+        int first = 1;
+        while (tok) {
+            char* colon = strchr(tok, ':');
+            if (colon) *colon = '\0';
+            char* nm = trim(tok);
+            if (*nm) {
+                if (!first) strncat(call_out, ", ", call_size - strlen(call_out) - 1);
+                strncat(call_out, nm, call_size - strlen(call_out) - 1);
+                first = 0;
+            }
+            tok = strtok_r(NULL, ",", &save);
+        }
+    }
+    strncat(call_out, ")", call_size - strlen(call_out) - 1);
+}
+
+static const char* kind_label(DefKind k) {
+    switch (k) {
+        case DEF_EXTERN:   return "extern";
+        case DEF_CONST:    return "const";
+        case DEF_STRUCT:   return "struct";
+        case DEF_FUNCTION: default: return "fn";
+    }
+}
+
+static void emit_head(FILE* f, const char* title) {
     fprintf(f, "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
     fprintf(f, "  <meta charset=\"UTF-8\">\n");
     fprintf(f, "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n");
-    fprintf(f, "  <title>Aether Standard Library</title>\n");
+    fprintf(f, "  <title>%s</title>\n", title);
     fprintf(f, "  <link rel=\"stylesheet\" href=\"style.css\">\n");
     fprintf(f, "</head>\n<body>\n");
+}
 
-    // Sidebar
+static void generate_index(const char* output_dir) {
+    char filepath[600];
+    snprintf(filepath, sizeof(filepath), "%s/index.html", output_dir);
+    FILE* f = fopen(filepath, "w");
+    if (!f) { fprintf(stderr, "Error: cannot create %s\n", filepath); return; }
+
+    emit_head(f, "Aether Standard Library");
+
     fprintf(f, "<nav class=\"sidebar\">\n");
     fprintf(f, "  <div class=\"sidebar-header\">\n");
     fprintf(f, "    <h1>Aether</h1>\n");
@@ -404,203 +797,165 @@ static void generate_index(const char* output_dir) {
     fprintf(f, "  <input type=\"text\" id=\"search\" placeholder=\"Search functions...\" onkeyup=\"search()\">\n");
     fprintf(f, "  <h2>Modules</h2>\n");
     fprintf(f, "  <ul class=\"module-list\">\n");
-
     for (int i = 0; i < module_count; i++) {
-        fprintf(f, "    <li><a href=\"%s.html\">%s</a></li>\n",
-                modules[i].name, modules[i].name);
+        fprintf(f, "    <li><a href=\"%s.html\">%s</a></li>\n", modules[i].name, modules[i].name);
     }
-
     fprintf(f, "  </ul>\n</nav>\n");
 
-    // Main content
     fprintf(f, "<main class=\"content\">\n");
     fprintf(f, "  <div class=\"hero\">\n");
     fprintf(f, "    <h1>Standard Library</h1>\n");
-    fprintf(f, "    <p>Built-in functions for strings, collections, networking, file I/O, and more.</p>\n");
+    fprintf(f, "    <p>The public <code>.ae</code> API: import a module with "
+               "<code>import std.&lt;name&gt;</code> and call its exports as "
+               "<code>&lt;name&gt;.&lt;function&gt;</code>.</p>\n");
     fprintf(f, "  </div>\n");
 
     fprintf(f, "  <div class=\"module-grid\">\n");
-
     for (int i = 0; i < module_count; i++) {
-        const char* desc = get_module_description(modules[i].name);
+        char desc[600], esc[1200];
+        short_description(&modules[i], desc, sizeof(desc));
+        html_escape(desc, esc, sizeof(esc));
         fprintf(f, "    <a href=\"%s.html\" class=\"module-card\">\n", modules[i].name);
         fprintf(f, "      <h3>%s</h3>\n", modules[i].name);
-        fprintf(f, "      <p>%s</p>\n", desc);
+        fprintf(f, "      <p>%s</p>\n", esc);
+        fprintf(f, "      <span class=\"count\">%d exports</span>\n", modules[i].function_count);
         fprintf(f, "    </a>\n");
     }
-
     fprintf(f, "  </div>\n");
 
-    // Quick reference - all functions (hidden by default, shown on search)
+    /* Hidden search index across every exported symbol. */
     fprintf(f, "  <div id=\"search-results\" class=\"search-results hidden\">\n");
     fprintf(f, "    <h2>Search Results</h2>\n");
     fprintf(f, "    <ul class=\"function-list\" id=\"all-functions\">\n");
-
     for (int i = 0; i < module_count; i++) {
         for (int j = 0; j < modules[i].function_count; j++) {
-            Function* func = &modules[i].functions[j];
-            char escaped_name[512];
-            html_escape(func->name, escaped_name, sizeof(escaped_name));
-            fprintf(f, "      <li class=\"function-item\" data-name=\"%s\"><a href=\"%s.html#%s\"><span class=\"fn-name\">%s</span><span class=\"fn-module\">%s</span></a></li>\n",
-                    escaped_name, modules[i].name, escaped_name, escaped_name, modules[i].name);
+            Function* fn = &modules[i].functions[j];
+            char esc[256];
+            html_escape(fn->name, esc, sizeof(esc));
+            fprintf(f, "      <li class=\"function-item\" data-name=\"%s\">"
+                       "<a href=\"%s.html#%s\"><span class=\"fn-name\">%s</span>"
+                       "<span class=\"fn-module\">%s</span></a></li>\n",
+                    esc, modules[i].name, esc, esc, modules[i].name);
         }
     }
-
     fprintf(f, "    </ul>\n");
     fprintf(f, "  </div>\n");
     fprintf(f, "</main>\n");
 
-    // Search script
     fprintf(f, "<script src=\"search.js\"></script>\n");
     fprintf(f, "</body>\n</html>\n");
-
     fclose(f);
     printf("Generated: %s\n", filepath);
 }
 
-// Generate module page
 static void generate_module_page(const char* output_dir, Module* mod) {
-    char filepath[512];
+    char filepath[600];
     snprintf(filepath, sizeof(filepath), "%s/%s.html", output_dir, mod->name);
-
     FILE* f = fopen(filepath, "w");
-    if (!f) {
-        fprintf(stderr, "Error: Cannot create %s\n", filepath);
-        return;
-    }
+    if (!f) { fprintf(stderr, "Error: cannot create %s\n", filepath); return; }
 
-    const char* mod_desc = get_module_description(mod->name);
+    char title[128];
+    snprintf(title, sizeof(title), "%s - Aether", mod->name);
+    emit_head(f, title);
 
-    fprintf(f, "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
-    fprintf(f, "  <meta charset=\"UTF-8\">\n");
-    fprintf(f, "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n");
-    fprintf(f, "  <title>%s - Aether</title>\n", mod->name);
-    fprintf(f, "  <link rel=\"stylesheet\" href=\"style.css\">\n");
-    fprintf(f, "</head>\n<body>\n");
+    char short_desc[600], short_esc[1200];
+    short_description(mod, short_desc, sizeof(short_desc));
+    html_escape(short_desc, short_esc, sizeof(short_esc));
 
-    // Sidebar
+    /* Sidebar */
     fprintf(f, "<nav class=\"sidebar\">\n");
     fprintf(f, "  <div class=\"sidebar-header\">\n");
     fprintf(f, "    <h1><a href=\"index.html\">Aether</a></h1>\n");
     fprintf(f, "    <p class=\"tagline\">Standard Library</p>\n");
     fprintf(f, "  </div>\n");
     fprintf(f, "  <input type=\"text\" id=\"search\" placeholder=\"Search %s...\" onkeyup=\"searchModule()\">\n", mod->name);
-    fprintf(f, "  <h2>Functions</h2>\n");
+    fprintf(f, "  <h2>Exports</h2>\n");
     fprintf(f, "  <ul class=\"function-nav\">\n");
-
     for (int i = 0; i < mod->function_count; i++) {
-        // Show shorter function names (strip aether_ prefix)
-        const char* display_name = mod->functions[i].name;
-        if (strncmp(display_name, "aether_", 7) == 0) {
-            display_name += 7;
-        }
-        char escaped_name[512], escaped_display[512];
-        html_escape(mod->functions[i].name, escaped_name, sizeof(escaped_name));
-        html_escape(display_name, escaped_display, sizeof(escaped_display));
-        fprintf(f, "    <li><a href=\"#%s\">%s</a></li>\n", escaped_name, escaped_display);
+        char esc[256];
+        html_escape(mod->functions[i].name, esc, sizeof(esc));
+        fprintf(f, "    <li><a href=\"#%s\">%s</a></li>\n", esc, esc);
     }
-
     fprintf(f, "  </ul>\n");
     fprintf(f, "  <hr>\n");
     fprintf(f, "  <h2>Modules</h2>\n");
     fprintf(f, "  <ul class=\"module-list\">\n");
-
     for (int i = 0; i < module_count; i++) {
         const char* active = (strcmp(modules[i].name, mod->name) == 0) ? " class=\"active\"" : "";
         fprintf(f, "    <li%s><a href=\"%s.html\">%s</a></li>\n", active, modules[i].name, modules[i].name);
     }
-
     fprintf(f, "  </ul>\n</nav>\n");
 
-    // Main content
+    /* Main content */
     fprintf(f, "<main class=\"content\">\n");
     fprintf(f, "  <div class=\"module-header\">\n");
     fprintf(f, "    <h1>%s</h1>\n", mod->name);
-    fprintf(f, "    <p class=\"module-desc\">%s</p>\n", mod_desc);
+    fprintf(f, "    <p class=\"module-desc\">%s</p>\n", short_esc);
+    fprintf(f, "    <p class=\"import-line\"><code>import std.%s</code></p>\n", mod->name);
     fprintf(f, "  </div>\n");
 
     fprintf(f, "  <div class=\"functions\" id=\"functions\">\n");
-
     for (int i = 0; i < mod->function_count; i++) {
-        Function* func = &mod->functions[i];
+        Function* fn = &mod->functions[i];
 
-        // Strip aether_ prefix for display
-        const char* display_name = func->name;
-        if (strncmp(display_name, "aether_", 7) == 0) {
-            display_name += 7;
-        }
+        char esc_name[256], esc_doc[MAX_DOC * 2];
+        html_escape(fn->name, esc_name, sizeof(esc_name));
+        html_escape(fn->doc, esc_doc, sizeof(esc_doc));
 
-        char escaped_name[512], escaped_display[512], escaped_doc[MAX_DOC * 2];
-        html_escape(func->name, escaped_name, sizeof(escaped_name));
-        html_escape(display_name, escaped_display, sizeof(escaped_display));
-        html_escape(func->doc, escaped_doc, sizeof(escaped_doc));
+        fprintf(f, "    <div class=\"function\" id=\"%s\" data-name=\"%s\">\n", esc_name, esc_name);
+        fprintf(f, "      <h3 class=\"function-name\">%s <span class=\"kind\">%s</span></h3>\n",
+                esc_name, kind_label(fn->kind));
 
-        fprintf(f, "    <div class=\"function\" id=\"%s\" data-name=\"%s\">\n", escaped_name, escaped_name);
-        fprintf(f, "      <h3 class=\"function-name\">%s</h3>\n", escaped_display);
+        if (fn->kind == DEF_CONST) {
+            char esc_val[512];
+            html_escape(fn->value[0] ? fn->value : "", esc_val, sizeof(esc_val));
+            fprintf(f, "      <pre class=\"usage\"><code>%s%s%s</code></pre>\n",
+                    esc_name,
+                    fn->value[0] ? " = " : "",
+                    esc_val);
+        } else if (fn->kind == DEF_STRUCT) {
+            fprintf(f, "      <pre class=\"usage\"><code>struct %s</code></pre>\n", esc_name);
+        } else {
+            char call[1024], esc_call[2048];
+            build_usage(fn, call, sizeof(call));
+            html_escape(call, esc_call, sizeof(esc_call));
 
-        // Show usage example with clean name (no aether_ prefix)
-        fprintf(f, "      <pre class=\"usage\"><code>%s(", display_name);
+            if (fn->return_type[0]) {
+                char esc_ret[512];
+                html_escape(fn->return_type, esc_ret, sizeof(esc_ret));
+                fprintf(f, "      <pre class=\"usage\"><code>%s <span class=\"arrow\">-&gt;</span> %s</code></pre>\n",
+                        esc_call, esc_ret);
+            } else {
+                fprintf(f, "      <pre class=\"usage\"><code>%s</code></pre>\n", esc_call);
+            }
 
-        // Add parameter placeholders
-        if (strlen(func->aether_params) > 0) {
-            // Parse params and show just names
-            char params_copy[512];
-            strncpy(params_copy, func->aether_params, sizeof(params_copy) - 1);
-            char* p = params_copy;
-            int first = 1;
-            while (*p) {
-                // Find param name (before the colon)
-                char* colon = strchr(p, ':');
-                if (colon) {
-                    *colon = '\0';
-                    if (!first) fprintf(f, ", ");
-                    fprintf(f, "%s", p);
-                    first = 0;
-                    // Skip to next param
-                    p = colon + 1;
-                    char* comma = strchr(p, ',');
-                    if (comma) {
-                        p = comma + 1;
-                        while (*p == ' ') p++;
-                    } else {
-                        break;
-                    }
-                } else {
-                    break;
-                }
+            /* Full typed parameter line. */
+            if (fn->params[0]) {
+                char esc_params[2048];
+                html_escape(fn->params, esc_params, sizeof(esc_params));
+                fprintf(f, "      <p class=\"signature\"><span class=\"sig-params\">%s</span></p>\n", esc_params);
             }
         }
-        fprintf(f, ")</code></pre>\n");
 
-        if (strlen(func->doc) > 0) {
-            fprintf(f, "      <p class=\"doc\">%s</p>\n", escaped_doc);
+        if (fn->doc[0]) {
+            fprintf(f, "      <p class=\"doc\">%s</p>\n", esc_doc);
         }
-
-
         fprintf(f, "    </div>\n");
     }
-
     fprintf(f, "  </div>\n");
     fprintf(f, "</main>\n");
 
-    // Search script
     fprintf(f, "<script src=\"search.js\"></script>\n");
     fprintf(f, "</body>\n</html>\n");
-
     fclose(f);
     printf("Generated: %s\n", filepath);
 }
 
-// Generate CSS
 static void generate_css(const char* output_dir) {
-    char filepath[512];
+    char filepath[600];
     snprintf(filepath, sizeof(filepath), "%s/style.css", output_dir);
-
     FILE* f = fopen(filepath, "w");
-    if (!f) {
-        fprintf(stderr, "Error: Cannot create %s\n", filepath);
-        return;
-    }
+    if (!f) { fprintf(stderr, "Error: cannot create %s\n", filepath); return; }
 
     fprintf(f,
 "* { margin: 0; padding: 0; box-sizing: border-box; }\n\n"
@@ -614,9 +969,9 @@ static void generate_css(const char* output_dir) {
 "  min-height: 100vh;\n"
 "}\n\n"
 
-"a { color: inherit; text-decoration: none; }\n\n"
+"a { color: inherit; text-decoration: none; }\n"
+"code { font-family: 'SF Mono', 'Fira Code', monospace; }\n\n"
 
-/* Sidebar */
 ".sidebar {\n"
 "  width: 240px;\n"
 "  background: #111;\n"
@@ -627,17 +982,8 @@ static void generate_css(const char* output_dir) {
 "  border-right: 1px solid #222;\n"
 "}\n\n"
 
-".sidebar-header h1 {\n"
-"  font-size: 1.1rem;\n"
-"  font-weight: 600;\n"
-"  color: #fff;\n"
-"}\n\n"
-
-".sidebar-header .tagline {\n"
-"  font-size: 0.75rem;\n"
-"  color: #666;\n"
-"  margin-top: 2px;\n"
-"}\n\n"
+".sidebar-header h1 { font-size: 1.1rem; font-weight: 600; color: #fff; }\n"
+".sidebar-header .tagline { font-size: 0.75rem; color: #666; margin-top: 2px; }\n\n"
 
 "#search {\n"
 "  width: 100%%;\n"
@@ -676,21 +1022,16 @@ static void generate_css(const char* output_dir) {
 "  font-family: 'SF Mono', 'Fira Code', monospace;\n"
 "  font-size: 0.8rem;\n"
 "  padding: 4px 10px;\n"
+"  overflow: hidden;\n"
+"  text-overflow: ellipsis;\n"
+"  white-space: nowrap;\n"
 "}\n\n"
 
-".module-list li a:hover, .function-nav li a:hover {\n"
-"  background: #1a1a1a;\n"
-"  color: #fff;\n"
-"}\n\n"
-
-".module-list .active a {\n"
-"  background: #1a2a3a;\n"
-"  color: #4a9eff;\n"
-"}\n\n"
+".module-list li a:hover, .function-nav li a:hover { background: #1a1a1a; color: #fff; }\n"
+".module-list .active a { background: #1a2a3a; color: #4a9eff; }\n\n"
 
 "hr { border: none; border-top: 1px solid #222; margin: 16px 0; }\n\n"
 
-/* Main content */
 ".content {\n"
 "  margin-left: 240px;\n"
 "  padding: 32px 40px;\n"
@@ -700,13 +1041,14 @@ static void generate_css(const char* output_dir) {
 
 ".hero { margin-bottom: 40px; }\n"
 ".hero h1 { font-size: 1.5rem; font-weight: 600; color: #fff; margin-bottom: 8px; }\n"
-".hero p { color: #666; font-size: 0.95rem; }\n\n"
+".hero p { color: #888; font-size: 0.95rem; }\n"
+".hero code, .module-desc code, .import-line code { color: #7dd3fc; background: #141414; padding: 1px 5px; border-radius: 4px; font-size: 0.85em; }\n\n"
 
 ".module-header { margin-bottom: 32px; }\n"
 ".module-header h1 { font-size: 1.4rem; font-weight: 600; color: #fff; margin-bottom: 4px; }\n"
-".module-desc { color: #666; font-size: 0.9rem; }\n\n"
+".module-desc { color: #888; font-size: 0.9rem; }\n"
+".import-line { margin-top: 8px; }\n\n"
 
-/* Module grid */
 ".module-grid {\n"
 "  display: grid;\n"
 "  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));\n"
@@ -724,11 +1066,11 @@ static void generate_css(const char* output_dir) {
 
 ".module-card:hover { border-color: #333; background: #181818; }\n"
 ".module-card h3 { font-size: 0.95rem; color: #fff; margin-bottom: 4px; }\n"
-".module-card p { font-size: 0.8rem; color: #666; }\n\n"
+".module-card p { font-size: 0.8rem; color: #888; margin-bottom: 8px; }\n"
+".module-card .count { font-size: 0.7rem; color: #555; }\n\n"
 
-/* Search results */
 ".search-results { margin-top: 32px; }\n"
-".search-results h2 { font-size: 0.85rem; color: #666; margin-bottom: 16px; }\n\n"
+".search-results h2 { font-size: 0.85rem; color: #888; margin-bottom: 16px; }\n\n"
 
 ".function-list { list-style: none; }\n"
 ".function-item a {\n"
@@ -743,7 +1085,6 @@ static void generate_css(const char* output_dir) {
 ".fn-name { font-family: 'SF Mono', monospace; font-size: 0.85rem; color: #d4d4d4; }\n"
 ".fn-module { font-size: 0.75rem; color: #555; }\n\n"
 
-/* Function cards */
 ".function {\n"
 "  background: #141414;\n"
 "  padding: 20px;\n"
@@ -757,23 +1098,43 @@ static void generate_css(const char* output_dir) {
 "  font-weight: 500;\n"
 "  color: #fff;\n"
 "  margin-bottom: 8px;\n"
+"  font-family: 'SF Mono', 'Fira Code', monospace;\n"
+"}\n\n"
+
+".function-name .kind {\n"
+"  font-family: -apple-system, sans-serif;\n"
+"  font-size: 0.65rem;\n"
+"  font-weight: 500;\n"
+"  text-transform: uppercase;\n"
+"  letter-spacing: 0.05em;\n"
+"  color: #4a9eff;\n"
+"  background: #14202e;\n"
+"  padding: 2px 6px;\n"
+"  border-radius: 4px;\n"
+"  margin-left: 8px;\n"
+"  vertical-align: middle;\n"
 "}\n\n"
 
 ".usage {\n"
 "  background: #0a0a0a;\n"
 "  padding: 10px 14px;\n"
 "  border-radius: 6px;\n"
-"  margin-bottom: 10px;\n"
+"  margin-bottom: 8px;\n"
 "  overflow-x: auto;\n"
 "}\n\n"
 
-".usage code {\n"
-"  font-family: 'SF Mono', 'Fira Code', monospace;\n"
-"  font-size: 0.85rem;\n"
-"  color: #7dd3fc;\n"
-"}\n\n"
+".usage code { font-size: 0.85rem; color: #7dd3fc; }\n"
+".usage .arrow { color: #666; }\n\n"
 
-".doc { color: #888; font-size: 0.9rem; }\n\n"
+".signature {\n"
+"  font-family: 'SF Mono', 'Fira Code', monospace;\n"
+"  font-size: 0.78rem;\n"
+"  color: #888;\n"
+"  margin-bottom: 8px;\n"
+"}\n"
+".signature .sig-params { color: #c0a0e0; }\n\n"
+
+".doc { color: #999; font-size: 0.9rem; }\n\n"
 
 ".hidden { display: none !important; }\n\n"
 
@@ -787,16 +1148,11 @@ static void generate_css(const char* output_dir) {
     printf("Generated: %s\n", filepath);
 }
 
-// Generate search.js
 static void generate_search_js(const char* output_dir) {
-    char filepath[512];
+    char filepath[600];
     snprintf(filepath, sizeof(filepath), "%s/search.js", output_dir);
-
     FILE* f = fopen(filepath, "w");
-    if (!f) {
-        fprintf(stderr, "Error: Cannot create %s\n", filepath);
-        return;
-    }
+    if (!f) { fprintf(stderr, "Error: cannot create %s\n", filepath); return; }
 
     fprintf(f,
 "// Index page search - shows results, hides module grid\n"
@@ -870,25 +1226,13 @@ static void generate_search_js(const char* output_dir) {
     printf("Generated: %s\n", filepath);
 }
 
-// Scan directory for header files
-static void scan_directory(const char* dir_path, const char* module_name) {
-    DIR* dir = opendir(dir_path);
-    if (!dir) return;
+/* ---------------------------------------------------------------------- */
+/* Driver                                                                  */
+/* ---------------------------------------------------------------------- */
 
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != NULL) {
-        if (entry->d_name[0] == '.') continue;
-
-        // Check if it's a .h file
-        const char* ext = strrchr(entry->d_name, '.');
-        if (ext && strcmp(ext, ".h") == 0) {
-            char filepath[512];
-            snprintf(filepath, sizeof(filepath), "%s/%s", dir_path, entry->d_name);
-            parse_header(filepath, module_name);
-        }
-    }
-
-    closedir(dir);
+/* qsort comparator: modules alphabetically by name. */
+static int module_cmp(const void* a, const void* b) {
+    return strcmp(((const Module*)a)->name, ((const Module*)b)->name);
 }
 
 int main(int argc, char** argv) {
@@ -901,13 +1245,11 @@ int main(int argc, char** argv) {
     const char* std_dir = argv[1];
     const char* output_dir = argv[2];
 
-    // Create output directory
     mkdir(output_dir, 0755);
 
-    // Scan std/ subdirectories
     DIR* dir = opendir(std_dir);
     if (!dir) {
-        fprintf(stderr, "Error: Cannot open %s\n", std_dir);
+        fprintf(stderr, "Error: cannot open %s\n", std_dir);
         return 1;
     }
 
@@ -915,28 +1257,46 @@ int main(int argc, char** argv) {
     while ((entry = readdir(dir)) != NULL) {
         if (entry->d_name[0] == '.') continue;
 
-        char subdir_path[512];
+        char subdir_path[600];
         snprintf(subdir_path, sizeof(subdir_path), "%s/%s", std_dir, entry->d_name);
 
         struct stat st;
-        if (stat(subdir_path, &st) == 0 && S_ISDIR(st.st_mode)) {
-            printf("Scanning module: %s\n", entry->d_name);
-            scan_directory(subdir_path, entry->d_name);
-        }
+        if (stat(subdir_path, &st) != 0 || !S_ISDIR(st.st_mode)) continue;
+
+        char module_ae[700];
+        snprintf(module_ae, sizeof(module_ae), "%s/module.ae", subdir_path);
+        if (stat(module_ae, &st) != 0 || !S_ISREG(st.st_mode)) continue;
+
+        printf("Scanning module: %s\n", entry->d_name);
+        parse_module_ae(module_ae, entry->d_name);
     }
     closedir(dir);
 
+    /* Sort modules alphabetically for a stable, predictable layout. */
+    qsort(modules, module_count, sizeof(Module), module_cmp);
+
+    /* Drop modules whose exports yielded nothing documentable (defensive). */
+    int kept = 0;
+    for (int i = 0; i < module_count; i++) {
+        if (modules[i].function_count > 0) {
+            if (kept != i) modules[kept] = modules[i];
+            kept++;
+        }
+    }
+    module_count = kept;
+
+    int total = 0;
     printf("\nParsed %d modules:\n", module_count);
     for (int i = 0; i < module_count; i++) {
-        printf("  - %s: %d functions\n", modules[i].name, modules[i].function_count);
+        printf("  - %s: %d exports\n", modules[i].name, modules[i].function_count);
+        total += modules[i].function_count;
     }
+    printf("  total exports: %d\n", total);
 
-    // Generate output
     printf("\nGenerating documentation...\n");
     generate_css(output_dir);
     generate_search_js(output_dir);
     generate_index(output_dir);
-
     for (int i = 0; i < module_count; i++) {
         generate_module_page(output_dir, &modules[i]);
     }


### PR DESCRIPTION
## Summary

The generated stdlib API docs (`docs/api/*.html`) were produced by a generator (`tools/docgen`) that parsed **C headers**, so they documented the wrong layer: `*_raw` internals and header-only utilities, **wrong signatures** (e.g. json `get_string` shown as a single-value C function instead of the real `(string, string)` tuple wrapper), and they **omitted most of the public API** (os/fs/io/string were each missing dozens of functions). The HTML was also unversioned and ~2 months stale.

This rewrites the generator to document the **user-facing `.ae` API**: for each `std/<module>/module.ae`, it parses the `exports (...)` list and renders each exported function's parameters, return type (including tuple returns), kind (fn/extern/const/struct), and doc-comment. The HTML emitter/templates are preserved. **Coverage goes from 9 modules to 47** (every std module with an exports block), regenerated via `make docs`.

## Bugs found and fixed while reviewing the rewrite

- **Stack overflow in `strip_annotations()`** — it wrote up to 1024 bytes into 256/512-byte caller buffers. This silently truncated every multi-parameter signature (`object_get(obj)` instead of `object_get(obj, key)`) and aborted outright in isolation. Now bounded by the destination capacity.
- **Call-site names** — the `<module>.` namespace consumes a leading `<module>_` prefix, so `string_pad_start` is now documented as `pad_start` (called as `string.pad_start`); exports without the prefix (json's `get_string`) are unchanged.
- **Annotation-strip spacing** — dropped the stray space left before a separator (`(string @heap, int)` → `(string, int)`).

## Verification

- `tools/docgen` builds `-Wall -Wextra -Werror` clean.
- Regenerated output spot-checked: json getters show their `(value, err)` tuple returns; `object_get(obj, key)`/`object_set(obj, key, value)` render all params; fs/os/io/string list their full export sets; no `@heap`-spacing artifacts (0 remaining); per-module function counts are sane with no prefix-collision collapse.

Note: the diff is large because it includes the regenerated HTML for all 47 modules. The meaningful change to review is `tools/docgen/docgen.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)