### PR TITLE
fix(benchmarks): derive Aether runtime sources from the MANIFEST (suite Aether entry was failing to build)

### DIFF
--- a/benchmarks/cross-language/aether/Makefile
+++ b/benchmarks/cross-language/aether/Makefile
@@ -2,18 +2,16 @@ AETHER_COMPILER = ../../../build/aetherc
 CC = gcc
 CFLAGS = -O3 -march=native -flto -fno-plt -I../../../compiler -I../../../runtime -I../../../runtime/actors -I../../../runtime/scheduler -I../../../runtime/config -I../../../runtime/utils -I../../../std -I../../../std/string -I../../../std/io -I../../../std/math -I../../../std/net -I../../../std/collections -I../../../std/json
 LDFLAGS = -flto -pthread -lm
-RUNTIME_SRCS = ../../../runtime/scheduler/multicore_scheduler.c \
-               ../../../runtime/scheduler/aether_io_poller_epoll.c \
-               ../../../runtime/scheduler/aether_io_poller_kqueue.c \
-               ../../../runtime/scheduler/aether_io_poller_poll.c \
-               ../../../runtime/aether_numa.c \
-               ../../../runtime/aether_runtime.c \
-               ../../../runtime/config/aether_optimization_config.c \
-               ../../../runtime/utils/aether_cpu_detect.c \
-               ../../../runtime/actors/aether_send_buffer.c \
-               ../../../runtime/actors/aether_send_message.c \
-               ../../../runtime/actors/aether_actor_thread.c \
-               ../../../runtime/actors/aether_panic.c
+# Runtime sources, taken from the build MANIFEST (regenerated on every
+# `make stdlib`, the same set linked into libaether.a) so this list never
+# drifts as the runtime grows. A hand-maintained subset went stale and the
+# link broke on a newly-emitted symbol (`aether_capsicum_autosandbox`), which
+# surfaced only as "Aether [SKIP] Build failed" in the suite. Compiled from
+# source (not libaether.a) so the runtime gets the same `-O3 -march=native
+# -flto` as the benchmark, for a fair comparison. Only `runtime/` entries are
+# needed — these actor microbenchmarks don't touch std.
+MANIFEST := ../../../build/MANIFEST
+RUNTIME_SRCS := $(addprefix ../../../,$(shell grep '^runtime/' $(MANIFEST) 2>/dev/null))
 
 .PHONY: all clean ping_pong counting thread_ring fork_join skynet
 


### PR DESCRIPTION
## Summary

The cross-language benchmark suite's **Aether entry couldn't build** — it showed up as `Aether... [SKIP] Build failed` while C/C++/Go/Rust ran. Root cause: `benchmarks/cross-language/aether/Makefile` compiled the runtime from a **hand-maintained `RUNTIME_SRCS` subset** that went stale. Codegen now emits a call to `aether_capsicum_autosandbox` (the auto-sandbox startup hook), whose source wasn't in the list, so the link failed with `Undefined symbols for architecture arm64`.

## Fix

Derive `RUNTIME_SRCS` from **`build/MANIFEST`** — the authoritative link-suitable source set, regenerated on every `make stdlib` and the same sources linked into `libaether.a`:

```make
MANIFEST := ../../../build/MANIFEST
RUNTIME_SRCS := $(addprefix ../../../,$(shell grep '^runtime/' $(MANIFEST) 2>/dev/null))
```

- Can't drift as the runtime grows (the same root cause as #959's incomplete source fallback).
- Auto-excludes the non-static-link files a blind glob would wrongly pull in (the LD_PRELOAD shim, the superseded actor impl, the coop scheduler) — the MANIFEST already curates these out.
- Still compiled from source (not `libaether.a`) so the runtime keeps the benchmark's `-O3 -march=native -flto` for a fair comparison; only `runtime/` entries are taken (these actor microbenchmarks don't touch std).

## Verification

All five benchmarks build and run from the Makefile:

```
ping_pong, counting, thread_ring, fork_join, skynet → all "Done"
./ping_pong → ns/msg: 140   Throughput: 7.09 M msg/sec
```