### PR TITLE
fix(codegen): module-global string var writes the static, not a local shadow

### DIFF
--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -1648,13 +1648,37 @@ static void collect_references(ASTNode* node, TrackedVar* vars, int var_count) {
     }
 }
 
+/* Is `name` a module-level `var` global? Such a name, when it appears
+ * as the LHS of a bare `name = expr` inside a function, parses as an
+ * AST_VARIABLE_DECLARATION but is NOT a new local — it is a WRITE to
+ * the file-scope `static` (#701). Treating it as a local declaration
+ * makes the unused-variable pass flag pure-setter functions
+ * (`set_x(v) { x = v }`) with a spurious "unused variable 'x'": the
+ * write-only assignment never reads the name, and collect_references
+ * deliberately skips a declaration's LHS. The scalar case escaped
+ * notice only because its setters read-modify-write (`x = x + 1`).
+ * Caller passes the module-global name set so these writes are not
+ * mistaken for unused local declarations. */
+static int is_module_global_name(const char** global_names, int global_count,
+                                 const char* name) {
+    if (!name || !global_names) return 0;
+    for (int i = 0; i < global_count; i++) {
+        if (global_names[i] && strcmp(global_names[i], name) == 0) return 1;
+    }
+    return 0;
+}
+
 // Collect variable declarations from a block (non-recursive into nested functions)
-static int collect_declarations(ASTNode* node, TrackedVar* vars, int var_count) {
+static int collect_declarations(ASTNode* node, TrackedVar* vars, int var_count,
+                                const char** global_names, int global_count) {
     if (!node || var_count >= MAX_TRACKED_VARS) return var_count;
 
     if (node->type == AST_VARIABLE_DECLARATION && node->value) {
-        // Skip _ prefixed names (intentional discard)
-        if (node->value[0] != '_') {
+        // Skip _ prefixed names (intentional discard) and writes to a
+        // module-level `var` global (a store to the file-scope static,
+        // not a local declaration).
+        if (node->value[0] != '_' &&
+            !is_module_global_name(global_names, global_count, node->value)) {
             vars[var_count].name = node->value;
             vars[var_count].line = node->line;
             vars[var_count].col = node->column;
@@ -1669,12 +1693,14 @@ static int collect_declarations(ASTNode* node, TrackedVar* vars, int var_count) 
     }
 
     for (int i = 0; i < node->child_count; i++) {
-        var_count = collect_declarations(node->children[i], vars, var_count);
+        var_count = collect_declarations(node->children[i], vars, var_count,
+                                         global_names, global_count);
     }
     return var_count;
 }
 
-static void check_unused_variables(ASTNode* body) {
+static void check_unused_variables(ASTNode* body, const char** global_names,
+                                   int global_count) {
     if (!body) return;
 
     TrackedVar vars[MAX_TRACKED_VARS];
@@ -1682,7 +1708,8 @@ static void check_unused_variables(ASTNode* body) {
 
     // Collect declarations
     for (int i = 0; i < body->child_count; i++) {
-        var_count = collect_declarations(body->children[i], vars, var_count);
+        var_count = collect_declarations(body->children[i], vars, var_count,
+                                         global_names, global_count);
     }
 
     if (var_count == 0) return;
@@ -2385,17 +2412,35 @@ int typecheck_program(ASTNode* program) {
         typecheck_node(program->children[i], global_table);
     }
 
+    // Collect module-level `var` global names (#701). A bare
+    // `name = expr` inside a function whose `name` is one of these is a
+    // write to the file-scope static, not a local declaration — the
+    // unused-variable pass must not flag write-only setters for them.
+    const char* global_var_names[MAX_TRACKED_VARS];
+    int global_var_count = 0;
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* child = program->children[i];
+        if (child && child->type == AST_EXPORT_STATEMENT && child->child_count > 0) {
+            child = child->children[0];  // unwrap `export var ...`
+        }
+        if (child && child->type == AST_CONST_DECLARATION && child->value &&
+            child->annotation && strcmp(child->annotation, "global_var") == 0 &&
+            global_var_count < MAX_TRACKED_VARS) {
+            global_var_names[global_var_count++] = child->value;
+        }
+    }
+
     // Third pass: unused variable + unreachable code analysis
     for (int i = 0; i < program->child_count; i++) {
         ASTNode* child = program->children[i];
         if ((child->type == AST_FUNCTION_DEFINITION || child->type == AST_BUILDER_FUNCTION) && child->child_count > 0) {
             ASTNode* body = child->children[child->child_count - 1];
-            check_unused_variables(body);
+            check_unused_variables(body, global_var_names, global_var_count);
             check_unreachable_code(body);
         } else if (child->type == AST_MAIN_FUNCTION && child->child_count > 0) {
             // main() has a BLOCK child containing the actual statements
             ASTNode* main_body = child->children[0];
-            check_unused_variables(main_body);
+            check_unused_variables(main_body, global_var_names, global_var_count);
             check_unreachable_code(main_body);
         }
     }

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1645,7 +1645,23 @@ static void collect_heap_string_var_names(CodeGenerator* gen, ASTNode* node,
     if (!node || *count >= cap) return;
 
     if (node->type == AST_VARIABLE_DECLARATION && node->value &&
-        strcmp(node->value, "_") != 0) {
+        strcmp(node->value, "_") != 0 &&
+        !is_module_global_var(gen, node->value)) {
+        /* #701/#744: a module-level string `var` is a file-scope
+         * `static const char*`, not a function local. It must NOT be
+         * collected as a heap-tracked local — doing so would (a) hoist
+         * a shadowing `const char* <name> = NULL;` over the global,
+         * (b) route the write through the reassignment wrapper into
+         * that shadow (so cross-function reads never see the new
+         * value), and (c) push a function-exit defer-free that frees
+         * the process-lifetime global (a UAF/double-free across
+         * calls). Skipping the name here leaves is_var_declared false,
+         * so the AST_VARIABLE_DECLARATION emitter routes the write to
+         * the static (is_module_global_var branch) exactly like the
+         * scalar case, and the global is never freed — the latest
+         * value persists for the process lifetime, mirroring the
+         * scalar/#701 model. This matches how hoist_loop_vars and the
+         * if-branch hoists already skip module globals by name. */
         // Decide whether this declaration's LHS deserves a tracker.
         // Bare `_` is a per-use discard, never a tracked variable —
         // skipped here so a string-typed `_` destructure slot doesn't

--- a/tests/integration/module_globals/string_setter.ae
+++ b/tests/integration/module_globals/string_setter.ae
@@ -1,0 +1,66 @@
+// #701 follow-up — a STRING-typed module-level `var` global.
+//
+// The scalar case (int/long/uint64/ptr) worked, but a string-typed
+// module global was miscompiled: codegen's heap-string tracker hoisted
+// a function-LOCAL `const char* token = NULL;` shadow over the file-
+// scope `static`, so a setter wrote the shadow and cross-function reads
+// never saw the new value (it always returned the initializer). The
+// fix makes the heap-string collection/hoist path consult the module-
+// global registry — exactly like the scalar #701/#744 paths — so the
+// write targets the file-scope static (a real lvalue) with no shadow
+// and no defer-free of the process-lifetime global.
+//
+// Behavioural gate: exit(1) if a cross-call read of the global does not
+// observe the setter's write. A scalar global is exercised in the same
+// program to guard against regressing #701.
+
+import std.string
+
+extern exit(code: int)
+
+var token: string = "none"   // STRING module global (the #701 string gap)
+var calls = 0                // scalar module global (guards #701)
+
+set_token(s: string) {
+    token = s                // pure write — must hit the file-scope static
+    calls = calls + 1
+}
+
+get_token() -> string {
+    return token             // cross-function read of the same static
+}
+
+call_count() -> int {
+    return calls
+}
+
+main() {
+    // Initializer is observable before any setter runs.
+    if !string.equals(get_token(), "none") {
+        print("FAIL: initial value not observed\n")
+        exit(1)
+    }
+
+    set_token("secret-xyz")
+    if !string.equals(get_token(), "secret-xyz") {
+        print("FAIL: setter write not observed cross-call (string shadow)\n")
+        exit(1)
+    }
+
+    // Reassign again: the latest value persists; the previous value is
+    // not double-freed (a module global is process-lifetime, never freed
+    // by the function-exit defer / reassignment-free path).
+    set_token("third")
+    if !string.equals(get_token(), "third") {
+        print("FAIL: second setter write not observed\n")
+        exit(1)
+    }
+
+    // Scalar global still accumulates across calls (#701 guard).
+    if call_count() != 2 {
+        print("FAIL: scalar module global did not persist (#701 regression)\n")
+        exit(1)
+    }
+
+    print("PASS: string module-global setter writes the global cross-call\n")
+}


### PR DESCRIPTION
## Summary

A **string-typed module-level `var` was miscompiled**: a setter's write went to a function-local shadow instead of the module global, so cross-function reads never saw it. Found while updating `docs/per-process-config.md` (it had documented module-level `var` as unsupported; once documented, the string case turned out to be broken).

Scalar module globals (`int`/`long`/`uint64`/`ptr`, #701) worked; only the string-typed case hit this path.

## Root cause

The heap-string tracker's `collect_heap_string_var_names` treated the string global as a heap-tracked local, so codegen:
1. hoisted a function-local `const char* <name> = NULL;` shadow over the file-scope `static`,
2. routed the setter's write through the reassignment wrapper into that **shadow**, and
3. pushed a function-exit defer-free over a **process-lifetime global**.

So `set_token("x"); ... get_token()` returned the initializer, not `"x"`.

```c
// before (buggy)                          // after (fixed)
static const char* token = "none";         static const char* token = "none";
void set_token(const char* s) {            void set_token(const char* s) {
    const char* token = NULL;  // shadow       token = s;   // writes the static
    { ...; token = s; ... }
    if (_heap_token) free(token); // !!
}
```

## Fix

`collect_heap_string_var_names` skips module globals — mirroring the scalar #701/#744 hoist skips — so the write routes to the file-scope `static` (a real lvalue), with no shadow and **no defer-free of the global** (so no UAF/double-free; the latest value persists for the process lifetime, exactly like the scalar model).

Secondary: a write-only setter (`set_x(v) { x = v }`) of a module global produced a spurious `warning[W1001]: unused variable 'x'` — the bare `x = expr` parses as a declaration whose LHS the reference pass skips. `typecheck_program` now collects the module-global `var` names and threads them through `check_unused_variables` so those writes aren't mistaken for unused locals. (The scalar case escaped this only because its setters read-modify-write.)

## Test

Adds `tests/integration/module_globals/string_setter.ae`: cross-call reads of a string module global through a setter (initial value, two reassignments), plus a scalar global in the same program guarding against a #701 regression.

## Verification

- `make compiler ae stdlib EXTRA_CFLAGS="-Werror"` — clean, zero warnings.
- New test passes; existing `module_globals` tests (counters/lcg_prng/nested_block_init) stay green.
- `make examples` — 83/83.
- `make test-ae` — 739/739.
- The W1001 false-positive is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)