### PR TITLE
fix(ci): skip emit_lib_const on Windows (unblocks the Windows jobs on main + all PRs)

### DIFF
--- a/tests/integration/emit_lib_const/test_emit_lib_const.sh
+++ b/tests/integration/emit_lib_const/test_emit_lib_const.sh
@@ -10,6 +10,18 @@
 #
 # Also asserts `ae lib-info` reports the constants (schema 1.2).
 
+# Skip on Windows — `--emit=lib` artifact hosting consumes the .so through the
+# POSIX dlopen + lib<module>.so binimport path (DLL hosting is a follow-up, see
+# tools/ae.c). The sibling .so-consume tests (emit_lib, emit_lib_composite,
+# emit_lib_dual_build) all skip here for the same reason; this one was added
+# without the guard and so failed the Windows matrix instead of skipping.
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP] test_emit_lib_const on Windows (POSIX dlopen / .so hosting)"
+        exit 0
+        ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 AE="$ROOT/build/ae"


### PR DESCRIPTION
## Summary

`main` is currently **red on Windows** (the `Windows / MinGW-w64` and `Windows / GCC (MSYS2)` jobs), and every open PR inherits it because GitHub runs PR checks on a merge with `main`. The cause is a single test.

`emit_lib_const` (added in #854) exercises `--emit=lib` artifact hosting, which consumes the `.so` through the POSIX `dlopen` + `lib<module>.so` binimport path. DLL hosting on Windows is an acknowledged follow-up (see `tools/ae.c`). **Every sibling `.so`-consume test already skips on Windows** — `emit_lib`, `emit_lib_composite`, `emit_lib_dual_build` all have the `MINGW*|MSYS*|CYGWIN*|Windows_NT` guard. `emit_lib_const` shipped without it, so on the Windows matrix it builds the `.so` and **fails** instead of skipping.

This adds the same guard. POSIX runs are unchanged — they still build the `.so`, consume it through the binimport path, and assert `ae lib-info` + all five exported constants.

## Why a standalone PR

The bug is in `main` itself, so it can't be fixed from a feature branch (a PR branch editing this file would add/add-conflict with main's copy). Merging this one-line fix to `main` turns the Windows jobs green there **and on every open PR automatically** on the next CI run — no rebasing required.

## Verification

- macOS/Linux: the test still runs in full and passes (`[PASS] emit_lib_const: exported consts cross the .so boundary`) — the guard only matches Windows shells.
- `sh -n` syntax-clean.
- Matches the existing skip convention used by the three sibling emit-lib tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)