### PR TITLE
fix(compiler): imported distinct types across modules (#908) + struct-string-tuple heap double-free (#911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,33 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.320.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Fixed
+
+- **Imported `distinct` types now resolve across the module boundary** (#908).
+  A `type X = distinct Base` defined in an imported module was never merged into
+  the consumer's program, so the distinct-resolution pass never learned `X` —
+  every cross-module `expr as X` / `x as Base` failed (`cannot cast X to Base`)
+  and codegen emitted an unknown C type `X`. The bug surfaced via the builder-
+  child (`_ctx`) path but was broader: any cross-module distinct wrap/unwrap was
+  affected. The module merge now pulls imported `distinct` defs into the program
+  (bare name, like struct defs), at both the direct-import and transitive-pull-in
+  sites, so every reference resolves.
+- **Heap double-free returning a string-field struct in a tuple** (#911). A
+  `-> (StructWithStringField, err)` constructor whose field was initialized from
+  a string variable double-freed at runtime (`free(): invalid pointer`): the
+  struct literal hard-coded `._heap_<field> = 1`, claiming ownership even when
+  the source variable held a *borrowed* string (`e = s`), so the struct's
+  owned-field free ran on a pointer it never owned. The field's heap-ownership
+  flag now mirrors the source variable's runtime `_heap_<v>` flag, and the
+  variable is disowned (move) so its deferred free is a no-op — exactly one free,
+  ASan/leak-clean for the genuinely-heap case. Unblocks the idiomatic "parse a
+  record at the boundary, return `(Record, err)`" shape.
 
 ## [0.320.0]
 

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -1476,6 +1476,22 @@ static int program_has_struct(ASTNode* program, const char* name) {
     return 0;
 }
 
+/* #908: a `type X = distinct Base` def already present in the program (the
+ * consumer's own, or an earlier merge). Used to dedup distinct-def merges. */
+static int program_has_distinct(ASTNode* program, const char* name) {
+    if (!program || !name) return 0;
+    for (int m = 0; m < program->child_count; m++) {
+        ASTNode* existing = program->children[m];
+        if (!existing) continue;
+        ASTNode* unwrapped = unwrap_export(existing);
+        if (unwrapped && unwrapped->type == AST_DISTINCT_TYPE_DEF &&
+            unwrapped->value && strcmp(unwrapped->value, name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Apply M's own `import X (a, b, c)` selective-import rewrites to a body
 // that's about to be cloned out of M into the consumer's program AST.
 //
@@ -1920,6 +1936,22 @@ void module_merge_into_program(ASTNode* program) {
                 ASTNode* clone = clone_ast_node(decl);
                 clone->is_imported = 1;
                 insert_child_at(program, clone, insert_idx++);
+            } else if (decl->type == AST_DISTINCT_TYPE_DEF && decl->value) {
+                // #908: `type X = distinct Base` from an imported module must
+                // enter the consumer's program AST (bare name, like structs)
+                // so resolve_distinct_types learns `X` and rewrites every
+                // `expr as X` / `x as Base` reference inside the merged
+                // constructor/unwrap/builder-child functions. Without this the
+                // imported distinct stays an unresolved TYPE_STRUCT{X}
+                // placeholder: the `as` cast fails its kind check ("cannot
+                // cast X to Base") and codegen emits an unknown C type `X`.
+                // Bypasses the selective-import filter on purpose (same as
+                // structs): a merged body that casts to/from `X` cannot
+                // type-check without the def in scope.
+                if (program_has_distinct(program, decl->value)) continue;
+                ASTNode* clone = clone_ast_node(decl);
+                clone->is_imported = 1;
+                insert_child_at(program, clone, insert_idx++);
             }
             // Skip AST_MAIN_FUNCTION, AST_IMPORT_STATEMENT, etc.
         }
@@ -2168,6 +2200,12 @@ void module_merge_into_program(ASTNode* program) {
                     // the function in.
                     if (program_has_struct(program, decl->value)) continue;
 
+                    ASTNode* clone = clone_ast_node(decl);
+                    clone->is_imported = 1;
+                    insert_child_at(program, clone, insert_idx++);
+                } else if (decl->type == AST_DISTINCT_TYPE_DEF && decl->value) {
+                    // #908: transitive sibling of the distinct-def merge above.
+                    if (program_has_distinct(program, decl->value)) continue;
                     ASTNode* clone = clone_ast_node(decl);
                     clone->is_imported = 1;
                     insert_child_at(program, clone, insert_idx++);

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -4178,7 +4178,34 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
              * <Struct>_destroy() reclaims the buffer at scope exit.
              * Plain initializers (literal strings, scalars) default
              * to _heap_<field> = 0 via C99 designated-init's zero-
-             * fill of unmentioned fields. */
+             * fill of unmentioned fields.
+             *
+             * #911: when a field ADOPTS a heap-string *variable* (`.f = v`
+             * with v a tracked heap-string local), ownership MOVES from the
+             * variable into the struct. The variable's own function-exit
+             * free must then be suppressed, or the same buffer is freed
+             * twice (once via the struct's owned-field free, once via the
+             * variable's deferred free) — the double-free crash. We collect
+             * the adopted variable names and, after the literal, clear their
+             * `_heap_<v>` flags inside a statement-expression so the exit
+             * free's `if (_heap_<v>)` guard skips them. */
+            const char* moved_vars[16];
+            int moved_count = 0;
+            int any_moved = 0;
+            for (int i = 0; i < expr->child_count; i++) {
+                ASTNode* fi = expr->children[i];
+                if (fi && fi->type == AST_ASSIGNMENT && fi->child_count > 0 &&
+                    fi->children[0]->type == AST_IDENTIFIER &&
+                    fi->children[0]->value &&
+                    is_heap_string_var(gen, fi->children[0]->value)) {
+                    any_moved = 1; break;
+                }
+            }
+            /* When a variable is moved into a field, build the struct into a
+             * temp inside a statement-expression, clear the moved-from vars'
+             * heap flags, then yield the temp. Otherwise emit the literal
+             * directly. */
+            if (any_moved) fprintf(gen->output, "({ %s _ae_slit = ", expr->value);
             fprintf(gen->output, "(%s){", expr->value);
             int emitted = 0;
             for (int i = 0; i < expr->child_count; i++) {
@@ -4190,16 +4217,42 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         generate_expression(gen, field_init->children[0]);
                     }
                     emitted++;
-                    /* If the init is heap-classified, also set the
-                     * hidden tracker. */
+                    /* If the init is heap-classified, also set the hidden
+                     * tracker. For a heap-tracked *variable* source, the
+                     * ownership is RUNTIME-conditional on the variable's own
+                     * `_heap_<v>` flag (#911): `e = s` leaves a borrowed,
+                     * non-heap value, so `._heap_<field> = 1` would make the
+                     * struct free a string it never owned (a bad free of the
+                     * caller's literal). Mirror the runtime flag instead, and
+                     * record the variable as moved-from so its flag is cleared
+                     * (the deferred free becomes a no-op). For non-variable
+                     * heap sources (an interp/concat temp), the value is freshly
+                     * owned, so a constant 1 is correct. */
                     if (field_init->child_count > 0 &&
                         is_heap_string_expr(gen, field_init->children[0])) {
-                        fprintf(gen->output, ", ._heap_%s = 1", field_init->value);
+                        ASTNode* src = field_init->children[0];
+                        if (src->type == AST_IDENTIFIER && src->value &&
+                            is_heap_string_var(gen, src->value)) {
+                            fprintf(gen->output, ", ._heap_%s = _heap_%s",
+                                    field_init->value, src->value);
+                            if (moved_count < 16) moved_vars[moved_count++] = src->value;
+                        } else {
+                            fprintf(gen->output, ", ._heap_%s = 1", field_init->value);
+                        }
                         emitted++;
                     }
                 }
             }
             fprintf(gen->output, "}");
+            if (any_moved) {
+                /* #911: disown each moved-from variable so its function-exit
+                 * `if (_heap_<v>)` free is a no-op (ownership now in the
+                 * struct). Then yield the built struct. */
+                fprintf(gen->output, ";");
+                for (int m = 0; m < moved_count; m++)
+                    fprintf(gen->output, " _heap_%s = 0;", moved_vars[m]);
+                fprintf(gen->output, " _ae_slit; })");
+            }
             break;
         }
         

--- a/tests/integration/distinct_cross_module_builder/lib/distmod/module.ae
+++ b/tests/integration/distinct_cross_module_builder/lib/distmod/module.ae
@@ -1,0 +1,9 @@
+import std.list
+import std.string
+exports (doc, child, num, unwrap)
+type Num = distinct int
+num(value: int) -> Num { return value as Num }
+unwrap(value: Num) -> int { return value as int }
+child(_ctx: ptr, value: Num) { println(string.from_int(value as int)) }
+builder doc() with list_new {
+}

--- a/tests/integration/distinct_cross_module_builder/main.ae
+++ b/tests/integration/distinct_cross_module_builder/main.ae
@@ -1,0 +1,9 @@
+import distmod (doc, child, num, unwrap)
+main() {
+    // plain cross-module distinct wrap/unwrap
+    println("${unwrap(num(5))}")
+    // distinct unwrap inside an imported builder child (#908)
+    doc() {
+        child(num(7))
+    }
+}

--- a/tests/integration/distinct_cross_module_builder/test_distinct_cross_module_builder.sh
+++ b/tests/integration/distinct_cross_module_builder/test_distinct_cross_module_builder.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Regression #908: a `type X = distinct Base` imported from another module must
+# resolve in cross-module constructors/unwraps AND in builder-child (`_ctx`)
+# functions. Before the fix the imported distinct def wasn't merged into the
+# consumer program, so `value as int` failed ("cannot cast Num to int") and
+# codegen emitted an unknown C type `Num`.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] ae not built"; exit 0; }
+OUT="$(cd "$SCRIPT_DIR" && AETHER_HOME="$ROOT" "$AE" run --lib ./lib main.ae 2>&1)"
+EXPECT="5
+7"
+if [ "$OUT" = "$EXPECT" ]; then
+    echo "  [PASS] distinct_cross_module_builder: imported distinct resolves in builder child + cross-module"
+else
+    echo "  [FAIL] distinct_cross_module_builder:"; echo "$OUT" | sed 's/^/      /'; exit 1
+fi

--- a/tests/regression/test_issue911_struct_string_tuple_no_doublefree.ae
+++ b/tests/regression/test_issue911_struct_string_tuple_no_doublefree.ae
@@ -1,0 +1,26 @@
+// Regression #911: a string-field struct returned in a (struct, err) tuple,
+// with the field initialized from a string VARIABLE, double-freed (the struct
+// claimed ownership of a borrowed string). Borrowed-param and genuinely-heap
+// (interp) cases must both behave: no crash, no leak, exactly one free.
+struct Rec { name: string }
+
+// borrowed: e = s (a param) — struct must NOT free it
+from_borrowed(s: string) -> (Rec, string) {
+    e = s
+    return Rec { name: e }, ""
+}
+// owned: e = interp (fresh heap) — struct frees it once
+from_heap(x: string) -> (Rec, string) {
+    e = "hi ${x}"
+    return Rec { name: e }, ""
+}
+
+main() {
+    a, ea = from_borrowed("borrowed")
+    b, eb = from_heap("world")
+    if a.name == "borrowed" && b.name == "hi world" {
+        println("PASS: #911 struct-string-in-tuple ownership")
+    } else {
+        println("FAIL: ${a.name} / ${b.name}")
+    }
+}


### PR DESCRIPTION
Two compiler fixes, both surfaced by the C→Aether port work. `Closes #908`, `Closes #911`.

## #908 — imported `distinct` types resolve across the module boundary

A `type X = distinct Base` defined in an **imported** module was never merged into the consumer's program, so the distinct-resolution pass never learned `X`. Every cross-module `expr as X` / `x as Base` then failed its kind check (`cannot cast X to Base`) and codegen emitted an unknown C type `X`.

The issue reported it via the builder-child (`_ctx`) path, but the bug was broader — **any** cross-module distinct wrap/unwrap broke (the issue's claim that "ordinary cross-module distinct works" turned out incorrect; that path emitted `unknown type name 'Num'` in C).

**Fix:** the module merge now pulls imported `AST_DISTINCT_TYPE_DEF` nodes into the consumer program under their bare name — exactly mirroring the existing struct-def merge — at both the direct-import and transitive-BFS sites. `resolve_distinct_types` then sees the def and rewrites every reference.

## #911 — heap double-free returning a string-field struct in a tuple

A `-> (StructWithStringField, err)` constructor whose field was set from a string **variable** double-freed at runtime (`free(): invalid pointer` / SIGABRT). The struct literal hard-coded `._heap_<field> = 1`, claiming ownership even when the source variable held a **borrowed** string (`e = s`, a param), so the struct's owned-field free ran on a pointer it never owned (the caller's literal).

**Fix:** for a heap-tracked variable source, the field's ownership flag now mirrors the source's *runtime* flag (`._heap_<field> = _heap_<v>`), and the variable is disowned via a statement-expression (`_heap_<v> = 0`) so its deferred free becomes a no-op — exactly one free. Verified **ASan/leak-clean** for the genuinely-heap (interp) case; the borrowed case no longer frees a non-owned pointer.

This unblocks the idiomatic "parse a record at the boundary, return `(Record, err)`" shape (the one the parse-don't-validate worked example had to route around).

## Testing

- `tests/integration/distinct_cross_module_builder/` — #908: distinct unwrap in an imported builder child **and** plain cross-module wrap/unwrap.
- `tests/regression/test_issue911_struct_string_tuple_no_doublefree.ae` — #911: borrowed-param and genuinely-heap cases both correct.
- Full `make test-ae`: **665 pass, 0 real failures**. (2 `(shell test)` fails are pre-existing HTTP/2 / reverse-proxy env flakes — confirmed identical on clean `main` after stashing these changes, and these changes touch zero http/net files.)
- Targeted regression sweep green: the #465 struct-field-heap-ownership tests, `issue_752_struct_string_tuple` (4/4), `test_issue480_distinct`, and the ptr-as-struct / by-value-struct-return tests.

No `[skip actions]` — compiler changes (incl. a memory-safety fix), so the Windows + leak-detection CI matrix should run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)