### PR TITLE
feat(contrib/host/lua): table builder for callback returns (#910) + doc/CHANGELOG fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.321.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **Labeled `break` / `continue`** (#893). A `while` / `for` loop can carry a
+  label — `outer: while ...` — and `break outer` / `continue outer` then target
+  that loop from inside a nested loop (`break` exits it, `continue` jumps to its
+  next iteration). This replaces the boolean-flag emulation a faithful C port
+  otherwise needs for a nested-loop early exit (the `goto cleanup` idiom). The
+  label must be on the same line as the `break`/`continue`; a label naming no
+  enclosing loop is a compile-time error; defers in the unwound scopes still run
+  (LIFO) before the jump. Unlabeled `break`/`continue` are unchanged.
 
 ## [0.321.0]
 
@@ -36,15 +49,6 @@ next version number before tagging the release.
 ## [0.320.0]
 
 ### Added
-
-- **Labeled `break` / `continue`** (#893). A `while` / `for` loop can carry a
-  label — `outer: while ...` — and `break outer` / `continue outer` then target
-  that loop from inside a nested loop (`break` exits it, `continue` jumps to its
-  next iteration). This replaces the boolean-flag emulation a faithful C port
-  otherwise needs for a nested-loop early exit (the `goto cleanup` idiom). The
-  label must be on the same line as the `break`/`continue`; a label naming no
-  enclosing loop is a compile-time error; defers in the unwound scopes still run
-  (LIFO) before the jump. Unlabeled `break`/`continue` are unchanged.
 
 - **`@c_struct` typed overlays — width-correct C-struct field access over a
   raw `ptr`** (#891). Declare a C struct's layout once with explicit offsets

--- a/contrib/host/TODO.md
+++ b/contrib/host/TODO.md
@@ -16,6 +16,114 @@
 
 ## Lua
 - [x] Tested and working well. Cleanest host module.
+- [x] **Bidirectional embedding API (#904)** — persistent host-owned VM
+  (`lua.vm_new`), host-callback registration (`lua.vm_register` — an Aether
+  `@c_callback` callable from script, dotted names build the prefix table),
+  typed args/returns inside callbacks (`lua.arg_*` / `lua.push_*` /
+  `push_tagged_table` / `raise_error`), typed `eval` result
+  (`lua.vm_result_type/_int/_str/_bool`), injected globals
+  (`lua.vm_set_global_str/_int/_strlist`), and an instruction-count guard
+  (`lua.vm_set_instruction_limit`). This is the **template** for the rollout
+  plan below. PR #906.
+
+## Bidirectional API rollout (which other hosts get the #904 treatment)
+
+The #904 work added a second tier on top of the fire-and-forget surface every
+host shares (`init`/`run`/`run_sandboxed`/`run_sandboxed_with_map`/`finalize`):
+a **persistent typed VM + host callbacks + typed marshalling both ways**. Lua
+is the only host with it today. Who should get it, and how hard:
+
+**Tier-1 candidates — in-process dlopen hosts with a C value-stack to bridge
+(highest value, the Lua pattern ports directly):**
+
+- [ ] **Python** (`contrib/host/python`) — HIGHEST value after Lua. CPython's
+  C-API has the exact shapes: `PyObject_CallObject` / `PyCFunction` for host
+  callbacks, `PyArg_*` + `Py_BuildValue` for typed args/returns,
+  `PyRun_String` returning a `PyObject*` for typed eval, `PyDict_SetItemString`
+  on `__main__` for globals, and `PyEval_SetTrace`/sys.settrace for the
+  instruction guard. Marshalling table: int/float/str/bool/None/list/dict ↔
+  the same typed tags Lua uses. Effort: **medium-high** (CPython refcounting
+  discipline is the wrinkle — every `PyObject*` the bridge holds needs
+  correct `Py_INCREF`/`DECREF`, unlike Lua's stack-GC).
+
+- [ ] **Duktape / JS** (`contrib/host/duktape`, `js` is its alias) — HIGH
+  value, LOWEST effort of the JS-family. Duktape's stack API is almost
+  identical in shape to Lua's (`duk_push_*` / `duk_get_*` / `duk_get_top` /
+  `duk_push_c_function` with a magic/hidden-symbol upvalue for the host fn
+  ptr; `duk_pcompile`+`duk_pcall` for typed eval; `duk_put_global_string` for
+  globals; `duk_set_global_object` + a custom exec-timeout via the
+  `DUK_USE_EXEC_TIMEOUT_CHECK` hook). The Lua trampoline pattern (host fn ptr
+  through a hidden property) maps over almost line-for-line. **Best
+  second-after-Lua pick on effort/value.**
+
+- [ ] **Tcl** (`contrib/host/tcl`) — MEDIUM value, LOW-MEDIUM effort. Tcl's C
+  API is command-oriented, not stack-oriented: host callbacks register as
+  `Tcl_CreateObjCommand` (the host fn reads `objv[]` Tcl_Obj args and sets the
+  interp result), typed values via `Tcl_GetIntFromObj`/`Tcl_NewStringObj`/etc,
+  `Tcl_Eval` + `Tcl_GetObjResult` for typed eval, `Tcl_SetVar` for globals,
+  `Tcl_LimitSetCommands`/`Tcl_LimitTypeSet` for the guard. Different idiom from
+  Lua but a clean 1:1 mapping; everything's already a `Tcl_Obj`.
+
+- [ ] **Ruby** (`contrib/host/ruby`) — MEDIUM value, HIGH effort. MRI's
+  embedding C-API can do it (`rb_define_global_function` with a
+  `VALUE(*)(int,VALUE*,VALUE)` callback, `rb_funcall`, `rb_eval_string_protect`
+  returning a `VALUE`, `rb_gv_set` for globals, `rb_add_event_hook` for the
+  guard), but the GVL + `rb_protect` exception-safety + `VALUE` GC-marking make
+  it the fiddliest of the in-process set. Do after Python proves the
+  refcounted-host pattern.
+
+- [ ] **Perl** (`contrib/host/perl`) — MEDIUM value, HIGH effort. Doable via
+  XS-style C (`newXS` for callbacks reading the Perl stack `SP`/`ST(i)`,
+  `eval_pv` returning an `SV*`, `set_sv`/`get_sv` for globals), but Perl's
+  stack-macro C-API (`dSP`/`PUSHMARK`/`SPAGAIN`) is the most error-prone to
+  hand-write. The TODO already notes Perl/Ruby shared-map outputs need XS/C-ext
+  to write back — same underlying gap; this would close it properly.
+
+**Tier-2 candidates — in-process but a partial head start:**
+
+- [ ] **Factor** (`contrib/host/factor`) — already has `factor_eval -> string`,
+  `factor_set`/`factor_get` over a persistent VM (the precedent #904 cited).
+  The gaps vs Lua: (a) **host-callback registration** (Factor would register a
+  host word that re-enters Aether), and (b) **typed** eval result instead of
+  the stringified `factor_eval`. Concatenative stack model actually suits the
+  push/pop callback API well. MEDIUM effort; mostly additive.
+
+- [ ] **Racket / Rhombus** (`contrib/host/racket`, `rhombus`) — already
+  `racket_eval`/`set`/`get` over the shared Chez VM. Adding callbacks means
+  exposing a host procedure into the Racket namespace (`scheme_make_prim_w_arity`
+  / the FFI) and a typed result reader off `Scheme_Object*`. The
+  static-link + Chez-value-macro constraints (per the racket README caveats)
+  make this MEDIUM-HIGH effort and lower priority — no Redis-class consumer
+  asking yet.
+
+**Out of scope — separate-process hosts (no in-process VM to bridge):**
+
+- Java (`contrib/host/java`) — JVM is separate-process via Panama; the
+  callback story is the existing shared-memory + Panama FFI, not a C value
+  stack. A bidirectional surface here is a *different* design (Panama upcalls),
+  not the #904 pattern. Note separately if a consumer needs it.
+- Go / TinyGo (`go`, `tinygo`) — `go` is separate-subprocess; `tinygo` is
+  c-shared but exposes fixed exported funcs, not a callback-registration VM.
+- aether (`contrib/host/aether`) — separate-process Aether-in-Aether.
+
+### Suggested order
+
+1. **Duktape/JS** — lowest effort, the Lua trampoline pattern ports nearly
+   verbatim; proves the rollout on a second stack-API host.
+2. **Python** — highest downstream value; establishes the refcounted-host
+   pattern (the template for Ruby/Perl).
+3. **Tcl** — clean command-oriented mapping; low risk.
+4. **Factor** — additive on its existing two-way surface.
+5. **Ruby**, then **Perl** — highest effort; do last, reusing Python's
+   refcount/exception-safety lessons. Closes the long-standing Perl/Ruby
+   shared-map-writeback gap noted under "All host modules" above.
+
+Each should mirror Lua's shape exactly — same `vm_*` / `arg_*` / `push_*`
+naming and the same `LUA_T*`-style typed-value tag constants (rename per host,
+e.g. `PY_T*`) — so a consumer that learns one host's bidirectional API knows
+them all. Each needs a `tests/integration/host_<lang>_bidirectional/` test
+modelled on `host_lua_bidirectional/` (callback + typed result + global inject
++ guard), SKIPping without the dev library.
 
 ## JS (Duktape)
 - [x] Purest containment — no LD_PRELOAD needed; only explicitly-exposed functions are callable. Bindings: `print`, `env`, `readFile`, `fileExists`, `writeFile`, `exec`. All sandbox-checked via `check_sandbox` against the active grant list.

--- a/contrib/host/lua/README.md
+++ b/contrib/host/lua/README.md
@@ -115,11 +115,58 @@ main() {
 | `lua.vm_set_instruction_limit(vm, budget, every)` | count-hook guard; abort after `budget` VM instructions |
 | `lua.arg_count/_type/_str/_int/_bool(vm, i)` | **inside a callback**: read args (1-based) |
 | `lua.push_int/_str/_bool/_nil(vm, v)` | **inside a callback**: push a result |
+| `lua.push_double(vm, v)` | push a RESP3 Double (integral → Lua number, else precise string) |
 | `lua.push_tagged_table(vm, "ok"\|"err", msg)` | push a Redis-style `{ok=…}`/`{err=…}` table |
 | `lua.raise_error(vm, msg) -> int` | raise a Lua error from a callback (`return lua.raise_error(vm, m)`) |
 
 Typed-value tags exported as consts: `LUA_TNIL`, `LUA_TBOOL`, `LUA_TINT`,
 `LUA_TSTR`, `LUA_TTABLE`, `LUA_TERR`, `LUA_TOTHER`.
+
+### Returning arrays / maps / nested tables from a callback (#910)
+
+A faithful `redis.call` returns RESP multibulks — arrays (`KEYS`, `LRANGE`,
+`SMEMBERS`), maps (`HGETALL`), and nested arrays-of-arrays. The table builder
+constructs them inside a callback. **The table being built is the top of the
+stack:** `table_begin` pushes a fresh one, the `seti_*`/`set_*` ops write into
+it, and nesting is just another `table_begin` closed with `table_end_seti` /
+`table_end_setfield`.
+
+| Call | Effect |
+|------|--------|
+| `lua.table_begin(vm, narr, nrec)` | push a fresh table (`narr`/`nrec` are size hints) |
+| `lua.table_seti_str/_int/_bool(vm, i, v)` | array set: `t[i] = v` (1-based) |
+| `lua.table_set_str/_int/_bool(vm, key, v)` | map set: `t[key] = v` |
+| `lua.table_end_seti(vm, i)` | close the current child table into its parent at `[i]` |
+| `lua.table_end_setfield(vm, key)` | close the current child table into its parent at `[key]` |
+| `lua.table_finish(vm)` | finish the outermost table (it stays on the stack as the return) |
+
+```aether
+// redis.call('KEYS', pattern) -> {"k1","k2","k3"}
+@c_callback
+redis_keys(vm: ptr) -> int {
+    lua.table_begin(vm, 3, 0)
+    lua.table_seti_str(vm, 1, "k1")
+    lua.table_seti_str(vm, 2, "k2")
+    lua.table_seti_str(vm, 3, "k3")
+    lua.table_finish(vm)
+    return 1                      // the table is the single return value
+}
+
+// array-of-arrays: { {"a","b"}, {"c"} }
+@c_callback
+nested(vm: ptr) -> int {
+    lua.table_begin(vm, 2, 0)     // outer
+    lua.table_begin(vm, 2, 0)     // inner #1 (now on top)
+    lua.table_seti_str(vm, 1, "a")
+    lua.table_seti_str(vm, 2, "b")
+    lua.table_end_seti(vm, 1)     // outer[1] = inner#1
+    lua.table_begin(vm, 1, 0)     // inner #2
+    lua.table_seti_str(vm, 1, "c")
+    lua.table_end_seti(vm, 2)     // outer[2] = inner#2
+    lua.table_finish(vm)
+    return 1
+}
+```
 
 This is the next tier above the factor bridge's two-way persistent-VM + shared-
 map model: **host-callbacks-with-typed-marshalling**, in both directions.
@@ -149,6 +196,11 @@ The bidirectional API (#904) has a dedicated end-to-end test:
   **typed** results (int `142`, string `hello k2`) plus that the
   instruction-limit guard aborts an infinite loop. SKIPs when no matching
   liblua headers + runtime soname are found.
+- [`../../../tests/integration/host_lua_table_builder/`](../../../tests/integration/host_lua_table_builder/)
+  — the #910 table builder: callbacks returning a multi-element array
+  (`{"k1","k2","k3"}`), a string-keyed map (`{field=…, count=…}`), and a nested
+  array-of-arrays (`{{"a","b"},{"c"}}`), with a Lua script asserting each shape.
+  Same SKIP gate.
 
 The fire-and-forget surface is covered by two cross-cutting tests:
 

--- a/contrib/host/lua/aether_host_lua.c
+++ b/contrib/host/lua/aether_host_lua.c
@@ -616,6 +616,130 @@ int lua_raise_error(void* vm, const char* msg) {
     return g_lua.lua_error(s);   /* longjmps; never returns */
 }
 
+// === #910 host-callback table builder ======================================
+//
+// A host callback can push scalars and a single {ok}/{err} table, but a
+// faithful `redis.call` returns RESP multibulks — arrays / maps / nested
+// tables (`KEYS`, `LRANGE`, `HGETALL`, `SMEMBERS`, array-of-arrays). This
+// builder exposes the same lua_createtable + lua_seti/setfield machinery the
+// global-injection path already uses, for callback RETURNS.
+//
+// Model: "the table being built is on top of the stack." table_begin pushes a
+// fresh table; the table_set* ops write into the top table; table_begin can be
+// nested (push a child table), and table_end_seti / table_end_setfield store
+// the finished child into the parent (now exposed at the top) at an index/key
+// and pop back to the parent. A small depth tracker guards underflow.
+//
+// Typical use, building {"k1","k2"} as a callback return:
+//   lua_table_begin(vm, 2, 0);
+//   lua_table_seti_str(vm, 1, "k1");
+//   lua_table_seti_str(vm, 2, "k2");
+//   return 1;   // the table is the single return value, left on the stack
+//
+// Nested (array-of-arrays) — outer[1] = {"a"}:
+//   lua_table_begin(vm, 1, 0);        // outer
+//   lua_table_begin(vm, 1, 0);        // inner (child, on top)
+//   lua_table_seti_str(vm, 1, "a");
+//   lua_table_end_seti(vm, 1);        // outer[1] = inner; back to outer on top
+//   return 1;
+
+#define AE_LUA_TBL_MAXDEPTH 32
+static int g_tbl_depth = 0;   /* per-process; the EVAL model is single-threaded */
+
+/* Push a fresh table; it becomes the top-of-stack "current" table. */
+void lua_table_begin(void* vm, int narr, int nrec) {
+    if (!vm) return;
+    if (g_tbl_depth >= AE_LUA_TBL_MAXDEPTH) return;  /* guard runaway nesting */
+    g_lua.lua_createtable((lua_State*)vm, narr < 0 ? 0 : narr, nrec < 0 ? 0 : nrec);
+    g_tbl_depth++;
+}
+
+/* Array sets: current_table[i] = value  (1-based, Lua convention). */
+void lua_table_seti_str(void* vm, int i, const char* v) {
+    if (!vm || g_tbl_depth <= 0) return;
+    lua_State* s = (lua_State*)vm;
+    g_lua.lua_pushstring(s, v ? v : "");
+    g_lua.lua_seti(s, -2, (lua_Integer)i);
+}
+void lua_table_seti_int(void* vm, int i, long v) {
+    if (!vm || g_tbl_depth <= 0) return;
+    lua_State* s = (lua_State*)vm;
+    g_lua.lua_pushinteger(s, (lua_Integer)v);
+    g_lua.lua_seti(s, -2, (lua_Integer)i);
+}
+void lua_table_seti_bool(void* vm, int i, int v) {
+    if (!vm || g_tbl_depth <= 0) return;
+    lua_State* s = (lua_State*)vm;
+    g_lua.lua_pushboolean(s, v);
+    g_lua.lua_seti(s, -2, (lua_Integer)i);
+}
+
+/* Map sets: current_table[key] = value  (string keys, RESP3 map/hash shape). */
+void lua_table_set_str(void* vm, const char* key, const char* v) {
+    if (!vm || g_tbl_depth <= 0 || !key) return;
+    lua_State* s = (lua_State*)vm;
+    g_lua.lua_pushstring(s, v ? v : "");
+    g_lua.lua_setfield(s, -2, key);
+}
+void lua_table_set_int(void* vm, const char* key, long v) {
+    if (!vm || g_tbl_depth <= 0 || !key) return;
+    lua_State* s = (lua_State*)vm;
+    g_lua.lua_pushinteger(s, (lua_Integer)v);
+    g_lua.lua_setfield(s, -2, key);
+}
+void lua_table_set_bool(void* vm, const char* key, int v) {
+    if (!vm || g_tbl_depth <= 0 || !key) return;
+    lua_State* s = (lua_State*)vm;
+    g_lua.lua_pushboolean(s, v);
+    g_lua.lua_setfield(s, -2, key);
+}
+
+/* Close the current (child) table by storing it into the now-exposed parent
+ * table at array index `i`, then leaving the parent on top. Requires at least
+ * two open tables (a parent and the child). */
+void lua_table_end_seti(void* vm, int i) {
+    if (!vm || g_tbl_depth < 2) return;   /* need parent + child */
+    lua_State* s = (lua_State*)vm;
+    /* stack: [..., parent, child]. Store child into parent[i]; lua_seti pops
+     * the value (the child), leaving the parent on top. */
+    g_lua.lua_seti(s, -2, (lua_Integer)i);
+    g_tbl_depth--;
+}
+/* Close the current (child) table into the parent at string key `key`. */
+void lua_table_end_setfield(void* vm, const char* key) {
+    if (!vm || g_tbl_depth < 2 || !key) return;
+    lua_State* s = (lua_State*)vm;
+    g_lua.lua_setfield(s, -2, key);
+    g_tbl_depth--;
+}
+/* Finish the OUTERMOST table: it stays on the stack as the callback's return
+ * value. Just resets the depth tracker (the table is already on top). Call
+ * once, matching the first lua_table_begin, then `return 1`. */
+void lua_table_finish(void* vm) {
+    (void)vm;
+    if (g_tbl_depth > 0) g_tbl_depth--;
+}
+
+// --- RESP3 typed scalars the callback can also return ----------------------
+/* Lua has one number type (5.3+ distinguishes int/float subtypes); a RESP3
+ * Double marshals to a Lua float. We push via the number path. */
+void lua_push_double(void* vm, double v) {
+    if (!vm) return;
+    /* lua_pushnumber isn't in the dlsym table; push the textual form is wrong
+     * for a Double. Use lua_pushinteger's sibling only if integral; otherwise
+     * fall back to a string so no precision is silently lost on 5.3 where the
+     * float push isn't resolved. Most RESP Doubles arrive integral. */
+    lua_State* s = (lua_State*)vm;
+    double r = v < 0 ? -v : v;
+    if (r == (double)(long)v) {
+        g_lua.lua_pushinteger(s, (lua_Integer)(long)v);
+    } else {
+        char buf[40];
+        snprintf(buf, sizeof(buf), "%.17g", v);
+        g_lua.lua_pushstring(s, buf);
+    }
+}
+
 // --- execution guard: instruction-count hook -------------------------------
 // The host arms a count hook; when the budget is hit the hook raises a Lua
 // error (the script-timeout shape). One global budget per process is enough
@@ -686,4 +810,16 @@ void  lua_push_nil(void* vm) { (void)vm; }
 void  lua_push_tagged_table(void* vm, const char* f, const char* m) { (void)vm; (void)f; (void)m; }
 int   lua_raise_error(void* vm, const char* m) { (void)vm; (void)m; return 0; }
 void  lua_vm_set_instruction_limit(void* vm, long b, int e) { (void)vm; (void)b; (void)e; }
+// #910 table builder — unavailable stubs.
+void  lua_table_begin(void* vm, int a, int r) { (void)vm; (void)a; (void)r; }
+void  lua_table_seti_str(void* vm, int i, const char* v) { (void)vm; (void)i; (void)v; }
+void  lua_table_seti_int(void* vm, int i, long v) { (void)vm; (void)i; (void)v; }
+void  lua_table_seti_bool(void* vm, int i, int v) { (void)vm; (void)i; (void)v; }
+void  lua_table_set_str(void* vm, const char* k, const char* v) { (void)vm; (void)k; (void)v; }
+void  lua_table_set_int(void* vm, const char* k, long v) { (void)vm; (void)k; (void)v; }
+void  lua_table_set_bool(void* vm, const char* k, int v) { (void)vm; (void)k; (void)v; }
+void  lua_table_end_seti(void* vm, int i) { (void)vm; (void)i; }
+void  lua_table_end_setfield(void* vm, const char* k) { (void)vm; (void)k; }
+void  lua_table_finish(void* vm) { (void)vm; }
+void  lua_push_double(void* vm, double v) { (void)vm; (void)v; }
 #endif

--- a/contrib/host/lua/aether_host_lua.h
+++ b/contrib/host/lua/aether_host_lua.h
@@ -35,4 +35,17 @@ void  lua_push_tagged_table(void* vm, const char* field, const char* msg);
 int   lua_raise_error(void* vm, const char* msg);
 void  lua_vm_set_instruction_limit(void* vm, long budget, int every);
 
+/* #910 host-callback table builder (RESP multibulk → Lua table). */
+void  lua_table_begin(void* vm, int narr, int nrec);
+void  lua_table_seti_str(void* vm, int i, const char* v);
+void  lua_table_seti_int(void* vm, int i, long v);
+void  lua_table_seti_bool(void* vm, int i, int v);
+void  lua_table_set_str(void* vm, const char* key, const char* v);
+void  lua_table_set_int(void* vm, const char* key, long v);
+void  lua_table_set_bool(void* vm, const char* key, int v);
+void  lua_table_end_seti(void* vm, int i);
+void  lua_table_end_setfield(void* vm, const char* key);
+void  lua_table_finish(void* vm);
+void  lua_push_double(void* vm, double v);
+
 #endif

--- a/contrib/host/lua/module.ae
+++ b/contrib/host/lua/module.ae
@@ -46,8 +46,12 @@ exports (
     lua_vm_eval, lua_vm_result_type, lua_vm_result_int, lua_vm_result_str,
     lua_vm_result_bool, lua_vm_pop_result, lua_vm_set_instruction_limit,
     lua_arg_count, lua_arg_type, lua_arg_str, lua_arg_int, lua_arg_bool,
-    lua_push_int, lua_push_str, lua_push_bool, lua_push_nil,
+    lua_push_int, lua_push_str, lua_push_bool, lua_push_nil, lua_push_double,
     lua_push_tagged_table, lua_raise_error,
+    // #910 table builder (RESP multibulk → Lua array/map/nested table)
+    lua_table_begin, lua_table_seti_str, lua_table_seti_int, lua_table_seti_bool,
+    lua_table_set_str, lua_table_set_int, lua_table_set_bool,
+    lua_table_end_seti, lua_table_end_setfield, lua_table_finish,
     // typed-value tags (returned by *_result_type / *_arg_type)
     LUA_TNIL, LUA_TBOOL, LUA_TINT, LUA_TSTR, LUA_TTABLE, LUA_TERR, LUA_TOTHER
 )
@@ -110,7 +114,31 @@ extern lua_push_int(vm: ptr, v: long)
 extern lua_push_str(vm: ptr, v: string)
 extern lua_push_bool(vm: ptr, v: int)
 extern lua_push_nil(vm: ptr)
+// A RESP3 Double — pushed as a Lua number (integral) or precise string.
+extern lua_push_double(vm: ptr, v: float)
 // Redis-style { ok = msg } / { err = msg } single-field table.
 extern lua_push_tagged_table(vm: ptr, field: string, msg: string)
 // Raise a Lua error (longjmps; `return lua.raise_error(vm, m)` from the cb).
 extern lua_raise_error(vm: ptr, msg: string) -> int
+
+// --- #910 table builder: RESP multibulk → Lua array / map / nested table ----
+// The table being built is the top of the stack. `begin` pushes a fresh table;
+// `seti_*` set array element i (1-based); `set_*` set a string key; nest with
+// another `begin` then `end_seti`/`end_setfield` to store the child into the
+// parent. `finish` leaves the outermost table as the callback's return value.
+//
+//   t = lua.table_begin(vm, 2, 0)        // {} with array hint
+//   lua.table_seti_str(vm, 1, "k1")      // t[1] = "k1"
+//   lua.table_seti_str(vm, 2, "k2")      // t[2] = "k2"
+//   lua.table_finish(vm)                 // leave it on the stack
+//   return 1
+extern lua_table_begin(vm: ptr, narr: int, nrec: int)
+extern lua_table_seti_str(vm: ptr, i: int, v: string)
+extern lua_table_seti_int(vm: ptr, i: int, v: long)
+extern lua_table_seti_bool(vm: ptr, i: int, v: int)
+extern lua_table_set_str(vm: ptr, key: string, v: string)
+extern lua_table_set_int(vm: ptr, key: string, v: long)
+extern lua_table_set_bool(vm: ptr, key: string, v: int)
+extern lua_table_end_seti(vm: ptr, i: int)
+extern lua_table_end_setfield(vm: ptr, key: string)
+extern lua_table_finish(vm: ptr)

--- a/docs/parse-dont-validate-review.md
+++ b/docs/parse-dont-validate-review.md
@@ -1,0 +1,253 @@
+# Parse, Don't Validate — the Aether Way
+
+One rule, three words, older than any of the languages that argue about it:
+
+> **Parse, don't validate.** Make the type system carry the proof, not your memory.
+
+A **validator** asks "is this okay?", answers `true`/`false`, and then forgets
+what it learned the instant it returns. Three call-frames later a `string` is
+just a `string` — indistinguishable from `""` — so you check it again, or you
+hope. A **parser** takes a less-precise value and returns a *more*-precise one:
+the check and its result are the same act, and the result is a type the rest of
+the program can trust without re-checking.
+
+The difference is purely *what survives the check*. Both of these do the same
+work; only one keeps the receipt:
+
+```aether
+// VALIDATE — the proof evaporates. The bool is discarded; `s` is still `string`.
+is_nonempty(s: string) -> bool { return string.length(s) > 0 }
+
+// PARSE — the proof is the return type. To hold a NonEmpty you MUST have checked.
+type NonEmpty = distinct string
+parse_nonempty(s: string where string.length(s) > 0) -> NonEmpty { return s as NonEmpty }
+```
+
+Aether is built to make the second one the path of least resistance. This guide
+is how.
+
+## Why Aether is a good language for this
+
+Most discussion of "parse, don't validate" is about wrestling a *structurally
+typed* language (TypeScript: `string is string is string`, no real newtype) into
+faking nominal identity with phantom-`unique symbol` brands and `as Email` casts
+the type system merely tolerates. Aether skips that whole fight. The three things
+those workarounds approximate are first-class here:
+
+| What the technique needs | What Aether gives you |
+|--------------------------|------------------------|
+| A type distinct from its base that can't be forged | **`type X = distinct Base`** — a real, zero-cost newtype (#480) |
+| A checked smart constructor | a normal function returning that type, optionally **`where`-guarded** (#525) or returning **`(value, err)`** |
+| A wall between "outside data" and "trusted data" | the compiler refuses to cross a `distinct` boundary without an explicit `as` |
+
+So in Aether the slogan reads concretely: **parse a `string`/`int`/`ptr` from the
+outside world into a `distinct` domain type at the boundary, and every function
+downstream that takes that type is handed the proof for free.**
+
+## The two moves: strengthen the argument, or weaken the result
+
+There are exactly two honest ways to make a function total — to stop it lying
+about inputs it can't actually handle. Both keep the proof; they differ in
+*where* the obligation lands.
+
+**Weaken the result** — return `(value, err)`. The function admits it might fail
+and hands the caller both outcomes. Use this for **untrusted input** that can
+legitimately be malformed (a config string, a network field, user text):
+
+```aether
+type Email = distinct string
+
+parse_email(raw: string) -> (Email, string) {     // empty err = success
+    if string.contains(raw, "@") != 0 { return raw as Email, "" }
+    return "" as Email, "missing @"
+}
+```
+
+**Strengthen the argument** — demand the precise type. The check happens *once*,
+where the value is constructed; every consumer downstream is redundant-check-free;
+and if an upstream stops guaranteeing the property, the program **stops
+compiling**. Use this for **invariants the rest of your code should be able to
+assume** (non-empty, in-range, already-authorized):
+
+```aether
+type Age = distinct int
+
+parse_age(raw: int where raw >= 0 && raw <= 150) -> Age { return raw as Age }
+
+// Consumers take the strong type. A raw int can never reach this function.
+birthday_message(a: Age) -> string { return "you are ${a as int}" }
+```
+
+The strengthen-the-argument move is the one worth internalizing, because it's the
+one that turns a *runtime* check into a *compile-time* guarantee. Pass a raw value
+where a `distinct` is required and you get a compile error, not a crash:
+
+```aether
+birthday_message(30)
+// error[E0200]: Argument 1 'a' of 'birthday_message': expected int, got int —
+//   a distinct type needs an explicit `as` cast at the boundary
+```
+
+That error is the entire point of the technique, delivered by the compiler. The
+check can't drift out of sync with its use, because the use won't type-check
+without it.
+
+## The smell to hunt for: `-> bool` and bare side-effect checks
+
+The single most useful instinct: **be suspicious of any check whose result you
+can ignore.** A `check_x(v) -> bool` (or a function that just throws/aborts and
+returns nothing) is omittable — drop the call and the code still compiles,
+because nothing depends on its result. That's not a style nit; it's how the
+"impossible" case sneaks back in months later when someone deletes the guard
+upstream.
+
+```aether
+// SMELL — omittable. Nothing forces a caller to consult this.
+ensure_nonempty(s: string) -> bool { return string.length(s) > 0 }
+
+// FIX — load-bearing. To proceed you NEED the result, so the check can't be skipped.
+parse_nonempty(s: string where string.length(s) > 0) -> NonEmpty { return s as NonEmpty }
+```
+
+Practical rule: when you catch yourself adding the *third* defensive `if` across
+three files all checking the same thing, you validated where you should have
+parsed. Replace the `-> bool` checker with a `-> DistinctType` parser, change the
+downstream functions to take the distinct type, and let the call sites fail to
+compile *upward* until you reach the real boundary — the one place the raw value
+genuinely enters. Do the parse there, once.
+
+## Name the two states: raw in, trusted out
+
+The cleanest large-scale version is to give the untrusted shape and the trusted
+shape **different names**, with a parser as the only bridge. Illegal states then
+can't be represented: a trusted value simply has no constructor that skips the
+check.
+
+```aether
+import std.string
+
+type Email = distinct string
+type Age   = distinct int
+
+struct RawUser   { email: string, age: int }   // straight off the wire — suspect
+struct ValidUser { email: Email,  age: Age  }   // earned trust — safe everywhere
+
+// Each field-parser carries its own precondition in the signature, so the
+// constructor below is unconditional — there is no way to build a half-valid
+// ValidUser, because a failing input never reaches the struct literal.
+parse_email(raw: string where string_contains(raw, "@") != 0) -> Email { return raw as Email }
+parse_age(raw: int where raw >= 0 && raw <= 150) -> Age { return raw as Age }
+
+parse_user(u: RawUser) -> ValidUser {
+    return ValidUser { email: parse_email(u.email), age: parse_age(u.age) }
+}
+
+// This signature is a guarantee: it is impossible to call with unparsed fields.
+send_welcome(u: ValidUser) -> string { return "welcome ${u.email as string}" }
+```
+
+`send_welcome(ValidUser)` is safe by construction. There is no path that produces
+a `ValidUser` without going through the parsers, because its fields are `Email`
+and `Age` and those types have only one door each. The proof lives in the field
+types — enforced, not merely documented. (If you need to *recover* from bad input
+rather than panic, give the field parsers `-> (Email, err)` shapes and thread the
+errors; the `where`-guarded form here is the right one when malformed input is a
+programmer error, not an expected case.)
+
+## Where this pays off most: "config IS code" → "config IS *parsed* code"
+
+Aether's pitch for server-shaped libraries is **config IS code** (see
+[`closures-and-builder-dsl.md`](closures-and-builder-dsl.md) and LLM.md): don't
+ship a YAML loader — expose your start-surface as a closure-DSL block and let the
+operator's config be a `.ae` file they `ae run`. The builder-DSL machinery makes
+that block *read* declaratively and *wire* itself.
+
+But an operator-authored `.ae` config block **is outside data** — King's blob
+from the wire, just written in your own syntax. A setter that takes a raw string:
+
+```aether
+set_release("21")          // "21" stays a bare string forever — the validator smell
+```
+
+…throws the proof away. The upgrade is to make **the DSL setters the parsing
+boundary**, so the filled config object holds domain types, not raw strings:
+
+```aether
+type Version = distinct string
+parse_version(s: string where string.length(s) > 0) -> Version { return s as Version }
+
+set_release(parse_version("21"))   // the config now holds a Version
+```
+
+The builder function body that consumes the config then can't be handed an
+unparsed value — the boundary parsed once, and the types carry it the rest of the
+way. Two named states, one parser between them: the operator's block is the *raw*
+side, the builder's filled config is the *trusted* side.
+
+This is the same shape as Aether's **sandbox** model, one level up. The danger
+"parse, don't validate" warns against — *shotgun parsing*, checks scattered
+through processing code so a program acts on a valid *prefix* before hitting an
+invalid suffix, leaving state it can't roll back — is exactly what a two-phase
+**parse-then-execute** structure prevents. Aether's `--emit=lib` capability gate
+and the LD_PRELOAD grant list are that structure at the program scale:
+*gate-then-run* is *parse-then-execute*. Deciding up front what untrusted `.ae`
+may reach, before it touches anything real, is the same security argument King
+makes for parsing input up front — applied to capabilities instead of values.
+
+## A complete boundary, end to end
+
+Pulling the moves together — recoverable parse for the malformable field,
+`where`-guard for the invariant, distinct types so the consumer is safe:
+
+```aether
+import std.string
+
+type Email = distinct string
+type Age   = distinct int
+
+parse_email(raw: string) -> (Email, string) {
+    if string.contains(raw, "@") != 0 { return raw as Email, "" }
+    return "" as Email, "missing @"
+}
+parse_age(raw: int where raw >= 0 && raw <= 150) -> Age { return raw as Age }
+
+send_welcome(e: Email, a: Age) -> string {
+    return "welcome ${e as string} (${a as int})"
+}
+
+main() {
+    em, err = parse_email("ada@example.com")
+    if err != "" { println("reject: ${err}"); return }   // fail at the boundary…
+    ag = parse_age(30)
+    println(send_welcome(em, ag))                          // …trusted from here on
+    // -> welcome ada@example.com (30)
+}
+```
+
+Every check happens once, at the top. Below the boundary there are no defensive
+`if`s, no re-validation, no "this should never happen" branches — the types
+already ruled those out.
+
+## The toolkit, in one place
+
+| Need | Reach for | Notes |
+|------|-----------|-------|
+| A domain type distinct from its base | `type X = distinct Base` | zero-cost; crossing in/out needs an explicit `as` |
+| Parse untrusted input that may be malformed | a `-> (X, err)` function | stdlib convention; `""` err = success |
+| Enforce an invariant at the boundary | a `where`-guarded parameter | runtime-checked; violation is a loud panic naming the condition |
+| Make the consumer safe by construction | take the `distinct` type as a parameter | raw values fail to compile (E0200) → the check can't drift |
+| Handle a parse result honestly | `(value, err)` + `match` | no exception hiding in the call stack |
+| Two named states | a `Raw*` struct and a `Valid*` struct | one parser between them; illegal state unrepresentable |
+
+The discipline is still yours — nothing *forces* you to take a `distinct` type at
+a boundary. But Aether is the rare language where, once you reach for it, the
+compiler insists the rest of the way. Most languages let you do the right thing.
+Aether nudges, and then holds the line.
+
+---
+
+*Lineage: Alexis King, ["Parse, don't validate"](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)
+(2019, Haskell); Christian Kjær Larsen, ["Parse, Don't Validate — In a Language
+That Doesn't Want You To"](https://cekrem.github.io/posts/parse-dont-validate-typescript-edition/)
+(2026, TypeScript). All Aether examples in this document compile and run as
+shown; the E0200 errors are the actual compiler output.*

--- a/tests/integration/host_lua_table_builder/test_host_lua_table_builder.sh
+++ b/tests/integration/host_lua_table_builder/test_host_lua_table_builder.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# #910 host-callback table builder: a host callback can return a multi-element
+# array, a string-keyed map, and a nested array-of-arrays (the RESP multibulk →
+# Lua-table shapes `redis.call('KEYS'/'HGETALL'/...)` needs). Follow-up to #904.
+#
+# SKIPs cleanly when matching liblua headers + runtime soname aren't present.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT) echo "  [SKIP] host_lua_table_builder on Windows"; exit 0 ;;
+esac
+LUA_CFLAGS=""; LUA_LIBS=""; LUA_SONAME=""
+for v in lua5.4 lua5.3 lua5.2; do
+    if pkg-config --exists "$v" 2>/dev/null; then cf="$(pkg-config --cflags "$v")"
+    elif [ -f "/usr/include/$v/lua.h" ]; then cf="-I/usr/include/$v"
+    else continue; fi
+    so="$(ldconfig -p 2>/dev/null | grep -oE "liblua${v#lua}\.so[^ ]*" | grep -vi 'c++' | head -1)"
+    [ -z "$so" ] && so="$(ls /usr/lib/*/liblua${v#lua}.so.* 2>/dev/null | grep -vi 'c++' | head -1)"
+    if [ -n "$cf" ] && [ -n "$so" ]; then LUA_CFLAGS="$cf"; LUA_LIBS="-llua${v#lua}"; LUA_SONAME="$so"; break; fi
+done
+if [ -z "$LUA_CFLAGS" ] || [ -z "$LUA_SONAME" ]; then
+    echo "  [SKIP] host_lua_table_builder: no matching liblua headers+runtime"; exit 0; fi
+[ -f "$ROOT/build/libaether.a" ] || { echo "  [SKIP] libaether.a not built"; exit 0; }
+export AETHER_LUA_SONAME="$LUA_SONAME"
+TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
+
+if ! gcc -o "$TMPDIR/t" \
+    "$ROOT/contrib/host/lua/aether_host_lua.c" \
+    "$ROOT/runtime/aether_sandbox.c" "$ROOT/runtime/aether_shared_map.c" \
+    $LUA_CFLAGS -I"$ROOT" -I"$ROOT/runtime" -DAETHER_HAS_LUA -DAETHER_HAS_SANDBOX \
+    -L"$ROOT/build" -laether $LUA_LIBS -ldl -lm -lrt -lpthread \
+    -Wno-discarded-qualifiers -xc - 2>"$TMPDIR/cc.log" << 'CEOF'
+#include <stdio.h>
+#include "contrib/host/lua/aether_host_lua.h"
+void aether_args_init(int a, char** v){(void)a;(void)v;}
+void* _aether_ctx_stack[64]; int _aether_ctx_depth = 0;
+
+/* returns {"k1","k2","k3"} — the KEYS/SMEMBERS shape */
+static int cb_array(void* vm) {
+    lua_table_begin(vm, 3, 0);
+    lua_table_seti_str(vm, 1, "k1");
+    lua_table_seti_str(vm, 2, "k2");
+    lua_table_seti_str(vm, 3, "k3");
+    lua_table_finish(vm);
+    return 1;
+}
+/* returns {field="f1", count=7} — the HGETALL/map shape */
+static int cb_map(void* vm) {
+    lua_table_begin(vm, 0, 2);
+    lua_table_set_str(vm, "field", "f1");
+    lua_table_set_int(vm, "count", 7);
+    lua_table_finish(vm);
+    return 1;
+}
+/* returns {{"a","b"},{"c"}} — array of arrays (nested) */
+static int cb_nested(void* vm) {
+    lua_table_begin(vm, 2, 0);          /* outer */
+    lua_table_begin(vm, 2, 0);          /* inner #1 */
+    lua_table_seti_str(vm, 1, "a");
+    lua_table_seti_str(vm, 2, "b");
+    lua_table_end_seti(vm, 1);          /* outer[1] = inner#1 */
+    lua_table_begin(vm, 1, 0);          /* inner #2 */
+    lua_table_seti_str(vm, 1, "c");
+    lua_table_end_seti(vm, 2);          /* outer[2] = inner#2 */
+    lua_table_finish(vm);
+    return 1;
+}
+
+int main(void) {
+    void* vm = lua_vm_new();
+    if (!vm) { printf("FAIL vm\n"); return 1; }
+    lua_vm_register(vm, "host.arr",    (void*)cb_array);
+    lua_vm_register(vm, "host.map",    (void*)cb_map);
+    lua_vm_register(vm, "host.nested", (void*)cb_nested);
+
+    /* The script exercises each shape exactly as a real EVAL would. */
+    int rc = lua_vm_eval(vm,
+        "local a = host.arr()\n"
+        "assert(#a == 3 and a[1]=='k1' and a[3]=='k3', 'array')\n"
+        "local m = host.map()\n"
+        "assert(m.field=='f1' and m.count==7, 'map')\n"
+        "local n = host.nested()\n"
+        "assert(#n==2 and #n[1]==2 and n[1][2]=='b' and n[2][1]=='c', 'nested')\n"
+        "return a[1] .. ',' .. m.field .. ',' .. n[1][1] .. n[2][1]\n");
+    if (rc != 0) { printf("FAIL eval: %s\n", lua_vm_result_str(vm)); return 1; }
+    printf("result=%s\n", lua_vm_result_str(vm));
+    lua_vm_pop_result(vm);
+    lua_vm_free(vm);
+    return 0;
+}
+CEOF
+then
+    echo "  [SKIP] host_lua_table_builder: harness compile/link failed"
+    head -8 "$TMPDIR/cc.log" | sed 's/^/      /'; exit 0
+fi
+
+OUT="$("$TMPDIR/t" 2>&1)"
+if echo "$OUT" | grep -q "result=k1,f1,ac"; then
+    echo "  [PASS] host_lua_table_builder: array + map + nested array-of-arrays"
+else
+    echo "  [FAIL] host_lua_table_builder: $OUT"; exit 1
+fi


### PR DESCRIPTION
Two commits, bundled into one PR to run CI once (the contrib C change triggers the matrix; the docs ride along free). `Closes #910`.

## #910 — host-callback table builder (the feature)

Follow-up to #904. A faithful `redis.call` returns RESP multibulks — arrays (`KEYS`/`LRANGE`/`SMEMBERS`), maps (`HGETALL`), nested arrays-of-arrays — but the bidirectional Lua bridge could only return scalars and a single `{ok}`/`{err}` table. This adds a table builder for callback returns, reusing the bridge's existing `lua_createtable` + `lua_seti`/`setfield` dlsym machinery.

**Model:** the table being built is the top of the stack — `table_begin` pushes a fresh table, `table_seti_*` / `table_set_*` write into it, nesting is another `table_begin` closed with `table_end_seti`/`table_end_setfield`, and `table_finish` leaves the outermost table as the callback's return. Plus `push_double` for the RESP3 Double scalar.

```aether
@c_callback
redis_keys(vm: ptr) -> int {          // redis.call('KEYS', pat) -> {"k1","k2"}
    lua.table_begin(vm, 2, 0)
    lua.table_seti_str(vm, 1, "k1")
    lua.table_seti_str(vm, 2, "k2")
    lua.table_finish(vm)
    return 1
}
```

Test `tests/integration/host_lua_table_builder/` exercises array, string-keyed map, and nested array-of-arrays returns, with a Lua script asserting each shape (SKIPs without liblua). Unblocks the issue's `KEYSDEL.lua` (`redis.call('KEYS', pattern)` → Lua array → `unpack`).

## Doc / CHANGELOG fixes (doc-only commit, rides free)

- **CHANGELOG.md**: #893 (labeled break/continue) was misfiled under the already-tagged `## [0.320.0]`; per `git tag --contains` it shipped in no tag yet → moved to a fresh `## [current]`. Also restored the workflow note (recurring release-pipeline `[current]` drift). 0.320.0 (#889/#891) and 0.321.0 (#908/#911) were already correct and untouched.
- **contrib/host/TODO.md**: the bidirectional-API rollout plan (which host bridges should get the #904/#910 treatment, by effort/value).
- **docs/parse-dont-validate-review.md**: the Aether-native "parse, don't validate" guide (distinct types / `where` / `(value, err)`); all examples compile and run as shown.

## Testing

`make contrib MODULES=lua` builds clean; `host_lua_table_builder` passes (array+map+nested); `host_lua_bidirectional` (#904) still passes — no regression to the tier this extends. CI runs the full matrix (no `[skip actions]` — contrib C code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)