### PR TITLE
feat(compiler): address-of operator &lvalue (#890) + array-to-pointer decay (#892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ next version number before tagging the release.
 
 ### Added
 
+- **Address-of operator `&lvalue`** (#890). Prefix `&` takes the address of an
+  lvalue and lowers to C's `&` — `&(p as *T).field` → `&((T*)p)->field`,
+  `&local.field` → `&local.field`, plus `&local` / `&arr[i]`. The result is a
+  pointer (assignable to a `ptr` parameter), so a C extern with a
+  `&struct->field` out-param (in-place mutation, sub-field write, resize
+  destination) is callable without raw `mem.long_to_ptr(base + OFFSET)` offset
+  math.
+
+- **Array-to-pointer decay in pointer context** (#892). A named fixed-size
+  array decays to a pointer to its first element when used as an inferred
+  binding initializer, a `ptr`-typed argument, or in a pointer comparison
+  (C semantics). `ids = static_ids` (with `byte[128] static_ids`) infers `ids`
+  as a `ptr`, so a later `ids = heap` / `ids = null` stays legal — the
+  stack-buffer-with-heap-fallback idiom. An array *literal* (`x = [1,2,3]`)
+  still binds a real array; annotate explicitly to keep the array type.
+
 - **Distinct types: `type Name = distinct Base`** (#480). A zero-cost nominal
   wrapper over a scalar / `string` / `ptr` base — `type USD = distinct float`,
   `type Fd = distinct int`. Lowers to the base C type (no boxing), but the type

--- a/compiler/analysis/type_inference.c
+++ b/compiler/analysis/type_inference.c
@@ -364,8 +364,21 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                 if (is_type_inferrable(node->node_type)) {
                     Type* init_type = node->children[0]->node_type;
                     if (init_type && init_type->kind != TYPE_UNKNOWN) {
-                        node->node_type = clone_type(init_type);
-                        add_constraint(ctx, node, init_type, "variable initialization");
+                        /* #892: a NAMED array initializer decays to a pointer
+                         * (C array-to-pointer decay), so `ids = static_ids`
+                         * (static_ids: byte[N]) infers `ids` as a plain `ptr`
+                         * and a later `ids = heap` stays legal. Mirror the
+                         * decay in the typechecker (infer path) so codegen
+                         * emits `void* ids`, not an array declarator. An array
+                         * LITERAL is not an identifier, so it still binds an
+                         * array. */
+                        if (init_type->kind == TYPE_ARRAY &&
+                            node->children[0]->type == AST_IDENTIFIER) {
+                            node->node_type = create_type(TYPE_PTR);
+                        } else {
+                            node->node_type = clone_type(init_type);
+                            add_constraint(ctx, node, init_type, "variable initialization");
+                        }
                     }
                 }
             }

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -994,7 +994,14 @@ int is_type_compatible(Type* from, Type* to) {
     if (from->kind == TYPE_ARRAY && to->kind == TYPE_ARRAY) {
         return is_type_compatible(from->element_type, to->element_type);
     }
-    
+
+    // #892: array-to-pointer decay (C semantics). A fixed-size array is
+    // assignable to a pointer — `ptr p = byte_buf`, a `ptr`-typed argument,
+    // or comparison against a pointer. This already worked at call sites; the
+    // rule makes it uniform so a stack-buffer-with-heap-fallback binding
+    // (`ids = static_ids; ... ids = heap`) type-checks.
+    if (from->kind == TYPE_ARRAY && to->kind == TYPE_PTR) return 1;
+
     // Actor reference compatibility
     // Bare actor_ref (no type parameter) is compatible with any actor_ref
     if (from->kind == TYPE_ACTOR_REF && to->kind == TYPE_ACTOR_REF) {
@@ -1625,7 +1632,18 @@ Type* infer_unary_type(ASTNode* operand, AeTokenType operator) {
         case TOKEN_INCREMENT:
         case TOKEN_DECREMENT:
             return clone_type(operand_type); // Same type as operand
-            
+
+        case TOKEN_AMPERSAND: {
+            /* #890: address-of `&lvalue` yields a pointer to the operand's
+             * type — `&x` where `x: T` is `*T` (TYPE_PTR with element_type T).
+             * Carries the pointee type for `as *T` round-trips and deref, and
+             * is assignable to a bare `ptr` parameter (the C `&field`
+             * out-param case the issue targets). */
+            Type* p = create_type(TYPE_PTR);
+            p->element_type = clone_type(operand_type);
+            return p;
+        }
+
         default:
             return create_type(TYPE_UNKNOWN);
     }
@@ -3506,7 +3524,21 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 // If variable has no explicit type (TYPE_UNKNOWN), use initializer's type
                 if (!stmt->node_type || stmt->node_type->kind == TYPE_UNKNOWN) {
                     if (stmt->node_type) free_type(stmt->node_type);
-                    stmt->node_type = clone_type(init_type);
+                    /* #892: a NAMED array used as an initializer decays to a
+                     * pointer, matching C's array-to-pointer decay. So
+                     * `ids = static_ids` (static_ids: byte[N]) infers `ids`
+                     * as a plain `ptr`, not an array type — keeping a later
+                     * `ids = heap` / `ids = null` legal (the stack-buffer-
+                     * with-heap-fallback C idiom). An array LITERAL
+                     * initializer (`x = [1,2,3]`) is NOT an identifier, so it
+                     * still binds a real array; only a named-array lvalue
+                     * decays. */
+                    if (init_type && init_type->kind == TYPE_ARRAY &&
+                        init && init->type == AST_IDENTIFIER) {
+                        stmt->node_type = create_type(TYPE_PTR);
+                    } else {
+                        stmt->node_type = clone_type(init_type);
+                    }
                 } else if (!array_const_int_narrow && !is_assignable(init_type, stmt->node_type)) {
                     // Has explicit type but initializer doesn't match
                     free_type(init_type);

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -1818,7 +1818,23 @@ ASTNode* parse_unary_expression(Parser* parser) {
         if (!operand) return NULL;
         return create_unary_expression(operand, operator);
     }
-    
+
+    // #890: prefix `&` is the address-of operator on an lvalue —
+    // `&local.field`, `&(p as *T).field`, `&local`, `&arr[i]`. It lowers to
+    // C's `&` and is typed as a pointer, so a C extern with a `&struct->field`
+    // out-param can be called without raw `mem.long_to_ptr(base + OFFSET)`
+    // offset math. A leading `&` here is unambiguous: a *binary* `&` (bitwise
+    // AND) is consumed by the binary-expression parser, never reaching the
+    // operand position. The operand is parsed at postfix precedence so member
+    // access / cast / index bind tighter than `&` (matching C: `&p.b` is
+    // `&(p.b)`).
+    if (operator->type == TOKEN_AMPERSAND) {
+        advance_token(parser);
+        ASTNode* operand = parse_unary_expression(parser);
+        if (!operand) return NULL;
+        return create_unary_expression(operand, operator);
+    }
+
     return parse_postfix_expression(parser);
 }
 

--- a/docs/c-interop.md
+++ b/docs/c-interop.md
@@ -618,6 +618,29 @@ main() {
 
 The `as` keyword is the same token already used for module-import aliasing (`import std.cryptography as crypto`). The two parses don't collide because import-aliasing is recognised only inside `import` statements; expression-level `as *T` is recognised only as a postfix operator on expressions. Both forms continue to work in the same source file.
 
+### Address of a field — `&lvalue`
+
+The prefix `&` operator takes the address of an lvalue and lowers directly to C's `&`. This is what a C extern with a `&struct->field` out-parameter needs (in-place mutation, a sub-field written by the callee, a `memcpy`/resize destination):
+
+```aether
+extern struct JSObject {
+    proto: long
+    u: union { array: struct { tab: long  len: uint32_t } }
+}
+extern js_shrink_value_array(ctx: ptr, slot: ptr, new_len: int)
+
+shrink(ctx: ptr, p: ptr, new_len: int) {
+    js_shrink_value_array(ctx, &(p as *JSObject).u.array.tab, new_len)
+}
+```
+
+- `&(p as *T).field` lowers to `&((T*)p)->field` — the address of a field on an `extern struct` / `*StructName` overlay.
+- `&local.field` lowers to `&local.field` — the address of a field on an Aether-owned value struct.
+- `&local` and `&arr[i]` work the same way (address of a local, address of an array element).
+- The result is typed as a pointer to the field's type (`*T`), assignable to a bare `ptr` parameter. Like the overlay casts, it is a raw view: the pointer is valid only while the underlying storage is.
+
+Without `&`, a `&struct->field` out-param forces raw `mem.long_to_ptr(base + OFFSET)` offset math, re-introducing the hand-maintained offset constant the typed overlay was meant to eliminate.
+
 ### Typed array view — `expr as T[]`
 
 The third axis of the `as` family (after `*StructName` and `fn(...) -> R`). Views a raw `ptr` as a typed C element-pointer so subscript access scales by `sizeof(T)` automatically. Use this whenever the underlying storage is a `malloc`'d typed buffer and you'd otherwise be writing `mem.set_int(buf, 4*i, v)` boilerplate.

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -150,6 +150,20 @@ string[5] names;           // Array of 5 strings
 float[100] values;         // Array of 100 floats
 ```
 
+**Array-to-pointer decay.** A named fixed-size array decays to a pointer to its first element in pointer context — when assigned to an inferred binding, passed as a `ptr`-typed argument, or compared against a pointer (the same rule C uses):
+
+```aether
+byte[128] static_ids
+ids = static_ids           // `ids` is inferred as a `ptr` (decays), not an array
+heap = null
+if id_count > 8 {
+    heap = malloc(256)
+    ids = heap             // legal: `ids` is a reassignable pointer
+}
+```
+
+This is the stack-buffer-with-heap-fallback idiom (`T buf[N]; T* p = buf; if (n > N) p = malloc(...)`). Only a *named array* decays; an array *literal* initializer (`x = [1, 2, 3]`) still binds a real array. To keep the array type, annotate the binding explicitly (`x: byte[128] = ...`).
+
 ### Sequence Types (`*StringSeq`)
 
 `*StringSeq` is a cons-cell linked list of strings — Erlang/Elixir-shaped, with O(1) head/tail/cons/length and refcount-based structural sharing. Empty list is the `NULL` pointer; each cell carries a cached length.

--- a/tests/regression/test_issue890_address_of_field.ae
+++ b/tests/regression/test_issue890_address_of_field.ae
@@ -1,0 +1,39 @@
+// Regression: issue #890 — the address-of operator `&lvalue` takes the
+// address of a struct field (or any lvalue), lowering to C's `&`. This lets a
+// C extern with a `&struct->field` out-param be called without raw
+// `mem.long_to_ptr(base + OFFSET)` offset math.
+//   &local.field          ->  &local.field
+//   &(p as *T).field       ->  &((T*)p)->field
+
+import std.mem
+extern exit(code: int)
+
+struct Pair { a: long  b: long }
+extern struct JSObject { proto: long  tab: long }   // tab at byte offset 8
+
+// A C-style helper that writes a long THROUGH a pointer to a field.
+fill_long(dst: ptr, v: long) { mem.set_long(dst, 0, v) }
+
+// Mutate a field in place via &(p as *T).field on an extern-struct overlay.
+poke_tab(p: ptr) { fill_long(&(p as *JSObject).tab, 42) }
+
+main() {
+    // &local.field on an Aether-owned value struct.
+    pr = Pair { a: 1, b: 2 }
+    fill_long(&pr.b, 99)
+    if pr.b != 99 {
+        println("FAIL #890: &local.field did not write through")
+        exit(1)
+    }
+
+    // &(p as *T).field on a typed overlay over a raw buffer.
+    byte[16] buf
+    mem.set_long(buf, 0, 7)
+    poke_tab(buf)                 // buf decays to ptr at the call site
+    if mem.get_long(buf, 8) != 42 {
+        println("FAIL #890: &(p as *T).field did not write through")
+        exit(1)
+    }
+
+    println("PASS: #890 address-of struct field")
+}

--- a/tests/regression/test_issue892_array_ptr_decay.ae
+++ b/tests/regression/test_issue892_array_ptr_decay.ae
@@ -1,0 +1,37 @@
+// Regression: issue #892 — a named fixed-size array (`byte[N]`) decays to a
+// pointer when used as an initializer, matching C's array-to-pointer decay. So
+// `ids = static_ids` infers `ids` as a plain `ptr` (not an array type), and a
+// later `ids = heap` / `ids = null` is legal — the stack-buffer-with-heap-
+// fallback C idiom (`T buf[N]; T* p = buf; if (n > N) p = malloc(...)`).
+
+import std.mem
+extern exit(code: int)
+extern malloc(n: uint64) -> ptr
+extern free(p: ptr)
+
+main() {
+    byte[128] static_ids
+    mem.set_int(static_ids, 0, 11)
+
+    ids = static_ids                 // decays to ptr (was: "array type not assignable")
+    if mem.get_int(ids, 0) != 11 {
+        println("FAIL #892: decayed pointer does not alias the array")
+        exit(1)
+    }
+
+    // Reassign the same binding to a heap pointer — only legal if `ids` is ptr.
+    heap = null
+    id_count = 9
+    if id_count > 8 {
+        heap = malloc(256)
+        ids = heap
+    }
+    mem.set_int(ids, 4, 42)
+    if mem.get_int(ids, 4) != 42 {
+        println("FAIL #892: write through reassigned heap pointer failed")
+        exit(1)
+    }
+    if heap != null { free(heap) }
+
+    println("PASS: #892 array decays to pointer in pointer context")
+}


### PR DESCRIPTION
## Summary

Two C-FFI papercuts from the mquickjs port. Both are about reaching C memory faithfully from typed Aether.

Closes #890
Closes #892

(The third issue in the cluster, #894 — passing an Aether function where a C fn-pointer is expected — was verified **already working** on `main` and closed separately, with a libc-`qsort` + Aether-comparator proof.)

### #890 — address-of operator `&lvalue`

Prefix `&` now takes the address of an lvalue, lowering to C's `&`:

- `&(p as *T).field` → `&((T*)p)->field`  (field on an `extern struct` / `*StructName` overlay)
- `&local.field` → `&local.field`  (field on an Aether-owned value struct)
- `&local`, `&arr[i]` likewise

The result is typed as a pointer to the field's type, so a C extern with a `&struct->field` out-param (in-place mutation, a sub-field written by the callee, a resize/`memcpy` destination) is callable directly — retiring the raw `mem.long_to_ptr(base + OFFSET)` fallback that re-introduced hand-maintained offset constants.

Parser-only addition plus a type rule: a leading `&` in operand position is unambiguous (binary `&` is consumed by the binary-expression parser), the operand binds at postfix precedence (so `&p.b` is `&(p.b)`, matching C), and the existing unary `(&(operand))` emission composes with member-access lvalue lowering — no codegen change needed.

### #892 — array-to-pointer decay in pointer context

A named fixed-size array decays to a pointer to its first element when used in pointer context (C semantics):

```aether
byte[128] static_ids
ids = static_ids        // `ids` infers as a `ptr`, not an array type
heap = null
if id_count > 8 {
    heap = malloc(256)
    ids = heap          // legal: `ids` is a reassignable pointer
}
```

This is the stack-buffer-with-heap-fallback idiom. Applied in both inference passes (`type_inference.c` drives codegen; the typechecker mirrors it), and `is_assignable` now treats `array → ptr` as a valid decay. Restricted to a *named-array* RHS — an array *literal* (`x = [1,2,3]`) still binds a real array, and an explicit `x: byte[N] = ...` keeps the array type.

## Tests

- `tests/regression/test_issue890_address_of_field.ae` — `&local.field` and `&(p as *T).field` write through, self-checking.
- `tests/regression/test_issue892_array_ptr_decay.ae` — `byte[N]` decays at assignment and the binding is reassignable to a heap pointer.

## Verification

- C unit suite: 231/231.
- `.ae` regression + `make examples`: no new failures — the only failures on this machine are the pre-existing no-OpenSSL/TLS/base64 artifacts (the local stdlib is built without OpenSSL) and a sandbox-runtime-link artifact, neither touched by these changes. The array-decay change is exercised by the full array-using suite with no regressions.
- `-Wall -Wextra -Werror` clean on all three changed translation units.

## Docs

- `docs/c-interop.md`: new "Address of a field — `&lvalue`" subsection.
- `docs/language-reference.md`: array-to-pointer decay note in Array Types.
- `CHANGELOG.md`: entries for #890 and #892.