### PR TITLE
docs(contrib/host): link & discuss tests in every host README [skip actions]

### DIFF
--- a/contrib/host/aether/README.md
+++ b/contrib/host/aether/README.md
@@ -100,6 +100,33 @@ See [containment-sandbox.md](../../../docs/containment-sandbox.md) for
 the full security model, including limitations (statically linked
 binaries bypass LD_PRELOAD).
 
+## Testing
+
+The end-to-end test lives at
+[`tests/integration/host_aether/`](../../../tests/integration/host_aether/).
+Unlike the VM-host tests (which embed one interpreter and call into it),
+this one exercises Aether-hosting-Aether: a host program compiles a
+*second* Aether program to a native binary and runs it as a subprocess.
+So there are two `.ae` files —
+[`uses_aether.ae`](../../../tests/integration/host_aether/uses_aether.ae)
+is the host/driver, and
+[`child.ae`](../../../tests/integration/host_aether/child.ae) is the
+trivial child it compiles and spawns (it just prints a sentinel line).
+The driver calls `aether_host_run_script(child)` on the **unsandboxed**
+rung (the `run_sandboxed` / `*_with_map` paths need
+`libaether_sandbox.so` + LD_PRELOAD, so they stay out of the portable CI
+path), and asserts the child exited `0`.
+
+The runner is
+[`test_host_aether.sh`](../../../tests/integration/host_aether/test_host_aether.sh).
+It **SKIPs** (never fails) in two cases: when `build/ae` hasn't been
+built, and when the platform isn't Linux/macOS (the bridge `.c` compiles
+to an empty stub elsewhere, so there's nothing to link).  Where it does
+run, it compiles the bridge into `build/contrib/`, points
+`AETHER_AE_PATH` at the freshly built `ae`, sets `AETHER_HOST_CHILD` to
+`child.ae`, runs the driver, and greps stdout for the
+`PASS: aether host compile + run round-trip` line.
+
 ## TODO
 
 - [x] Shared map serialization to shm in `run_sandboxed_with_map`

--- a/contrib/host/duktape/README.md
+++ b/contrib/host/duktape/README.md
@@ -97,3 +97,21 @@ containment model of the host bridges.
 - The `DUK_COMPILE_*` flag constants used by `duk_peval_string` are
   baked directly (public ABI of Duktape's compile-flags interface;
   same shape as Ruby's `Qnil`-as-literal in that bridge).
+
+## Testing
+
+There's no dedicated `host_duktape/` end-to-end test (no fib-style
+set-piece). Coverage comes from two cross-cutting tests instead:
+
+- [`tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh)
+  — the `run_sandboxed_with_map` shared-map round-trip run across
+  ALL host bridges. Its JS (Duktape) case compiles
+  `aether_host_duktape.c`, seeds a map (`name`=Bob, `count`=7),
+  runs JS that reads those keys, writes back `doubled`, and tries to
+  tamper with `name`; it asserts the read, the write (`result=14`),
+  and that the frozen `name` stays `Bob`. SKIPs when Duktape's dev
+  headers aren't installed.
+- [`tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh)
+  — the `make contrib` smoke test; its `duktape` catalogue entry
+  verifies the bridge archive `libaether_host_duktape.a` compiles and
+  archives cleanly.

--- a/contrib/host/factor/README.md
+++ b/contrib/host/factor/README.md
@@ -217,3 +217,28 @@ experiment:
    ```
 3. `ae build` an Aether program with `import contrib.host.factor` — the
    bridge `.a` is auto-linked by the generic host-bridge scanner.
+
+## Testing
+
+The dedicated end-to-end test lives at
+[`tests/integration/host_factor/`](../../../tests/integration/host_factor/) —
+[`uses_factor.ae`](../../../tests/integration/host_factor/uses_factor.ae) is the
+driver (the fib(10)=55 set-piece: a Factor script defines a recursive `fib`,
+`eval` captures its printed output, and a second script writes the first ten
+terms into the shared namespace under `fib0..fib9` for Aether to read back as a
+k-v map — also pinning the stack-effect error contract, a read-mutate-write
+round-trip, and the absent-key `""` shape), and
+[`test_host_factor.sh`](../../../tests/integration/host_factor/test_host_factor.sh)
+is the runner: it builds the factor host `.a` (skipped by the default contrib
+build), runs the driver, and greps for `PASS`. Because this host needs the fork,
+it **SKIPs** (never fails) when `$AETHER_FACTOR_SONAME` / `$AETHER_FACTOR_IMAGE`
+are unset or don't point at real files — CI machines without the runtime no-op
+cleanly.
+
+Factor is also covered by the cross-host shared-map test
+[`tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh),
+which runs the same `run_sandboxed_with_map` round-trip across every available
+host. Its Factor case hands in the text `the cat sat on the mat the cat` and
+map-reduces a word-frequency histogram into the shared map under keys discovered
+at runtime, then reads them back (`the=3`, `cat=2`, six keys total). It too
+**SKIPs** Factor when the two env vars are unset or missing.

--- a/contrib/host/go/README.md
+++ b/contrib/host/go/README.md
@@ -71,3 +71,32 @@ Mode 2 (`go.run_sandboxed`) skips all of that: compile with `go
 build -o bin script.go` ahead of time, then run just `bin` under
 tight grants. Much smaller attack surface if the intent is to
 contain *the script's* effects, not the toolchain's.
+
+## Testing
+
+This host has no dedicated integration test of its own. The closest
+end-to-end coverage of the Go path lives at
+[`tests/integration/host_tinygo/`](../../../tests/integration/host_tinygo/),
+the sibling [`tinygo`](../tinygo/) host — which is built with the same
+Go toolchain (`CGO_ENABLED=1 go build -buildmode=c-shared`, despite
+the "tinygo" brand on the bridge).
+[`uses_tinygo.ae`](../../../tests/integration/host_tinygo/uses_tinygo.ae)
+is the driver (it `dlopen`s the c-shared `.so` and exercises five
+wrapper signatures — `Answer`, `Add`, `Negate`, `Greet`), and
+[`test_host_tinygo.sh`](../../../tests/integration/host_tinygo/test_host_tinygo.sh)
+is the runner.
+
+Like this host, that test **SKIPs** (never fails) when `go` is not on
+`$PATH` — so it no-ops on CI machines without the Go toolchain. With
+`go` available it builds the `.so` from a tmpdir copy of the example
+source, runs the driver, and asserts each expected output line.
+
+```sh
+tests/integration/host_tinygo/test_host_tinygo.sh
+```
+
+Note the difference in embedding model: the tinygo test loads Go
+*in-process* as a c-shared library, whereas this `go` host shells out
+to a **separate subprocess** (see "Containment model" above). The
+toolchain-on-`$PATH` gate and the build command are the shared parts;
+the runtime invocation path is not.

--- a/contrib/host/java/README.md
+++ b/contrib/host/java/README.md
@@ -61,6 +61,46 @@ during class loading and TLS init, and nothing more. Source paths were
 captured empirically via `strace java -version` on Corretto 24 (Debian)
 and Temurin 21 (Ubuntu).
 
+## Testing
+
+Three tests exercise the Java host. All **SKIP** (never fail) on Windows or
+when `javac`/`java` aren't on `PATH`; the two FFI tests additionally SKIP
+unless the JDK is 22+, the version that stabilized Panama
+(`java.lang.foreign.*`).
+
+The end-to-end test is
+[`tests/integration/embedded_java_trading_e2e/`](../../../tests/integration/embedded_java_trading_e2e/)
+— [`test_embedded_java_trading_e2e.sh`](../../../tests/integration/embedded_java_trading_e2e/test_embedded_java_trading_e2e.sh)
+copies `examples/embedded-java/trading/` to a temp dir, runs its `build.sh`
+(namespace build + `javac` + `java`), and asserts the full trading set-piece:
+each event fires with the right id (`OrderPlaced 100`, `OrderRejected 101`,
+`UnknownTicker 102`, `TradeKilled 100`), the book ends at `{100=KILLED}`, and
+both the Java host's `[event]` lines and the Aether library's `[ae]` lines
+reach stdout in order.
+
+The namespace/FFI test is
+[`tests/integration/namespace_java/`](../../../tests/integration/namespace_java/)
+— [`test_namespace_java.sh`](../../../tests/integration/namespace_java/test_namespace_java.sh)
+runs `ae build --namespace .` on [`calc.ae`](../../../tests/integration/namespace_java/calc.ae)
+to emit both the `.so` and a generated Java SDK
+(`com/example/calc/CalcGeneratedSdk.java`), then compiles and runs
+[`Check.java`](../../../tests/integration/namespace_java/Check.java) against it
+to confirm the generated SDK round-trips a call and the `[ae]` script-side
+output is visible to the host.
+
+The shared-map round-trip is
+[`tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh)
+— its Java case gates on `build/aether-sandbox.jar` (built by
+[`build.sh`](build.sh) above) plus a JDK, then spawns `java` with the
+`-javaagent` jar from a C parent that froze a shared map into shm, asserting
+the agent reads and writes it back (`result=processed Frank`, `status=ok`) and
+that the frozen input is untampered.
+
+Note the Java host is a JVM-side jar, not a C bridge archive, so it is **not**
+part of `make contrib` ([`tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh),
+which archives the dlopen/Panama C hosts); build its jar with
+[`build.sh`](build.sh) instead.
+
 ## Notes
 
 - Requires `--enable-native-access=ALL-UNNAMED` for Panama FFI

--- a/contrib/host/js/README.md
+++ b/contrib/host/js/README.md
@@ -1,0 +1,88 @@
+# contrib.host.js — Embedded JavaScript (alias of Duktape)
+
+`contrib.host.js` is a **back-compat alias** for
+`contrib.host.duktape` — the embedded Duktape ES5.1 JavaScript
+engine. It exists only so that older code written against
+`import contrib.host.js` keeps working; new code should prefer
+`import contrib.host.duktape` directly, because the engine name is
+the honest one and lets future runtimes (`--with=quickjs`,
+`--with=v8`, …) coexist later without ambiguity.
+
+```aether
+import contrib.host.js
+
+main() {
+    js.run("print('hello from js: ' + Duktape.version);")
+}
+```
+
+## How the alias works
+
+`module.ae` is a thin re-export shim with **no C artifacts of its
+own**. Each `@extern("…")` binds an Aether-side `js_*` name to the
+renamed C symbol (`duktape_*`) in `libaether_host_duktape.a`. There
+is no separate `libaether_host_js.a` — `ae build`'s import-driven
+auto-link recognises `js` as an alias and links the duktape bridge
+archive. The duktape bridge in turn `dlopen`s libduktape at the
+deploy host's runtime (no `-lduktape` on the link line); see the
+[duktape README](../duktape/README.md) for soname discovery,
+`AETHER_DUKTAPE_SONAME`, and the containment model.
+
+## API
+
+All five entry points delegate to the duktape bridge's C functions:
+
+| Aether call                          | C symbol                          | Returns |
+|--------------------------------------|-----------------------------------|---------|
+| `js.run(code)`                       | `duktape_run`                     | `int`   |
+| `js.run_sandboxed(perms, code)`      | `duktape_run_sandboxed`           | `int`   |
+| `js.run_sandboxed_with_map(perms, code, map_token)` | `duktape_run_sandboxed_with_map` | `int` |
+| `js.init()`                          | `duktape_init`                    | `int`   |
+| `js.finalize()`                      | `duktape_finalize`                | —       |
+
+`perms` is a permission list pointer (e.g. `env` / `*`); the
+sandboxed variants permission-check the native bindings (`env`,
+`readFile`, `fileExists`, `writeFile`, `exec`).
+
+## Shared map
+
+`js.run_sandboxed_with_map(perms, code, map_token)` exposes a host
+shared map to the script via the `aether_map_get(key)` /
+`aether_map_put(key, value)` JS globals. Writes are gated by the
+map token: once the host revokes the input token, further
+`aether_map_put` calls are rejected, so seeded keys cannot be
+tampered with.
+
+## Building
+
+`js` has no archive of its own — building duktape covers it:
+
+```sh
+make contrib MODULES=duktape && make install-contrib
+```
+
+or, containerised, `aether-build --with=duktape --rebuild-image`
+(the alias `--with=js` is also accepted).
+
+## Testing
+
+There's no dedicated fib-style end-to-end test for the `js` host
+(unlike factor or racket); since it is an alias, its coverage is the
+duktape bridge plus the cross-host shared-map test:
+
+- [`../../../tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh)
+  — the `run_sandboxed_with_map` shared-map round-trip run across all
+  host bridges. The "JS (Duktape)" case compiles
+  `contrib/host/duktape/aether_host_duktape.c`, seeds a map
+  (`name`=Bob, `count`=7), runs JS that reads those keys via
+  `aether_map_get`, writes back `doubled` via `aether_map_put`, and
+  tries to tamper with `name`. It asserts the read
+  (`js:name=Bob,count=7,secret=nil`), the write (`js:result=14`), and
+  that the frozen `name` stays `Bob` (`js:untampered=Bob`) after the
+  token is revoked. SKIPs when Duktape's dev headers aren't installed.
+- [`../../../tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh)
+  — the `make contrib` smoke test. It has no `js` entry (the alias
+  ships no archive); the underlying `duktape` catalogue entry verifies
+  the bridge archive `libaether_host_duktape.a` compiles and archives
+  cleanly. SKIPs when `pkg-config` (or the default include path) finds
+  no `duktape` dev kit.

--- a/contrib/host/lua/README.md
+++ b/contrib/host/lua/README.md
@@ -77,3 +77,24 @@ main() {
 - Symbol versioning (`lua_close@@LUA_5.4`): dlsym strips version
   tags, so `dlsym(h, "lua_close")` works against 5.3 or 5.4
   indifferently.
+
+## Testing
+
+Lua has no dedicated fib-style end-to-end test like factor or racket
+do. Its coverage comes from two cross-cutting tests:
+
+- [`../../../tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh)
+  — the cross-host shared-map round-trip. The Lua case seeds a shared
+  map with `name=Alice` / `age=30`, runs Lua under
+  `lua_run_sandboxed_with_map`, and asserts the script reads both keys
+  (and gets `nil` for an absent `secret`), writes back
+  `greeting=hello Alice`, and that a tamper attempt
+  (`aether_map_put('name', 'TAMPERED')`) is rejected once the input
+  token is revoked — `name` stays `Alice`. SKIPs when no liblua /
+  `lua5.x` dev package is detected.
+- [`../../../tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh)
+  — the `make contrib` smoke test. Confirms the `host_lua` bridge
+  archive (`build/contrib/libaether_host_lua.a`) builds from
+  `aether_host_lua.c`. SKIPs the module when `pkg-config` finds no
+  `lua5.4` / `lua5.3` / `lua` dev kit (hard-fails only in explicit
+  `MODULES=lua` mode).

--- a/contrib/host/perl/README.md
+++ b/contrib/host/perl/README.md
@@ -87,3 +87,24 @@ Perl's own `perl_run`/`perl_init` symbols.
 - `ERRSV` macro replaced with `Perl_get_sv(my_perl, "@", 0)` which
   fetches the `$@` SV via Perl's symbol-table lookup (no
   `PL_errgv`-struct-field access).
+
+## Testing
+
+Perl has **no dedicated fib-style end-to-end test** like
+[contrib.host.factor](../factor/) or
+[contrib.host.racket](../racket/). Its coverage is the cross-host
+shared-map test plus a contrib-build smoke check:
+
+- [`tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh)
+  exercises `aether_perl_run_sandboxed_with_map` in the same
+  shared-map round-trip it runs across **all** hosts: it hands Perl a
+  map (`name`/`score`), the script reads it (`aether_map_get`), writes
+  a key back (`aether_map_put('grade', 'A')`), and tries to tamper a
+  frozen input key — the test asserts Perl read the values and that
+  the frozen input stayed **untampered**. It **SKIPs** Perl (never
+  fails) when `$PERL_AVAILABLE` is 0, i.e. when no Perl is detected.
+- [`tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh)
+  verifies `make contrib` builds the `host_perl` archive
+  (`libaether_host_perl.a`). It SKIPs the perl module when `perl
+  -MExtUtils::Embed` isn't usable, and hard-fails it only under
+  `make contrib MODULES=perl` (the explicit `--with=perl` path).

--- a/contrib/host/python/README.md
+++ b/contrib/host/python/README.md
@@ -125,3 +125,40 @@ main() {
 - The `Py_RETURN_NONE` / `Py_INCREF` macros are replaced with
   explicit `g_py.Py_IncRef(g_py.py_none); return g_py.py_none;`
   to avoid the macros' direct struct-field access.
+
+## Testing
+
+Three tests exercise this host, each covering a different facet:
+
+- **Namespace / FFI** —
+  [`tests/integration/namespace_python/`](../../../tests/integration/namespace_python/),
+  driven by
+  [`test_namespace_python.sh`](../../../tests/integration/namespace_python/test_namespace_python.sh).
+  This goes the *other* direction from embedding: `ae build --namespace`
+  compiles [`calc.ae`](../../../tests/integration/namespace_python/calc.ae)
+  into a `.so` plus a generated `calc_generated_sdk.py` wrapper, then
+  [`check.py`](../../../tests/integration/namespace_python/check.py)
+  imports the SDK and round-trips the full surface — `describe()`
+  metadata (inputs `limit`/`name`, events `Computed`/`Overflow`), the
+  input setters, the event handlers, and the script functions
+  (`double_it`, `label`, `is_positive`), including the overflow path. It
+  also asserts the Aether-side `[ae]` `println` output reaches the host's
+  stdout. SKIPs on Windows or when `python3` is absent.
+
+- **Shared-map interop** —
+  [`tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh),
+  the cross-host round-trip for `run_sandboxed_with_map`. The Python
+  case hands the guest a frozen input map (`name=Charlie`, `factor=5`),
+  the script reads those keys plus an absent `secret` (which comes back
+  as `None`), writes `product=50` (`factor * 10`), and tries to overwrite
+  the frozen `name` to `TAMPERED`; Aether reads the map back and asserts
+  the write landed and the frozen input is untampered. SKIPs when the
+  Python dev package isn't installed.
+
+- **Build smoke** —
+  [`tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh),
+  run by `make contrib`. It probes for Python via `python3-config` and,
+  when present, compiles + archives the bridge as
+  `build/contrib/libaether_host_python.a` (the `python` catalogue entry).
+  In the default build-all mode a missing dep is a silent SKIP; under
+  `make contrib MODULES=python` it's a hard failure.

--- a/contrib/host/racket/README.md
+++ b/contrib/host/racket/README.md
@@ -191,3 +191,28 @@ Then `ae build` an Aether program with `import contrib.host.racket`, with
 import scanner, and `libracketcs.a` is added alongside it. `import
 contrib.host.rhombus` links the **same** archive (it carries both the
 `racket_*` and `rhombus_*` ABI; Rhombus is a `#lang` on this VM).
+
+## Testing
+
+The end-to-end test lives at
+[`tests/integration/host_racket/`](../../../tests/integration/host_racket/) —
+[`uses_racket.ae`](../../../tests/integration/host_racket/uses_racket.ae) is the
+driver (the fib(10)=55 set-piece, the same shape as
+[contrib.host.factor](../factor/)'s test: it evaluates Racket, checks the error
+contract, and round-trips a scalar k-v map), and
+[`test_host_racket.sh`](../../../tests/integration/host_racket/test_host_racket.sh)
+is the runner.
+
+Like the build, the test gates on the four `$AETHER_RACKET_*` env vars above: it
+**SKIPs** (never fails) when they're unset — so it no-ops on CI machines without
+a built Racket CS. With them set it compiles the driver with `aetherc`, links
+the bridge + `libracketcs.a`, runs it, and asserts the `PASS:` line. Run it
+directly once the env vars point at your Racket CS tree:
+
+```sh
+AETHER_RACKET_INCLUDE=/path/to/racket/racket/include \
+AETHER_RACKET_LIB=/path/to/racket/racket/lib/libracketcs.a \
+AETHER_RACKET_BOOT_DIR=/path/to/racket/racket/lib \
+AETHER_RACKET_COLLECTS=/path/to/racket/racket/collects \
+  tests/integration/host_racket/test_host_racket.sh
+```

--- a/contrib/host/rhombus/README.md
+++ b/contrib/host/rhombus/README.md
@@ -77,3 +77,28 @@ and `AETHER_RACKET_COLLECTS` must include where that package landed. The
 `rhombus.*` call, so programs that only use `racket.*` never pay for it. In a
 fire-once tool the combined Racket-boot + Rhombus-require cost dominates — this
 host is meant for long-lived processes that amortize it.
+
+## Testing
+
+The end-to-end test lives at
+[`tests/integration/host_rhombus/`](../../../tests/integration/host_rhombus/) —
+[`uses_rhombus.ae`](../../../tests/integration/host_rhombus/uses_rhombus.ae) is
+the driver (same shape as [contrib.host.racket](../racket/)'s fib(10)=55
+set-piece): it evaluates recursive `fib` in Rhombus's infix shrubbery syntax and
+checks the result, exercises the `error:` contract with an unbound name, and —
+because Rhombus and Racket are one VM and one map — has a Racket script write
+`fib0..fib9` into the shared hash, then reads all ten terms back through
+`rhombus.get`, and finally round-trips a scalar key each direction
+(`racket.set`→`rhombus.get` and back).
+[`test_host_rhombus.sh`](../../../tests/integration/host_rhombus/test_host_rhombus.sh)
+is the runner.
+
+Because Rhombus is a `#lang` on the same embedded Racket CS, the test shares the
+`$AETHER_RACKET_*` env-var gate with [host_racket](../racket/): it **SKIPs**
+(never fails) when `AETHER_RACKET_INCLUDE` / `_LIB` / `_BOOT_DIR` are unset, so
+it no-ops on CI machines without a built Racket CS. With them set it compiles
+the driver with `aetherc`, links the shared Racket bridge + `libracketcs.a`,
+runs it, and asserts the `PASS:` line. It additionally **SKIPs** (rather than
+fails) when the `rhombus` package isn't installed in that Racket — the first
+eval comes back as an `error:` naming the missing `#lang`, which the runner
+detects.

--- a/contrib/host/ruby/README.md
+++ b/contrib/host/ruby/README.md
@@ -127,3 +127,38 @@ main() {
 - Ruby's `subst.h` `#define snprintf ruby_snprintf` is undef'd
   immediately after `#include <ruby.h>` — the bridge uses libc
   snprintf for plain string assembly, not Ruby's format extensions.
+
+## Testing
+
+Three tests exercise the Ruby host; all SKIP cleanly when Ruby isn't
+installed, so they no-op on hosts without it.
+
+- **Namespace / FFI SDK** —
+  [`tests/integration/namespace_ruby/`](../../../tests/integration/namespace_ruby/).
+  [`test_namespace_ruby.sh`](../../../tests/integration/namespace_ruby/test_namespace_ruby.sh)
+  runs `ae build --namespace .` on
+  [`calc.ae`](../../../tests/integration/namespace_ruby/calc.ae) (a tiny
+  `double_it` / `label` / `is_positive` namespace that emits `Computed` /
+  `Overflow` events), which emits both the `.so` and a
+  `calc_generated_sdk.rb`. The generated SDK is loaded over Fiddle (ships
+  with MRI 1.9.2+, no gem install) by
+  [`check.rb`](../../../tests/integration/namespace_ruby/check.rb), which
+  exercises the full surface — discovery (`describe`), input setters, event
+  handlers, and function calls — asserts the round-trip values, and checks
+  that the Aether script's `[ae]`-tagged stdout reaches the host.
+
+- **Shared-map interop** —
+  [`tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh).
+  Its Ruby case calls `ruby_run_sandboxed_with_map` against a live
+  Aether-owned shared map: the Ruby snippet reads input keys
+  (`name`/`level`), writes a new `rank` key, and attempts to overwrite a
+  frozen input. The test asserts the reads (`secret` is `nil`) and that the
+  frozen input is untampered — the cross-host round-trip every bridge shares.
+
+- **Build smoke** —
+  [`tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh).
+  `make contrib` (or `make contrib MODULES=ruby`) drives this; the `ruby`
+  catalogue entry compiles `aether_host_ruby.c` and archives
+  `libaether_host_ruby.a`. The `probe_ruby` step pkg-config-probes
+  `ruby-3.2 / 3.1 / 3.0 / ruby` — a missing dev kit SKIPs in default mode
+  but is a hard failure under explicit `MODULES=ruby`.

--- a/contrib/host/tcl/README.md
+++ b/contrib/host/tcl/README.md
@@ -79,3 +79,18 @@ main() {
   rewrites.
 - `TCL_OK = 0` / `TCL_ERROR = 1` constants are stable across Tcl
   8.x and 9.x.
+
+## Testing
+
+Automated coverage today is the contrib-build smoke test at
+[`tests/scripts/contrib_build.sh`](../../../tests/scripts/contrib_build.sh) —
+the `tcl|host_tcl …` catalogue entry builds `aether_host_tcl.c` (gated on its
+`probe_tcl` Tcl-headers probe) so `make contrib` produces and links the
+`libaether_host_tcl.a` bridge archive. It confirms the bridge compiles and has
+no unresolved Tcl symbols, but exercises nothing at runtime.
+
+There is **no dedicated end-to-end test** for tcl — no `host_tcl/` driver in
+the shape of [contrib.host.racket](../racket/)'s fib(10)=55 set-piece — and tcl
+is **not** in the cross-host shared-map test
+([`tests/sandbox/test_shared_map_all.sh`](../../../tests/sandbox/test_shared_map_all.sh)).
+Both are gaps worth filling.

--- a/contrib/host/tinygo/README.md
+++ b/contrib/host/tinygo/README.md
@@ -161,6 +161,22 @@ window.
   TinyGo exports package-level `Name` automatically — you must
   annotate each function you want callable from C / Aether.
 
+## Testing
+
+The end-to-end test lives at
+[`tests/integration/host_tinygo/`](../../../tests/integration/host_tinygo/) —
+[`uses_tinygo.ae`](../../../tests/integration/host_tinygo/uses_tinygo.ae)
+is the driver (loads the c-shared `.so` at `$TINYGO_LIB`, built from
+`examples/greet.go`, and exercises one call per wrapper shape:
+`Answer = 42`, `Add(2, 40) = 42`, `Negate(7) = -7`, `hello, world`),
+and
+[`test_host_tinygo.sh`](../../../tests/integration/host_tinygo/test_host_tinygo.sh)
+is the runner. The runner **SKIPs** (never fails) when `go` is not on
+PATH, matching `contrib/host/go`'s pattern so CI stays green on machines
+without the toolchain. When `go` is present it builds a c-shared `.so`
+with `CGO_ENABLED=1 go build -buildmode=c-shared`, loads it via
+`contrib.host.tinygo`, and asserts each expected line.
+
 ## See also
 
 - [`contrib/host/go/`](../go/) — full Go via subprocess + LD_PRELOAD


### PR DESCRIPTION
Every embedded-language host README under `contrib/host/` now has a **## Testing** section that links to and discusses the integration test(s) exercising that host — so the executable spec is discoverable from the docs.

## What changed

14 host READMEs (13 modified + a new `contrib/host/js/README.md`), docs-only:

| Host | Linked tests |
|------|-------------|
| racket, rhombus, factor, aether, tinygo | dedicated `tests/integration/host_*` end-to-end (fib set-piece + error contract + k-v round-trip) |
| factor, lua, perl, duktape, python, ruby, java, js | cross-host `tests/sandbox/test_shared_map_all.sh` (shared-map round-trip) |
| python, ruby, java | `tests/integration/namespace_*` (namespace/FFI) |
| (most) | `tests/scripts/contrib_build.sh` where it builds that host's archive |

Each section describes what the test actually verifies (read from source, not invented) and its SKIP-when-toolchain-absent behavior.

## Honest gaps flagged, not papered over

- **tcl** — only the contrib-build smoke; no shared-map or e2e coverage (noted as a gap).
- **go** — no dedicated test; points at the sibling `tinygo` e2e as closest coverage.
- **js** — new README; documented as a back-compat alias for the duktape engine.
- **java** — its jar is built by `contrib/host/java/build.sh`, *not* `contrib_build.sh`; corrected rather than misstated.

All links are relative (`../../../tests/...`) and verified to resolve on disk.

`[skip actions]` — doc-only, no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)