### PR TITLE
fix(ae): macOS arm64 build/link + install robustness (#959)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,25 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **macOS arm64: `ae build` couldn't link anything off a released package**
+  (#959). Three build-toolchain fixes:
+  - **Flat runtime-archive fallback.** `ae build` looked for the prebuilt
+    archive only at the canonical nested `lib/aether/libaether.a`. The macOS
+    arm64 v0.331/0.332 packages shipped it flat at `lib/libaether.a`, so the
+    lookup missed it and fell back to compiling an *incomplete* runtime source
+    list — every build, even hello-world, then failed to link (`Undefined
+    symbols ... _aether_io_poller_init`). `ae build` now falls back to the flat
+    archive before the source path; the complete archive links.
+  - **Version-agnostic homebrew link paths.** The link flags baked into `ae`
+    came from `pkg-config`, which on homebrew emits versioned
+    `-L/opt/homebrew/Cellar/<pkg>/<ver>/lib` paths — so `ld: library 'ssl' not
+    found` the moment a formula was upgraded. The build now rewrites those to
+    the version-agnostic `/opt/homebrew/opt/<pkg>/lib` symlinks homebrew keeps
+    current. No-op on non-homebrew layouts.
+  - **Corrupt-archive guard on install.** `ae version install` now validates
+    that the extracted `libaether.a` is a well-formed `ar` archive of plausible
+    size, catching the interrupted/partial extract that left a truncated
+    archive (undefined symbols) and a broken install with no hint at the cause.
 - **`ae build` now fails on an imported module's compile error** (#953). `ae
   build` accepted an entry program whose *imported* module did not compile —
   the parser's error recovery dropped the offending construct (e.g. an invalid

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,22 @@ ifneq ($(PCRE2_LDFLAGS),)
   PCRE2_CFLAGS += -DAETHER_HAS_PCRE2
 endif
 
+# #959: homebrew's pkg-config .pc files emit versioned
+# `-L/opt/homebrew/Cellar/<pkg>/<version>/lib` paths. Those `-L` dirs get
+# baked into the shipped `ae` binary (via -DAETHER_*_LIBS below) and break
+# every user `ae build` with `ld: library 'ssl' not found` the moment the
+# formula is upgraded to a new version. Rewrite each Cellar path to the
+# version-agnostic `/opt/homebrew/opt/<pkg>` symlink homebrew always keeps
+# pointed at the current version. A no-op on layouts without `/Cellar/`
+# (Linux, MacPorts, custom prefixes), so it applies unconditionally. The
+# CFLAGS keep the as-probed paths — they are only used to build Aether
+# itself (where the probed version is present), never baked into user builds.
+cellar_to_opt = $(shell printf '%s' '$(1)' | sed 's|/Cellar/\([^/]*\)/[^/]*|/opt/\1|g')
+OPENSSL_LDFLAGS := $(call cellar_to_opt,$(OPENSSL_LDFLAGS))
+ZLIB_LDFLAGS    := $(call cellar_to_opt,$(ZLIB_LDFLAGS))
+NGHTTP2_LDFLAGS := $(call cellar_to_opt,$(NGHTTP2_LDFLAGS))
+PCRE2_LDFLAGS   := $(call cellar_to_opt,$(PCRE2_LDFLAGS))
+
 # -fPIC on every runtime/stdlib object so the precompiled `build/libaether.a`
 # can be linked into a shared object by `ae build --emit=lib`. Without it,
 # any `--emit=lib` build that pulls in a TLS-using runtime object (e.g.

--- a/docs/install-layout.md
+++ b/docs/install-layout.md
@@ -57,6 +57,12 @@ Two consumption shapes, in priority order:
    itself uses this same path — see `cmd_cflags` for the
    construction.
 
+   `ae build` is tolerant of a package that ships the archive **flat** at
+   `<prefix>/lib/libaether.a` instead: it tries the canonical nested path
+   first and falls back to the flat one before resorting to the
+   compile-from-source path below (#959). The nested layout is still the
+   canonical one `install.sh` and `make install` produce.
+
 2. **Compile from source**, falling through to the `.c` files in
    `share/aether/`. This is what `ae build` does when
    `libaether.a` isn't found. It's also what tooling like

--- a/tests/integration/flat_lib_fallback/test_flat_lib_fallback.sh
+++ b/tests/integration/flat_lib_fallback/test_flat_lib_fallback.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Regression (#959): `ae build` must link against a prebuilt runtime archive
+# shipped FLAT at lib/libaether.a, not only the canonical nested
+# lib/aether/libaether.a. The macOS arm64 v0.331/0.332 packages shipped it
+# flat; `ae build` looked only at the nested path, missed it, and fell back to
+# compiling an INCOMPLETE runtime source list — so every build (even
+# hello-world) failed to link with "Undefined symbols ... _aether_io_poller_init".
+#
+# Strategy: do a real install to a temp prefix (which lays the archive out
+# nested), then relocate it to the flat path to mimic the package layout, and
+# confirm `ae build` finds the flat archive (not the source fallback) and links.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+if [ ! -x "$ROOT/build/ae" ] || [ ! -f "$ROOT/install.sh" ]; then
+    echo "  [SKIP] flat_lib_fallback: ae/install.sh not built"
+    exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+prefix="$tmpdir/inst"
+
+if ! "$ROOT/install.sh" "$prefix" < /dev/null > "$tmpdir/install.log" 2>&1; then
+    echo "  [SKIP] flat_lib_fallback: install.sh failed (cannot set up fixture)"
+    sed 's/^/        /' "$tmpdir/install.log" | head -8
+    exit 0
+fi
+
+nested="$prefix/lib/aether/libaether.a"
+if [ ! -f "$nested" ]; then
+    echo "  [SKIP] flat_lib_fallback: install produced no prebuilt archive to relocate"
+    exit 0
+fi
+
+# Mimic the macOS package: archive flat at lib/, none nested under lib/aether/.
+cp "$nested" "$prefix/lib/libaether.a"
+rm -f "$nested"
+
+printf 'main() { println("flat-lib ok") }' > "$tmpdir/hello.ae"
+AETHER_HOME="$prefix" "$prefix/bin/ae" build "$tmpdir/hello.ae" -o "$tmpdir/hello" \
+    --verbose > "$tmpdir/build.log" 2>&1
+build_rc=$?
+
+fail=0
+if [ "$build_rc" -ne 0 ] || [ ! -x "$tmpdir/hello" ]; then
+    echo "  [FAIL] flat_lib_fallback: ae build did not link against the flat lib/libaether.a"
+    sed 's/^/        /' "$tmpdir/build.log" | tail -15
+    fail=1
+elif ! "$tmpdir/hello" 2>/dev/null | grep -q "flat-lib ok"; then
+    echo "  [FAIL] flat_lib_fallback: built binary did not run correctly"
+    fail=1
+fi
+
+# It must have resolved the flat archive, not silently used the (incomplete)
+# source fallback.
+if grep -q "source fallback" "$tmpdir/build.log"; then
+    echo "  [FAIL] flat_lib_fallback: ae fell back to source compile instead of using lib/libaether.a"
+    grep -i 'toolchain.*lib' "$tmpdir/build.log" | sed 's/^/        /'
+    fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "  [PASS] flat_lib_fallback: ae build links the flat lib/libaether.a (no incomplete source fallback)"
+fi
+exit $fail

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1173,6 +1173,21 @@ found_root:
         snprintf(tc.lib, sizeof(tc.lib), "%s/build/libaether.a", tc.root);
     } else {
         snprintf(tc.lib, sizeof(tc.lib), "%s/lib/aether/libaether.a", tc.root);
+        /* #959: prefer the nested canonical archive, but fall back to a flat
+         * lib/libaether.a if that's all the package shipped. The flat archive
+         * is complete; the from-source fallback below is NOT (it omits the
+         * io-poller, sandbox/capsicum, http2, string_seq, and caps runtime
+         * sources), so a package that placed the archive flat — as the macOS
+         * arm64 v0.331/0.332 packages did — silently produced an unlinkable
+         * binary ("Undefined symbols ... _aether_io_poller_init"). Take the
+         * complete flat archive over the incomplete source compile. */
+        if (!path_exists(tc.lib)) {
+            char flat[1024];
+            snprintf(flat, sizeof(flat), "%s/lib/libaether.a", tc.root);
+            if (path_exists(flat)) {
+                snprintf(tc.lib, sizeof(tc.lib), "%s/lib/libaether.a", tc.root);
+            }
+        }
     }
     tc.has_lib = path_exists(tc.lib);
 
@@ -6374,6 +6389,59 @@ static int cmd_version_install(const char* version) {
             fprintf(stderr, "This version may not have a release for " AE_PLATFORM ".\n");
             fprintf(stderr, "Available versions: ae version list\n");
             return 1;
+        }
+    }
+
+    // #959: integrity-check the prebuilt runtime archive after extraction.
+    // An interrupted/partial extract has been observed to leave a truncated
+    // libaether.a whose symbols are undefined (U) instead of defined (T), so
+    // every later `ae build` fails to link with nothing pointing at the cause.
+    // Validate that the archive (canonical nested path, or the flat fallback
+    // some packages ship) is a well-formed `ar` archive of plausible size; on
+    // failure remove the install and tell the user to retry, rather than
+    // leaving a landmine. Skipped when the package ships sources only (no
+    // prebuilt archive present). This does not replace a full checksum verify
+    // (which needs the release pipeline to publish per-asset sums) but catches
+    // the truncation that actually corrupted a macOS download.
+    {
+        char arch_path[1024];
+        snprintf(arch_path, sizeof(arch_path), "%s/lib/aether/libaether.a", ver_dir);
+        if (!path_exists(arch_path))
+            snprintf(arch_path, sizeof(arch_path), "%s/lib/libaether.a", ver_dir);
+        if (path_exists(arch_path)) {
+            FILE* lf = fopen(arch_path, "rb");
+            int ok = 0;
+            if (lf) {
+                char hdr[8] = {0};
+                size_t n = fread(hdr, 1, sizeof(hdr), lf);
+                fseek(lf, 0, SEEK_END);
+                long lsize = ftell(lf);
+                fclose(lf);
+                /* `ar` archives begin with the 8-byte magic "!<arch>\n" on
+                 * every platform we ship (GNU/BSD/macOS ar). A complete
+                 * runtime+stdlib archive is multi-megabyte; a truncated one
+                 * falls well short of this conservative 64 KB floor. */
+                ok = (n == sizeof(hdr) &&
+                      memcmp(hdr, "!<arch>\n", sizeof(hdr)) == 0 &&
+                      lsize > 65536);
+            }
+            if (!ok) {
+                char rmc[1024];
+#ifdef _WIN32
+                snprintf(rmc, sizeof(rmc), "rmdir /S /Q \"%s\"", ver_dir);
+#else
+                snprintf(rmc, sizeof(rmc), "rm -rf '%s'", ver_dir);
+#endif
+                if (system(rmc) != 0) { /* cleanup failed — non-fatal */ }
+                fprintf(stderr,
+                    "Error: %s installed a corrupt runtime archive "
+                    "(lib/.../libaether.a is truncated or not an `ar` archive).\n",
+                    vtag);
+                fprintf(stderr,
+                    "The download or extraction was likely interrupted. "
+                    "Re-run: ae version install %s\n", vtag);
+                return 1;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

On released **macOS arm64** packages, `ae build` could not link *anything* — even hello-world (`Undefined symbols ... _aether_io_poller_init`). Three build-toolchain fixes from #959, all in the `ae` driver / build:

### 1. Flat runtime-archive fallback
`ae build` resolved the prebuilt archive only at the canonical nested `lib/aether/libaether.a`. The macOS arm64 v0.331/0.332 packages shipped it **flat** at `lib/libaether.a`, so the lookup missed it and fell back to compiling an **incomplete** runtime source list (omitting io-poller, sandbox/capsicum, http2, string_seq, caps) → link failure on every build.

`ae build` now falls back to the flat archive before the source path. Both link paths already derive `-L` from the resolved archive's directory, so the flat archive links cleanly. The nested layout stays canonical.

### 2. Version-agnostic homebrew link paths
The link flags baked into `ae` come from `pkg-config`, which on homebrew emits versioned `-L/opt/homebrew/Cellar/<pkg>/<ver>/lib` paths — so `ld: library 'ssl' not found` the moment a formula is upgraded (e.g. `openssl@3` 3.6.2 → 3.6.3). The build now rewrites those to the version-agnostic `/opt/homebrew/opt/<pkg>/lib` symlinks homebrew keeps current. No-op on non-homebrew layouts (Linux/MacPorts/custom prefixes have no `/Cellar/`).

```
# baked into build/ae, before → after
-L/opt/homebrew/Cellar/openssl@3/3.6.3/lib   →   -L/opt/homebrew/opt/openssl@3/lib
```

### 3. Corrupt-archive guard on install
`ae version install` now validates that the extracted `libaether.a` is a well-formed `ar` archive of plausible size, catching the interrupted/partial extract that left a truncated archive (undefined symbols) and a broken install with no hint at the cause. (A full per-asset checksum verify additionally needs the release pipeline to publish sums — noted as a follow-up; this catches the truncation actually observed.)

## Test

`tests/integration/flat_lib_fallback` — installs to a temp prefix, relocates the archive to the flat path to mimic the macOS package, and asserts `ae build` links against it instead of the incomplete source fallback. (Shell-driven; no `.ae` fixtures, so nothing to prune from the normal run.)

## Verification (macOS arm64)

- hello-world **links and runs**; the baked `ae` carries `/opt/homebrew/opt/<pkg>` link paths (no Cellar versions).
- Unit suite **231/231**; the flat-lib regression test passes; full `.ae` suite run in progress.

Docs: CHANGELOG; `install-layout.md` notes the flat-archive tolerance.

Closes #959