### PR TITLE
fix: module-var narrowing guard (#929) and per-slot duration interpolation (#927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,30 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.323.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Fixed
+
+- **Module-scope `var` now honours the silent-narrowing guard** (#929). A
+  module-scope `var x = 0` infers a 32-bit `int` from its bare initializer,
+  exactly like the local `x = 0` form — but the #698 narrowing guard (E0200)
+  only fired on locals, so a later 64-bit assignment to the global
+  (`x = os.now_monotonic_ns()`) truncated silently. The parser now marks the
+  global's inferred type and the typechecker carries that marker onto the
+  symbol, so the assignment raises E0200 with the same "annotate the
+  declaration" suggestion. An explicit width (`var x: long = 0`) is exempt, and
+  a plain int global assigned int values is unaffected.
+
+- **Multiple `${duration}` interpolations in one string render distinct values**
+  (#927). The codegen helper `_aether_duration_repr` returned a shared static
+  buffer, so when several durations appeared in a single interpolated string
+  (`"${a} ${b} ${c}"`) all `%s` slots pointed at the last-formatted value —
+  every slot printed the same duration. The helper now hands out a small ring of
+  buffers, so up to eight distinct durations coexist in one printf/snprintf.
 
 ## [0.323.0]
 

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -2235,6 +2235,18 @@ int typecheck_program(ASTNode* program) {
                     ctype = clone_type(child->children[0]->node_type);
                 }
                 add_symbol(global_table, child->value, ctype, 0, 0, 0);
+                /* #929: a module-scope `var x = 0` is a global_var whose type
+                 * was inferred 32-bit int from a bare initializer. Carry the
+                 * parser's `type_inferred` marker onto the symbol (mirroring
+                 * the local AST_VARIABLE_DECLARATION path) so the #698
+                 * silent-narrowing guard fires on a later 64-bit assignment to
+                 * it — without this, `cell = os.now_monotonic_ns()` truncated
+                 * silently for a global where the same code errors for a local. */
+                if (child->type_inferred && ctype &&
+                    (ctype->kind == TYPE_INT)) {
+                    Symbol* gs = lookup_symbol_local(global_table, child->value);
+                    if (gs) gs->type_inferred = 1;
+                }
                 break;
             }
             case AST_MAIN_FUNCTION:

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -3399,8 +3399,17 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     print_line(gen, "    if (!s) return \"(null)\";");
     print_line(gen, "    return aether_string_data(s);");
     print_line(gen, "}");
+    /* #927: multiple ${duration} interpolations can be live in a SINGLE
+     * printf/snprintf call (all args evaluate before the format runs), so a
+     * single shared static buffer would have every %%s slot show the last
+     * result. Hand out a small ring of buffers — one per call — so up to
+     * AE_DUR_BUFS distinct results coexist in one expression. */
+    print_line(gen, "#define AE_DUR_BUFS 8");
     print_line(gen, "static inline const char* _aether_duration_repr(int64_t ns) {");
-    print_line(gen, "    static char _buf[64];");
+    print_line(gen, "    static char _bufs[AE_DUR_BUFS][64];");
+    print_line(gen, "    static unsigned _slot = 0;");
+    print_line(gen, "    char* _buf = _bufs[_slot];");
+    print_line(gen, "    _slot = (_slot + 1) %% AE_DUR_BUFS;");
     print_line(gen, "    int64_t abs_ns = ns < 0 ? -ns : ns;");
     print_line(gen, "    struct _du { const char* suffix; int64_t scale; } units[] = {");
     print_line(gen, "        {\"d\", 86400000000000LL}, {\"h\", 3600000000000LL},");
@@ -3410,10 +3419,10 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     print_line(gen, "    for (size_t i = 0; i < sizeof(units) / sizeof(units[0]); i++) {");
     print_line(gen, "        if (abs_ns >= units[i].scale || units[i].scale == 1) {");
     print_line(gen, "            if (ns %% units[i].scale == 0) {");
-    print_line(gen, "                snprintf(_buf, sizeof(_buf), \"%%lld%%s\", (long long)(ns / units[i].scale), units[i].suffix);");
+    print_line(gen, "                snprintf(_buf, 64, \"%%lld%%s\", (long long)(ns / units[i].scale), units[i].suffix);");
     print_line(gen, "            } else {");
     print_line(gen, "                double v = (double)ns / (double)units[i].scale;");
-    print_line(gen, "                snprintf(_buf, sizeof(_buf), \"%%.9g%%s\", v, units[i].suffix);");
+    print_line(gen, "                snprintf(_buf, 64, \"%%.9g%%s\", v, units[i].suffix);");
     print_line(gen, "            }");
     print_line(gen, "            return _buf;");
     print_line(gen, "        }");

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -5257,6 +5257,13 @@ ASTNode* parse_top_level_decl(Parser* parser) {
                     node->node_type = vtype;
                 } else if (vval->node_type) {
                     node->node_type = clone_type(vval->node_type);
+                    /* #929: no explicit type annotation — the width was
+                     * INFERRED from the initializer (bare `var x = 0` → 32-bit
+                     * int). Mark it so the #698 silent-narrowing guard fires on
+                     * a later 64-bit assignment to this global, matching the
+                     * local `x = expr` path (an explicit `var x: long`/`: T`
+                     * leaves this 0 and is exempt). */
+                    node->type_inferred = 1;
                 } else {
                     node->node_type = create_type(TYPE_UNKNOWN);
                 }

--- a/tests/integration/duration_interp_multi/test_duration_interp_multi.sh
+++ b/tests/integration/duration_interp_multi/test_duration_interp_multi.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Issue #927: multiple ${duration} interpolations in ONE string each
+# rendered the SAME value, because _aether_duration_repr() returned a
+# shared static buffer — every result in a single printf/snprintf
+# pointed at the last-formatted value. The fix hands out a small ring
+# of buffers, so several distinct durations coexist in one expression.
+#
+# This test puts three durations of different magnitudes into one
+# interpolated string (twice, in different orders) and asserts each
+# slot renders its OWN value.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+cat > /tmp/ae_dur_interp_multi.ae << 'EOF'
+main() {
+    a = 5s
+    b = 250ms
+    c = 3h
+    println("a=${a} b=${b} c=${c}")
+    println("again ${c} ${a} ${b}")
+    // Four in one line, all distinct.
+    println("${a} ${b} ${c} ${a}")
+}
+EOF
+
+output=$(AETHER_HOME="" "$ROOT/build/ae" run /tmp/ae_dur_interp_multi.ae 2>&1)
+rc=$?
+rm -f /tmp/ae_dur_interp_multi.ae
+
+if [ "$rc" -ne 0 ]; then
+    echo "duration_interp_multi: FAIL (program errored, rc=$rc)"
+    echo "$output" | head -20 | sed 's/^/  /'
+    exit 1
+fi
+
+expected_l1="a=5s b=250ms c=3h"
+expected_l2="again 3h 5s 250ms"
+expected_l3="5s 250ms 3h 5s"
+
+l1=$(echo "$output" | sed -n '1p')
+l2=$(echo "$output" | sed -n '2p')
+l3=$(echo "$output" | sed -n '3p')
+
+fail=0
+[ "$l1" = "$expected_l1" ] || { echo "  line1: got [$l1] want [$expected_l1]"; fail=1; }
+[ "$l2" = "$expected_l2" ] || { echo "  line2: got [$l2] want [$expected_l2]"; fail=1; }
+[ "$l3" = "$expected_l3" ] || { echo "  line3: got [$l3] want [$expected_l3]"; fail=1; }
+
+if [ "$fail" -ne 0 ]; then
+    echo "duration_interp_multi: FAIL (a ${duration} slot rendered the wrong value)"
+    exit 1
+fi
+
+echo "duration_interp_multi: PASS"
+exit 0

--- a/tests/integration/module_var_narrowing/test_module_var_narrowing.sh
+++ b/tests/integration/module_var_narrowing/test_module_var_narrowing.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Issue #929: the #698 silent-narrowing guard (E0200) was not applied
+# to a MODULE-SCOPE `var x = 0`. The width was inferred as 32-bit int
+# from the bare initializer, but a later 64-bit assignment to the
+# global truncated silently — unlike the identical local-variable path,
+# which already errored. The fix marks the global's inferred type so
+# the guard fires.
+#
+# Three cases:
+#   1. inferred-int global + 64-bit assignment  -> MUST error E0200
+#   2. explicit `var x: long` global            -> MUST compile (exempt)
+#   3. plain int global + int assignment        -> MUST compile (no false +)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+# --- Case 1: must be rejected with E0200 -----------------------------
+cat > /tmp/ae_modvar_bad.ae << 'EOF'
+import std.os
+var cell = 0
+main() {
+    cell = os.now_monotonic_ns()
+    println("${cell}")
+}
+EOF
+out1=$(AETHER_HOME="" "$AE" build /tmp/ae_modvar_bad.ae -o /tmp/ae_modvar_bad_out 2>&1)
+rm -f /tmp/ae_modvar_bad.ae /tmp/ae_modvar_bad_out
+if ! echo "$out1" | grep -q "E0200"; then
+    echo "module_var_narrowing: FAIL (inferred-int global was NOT guarded)"
+    echo "$out1" | head -20 | sed 's/^/  /'
+    exit 1
+fi
+
+# --- Case 2: explicit long global must compile -----------------------
+cat > /tmp/ae_modvar_long.ae << 'EOF'
+import std.os
+var cell: long = 0
+main() {
+    cell = os.now_monotonic_ns()
+    println("${cell}")
+}
+EOF
+out2=$(AETHER_HOME="" "$AE" build /tmp/ae_modvar_long.ae -o /tmp/ae_modvar_long_out 2>&1)
+rc2=$?
+rm -f /tmp/ae_modvar_long.ae /tmp/ae_modvar_long_out
+if [ "$rc2" -ne 0 ]; then
+    echo "module_var_narrowing: FAIL (explicit-long global was wrongly rejected)"
+    echo "$out2" | head -20 | sed 's/^/  /'
+    exit 1
+fi
+
+# --- Case 3: plain int global, int assignment must compile -----------
+cat > /tmp/ae_modvar_int.ae << 'EOF'
+var counter = 0
+main() {
+    counter = counter + 1
+    counter = 42
+    println("${counter}")
+}
+EOF
+out3=$(AETHER_HOME="" "$AE" build /tmp/ae_modvar_int.ae -o /tmp/ae_modvar_int_out 2>&1)
+rc3=$?
+rm -f /tmp/ae_modvar_int.ae /tmp/ae_modvar_int_out
+if [ "$rc3" -ne 0 ]; then
+    echo "module_var_narrowing: FAIL (plain int global was wrongly rejected)"
+    echo "$out3" | head -20 | sed 's/^/  /'
+    exit 1
+fi
+
+echo "module_var_narrowing: PASS"
+exit 0


### PR DESCRIPTION
Two contained compiler bugfixes in one PR (per request; #928 UFCS is a separate effort).

## #929 — module-scope `var` ignored the silent-narrowing guard

A module-scope `var x = 0` infers a 32-bit `int` from its bare initializer, exactly like the local `x = 0` form. But the #698 narrowing guard (E0200) only fired on locals, so a later 64-bit assignment to the global truncated **silently**:

```aether
import std.os
var cell = 0
main() {
    cell = os.now_monotonic_ns()   // was: silent 64→32 truncation
    println("${cell}")
}
```

The parser now sets the `type_inferred` marker on the top-level `var` node (`parser.c`), and the typechecker carries it onto the global symbol (`typechecker.c`), so the assignment raises **E0200** with the same "annotate the declaration" suggestion the local path already gave.

- `var cell = 0` + 64-bit assignment → **E0200** (was silent truncation)
- `var cell: long = 0` → compiles (explicit width is exempt)
- `var counter = 0` + int assignment → compiles (no false positive)

## #927 — multiple `${duration}` interpolations all rendered the same value

The codegen helper `_aether_duration_repr` returned a shared `static char` buffer. When several durations appeared in one interpolated string, all the `_aether_duration_repr(...)` calls evaluated before the single `printf`/`snprintf` ran, so every `%s` slot pointed at the **last-formatted** value:

```aether
a = 5s; b = 250ms; c = 3h
println("a=${a} b=${b} c=${c}")   // was: "a=3h b=3h c=3h"; now: "a=5s b=250ms c=3h"
```

The helper now hands out a small **ring of buffers** (`AE_DUR_BUFS = 8`), so up to eight distinct durations coexist in one printf/snprintf. No call-site signature change.

## Tests

- `tests/integration/module_var_narrowing/` — asserts E0200 fires for the inferred-int global, and that the explicit-long and plain-int globals still compile.
- `tests/integration/duration_interp_multi/` — three/four distinct durations of different magnitudes in one string, in different orders, each rendering its own value.

Full `make test-ae` is green (778 passed) apart from the pre-existing `http_server_h2` / `http_h2_concurrent_dispatch` curl-HTTP2-stress flakes — both pass in isolation and are unrelated to these changes (no HTTP path touched).

Closes #929
Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)