### PR TITLE
feat: method-call-on-value (UFCS) for fluent DSLs (#928)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,28 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.325.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Added
+
+- **Method-call-on-value (UFCS)** (#928). `x.f(args)` now desugars to
+  `f(x, args)` when `f` is a free function whose first parameter type matches
+  `typeof(x)` — the missing primitive for fluent / method-chaining DSLs
+  (`expect(5).to_equal(5)`, `subject.inc().to_equal(6)`). It works on any
+  receiver expression: a call result, a stored value, or a pointer
+  (`c.bump()` → `bump(c)` for `c: *Counter`). UFCS is a strict **last-resort**
+  fallback — module-qualified calls (`string.length(s)`), struct-field access,
+  and function-pointer-field dispatch all keep priority, so nothing that
+  compiled before changes meaning; UFCS only fires on a dotted call that would
+  otherwise be an "Undefined function" error. A receiver whose type doesn't
+  match the candidate's first parameter declines cleanly (no silent coercion).
+  No new declaration syntax and no codegen change: existing free functions
+  become chainable, and the rewritten call lowers like any other by-value
+  call.
 
 ## [0.325.0]
 

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -5039,8 +5039,146 @@ static Type* resolve_fnptr_struct_field(SymbolTable* table, const char* recv_nam
     return NULL;
 }
 
+/* #928 UFCS support: the first declared parameter node of a user
+ * function (the slot a `recv.method(...)` receiver would fill). Returns
+ * NULL for builtins/externs with no AST body, or a zero-param function.
+ * Mirrors the param-walk in count_function_params (last child = body;
+ * guard clauses skipped). */
+static ASTNode* ufcs_first_param(ASTNode* func) {
+    if (!func || func->child_count == 0) return NULL;
+    for (int i = 0; i < func->child_count - 1; i++) {
+        ASTNode* child = func->children[i];
+        if (child->type == AST_VARIABLE_DECLARATION ||
+            child->type == AST_PATTERN_VARIABLE ||
+            child->type == AST_PATTERN_LITERAL) {
+            return child;
+        }
+    }
+    return NULL;
+}
+
+/* #928 method-call-on-value (UFCS): rewrite `recv.method(args)` into the
+ * free-function call `method(recv, args)` when `method` is a free function
+ * whose FIRST parameter type unifies with typeof(recv). Strictly a
+ * LAST-RESORT fallback — it only runs after module-qualified resolution,
+ * struct-field, and fnptr-field dispatch have all declined, so nothing
+ * that compiles today changes meaning (UFCS only fires on what currently
+ * errors with "Undefined function").
+ *
+ * Two entry shapes reach here:
+ *   (a) parser tagged the call `ufcs` and already put the receiver subtree
+ *       at children[0] (the receiver was NOT a bare identifier, e.g. a
+ *       call result `expect(5).to_eq(...)`). call->value is the bare
+ *       method name.
+ *   (b) call->value is the dotted name `recv.method` where `recv` is a
+ *       single identifier (a local value), and children[] are the plain
+ *       args — the legacy member-call shape that previously errored.
+ *
+ * On success the call node is left in canonical `method(recv, args...)`
+ * form (value = method, children = [recv, args...]) and 1 is returned so
+ * the caller continues into the normal arity/type-check path. Returns 0
+ * when no UFCS match applies (caller then emits its Undefined-function
+ * error). */
+static int try_ufcs_rewrite(ASTNode* call, SymbolTable* table) {
+    if (!call || !call->value) return 0;
+
+    int parser_tagged = (call->annotation && strcmp(call->annotation, "ufcs") == 0);
+
+    ASTNode* recv = NULL;       /* receiver expression (owned by call) */
+    char* method = NULL;        /* bare method name (heap; freed before return) */
+    int recv_is_child0 = 0;     /* receiver already sits at children[0] */
+
+    if (parser_tagged) {
+        if (call->child_count < 1) return 0;
+        recv = call->children[0];
+        recv_is_child0 = 1;
+        method = strdup(call->value);
+    } else {
+        /* shape (b): split a single-identifier dotted name. Bail if the
+         * receiver part itself contains a dot (that's a module path, not a
+         * value receiver) — those are handled by qualified resolution. */
+        char* dot = strrchr(call->value, '.');
+        if (!dot || dot == call->value) return 0;
+        size_t rlen = (size_t)(dot - call->value);
+        if (memchr(call->value, '.', rlen)) return 0;  /* multi-dot → not UFCS */
+        char rname[200];
+        if (rlen >= sizeof(rname)) return 0;
+        memcpy(rname, call->value, rlen);
+        rname[rlen] = '\0';
+        /* The receiver must be a known value (local/global), not a module
+         * or type name. If it doesn't resolve as a value symbol, this isn't
+         * UFCS — let the normal Undefined-function error stand. */
+        Symbol* rsym = lookup_symbol(table, rname);
+        if (!rsym || rsym->is_function) return 0;
+        recv = create_ast_node(AST_IDENTIFIER, rname, call->line, call->column);
+        method = strdup(dot + 1);
+    }
+
+    if (!method) { if (!recv_is_child0) free_ast_node(recv); return 0; }
+
+    /* Resolve the method as a free function. */
+    Symbol* fsym = lookup_symbol(table, method);
+    if (!fsym || !fsym->is_function || !fsym->node) {
+        free(method);
+        if (!recv_is_child0) free_ast_node(recv);
+        return 0;
+    }
+    ASTNode* p0 = ufcs_first_param(fsym->node);
+    if (!p0) {  /* zero-param function — nothing to receive */
+        free(method);
+        if (!recv_is_child0) free_ast_node(recv);
+        return 0;
+    }
+
+    /* First-param type must unify with typeof(recv). */
+    typecheck_expression(recv, table);
+    Type* rtype = infer_type(recv, table);
+    int match = (rtype && p0->node_type &&
+                 (types_equal(rtype, p0->node_type) ||
+                  rtype->kind == TYPE_UNKNOWN ||
+                  p0->node_type->kind == TYPE_UNKNOWN));
+    if (rtype) free_type(rtype);
+    if (!match) {
+        free(method);
+        if (!recv_is_child0) free_ast_node(recv);
+        return 0;
+    }
+
+    /* Splice into `method(recv, args...)`. For shape (a) the receiver is
+     * already children[0], so only the call name changes. For shape (b)
+     * prepend the synthesized receiver. */
+    if (!recv_is_child0) {
+        int old = call->child_count;
+        ASTNode** nc = malloc(sizeof(ASTNode*) * (old + 1));
+        nc[0] = recv;
+        for (int i = 0; i < old; i++) nc[i + 1] = call->children[i];
+        if (call->children) free(call->children);
+        call->children = nc;
+        call->child_count = old + 1;
+    }
+    free(call->value);
+    call->value = method;            /* transfer ownership */
+    if (call->annotation) { free(call->annotation); call->annotation = NULL; }
+    return 1;
+}
+
 int typecheck_function_call(ASTNode* call, SymbolTable* table) {
     if (!call || call->type != AST_FUNCTION_CALL) return 0;
+
+    /* #928 UFCS, shape (a): the parser tagged this as a method-call on a
+     * non-identifier receiver (e.g. `expect(5).to_eq(...)`) and stashed the
+     * receiver subtree at children[0]. Rewrite to `method(recv, args)` up
+     * front so the normal resolution + arity path below sees a plain call.
+     * If no free function matches the receiver type, fall through with the
+     * tag cleared so the standard Undefined-function diagnostic fires. */
+    if (call->annotation && strcmp(call->annotation, "ufcs") == 0) {
+        if (!try_ufcs_rewrite(call, table)) {
+            /* Not a UFCS match. Drop the tag; restore a useful name for the
+             * error (the bare method name is already in call->value). */
+            free(call->annotation);
+            call->annotation = NULL;
+        }
+    }
 
     // heap.free(p) — the counterpart to heap.new(T) (issue #564). Not a
     // real function symbol; codegen lowers it to free(p). Validate the
@@ -5215,6 +5353,19 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
                 call->annotation = strdup(is_ptr ? "fnfield_ptr" : "fnfield_val");
                 return 1;
             }
+        }
+    }
+
+    /* #928 UFCS, shape (b): a `recv.method(args)` where `recv` is a local
+     * value (not a module, not a struct field, not a fnptr field — all
+     * tried above and declined). Last resort: rewrite to `method(recv,
+     * args)` if `method` is a free function whose first param matches
+     * typeof(recv), then re-resolve and fall through to the normal
+     * arity/type-check path. */
+    if ((!symbol || !symbol->is_function) && call->value &&
+        strchr(call->value, '.')) {
+        if (try_ufcs_rewrite(call, table)) {
+            symbol = lookup_qualified_symbol(table, call->value);
         }
     }
 

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -1601,6 +1601,12 @@ static ASTNode* parse_postfix_expression(Parser* parser) {
 
             // Extract function name - handle both simple and namespaced calls
             const char* func_name = NULL;
+            // #928 UFCS shape (a): a method-call on a NON-identifier
+            // receiver (a call result, an indexed value, etc. —
+            // `expect(5).to_eq(...)`). The receiver subtree is detached
+            // here and handed to the typechecker as the implicit first
+            // argument; ufcs_recv holds it until the call node exists.
+            ASTNode* ufcs_recv = NULL;
             if (expr && expr->type == AST_IDENTIFIER && expr->value) {
                 // Simple call: foo()
                 func_name = strdup(expr->value);
@@ -1608,10 +1614,21 @@ static ASTNode* parse_postfix_expression(Parser* parser) {
                        expr->child_count > 0 && expr->children[0] &&
                        expr->children[0]->type == AST_IDENTIFIER) {
                 // Namespaced call: namespace.func() -> store as "namespace.func"
+                // (the receiver MIGHT be a value, not a module — the
+                // typechecker tries qualified resolution first and only
+                // falls back to UFCS, shape (b), if that fails.)
                 char qualified_name[256];
                 snprintf(qualified_name, sizeof(qualified_name), "%s.%s",
                          expr->children[0]->value, expr->value);
                 func_name = strdup(qualified_name);
+            } else if (expr && expr->type == AST_MEMBER_ACCESS && expr->value &&
+                       expr->child_count > 0 && expr->children[0]) {
+                // #928 UFCS shape (a): receiver is not a bare identifier, so
+                // there is no qualified name to form. Carry the bare method
+                // name and detach the receiver subtree.
+                func_name = strdup(expr->value);
+                ufcs_recv = expr->children[0];
+                expr->children[0] = NULL;   // detach so free_ast_node(expr) won't reclaim it
             }
 
             // heap.new(TypeName) — like sizeof, the argument is a *type
@@ -1640,6 +1657,16 @@ static ASTNode* parse_postfix_expression(Parser* parser) {
             advance_token(parser); // consume '('
 
             ASTNode* func_call = create_ast_node(AST_FUNCTION_CALL, func_name, op->line, op->column);
+
+            // #928 UFCS shape (a): mark the node and seat the detached
+            // receiver as the implicit first argument (children[0]). The
+            // typechecker rewrites `method(recv, args)` and clears the tag;
+            // if no free function matches, the tag is dropped and the
+            // standard Undefined-function error fires on `func_name`.
+            if (ufcs_recv) {
+                func_call->annotation = strdup("ufcs");
+                add_child(func_call, ufcs_recv);
+            }
 
             // Parse arguments
             if (!match_token(parser, TOKEN_RIGHT_PAREN)) {

--- a/docs/928-method-call-on-value-scoping.md
+++ b/docs/928-method-call-on-value-scoping.md
@@ -147,3 +147,37 @@ subtree for general dotted calls; (2) typechecker UFCS fallback with
 first-param unification and strict last-resort ordering; (3) tests for the
 chain, the precedence (module/field win), and the no-match error. Codegen
 is untouched.
+
+---
+
+## Status: IMPLEMENTED (this PR)
+
+Option 1 (UFCS) is implemented exactly as scoped above — no codegen change.
+
+- **Parser** (`parser/parser.c`, postfix call handler). A dotted call whose
+  receiver is **not** a bare identifier (a call result, an indexed value —
+  `expect(5).to_eq(...)`) previously produced no callee name and failed as
+  `Undefined function '?'`. It now detaches the receiver subtree, carries the
+  bare method name, tags the call node `ufcs`, and seats the receiver as
+  `children[0]`. The `identifier.member()` path is unchanged (still forms the
+  qualified name first).
+- **Typechecker** (`analysis/typechecker.c`, `try_ufcs_rewrite`). Two entry
+  shapes both rewrite to canonical `method(recv, args)`:
+  - shape (a): the parser-tagged node (receiver already at `children[0]`);
+    handled at the top of `typecheck_function_call`.
+  - shape (b): a `recv.method(args)` where `recv` is a single-identifier
+    **value** — tried as a strict last resort, right after the #749
+    fnptr-field fallback and before the Undefined-function error.
+  In both shapes UFCS only fires when `method` resolves to a free function
+  whose first parameter type unifies with `typeof(recv)`; otherwise it
+  declines and the standard error stands. Module-qualified resolution,
+  struct-field, and fnptr-field dispatch all keep priority, so nothing that
+  compiled before changes meaning.
+- **Codegen**: untouched. The rewritten node is an ordinary call.
+
+Verified: chained call-result receivers (`expect(5).inc().to_equal(6)`),
+stored-value receivers, pointer receivers (`c.bump()` →
+`bump(c)` with `c: *Counter`), module calls still resolving, and both
+decline paths (no such free function; first-param type mismatch) producing a
+clean `Undefined function` error rather than a miscompile. Regression test:
+`tests/integration/ufcs_method_call/`.

--- a/docs/928-method-call-on-value-scoping.md
+++ b/docs/928-method-call-on-value-scoping.md
@@ -1,0 +1,149 @@
+# #928 — Method-call-on-value: scoping note
+
+Two candidate mechanisms for `subject.matcher().matcher()`. This note
+grounds each in the *current* compiler (parser dot-call handling,
+typechecker call resolution, by-value struct codegen) so the pick is made
+against real seams, not a sketch. All findings verified against the live
+`build/aetherc` at the tip of `main`.
+
+## The shared call site in the compiler
+
+A dotted call `recv.member(args)` is parsed in the postfix loop of
+`parse_postfix_expression` (`parser/parser.c` ~1576). Today the callee name
+is only synthesised for two receiver shapes (parser.c:1602–1615):
+
+- `expr` is a bare `AST_IDENTIFIER` → simple call `foo()`.
+- `expr` is `AST_MEMBER_ACCESS` whose **child[0] is an `AST_IDENTIFIER`** →
+  qualified name `"ns.func"` (this is how `string.length()` /
+  `math.pow()` module calls are formed).
+
+For any **other** receiver — notably a *call result*, `expect(5).to_*` —
+`func_name` stays `NULL` and typecheck reports `Undefined function '?'`.
+That is the first repro in the issue. So **whichever mechanism we pick, the
+parser must be taught to carry the receiver subtree for the general dotted
+call**, not just `identifier.member`.
+
+Call resolution then happens in the typechecker (`analysis/typechecker.c`
+~5160–5240). There is already a precedent for a *fallback* when
+`recv.field(args)` doesn't resolve as a function symbol: #749 dispatches
+through a function-pointer **struct field** (typechecker.c:5189–5218),
+splitting `recv` from `field` on the last `.` and tagging the node
+`fnfield_ptr`/`fnfield_val` for codegen. UFCS slots in as a **sibling
+fallback right next to it**.
+
+## The cost question (answered)
+
+The issue asks for a compiler opinion on per-hop struct-copy cost. Verified
+by emitting C for a 2-field `Subject` threaded through `bump(bump(a))`:
+
+```c
+typedef struct Subject { int val; int neg; } Subject;
+Subject bump(Subject s) { return (Subject){.val = (s.val + 1), .neg = s.neg}; }
+...
+Subject b = bump(bump(a));
+```
+
+By-value structs lower to **plain C by-value** — no heap alloc, no
+refcount, no hidden pointer threading. A chain of N matcher calls on a
+small subject record is N register-width struct copies, which the C backend
+elides under `-O2` (a 2–3 field record passes in registers). **The
+hot-test-loop concern is unfounded; this is cheap.** Both mechanisms below
+lower to exactly this shape — the codegen is *already done*, we only change
+how the call is spelled and resolved.
+
+---
+
+## Option 1 — UFCS (`x.f(args)` ⇒ `f(x, args)`)
+
+**Rule.** When `recv.method(args)` does not resolve as (a) a
+module-qualified call, (b) a struct field / fnptr-field, then if there is a
+free function `method` whose **first parameter type unifies with
+`typeof(recv)`**, rewrite to `method(recv, args)` and typecheck that.
+
+**Changes.**
+- *Parser*: in the postfix `(` handler, when the receiver is not one of the
+  two existing shapes, emit a call node that **retains the receiver
+  subtree** as an implicit first argument, tagged (e.g. `ufcs_pending`) so
+  the typechecker knows the dotted head is a *method name*, not a qualified
+  module path. (Module-qualified `ns.func()` keeps its existing fast path —
+  no behaviour change for `string.length()`.)
+- *Typechecker*: a new fallback branch beside the #749 fnptr-field block:
+  resolve the bare `method` name as a free function, check
+  `param[0] == typeof(recv)`, splice `recv` as arg 0, then run the normal
+  arity/type checks on the combined arg list. Stamp the return type for
+  chaining.
+- *Codegen*: **none.** The rewritten node is an ordinary call —
+  `to_equal(expect(5), 5)` — which already lowers correctly.
+
+**Disambiguation (the one real subtlety).** `a.b(c)` is now three-way
+ambiguous: module call, struct/fnptr field, or UFCS. Order is what keeps it
+safe: keep the existing module + field resolution **first**, UFCS strictly
+**last** (only on what currently errors). That makes UFCS purely additive —
+nothing that compiles today changes meaning. A `method` that collides with
+a real field name resolves to the field (status quo wins).
+
+**Pros.** Smallest change; no new declaration syntax; every existing free
+function becomes chainable; dissolves the `fw`-threading awkwardness the
+issue calls out (the subject record carries context). Matches the author's
+stated lean. D/Nim precedent.
+
+**Cons.** Dispatch is on first-param type only — no overload set / no
+receiver-type namespacing, so two modules each exporting `to_equal` would
+need disambiguation by import. Reads as a method but is a free function
+(some find that surprising).
+
+**Rough size.** Parser: ~1 branch + retain-subtree. Typechecker: ~1
+fallback branch mirroring #749. Codegen: 0. Tests: positive chain, the
+no-match error, the module/field-still-wins precedence cases.
+
+---
+
+## Option 2 — Receiver methods (`fn (s: Subject) f(args)`)
+
+**Rule.** A new declaration form binds `f` as a method of the receiver
+type; `recv.f(args)` dispatches on `typeof(recv)`.
+
+**Changes.**
+- *Lexer/parser*: a **new declaration grammar** — `fn (recv: T) name(params)
+  -> R { ... }`. This is the `E0100: Expected LEFT_BRACE, got IDENTIFIER`
+  repro in the issue; the `fn` keyword path has to learn the
+  parenthesised-receiver prefix.
+- *Symbol table*: a **method table keyed by (receiver type, name)** —
+  genuinely new machinery (today functions live in one flat namespace).
+- *Typechecker*: dispatch `recv.f` through the method table; receiver
+  becomes implicit arg 0.
+- *Codegen*: lower to a mangled free function `T__f(T recv, ...)` — same
+  by-value shape as Option 1, just a name-mangling step.
+
+**Pros.** Familiar Go shape; receiver-type namespacing means two types can
+both have `to_equal` with no collision; clearer intent at the declaration.
+
+**Cons.** Biggest surface: new declaration grammar **and** a method table
+**and** dispatch rules **and** name mangling. More places to get the
+interaction with existing module/field resolution wrong. Doesn't make
+*existing* free functions chainable — everything must be re-declared as a
+method.
+
+**Rough size.** Parser: new grammar production (non-trivial). Symbol
+table: new keyed structure. Typechecker: new dispatch path. Codegen:
+mangling. Tests: a broad matrix. ~3–4× Option 1.
+
+---
+
+## Recommendation
+
+**Option 1 (UFCS), implemented as a last-resort fallback** beside the
+existing #749 fnptr-field dispatch. It is the smallest change, it is purely
+additive (nothing that compiles today shifts meaning, because UFCS only
+fires on what currently errors), it makes the whole existing free-function
+surface chainable, and it lands the motivating assertion-DSL family without
+a new declaration grammar or a method table. The cost concern is already
+disproven by the by-value codegen. Option 2's only real win — receiver-type
+namespacing of method names — is not needed by the motivating use case and
+can be layered later if overload collisions ever bite.
+
+If we adopt UFCS, the build order is: (1) parser retains the receiver
+subtree for general dotted calls; (2) typechecker UFCS fallback with
+first-param unification and strict last-resort ordering; (3) tests for the
+chain, the precedence (module/field win), and the no-match error. Codegen
+is untouched.

--- a/tests/integration/ufcs_method_call/probe.ae
+++ b/tests/integration/ufcs_method_call/probe.ae
@@ -1,0 +1,56 @@
+// #928 UFCS (method-call-on-value): `x.f(args)` desugars to `f(x, args)`
+// when `f` is a free function whose first parameter matches typeof(x).
+// This is the positive program — every line must run; it self-asserts by
+// printing a fixed transcript the shell test pins exactly.
+
+struct Subject {
+    val,
+    neg
+}
+
+expect(v: int) -> Subject {
+    return Subject{ val: v, neg: 0 }
+}
+
+// Returns the receiver so calls chain (fluent-interface shape).
+to_equal(s: Subject, want: int) -> Subject {
+    if s.val == want {
+        println("eq ok")
+    } else {
+        println("eq FAIL")
+    }
+    return s
+}
+
+inc(s: Subject) -> Subject {
+    return Subject{ val: s.val + 1, neg: s.neg }
+}
+
+// Pointer receiver — in-place mutation through `*T`.
+struct Counter { n }
+bump(c: *Counter) {
+    c.n = c.n + 1
+}
+
+main() {
+    // shape (a): UFCS on a call result.
+    _ = expect(5).to_equal(5)
+
+    // chain: expect(5).inc() == Subject{6}, then .to_equal(6).
+    _ = expect(5).inc().to_equal(6)
+
+    // longer chain — two incs.
+    _ = expect(1).inc().inc().to_equal(3)
+
+    // shape (b): UFCS on a stored value.
+    a = expect(7)
+    _ = a.to_equal(7)
+
+    // pointer receiver, mutate in place.
+    c = heap.new(Counter)
+    c.n = 0
+    c.bump()
+    c.bump()
+    c.bump()
+    println("count ${c.n}")
+}

--- a/tests/integration/ufcs_method_call/test_ufcs_method_call.sh
+++ b/tests/integration/ufcs_method_call/test_ufcs_method_call.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Issue #928: method-call-on-value (UFCS). `x.f(args)` desugars to
+# `f(x, args)` when `f` is a free function whose first parameter type
+# matches typeof(x). Implemented as a strict last-resort fallback, so it
+# only fires on dotted calls that would otherwise be "Undefined function"
+# — module-qualified calls and struct/fnptr-field dispatch keep priority.
+#
+# Covers: the positive transcript (chained call-result receiver, stored-
+# value receiver, pointer receiver), precedence (a real module call still
+# resolves), and the two ways UFCS must DECLINE (no such free function;
+# first-param type mismatch) — both of which must surface a clean
+# Undefined-function error, not a miscompile.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+# --- Positive: the probe program runs and prints the pinned transcript --
+out=$(AETHER_HOME="" "$AE" run "$SCRIPT_DIR/probe.ae" 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    echo "ufcs_method_call: FAIL (probe errored, rc=$rc)"
+    echo "$out" | head -20 | sed 's/^/  /'
+    exit 1
+fi
+expected="eq ok
+eq ok
+eq ok
+eq ok
+count 3"
+if [ "$out" != "$expected" ]; then
+    echo "ufcs_method_call: FAIL (transcript mismatch)"
+    echo "  --- got ---";      echo "$out"      | sed 's/^/  /'
+    echo "  --- want ---";     echo "$expected" | sed 's/^/  /'
+    exit 1
+fi
+
+# --- Precedence: a genuine module call must NOT be hijacked by UFCS ------
+cat > /tmp/ae_ufcs_mod.ae << 'EOF'
+import std.string
+main() {
+    s = "hello"
+    println("${string.length(s)}")
+}
+EOF
+mod_out=$(AETHER_HOME="" "$AE" run /tmp/ae_ufcs_mod.ae 2>&1)
+mod_rc=$?
+rm -f /tmp/ae_ufcs_mod.ae
+if [ "$mod_rc" -ne 0 ] || [ "$mod_out" != "5" ]; then
+    echo "ufcs_method_call: FAIL (module call regressed: rc=$mod_rc out=[$mod_out])"
+    exit 1
+fi
+
+# --- Decline 1: no matching free function -> clean Undefined error -------
+cat > /tmp/ae_ufcs_nomatch.ae << 'EOF'
+struct Foo { x }
+main() {
+    f = Foo{ x: 1 }
+    _ = f.no_such_method(2)
+}
+EOF
+nm_out=$(AETHER_HOME="" "$AE" build /tmp/ae_ufcs_nomatch.ae -o /tmp/ae_ufcs_nomatch_out 2>&1)
+rm -f /tmp/ae_ufcs_nomatch.ae /tmp/ae_ufcs_nomatch_out
+if ! echo "$nm_out" | grep -q "Undefined function"; then
+    echo "ufcs_method_call: FAIL (no-match UFCS did not produce Undefined-function error)"
+    echo "$nm_out" | head -10 | sed 's/^/  /'
+    exit 1
+fi
+
+# --- Decline 2: first-param type mismatch -> must NOT rewrite ------------
+cat > /tmp/ae_ufcs_mismatch.ae << 'EOF'
+struct A { x }
+struct B { y }
+takes_b(b: B, n: int) -> int { return b.y + n }
+main() {
+    a = A{ x: 1 }
+    _ = a.takes_b(2)
+}
+EOF
+mm_out=$(AETHER_HOME="" "$AE" build /tmp/ae_ufcs_mismatch.ae -o /tmp/ae_ufcs_mismatch_out 2>&1)
+rm -f /tmp/ae_ufcs_mismatch.ae /tmp/ae_ufcs_mismatch_out
+if ! echo "$mm_out" | grep -q "Undefined function"; then
+    echo "ufcs_method_call: FAIL (type-mismatched receiver was wrongly rewritten)"
+    echo "$mm_out" | head -10 | sed 's/^/  /'
+    exit 1
+fi
+
+echo "ufcs_method_call: PASS"
+exit 0


### PR DESCRIPTION
Implements **#928** — method-call-on-value (UFCS): `x.f(args)` desugars to `f(x, args)` when `f` is a free function whose first parameter type matches `typeof(x)`. The missing primitive for fluent / method-chaining assertion DSLs (the Aeocha motivating case):

```aether
expect(5).to_equal(5)
expect(5).inc().to_equal(6)        // chains
a = expect(7); a.to_equal(7)       // stored-value receiver
c.bump()                           // pointer receiver: bump(c) for c: *Counter
```

## Implementation

**No codegen change** — the rewritten node is an ordinary by-value call.

- **Parser** (`parser.c`). A dotted call whose receiver is **not** a bare identifier (a call result like `expect(5).to_*`) previously had no callee name and failed as `Undefined function '?'`. It now detaches the receiver subtree, carries the bare method name, tags the node `ufcs`, and seats the receiver as `children[0]`. The `identifier.member()` path is unchanged.
- **Typechecker** (`typechecker.c`, `try_ufcs_rewrite`). Rewrites both entry shapes to canonical `method(recv, args)`: shape (a) parser-tagged node handled up front; shape (b) `recv.method()` on a single-identifier value tried as a **strict last resort**, after the #749 fnptr-field fallback and before the Undefined-function error. UFCS only fires when the method resolves to a free function whose first param unifies with `typeof(recv)`.

## Precedence / safety

Purely additive: module-qualified calls (`string.length(s)`), struct-field access, and fnptr-field dispatch all keep priority. UFCS only fires on a dotted call that would **otherwise** be `Undefined function`, so nothing that compiled before changes meaning. A type-mismatched receiver declines cleanly — no silent coercion.

## Tests

`tests/integration/ufcs_method_call/` covers chained call-result receivers, stored-value and pointer receivers, module-call precedence, and both decline paths (no matching free function; first-param type mismatch).

Full `make test-ae` green (**779 passed**) apart from the pre-existing `http_server_h2` / `http_h2_concurrent_dispatch` curl-HTTP2-stress flakes (pass in isolation; unrelated).

## Docs

`docs/928-method-call-on-value-scoping.md` carries the design rationale (UFCS vs. receiver methods, the by-value-codegen cost analysis) plus an implementation-status addendum — secondary to the implementation.

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)