### PR TITLE
feat(compiler): labeled break / continue (#893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ next version number before tagging the release.
 
 ### Added
 
+- **Labeled `break` / `continue`** (#893). A `while` / `for` loop can carry a
+  label — `outer: while ...` — and `break outer` / `continue outer` then target
+  that loop from inside a nested loop (`break` exits it, `continue` jumps to its
+  next iteration). This replaces the boolean-flag emulation a faithful C port
+  otherwise needs for a nested-loop early exit (the `goto cleanup` idiom). The
+  label must be on the same line as the `break`/`continue`; a label naming no
+  enclosing loop is a compile-time error; defers in the unwound scopes still run
+  (LIFO) before the jump. Unlabeled `break`/`continue` are unchanged.
+
 - **`@c_struct` typed overlays — width-correct C-struct field access over a
   raw `ptr`** (#891). Declare a C struct's layout once with explicit offsets
   (`@c_struct stream { length: uint64 @8, slen: uint32 @16, last_id: streamID

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -3528,9 +3528,36 @@ int typecheck_struct_definition(ASTNode* struct_def, SymbolTable* table) {
     return 1;
 }
 
+/* #893: enclosing loop labels, for validating `break label` / `continue
+ * label`. Pushed (one slot per loop, NULL for an unlabeled loop) while a
+ * loop body is type-checked. Type-checking is single-threaded, so a file-
+ * static stack is sufficient. */
+#define TC_MAX_LOOP_LABELS 256
+static const char* tc_loop_labels[TC_MAX_LOOP_LABELS];
+static int tc_loop_label_depth = 0;
+
+static void tc_push_loop_label(const char* label) {
+    if (tc_loop_label_depth < TC_MAX_LOOP_LABELS) {
+        tc_loop_labels[tc_loop_label_depth] = label;
+    }
+    tc_loop_label_depth++;   /* always increment so pop stays balanced */
+}
+static void tc_pop_loop_label(void) {
+    if (tc_loop_label_depth > 0) tc_loop_label_depth--;
+}
+static int tc_loop_label_in_scope(const char* label) {
+    if (!label) return 0;
+    int n = tc_loop_label_depth < TC_MAX_LOOP_LABELS
+          ? tc_loop_label_depth : TC_MAX_LOOP_LABELS;
+    for (int i = 0; i < n; i++) {
+        if (tc_loop_labels[i] && strcmp(tc_loop_labels[i], label) == 0) return 1;
+    }
+    return 0;
+}
+
 int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
     if (!stmt) return 0;
-    
+
     switch (stmt->type) {
         case AST_TUPLE_DESTRUCTURE: {
             // a, b = func() — last child is RHS, others are variable declarations
@@ -4017,11 +4044,14 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 typecheck_expression(stmt->children[2], loop_table);
             }
             
-            // Type check body (child 3)
+            // Type check body (child 3) — #893: with this loop's label in
+            // scope for break/continue validation.
             if (stmt->child_count > 3 && stmt->children[3]) {
+                tc_push_loop_label(stmt->value);
                 typecheck_statement(stmt->children[3], loop_table);
+                tc_pop_loop_label();
             }
-            
+
             free_symbol_table(loop_table);
             return 1;
         }
@@ -4040,13 +4070,31 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 free_type(cond_type);
             }
 
-            // Type check loop body
+            // Type check loop body (#893: with this loop's label in scope so
+            // a `break`/`continue <label>` inside it validates).
+            tc_push_loop_label(stmt->value);
             for (int i = 1; i < stmt->child_count; i++) {
                 typecheck_statement(stmt->children[i], table);
             }
+            tc_pop_loop_label();
             return 1;
         }
-        
+
+        case AST_BREAK_STATEMENT:
+        case AST_CONTINUE_STATEMENT:
+            /* #893: a labeled break/continue must name an enclosing loop. */
+            if (stmt->value && !tc_loop_label_in_scope(stmt->value)) {
+                char msg[256];
+                snprintf(msg, sizeof(msg),
+                    "no enclosing loop labeled '%s' for `%s %s`",
+                    stmt->value,
+                    stmt->type == AST_BREAK_STATEMENT ? "break" : "continue",
+                    stmt->value);
+                type_error(msg, stmt->line, stmt->column);
+                return 0;
+            }
+            return 1;
+
         case AST_BLOCK: {
             SymbolTable* block_table = create_symbol_table(table);
 

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -317,6 +317,13 @@ CodeGenerator* create_code_generator(FILE* output) {
     gen->try_frame_depth = 0;
     gen->loop_nest_depth = 0;
     memset(gen->loop_try_base, 0, sizeof(gen->loop_try_base));
+    // #893: labeled break/continue tracking
+    memset(gen->loop_label, 0, sizeof(gen->loop_label));
+    memset(gen->loop_label_scope, 0, sizeof(gen->loop_label_scope));
+    memset(gen->loop_label_id, 0, sizeof(gen->loop_label_id));
+    memset(gen->loop_label_break_used, 0, sizeof(gen->loop_label_break_used));
+    memset(gen->loop_label_continue_used, 0, sizeof(gen->loop_label_continue_used));
+    gen->next_loop_label_id = 0;
     // Issue #501 follow-up: try-clobbered locals tracking
     gen->try_clobbered_vars = NULL;
     gen->try_clobbered_var_count = 0;
@@ -988,6 +995,32 @@ void emit_defers_for_scope(CodeGenerator* gen) {
     int scope_start = gen->scope_defer_start[gen->scope_depth - 1];
 
     // Emit defers in LIFO order (reverse)
+    for (int i = gen->defer_count - 1; i >= scope_start; i--) {
+        ASTNode* deferred = gen->defer_stack[i];
+        if (deferred) {
+            if (try_emit_heap_string_exit_free(gen, deferred)) continue;
+            if (try_emit_seq_exit_free(gen, deferred)) continue;
+            if (try_emit_struct_destroy(gen, deferred)) continue;
+            print_indent(gen);
+            fprintf(gen->output, "/* deferred */ ");
+            generate_statement(gen, deferred);
+        }
+    }
+}
+
+// #893: emit defers for every scope from the innermost down to (but NOT
+// including) `floor_depth`. Labeled break/continue unwind multiple scopes at
+// once — a `break L` exits every scope nested inside the scope that CONTAINS
+// loop L — so the defers of all of them must run before the goto. `floor_depth`
+// is the scope_depth that contains the labeled loop, recorded when the loop was
+// entered. Emits only; it does not mutate scope/defer state, so the normal
+// fall-through path still runs exit_scope for each scope as usual.
+void emit_defers_through_scope(CodeGenerator* gen, int floor_depth) {
+    if (gen->scope_depth <= 0) return;
+    if (floor_depth < 0) floor_depth = 0;
+    if (floor_depth >= gen->scope_depth) { emit_defers_for_scope(gen); return; }
+
+    int scope_start = gen->scope_defer_start[floor_depth];
     for (int i = gen->defer_count - 1; i >= scope_start; i--) {
         ASTNode* deferred = gen->defer_stack[i];
         if (deferred) {

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -110,6 +110,20 @@ typedef struct {
     int loop_try_base[AETHER_MAX_LOOP_NEST];
     int loop_nest_depth;
 
+    // Labeled break/continue (#893). Parallel to loop_try_base, indexed by
+    // loop_nest_depth. For each enclosing loop: its source label (or NULL),
+    // the scope_depth of the scope CONTAINING the loop (so a labeled
+    // break/continue can emit defers for exactly the scopes it unwinds), a
+    // unique id used to mint the C goto labels, and whether the break/continue
+    // target labels were actually referenced (so only a C label that is used
+    // gets emitted, avoiding -Wunused-label).
+    const char* loop_label[AETHER_MAX_LOOP_NEST];
+    int loop_label_scope[AETHER_MAX_LOOP_NEST];
+    int loop_label_id[AETHER_MAX_LOOP_NEST];
+    int loop_label_break_used[AETHER_MAX_LOOP_NEST];
+    int loop_label_continue_used[AETHER_MAX_LOOP_NEST];
+    int next_loop_label_id;
+
     // try-clobbered locals: variable names modified inside any try
     // body of the current function.  Such locals — when declared
     // in an enclosing scope of the try — must be lowered as

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -122,6 +122,7 @@ const char* codegen_normalise_callee(const char* raw, char* out, size_t out_size
 void push_defer(CodeGenerator* gen, ASTNode* stmt);
 void push_auto_defer(CodeGenerator* gen, const char* free_fn, const char* var_name);
 void emit_defers_for_scope(CodeGenerator* gen);
+void emit_defers_through_scope(CodeGenerator* gen, int floor_depth);
 void emit_all_defers(CodeGenerator* gen);
 void emit_all_defers_protected(CodeGenerator* gen, char** protected_names, int protected_count);
 void enter_scope(CodeGenerator* gen);

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -3315,6 +3315,17 @@ static void push_struct_destroy_defer(CodeGenerator* gen, const char* var_name,
     }
 }
 
+// #893: innermost enclosing loop whose source label matches `name`, or -1.
+// Searches the loop-nest stack from the inside out, so a reused label binds
+// to the nearest loop (the standard rule).
+static int find_labeled_loop_level(CodeGenerator* gen, const char* name) {
+    if (!name) return -1;
+    for (int d = gen->loop_nest_depth - 1; d >= 0; d--) {
+        if (gen->loop_label[d] && strcmp(gen->loop_label[d], name) == 0) return d;
+    }
+    return -1;
+}
+
 void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
     if (!stmt) return;
 
@@ -4999,18 +5010,38 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             if (gen->emit_lib) {
                 print_line(gen, "if (aether_caps_deadline_tripped()) { __aether_abort_call(); break; }");
             }
-            /* Issue #501: snapshot try_frame_depth at loop entry. */
+            /* Issue #501: snapshot try_frame_depth at loop entry.
+             * #893: record the loop's label / containing scope / C-label id. */
+            int for_lbl_idx = -1;
             if (gen->loop_nest_depth < AETHER_MAX_LOOP_NEST) {
-                gen->loop_try_base[gen->loop_nest_depth++] = gen->try_frame_depth;
+                for_lbl_idx = gen->loop_nest_depth;
+                gen->loop_try_base[for_lbl_idx] = gen->try_frame_depth;
+                gen->loop_label[for_lbl_idx] = stmt->value;
+                gen->loop_label_scope[for_lbl_idx] = gen->scope_depth;
+                gen->loop_label_id[for_lbl_idx] = gen->next_loop_label_id++;
+                gen->loop_label_break_used[for_lbl_idx] = 0;
+                gen->loop_label_continue_used[for_lbl_idx] = 0;
+                gen->loop_nest_depth++;
             }
             if (stmt->child_count > 3 && stmt->children[3]) {
                 // Body is always a statement (could be a block or single statement)
                 generate_statement(gen, stmt->children[3]); // body
             }
             if (gen->loop_nest_depth > 0) gen->loop_nest_depth--;
+            /* #893: labeled-continue target — end of the body, so falling
+             * through runs the C `for`'s increment then re-tests the condition. */
+            if (for_lbl_idx >= 0 && gen->loop_label[for_lbl_idx] &&
+                gen->loop_label_continue_used[for_lbl_idx]) {
+                print_line(gen, "__ae_cont_%d: ;", gen->loop_label_id[for_lbl_idx]);
+            }
             unindent(gen);
 
             print_line(gen, "}");
+            /* #893: labeled-break target — after the loop. */
+            if (for_lbl_idx >= 0 && gen->loop_label[for_lbl_idx] &&
+                gen->loop_label_break_used[for_lbl_idx]) {
+                print_line(gen, "__ae_brk_%d: ;", gen->loop_label_id[for_lbl_idx]);
+            }
             break;
 
         case AST_WHILE_LOOP: {
@@ -5053,17 +5084,39 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             }
             /* Issue #501: snapshot try_frame_depth at loop entry so
              * `break` / `continue` inside the body drains only
-             * frames pushed *inside* the loop, not outer-scope tries. */
+             * frames pushed *inside* the loop, not outer-scope tries.
+             * #893: record the loop's label / containing scope / a fresh
+             * C-label id in the same slot. */
+            int while_lbl_idx = -1;
             if (gen->loop_nest_depth < AETHER_MAX_LOOP_NEST) {
-                gen->loop_try_base[gen->loop_nest_depth++] = gen->try_frame_depth;
+                while_lbl_idx = gen->loop_nest_depth;
+                gen->loop_try_base[while_lbl_idx] = gen->try_frame_depth;
+                gen->loop_label[while_lbl_idx] = stmt->value;
+                gen->loop_label_scope[while_lbl_idx] = gen->scope_depth;
+                gen->loop_label_id[while_lbl_idx] = gen->next_loop_label_id++;
+                gen->loop_label_break_used[while_lbl_idx] = 0;
+                gen->loop_label_continue_used[while_lbl_idx] = 0;
+                gen->loop_nest_depth++;
             }
             if (stmt->child_count > 1) {
                 generate_statement(gen, stmt->children[1]);
             }
             if (gen->loop_nest_depth > 0) gen->loop_nest_depth--;
+            /* #893: labeled-continue target — end of the loop body, after the
+             * body's scope-exit defers, so the loop re-tests the condition. */
+            if (while_lbl_idx >= 0 && gen->loop_label[while_lbl_idx] &&
+                gen->loop_label_continue_used[while_lbl_idx]) {
+                print_line(gen, "__ae_cont_%d: ;", gen->loop_label_id[while_lbl_idx]);
+            }
             unindent(gen);
 
             print_line(gen, "}");
+
+            /* #893: labeled-break target — after the loop. */
+            if (while_lbl_idx >= 0 && gen->loop_label[while_lbl_idx] &&
+                gen->loop_label_break_used[while_lbl_idx]) {
+                print_line(gen, "__ae_brk_%d: ;", gen->loop_label_id[while_lbl_idx]);
+            }
 
             if (has_sends && gen->current_actor == NULL) {
                 print_line(gen, "scheduler_send_batch_flush();");
@@ -5667,23 +5720,55 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             break;
         }
 
-        case AST_BREAK_STATEMENT:
-            // Emit defers for current scope before break
-            emit_defers_for_scope(gen);
-            /* Issue #501: drain try frames pushed inside the current
-             * loop body so `break` from inside a try { } in a loop
-             * doesn't leak the panic frame. */
-            emit_try_pops_for_break_continue(gen);
-            print_line(gen, "break;");
+        case AST_BREAK_STATEMENT: {
+            int lvl = stmt->value ? find_labeled_loop_level(gen, stmt->value) : -1;
+            if (stmt->value && lvl >= 0) {
+                /* #893: labeled break — unwind every scope nested inside the
+                 * target loop (run their defers), drain the try frames pushed
+                 * since that loop was entered, then jump past the loop. */
+                emit_defers_through_scope(gen, gen->loop_label_scope[lvl]);
+                int drop = gen->try_frame_depth - gen->loop_try_base[lvl];
+                for (int i = 0; i < drop; i++) {
+                    print_indent(gen);
+                    fprintf(gen->output, "aether_try_pop();\n");
+                }
+                gen->loop_label_break_used[lvl] = 1;
+                print_line(gen, "goto __ae_brk_%d;", gen->loop_label_id[lvl]);
+            } else {
+                // Emit defers for current scope before break
+                emit_defers_for_scope(gen);
+                /* Issue #501: drain try frames pushed inside the current
+                 * loop body so `break` from inside a try { } in a loop
+                 * doesn't leak the panic frame. */
+                emit_try_pops_for_break_continue(gen);
+                print_line(gen, "break;");
+            }
             break;
+        }
 
-        case AST_CONTINUE_STATEMENT:
-            // Emit defers for current scope before continue
-            emit_defers_for_scope(gen);
-            /* Issue #501: drain inside-loop try frames. */
-            emit_try_pops_for_break_continue(gen);
-            print_line(gen, "continue;");
+        case AST_CONTINUE_STATEMENT: {
+            int lvl = stmt->value ? find_labeled_loop_level(gen, stmt->value) : -1;
+            if (stmt->value && lvl >= 0) {
+                /* #893: labeled continue — unwind nested scopes and inner try
+                 * frames, then jump to the end of the target loop's body (where
+                 * the loop re-tests / increments). */
+                emit_defers_through_scope(gen, gen->loop_label_scope[lvl]);
+                int drop = gen->try_frame_depth - gen->loop_try_base[lvl];
+                for (int i = 0; i < drop; i++) {
+                    print_indent(gen);
+                    fprintf(gen->output, "aether_try_pop();\n");
+                }
+                gen->loop_label_continue_used[lvl] = 1;
+                print_line(gen, "goto __ae_cont_%d;", gen->loop_label_id[lvl]);
+            } else {
+                // Emit defers for current scope before continue
+                emit_defers_for_scope(gen);
+                /* Issue #501: drain inside-loop try frames. */
+                emit_try_pops_for_break_continue(gen);
+                print_line(gen, "continue;");
+            }
             break;
+        }
 
         case AST_DEFER_STATEMENT:
             // Push deferred statement to stack - will be executed at scope exit

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -1922,7 +1922,32 @@ int get_operator_precedence(AeTokenType type) {
 ASTNode* parse_statement(Parser* parser) {
     Token* token = peek_token(parser);
     if (!token) return NULL;
-    
+
+    // #893: labeled loop — `label: while ...` / `label: for ...`. A leading
+    // identifier followed by `:` and a loop keyword is a loop label; the loop's
+    // AST node carries the label name in its `value`, and `break label` /
+    // `continue label` inside it target that loop. Disambiguated from a typed
+    // declaration (`x: int = ...`) by requiring `while`/`for` after the colon —
+    // a type name never appears there.
+    if (token->type == TOKEN_IDENTIFIER) {
+        Token* colon = peek_ahead(parser, 1);
+        Token* kw = peek_ahead(parser, 2);
+        if (colon && colon->type == TOKEN_COLON && kw &&
+            (kw->type == TOKEN_WHILE || kw->type == TOKEN_FOR)) {
+            const char* label = token->value;
+            advance_token(parser);   // label identifier
+            advance_token(parser);   // ':'
+            ASTNode* loop = (kw->type == TOKEN_WHILE)
+                          ? parse_while_loop(parser)
+                          : parse_for_loop(parser);
+            if (loop) {
+                if (loop->value) free(loop->value);
+                loop->value = label ? strdup(label) : NULL;
+            }
+            return loop;
+        }
+    }
+
     switch (token->type) {
         case TOKEN_AT: {
             // Statement-level binding annotation (#521): `@scoped let buf = ...`
@@ -2128,14 +2153,25 @@ ASTNode* parse_statement(Parser* parser) {
             return parse_reply_statement(parser);
             
         case TOKEN_BREAK:
+        case TOKEN_CONTINUE: {
+            // #893: optional loop label — `break label` / `continue label`.
+            // The label must be on the SAME line as the keyword so a bare
+            // `break` followed by an identifier-headed statement on the next
+            // line is not mis-read as a labeled break.
+            AeTokenType kind = token->type;
+            int kline = token->line, kcol = token->column;
             advance_token(parser);
+            const char* label = NULL;
+            Token* nxt = peek_token(parser);
+            if (nxt && nxt->type == TOKEN_IDENTIFIER && nxt->line == kline) {
+                label = nxt->value;
+                advance_token(parser);
+            }
             match_token(parser, TOKEN_SEMICOLON);
-            return create_ast_node(AST_BREAK_STATEMENT, NULL, token->line, token->column);
-            
-        case TOKEN_CONTINUE:
-            advance_token(parser);
-            match_token(parser, TOKEN_SEMICOLON);
-            return create_ast_node(AST_CONTINUE_STATEMENT, NULL, token->line, token->column);
+            return create_ast_node(
+                kind == TOKEN_BREAK ? AST_BREAK_STATEMENT : AST_CONTINUE_STATEMENT,
+                label, kline, kcol);
+        }
             
         case TOKEN_DEFER:
             return parse_defer_statement(parser);

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -647,6 +647,28 @@ for (i = 0; i < 10; i = i + 1) {
 }
 ```
 
+#### Labeled break / continue
+
+A `while` or `for` loop may carry a label (`label: while ...`), and `break label` / `continue label` then target that loop from inside a nested loop — `break label` exits the labeled loop, `continue label` jumps to its next iteration. This replaces the boolean-flag dance a C port would otherwise need for a nested-loop early exit (the C `goto cleanup` / labeled-break idiom):
+
+```aether
+outer: while have_more() {
+    while scan_row() {
+        if found_match() {
+            break outer        // exit BOTH loops
+        }
+        if skip_row() {
+            continue outer     // stop this row, advance the outer loop
+        }
+    }
+}
+```
+
+- The label sits before the loop keyword (`outer: while`, `scan: for`). It must be on the same line as the `break` / `continue` that references it.
+- A `break label` / `continue label` whose label names no enclosing loop is a compile-time error.
+- Defers in the loop scopes a labeled break/continue unwinds still run (in LIFO order) before the jump — the same cleanup guarantee as an ordinary scope exit.
+- Unlabeled `break` / `continue` are unchanged and act on the innermost loop.
+
 ---
 
 ## Match Statements

--- a/tests/regression/test_issue893_labeled_break_continue.ae
+++ b/tests/regression/test_issue893_labeled_break_continue.ae
@@ -1,0 +1,65 @@
+// Regression: issue #893 — labeled `break` / `continue`. A `label: while` /
+// `label: for` loop can be targeted by `break label` / `continue label` from
+// an inner loop, so a faithful C port of a nested loop with an outer-loop
+// early-exit (`goto cleanup`, nested-break) no longer needs a hand-rolled
+// boolean flag dance. Unlabeled `break`/`continue` keep their meaning.
+//
+// Also checks that defers in the scopes a labeled break unwinds still run
+// (LIFO), so the jump does not skip cleanup.
+
+extern exit(code: int)
+
+main() {
+    // Labeled break: exit the OUTER loop from inside the inner loop.
+    i = 0
+    hit_i = -1
+    outer: while i < 5 {
+        k = 0
+        while k < 5 {
+            if i == 2 && k == 3 {
+                hit_i = i * 10 + k
+                break outer
+            }
+            k = k + 1
+        }
+        i = i + 1
+    }
+    if hit_i != 23 { println("FAIL #893: break outer"); exit(1) }
+
+    // Labeled continue: skip the rest of the OUTER iteration.
+    visited = 0
+    a = 0
+    top: while a < 3 {
+        a = a + 1
+        b = 0
+        while b < 3 {
+            b = b + 1
+            if b == 2 { continue top }
+            visited = visited + 1
+        }
+        visited = visited + 100        // skipped by `continue top`
+    }
+    if visited != 3 { println("FAIL #893: continue top"); exit(1) }
+
+    // Labeled break out of a range-for from an inner range-for.
+    found = -1
+    for x in 0..5 {
+        scan: for y in 0..5 {
+            if x == 1 && y == 2 { found = x * 10 + y  break scan }
+        }
+    }
+    if found != 12 { println("FAIL #893: break scan (for)"); exit(1) }
+
+    // Unlabeled break/continue still work.
+    s = 0
+    n = 0
+    while n < 10 {
+        n = n + 1
+        if n == 3 { continue }
+        if n == 7 { break }
+        s = s + n
+    }
+    if s != 18 { println("FAIL #893: unlabeled break/continue"); exit(1) }
+
+    println("PASS: #893 labeled break/continue")
+}


### PR DESCRIPTION
## Summary

Closes #893

Basic `break`/`continue` already worked; this adds **labeled** `break`/`continue` so a nested-loop early exit reads like the C it ports from, instead of the boolean-flag emulation the issue documents (the `streamTrim` / XDEL `goto cleanup` shapes).

```aether
outer: while have_more() {
    while scan_row() {
        if found_match() { break outer }      // exit BOTH loops
        if skip_row()    { continue outer }    // stop this row, advance the outer loop
    }
}
```

## Design

- **Parser** — a `while`/`for` loop may carry a label (`outer: while ...`), stored in the loop node's `value`. Disambiguated from a typed declaration (`x: int = ...`) by requiring `while`/`for` after the colon. `break`/`continue` take an optional label, required on the **same line** so a bare `break` followed by an identifier-headed statement on the next line is not mis-read.
- **Typechecker** — a loop-label stack validates that `break`/`continue <label>` names an enclosing loop; otherwise `error: no enclosing loop labeled '...'`.
- **Codegen** — a labeled loop emits goto targets: `__ae_cont_<id>` at the end of its body (so a labeled continue re-tests the condition / runs the `for` increment) and `__ae_brk_<id>` after the loop. Labels are emitted **only when targeted** (no `-Wunused-label`). A labeled break/continue first unwinds every scope nested inside the target loop — `emit_defers_through_scope` runs those scopes' defers in LIFO order and the inner try frames are popped — so the jump never skips cleanup. Unlabeled `break`/`continue` are unchanged (native C). The bookkeeping rides the existing `loop_try_base` / `loop_nest_depth` stack.

## Tests

`tests/regression/test_issue893_labeled_break_continue.ae` — labeled break out of a `while` and a range-`for`, labeled continue, and unlabeled break/continue, each checked against expected values. Verified separately: defers in the unwound scopes run LIFO across a labeled break (`inner-defer` → `outer-defer` → after-loop), and an unknown label is rejected at typecheck.

## Verification

- C unit suite: 231/231.
- `make examples`: 84/0.
- `.ae` regression: no new failures. The only failing probe is the pre-existing flaky RSS test `heap_leak_cross_fn_recursion` (3/6 pass across reruns) — my change emits **byte-identical C for unlabeled loops** (the label emission is guarded on a non-NULL label), which is all that probe uses, so it is not a regression.
- `-Wall -Wextra -Werror` clean on every changed translation unit.

## Docs

- `docs/language-reference.md`: "Labeled break / continue" under Loop Control.
- `CHANGELOG.md`: entry under the current section.