### PR TITLE
Actor ask/reply fix + compile-time eval & `when` + seq combinators + finish caps audit

### DIFF
--- a/compiler/aetherc.c
+++ b/compiler/aetherc.c
@@ -1312,6 +1312,25 @@ int compile_source(const char* input_path, const char* output_path) {
         return 0;
     }
 
+    // Step 2.68: compile-time `when` / static-if resolution (#483).
+    // Evaluates each `when` condition (target.os / target.arch / const bool)
+    // at compile time and prunes the AST to the selected arm BEFORE type
+    // checking and codegen run. The unselected arm — including any platform-
+    // specific extern it declares — is freed here, so it is never resolved,
+    // type-checked, or emitted. Runs after module merge so `when`s in merged
+    // module bodies are resolved too, and BEFORE the --emit=lib import gate
+    // and typecheck so both see the post-prune program. A non-const `when`
+    // condition is a hard error (returns non-zero) — we never guess an arm.
+    if (resolve_when_statements(program) != 0) {
+        report_compilation_failure(input_path);
+        module_registry_shutdown();
+        free_ast_node(program);
+        for (int k = 0; k < token_count; k++) free_token(tokens[k]);
+        free_parser(parser);
+        free(source);
+        return 0;
+    }
+
     // Step 2.7: --emit=lib capability-empty check.
     // In lib mode the output is consumed by another process (Java host,
     // Python script, etc.) that owns network/filesystem/process access.

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -814,12 +814,21 @@ static int byte_assignment_literal_out_of_range(ASTNode* init) {
  *   - Interpolated string ("${X}") where every interpolated value
  *     is itself a const-expression — useful for building
  *     concatenated literal-ish strings at the const layer
+ *   - Array literal where every element is a const-expression
+ *     (lowered to a `static const` C array, not #define-inlined)
+ *   - A HARD-WHITELISTED pure-conversion call on const arguments —
+ *     `string.from_int` / `string.from_long` / `string.from_float` /
+ *     `string.concat` (see is_const_expr_call). The optimizer folds
+ *     these to a literal post-typecheck (issue #482).
  *
  * Disallowed:
- *   - Function calls (the headline trap Nico flagged)
+ *   - Any function call NOT on the whitelist (the headline trap Nico
+ *     flagged — an arbitrary call is inlined per use, re-evaluating
+ *     side effects; and a general compile-time evaluator could
+ *     synthesize std.fs / std.net calls past the --emit=lib
+ *     capability gate, so the folder is whitelist-only by design)
  *   - Member access (could be a namespaced call; treat as non-const)
  *   - Struct literals (would allocate fresh per use)
- *   - Array / sequence literals
  *   - Anything else
  *
  * `table` may be NULL — when called from the global pre-pass, the
@@ -827,6 +836,38 @@ static int byte_assignment_literal_out_of_range(ASTNode* init) {
  * we treat unknown identifiers as non-const to err on the safe
  * side. The check is robust to NULL.
  */
+
+static int is_const_expression(ASTNode* expr, SymbolTable* table);
+
+/* The hard whitelist of pure conversions that may appear in a const
+ * initializer. Kept byte-for-byte in sync with the optimizer's
+ * is_whitelisted_string_call (compiler/codegen/optimizer.c) — that pass
+ * folds exactly these to literals after typecheck. Accepts both the
+ * dotted source spelling (`string.from_int`) and the underscored
+ * C-symbol spelling (`string_from_int`) a merged/imported callee can
+ * carry. NOTHING outside this list is admissible. */
+static int is_const_expr_call(ASTNode* expr) {
+    if (!expr || expr->type != AST_FUNCTION_CALL || !expr->value) return 0;
+    const char* name = expr->value;
+    static const char* const whitelist[] = {
+        "from_int", "from_long", "from_float", "concat"
+    };
+    for (size_t i = 0; i < sizeof(whitelist) / sizeof(whitelist[0]); i++) {
+        char dotted[64], under[64];
+        snprintf(dotted, sizeof(dotted), "string.%s", whitelist[i]);
+        snprintf(under,  sizeof(under),  "string_%s", whitelist[i]);
+        if (strcmp(name, dotted) == 0 || strcmp(name, under) == 0) {
+            /* Arguments must themselves be const-expressions — guards
+             * `string.from_int(rand())` and the like. */
+            for (int a = 0; a < expr->child_count; a++) {
+                if (!is_const_expression(expr->children[a], NULL)) return 0;
+            }
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static int is_const_expression(ASTNode* expr, SymbolTable* table) {
     if (!expr) return 0;
     switch (expr->type) {
@@ -864,13 +905,32 @@ static int is_const_expression(ASTNode* expr, SymbolTable* table) {
             return 1;
         }
         case AST_FUNCTION_CALL:
+            /* Only the hard whitelist of pure conversions (folded to
+             * literals by the optimizer post-typecheck). Every other
+             * call stays rejected. */
+            return is_const_expr_call(expr);
         case AST_MEMBER_ACCESS:
         case AST_STRUCT_LITERAL:
+            return 0;
         case AST_ARRAY_LITERAL:
+            /* A bare array literal is NOT a scalar const — it cannot be
+             * #define-inlined. It is admissible only in the const-array
+             * form (`const A[] = [...]` / `const A: T[N] = [...]`), which
+             * carries the "array_const" annotation and is gated at the
+             * declaration site (where each element is checked with
+             * is_const_array_element). */
             return 0;
         default:
             return 0;
     }
+}
+
+/* Element check for a const array literal. Each element must be a
+ * compile-time constant (literal, const identifier, folded const
+ * expression, or a whitelisted pure-conversion call). Used by the
+ * array_const branch of the const-declaration typecheck. */
+static int is_const_array_element(ASTNode* elem, SymbolTable* table) {
+    return is_const_expression(elem, table);
 }
 
 // Type compatibility functions
@@ -2823,9 +2883,20 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 if (stmt->type == AST_CONST_DECLARATION &&
                     !is_const_expression(init, table)) {
                     /* Allow array literals for const arr[] = [...] declarations.
-                     * These emit static const arrays, not #define-inlined forms. */
+                     * These emit static const arrays, not #define-inlined forms.
+                     * Each element must itself be a compile-time constant — a
+                     * non-const element (e.g. `[foo(), 2]`) is rejected so the
+                     * static initializer stays well-formed. */
                     int is_array_const = (stmt->annotation && strcmp(stmt->annotation, "array_const") == 0 &&
                                           init->type == AST_ARRAY_LITERAL);
+                    if (is_array_const) {
+                        for (int ei = 0; ei < init->child_count; ei++) {
+                            if (!is_const_array_element(init->children[ei], table)) {
+                                is_array_const = 0;
+                                break;
+                            }
+                        }
+                    }
                     if (!is_array_const) {
                         char msg[512];
                         if (stmt->annotation && strcmp(stmt->annotation, "global_var") == 0) {

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -386,6 +386,7 @@ const char* ast_node_type_to_string(ASTNodeType type) {
         case AST_ASSIGNMENT: return "ASSIGNMENT";
         case AST_COMPOUND_ASSIGNMENT: return "COMPOUND_ASSIGNMENT";
         case AST_IF_STATEMENT: return "IF_STATEMENT";
+        case AST_WHEN_STATEMENT: return "WHEN_STATEMENT";
         case AST_FOR_LOOP: return "FOR_LOOP";
         case AST_WHILE_LOOP: return "WHILE_LOOP";
         case AST_SWITCH_STATEMENT: return "SWITCH_STATEMENT";

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -42,6 +42,7 @@ typedef enum {
     AST_ASSIGNMENT,
     AST_COMPOUND_ASSIGNMENT,  // x += expr, x -= expr, etc.
     AST_IF_STATEMENT,
+    AST_WHEN_STATEMENT,        // compile-time `when` / static-if (issue #483)
     AST_FOR_LOOP,
     AST_WHILE_LOOP,
     AST_SWITCH_STATEMENT,

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -2829,6 +2829,37 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
     gen->current_function = prev_current_function;
 }
 
+/* Recursively find the first `reply <Msg> { ... }` message-constructor name
+ * in a receive-arm body subtree. A reply may be nested in if/else, while,
+ * or match branches — not just at the top level (#736) — so the
+ * request->reply type map pre-pass must DESCEND, not only scan direct
+ * children. Without this, a branched reply leaves the request unmapped and
+ * the `?` ask reads a garbage reply slot. Does not descend into nested
+ * function/actor/builder/closure definitions, whose replies (if any) belong
+ * to a different receive scope. */
+static const char* find_first_reply_msg(ASTNode* node) {
+    if (!node) return NULL;
+    if (node->type == AST_REPLY_STATEMENT) {
+        if (node->child_count > 0 && node->children[0] &&
+            node->children[0]->type == AST_MESSAGE_CONSTRUCTOR &&
+            node->children[0]->value) {
+            return node->children[0]->value;
+        }
+        return NULL;
+    }
+    if (node->type == AST_FUNCTION_DEFINITION ||
+        node->type == AST_ACTOR_DEFINITION ||
+        node->type == AST_BUILDER_FUNCTION ||
+        node->type == AST_CLOSURE) {
+        return NULL;
+    }
+    for (int i = 0; i < node->child_count; i++) {
+        const char* r = find_first_reply_msg(node->children[i]);
+        if (r) return r;
+    }
+    return NULL;
+}
+
 void generate_program(CodeGenerator* gen, ASTNode* program) {
     if (!program || program->type != AST_PROGRAM) return;
     gen->program = program;
@@ -3744,23 +3775,20 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
                 ASTNode* body = arm->children[1];
                 if (!pattern || !pattern->value || !body) continue;
                 const char* req_msg = pattern->value;
-                for (int s = 0; s < body->child_count; s++) {
-                    ASTNode* stmt = body->children[s];
-                    if (!stmt || stmt->type != AST_REPLY_STATEMENT) continue;
-                    if (stmt->child_count > 0 && stmt->children[0] &&
-                        stmt->children[0]->type == AST_MESSAGE_CONSTRUCTOR &&
-                        stmt->children[0]->value) {
-                        const char* reply_msg = stmt->children[0]->value;
-                        if (gen->reply_type_count >= gen->reply_type_capacity) {
-                            gen->reply_type_capacity = gen->reply_type_capacity ? gen->reply_type_capacity * 2 : 16;
-                            gen->reply_type_map = realloc(gen->reply_type_map,
-                                gen->reply_type_capacity * sizeof(*gen->reply_type_map));
-                        }
-                        gen->reply_type_map[gen->reply_type_count].request_msg = strdup(req_msg);
-                        gen->reply_type_map[gen->reply_type_count].reply_msg = strdup(reply_msg);
-                        gen->reply_type_count++;
-                        break;
+                /* Search the whole arm body (incl. if/else/while/match
+                 * branches), not just its direct children — a branched
+                 * `reply` must still map the request to its reply type
+                 * (#736). */
+                const char* reply_msg = find_first_reply_msg(body);
+                if (reply_msg) {
+                    if (gen->reply_type_count >= gen->reply_type_capacity) {
+                        gen->reply_type_capacity = gen->reply_type_capacity ? gen->reply_type_capacity * 2 : 16;
+                        gen->reply_type_map = realloc(gen->reply_type_map,
+                            gen->reply_type_capacity * sizeof(*gen->reply_type_map));
                     }
+                    gen->reply_type_map[gen->reply_type_count].request_msg = strdup(req_msg);
+                    gen->reply_type_map[gen->reply_type_count].reply_msg = strdup(reply_msg);
+                    gen->reply_type_count++;
                 }
             }
         }

--- a/compiler/codegen/optimizer.c
+++ b/compiler/codegen/optimizer.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include <errno.h>
 
 OptimizationStats global_opt_stats = {0, 0, 0, 0, 0};
 
@@ -125,20 +126,172 @@ static ASTNode* fold_binary_expression(ASTNode* node) {
     return node;
 }
 
+/* ---------------------------------------------------------------------------
+ * Compile-time constant evaluation, phase-1 (issue #482)
+ *
+ * A HARD-WHITELISTED folder — emphatically NOT a general interpreter. A
+ * general compile-time evaluator could synthesize std.fs / std.net calls
+ * that slip past the `--emit=lib` capability gate, so only the explicit
+ * whitelist below is ever folded. Everything else is left untouched here
+ * and rejected upstream by `is_const_expression` in the typechecker.
+ *
+ * The whitelist (mirrors the typechecker's `is_const_expr_call`):
+ *   string.from_int(<int const>)    -> decimal literal string
+ *   string.from_long(<int const>)   -> decimal literal string
+ *   string.from_float(<num const>)  -> %g literal string
+ *   string.concat(<str const>, <str const>) -> concatenated literal string
+ *
+ * Arithmetic (+ - * / %) on numeric literals is folded by
+ * fold_binary_expression above and predates this phase.
+ * ------------------------------------------------------------------------- */
+
+/* True when `name` is the dotted source spelling OR the underscored
+ * C-symbol spelling of one of the whitelisted pure conversions. The
+ * parser stores dotted callees (`string.from_int`); imported/merged
+ * callees can arrive underscored (`string_from_int`), so accept both. */
+static int is_whitelisted_string_call(const char* name, const char* dotted) {
+    if (!name) return 0;
+    char buf[64];
+    snprintf(buf, sizeof(buf), "string.%s", dotted);
+    if (strcmp(name, buf) == 0) return 1;
+    snprintf(buf, sizeof(buf), "string_%s", dotted);
+    if (strcmp(name, buf) == 0) return 1;
+    return 0;
+}
+
+// Helper: create a string literal node (value carries the raw bytes; the
+// codegen adds the surrounding quotes + escapes on emit).
+static ASTNode* create_string_literal(const char* value, int line, int column) {
+    ASTNode* node = create_ast_node(AST_LITERAL, value, line, column);
+    if (node) node->node_type = create_type(TYPE_STRING);
+    return node;
+}
+
+// True when `node` is a string literal we can read the bytes of.
+static int is_string_literal(ASTNode* node) {
+    return node && node->type == AST_LITERAL && node->value &&
+           node->node_type && node->node_type->kind == TYPE_STRING;
+}
+
+/* Fold a whitelisted pure-conversion call on constant arguments into a
+ * string literal. Returns the folded literal (and frees `node`) on
+ * success, or `node` unchanged when the call is not in the whitelist /
+ * its arguments are not constants / the value would not be representable.
+ *
+ * Width discipline: from_int folds in 32-bit, from_long in 64-bit. An
+ * out-of-range argument for the chosen width is NOT folded — it is left
+ * as the runtime call so behaviour is unchanged (no silently-wrong
+ * literal). */
+static ASTNode* fold_const_string_call(ASTNode* node) {
+    if (!node || node->type != AST_FUNCTION_CALL || !node->value) return node;
+
+    // string.from_int / string.from_long — one numeric-literal argument.
+    int is_from_int  = is_whitelisted_string_call(node->value, "from_int");
+    int is_from_long = is_whitelisted_string_call(node->value, "from_long");
+    int is_from_flt  = is_whitelisted_string_call(node->value, "from_float");
+
+    if ((is_from_int || is_from_long || is_from_flt) && node->child_count == 1) {
+        ASTNode* arg = node->children[0];
+        if (!is_constant(arg) || !arg->value) return node;  // non-literal arg: leave runtime call
+        char buf[64];
+        if (is_from_flt) {
+            double v = get_constant_value(arg);
+            snprintf(buf, sizeof(buf), "%g", v);
+        } else {
+            /* Parse the integer literal text directly (not through the
+             * lossy double in get_constant_value) so 64-bit values past
+             * 2^53 fold exactly. strtoll handles decimal and 0x; 0b / 0o
+             * are uncommon as conversion args, so a literal we cannot
+             * parse exactly is left as the runtime call. */
+            errno = 0;
+            char* end = NULL;
+            const char* s = arg->value;
+            long long v;
+            if (s[0] == '0' && (s[1] == 'b' || s[1] == 'B')) {
+                v = strtoll(s + 2, &end, 2);
+            } else if (s[0] == '0' && (s[1] == 'o' || s[1] == 'O')) {
+                v = strtoll(s + 2, &end, 8);
+            } else {
+                v = strtoll(s, &end, 0);  // decimal / 0x
+            }
+            if (errno != 0 || !end || *end != '\0') return node;  // unparseable / overflow
+            if (is_from_int) {
+                // 32-bit width: an out-of-range value would print a
+                // different string than the runtime int truncation, so
+                // leave it as the runtime call rather than fold wrongly.
+                if (v < -2147483647LL - 1 || v > 2147483647LL) return node;
+                snprintf(buf, sizeof(buf), "%d", (int)v);
+            } else {
+                snprintf(buf, sizeof(buf), "%lld", v);
+            }
+        }
+        ASTNode* folded = create_string_literal(buf, node->line, node->column);
+        if (!folded) return node;
+        global_opt_stats.constants_folded++;
+        free_ast_node(node);
+        return folded;
+    }
+
+    // string.concat(a, b) — two string-literal arguments fold to one literal.
+    if (is_whitelisted_string_call(node->value, "concat") && node->child_count == 2) {
+        ASTNode* a = node->children[0];
+        ASTNode* b = node->children[1];
+        if (!is_string_literal(a) || !is_string_literal(b)) return node;
+        size_t la = strlen(a->value), lb = strlen(b->value);
+        char* joined = (char*)malloc(la + lb + 1);
+        if (!joined) return node;
+        memcpy(joined, a->value, la);
+        memcpy(joined + la, b->value, lb);
+        joined[la + lb] = '\0';
+        ASTNode* folded = create_string_literal(joined, node->line, node->column);
+        free(joined);
+        if (!folded) return node;
+        global_opt_stats.constants_folded++;
+        free_ast_node(node);
+        return folded;
+    }
+
+    return node;
+}
+
 // Constant folding main function
 ASTNode* optimize_constant_folding(ASTNode* node) {
     if (!node) return NULL;
-    
+
     // Handle binary expressions
     if (node->type == AST_BINARY_EXPRESSION) {
         return fold_binary_expression(node);
     }
-    
-    // Recursively optimize children
+
+    // Recursively optimize children FIRST so nested constants (and
+    // string-literal arguments produced by an inner fold) are available
+    // before we try to fold this node.
     for (int i = 0; i < node->child_count; i++) {
         node->children[i] = optimize_constant_folding(node->children[i]);
     }
-    
+
+    // Whitelisted pure-conversion calls fold to a string literal once
+    // their arguments are themselves constants.
+    if (node->type == AST_FUNCTION_CALL) {
+        return fold_const_string_call(node);
+    }
+
+    /* A `const` whose RHS folded to a string literal must have its
+     * declared type updated to `string`: the parser inferred the type
+     * from the original conversion call (which returns `ptr`), but the
+     * folded RHS is now a literal string. The `#define`/local emit keys
+     * off this type for the heap-string vs. literal decision. */
+    if (node->type == AST_CONST_DECLARATION && node->child_count > 0 &&
+        is_string_literal(node->children[0])) {
+        int is_array = node->annotation &&
+                       strcmp(node->annotation, "array_const") == 0;
+        if (!is_array &&
+            (!node->node_type || node->node_type->kind != TYPE_STRING)) {
+            if (node->node_type) free_type(node->node_type);
+            node->node_type = create_type(TYPE_STRING);
+        }
+    }
+
     return node;
 }
 

--- a/compiler/codegen/optimizer.c
+++ b/compiler/codegen/optimizer.c
@@ -311,6 +311,276 @@ static int is_constant_condition(ASTNode* node, int* is_truthy) {
     return 0;
 }
 
+// ---------------------------------------------------------------------------
+// Compile-time `when` / static-if resolution (issue #483)
+//
+// A `when COND { ... } else { ... }` is evaluated entirely at compile time:
+// only the selected arm survives into type-checking and codegen. The dead
+// arm parses but is pruned here, BEFORE typecheck runs (called from aetherc.c
+// between parse and typecheck), so a platform-specific extern in the dead arm
+// is never resolved, type-checked, or emitted.
+//
+// `target.os` / `target.arch` are compiler-provided compile-time string
+// constants for the build target. They are sourced from the SAME C
+// preprocessor macros the runtime's os.platform() uses (std/os/aether_os.c
+// os_platform_raw), so the canonical names match across the toolchain:
+// os ∈ {"windows","darwin","linux","freebsd","openbsd","netbsd",
+// "dragonfly","solaris","wasm","unknown"}; arch ∈ {"x86_64","aarch64",
+// "x86","arm","riscv64","ppc64","wasm","unknown"}. The target is the host
+// (aetherc emits C compiled by the host toolchain; there is no cross-target
+// flag today), exactly as os.platform() and select() already assume.
+// ---------------------------------------------------------------------------
+
+static const char* target_os_string(void) {
+#if defined(_WIN32) || defined(_WIN64)
+    return "windows";
+#elif defined(__APPLE__)
+    return "darwin";
+#elif defined(__linux__)
+    return "linux";
+#elif defined(__FreeBSD__)
+    return "freebsd";
+#elif defined(__OpenBSD__)
+    return "openbsd";
+#elif defined(__NetBSD__)
+    return "netbsd";
+#elif defined(__DragonFly__)
+    return "dragonfly";
+#elif defined(__sun) && (defined(__SVR4) || defined(__svr4__))
+    return "solaris";
+#elif defined(__EMSCRIPTEN__) || defined(__wasi__) || defined(__wasm__)
+    return "wasm";
+#else
+    return "unknown";
+#endif
+}
+
+static const char* target_arch_string(void) {
+#if defined(__x86_64__) || defined(_M_X64) || defined(__amd64__)
+    return "x86_64";
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm64__)
+    return "aarch64";
+#elif defined(__i386__) || defined(_M_IX86)
+    return "x86";
+#elif defined(__arm__) || defined(_M_ARM)
+    return "arm";
+#elif defined(__riscv) && (__riscv_xlen == 64)
+    return "riscv64";
+#elif defined(__powerpc64__) || defined(__ppc64__)
+    return "ppc64";
+#elif defined(__EMSCRIPTEN__) || defined(__wasi__) || defined(__wasm__)
+    return "wasm";
+#else
+    return "unknown";
+#endif
+}
+
+// If `node` is the compiler-provided `target.os` / `target.arch` member
+// access, return its compile-time string value; otherwise NULL.
+static const char* when_target_field_value(ASTNode* node) {
+    if (!node || node->type != AST_MEMBER_ACCESS || !node->value) return NULL;
+    if (node->child_count < 1 || !node->children[0]) return NULL;
+    ASTNode* base = node->children[0];
+    if (base->type != AST_IDENTIFIER || !base->value) return NULL;
+    if (strcmp(base->value, "target") != 0) return NULL;
+    if (strcmp(node->value, "os") == 0)   return target_os_string();
+    if (strcmp(node->value, "arch") == 0) return target_arch_string();
+    return NULL;
+}
+
+// Result of evaluating a `when` condition at compile time.
+typedef enum {
+    WHEN_EVAL_ERROR = 0,   // not a recognised compile-time constant
+    WHEN_EVAL_FALSE,
+    WHEN_EVAL_TRUE
+} WhenEvalResult;
+
+// Evaluate a `when` condition expression to a compile-time boolean.
+// Supported forms (composed freely with `&&`, `||`, `!`, and parens):
+//   - target.os == "<str>" / target.os != "<str>"
+//   - target.arch == "<str>" / target.arch != "<str>"
+//   - "<str>" == "<str>" (and !=) between any two constant strings
+//   - boolean literals `true` / `false`
+//   - a numeric literal (nonzero is true) — lets `when 1 {}` work
+// Returns WHEN_EVAL_ERROR for anything not reducible to a constant bool;
+// the caller turns that into a clear compile error rather than guessing.
+static WhenEvalResult when_eval_condition(ASTNode* cond) {
+    if (!cond) return WHEN_EVAL_ERROR;
+
+    // Parenthesised / passthrough wrappers: a unary `!` is the only
+    // operator we special-case; otherwise fall through to literal/binary.
+    if (cond->type == AST_UNARY_EXPRESSION && cond->value &&
+        strcmp(cond->value, "!") == 0 && cond->child_count >= 1) {
+        WhenEvalResult inner = when_eval_condition(cond->children[0]);
+        if (inner == WHEN_EVAL_ERROR) return WHEN_EVAL_ERROR;
+        return inner == WHEN_EVAL_TRUE ? WHEN_EVAL_FALSE : WHEN_EVAL_TRUE;
+    }
+
+    if (cond->type == AST_LITERAL && cond->value) {
+        if (strcmp(cond->value, "true") == 0) return WHEN_EVAL_TRUE;
+        if (strcmp(cond->value, "false") == 0) return WHEN_EVAL_FALSE;
+        // A string literal alone is not a boolean condition.
+        if (cond->node_type && cond->node_type->kind == TYPE_STRING)
+            return WHEN_EVAL_ERROR;
+        return atof(cond->value) != 0.0 ? WHEN_EVAL_TRUE : WHEN_EVAL_FALSE;
+    }
+
+    if (cond->type == AST_BINARY_EXPRESSION && cond->value &&
+        cond->child_count >= 2) {
+        ASTNode* l = cond->children[0];
+        ASTNode* r = cond->children[1];
+
+        // Logical connectives compose sub-conditions.
+        if (strcmp(cond->value, "&&") == 0) {
+            WhenEvalResult a = when_eval_condition(l);
+            WhenEvalResult b = when_eval_condition(r);
+            if (a == WHEN_EVAL_ERROR || b == WHEN_EVAL_ERROR) return WHEN_EVAL_ERROR;
+            return (a == WHEN_EVAL_TRUE && b == WHEN_EVAL_TRUE)
+                       ? WHEN_EVAL_TRUE : WHEN_EVAL_FALSE;
+        }
+        if (strcmp(cond->value, "||") == 0) {
+            WhenEvalResult a = when_eval_condition(l);
+            WhenEvalResult b = when_eval_condition(r);
+            if (a == WHEN_EVAL_ERROR || b == WHEN_EVAL_ERROR) return WHEN_EVAL_ERROR;
+            return (a == WHEN_EVAL_TRUE || b == WHEN_EVAL_TRUE)
+                       ? WHEN_EVAL_TRUE : WHEN_EVAL_FALSE;
+        }
+
+        // String equality/inequality. Each side is either `target.os`/
+        // `target.arch` or a string literal; both must resolve to a string.
+        int is_eq = strcmp(cond->value, "==") == 0;
+        int is_ne = strcmp(cond->value, "!=") == 0;
+        if (is_eq || is_ne) {
+            const char* ls = when_target_field_value(l);
+            if (!ls && l->type == AST_LITERAL && l->node_type &&
+                l->node_type->kind == TYPE_STRING) ls = l->value;
+            const char* rs = when_target_field_value(r);
+            if (!rs && r->type == AST_LITERAL && r->node_type &&
+                r->node_type->kind == TYPE_STRING) rs = r->value;
+            if (ls && rs) {
+                int equal = strcmp(ls, rs) == 0;
+                int truth = is_eq ? equal : !equal;
+                return truth ? WHEN_EVAL_TRUE : WHEN_EVAL_FALSE;
+            }
+            // Fall back to numeric/bool equality on two constant literals.
+            int l_truthy = 0, r_truthy = 0;
+            if (is_constant_condition(l, &l_truthy) &&
+                is_constant_condition(r, &r_truthy)) {
+                int equal = (l_truthy == r_truthy);
+                int truth = is_eq ? equal : !equal;
+                return truth ? WHEN_EVAL_TRUE : WHEN_EVAL_FALSE;
+            }
+            return WHEN_EVAL_ERROR;
+        }
+    }
+
+    return WHEN_EVAL_ERROR;
+}
+
+// Tracks whether any `when` failed to resolve, so the driver can fail the
+// build with a non-zero status instead of silently dropping code.
+static int g_when_error_count = 0;
+
+// Replace the `when` child at parent->children[idx] with the children of its
+// selected arm (an AST_BLOCK), spliced in place. Splicing the arm's children
+// (rather than nesting the AST_BLOCK) keeps top-level externs/imports at top
+// level and avoids introducing a spurious C scope around a statement arm's
+// locals — the arm braces are a compile-time grouping, not a runtime block.
+// Frees the `when` node and the discarded arm. Returns the number of nodes
+// that now occupy the slot (the arm's child count), so the caller can
+// continue scanning from the right place.
+static int splice_when_selected_arm(ASTNode* parent, int idx, ASTNode* selected_arm) {
+    ASTNode* when_node = parent->children[idx];
+
+    // Detach the selected arm so freeing the `when` node doesn't free it.
+    int n = selected_arm ? selected_arm->child_count : 0;
+    ASTNode** spliced = NULL;
+    if (n > 0) {
+        spliced = (ASTNode**)malloc(sizeof(ASTNode*) * (size_t)n);
+        for (int i = 0; i < n; i++) {
+            spliced[i] = selected_arm->children[i];
+            selected_arm->children[i] = NULL;  // transfer ownership
+        }
+        selected_arm->child_count = 0;
+    }
+
+    // Free the entire `when` subtree (condition + both arms; the selected
+    // arm's children were transferred out above, so they survive).
+    free_ast_node(when_node);
+
+    // Rebuild parent->children with the spliced nodes in place of slot idx.
+    int old_count = parent->child_count;
+    int new_count = old_count - 1 + n;
+    ASTNode** rebuilt = (ASTNode**)malloc(sizeof(ASTNode*) * (size_t)(new_count > 0 ? new_count : 1));
+    int w = 0;
+    for (int i = 0; i < old_count; i++) {
+        if (i == idx) {
+            for (int j = 0; j < n; j++) rebuilt[w++] = spliced[j];
+        } else {
+            rebuilt[w++] = parent->children[i];
+        }
+    }
+    free(parent->children);
+    free(spliced);
+    parent->children = rebuilt;
+    parent->child_count = new_count;
+    return n;
+}
+
+// Recursively resolve every `when` statement in the subtree rooted at `node`,
+// scanning the children of each node so a `when` can be replaced in place by
+// its selected arm's contents. Runs before typecheck; the unselected arm is
+// freed and never seen by later phases.
+static void resolve_when_in_children(ASTNode* node) {
+    if (!node) return;
+    for (int i = 0; i < node->child_count; i++) {
+        ASTNode* child = node->children[i];
+        if (child && child->type == AST_WHEN_STATEMENT && child->child_count >= 2) {
+            ASTNode* cond = child->children[0];
+            WhenEvalResult r = when_eval_condition(cond);
+            if (r == WHEN_EVAL_ERROR) {
+                g_when_error_count++;
+                fprintf(stderr,
+                    "Error: `when` condition at line %d is not a compile-time "
+                    "constant.\n"
+                    "       Supported forms: target.os == \"<os>\", "
+                    "target.os != \"<os>\", target.arch == \"<arch>\",\n"
+                    "       a bool literal, and combinations with && / || / !.\n",
+                    child->line);
+                // Leave the node in place but neutralise it so we don't
+                // descend into a half-built arm; it won't survive anyway
+                // because the build fails. Skip it.
+                continue;
+            }
+            ASTNode* selected = NULL;
+            if (r == WHEN_EVAL_TRUE) {
+                selected = child->children[1];
+            } else if (child->child_count >= 3) {
+                selected = child->children[2];
+            }
+            // Resolve any nested `when`s inside the selected arm first, so
+            // the spliced-in nodes are already fully resolved.
+            resolve_when_in_children(selected);
+            int spliced = splice_when_selected_arm(node, i, selected);
+            // Re-examine the slot we just filled (the first spliced node may
+            // itself be a `when` from an `else when` chain wrapper).
+            i += spliced - 1;
+            if (i < -1) i = -1;
+            continue;
+        }
+        resolve_when_in_children(child);
+    }
+}
+
+// Public entry: resolve all compile-time `when` statements in `program`.
+// Returns 0 on success, non-zero if any `when` condition was not a
+// compile-time constant (the driver then aborts the build).
+int resolve_when_statements(ASTNode* program) {
+    g_when_error_count = 0;
+    resolve_when_in_children(program);
+    return g_when_error_count;
+}
+
 // Dead code elimination
 ASTNode* optimize_dead_code(ASTNode* node) {
     if (!node) return NULL;

--- a/compiler/codegen/optimizer.h
+++ b/compiler/codegen/optimizer.h
@@ -20,6 +20,15 @@ ASTNode* optimize_tail_calls(ASTNode* node);
 // Apply all optimizations
 ASTNode* optimize_ast(ASTNode* node);
 
+// Compile-time `when` / static-if resolution (issue #483).
+// Evaluates each `when` condition at compile time and prunes the AST to the
+// selected arm, IN PLACE, before type-checking. The unselected arm is freed
+// and never type-checked or emitted. `target.os` / `target.arch` are
+// compiler-provided compile-time string constants for the build target.
+// Returns 0 on success; non-zero if any `when` condition was not a
+// compile-time constant (the driver aborts the build).
+int resolve_when_statements(ASTNode* program);
+
 // Optimization statistics
 typedef struct {
     int constants_folded;

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -17,6 +17,7 @@ Parser* create_parser(Token** tokens, int token_count) {
     parser->suppress_errors = 0;  // By default, show errors
     parser->parsing_builder = 0;
     parser->in_condition = 0;
+    parser->when_top_level = 0;
     return parser;
 }
 
@@ -1969,7 +1970,19 @@ ASTNode* parse_statement(Parser* parser) {
 
         case TOKEN_IF:
             return parse_if_statement(parser);
-            
+
+        case TOKEN_WHEN: {
+            // Compile-time `when` / static-if (#483). The guard use of
+            // `when` only appears after a clause's parameter list inside
+            // parse_function_definition, never at statement head, so this
+            // is unambiguous. Statement-level arms hold statements.
+            int saved = parser->when_top_level;
+            parser->when_top_level = 0;
+            ASTNode* w = parse_when_statement(parser);
+            parser->when_top_level = saved;
+            return w;
+        }
+
         case TOKEN_FOR:
             return parse_for_loop(parser);
             
@@ -2204,6 +2217,101 @@ ASTNode* parse_python_style_declaration(Parser* parser) {
 
     match_token(parser, TOKEN_SEMICOLON);
     return decl;
+}
+
+// Compile-time `when` / static-if (issue #483).
+//
+//   when target.os == "windows" { ... } else { ... }
+//
+// `when` already exists as TOKEN_WHEN for function-clause guards
+// (`fib(n) when n > 1 -> ...`), but that use only appears AFTER a
+// parameter list inside parse_function_definition — never at the head
+// of a statement or top-level declaration. So a `when` reached from
+// parse_statement / parse_top_level_decl is unambiguously the static-if
+// form; the guard parse is untouched.
+//
+// The condition is evaluated at compile time by a pre-typecheck pass
+// (resolve_when_statements, in aetherc.c) which prunes the AST down to
+// the selected arm BEFORE type-checking or codegen run on it. The
+// UNSELECTED arm parses but is never type-checked or emitted — that is
+// what lets a platform-specific extern be gated cleanly.
+//
+// AST layout mirrors AST_IF_STATEMENT:
+//   children[0] = condition expression
+//   children[1] = then-arm  (an AST_BLOCK of statements/decls)
+//   children[2] = else-arm  (optional AST_BLOCK), present iff `else` given
+//
+// An arm body is a brace-delimited list. Its items are parsed with the
+// same grammar the surrounding context would use: a top-level-only
+// construct (extern / import / struct / func / ...) goes through
+// parse_top_level_decl, everything else through parse_statement. This
+// lets a single `when` form serve both statement bodies and top-level
+// declaration groups (including a `when` nested inside another `when`).
+
+// Parse one `{ ... }` arm of a `when`. At top level the items are
+// declarations (extern / import / func / struct / ...) parsed via
+// parse_top_level_decl, so a platform-gated extern parses identically to a
+// bare top-level one. At statement level the items are ordinary statements.
+// Returns an AST_BLOCK whose children are the arm items.
+static ASTNode* parse_when_arm(Parser* parser) {
+    if (!expect_token(parser, TOKEN_LEFT_BRACE)) return NULL;
+    int top_level = parser->when_top_level;
+    ASTNode* arm = create_ast_node(AST_BLOCK, NULL, 0, 0);
+    while (!match_token(parser, TOKEN_RIGHT_BRACE)) {
+        if (is_at_end(parser)) break;
+        int start_token = parser->current_token;
+        ASTNode* item = top_level
+            ? parse_top_level_decl(parser)
+            : parse_statement(parser);
+        if (item) {
+            add_child(arm, item);
+        } else if (parser->current_token == start_token) {
+            // Guarantee forward progress on a malformed item.
+            parser_error(parser, "Expected statement or declaration in `when` arm");
+            advance_token(parser);
+        }
+    }
+    return arm;
+}
+
+ASTNode* parse_when_statement(Parser* parser) {
+    Token* when_tok = advance_token(parser);  // consume `when`
+
+    // Parse the compile-time condition. Reuse the `in_condition` guard so a
+    // trailing `{` is read as the arm body, not a closure on the condition.
+    int saved_in_condition = parser->in_condition;
+    parser->in_condition = 1;
+    ASTNode* condition = parse_expression(parser);
+    parser->in_condition = saved_in_condition;
+    if (!condition) return NULL;
+
+    ASTNode* then_arm = parse_when_arm(parser);
+    if (!then_arm) return NULL;
+
+    ASTNode* when_stmt = create_ast_node(AST_WHEN_STATEMENT, NULL,
+                                         when_tok ? when_tok->line : 0,
+                                         when_tok ? when_tok->column : 0);
+    add_child(when_stmt, condition);
+    add_child(when_stmt, then_arm);
+
+    if (match_token(parser, TOKEN_ELSE)) {
+        // `else when ...` chains: an else arm that is itself a `when`.
+        if (peek_token(parser) && peek_token(parser)->type == TOKEN_WHEN) {
+            ASTNode* else_when = parse_when_statement(parser);
+            if (else_when) {
+                ASTNode* wrap = create_ast_node(AST_BLOCK, NULL, 0, 0);
+                add_child(wrap, else_when);
+                add_child(when_stmt, wrap);
+            }
+        } else {
+            ASTNode* else_arm = parse_when_arm(parser);
+            if (else_arm) {
+                add_child(when_stmt, else_arm);
+            }
+        }
+    }
+
+    return when_stmt;
 }
 
 ASTNode* parse_if_statement(Parser* parser) {
@@ -4415,22 +4523,28 @@ ASTNode* parse_struct_definition(Parser* parser) {
     return struct_def;
 }
 
-ASTNode* parse_program(Parser* parser) {
-    ASTNode* program = create_ast_node(AST_PROGRAM, NULL, 0, 0);
-    
-    int safety_counter = 0;
-    // Safety limit to prevent infinite loops on malformed input
-    const int MAX_ITERATIONS = 10000;
-    
-    while (!is_at_end(parser) && safety_counter < MAX_ITERATIONS) {
-        safety_counter++;
-        
+// Parse a single top-level declaration (module / import / func / struct /
+// extern / const / etc.). Returns the parsed node, or NULL when the item
+// was consumed by error recovery (the parser has advanced past it). Factored
+// out of parse_program so the top-level `when` static-if (issue #483) can
+// parse declarations inside its arms with the exact same grammar — an extern
+// or import gated behind `when` parses identically to a top-level one.
+ASTNode* parse_top_level_decl(Parser* parser) {
+    {
         Token* token = peek_token(parser);
-        if (!token) break;
-        
+        if (!token) return NULL;
+
         ASTNode* node = NULL;
-        
+
         switch (token->type) {
+            case TOKEN_WHEN: {
+                // Top-level static-if: its arms hold declarations.
+                int saved = parser->when_top_level;
+                parser->when_top_level = 1;
+                ASTNode* w = parse_when_statement(parser);
+                parser->when_top_level = saved;
+                return w;
+            }
             case TOKEN_MODULE:
                 node = parse_module_declaration(parser);
                 break;
@@ -4475,7 +4589,7 @@ ASTNode* parse_program(Parser* parser) {
                 //     aether_name(...) { return c_symbol_name(...) }
                 // …without the wrapper. Closes #234.
                 Token* at_tok = expect_token(parser, TOKEN_AT);
-                if (!at_tok) { advance_token(parser); continue; }
+                if (!at_tok) { advance_token(parser); return NULL; }
                 // Two attribute forms accepted at top-level:
                 //   @extern("c_symbol") aether_name(params) -> ret    (#234)
                 //   @c_callback aether_name(params) -> ret { body }   (#235)
@@ -4493,7 +4607,7 @@ ASTNode* parse_program(Parser* parser) {
                 if (attr && attr->type == TOKEN_IDENTIFIER &&
                     attr->value && strcmp(attr->value, "derive") == 0) {
                     advance_token(parser);  // consume 'derive'
-                    if (!expect_token(parser, TOKEN_LEFT_PAREN)) continue;
+                    if (!expect_token(parser, TOKEN_LEFT_PAREN)) return NULL;
                     // Parse the comma-separated derive list.
                     char tag[256];
                     snprintf(tag, sizeof(tag), "derive:");
@@ -4511,7 +4625,7 @@ ASTNode* parse_program(Parser* parser) {
                         first = 0;
                         if (!match_token(parser, TOKEN_COMMA)) break;
                     }
-                    if (!expect_token(parser, TOKEN_RIGHT_PAREN)) continue;
+                    if (!expect_token(parser, TOKEN_RIGHT_PAREN)) return NULL;
                     // The next decl should be a struct. Parse it via the
                     // normal struct path, then attach the annotation.
                     Token* next_tok = peek_token(parser);
@@ -4525,7 +4639,7 @@ ASTNode* parse_program(Parser* parser) {
                         break;
                     } else {
                         parser_error(parser, "@derive(...) must precede a `struct` definition");
-                        continue;
+                        return NULL;
                     }
                 }
                 if (attr && attr->type == TOKEN_IDENTIFIER &&
@@ -4564,13 +4678,13 @@ ASTNode* parse_program(Parser* parser) {
                 if (!attr || attr->type != TOKEN_EXTERN) {
                     parser_error(parser, "unknown attribute (expected @extern(\"...\") or @c_callback)");
                     advance_token(parser);
-                    continue;
+                    return NULL;
                 }
                 advance_token(parser);
                 expect_token(parser, TOKEN_LEFT_PAREN);
                 Token* sym = expect_token(parser, TOKEN_STRING_LITERAL);
                 expect_token(parser, TOKEN_RIGHT_PAREN);
-                if (!sym || !sym->value) { advance_token(parser); continue; }
+                if (!sym || !sym->value) { advance_token(parser); return NULL; }
                 // Now parse the function declaration that follows.
                 // We use parse_extern_declaration's shape (params with
                 // mandatory types, no body) but the Aether name comes
@@ -4579,7 +4693,7 @@ ASTNode* parse_program(Parser* parser) {
                 // pretending `extern` came in: easier to inline the small
                 // amount of code than to rework parse_extern_declaration.
                 Token* fname = expect_token(parser, TOKEN_IDENTIFIER);
-                if (!fname) continue;
+                if (!fname) return NULL;
                 expect_token(parser, TOKEN_LEFT_PAREN);
                 ASTNode* ext = create_ast_node(AST_EXTERN_FUNCTION, fname->value,
                                                at_tok->line, at_tok->column);
@@ -4689,7 +4803,7 @@ ASTNode* parse_program(Parser* parser) {
                 } else {
                     parser_error(parser, "Expected function definition after 'builder' at top level");
                     advance_token(parser);
-                    continue;
+                    return NULL;
                 }
                 break;
             }
@@ -4709,15 +4823,15 @@ ASTNode* parse_program(Parser* parser) {
                 int vline = token->line, vcol = token->column;
                 advance_token(parser); // consume 'var'
                 Token* vname = expect_token(parser, TOKEN_IDENTIFIER);
-                if (!vname) { advance_token(parser); continue; }
+                if (!vname) { advance_token(parser); return NULL; }
                 Type* vtype = NULL;
                 if (peek_token(parser) && peek_token(parser)->type == TOKEN_COLON) {
                     advance_token(parser); // consume ':'
                     vtype = parse_type(parser);
                 }
-                if (!expect_token(parser, TOKEN_ASSIGN)) { advance_token(parser); continue; }
+                if (!expect_token(parser, TOKEN_ASSIGN)) { advance_token(parser); return NULL; }
                 ASTNode* vval = parse_expression(parser);
-                if (!vval) { advance_token(parser); continue; }
+                if (!vval) { advance_token(parser); return NULL; }
                 node = create_ast_node(AST_CONST_DECLARATION, vname->value, vline, vcol);
                 add_child(node, vval);
                 node->annotation = strdup("global_var");
@@ -4736,7 +4850,7 @@ ASTNode* parse_program(Parser* parser) {
                 int cline = token->line, ccol = token->column;
                 advance_token(parser); // consume 'const'
                 Token* cname = expect_token(parser, TOKEN_IDENTIFIER);
-                if (!cname) { advance_token(parser); continue; }
+                if (!cname) { advance_token(parser); return NULL; }
 
                 int is_array = 0;
                 /* #745: explicit element type for a module-level const
@@ -4755,7 +4869,7 @@ ASTNode* parse_program(Parser* parser) {
                      * TYPE_ARRAY (element + size), so `long[3]` arrives
                      * here as array(long, 3). */
                     annotated_type = parse_type(parser);
-                    if (!annotated_type) { advance_token(parser); continue; }
+                    if (!annotated_type) { advance_token(parser); return NULL; }
                     if (annotated_type->kind == TYPE_ARRAY) {
                         is_array = 1;
                     }
@@ -4763,16 +4877,16 @@ ASTNode* parse_program(Parser* parser) {
                 // Untyped array form: const NAME[] = [...]
                 else if (peek_token(parser) && peek_token(parser)->type == TOKEN_LEFT_BRACKET) {
                     advance_token(parser); // consume '['
-                    if (!expect_token(parser, TOKEN_RIGHT_BRACKET)) { advance_token(parser); continue; }
+                    if (!expect_token(parser, TOKEN_RIGHT_BRACKET)) { advance_token(parser); return NULL; }
                     is_array = 1;
                 }
 
                 if (!expect_token(parser, TOKEN_ASSIGN)) {
                     if (annotated_type) free_type(annotated_type);
-                    advance_token(parser); continue;
+                    advance_token(parser); return NULL;
                 }
                 ASTNode* cval = parse_expression(parser);
-                if (!cval) { if (annotated_type) free_type(annotated_type); advance_token(parser); continue; }
+                if (!cval) { if (annotated_type) free_type(annotated_type); advance_token(parser); return NULL; }
                 node = create_ast_node(AST_CONST_DECLARATION, cname->value, cline, ccol);
                 add_child(node, cval);
 
@@ -4844,7 +4958,7 @@ ASTNode* parse_program(Parser* parser) {
                 } else {
                     parser_error(parser, "Unexpected identifier at top level (expected actor, struct, or function)");
                     advance_token(parser);
-                    continue;
+                    return NULL;
                 }
                 break;
             }
@@ -4874,7 +4988,7 @@ ASTNode* parse_program(Parser* parser) {
                 } else {
                     parser_error(parser, "Expected function definition after type keyword");
                     advance_token(parser);
-                    continue;
+                    return NULL;
                 }
                 break;
             }
@@ -4943,23 +5057,44 @@ ASTNode* parse_program(Parser* parser) {
                                 advance_token(parser);
                             }
                         }
-                        continue;
+                        return NULL;
                     }
                 }
                 parser_error(parser, "Expected actor, struct, function, or main");
                 advance_token(parser);
-                continue;
+                return NULL;
         }
-        
+
+        return node;
+    }
+}
+
+ASTNode* parse_program(Parser* parser) {
+    ASTNode* program = create_ast_node(AST_PROGRAM, NULL, 0, 0);
+
+    int safety_counter = 0;
+    // Safety limit to prevent infinite loops on malformed input
+    const int MAX_ITERATIONS = 10000;
+
+    while (!is_at_end(parser) && safety_counter < MAX_ITERATIONS) {
+        safety_counter++;
+
+        int start_token = parser->current_token;
+        ASTNode* node = parse_top_level_decl(parser);
         if (node) {
             add_child(program, node);
+        } else if (parser->current_token == start_token) {
+            // Error recovery in parse_top_level_decl did not consume a token
+            // (e.g. NULL produced without advancing); step over to guarantee
+            // forward progress and avoid spinning the safety counter.
+            advance_token(parser);
         }
     }
-    
+
     if (safety_counter >= MAX_ITERATIONS) {
         parser_message(parser, "Error: Parser safety limit reached - possible infinite loop");
         return NULL;
     }
-    
+
     return program;
 }

--- a/compiler/parser/parser.h
+++ b/compiler/parser/parser.h
@@ -15,6 +15,10 @@ typedef struct {
                           // trailing-block parsing on function calls so the
                           // `{` belongs to the if/while body, not a trailing
                           // closure on the last call in the condition.
+    int when_top_level;   // Flag: the `when` static-if currently being parsed
+                          // sits at top level, so its arm items are parsed as
+                          // declarations (parse_top_level_decl) rather than
+                          // statements. Saved/restored around nested `when`s.
 } Parser;
 
 // Parser functions
@@ -46,6 +50,8 @@ ASTNode* parse_variable_declaration(Parser* parser);
 ASTNode* parse_variable_declaration_with_semicolon(Parser* parser, bool expect_semicolon);
 ASTNode* parse_python_style_declaration(Parser* parser);
 ASTNode* parse_if_statement(Parser* parser);
+ASTNode* parse_when_statement(Parser* parser);   // compile-time `when` / static-if (#483)
+ASTNode* parse_top_level_decl(Parser* parser);   // one top-level declaration (used by parse_program and top-level `when`)
 ASTNode* parse_for_loop(Parser* parser);
 ASTNode* parse_while_loop(Parser* parser);
 ASTNode* parse_switch_statement(Parser* parser);

--- a/docs/compile-time-eval.md
+++ b/docs/compile-time-eval.md
@@ -1,0 +1,89 @@
+# Compile-time constant evaluation (phase-1)
+
+Aether's `const` is *substitution-at-each-use*: the compiler inlines the
+RHS expression at every reference rather than allocating storage. For a
+literal (`const PI = 3.14`) that is exactly right. For an arbitrary call
+(`const G = make_thing()`) it is silently wrong — every reference would
+re-run the call, re-allocating / re-side-effecting. The typechecker
+therefore rejects non-constant const initializers.
+
+Phase-1 (issue #482) extends the set of initializers the compiler can
+evaluate *at compile time* — folding them to a plain literal before
+codegen so they inline correctly and run once, not per use. It is a
+**hard-whitelisted folder, not an interpreter**.
+
+## What folds
+
+| Initializer | Folds to | Notes |
+|---|---|---|
+| `2 + 3 * 4` (arithmetic on numeric literals: `+ - * / %`) | `14` | Predates phase-1; in the correct width (int = 32-bit, float = double). Division/modulo by zero is *not* folded. |
+| `string.from_int(<int const>)` | `"42"` | Folded in 32-bit width. |
+| `string.from_long(<int const>)` | `"9999999999"` | Folded in 64-bit width. |
+| `string.from_float(<num const>)` | `"3.14"` | `%g` formatting. |
+| `string.concat(<str const>, <str const>)` | `"ab"` | Both operands must be string literals (or fold to them). |
+| `const A: int[3] = [1, 2, 3]` / `const A[] = [...]` | `static const int A[] = {1, 2, 3}` | Const array literal. Every element must itself be a compile-time constant. |
+
+Folds compose: `string.concat(string.from_int(1), "x")` folds to `"1x"`
+because the optimizer recurses into arguments before folding the
+enclosing call.
+
+These also work inside another const: `const HALF = MAX / 2` where `MAX`
+is itself a const.
+
+## What does NOT fold (and why)
+
+- **Any function call outside the whitelist** — e.g. `string.upper(...)`,
+  `string.trim(...)`, a user function, an `extern`, `malloc`. Even though
+  some of these are pure, they are rejected in a const initializer with:
+
+  > `const initializer must be a compile-time constant expression — …`
+
+  This is deliberate. A *general* compile-time evaluator would be able to
+  synthesize `std.fs` / `std.net` calls and evaluate them at build time,
+  which would run filesystem / network code **past the `--emit=lib`
+  capability gate** — the gate that decides which side effects a compiled
+  artifact is allowed to perform. By folding *only* an explicit,
+  audited whitelist of pure value conversions, the build step performs no
+  I/O and grants no capability it would not otherwise grant.
+
+- **`string + string`** — the `+` operator is not defined for strings
+  anywhere in Aether (it is rejected at typecheck with
+  `'+' is not defined for strings`). Build a constant string with
+  `string.concat(...)` instead. `const G = "a" + "b"` does **not** work
+  by design; `const G = string.concat("a", "b")` does.
+
+- **Struct literals**, **member access**, and **non-constant array
+  elements** — rejected; each would either allocate fresh per use or is
+  not a value the substitution model can inline.
+
+- **Out-of-range / undefined folds** — a `string.from_int` argument that
+  does not fit in 32 bits, or a division by zero, is **not** folded. The
+  expression is left as-is rather than producing a silently-wrong
+  literal. (For `from_int` the result would have been the runtime
+  32-bit-truncated call, so leaving it untouched preserves existing
+  behaviour exactly.)
+
+## Where it lives
+
+- **Whitelist gate (accept/reject):** `is_const_expression` /
+  `is_const_expr_call` in `compiler/analysis/typechecker.c`. Runs during
+  typecheck; admits exactly the whitelist, rejects everything else with a
+  source-mapped diagnostic.
+- **Folder (call → literal):** `fold_const_string_call` and the
+  `AST_FUNCTION_CALL` / `AST_CONST_DECLARATION` arms of
+  `optimize_constant_folding` in `compiler/codegen/optimizer.c`. Runs
+  after typecheck, before codegen. The two lists are kept byte-for-byte
+  in sync (`is_whitelisted_string_call` ↔ the typechecker whitelist).
+- **Lowering:** a folded scalar const lowers to `#define NAME (value)`; a
+  const array lowers to `static const T NAME[] = {…}`
+  (`compiler/codegen/codegen_stmt.c` for locals,
+  `compiler/codegen/codegen.c` for module-level).
+
+## Phase-1 scope
+
+Phase-1 is intentionally narrow: arithmetic on numeric literals, the four
+whitelisted `string.*` conversions, and constant array literals. There is
+no general const evaluator, no compile-time loop unrolling beyond the
+existing closed-form loop passes, and no evaluation of user functions. Any
+broadening of the whitelist must preserve the capability-gate invariant
+above: only pure, I/O-free value conversions are ever eligible.

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -49,6 +49,11 @@ pattern.
 | `string.seq_concat(a, b)` | O(\|a\|) — `a` copied, `b` shared via refcount bump |
 | `string.seq_take(s, n)` | O(min(n, length)) — fresh independent spine |
 | `string.seq_drop(s, n)` | O(min(n, length)) — pointer walk only, returns retained tail |
+| `string.seq_each(s, f)` | O(n) — iterative spine walk, side effects |
+| `string.seq_map(s, f)` | O(n) — iterative; fresh independent spine |
+| `string.seq_filter(s, pred)` | O(n) — iterative; fresh independent spine |
+| `string.seq_reduce(s, init, f)` | O(n) — iterative left fold |
+| `string.seq_zip_each(a, b, f)` | O(min(\|a\|, \|b\|)) — iterative, stops at shorter |
 
 ## Building, walking, freeing
 
@@ -126,12 +131,11 @@ omitted but the dispatch test is still emitted — same
 
 ## Combinators
 
-The four built-in structural ops are all closure-free — they don't
-take an Aether function as a parameter, so the FFI surface stays
-simple. Closure-bearing siblings (`map` / `filter` / `foldl`) are
-deferred to a follow-up change set once the Aether-callback-from-C
-bridge is settled; until then, walk the spine with `match` and
-build the result with `cons`.
+There are two families. The four **structural** ops below are
+closure-free — they don't take an Aether function, so the FFI surface
+stays simple. The five **closure-bearing** combinators (`each` / `map`
+/ `filter` / `reduce` / `zip_each`, see the next section) take an
+Aether closure as the per-element callback.
 
 ```aether
 import std.string
@@ -180,6 +184,84 @@ conses each element back onto the second; the second argument is
 shared, never walked. `take` collects the first n elements into a
 reverse buffer then reverses to get them in order. `drop` is a pure
 pointer walk with a single `seq_retain` at the end.
+
+## Closure-bearing combinators
+
+These take an Aether closure as the per-element callback (issue #421 —
+multi-sequence iteration primitives). Every one is a single **iterative
+spine walk — O(n) time, O(1) auxiliary stack** (no recursion; that's
+the O(n²)→O(n) point of the issue):
+
+| Combinator | Callback | Returns |
+|---|---|---|
+| `string.seq_each(s, f)` | `\|x\| { ... }` (side effects) | nothing |
+| `string.seq_map(s, f)` | `\|x\| { return ... }` (`-> string`) | a NEW `*StringSeq`, order preserved |
+| `string.seq_filter(s, pred)` | `\|x\| { return 0/1 }` (`-> int`) | a NEW `*StringSeq` of truthy elements |
+| `string.seq_reduce(s, init, f)` | `\|acc, x\| { ... }` (`(ptr, string) -> ptr`) | the final accumulator (`ptr`) |
+| `string.seq_zip_each(a, b, f)` | `\|x, y\| { ... }` (side effects) | nothing |
+
+```aether
+import std.string
+
+s = string.split_to_seq("alpha,beta,gamma,delta", ",")
+
+// each — call the closure per element for its side effects. The
+// closure may capture (here, an outer `ref` counter).
+n = ref(0)
+string.seq_each(s, |x: string| {
+    ref_set(n, ref_get(n) + 1)
+    println(x)
+})                                   // prints all four; ref_get(n) == 4
+
+// map — fresh, independently-owned seq with the closure applied to
+// each element, order preserved. Free it with seq_free (or let scope
+// exit reclaim it); `s` is untouched.
+upper = string.seq_map(s, |x: string| { return string.to_upper(x) })
+// upper == ["ALPHA", "BETA", "GAMMA", "DELTA"]
+
+// filter — fresh seq of the elements whose predicate is truthy.
+five = string.seq_filter(s, |x: string| {
+    if string.length(x) == 5 { return 1 }
+    return 0
+})                                   // ["alpha", "gamma", "delta"]
+
+// reduce — left fold. acc is an opaque `ptr` the closure threads
+// through; here a `ref` cell holding a running character count.
+acc = ref(0)
+total = string.seq_reduce(s, acc, |a: ptr, x: string| {
+    ref_set(acc, ref_get(acc) + string.length(x))
+    return acc
+})                                   // ref_get(total) == 19
+
+// zip_each — implicit zip over two seqs, stopping at the shorter.
+keys = string.split_to_seq("a,b,c", ",")
+vals = string.split_to_seq("1,2,3,4,5", ",")
+string.seq_zip_each(keys, vals, |k: string, v: string| {
+    println("${k}=${v}")             // a=1, b=2, c=3 (stops at 3)
+})
+
+string.seq_free(upper)
+string.seq_free(five)
+```
+
+Ownership: `map` / `filter` build a fresh, caller-owned spine (freed via
+`seq_free`, or automatically at scope exit like any seq local) and leave
+the input untouched — `map` releases the transient string the closure
+returns after consing it (the new cell takes its own ref), so a freshly
+allocated mapped value such as `string.to_upper(x)` does not leak.
+`reduce` returns the caller's accumulator. `each` / `zip_each` return
+nothing and borrow their inputs. Under the hood the closure is heap-boxed
+into the combinator's `ptr` slot by the codegen (`_aether_box_closure`);
+the std runtime unboxes it, invokes the body with the captured
+environment as the implicit first argument, and frees the box (and its
+captured environment) when the walk completes — so a one-shot
+`string.seq_map(s, |x| ...)` does not leak the closure.
+
+> Closure-literal note: Aether infers a closure's return type from its
+> body, so write `|x: string| { return string.to_upper(x) }` (no
+> `-> Type` annotation on the closure itself). For a `reduce` whose
+> accumulator is a `ptr`, return a value whose `ptr` type is
+> unambiguous to inference — e.g. a captured `ref` cell, as above.
 
 ## Building from existing string-array shapes
 

--- a/docs/when-static-if.md
+++ b/docs/when-static-if.md
@@ -1,0 +1,164 @@
+# Compile-time `when` / static-if
+
+`when` is a compile-time `if`. The condition is evaluated by the compiler,
+and **only the selected arm is type-checked and emitted** — the other arm
+parses but is pruned before any later phase ever sees it. This lets `.ae`
+source fork by platform or build capability *visibly in Aether* instead of
+pushing `#ifdef` into the generated C.
+
+```aether
+when target.os == "windows" {
+    extern win_only(handle: ptr) -> int
+    poll(h: ptr) -> int { return win_only(h) }
+} else {
+    poll(h: ptr) -> int { return posix_poll(h) }
+}
+```
+
+On a non-Windows host the `windows` arm — extern binding and all — is
+discarded before type-checking. `win_only` never has to exist, type-check,
+or link. That is the whole point: platform-specific externs and bindings
+are gated cleanly, with no dead symbol leaking into the build.
+
+## Surface
+
+```
+when <const-condition> {
+    <statements or top-level declarations>
+} else {
+    <statements or top-level declarations>
+}
+```
+
+- Works as a **statement** inside a function body (the arms hold
+  statements), and at **top level** around declarations — functions,
+  externs, imports, structs (the arms hold declarations). The two forms
+  are distinguished by where the `when` appears; you write them the same
+  way.
+- The `else` is optional. When the condition is false and there is no
+  `else`, the `when` simply contributes nothing.
+- Arms chain with `else when`:
+
+  ```aether
+  when target.os == "darwin" {
+      ...
+  } else when target.os == "linux" {
+      ...
+  } else {
+      ...
+  }
+  ```
+
+- The arm braces are a **compile-time grouping**, not a runtime scope: at
+  top level the surviving arm's declarations are spliced directly into the
+  program, and in a function body the surviving arm's statements run in the
+  enclosing scope (no extra `{ }` block in the generated C).
+
+`when` is also the keyword for Erlang-style function-clause guards
+(`classify(x) when x < 0 -> ...`). Those are unaffected: a guard `when`
+only appears *after* a clause's parameter list, never at the head of a
+statement or declaration, so the two uses never collide.
+
+## Supported condition forms
+
+The condition must reduce to a compile-time constant boolean. Supported
+building blocks:
+
+| Form | Example |
+|---|---|
+| OS equality / inequality | `target.os == "linux"`, `target.os != "windows"` |
+| Architecture equality / inequality | `target.arch == "x86_64"`, `target.arch != "arm"` |
+| String-literal equality between two constants | `"a" == "b"` |
+| Boolean literal | `when true { ... }`, `when false { ... }` |
+| Numeric literal (nonzero is true) | `when 1 { ... }` |
+| Negation | `!(target.os == "windows")` |
+| Conjunction / disjunction | `target.os == "darwin" \|\| target.os == "linux"` |
+
+These compose freely with `&&`, `||`, and `!`.
+
+A condition that is **not** a compile-time constant (e.g. a runtime
+variable, an unsupported call, a comparison the folder doesn't recognise)
+is a **hard compile error** — the build fails with a message listing the
+supported forms. `when` never guesses an arm; if the compiler can't decide
+the condition at compile time, it stops.
+
+### `target.os` and `target.arch`
+
+`target.os` and `target.arch` are compiler-provided compile-time string
+constants describing the build target. They are sourced from the **same C
+preprocessor macros** the runtime's `os.platform()` uses (see
+`os_platform_raw` in `std/os/aether_os.c`), so the canonical names match
+across the toolchain. The target is the host: Aether emits C compiled by
+the host toolchain, and there is no cross-target flag today, exactly as
+`os.platform()` and `select()` already assume.
+
+| Constant | Canonical values |
+|---|---|
+| `target.os` | `"windows"`, `"darwin"` (macOS), `"linux"`, `"freebsd"`, `"openbsd"`, `"netbsd"`, `"dragonfly"`, `"solaris"`, `"wasm"`, `"unknown"` |
+| `target.arch` | `"x86_64"`, `"aarch64"`, `"x86"`, `"arm"`, `"riscv64"`, `"ppc64"`, `"wasm"`, `"unknown"` |
+
+Note macOS is `"darwin"` (matching `os.platform()` and Go/Rust's
+convention), not `"macos"`. `target.os` / `target.arch` are only meaningful
+inside a `when` condition.
+
+## Semantics: only the selected arm is type-checked and emitted
+
+The condition is evaluated by a pre-typecheck pass
+(`resolve_when_statements`, in `compiler/codegen/optimizer.c`, invoked from
+`compiler/aetherc.c` between parse and type-check). That pass:
+
+1. Const-evaluates each `when` condition.
+2. Replaces the `when` node, in place, with the contents of its selected
+   arm (splicing top-level declarations to top level, statement arms into
+   the enclosing block).
+3. Frees the unselected arm entirely.
+
+Because this runs **before** type-checking and symbol collection, the
+unselected arm is never type-checked, never collects symbols, and is never
+handed to codegen. An undefined function or a platform-only `extern` in the
+dead arm is therefore harmless — it is gone before anything can object to
+it. This is what makes `when` sound for gating platform bindings, rather
+than a cosmetic `if` that still requires the dead branch to compile.
+
+## How it complements `select()` and `--emit=lib --with=`
+
+- **`select()` is a *runtime* platform switch.** It lowers to an `#ifdef`
+  chain in the generated C, choosing a *value* per platform at the C-compile
+  step (`select(linux: a, macos: b, other: c)`). Every arm of a `select()`
+  must type-check, because the value is chosen in C, not in Aether. Use
+  `select()` to pick a constant per platform; use `when` to fork *which
+  code exists at all* — to gate an entire extern, function, or import that
+  only makes sense on one platform. See
+  [`named-args-and-select.md`](named-args-and-select.md).
+
+- **`--emit=lib --with=`** governs which *capabilities* (fs / net / os) a
+  compiled library is allowed to use. `when` operates one level up: it
+  decides *which declarations are in the program* before the capability
+  gate runs. The pruning pass runs before the `--emit=lib` import gate, so
+  an `import std.net` gated behind a `when` arm that the target doesn't
+  select is removed before the gate inspects the import set — a platform
+  whose arm doesn't pull in `std.net` won't trip the net-capability check.
+  See [`emit-lib.md`](emit-lib.md).
+
+- **`const` / compile-time constant folding** ([`compile-time-eval.md`](compile-time-eval.md))
+  is the value-level analogue: it folds constant *expressions* to literals.
+  `when` is the statement/declaration-level analogue: it folds a constant
+  *condition* to a choice of arm. The same capability-gate discipline
+  applies — the `when` condition evaluator is a small, audited folder
+  (OS/arch strings, bool/numeric literals, `== != && || !`), not a general
+  interpreter, so resolving a `when` performs no I/O.
+
+## Where it lives
+
+- **Parsing:** `parse_when_statement` in `compiler/parser/parser.c`, reached
+  from `parse_statement` (statement form) and `parse_top_level_decl`
+  (top-level form). AST node kind `AST_WHEN_STATEMENT`
+  (`compiler/ast.h`), laid out like `AST_IF_STATEMENT`:
+  `children[0]` = condition, `children[1]` = then-arm, `children[2]` =
+  optional else-arm.
+- **Condition evaluation + pruning:** `when_eval_condition`,
+  `target_os_string` / `target_arch_string`, and `resolve_when_statements`
+  in `compiler/codegen/optimizer.c`.
+- **Driver wiring:** `compiler/aetherc.c` calls `resolve_when_statements`
+  after module merge and the `@derive` pass, and before the `--emit=lib`
+  import gate and `typecheck_program`.

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -573,15 +573,19 @@ void map_free(HashMap* map) {
 MapKeys* map_keys_raw(HashMap* map) {
     if (!map) return NULL;
 
-    MapKeys* keys = (MapKeys*)malloc(sizeof(MapKeys));
+    MapKeys* keys = (MapKeys*)aether_caps_malloc(sizeof(MapKeys));
     if (!keys) return NULL;
     keys->count = 0;
     if (map->size == 0) {
         keys->keys = NULL;
         return keys;
     }
-    keys->keys = (AetherString**)malloc(map->size * sizeof(AetherString*));
-    if (!keys->keys) { free(keys); return NULL; }
+    /* The snapshot array holds exactly map->size pointers; the fill loop
+     * below increments keys->count once per entry, so at free time
+     * keys->count == map->size and the matching aether_caps_free size is
+     * exact regardless of later map mutation. */
+    keys->keys = (AetherString**)aether_caps_malloc(map->size * sizeof(AetherString*));
+    if (!keys->keys) { aether_caps_free(keys, sizeof(MapKeys)); return NULL; }
 
     for (int i = 0; i < map->capacity; i++) {
         HashMapEntry* entry = map->buckets[i];
@@ -596,7 +600,7 @@ MapKeys* map_keys_raw(HashMap* map) {
 
 void map_keys_free(MapKeys* keys) {
     if (!keys) return;
-    free(keys->keys);
-    free(keys);
+    aether_caps_free(keys->keys, (size_t)keys->count * sizeof(AetherString*));
+    aether_caps_free(keys, sizeof(MapKeys));
 }
 

--- a/std/collections/aether_floatarr.c
+++ b/std/collections/aether_floatarr.c
@@ -10,6 +10,7 @@
  * would cost an allocation per entry and chase an extra pointer. */
 
 #include "aether_collections.h"
+#include "../../runtime/aether_resource_caps.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -20,15 +21,15 @@ struct FloatArray {
 
 FloatArray* floatarr_new_raw(int size) {
     if (size < 0) return NULL;
-    FloatArray* arr = (FloatArray*)malloc(sizeof(*arr));
+    FloatArray* arr = (FloatArray*)aether_caps_malloc(sizeof(*arr));
     if (!arr) return NULL;
     arr->size = size;
     if (size == 0) {
         arr->data = NULL;   /* legal empty array; floatarr_free still OK */
         return arr;
     }
-    arr->data = (double*)calloc((size_t)size, sizeof(double));
-    if (!arr->data) { free(arr); return NULL; }
+    arr->data = (double*)aether_caps_calloc((size_t)size, sizeof(double));
+    if (!arr->data) { aether_caps_free(arr, sizeof(*arr)); return NULL; }
     return arr;
 }
 
@@ -68,6 +69,6 @@ void floatarr_fill(FloatArray* arr, double value) {
 
 void floatarr_free(FloatArray* arr) {
     if (!arr) return;
-    free(arr->data);
-    free(arr);
+    aether_caps_free(arr->data, (size_t)arr->size * sizeof(double));
+    aether_caps_free(arr, sizeof(*arr));
 }

--- a/std/collections/aether_stringseq.c
+++ b/std/collections/aether_stringseq.c
@@ -214,6 +214,148 @@ StringSeq* string_seq_drop(StringSeq* s, int n) {
     return string_seq_retain(cur);
 }
 
+/* ---- Closure-bearing combinators (issue #421) -----------------------
+ *
+ * Layout-compatible view of the codegen's `_AeClosure` box. The fields
+ * mirror the prologue typedef
+ *     typedef struct { void (*fn)(void); void* env; } _AeClosure;
+ * exactly; this TU never sees that typedef (it lives in the generated
+ * program's prologue), so we name our own. A function pointer and a
+ * data pointer are the same width on every target we build for, so the
+ * by-value layout matches byte-for-byte. Same approach as
+ * `AeClosureBox` in aether_collections.c. */
+typedef struct { void (*fn)(void); void* env; } AeSeqClosure;
+
+/* Reclaim a boxed closure handed in through a `ptr`-typed parameter.
+ * `_aether_box_closure` malloc'd both the box and (for a capturing
+ * closure) the env it points at; ownership transferred to us, so we
+ * free env first, then the box. NULL-safe — a non-capturing closure
+ * has env == NULL, and an absent callback has box == NULL. */
+static void seq_closure_free(void* box) {
+    if (!box) return;
+    AeSeqClosure* clo = (AeSeqClosure*)box;
+    if (clo->env) free(clo->env);
+    free(box);
+}
+
+void string_seq_each(StringSeq* s, void* f) {
+    if (!f) return;
+    AeSeqClosure clo = *(AeSeqClosure*)f;
+    /* `f(elem)` returns void; invoke through a void(env, const char*)
+     * signature. Iterative spine walk — O(n) time, O(1) stack. */
+    void (*body)(void*, const char*) = (void (*)(void*, const char*))clo.fn;
+    StringSeq* cur = s;
+    while (cur) {
+        body(clo.env, (const char*)cur->head);
+        cur = cur->tail;
+    }
+    seq_closure_free(f);
+}
+
+StringSeq* string_seq_map(StringSeq* s, void* f) {
+    if (!f) return NULL;
+    AeSeqClosure clo = *(AeSeqClosure*)f;
+    /* `f(elem) -> string`; the returned bytes are consed into a fresh
+     * spine (cons retains the head). Build a reversed prefix in O(1)
+     * per step, then reverse once at the end so order is preserved —
+     * the same allocate-then-reverse shape `string_seq_take` uses. */
+    const char* (*body)(void*, const char*) =
+        (const char* (*)(void*, const char*))clo.fn;
+    StringSeq* reversed = NULL;
+    StringSeq* cur = s;
+    while (cur) {
+        const char* mapped = body(clo.env, (const char*)cur->head);
+        StringSeq* cell = string_seq_cons(mapped, reversed);
+        /* The closure returns an OWNED heap string (a fresh
+         * `string.to_upper` / `string.concat` result has refcount 1).
+         * `cons` took its own retain on `mapped`, so the transient ref
+         * the closure handed us must be released here — otherwise the
+         * mapped string leaks one ref and never reaches 0 on
+         * `seq_free`. `string_release` is NULL-safe and a no-op on
+         * plain `char*` literals (no magic header), so a closure that
+         * returns a literal passes through unharmed. Release whether
+         * or not the cons succeeded (on OOM we still own the ref). */
+        string_release(mapped);
+        if (!cell) {
+            string_seq_free(reversed);
+            seq_closure_free(f);
+            return NULL;
+        }
+        /* cons retained `reversed`; drop our local so the new cell is
+         * the sole owner of the prior chain. */
+        string_seq_free(reversed);
+        reversed = cell;
+        cur = cur->tail;
+    }
+    StringSeq* result = string_seq_reverse(reversed);
+    string_seq_free(reversed);
+    seq_closure_free(f);
+    return result;
+}
+
+StringSeq* string_seq_filter(StringSeq* s, void* pred) {
+    if (!pred) return NULL;
+    AeSeqClosure clo = *(AeSeqClosure*)pred;
+    /* `pred(elem) -> int`; keep elements whose predicate is non-zero.
+     * Same reverse-then-reverse build as map so order is preserved and
+     * each step is O(1). */
+    int (*test)(void*, const char*) = (int (*)(void*, const char*))clo.fn;
+    StringSeq* reversed = NULL;
+    StringSeq* cur = s;
+    while (cur) {
+        if (test(clo.env, (const char*)cur->head)) {
+            StringSeq* cell = string_seq_cons((const char*)cur->head, reversed);
+            if (!cell) {
+                string_seq_free(reversed);
+                seq_closure_free(pred);
+                return NULL;
+            }
+            string_seq_free(reversed);
+            reversed = cell;
+        }
+        cur = cur->tail;
+    }
+    StringSeq* result = string_seq_reverse(reversed);
+    string_seq_free(reversed);
+    seq_closure_free(pred);
+    return result;
+}
+
+void* string_seq_reduce(StringSeq* s, void* init, void* f) {
+    if (!f) return init;
+    AeSeqClosure clo = *(AeSeqClosure*)f;
+    /* Left fold: `acc = f(acc, elem)`. acc and the result are opaque
+     * `ptr`s — the closure threads through whatever it likes (a boxed
+     * int, an accumulating StringSeq, a heap string handle). */
+    void* (*step)(void*, void*, const char*) =
+        (void* (*)(void*, void*, const char*))clo.fn;
+    void* acc = init;
+    StringSeq* cur = s;
+    while (cur) {
+        acc = step(clo.env, acc, (const char*)cur->head);
+        cur = cur->tail;
+    }
+    seq_closure_free(f);
+    return acc;
+}
+
+void string_seq_zip_each(StringSeq* a, StringSeq* b, void* f) {
+    if (!f) return;
+    AeSeqClosure clo = *(AeSeqClosure*)f;
+    /* Implicit zip: call `f(a_elem, b_elem)` per aligned pair, stopping
+     * at the shorter spine. Both inputs borrowed. O(min(|a|, |b|)). */
+    void (*body)(void*, const char*, const char*) =
+        (void (*)(void*, const char*, const char*))clo.fn;
+    StringSeq* ca = a;
+    StringSeq* cb = b;
+    while (ca && cb) {
+        body(clo.env, (const char*)ca->head, (const char*)cb->head);
+        ca = ca->tail;
+        cb = cb->tail;
+    }
+    seq_closure_free(f);
+}
+
 void* string_seq_to_array(StringSeq* s) {
     if (!s) return NULL;
     int n = s->length;

--- a/std/collections/aether_stringseq.h
+++ b/std/collections/aether_stringseq.h
@@ -161,4 +161,83 @@ StringSeq* string_seq_take(StringSeq* s, int n);
  * new allocations. */
 StringSeq* string_seq_drop(StringSeq* s, int n);
 
+/* ---- Closure-bearing combinators ------------------------------------
+ *
+ * Higher-order iteration over the cons spine, taking an Aether closure
+ * as the per-element callback (issue #421 — multi-sequence iteration
+ * primitives). These resolve the "deferred to a follow-up change set
+ * once the Aether-callback-from-C bridge is settled" note that the
+ * structural combinators above carried.
+ *
+ * Closure ABI
+ * -----------
+ * Each callback parameter is declared `ptr` (C `void*`) on both sides,
+ * and the Aether `extern` declares it `ptr` too. When a caller passes
+ * a closure literal into a `ptr`-typed slot, the codegen heap-BOXES it:
+ *
+ *     extern_fn(..., _aether_box_closure(
+ *         (_AeClosure){ .fn = (void(*)(void))_closure_fn_N, .env = _e }))
+ *
+ * where `_AeClosure` is the codegen prologue's
+ *
+ *     typedef struct { void (*fn)(void); void* env; } _AeClosure;
+ *
+ * `_aether_box_closure` malloc's a copy of that two-word struct and
+ * hands us the heap pointer. We mirror the layout locally as
+ * `AeSeqClosure` (see the .c — this TU need not see the prologue
+ * typedef) and read `.fn` / `.env` back out. The closure body is then
+ * invoked as
+ *
+ *     ((RET(*)(void* env, ARG1, ARG2, ...))clo.fn)(clo.env, a1, a2, ...)
+ *
+ * i.e. `env` (the captured environment, NULL for a non-capturing
+ * closure) is ALWAYS the implicit first argument, ahead of the declared
+ * parameters — exactly what codegen emits for `call(cb, ...)` and for
+ * the `_closure_fn_N(env, ...)` definition.
+ *
+ * Ownership: the box (and the `env` it points at, when non-NULL) is
+ * malloc'd by `_aether_box_closure` and OWNED BY THE CALLEE — the same
+ * contract `list_add_closure_owned` / `list_free` use in
+ * aether_collections.c. Each combinator below frees the env then the
+ * box before returning, so a one-shot `string.seq_map(s, |x| ...)` does
+ * not leak the closure.
+ *
+ * Complexity: every combinator is a single iterative spine walk —
+ * O(n) time, O(1) auxiliary stack (no recursion). `map`/`filter`
+ * build a fresh, independently-owned result spine (free with
+ * `string_seq_free`); `each`/`zip_each` return nothing; `reduce`
+ * returns the caller's accumulator.
+ */
+
+/* Apply `f(elem)` to each element, head-to-tail, for side effects.
+ * `f`'s return value (if any) is discarded. NULL-safe (empty seq is a
+ * no-op). `s` is borrowed — not consumed, not freed. */
+void string_seq_each(StringSeq* s, void* f);
+
+/* Return a NEW seq with `f(elem)` substituted for each element, order
+ * preserved. `f` must return a `string` (its result is consed into the
+ * fresh spine, which retains it). The result is caller-owned: free with
+ * `string_seq_free`. `s` is left untouched. NULL on OOM (any partial
+ * result spine is freed before return). O(n). */
+StringSeq* string_seq_map(StringSeq* s, void* f);
+
+/* Return a NEW seq of the elements for which `pred(elem)` is truthy
+ * (non-zero), order preserved. The result is caller-owned: free with
+ * `string_seq_free`. `s` is left untouched. NULL on empty result or
+ * OOM (any partial result spine is freed before return). O(n). */
+StringSeq* string_seq_filter(StringSeq* s, void* pred);
+
+/* Left fold: starting from `init`, compute `acc = f(acc, elem)` for
+ * each element head-to-tail, and return the final `acc`. `acc` and the
+ * return are opaque `ptr`s — the closure owns whatever it threads
+ * through. NULL-safe (empty seq returns `init` unchanged). O(n). */
+void* string_seq_reduce(StringSeq* s, void* init, void* f);
+
+/* Implicit-zip iteration over two seqs: call `f(a_elem, b_elem)` for
+ * each aligned pair, stopping at the end of the SHORTER seq. Covers
+ * issue #421's multi-sequence intent without dynamic typing. Both
+ * seqs are borrowed. NULL-safe (a NULL either side ends immediately).
+ * O(min(|a|, |b|)). */
+void string_seq_zip_each(StringSeq* a, StringSeq* b, void* f);
+
 #endif

--- a/std/http/proxy/aether_proxy_cache.c
+++ b/std/http/proxy/aether_proxy_cache.c
@@ -56,7 +56,7 @@ AetherProxyCache* aether_proxy_cache_new(int max_entries,
     if (default_ttl_sec < 0) return NULL;
     if (key_strategy < 0 || key_strategy > AETHER_PROXY_CACHE_KEY_METHOD_URL_VARY) return NULL;
 
-    AetherProxyCache* c = (AetherProxyCache*)calloc(1, sizeof(*c));
+    AetherProxyCache* c = (AetherProxyCache*)aether_caps_calloc(1, sizeof(*c));
     if (!c) return NULL;
     c->max_entries     = max_entries;
     c->max_body_bytes  = max_body_bytes;
@@ -68,7 +68,7 @@ AetherProxyCache* aether_proxy_cache_new(int max_entries,
     if (c->bucket_count < 16) c->bucket_count = 16;
     c->buckets = (AetherProxyCacheEntry**)calloc((size_t)c->bucket_count,
                                                   sizeof(AetherProxyCacheEntry*));
-    if (!c->buckets) { free(c); return NULL; }
+    if (!c->buckets) { aether_caps_free(c, sizeof(*c)); return NULL; }
 
     pthread_mutex_init(&c->lock, NULL);
     return c;
@@ -91,7 +91,7 @@ static void entry_free_one(AetherProxyCacheEntry* e) {
     free(e->etag);
     free(e->last_modified);
     free(e->vary_header);
-    free(e);
+    aether_caps_free(e, sizeof(*e));
 }
 
 void aether_proxy_cache_free(AetherProxyCache* cache) {
@@ -108,7 +108,7 @@ void aether_proxy_cache_free(AetherProxyCache* cache) {
     free(cache->buckets);
     pthread_mutex_unlock(&cache->lock);
     pthread_mutex_destroy(&cache->lock);
-    free(cache);
+    aether_caps_free(cache, sizeof(*cache));
 }
 
 /* FNV-1a 64-bit. */
@@ -447,7 +447,7 @@ void aether_proxy_cache_store(AetherProxyCache* cache,
     }
 
     /* Allocate the new entry. */
-    AetherProxyCacheEntry* e = (AetherProxyCacheEntry*)calloc(1, sizeof(*e));
+    AetherProxyCacheEntry* e = (AetherProxyCacheEntry*)aether_caps_calloc(1, sizeof(*e));
     if (!e) {
         free(base_key);
         free(full_key);

--- a/std/http/proxy/aether_proxy_opts.c
+++ b/std/http/proxy/aether_proxy_opts.c
@@ -7,12 +7,13 @@
  */
 
 #include "aether_proxy_internal.h"
+#include "../../../runtime/aether_resource_caps.h"
 
 #include <stdlib.h>
 #include <string.h>
 
 AetherProxyOpts* aether_proxy_opts_new(void) {
-    AetherProxyOpts* o = (AetherProxyOpts*)calloc(1, sizeof(*o));
+    AetherProxyOpts* o = (AetherProxyOpts*)aether_caps_calloc(1, sizeof(*o));
     if (!o) return NULL;
     /* Sensible defaults — all X-Forwarded-* on, host rewritten to
      * upstream, no path-prefix chop, 8 MiB body cap. */
@@ -32,7 +33,7 @@ void aether_proxy_opts_free(AetherProxyOpts* opts) {
     free(opts->route_pattern);
     free(opts->methods);
     free(opts->strip_path_prefix);
-    free(opts);
+    aether_caps_free(opts, sizeof(*opts));
 }
 
 const char* aether_proxy_opts_set_strip_prefix(AetherProxyOpts* opts,

--- a/std/http/proxy/aether_proxy_pool.c
+++ b/std/http/proxy/aether_proxy_pool.c
@@ -14,6 +14,7 @@
  */
 
 #include "aether_proxy_internal.h"
+#include "../../../runtime/aether_resource_caps.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -58,10 +59,10 @@ int aether_proxy_lb_algo_from_string(const char* name) {
 /* ----- AetherUpstream lifecycle ----- */
 
 static AetherUpstream* upstream_new(const char* base_url, int weight) {
-    AetherUpstream* u = (AetherUpstream*)calloc(1, sizeof(AetherUpstream));
+    AetherUpstream* u = (AetherUpstream*)aether_caps_calloc(1, sizeof(AetherUpstream));
     if (!u) return NULL;
     u->base_url = strdup(base_url);
-    if (!u->base_url) { free(u); return NULL; }
+    if (!u->base_url) { aether_caps_free(u, sizeof(AetherUpstream)); return NULL; }
     u->weight           = weight > 0 ? weight : 1;
     u->effective_weight = u->weight;
     u->current_weight   = 0;
@@ -95,7 +96,7 @@ static void upstream_free(AetherUpstream* u) {
     if (!u) return;
     pthread_mutex_destroy(&u->rl_lock);
     free(u->base_url);
-    free(u);
+    aether_caps_free(u, sizeof(AetherUpstream));
 }
 
 void aether_proxy_inflight_dec(AetherUpstream* u) {
@@ -114,7 +115,7 @@ AetherProxyPool* aether_proxy_pool_new(AetherProxyLbAlgo algo,
     if (dial_timeout_ms < 0)      return NULL;
     if (max_inflight_per_up < 0)  return NULL;
 
-    AetherProxyPool* p = (AetherProxyPool*)calloc(1, sizeof(*p));
+    AetherProxyPool* p = (AetherProxyPool*)aether_caps_calloc(1, sizeof(*p));
     if (!p) return NULL;
 
     p->algo                  = algo;
@@ -182,7 +183,7 @@ void aether_proxy_pool_free(AetherProxyPool* pool) {
     pthread_mutex_destroy(&pool->lock);
     pthread_mutex_destroy(&pool->hc_cv_lock);
     pthread_cond_destroy(&pool->hc_cv);
-    free(pool);
+    aether_caps_free(pool, sizeof(*pool));
 }
 
 /* ----- Drain ----- */

--- a/std/regex/aether_regex.c
+++ b/std/regex/aether_regex.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
 
 /* Mirror the file-static helpers in aether_string.c so we accept both
  * AetherString* and plain const char* at the FFI boundary, identically
@@ -105,7 +106,7 @@ void* aether_regex_compile(const void* pattern_s, int flags) {
     if (!code) { set_pcre2_error(errnum, offset); return NULL; }
     uint32_t ngroups = 0;
     pcre2_pattern_info(code, PCRE2_INFO_CAPTURECOUNT, &ngroups);
-    RegexHandle* h = (RegexHandle*)calloc(1, sizeof(RegexHandle));
+    RegexHandle* h = (RegexHandle*)aether_caps_calloc(1, sizeof(RegexHandle));
     if (!h) { pcre2_code_free(code); set_last_error("regex: out of memory"); return NULL; }
     h->code = code;
     h->ngroups = (int)ngroups + 1;
@@ -116,7 +117,7 @@ void aether_regex_free(void* h_) {
     if (!h_) return;
     RegexHandle* h = (RegexHandle*)h_;
     if (h->code) pcre2_code_free(h->code);
-    free(h);
+    aether_caps_free(h, sizeof(RegexHandle));
 }
 
 int aether_regex_matches(void* h_, const void* s_) {
@@ -148,7 +149,7 @@ void* aether_regex_captures(void* h_, const void* s_) {
     char* copy = (char*)malloc(slen + 1);
     if (!copy) { pcre2_match_data_free(md); set_last_error("regex: out of memory"); return NULL; }
     memcpy(copy, s, slen); copy[slen] = '\0';
-    RegexCaptures* c = (RegexCaptures*)calloc(1, sizeof(RegexCaptures));
+    RegexCaptures* c = (RegexCaptures*)aether_caps_calloc(1, sizeof(RegexCaptures));
     if (!c) { free(copy); pcre2_match_data_free(md); set_last_error("regex: out of memory"); return NULL; }
     c->md = md;
     c->subject = copy;
@@ -195,7 +196,7 @@ void aether_regex_captures_free(void* c_) {
     RegexCaptures* c = (RegexCaptures*)c_;
     if (c->md) pcre2_match_data_free(c->md);
     if (c->subject) free(c->subject);
-    free(c);
+    aether_caps_free(c, sizeof(RegexCaptures));
 }
 
 void* aether_regex_find_all(void* h_, const void* s_) {
@@ -238,7 +239,7 @@ void* aether_regex_find_all(void* h_, const void* s_) {
     if (!copy) { free(spans); set_last_error("regex: out of memory"); return NULL; }
     memcpy(copy, s, slen); copy[slen] = '\0';
 
-    RegexFindAll* fa = (RegexFindAll*)calloc(1, sizeof(RegexFindAll));
+    RegexFindAll* fa = (RegexFindAll*)aether_caps_calloc(1, sizeof(RegexFindAll));
     if (!fa) { free(copy); free(spans); set_last_error("regex: out of memory"); return NULL; }
     fa->count = count;
     fa->spans = spans;
@@ -265,7 +266,7 @@ void aether_regex_find_all_free(void* fa_) {
     RegexFindAll* fa = (RegexFindAll*)fa_;
     if (fa->spans) free(fa->spans);
     if (fa->subject) free(fa->subject);
-    free(fa);
+    aether_caps_free(fa, sizeof(RegexFindAll));
 }
 
 /* Internal substitute: shared by replace and replace_all (option toggles

--- a/std/string/module.ae
+++ b/std/string/module.ae
@@ -18,6 +18,8 @@ exports (
     string_seq_is_empty, string_seq_length, string_seq_retain, string_seq_free,
     string_seq_from_array, string_seq_to_array,
     string_seq_reverse, string_seq_concat, string_seq_take, string_seq_drop,
+    string_seq_each, string_seq_map, string_seq_filter, string_seq_reduce,
+    string_seq_zip_each,
     string_to_cstr, string_from_int, string_from_long, string_from_float,
     string_from_int_radix, string_pad_start, string_pad_end,
     string_to_int_raw, string_to_long_raw, string_to_float_raw, string_to_double_raw,
@@ -252,6 +254,31 @@ extern string_seq_reverse(s: *StringSeq) -> *StringSeq
 extern string_seq_concat(a: *StringSeq, b: *StringSeq) -> *StringSeq
 extern string_seq_take(s: *StringSeq, n: int) -> *StringSeq
 extern string_seq_drop(s: *StringSeq, n: int) -> *StringSeq
+
+// Closure-bearing combinators (#421 — multi-sequence iteration). Each
+// takes an Aether closure as the per-element callback. The callback
+// params are declared `ptr` so the codegen heap-BOXES the closure
+// (`_aether_box_closure`) into the slot; the C runtime unboxes, invokes
+// the body with the captured env as the implicit first argument, and
+// frees the box (+ its env) when the walk completes — so a one-shot
+// `string.seq_map(s, |x| ...)` does not leak the closure. All five are
+// a single iterative spine walk: O(n) time, O(1) auxiliary stack (no
+// recursion — that's the O(N^2)->O(N) point of the issue).
+//
+//   string.seq_each(s, |x| { ... })          // side effects, per element
+//   string.seq_map(s, |x| -> string)         // fresh seq, order preserved
+//   string.seq_filter(s, |x| -> int)         // fresh seq of truthy elems
+//   string.seq_reduce(s, init, |acc, x| ...) // left fold, returns acc
+//   string.seq_zip_each(a, b, |x, y| { ... })// implicit zip to shorter
+//
+// `map`/`filter` return a fresh, caller-owned *StringSeq (reclaimed
+// automatically at scope exit like any seq local). `reduce` returns the
+// caller's accumulator (`ptr`). `each`/`zip_each` return nothing.
+extern string_seq_each(s: *StringSeq, f: ptr)
+extern string_seq_map(s: *StringSeq, f: ptr) -> *StringSeq
+extern string_seq_filter(s: *StringSeq, pred: ptr) -> *StringSeq
+extern string_seq_reduce(s: *StringSeq, init: ptr, f: ptr) -> ptr
+extern string_seq_zip_each(a: *StringSeq, b: *StringSeq, f: ptr)
 
 // Conversion
 extern string_to_cstr(str: string) -> string

--- a/std/xml/aether_xml.c
+++ b/std/xml/aether_xml.c
@@ -8,6 +8,7 @@
  * config XML needs — see aether_xml.h.
  */
 #include "aether_xml.h"
+#include "../../runtime/aether_resource_caps.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -168,10 +169,10 @@ static void reset_event(XmlParser* p) {
 }
 
 XmlParser* xml_parser_new(const char* data, size_t len) {
-    XmlParser* p = (XmlParser*)calloc(1, sizeof(XmlParser));
+    XmlParser* p = (XmlParser*)aether_caps_calloc(1, sizeof(XmlParser));
     if (!p) return NULL;
     p->buf = (char*)malloc(len + 1);
-    if (!p->buf) { free(p); return NULL; }
+    if (!p->buf) { aether_caps_free(p, sizeof(XmlParser)); return NULL; }
     if (len) memcpy(p->buf, data, len);
     p->buf[len] = '\0';
     p->len = len;
@@ -192,7 +193,7 @@ void xml_parser_free(XmlParser* p) {
     free(p->attrs);
     free(p->pending_end);
     free(p->buf);
-    free(p);
+    aether_caps_free(p, sizeof(XmlParser));
 }
 
 static int xml_fail(XmlParser* p, const char* msg) {
@@ -431,7 +432,7 @@ struct XmlBuilder {
 };
 
 XmlBuilder* xml_builder_new(void) {
-    XmlBuilder* b = (XmlBuilder*)calloc(1, sizeof(XmlBuilder));
+    XmlBuilder* b = (XmlBuilder*)aether_caps_calloc(1, sizeof(XmlBuilder));
     if (!b) return NULL;
     sb_init(&b->sb);
     return b;
@@ -440,7 +441,7 @@ XmlBuilder* xml_builder_new(void) {
 void xml_builder_free(XmlBuilder* b) {
     if (!b) return;
     free(b->sb.data);
-    free(b);
+    aether_caps_free(b, sizeof(XmlBuilder));
 }
 
 static void close_open_tag(XmlBuilder* b) {

--- a/tests/integration/const_call_reject/test_const_call_reject.sh
+++ b/tests/integration/const_call_reject/test_const_call_reject.sh
@@ -6,6 +6,13 @@
 # a helpful diagnostic that points the user at std.config /
 # std.actors for process-global state. Section 2 of
 # nuther-ask-of-aether-team.md.
+#
+# Exception (issue #482, compile-time constant evaluation phase-1):
+# a HARD-WHITELISTED set of pure conversions — string.from_int /
+# string.from_long / string.from_float / string.concat — IS admissible
+# in a const initializer because the optimizer folds them to a literal
+# at compile time (no re-evaluation at use sites). Every OTHER call
+# stays rejected. See docs/compile-time-eval.md.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -47,13 +54,27 @@ main() { println("ok") }
 EOF
 expect_reject "top-level const = function call" /tmp/ae_const_bad1.ae
 
-# Case 2: top-level const = stdlib call.
+# Case 2: top-level const = NON-whitelisted std-namespaced call.
+# string.length is a real pure stdlib function but it is NOT on the
+# compile-time-fold whitelist, so it must still be rejected.
 cat > /tmp/ae_const_bad2.ae << 'EOF'
 import std.string
-const NAME = string.from_int(42)
+const N = string.length("hi")
 main() { println("ok") }
 EOF
-expect_reject "top-level const = std-namespaced call" /tmp/ae_const_bad2.ae
+expect_reject "top-level const = non-whitelisted std call" /tmp/ae_const_bad2.ae
+
+# Case 2b (issue #482): the whitelisted pure conversions ARE accepted
+# and fold to a literal — string.from_int / from_long / from_float /
+# concat. These do not re-evaluate at use sites because the optimizer
+# replaces the call with the literal it produces.
+cat > /tmp/ae_const_ok_fold.ae << 'EOF'
+import std.string
+const ID = string.from_int(42)
+const VER = string.concat("v", "1")
+main() { println("ok") }
+EOF
+expect_accept "whitelisted from_int/concat const folds (issue #482)" /tmp/ae_const_ok_fold.ae
 
 # Case 3: function-local const = call.
 cat > /tmp/ae_const_bad3.ae << 'EOF'
@@ -84,7 +105,7 @@ EOF
 expect_accept "arithmetic on const RHS still compiles" /tmp/ae_const_ok2.ae
 
 rm -f /tmp/ae_const_bad*.ae /tmp/ae_const_ok*.ae \
-      /tmp/ae_const_reject_out /tmp/ae_const_ok_out
+      /tmp/ae_const_reject_out /tmp/ae_const_ok_out /tmp/ae_const_ok_fold.ae
 
 echo ""
 echo "const_call_reject: $pass passed, $fail failed"

--- a/tests/regression/test_ask_reply_branched.ae
+++ b/tests/regression/test_ask_reply_branched.ae
@@ -1,0 +1,56 @@
+// #736 regression — synchronous ask/reply (`?`) with the `reply` statement
+// nested in if/else / nested-if branches, not just at the handler top level.
+//
+// The request->reply type-map pre-pass used to scan only the receive arm's
+// DIRECT children for a `reply`, so a branched reply left the request
+// unmapped and the `?` ask read a garbage reply slot (it returned a random
+// pointer instead of the replied value). The pre-pass now searches the whole
+// arm body recursively. This test pins the behaviour: every branch's reply
+// value must come back exactly.
+
+extern exit(code: int)
+
+message Q { x: int }
+message R { value: int }
+
+actor Svc {
+    state hits = 0
+    receive {
+        // Reply lives in BOTH branches of an if/else, and one branch nests
+        // another if/else — none of these are top-level statements of the
+        // arm body.
+        Q(x) -> {
+            hits = hits + 1
+            if x > 0 {
+                if x > 10 {
+                    reply R { value: 999 }
+                } else {
+                    reply R { value: x * 2 }
+                }
+            } else {
+                reply R { value: 0 - 1 }
+            }
+        }
+    }
+}
+
+check(label: string, got: int, want: int) {
+    if got != want {
+        println("FAIL: ${label} got ${got}, want ${want}")
+        exit(1)
+    }
+}
+
+main() {
+    s = spawn(Svc())
+
+    check("nested-if high branch", s ? Q { x: 50 }, 999)
+    check("nested-if low branch",  s ? Q { x: 4 },  8)
+    check("else branch",           s ? Q { x: 0 },  0 - 1)
+
+    // Repeat to confirm the reply slot is per-message, not stale across asks.
+    check("repeat high", s ? Q { x: 20 }, 999)
+    check("repeat low",  s ? Q { x: 1 },  2)
+
+    println("PASS: branched ask/reply returns each branch's value (#736)")
+}

--- a/tests/regression/test_const_fold_array.ae
+++ b/tests/regression/test_const_fold_array.ae
@@ -1,0 +1,46 @@
+// Regression: constant array literals as const initializers
+// (issue #482, compile-time-eval phase-1).
+//
+// Both the typed form `const A: T[N] = [...]` and the untyped form
+// `const A[] = [...]` lower to a file-scope `static const T A[] = {...}`.
+// Every element must itself be a compile-time constant; a non-const
+// element is rejected at typecheck (see test_const_call_reject.sh).
+
+// Typed const array — element type/size pinned by `: int[3]`.
+const TRIPLE: int[3] = [1, 2, 3]
+
+// Untyped const array — element type inferred from the literals.
+const SIZES[] = [4, 8, 16, 32, 64]
+
+// Const array of strings.
+const NAMES[] = ["alice", "bob", "carol"]
+
+main() {
+    fails = 0
+
+    if TRIPLE[0] != 1  { print("FAIL TRIPLE[0]\n"); fails = fails + 1 }
+    if TRIPLE[2] != 3  { print("FAIL TRIPLE[2]\n"); fails = fails + 1 }
+
+    if SIZES[0] != 4   { print("FAIL SIZES[0]\n"); fails = fails + 1 }
+    if SIZES[4] != 64  { print("FAIL SIZES[4]\n"); fails = fails + 1 }
+
+    // Sum the int array in a loop (indexes the static const table).
+    sum = 0
+    for (i = 0; i < 5; i = i + 1) {
+        sum = sum + SIZES[i]
+    }
+    if sum != 124 { print("FAIL SIZES sum\n"); fails = fails + 1 }
+
+    if NAMES[0] != "alice" { print("FAIL NAMES[0]\n"); fails = fails + 1 }
+    if NAMES[2] != "carol" { print("FAIL NAMES[2]\n"); fails = fails + 1 }
+
+    println(TRIPLE[1])  // expect: 2
+    println(NAMES[1])   // expect: bob
+
+    if fails == 0 {
+        print("PASS: const fold array\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}

--- a/tests/regression/test_const_fold_string.ae
+++ b/tests/regression/test_const_fold_string.ae
@@ -1,0 +1,39 @@
+// Regression: compile-time constant folding of whitelisted string
+// conversions (issue #482, compile-time-eval phase-1).
+//
+// `string.from_int` / `string.from_long` / `string.from_float` and
+// `string.concat` on constant arguments fold to a string literal at
+// compile time. The const therefore inlines a literal at each use
+// (no re-evaluation), exactly like `const PI = 3.14`.
+//
+// `string + string` is NOT a thing in Aether (rejected at typecheck),
+// so constant string building goes through string.concat.
+
+import std.string
+
+const ID    = string.from_int(42)              // -> "42"
+const BIG   = string.from_long(9999999999)     // -> "9999999999"  (64-bit width)
+const VER   = string.concat("v", "1")          // -> "v1"
+const LABEL = string.concat("id-", string.from_int(7))  // nested fold -> "id-7"
+
+main() {
+    fails = 0
+
+    if ID != "42"           { print("FAIL from_int\n");   fails = fails + 1 }
+    if BIG != "9999999999"  { print("FAIL from_long\n");  fails = fails + 1 }
+    if VER != "v1"          { print("FAIL concat\n");     fails = fails + 1 }
+    if LABEL != "id-7"      { print("FAIL nested concat\n"); fails = fails + 1 }
+
+    // Const inlines at each use — printing twice yields the same literal,
+    // and there is no per-use re-allocation (the value is a static literal).
+    println(ID)     // expect: 42
+    println(VER)    // expect: v1
+    println(LABEL)  // expect: id-7
+
+    if fails == 0 {
+        print("PASS: const fold string\n")
+    } else {
+        print("FAILED: ${fails}\n")
+        exit(1)
+    }
+}

--- a/tests/regression/test_seq_combinators.ae
+++ b/tests/regression/test_seq_combinators.ae
@@ -1,0 +1,193 @@
+// Regression test for the closure-bearing *StringSeq combinators
+// (issue #421 — multi-sequence iteration primitives):
+//
+//   string.seq_each(s, |x| { ... })            side effects, per element
+//   string.seq_map(s, |x| { return ... })      fresh seq, order preserved
+//   string.seq_filter(s, |x| { return 0/1 })   fresh seq of truthy elems
+//   string.seq_reduce(s, init, |acc, x| {...}) left fold, returns acc
+//   string.seq_zip_each(a, b, |x, y| { ... })  implicit zip to shorter
+//
+// Each combinator is invoked with a real Aether closure (capturing and
+// non-capturing). The closure is heap-boxed into the `ptr`-typed C slot
+// by the codegen and invoked via the `_AeClosure` { fn, env } ABI from
+// the std runtime. All five are iterative O(n) spine walks — no
+// recursion. We assert results and exit 0 on success, 1 on any failure.
+
+import std.string
+import std.strbuilder
+
+extern exit(code: int)
+
+// Walk the seq and join with "," for order-sensitive assertions.
+walk_join(s: *StringSeq) -> string {
+    sb = strbuilder.new(0)
+    first = 1
+    cur = s
+    while string.seq_is_empty(cur) == 0 {
+        if first == 0 {
+            strbuilder.append(sb, ",")
+        }
+        strbuilder.append(sb, string.seq_head(cur))
+        cur = string.seq_tail(cur)
+        first = 0
+    }
+    return strbuilder.finish(sb)
+}
+
+main() {
+    // ---- each (capturing closure, side effects) --------------------
+    //
+    // A `ref` cell captured by the closure accumulates a running count
+    // and a concatenation of the visited elements. Proves the captured
+    // environment (`.env`) is threaded correctly into the callback.
+    src = string.split_to_seq("alpha,beta,gamma,delta", ",")
+
+    count = ref(0)
+    sb_each = strbuilder.new(0)
+    string.seq_each(src, |x: string| {
+        ref_set(count, ref_get(count) + 1)
+        strbuilder.append(sb_each, x)
+        strbuilder.append(sb_each, ";")
+    })
+    if ref_get(count) != 4 {
+        println("FAIL 1a: each visited ${ref_get(count)} elems, want 4")
+        exit(1)
+    }
+    visited = strbuilder.finish(sb_each)
+    if string.equals(visited, "alpha;beta;gamma;delta;") != 1 {
+        println("FAIL 1b: each order=${visited}")
+        exit(1)
+    }
+    println("  PASS 1: each — capturing closure, count + order")
+
+    // ---- map (fresh seq, order preserved) --------------------------
+    //
+    // Uppercase each element. The result is a fresh, independently-owned
+    // spine; freeing it must not disturb `src`.
+    upper = string.seq_map(src, |x: string| {
+        return string.to_upper(x)
+    })
+    if string.seq_length(upper) != 4 {
+        println("FAIL 2a: map length=${string.seq_length(upper)}, want 4")
+        exit(1)
+    }
+    mj = walk_join(upper)
+    if string.equals(mj, "ALPHA,BETA,GAMMA,DELTA") != 1 {
+        println("FAIL 2b: map=${mj}, want ALPHA,BETA,GAMMA,DELTA")
+        exit(1)
+    }
+    string.seq_free(upper)
+    // Freeing the map result must leave src intact.
+    if string.equals(walk_join(src), "alpha,beta,gamma,delta") != 1 {
+        println("FAIL 2c: map's free corrupted src")
+        exit(1)
+    }
+    println("  PASS 2: map — uppercase, order preserved, src untouched")
+
+    // ---- filter (keep truthy) --------------------------------------
+    //
+    // Keep elements whose length is exactly 5 ("alpha", "gamma",
+    // "delta"); drop "beta" (4). Capturing closure not needed here —
+    // a non-capturing predicate exercises the env == NULL path.
+    keep = string.seq_filter(src, |x: string| {
+        if string.length(x) == 5 {
+            return 1
+        }
+        return 0
+    })
+    if string.seq_length(keep) != 3 {
+        println("FAIL 3a: filter length=${string.seq_length(keep)}, want 3")
+        exit(1)
+    }
+    fj = walk_join(keep)
+    if string.equals(fj, "alpha,gamma,delta") != 1 {
+        println("FAIL 3b: filter=${fj}, want alpha,gamma,delta")
+        exit(1)
+    }
+    string.seq_free(keep)
+
+    // Predicate that rejects everything yields the empty seq.
+    none = string.seq_filter(src, |x: string| {
+        return 0
+    })
+    if string.seq_is_empty(none) != 1 {
+        println("FAIL 3c: filter(always-false) should be empty")
+        exit(1)
+    }
+    string.seq_free(none)
+    println("  PASS 3: filter — length predicate + empty-result edge")
+
+    // ---- reduce (left fold, ptr accumulator) -----------------------
+    //
+    // Fold total character count across the spine. The accumulator is a
+    // `ptr` — a single `ref` cell mutated in place per step and threaded
+    // back out as the result (left-fold associativity: each call sees
+    // the acc the previous one returned). Returning the captured cell
+    // (`acc_cell`, a parent-scope var) keeps the closure's `ptr` result
+    // type unambiguous to inference and allocates no intermediates.
+    // Total = 5 + 4 + 5 + 5 = 19.
+    acc_cell = ref(0)
+    total = string.seq_reduce(src, acc_cell, |acc: ptr, x: string| {
+        ref_set(acc_cell, ref_get(acc_cell) + string.length(x))
+        return acc_cell
+    })
+    if ref_get(total) != 19 {
+        println("FAIL 4a: reduce total=${ref_get(total)}, want 19")
+        exit(1)
+    }
+
+    // reduce over the empty seq returns init unchanged (the closure is
+    // never invoked, so init flows straight through).
+    init0 = ref(42)
+    same = string.seq_reduce(string.seq_empty(), init0, |acc: ptr, x: string| {
+        ref_set(init0, ref_get(init0) + 1)
+        return init0
+    })
+    if ref_get(same) != 42 {
+        println("FAIL 4b: reduce(empty, init) changed init to ${ref_get(same)}")
+        exit(1)
+    }
+    println("  PASS 4: reduce — char-count fold + empty-seq returns init")
+
+    // ---- zip_each (implicit zip, stops at shorter) -----------------
+    //
+    // Pair keys with values; the value seq is longer, so iteration must
+    // stop at the shorter (3 pairs). Build "k=v;" for each pair.
+    keys = string.split_to_seq("a,b,c", ",")
+    vals = string.split_to_seq("1,2,3,4,5", ",")
+    pairs = ref(0)
+    sb_zip = strbuilder.new(0)
+    string.seq_zip_each(keys, vals, |k: string, v: string| {
+        ref_set(pairs, ref_get(pairs) + 1)
+        strbuilder.append(sb_zip, k)
+        strbuilder.append(sb_zip, "=")
+        strbuilder.append(sb_zip, v)
+        strbuilder.append(sb_zip, ";")
+    })
+    if ref_get(pairs) != 3 {
+        println("FAIL 5a: zip_each made ${ref_get(pairs)} pairs, want 3 (shorter seq)")
+        exit(1)
+    }
+    zj = strbuilder.finish(sb_zip)
+    if string.equals(zj, "a=1;b=2;c=3;") != 1 {
+        println("FAIL 5b: zip_each=${zj}, want a=1;b=2;c=3;")
+        exit(1)
+    }
+    string.seq_free(keys)
+    string.seq_free(vals)
+    println("  PASS 5: zip_each — implicit zip stops at shorter seq")
+
+    string.seq_free(src)
+
+    // Reclaim the `ref` accumulator cells — `ref(...)` mallocs a bare
+    // cell with no scope tracking, so they need an explicit `ref_free`
+    // to keep the test leak-clean. (`acc_cell` and `init0` are the same
+    // cells `total`/`same` alias, so they're freed once each.)
+    ref_free(count)
+    ref_free(acc_cell)
+    ref_free(init0)
+    ref_free(pairs)
+
+    println("OK")
+    exit(0)
+}

--- a/tests/regression/test_when_statement.ae
+++ b/tests/regression/test_when_statement.ae
@@ -1,0 +1,103 @@
+// Regression test: compile-time `when` / static-if (issue #483)
+//
+// A `when COND { ... } else { ... }` is evaluated at COMPILE time. Only the
+// selected arm reaches type-checking and codegen; the unselected arm parses
+// but is pruned before either runs. This test proves all three properties on
+// any host, with no host-specific expected output:
+//
+//   (a) The selected branch executes (we pick the branch by the real host OS
+//       and confirm the matching code ran).
+//   (b) A `when` whose UNSELECTED arm calls a DELIBERATELY-UNDEFINED function
+//       still compiles and runs — proving the dead arm is neither type-checked
+//       nor emitted. `when false { ... }` is always-false on every host, so
+//       the undefined call always lands in the dead arm.
+//   (c) `target.arch` resolves and selects an arm.
+//
+// If the dead arm were type-checked, `undefined_must_not_link()` would be an
+// "undefined function" error and the build would fail. If it were emitted, the
+// C compiler / linker would fail on the missing symbol. The test passing
+// end-to-end is the proof that neither happens.
+
+extern exit(code: int)
+
+main() {
+    // ---- (b) The dead arm references an undefined symbol. -----------------
+    // `false` is a compile-time-constant bool, so the `else` arm is selected
+    // on every host and the `then` arm (with the undefined call) is pruned
+    // before typecheck. If pruning didn't happen, compilation would fail.
+    when false {
+        // This function is never declared anywhere. It must never be
+        // type-checked or emitted.
+        undefined_must_not_link()
+    } else {
+        println("  PASS: unselected `when` arm with undefined symbol was pruned")
+    }
+
+    // Symmetric check: an always-true condition selects the `then` arm and
+    // the undefined call sits in the `else` arm.
+    when true {
+        println("  PASS: always-true `when` selected the then-arm")
+    } else {
+        also_undefined_must_not_link()
+    }
+
+    // ---- (a) Real host selection via target.os. ---------------------------
+    // Exactly one arm runs; the others are pruned. Confirm a branch executed.
+    os_selected = 0
+    when target.os == "darwin" {
+        println("  selected os arm: darwin")
+        os_selected = 1
+    } else when target.os == "linux" {
+        println("  selected os arm: linux")
+        os_selected = 1
+    } else when target.os == "windows" {
+        println("  selected os arm: windows")
+        os_selected = 1
+    } else {
+        println("  selected os arm: other")
+        os_selected = 1
+    }
+    if os_selected != 1 {
+        println("FAIL: no target.os arm was selected")
+        exit(1)
+    }
+
+    // `!=` form: this arm runs on any real target ("plan9" is never one), so
+    // the else (with its undefined call) is always pruned.
+    os_ne_seen = 0
+    when target.os != "plan9" {
+        os_ne_seen = 1
+    } else {
+        nonexistent_plan9_only()
+    }
+    if os_ne_seen != 1 {
+        println("FAIL: target.os != arm did not run")
+        exit(1)
+    }
+
+    // ---- (c) target.arch selection. ---------------------------------------
+    arch_selected = 0
+    when target.arch == "x86_64" {
+        println("  selected arch arm: x86_64")
+        arch_selected = 1
+    } else when target.arch == "aarch64" {
+        println("  selected arch arm: aarch64")
+        arch_selected = 1
+    } else {
+        println("  selected arch arm: other")
+        arch_selected = 1
+    }
+    if arch_selected != 1 {
+        println("FAIL: no target.arch arm was selected")
+        exit(1)
+    }
+
+    // ---- Combined condition with ||. --------------------------------------
+    when target.os == "darwin" || target.os == "linux" || target.os == "windows" {
+        println("  PASS: combined `||` condition selected a mainstream-OS arm")
+    } else {
+        only_on_exotic_os()
+    }
+
+    println("  PASS: all `when` static-if checks passed")
+}

--- a/tests/regression/test_when_toplevel.ae
+++ b/tests/regression/test_when_toplevel.ae
@@ -1,0 +1,40 @@
+// Regression test: TOP-LEVEL compile-time `when` / static-if (issue #483)
+//
+// `when` also works around top-level declarations (externs, functions,
+// imports). The headline use case: a platform-specific extern binding gated
+// cleanly so the host doesn't need the symbol to exist.
+//
+// On a non-Windows host the `windows` arm — which declares an extern for a
+// Windows-only C symbol and a function that calls it — is pruned BEFORE
+// typecheck and codegen. The undefined `win_only_symbol` is therefore never
+// resolved, type-checked, or linked. If pruning didn't happen, the build
+// would fail on the missing symbol. The test compiling + running is the proof.
+
+extern exit(code: int)
+
+when target.os == "windows" {
+    extern win_only_symbol(x: int) -> int
+    plat_value() -> int { return win_only_symbol(7) }
+    plat_name() -> string { return "windows" }
+} else when target.os == "darwin" {
+    plat_value() -> int { return 1 }
+    plat_name() -> string { return "darwin" }
+} else when target.os == "linux" {
+    plat_value() -> int { return 2 }
+    plat_name() -> string { return "linux" }
+} else {
+    plat_value() -> int { return 99 }
+    plat_name() -> string { return "other" }
+}
+
+main() {
+    v = plat_value()
+    n = plat_name()
+    println("  selected top-level arm: ${n} (plat_value=${v})")
+    // plat_value must be the defined-arm value, never the pruned windows arm.
+    if v == 0 {
+        println("FAIL: no top-level `when` arm was selected")
+        exit(1)
+    }
+    println("  PASS: top-level `when` selected a defined platform arm")
+}

--- a/tests/regression/test_when_toplevel.ae
+++ b/tests/regression/test_when_toplevel.ae
@@ -1,40 +1,47 @@
 // Regression test: TOP-LEVEL compile-time `when` / static-if (issue #483)
 //
-// `when` also works around top-level declarations (externs, functions,
-// imports). The headline use case: a platform-specific extern binding gated
-// cleanly so the host doesn't need the symbol to exist.
+// `when` works around top-level declarations (externs, functions, imports).
+// Two things are proven here, PORTABLY (the proof must hold on every host,
+// including Windows):
 //
-// On a non-Windows host the `windows` arm — which declares an extern for a
-// Windows-only C symbol and a function that calls it — is pruned BEFORE
-// typecheck and codegen. The undefined `win_only_symbol` is therefore never
-// resolved, type-checked, or linked. If pruning didn't happen, the build
-// would fail on the missing symbol. The test compiling + running is the proof.
+//   1. PRUNING. An arm whose condition is false on EVERY platform declares
+//      and calls an undefined C symbol. It must be pruned BEFORE typecheck
+//      and codegen on every host — if it weren't, the link would fail on the
+//      missing symbol. (The condition is a bogus OS name, never `windows`,
+//      so this arm is dead everywhere — a `target.os == "windows"` gate would
+//      make the undefined symbol the LIVE arm on a Windows runner.)
+//
+//   2. SELECTION. Real per-platform arms (no undefined symbols) pick exactly
+//      one branch by `target.os` on any host.
 
 extern exit(code: int)
 
+// (1) Pruning proof — dead on every platform.
+when target.os == "nonexistent_platform_xyz" {
+    extern never_linked_symbol(x: int) -> int
+    gated_value() -> int { return never_linked_symbol(7) }
+} else {
+    gated_value() -> int { return 42 }
+}
+
+// (2) Selection proof — one real arm is chosen per host, no missing symbols.
 when target.os == "windows" {
-    extern win_only_symbol(x: int) -> int
-    plat_value() -> int { return win_only_symbol(7) }
     plat_name() -> string { return "windows" }
 } else when target.os == "darwin" {
-    plat_value() -> int { return 1 }
     plat_name() -> string { return "darwin" }
 } else when target.os == "linux" {
-    plat_value() -> int { return 2 }
     plat_name() -> string { return "linux" }
 } else {
-    plat_value() -> int { return 99 }
     plat_name() -> string { return "other" }
 }
 
 main() {
-    v = plat_value()
-    n = plat_name()
-    println("  selected top-level arm: ${n} (plat_value=${v})")
-    // plat_value must be the defined-arm value, never the pruned windows arm.
-    if v == 0 {
-        println("FAIL: no top-level `when` arm was selected")
+    // If the always-false arm weren't pruned, `never_linked_symbol` would
+    // fail to link and this program would never build/run.
+    if gated_value() != 42 {
+        println("FAIL: an always-false top-level `when` arm was not pruned")
         exit(1)
     }
-    println("  PASS: top-level `when` selected a defined platform arm")
+    println("  selected top-level arm: ${plat_name()}")
+    println("  PASS: top-level `when` — always-false arm pruned + platform arm selected")
 }


### PR DESCRIPTION
Five issues — a correctness fix plus performance and language-ergonomics features — each its own reviewable commit, all root-cause (no hacks), green on every local gate.

## Issues closed

- **#736 — ask/reply works with branched `reply`** (correctness). The request→reply type-map pre-pass only scanned a receive arm's *direct* children, so a `reply` inside `if/else`/`while`/`match` left the request unmapped and the `?` ask read a **garbage reply slot**. Now searches the arm body recursively. (Confirmed the bug returned a random pointer; now returns each branch's value.)
- **#482 — compile-time constant evaluation** (perf). Folds `const` initializers at compile time as a **hard-whitelisted folder** (not an interpreter — a VM would breach the `--emit=lib` capability gate): `string.concat`, `string.from_int/long/float`, and constant arrays, on top of the existing arithmetic folding.
- **#421 — closure-based sequence combinators** (perf). `seq_each/map/filter/reduce` + 2-seq `seq_zip_each` over `*StringSeq` — single **iterative** spine walks (O(n) time, O(1) stack, no recursion), invoking Aether closures through the runtime ABI. 0 leaks.
- **#464 — finish the stdlib caps audit (T3)** (memory-safety). Route module-internal fixed-size allocations through the cap allocator (collections MapKeys/FloatArray, regex, xml, proxy). **Deliberately scoped to internal structs** — the public network structs are left raw because their free functions are called on caller/test-allocated instances, and cap-accounting such a free underflows the counter.
- **#483 — compile-time `when` / static-if** (ergonomics). A Nim-style `when target.os == "windows" { ... } else { ... }` where only the selected arm is type-checked and emitted — so platform-gated externs compile cleanly (the dead arm may reference undefined symbols). Reuses #482's const-evaluator; disambiguated from the existing `when` match-guard.

(#422 — symbol-stored hash slots — was investigated and **declined as architecturally inapplicable**: it presumes a runtime symbol environment Aether's AOT-to-C model doesn't have; the win it wants already exists as static struct-offset access. Not built, by design.)

## Two bugs caught during integration (and fixed)
- The first #464 pass converted **public** struct frees (`http_response_free`) to caps, which underflowed the accounting on test/externally-allocated instances — caught by the unit suite's underflow assert, root-caused, and fixed by scoping caps to module-internal structs only.
- #736 itself was the actor ask/reply correctness hole.

## Verification (all local, all green)
- `make compiler ae stdlib EXTRA_CFLAGS="-Werror"` — clean.
- CFLAGS-stripped compile of every touched std file (the include-path gotcha) — 0 failures.
- `make test` 231/231 · `make test-asan` 231/231 (no UAF/double-free, no caps underflow) · `make test-ae` 749/749 · `make examples` 84/84.
- macOS leaks gate — **213 programs, 0 over budget**; all five new regression tests 0 leaks.
- Verified directly: branched ask/reply returns correct values; the `when` dead-arm with an undefined symbol still compiles+runs; the existing `when` match-guard still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)