### PR TITLE
feat(compiler): sizeof/offsetof in const initializers (#879) + type/keyword tokens as value identifiers (#880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ next version number before tagging the release.
 
 ### Added
 
+- **`sizeof` / `offsetof` in `const` initializers** (#879). The two layout
+  builtins are now accepted in a top-level `const` initializer (and arithmetic
+  over them) — `const SIZEOF_T = sizeof(T)`, `const OFF = offsetof(T, field)`,
+  `const PAD = sizeof(T) + 8`. They lower to C compile-time constant
+  expressions, so a port that mirrors C structs as `extern struct` overlays can
+  centralise its offset/size table as named consts that are self-verifying by
+  construction (the C compiler folds each value) instead of hand-maintaining
+  numbers plus `_Static_assert` drift guards. The general "no function calls in
+  a `const` initializer" rule is unchanged; these two builtins are the carve-out.
+
+- **Type/keyword tokens usable as value identifiers** (#880). `ptr`, `byte`,
+  `func`, `state` and `after` can now be used as ordinary value identifiers —
+  parameter names, local names, struct field names, struct-literal fields, and
+  field-access targets — without the `` `name` `` backtick escape. These tokens
+  have meaning only in type / declaration-head / statement-head position, so a
+  bare occurrence in value position is unambiguously a name. A C→Aether port no
+  longer has to rename `ptr`→`ptr_`, `func`→`fn_val`, etc. (`match` and `union`
+  stay reserved — `match` heads a match expression; `union` is a C keyword that
+  can't be emitted as a C identifier — use the backtick escape for those.)
+
 - **Distinct types: `type Name = distinct Base`** (#480). A zero-cost nominal
   wrapper over a scalar / `string` / `ptr` base — `type USD = distinct float`,
   `type Fd = distinct int`. Lowers to the base C type (no boxing), but the type

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -905,6 +905,16 @@ static int is_const_expression(ASTNode* expr, SymbolTable* table) {
             }
             return 1;
         }
+        case AST_SIZEOF:
+        case AST_OFFSETOF:
+            /* #879: `sizeof(T)` / `offsetof(T, f)` lower to C compile-time
+             * constants (`((int)sizeof(struct T))` / `((int)offsetof(...))`)
+             * — no evaluation, allocation, or side effect. They are valid
+             * const initializers (the E0200 "function calls re-evaluate"
+             * rationale doesn't apply); they merely share call syntax. Lets a
+             * port centralise struct sizes/offsets as named `const`s instead
+             * of a hand-maintained, drift-prone offset table. */
+            return 1;
         case AST_FUNCTION_CALL:
             /* Only the hard whitelist of pure conversions (folded to
              * literals by the optimizer post-typecheck). Every other

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -123,6 +123,31 @@ static int token_is_reserved_keyword(Token* token) {
     return 1;
 }
 
+// #880: tokens accepted as an ordinary value identifier in name position —
+// a parameter / local binding, an assignment target, a tuple-destructure
+// slot. `ptr`/`byte` are keywords only in type position, `func` only as a
+// declaration head, `state`/`after` only as statement heads; none of those
+// roles reaches a value-identifier position, so accept the spelling (carried
+// in `->value`) as the name. Two members of the issue's list are deliberately
+// left out: `match` (heads a match expression — genuinely ambiguous in value
+// position) and `union` (a C keyword, so a value named `union` would emit
+// invalid C — supporting it needs value-identifier mangling in codegen, a
+// separate change).
+static int token_is_value_ident(const Token* token) {
+    if (!token) return 0;
+    switch (token->type) {
+        case TOKEN_IDENTIFIER:
+        case TOKEN_STATE:
+        case TOKEN_PTR:
+        case TOKEN_BYTE:
+        case TOKEN_FUNC:
+        case TOKEN_AFTER:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
 // C ABI scalar aliases — recognised exact C type spellings. When a
 // type-position identifier matches one, parse_type builds a Type with
 // the given `kind` (which governs all typechecking and arithmetic)
@@ -1016,7 +1041,8 @@ ASTNode* parse_primary_expression(Parser* parser) {
                     int looks_qualified_struct = 0;
                     if (t_after && t_after->type == TOKEN_RIGHT_BRACE) {
                         looks_qualified_struct = 1;
-                    } else if (t_after && t_after->type == TOKEN_IDENTIFIER) {
+                    } else if (t_after && token_is_value_ident(t_after)) {
+                        // #880: value-identifier keyword as the first field name
                         Token* t_colon = peek_ahead(parser, 5);
                         if (t_colon && t_colon->type == TOKEN_COLON) {
                             looks_qualified_struct = 1;
@@ -1036,8 +1062,14 @@ ASTNode* parse_primary_expression(Parser* parser) {
                         ASTNode* struct_lit = create_ast_node(AST_STRUCT_LITERAL, struct_name, s_line, s_col);
                         if (!match_token(parser, TOKEN_RIGHT_BRACE)) {
                             do {
-                                Token* field_name = expect_token(parser, TOKEN_IDENTIFIER);
-                                if (!field_name) { free_ast_node(struct_lit); return NULL; }
+                                // #880: accept value-identifier keyword field names
+                                Token* field_name = peek_token(parser);
+                                if (field_name && token_is_value_ident(field_name)) {
+                                    advance_token(parser);
+                                } else {
+                                    field_name = expect_token(parser, TOKEN_IDENTIFIER);
+                                    if (!field_name) { free_ast_node(struct_lit); return NULL; }
+                                }
                                 if (!expect_token(parser, TOKEN_COLON)) { free_ast_node(struct_lit); return NULL; }
                                 ASTNode* value_expr = parse_expression(parser);
                                 if (!value_expr) { free_ast_node(struct_lit); return NULL; }
@@ -1072,7 +1104,10 @@ ASTNode* parse_primary_expression(Parser* parser) {
                 if (after_brace && after_brace->type == TOKEN_RIGHT_BRACE) {
                     // TypeName {} — empty struct literal
                     looks_like_struct = true;
-                } else if (after_brace && after_brace->type == TOKEN_IDENTIFIER) {
+                } else if (after_brace && token_is_value_ident(after_brace)) {
+                    // #880: a first field named with a value-identifier keyword
+                    // (`ptr`/`byte`/`func`/`state`/`after`) still marks this as
+                    // a struct literal, not an identifier-then-block.
                     Token* after_field = peek_ahead(parser, 3);
                     if (after_field && after_field->type == TOKEN_COLON) {
                         // TypeName { field: value } — struct literal
@@ -1093,11 +1128,19 @@ ASTNode* parse_primary_expression(Parser* parser) {
                 // Parse field initializers
                 if (!match_token(parser, TOKEN_RIGHT_BRACE)) {
                     do {
-                        // Parse field name
-                        Token* field_name = expect_token(parser, TOKEN_IDENTIFIER);
-                        if (!field_name) {
-                            free_ast_node(struct_lit);
-                            return NULL;
+                        // Parse field name. #880: accept the value-identifier
+                        // keywords (`ptr`/`byte`/`func`/`state`/`after`) so a
+                        // literal can initialise a struct whose fields carry
+                        // those (valid-C) names.
+                        Token* field_name = peek_token(parser);
+                        if (field_name && token_is_value_ident(field_name)) {
+                            advance_token(parser);
+                        } else {
+                            field_name = expect_token(parser, TOKEN_IDENTIFIER);
+                            if (!field_name) {
+                                free_ast_node(struct_lit);
+                                return NULL;
+                            }
                         }
 
                         // Expect colon
@@ -1295,6 +1338,17 @@ ASTNode* parse_primary_expression(Parser* parser) {
 
         case TOKEN_STATE:
             // Outside actor bodies, 'state' is treated as a regular identifier
+        case TOKEN_PTR:
+        case TOKEN_BYTE:
+        case TOKEN_FUNC:
+        case TOKEN_AFTER:
+            // #880: these keywords have meaning only in type position
+            // (`ptr`/`byte`), as a declaration head (`func`) or as statement
+            // heads (`state`/`after`) — none of which reach a primary-
+            // expression operand. So in value position (e.g. `return ptr`,
+            // `ptr + 1`, `func.field`) accept them as ordinary identifiers.
+            // `match` (match-expression head) and `union` (a C keyword that
+            // can't be a C identifier) are deliberately NOT here (#880).
             return create_identifier_node(advance_token(parser));
 
         case TOKEN_PIPE:
@@ -2091,6 +2145,15 @@ ASTNode* parse_statement(Parser* parser) {
         case TOKEN_STATE:
             // Outside actor bodies, 'state' is a regular identifier
             // fall through
+        case TOKEN_FUNC:
+        case TOKEN_AFTER:
+            // #880: `func`/`after` have no statement-head role (and are not
+            // type keywords), so at the start of a statement they are a value
+            // identifier — a local binding (`func = compute()`), an
+            // assignment / compound-assign target, or the head of an
+            // expression statement. Routed through the identifier path below.
+            // (`ptr`/`byte` are type keywords: bare `byte b = ...` stays a
+            // typed declaration; the value-name form is `let byte = ...`.)
         case TOKEN_IDENTIFIER: {
             // Check if this is: identifier = expression (Python-style)
             // or tuple destructuring: identifier, identifier = expression
@@ -2120,7 +2183,7 @@ ASTNode* parse_statement(Parser* parser) {
                          next->type == TOKEN_LSHIFT_ASSIGN || next->type == TOKEN_RSHIFT_ASSIGN)) {
                 // Consume identifier
                 Token* name = peek_token(parser);
-                if (!name || (name->type != TOKEN_IDENTIFIER && name->type != TOKEN_STATE)) {
+                if (!token_is_value_ident(name)) {
                     parser_error(parser, "Expected identifier");
                     return NULL;
                 }
@@ -2192,9 +2255,10 @@ ASTNode* parse_variable_declaration_with_semicolon(Parser* parser, bool expect_s
 
 // Python-style variable declaration: x = 42 (no 'let', type inferred)
 ASTNode* parse_python_style_declaration(Parser* parser) {
-    // Accept TOKEN_IDENTIFIER or TOKEN_STATE (state is a regular identifier outside actors)
+    // Accept a value-identifier token as the binding name — TOKEN_IDENTIFIER,
+    // `state` (a regular identifier outside actors), or the #880 keyword set.
     Token* name = peek_token(parser);
-    if (!name || (name->type != TOKEN_IDENTIFIER && name->type != TOKEN_STATE)) {
+    if (!token_is_value_ident(name)) {
         parser_error(parser, "Expected identifier");
         return NULL;
     }
@@ -2222,7 +2286,7 @@ ASTNode* parse_python_style_declaration(Parser* parser) {
                 ASTNode* discard = create_ast_node(AST_VARIABLE_DECLARATION, "_", next_name->line, next_name->column);
                 discard->node_type = create_type(TYPE_UNKNOWN);
                 add_child(destructure, discard);
-            } else if (next_name->type == TOKEN_IDENTIFIER || next_name->type == TOKEN_STATE) {
+            } else if (token_is_value_ident(next_name)) {
                 advance_token(parser);
                 ASTNode* var = create_ast_node(AST_VARIABLE_DECLARATION, next_name->value, next_name->line, next_name->column);
                 var->node_type = create_type(TYPE_UNKNOWN);
@@ -3592,8 +3656,17 @@ ASTNode* parse_receive_statement(Parser* parser) {
 // already emitted). Caller wires the result into the parent struct's
 // children list.
 ASTNode* parse_extern_struct_field(Parser* parser) {
-    Token* fname = expect_token(parser, TOKEN_IDENTIFIER);
-    if (!fname) return NULL;
+    // #880: accept the value-identifier keywords (`ptr`/`byte`/`func`/`state`/
+    // `after`) as extern-struct field NAMES — these mirror C struct fields and
+    // are all valid C field identifiers. The `name:` form is unambiguous (the
+    // name is always first), so no type/name disambiguation is needed here.
+    Token* fname = peek_token(parser);
+    if (fname && token_is_value_ident(fname)) {
+        advance_token(parser);
+    } else {
+        fname = expect_token(parser, TOKEN_IDENTIFIER);
+        if (!fname) return NULL;
+    }
 
     if (!expect_token(parser, TOKEN_COLON)) return NULL;
 
@@ -4354,22 +4427,34 @@ ASTNode* parse_pattern(Parser* parser) {
             return pattern;
         }
         
+        // #880: `func`/`state`/`after` are keywords only as declaration /
+        // statement heads, never types — so in pattern / parameter-NAME
+        // position they are unambiguously a binding name (their `->value`
+        // holds the spelling). Accept them here as a variable pattern.
+        // (`ptr`/`byte` ARE type keywords, so they share the C-style
+        // typed-parameter block below, which disambiguates `byte b` (type)
+        // from `byte: int` / `byte` (name) by the next token.) `match`
+        // (expression head) and `union` (a C keyword) stay reserved (#880).
+        case TOKEN_FUNC:
+        case TOKEN_STATE:
+        case TOKEN_AFTER:
         case TOKEN_IDENTIFIER: {
             // Check if it's a wildcard _
-            if (strcmp(token->value, "_") == 0) {
+            if (token->type == TOKEN_IDENTIFIER && strcmp(token->value, "_") == 0) {
                 advance_token(parser);
-                ASTNode* pattern = create_ast_node(AST_PATTERN_LITERAL, "_", 
+                ASTNode* pattern = create_ast_node(AST_PATTERN_LITERAL, "_",
                                                   token->line, token->column);
                 pattern->node_type = create_type(TYPE_WILDCARD);
                 return pattern;
             }
-            
-            // Check if it's a struct pattern: Point{x: 0, y: 0}
+
+            // Check if it's a struct pattern: Point{x: 0, y: 0} (real
+            // identifiers only — a keyword token is never a struct name).
             Token* next = peek_ahead(parser, 1);
-            if (next && next->type == TOKEN_LEFT_BRACE) {
+            if (token->type == TOKEN_IDENTIFIER && next && next->type == TOKEN_LEFT_BRACE) {
                 return parse_struct_pattern(parser);
             }
-            
+
             // Regular variable pattern
             advance_token(parser);
             ASTNode* pattern = create_ast_node(AST_PATTERN_VARIABLE, token->value,
@@ -4443,6 +4528,33 @@ ASTNode* parse_pattern(Parser* parser) {
                 }
                 return pattern;
             }
+            // #880: `byte`/`ptr` are type keywords that double as natural value
+            // identifiers in C ports. When NOT followed by an identifier they
+            // are the parameter NAME, not a type — `f(byte: int)`, `f(ptr)`,
+            // `f(ptr = 0)`. (The `<type> <name>` C-style form above already
+            // consumed the `next == identifier` case.) The other type keywords
+            // in this group (int/float/...) are not value identifiers, so they
+            // keep falling through to expression parsing.
+            if (token->type == TOKEN_BYTE || token->type == TOKEN_PTR) {
+                advance_token(parser);
+                ASTNode* pattern = create_ast_node(AST_PATTERN_VARIABLE, token->value,
+                                                   token->line, token->column);
+                if (match_token(parser, TOKEN_COLON)) {
+                    Type* param_type = parse_type(parser);
+                    pattern->node_type = param_type ? param_type : create_type(TYPE_UNKNOWN);
+                } else {
+                    pattern->node_type = create_type(TYPE_UNKNOWN);
+                }
+                if (match_token(parser, TOKEN_ASSIGN)) {
+                    ASTNode* default_expr = parse_expression(parser);
+                    if (default_expr) {
+                        add_child(pattern, default_expr);
+                        if (pattern->annotation) free(pattern->annotation);
+                        pattern->annotation = strdup("has_default");
+                    }
+                }
+                return pattern;
+            }
             // Fall through to expression parsing
             return parse_expression(parser);
         }
@@ -4465,11 +4577,18 @@ ASTNode* parse_struct_pattern(Parser* parser) {
 
     if (!match_token(parser, TOKEN_RIGHT_BRACE)) {
         do {
-            Token* field = expect_token(parser, TOKEN_IDENTIFIER);
-            if (!field) break;
+            // #880: accept value-identifier keyword field names when
+            // destructuring (`Box{ ptr: p }`).
+            Token* field = peek_token(parser);
+            if (field && token_is_value_ident(field)) {
+                advance_token(parser);
+            } else {
+                field = expect_token(parser, TOKEN_IDENTIFIER);
+                if (!field) break;
+            }
 
             if (!expect_token(parser, TOKEN_COLON)) break;
-            
+
             ASTNode* field_pattern = parse_pattern(parser);
             if (field_pattern) {
                 // Store field name in pattern
@@ -4590,10 +4709,22 @@ ASTNode* parse_struct_definition(Parser* parser) {
             }
         }
 
-        Token* field_name = expect_token(parser, TOKEN_IDENTIFIER);
-        if (!field_name) {
-            if (c_type) free_type(c_type);
-            return NULL;
+        // #880: accept the value-identifier keywords (`ptr`/`byte`/`func`/
+        // `state`/`after`) as field NAMES — C ports routinely have struct
+        // fields so named, and each is a valid C struct-field identifier. The
+        // `<type> <name>` C-style form above already consumed the case where
+        // such a keyword is the field TYPE (e.g. `byte b`), so a keyword
+        // remaining here is the name. Anything else falls to the standard
+        // identifier error.
+        Token* field_name = peek_token(parser);
+        if (field_name && token_is_value_ident(field_name)) {
+            advance_token(parser);
+        } else {
+            field_name = expect_token(parser, TOKEN_IDENTIFIER);
+            if (!field_name) {
+                if (c_type) free_type(c_type);
+                return NULL;
+            }
         }
 
         // Create field node

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -289,6 +289,18 @@ const G_BUF = malloc(64)        // ERROR: const initializer must be a
 
 The reason is `const`'s substitution-at-each-use semantics: the compiler inlines the RHS at every reference rather than storing the value. For literal RHSs this is fine; for `make_thing()` it would re-call the function on every reference, allocating fresh state. If you need a process-global heap object initialised once and read everywhere, use [`std.config`](stdlib-reference.md#stdconfig--stringstring-kv) for string state or [`std.actors`](stdlib-reference.md#stdactors--name--actor_ref-registry) for actor references — both are described in the stdlib reference.
 
+**Exception — `sizeof` / `offsetof`.** The two layout builtins `sizeof(T)` and `offsetof(T, field)` *are* allowed in a `const` initializer (and arithmetic over them), even though they are spelled with call syntax. They lower to C compile-time constant expressions (`(int)sizeof(struct T)` / `(int)offsetof(struct T, field)`) — no evaluation, allocation, or side effect — so the substitution-at-each-use semantics are harmless:
+
+```aether
+extern struct JSString { gc_mark: uint64 : 1  len: uint64 : 60  buf: byte[] }
+
+const SIZEOF_JSSTRING = sizeof(JSString)          // ok — folds to a C constant
+const STR_BUF_OFFSET  = offsetof(JSString, buf)   // ok
+const STR_PADDED      = sizeof(JSString) + 8      // arithmetic over them is ok too
+```
+
+This lets a port that mirrors C structs as `extern struct` overlays centralise its offset/size table as named consts that are **self-verifying by construction** — the C compiler computes each value, so it cannot drift from the real layout — instead of hand-maintaining numeric offsets plus `_Static_assert` drift guards. The general "no function calls in a `const` initializer" rule is unchanged; these two layout builtins are the only carve-out.
+
 ### Mutable module-level globals
 
 Where a `const` is a fixed value, a module-level `var` is **one persistent, mutable word of state** shared by every function in the module — a PRNG seed, a monotonic counter, a one-slot cache:
@@ -1852,6 +1864,16 @@ The following identifiers are reserved:
 
 Note: `state` is context-sensitive — it is a keyword only inside actor bodies. In all other code, `state` can be used as a regular variable name.
 
+Note: **`ptr`, `byte`, `func`, `state` and `after` are usable as ordinary value identifiers** — parameter names, local names, struct field names, struct-literal fields, and field-access targets — *without* the backtick escape. These tokens have meaning only in type position (`ptr`/`byte`), as a declaration head (`func`), or as a statement head (`state`/`after`), none of which overlaps a value position, so a bare `ptr`/`byte`/`func`/`state`/`after` in value position is unambiguously a name:
+
+```aether
+add(ptr: int) -> int { return ptr + 1 }     // `ptr` is the parameter name
+struct Node { func: int  after: int }        // keyword-spelled field names
+main() { let byte = 7  println("${byte}") }  // keyword-spelled local
+```
+
+Two members of that family stay reserved in value position: `match` (it heads a match expression, so `match` as a bare value is genuinely ambiguous) and `union` (a C keyword — a value named `union` could not be emitted as valid C). For those, rename or use the backtick escape below. As a type keyword, `byte`/`ptr` still works in type position too: `byte b` declares `b` of type `byte` (the `<type> <name>` C-style form), while `byte: int` / `byte` in name position is the name.
+
 Note: `void` is **not** a reserved word — there is no `void` token. It is a plain identifier used by convention to *spell* the absence of a return value (e.g. `extern free(p: ptr) -> void`); a function that omits its `-> Type` annotation is the canonical void declaration. See [Functions](#functions).
 
 ### Raw identifiers — using a keyword as a name
@@ -1876,7 +1898,13 @@ addReply(`reply`: int, `after`: int) -> int {
 The escaped text is the name (`` `reply` `` is the identifier `reply`), so a
 raw identifier and the plain spelling refer to the same binding. The primary
 use is keeping a C→Aether port faithful: C APIs routinely use names like
-`reply`, `message`, `after`, and `ptr` that collide with Aether keywords.
+`reply`, `message`, and `when` that collide with Aether keywords.
+
+(For the common port collisions `ptr`, `byte`, `func`, `state` and `after`,
+the backtick escape is **not** required — they are accepted bare as value
+identifiers, see the note under [Keywords](#keywords) above. The escape is
+still the way to use a fully-reserved keyword such as `reply`, `message`,
+`when`, `match`, or `union` as a name.)
 
 Writing an *unescaped* reserved keyword where a name is expected is an error
 (`error[E0100]: '<kw>' is a reserved keyword …`) whose hint points to both the

--- a/tests/regression/test_issue879_const_sizeof_offsetof.ae
+++ b/tests/regression/test_issue879_const_sizeof_offsetof.ae
@@ -1,0 +1,42 @@
+// Regression: issue #879 — `sizeof(T)` / `offsetof(T, field)` are accepted in
+// a top-level `const` initializer (they lower to C compile-time constants),
+// including arithmetic over them and over other consts. This lets a port that
+// mirrors C structs as `extern struct` overlays centralise its layout table as
+// named consts that are self-verifying by construction (the C compiler folds
+// the value), instead of hand-maintaining numbers + _Static_asserts.
+
+extern exit(code: int)
+
+extern struct Layout {
+    a: int
+    b: int
+    c: int
+}
+
+const SIZEOF_LAYOUT = sizeof(Layout)          // 12 on a 4-byte-int target
+const OFF_B         = offsetof(Layout, b)      // 4
+const OFF_C         = offsetof(Layout, c)      // 8
+const PADDED        = sizeof(Layout) + 8       // arithmetic over sizeof
+const COMBINED      = offsetof(Layout, c) - offsetof(Layout, b)  // 4
+
+main() {
+    // Compare against the same builtins used inline (which were always legal),
+    // so the test is independent of the target's exact int width / alignment.
+    if SIZEOF_LAYOUT != sizeof(Layout) {
+        println("FAIL #879: const sizeof initializer")
+        exit(1)
+    }
+    if OFF_B != offsetof(Layout, b) {
+        println("FAIL #879: const offsetof initializer")
+        exit(1)
+    }
+    if PADDED != sizeof(Layout) + 8 {
+        println("FAIL #879: const arithmetic over sizeof")
+        exit(1)
+    }
+    if COMBINED != OFF_C - OFF_B {
+        println("FAIL #879: const arithmetic over offsetof consts")
+        exit(1)
+    }
+    println("PASS: #879 sizeof/offsetof usable in const initializers")
+}

--- a/tests/regression/test_issue880_keyword_value_idents.ae
+++ b/tests/regression/test_issue880_keyword_value_idents.ae
@@ -1,0 +1,63 @@
+// Regression: issue #880 — the type/keyword tokens `ptr`, `byte`, `func`,
+// `state` and `after` are usable as ordinary value identifiers (parameter
+// names, local names, struct field names + access, struct-literal fields)
+// WITHOUT the backtick escape, since none of them have a meaning in value
+// position. A C→Aether port can keep the source's identifier names instead of
+// mechanically renaming `ptr`→`ptr_`, `func`→`fn_val`, etc.
+//
+// `match` (heads a match expression) and `union` (a C keyword that cannot be a
+// C identifier) deliberately stay reserved — those still need a rename or the
+// backtick escape.
+
+extern exit(code: int)
+
+// Each token as a parameter name, used as a value in the body.
+add_ptr(ptr: int) -> int   { return ptr + 1 }
+add_func(func: int) -> int { return func + 1 }
+add_byte(byte: int) -> int { return byte + 1 }
+add_state(state: int) -> int { return state + 1 }
+add_after(after: int) -> int { return after + 1 }
+
+// C-style typed param: here `byte` is the TYPE and `b` the name — still works.
+cstyle_byte(byte b) -> int { return b + 1 }
+
+// Struct whose fields are spelled with the keyword tokens.
+struct Node {
+    ptr: int
+    func: int
+    after: int
+}
+
+main() {
+    if add_ptr(10) != 11 { println("FAIL #880: ptr param"); exit(1) }
+    if add_func(20) != 21 { println("FAIL #880: func param"); exit(1) }
+    if add_byte(30) != 31 { println("FAIL #880: byte param"); exit(1) }
+    if add_state(40) != 41 { println("FAIL #880: state param"); exit(1) }
+    if add_after(50) != 51 { println("FAIL #880: after param"); exit(1) }
+    if cstyle_byte(99) != 100 { println("FAIL #880: C-style byte type still works"); exit(1) }
+
+    // Struct field definition + literal + access with keyword names.
+    n = Node { ptr: 1, func: 2, after: 3 }
+    if n.ptr + n.func + n.after != 6 {
+        println("FAIL #880: struct field def/literal/access")
+        exit(1)
+    }
+
+    // Local bindings via `let` (works for all five).
+    let ptr = 100
+    let func = 200
+    let byte = 7
+    let after = 3
+    if ptr + func + byte + after != 310 {
+        println("FAIL #880: keyword-named locals")
+        exit(1)
+    }
+
+    // Bare assignment + compound-assignment on a keyword-named local.
+    func = func + 1
+    after += 10
+    if func != 201 { println("FAIL #880: bare assignment"); exit(1) }
+    if after != 13 { println("FAIL #880: compound assignment"); exit(1) }
+
+    println("PASS: #880 ptr/byte/func/state/after usable as value identifiers")
+}


### PR DESCRIPTION
## Summary

Two C-porting papercuts from the mquickjs port, both `extern struct` / C-port ergonomics.

Closes #879
Closes #880

### #879 — `sizeof` / `offsetof` in `const` initializers

`sizeof(T)` / `offsetof(T, field)` (and arithmetic over them) are now accepted in a top-level `const` initializer. They lower to C compile-time constant expressions (`(int)sizeof(struct T)` / `(int)offsetof(struct T, field)`) — no evaluation, allocation, or side effect — so the E0200 "function calls re-evaluate/re-allocate" rationale does not apply; they merely share call syntax. The general "no function calls in a `const` initializer" rule is unchanged; these two layout builtins are the only carve-out.

```aether
extern struct JSString { gc_mark: uint64 : 1  len: uint64 : 60  buf: byte[] }
const SIZEOF_JSSTRING = sizeof(JSString)
const STR_BUF_OFFSET  = offsetof(JSString, buf)
const STR_PADDED      = sizeof(JSString) + 8
```

This lets an `extern struct` port centralise its offset/size table as named consts that are self-verifying by construction (the C compiler folds each value, so it cannot drift from the real layout), retiring the hand-maintained numbers + `_Static_assert` drift guards.

Implementation: two cases in `is_const_expression` (typechecker).

### #880 — type/keyword tokens as value identifiers

`ptr`, `byte`, `func`, `state` and `after` are now usable as ordinary value identifiers — parameter names, local names, struct field names, struct-literal fields, field-access targets, and assignment targets — without the `` `name` `` backtick escape. These tokens carry meaning only in type / declaration-head / statement-head position, none of which overlaps a value position, so a bare occurrence in value position is unambiguously a name.

```aether
add(ptr: int) -> int { return ptr + 1 }
struct Node { func: int  after: int }
main() { let byte = 7  println("${byte}") }
```

Parser-only change: a new `token_is_value_ident` helper drives every value-identifier name site (`parse_pattern`, `parse_primary`, the statement-head dispatch, python-style declaration, tuple destructure, struct definition / extern-struct field, struct literal + its disambiguation heuristic, struct pattern). `ptr`/`byte` keep their type role — the C-style `byte b` typed form still parses, disambiguated from the `byte` / `byte: T` name form by the next token.

`match` (heads a match expression) and `union` (a C keyword that can't be emitted as a C identifier) deliberately stay reserved; the backtick escape (#867) still covers them. Supporting `union` as a value identifier needs value-identifier mangling across the codegen's many declarator-emission sites — a separate, focused change.

## Tests

- `tests/regression/test_issue879_const_sizeof_offsetof.ae` — sizeof/offsetof/arithmetic in const initializers, self-checking.
- `tests/regression/test_issue880_keyword_value_idents.ae` — the five tokens across params, locals, struct field def/literal/access, assignments; C-style `byte b` still works.

## Verification

- C unit suite: 231/231.
- `.ae` regression + integration: all parser-exercising tests pass; the only failures on this machine are pre-existing OpenSSL/TLS/base64 (the local stdlib is built without OpenSSL) and a sandbox-runtime link artifact — none touch the parser/typechecker.
- `make examples`: passes except the two sandbox-runtime-link examples (same pre-existing artifact).
- `-Wall -Wextra -Werror` clean on both changed translation units.
- Both changes only relax existing rules, so they cannot break code that compiled before.

## Docs

- `docs/language-reference.md`: const `sizeof`/`offsetof` carve-out; keyword notes for the value-usable tokens; raw-identifier section updated.
- `CHANGELOG.md`: entries for #879 and #880.