### PR TITLE
fix(lexer): heredoc closing-marker rule — eliminate silent truncation (#922)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **Heredoc closing-marker rule: no more silent truncation** (#922). A heredoc
+  body line that merely read like the closing marker could close the heredoc
+  early and silently drop the rest of the body. The close rule is now: a line
+  closes the heredoc only when it is the marker alone on its line AND its
+  indentation is at or below the shallowest body line — the terminator lives at
+  the content's base level. A more-indented marker-like line is therefore body
+  content (never a silent truncation); a lone marker indented *past* the body
+  matches nothing and is reported as an unterminated heredoc rather than
+  dropping content. The closing marker may still be indented (at/below the body
+  base; column 0 always works), the marker must be alone on its line
+  (`done END` / `xEND` stay content), and body dedent is unchanged (common
+  leading-whitespace / least-indented line, like Ruby's squiggly `<<~`). Docs
+  (`LLM.md`, language-reference) corrected — they wrongly claimed "column 0
+  only," which the lexer never enforced.
+
 - **Qualified type name `mod.Type` accepted in type positions** (#946). A
   module-qualified name was accepted as a value/call (`lib.mk(...)`, #878) but
   not as a *type* — the parser stopped at the `.` (`Expected RIGHT_PAREN, got

--- a/LLM.md
+++ b/LLM.md
@@ -199,10 +199,15 @@ plays that role), no interfaces.
   interpolation/escaping — reach for them to embed another language's
   source verbatim (`contrib.host.*` snippets, SQL) so the guest's own
   `"…"` need no `\"`. Use a normal `"…"` string when you want `${}`.
-  Closing marker at column 0. The common leading-whitespace prefix is
-  stripped (so you can indent the body to match surrounding code); the
-  strip is character-exact, so don't mix tabs/spaces in that prefix. Full
-  dedent rules: lexer.c `<<` case.
+  Closing marker is `MARKER` alone on its line; it MAY be indented, but
+  only at or below the body's shallowest line (it sits at the content's
+  base level — column 0 always works). A more-indented line that reads
+  like the marker is content, not a terminator, so it can't silently
+  truncate the body; a marker indented past the body is an unterminated-
+  heredoc error. The common leading-whitespace prefix is stripped (so you
+  can indent the body to match surrounding code); the strip is character-
+  exact, so don't mix tabs/spaces in that prefix. Full rules: lexer.c `<<`
+  case (#922).
 - **Trailing-closure brace goes on the call's line.** `f(x) { … }`
   attaches the block as a trailing closure; `f(x)` then `{ … }` on the
   next line is a separate bare-brace block (the compiler warns). Keep the

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdbool.h>
+#include <limits.h>
 #include "tokens.h"
 #include "lexer.h"
 
@@ -583,35 +584,79 @@ Token* next_token() {
                     char* buf = malloc(buf_capacity);
                     if (!buf) return create_token(TOKEN_ERROR, "out of memory", current_line, current_column);
                     int blen = 0;
+                    // Close detection (#922). Scan line by line. A line closes
+                    // the heredoc only when it is, in full, optional leading
+                    // whitespace followed by exactly the marker and then a line
+                    // ending or EOF — AND its indentation is at-or-below the
+                    // shallowest non-blank body line seen so far. The closing
+                    // marker lives at the content's base level: a line that is
+                    // *more* indented than the body but happens to equal the
+                    // marker is therefore body content, not a terminator, so an
+                    // indented marker-like line can never silently truncate the
+                    // body. (A lone marker indented PAST the body never matches,
+                    // so the scan runs to EOF and reports an unterminated
+                    // heredoc rather than dropping content.) The marker must be
+                    // the only token on its line — `foo MARK` / `xMARK` stay
+                    // content. Body dedent (below) is unchanged: common leading
+                    // whitespace, i.e. the least-indented line, like Ruby's
+                    // squiggly `<<~`.
+                    int min_body_indent = INT_MAX;
+                    int closed = 0;
                     while (current_pos < source_length) {
-                        // Check if current line starts with the marker
-                        // Skip optional \r before checking (Windows CRLF)
-                        int check_pos = current_pos;
-                        int match = 1;
-                        for (int mi = 0; mi < mlen; mi++) {
-                            if (check_pos + mi >= source_length || source[check_pos + mi] != marker[mi]) {
-                                match = 0;
-                                break;
-                            }
+                        // Leading whitespace of the line at current_pos.
+                        int ws = 0;
+                        while (current_pos + ws < source_length &&
+                               (source[current_pos + ws] == ' ' ||
+                                source[current_pos + ws] == '\t')) {
+                            ws++;
                         }
-                        // Marker must be followed by newline, \r\n, or EOF
-                        if (match) {
-                            int after = check_pos + mlen;
+                        int mpos = current_pos + ws;
+                        // Is the rest of the line exactly the marker + EOL/EOF?
+                        int is_marker_line = 0;
+                        if (mpos + mlen <= source_length &&
+                            memcmp(&source[mpos], marker, (size_t)mlen) == 0) {
+                            int after = mpos + mlen;
                             if (after >= source_length ||
                                 source[after] == '\n' ||
-                                (source[after] == '\r' && after + 1 < source_length && source[after + 1] == '\n')) {
-                                // Skip past the marker and line ending
-                                for (int mi = 0; mi < mlen; mi++) advance();
-                                if (peek() == '\r') advance();
-                                if (peek() == '\n') advance();
-                                break;
+                                (source[after] == '\r' && after + 1 < source_length &&
+                                 source[after + 1] == '\n')) {
+                                is_marker_line = 1;
                             }
                         }
-                        // Not the marker — copy this char to buffer
-                        // Skip \r in \r\n sequences (normalize to \n)
-                        char ch = peek();
-                        if (ch != '\r' || (current_pos + 1 < source_length && source[current_pos + 1] != '\n')) {
-                            // Grow buffer if needed
+                        if (is_marker_line && ws <= min_body_indent) {
+                            // Consume the marker line + its ending, then stop.
+                            for (int i = 0; i < ws + mlen; i++) advance();
+                            if (peek() == '\r') advance();
+                            if (peek() == '\n') advance();
+                            closed = 1;
+                            break;
+                        }
+                        // Body line. A blank line (only whitespace) does not
+                        // constrain the base indent, mirroring the dedent pass.
+                        int line_is_blank = (mpos >= source_length ||
+                                             source[mpos] == '\n' ||
+                                             (source[mpos] == '\r' && mpos + 1 < source_length &&
+                                              source[mpos + 1] == '\n'));
+                        if (!line_is_blank && ws < min_body_indent) min_body_indent = ws;
+                        // Copy the line and its newline, normalizing \r\n -> \n.
+                        while (peek() != '\n' && peek() != '\0') {
+                            char ch = peek();
+                            if (ch != '\r' || (current_pos + 1 < source_length &&
+                                               source[current_pos + 1] != '\n')) {
+                                if (blen >= buf_capacity - 1) {
+                                    buf_capacity *= 2;
+                                    char* new_buf = realloc(buf, buf_capacity);
+                                    if (!new_buf) {
+                                        free(buf);
+                                        return create_token(TOKEN_ERROR, "heredoc too large", current_line, current_column);
+                                    }
+                                    buf = new_buf;
+                                }
+                                buf[blen++] = ch;
+                            }
+                            advance();
+                        }
+                        if (peek() == '\n') {
                             if (blen >= buf_capacity - 1) {
                                 buf_capacity *= 2;
                                 char* new_buf = realloc(buf, buf_capacity);
@@ -621,9 +666,19 @@ Token* next_token() {
                                 }
                                 buf = new_buf;
                             }
-                            buf[blen++] = ch;
+                            buf[blen++] = '\n';
+                            advance();
+                        } else {
+                            break;   // EOF mid-line, no closing marker
                         }
-                        advance();
+                    }
+                    if (!closed) {
+                        free(buf);
+                        char err[MAX_IDENTIFIER_LENGTH + 64];
+                        snprintf(err, sizeof(err),
+                                 "unterminated heredoc: missing closing marker '%s'",
+                                 marker);
+                        return create_token(TOKEN_ERROR, err, start_line, current_column);
                     }
                     // Strip the final newline before the marker line.
                     // Content between the markers is preserved exactly,

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -1787,10 +1787,22 @@ WHERE active = 1
 SQL
 ```
 
-The body runs from the line after `<<MARKER` to a line whose first characters
-are exactly `MARKER` (the closing marker must be at column 0). Windows `\r\n`
-is normalized to `\n`, and the single newline immediately before the closing
-marker is dropped (it's syntax, not content).
+The body runs from the line after `<<MARKER` to the **closing-marker line**: a
+line that is, in full, optional leading whitespace followed by exactly `MARKER`
+and then the end of the line. The closing marker **may be indented** — it does
+not have to sit at column 0 — but its indentation must be **at or below** the
+shallowest body line (the terminator lives at the content's base level). Windows
+`\r\n` is normalized to `\n`, and the single newline immediately before the
+closing marker is dropped (it's syntax, not content).
+
+Because the terminator sits at the content's base level, a body line that is
+*more* indented than the rest but happens to read exactly like the marker is
+**body content, not a terminator** — so it can never silently truncate the
+string. (Conversely, a lone marker indented *past* the body matches nothing and
+the heredoc is reported as unterminated, rather than dropping content. Put the
+closing marker at column 0, or aligned with the body's base indent, and it
+always closes.) The marker must also be alone on its line: `done MARKER` and
+`xMARKER` stay content.
 
 **Common-indent dedent.** The longest run of leading whitespace shared by every
 *non-blank* line is stripped, so a heredoc can be indented to match its

--- a/tests/regression/test_issue922_heredoc_close.ae
+++ b/tests/regression/test_issue922_heredoc_close.ae
@@ -1,0 +1,61 @@
+// Regression: issue #922 — heredoc closing-marker rule.
+//
+// A line closes the heredoc only when it is (optional leading whitespace +
+// the marker + end-of-line) AND its indentation is at-or-below the shallowest
+// body line seen so far — the terminator lives at the content's base level.
+// Consequences this test pins:
+//   * an indented closing marker at the body's base level works;
+//   * a line that is MORE indented than the body but happens to equal the
+//     marker is body content, not a terminator — so it can never silently
+//     truncate the body (the bug this issue reported);
+//   * body dedent is unchanged (common leading whitespace / least-indented
+//     line, like Ruby's squiggly `<<~`).
+import std.string
+
+extern exit(code: int)
+
+check(got: string, want: string, label: string) {
+    if string.equals(got, want) != 1 {
+        print("FAIL #922 ")
+        print(label)
+        print(": <")
+        print(got)
+        print(">\n")
+        exit(1)
+    }
+}
+
+main() {
+    // 1. Column-0 marker, indented body — common-prefix dedent (unchanged).
+    a = <<END
+    line one
+    line two
+END
+    check(a, "line one\nline two", "col0-marker")
+
+    // 2. Indented closing marker at the body's base level — works.
+    b = <<MARK
+        body one
+        body two
+        MARK
+    check(b, "body one\nbody two", "indented-marker")
+
+    // 3. The reported bug: a deeper line that equals the marker is CONTENT,
+    //    not an early close — nothing after it is dropped.
+    c = <<MARK
+real content
+    MARK
+this stays
+MARK
+    check(c, "real content\n    MARK\nthis stays", "no-silent-truncation")
+
+    // 4. Relative indentation within the body is preserved after dedent.
+    d = <<END
+    outer
+      inner
+    outer2
+END
+    check(d, "outer\n  inner\nouter2", "relative-indent")
+
+    println("PASS: #922 heredoc close")
+}


### PR DESCRIPTION
## Summary

Closes #922

The heredoc close match was **unanchored** — any position followed by the marker + end-of-line closed the heredoc — so a body line that merely read like the marker (`    MARK`) closed it early and **silently dropped the rest of the body**. The docs and `LLM.md` compounded the confusion by claiming "closing marker at column 0," which the lexer never enforced.

### The rule (one coherent, intuitive principle)

A line closes the heredoc only when it is the marker **alone on its line** (optional leading whitespace, then exactly the marker, then EOL/EOF) **AND** its indentation is **at or below the shallowest body line** seen so far — the terminator lives at the content's base level.

```aether
s = <<MARK
real content
    MARK          // more indented than the body → CONTENT, not a terminator
this stays
MARK              // at the base level → closes here
// value: "real content\n    MARK\nthis stays"  (nothing dropped)
```

Consequences:
- A line more-indented than the body that happens to equal the marker is **body content, never a silent truncation**.
- A lone marker indented *past* the body matches nothing → the heredoc is reported as **unterminated** rather than silently consuming to EOF.
- The closing marker may still be indented (at/below the body base; **column 0 always works**) — the modern indented-marker convenience is kept.
- The marker must be alone on its line — `done MARK` / `xMARK` stay content (this also fixes the old mid-line match).
- **Body dedent is unchanged**: common leading-whitespace / least-indented line, like Ruby's squiggly `<<~`. Every existing column-0-marker + indented-body heredoc (all current tests, the `host-*` examples) is byte-identical.

Single-pass, O(n), line-by-line in the lexer, tracking the shallowest body indent as it scans.

### Why this rule (the design call)

The issue offered (a) keep permissive + fix docs, (b) switch to marker-column dedent (Swift/PHP-7.3), (c) tighten. Option (b) would have **broken** Aether's existing common-prefix dedent (which is the Ruby `<<~` "least-indented line" model — already modern), since all current heredocs put the marker at column 0 with an indented body. So this keeps the excellent dedent untouched and fixes only the **close detection**, with a rule that eliminates the silent-data-loss entirely while still allowing indented markers — strictly better than the word-marker heredoc languages (sh/Ruby/Perl) on the silent-truncation front.

## Tests

`tests/regression/test_issue922_heredoc_close.ae` — column-0 marker, indented marker at the body base, the no-silent-truncation case, and relative-indent preservation. Existing `test_heredoc.ae` / `test_heredoc_dedent.ae` pass unchanged.

## Verification

- C unit suite: 231/231.
- `make examples`: 84/0 (host-python/go/racket heredoc examples).
- `.ae` regression: no new failures (the lone failing probe is the pre-existing flaky RSS test `heap_leak_cross_fn_recursion`, passes on rerun; a lexer change can't touch its no-heredoc runtime path).
- `-Wall -Wextra -Werror` clean on `lexer.c`.

## Docs

- `docs/language-reference.md` heredoc section + `LLM.md` corrected (the "column 0 only" claim was wrong) + `CHANGELOG.md`.