### PR TITLE
docs(changelog): split the 0.309 mega-block into 0.311–0.316, restore [current] [skip actions]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.309.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
-## [0.309.0]
+## [current]
+
+## [0.316.0]
 
 ### Added
 
@@ -33,6 +35,10 @@ next version number before tagging the release.
   stay reserved — `match` heads a match expression; `union` is a C keyword that
   can't be emitted as a C identifier — use the backtick escape for those.)
 
+## [0.315.0]
+
+### Added
+
 - **Distinct types: `type Name = distinct Base`** (#480). A zero-cost nominal
   wrapper over a scalar / `string` / `ptr` base — `type USD = distinct float`,
   `type Fd = distinct int`. Lowers to the base C type (no boxing), but the type
@@ -42,6 +48,10 @@ next version number before tagging the release.
   declarations/assignments and at call-argument boundaries (a `Fd` parameter
   rejects a raw `int`; an `EUR` is rejected where `USD` is wanted) — the
   capability-token discipline now compiler-checked.
+
+## [0.314.0]
+
+### Added
 
 - **Gradual contracts: `where` clauses on function parameters** (#525). A
   parameter may carry a runtime-checked precondition: `divide(a: int, b: int
@@ -53,6 +63,10 @@ next version number before tagging the release.
   `--no-contracts` like the other contract checks. (`where` on bindings is a
   tracked follow-up — it needs a binding-syntax decision, since Aether bindings
   are prefix/inferred, not the issue's postfix `let x: T` form.)
+
+## [0.313.0]
+
+### Added
 
 - **Static purity inference + the `__pure(fn)` builtin** (#522). A whole-program
   analysis classifies each function pure/impure: pure means it transitively
@@ -70,6 +84,11 @@ next version number before tagging the release.
   `--with=fs,net,os` gate (whole-program) as a finer, per-function axis. A raw
   `extern` call is unclassifiable and is not flagged, matching the `--with=`
   gate's boundary.
+
+## [0.312.0]
+
+### Added
+
 - **`@scoped` bindings — opt-in escape analysis** (#521). A `let`/`var`
   declaration annotated `@scoped` (`@scoped let buf = make_buffer()`) declares
   that the value must not outlive its lexical block. The typechecker rejects
@@ -78,6 +97,11 @@ next version number before tagging the release.
   inserting it into a container (`list.add`/`map.put`/…). Only a scalar
   *derived* from it may escape (`return buf.len()`). Not a borrow checker —
   one opt-in annotation that turns a non-escape into a checked invariant.
+
+## [0.311.0]
+
+### Added
+
 - **Raw identifiers: `` `name` `` escapes a reserved keyword for use as an
   ordinary identifier** (#867). A backtick-delimited identifier is always
   lexed as a plain name, so a faithful C→Aether port can keep identifiers
@@ -119,6 +143,17 @@ next version number before tagging the release.
   E0301. The merge now injects a synthetic bare import for each merged module's
   own bare imports, re-opening the qualified surface (kept out of the
   user-explicit registry, preserving #243 sealed-scope isolation).
+
+## [0.310.0]
+
+_No user-facing language/stdlib changes recorded for this release; see git
+history for internal/infra commits._
+
+## [0.309.0]
+
+_The entries previously listed here were misattributed: they shipped across
+0.311–0.316 and have been moved to their correct release sections above. See
+those sections for the real 0.311–0.316 notes._
 
 ## [0.308.0]
 


### PR DESCRIPTION
## The drift

`CHANGELOG.md`'s top version header was `## [0.309.0]`, but the latest tag is **v0.316.0** — and 0.310 through 0.316 had **no entries at all**. The release pipeline kept renaming `[current]` → the next version each release, but the content was never split per-release, so a single `## [0.309.0]` block had absorbed eight releases' worth of notes. The workflow note (line 8) had also been mangled by the pipeline's `sed` to read `## [0.309.0]` instead of `## [current]`.

## The fix

Reattributed every entry to its real release. Boundaries determined authoritatively with `git tag --contains` on each feature PR's merge commit (not timestamp arithmetic — the merges landed minutes before each release cut):

| Release | Entries | via |
|---|---|---|
| 0.316.0 | #879 sizeof/offsetof in const, #880 keyword-value idents | PR #895 |
| 0.315.0 | #480 distinct types | PR #887 |
| 0.314.0 | #525 `where`-clause contracts | PR #885 |
| 0.313.0 | #522 purity inference, #481 effect tags | PR #883 |
| 0.312.0 | #521 `@scoped` escape analysis | PR #881 |
| 0.311.0 | #867 raw idents, #790 heap.new strings, #868 --audit-mem + Fixed #869/#870 | PR #875 |

- **0.309 / 0.310** had no entries in the block — left short breadcrumb notes (0.309 explains the entries moved; 0.310 notes no user-facing changes recorded).
- **Workflow note** restored to `## [current]`; a fresh empty `## [current]` seeded at the top so the next PR has somewhere to land (and the pipeline has a token to rename).

Verified: gapless `current → 0.316 → … → 0.308` header sequence, and per-release bullet counts match the PR→release mapping. No entry text changed — only regrouped under correct headers.

`[skip actions]` — doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)