### PR TITLE
docs(LLM.md): match-over-if-chain dispatch idiom + disambiguate the two `when`s [skip actions]

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -131,6 +131,19 @@ plays that role), no interfaces.
 
 ## Idioms that keep biting
 
+- **String/int dispatch → `match`, not an `if` chain.** `match (mode) {
+  "check" -> {…} "up" -> {…} _ -> {…} }` — string arms compare by content,
+  int arms by value, `_` is the wildcard. Beats a chained `if mode == "…"`
+  and a C-style `switch` (`case V:`, literals, no binding). `match` also
+  captures/destructures lists (`[h|t]`); for range/relational branching use
+  **guarded function clauses** (`grade(s) when s >= 90 -> "A"` — the Erlang-
+  style multi-clause form), and an `if`-expression for a value-producing
+  two-way choice. `match`/`switch` arms are literal-only; guards are the
+  escape to conditions. NB: this clause-level `when` (a runtime guard) is a
+  *different* construct from the top-level/statement **compile-time `when`**
+  (static-if: `when target.os == "windows" { … } else { … }`, only the
+  selected arm is type-checked/emitted — see `docs/when-static-if.md`). Same
+  keyword, two unrelated meanings.
 - **Go-style returns, not tuples-as-values.** `fs.write_atomic(path,
   data, len) -> string` — empty string = success, non-empty = error
   message. Don't "improve" the convention, it's consistent across all


### PR DESCRIPTION
Adds one "Idioms that keep biting" bullet to `LLM.md` (notes-to-self for an LLM picking up mid-task).

## What & why

A sibling repo hit the pattern this prevents — a chain of `if mode == "check" { … }` / `if mode == "up" { … }` where a `match` is cleaner. The bullet records:

- **String/int dispatch → `match`**, not an `if` chain or a C-style `switch` (strings compare by content, ints by value, `_` is the wildcard).
- Pointers to the right tool for the neighbouring cases: guarded function clauses for range/relational branching, `if`-expression for a value-producing two-way choice; `match`/`switch` arms are literal-only.

## Disambiguation fix

The bullet also clears up a keyword collision that became live in v0.310/0.311: the **compile-time `when`** (static-if — `when target.os == "windows" { … } else { … }`, only the selected arm is type-checked/emitted, `docs/when-static-if.md`) is a *different construct* from the Erlang-style **clause-level `when` guard** (`grade(s) when s >= 90 -> "A"`). Same keyword, two unrelated meanings — worth a future LLM not conflating them.

`[skip actions]` — doc-only, no compiler/std/runtime touched, so the CI matrix (Windows + leak-detection) adds nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)