### PR TITLE
docs(api): regenerate stdlib API docs (refresh drift)

### DIFF
--- a/docs/api/actors.html
+++ b/docs/api/actors.html
@@ -68,6 +68,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/arena.html
+++ b/docs/api/arena.html
@@ -65,6 +65,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/audit.html
+++ b/docs/api/audit.html
@@ -65,6 +65,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/bignum.html
+++ b/docs/api/bignum.html
@@ -81,6 +81,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/bits.html
+++ b/docs/api/bits.html
@@ -86,6 +86,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/bytes.html
+++ b/docs/api/bytes.html
@@ -98,6 +98,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/capsicum.html
+++ b/docs/api/capsicum.html
@@ -89,6 +89,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/cas.html
+++ b/docs/api/cas.html
@@ -63,6 +63,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/casper.html
+++ b/docs/api/casper.html
@@ -72,6 +72,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/collections.html
+++ b/docs/api/collections.html
@@ -96,6 +96,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/config.html
+++ b/docs/api/config.html
@@ -68,6 +68,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/cryptography.html
+++ b/docs/api/cryptography.html
@@ -110,6 +110,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/dir.html
+++ b/docs/api/dir.html
@@ -64,6 +64,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/dl.html
+++ b/docs/api/dl.html
@@ -64,6 +64,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/file.html
+++ b/docs/api/file.html
@@ -57,6 +57,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/floatarr.html
+++ b/docs/api/floatarr.html
@@ -69,6 +69,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/fs.html
+++ b/docs/api/fs.html
@@ -158,6 +158,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/host.html
+++ b/docs/api/host.html
@@ -73,6 +73,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/http.html
+++ b/docs/api/http.html
@@ -58,6 +58,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -52,6 +52,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>
@@ -254,6 +255,11 @@
       <p>std.signal — POSIX signal-number constants.</p>
       <span class="count">11 exports</span>
     </a>
+    <a href="snapshot.html" class="module-card">
+      <h3>snapshot</h3>
+      <p>std.snapshot — copy-on-write snapshot cell for read-mostly shared data.</p>
+      <span class="count">10 exports</span>
+    </a>
     <a href="strbuilder.html" class="module-card">
       <h3>strbuilder</h3>
       <p>std.strbuilder — amortised-O(1) string append.</p>
@@ -262,7 +268,7 @@
     <a href="string.html" class="module-card">
       <h3>string</h3>
       <p>std.string - String Module Import with: import std.string</p>
-      <span class="count">81 exports</span>
+      <span class="count">86 exports</span>
     </a>
     <a href="tcp.html" class="module-card">
       <h3>tcp</h3>
@@ -1223,6 +1229,16 @@
       <li class="function-item" data-name="SIGPIPE"><a href="signal.html#SIGPIPE"><span class="fn-name">SIGPIPE</span><span class="fn-module">signal</span></a></li>
       <li class="function-item" data-name="SIGALRM"><a href="signal.html#SIGALRM"><span class="fn-name">SIGALRM</span><span class="fn-module">signal</span></a></li>
       <li class="function-item" data-name="SIGTERM"><a href="signal.html#SIGTERM"><span class="fn-name">SIGTERM</span><span class="fn-module">signal</span></a></li>
+      <li class="function-item" data-name="aether_snapshot_new"><a href="snapshot.html#aether_snapshot_new"><span class="fn-name">aether_snapshot_new</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="aether_snapshot_load"><a href="snapshot.html#aether_snapshot_load"><span class="fn-name">aether_snapshot_load</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="aether_snapshot_store"><a href="snapshot.html#aether_snapshot_store"><span class="fn-name">aether_snapshot_store</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="aether_snapshot_cas"><a href="snapshot.html#aether_snapshot_cas"><span class="fn-name">aether_snapshot_cas</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="aether_snapshot_free"><a href="snapshot.html#aether_snapshot_free"><span class="fn-name">aether_snapshot_free</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="new"><a href="snapshot.html#new"><span class="fn-name">new</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="load"><a href="snapshot.html#load"><span class="fn-name">load</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="store"><a href="snapshot.html#store"><span class="fn-name">store</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="cas"><a href="snapshot.html#cas"><span class="fn-name">cas</span><span class="fn-module">snapshot</span></a></li>
+      <li class="function-item" data-name="free"><a href="snapshot.html#free"><span class="fn-name">free</span><span class="fn-module">snapshot</span></a></li>
       <li class="function-item" data-name="aether_strbuilder_new"><a href="strbuilder.html#aether_strbuilder_new"><span class="fn-name">aether_strbuilder_new</span><span class="fn-module">strbuilder</span></a></li>
       <li class="function-item" data-name="aether_strbuilder_append"><a href="strbuilder.html#aether_strbuilder_append"><span class="fn-name">aether_strbuilder_append</span><span class="fn-module">strbuilder</span></a></li>
       <li class="function-item" data-name="aether_strbuilder_append_n"><a href="strbuilder.html#aether_strbuilder_append_n"><span class="fn-name">aether_strbuilder_append_n</span><span class="fn-module">strbuilder</span></a></li>
@@ -1303,6 +1319,11 @@
       <li class="function-item" data-name="seq_concat"><a href="string.html#seq_concat"><span class="fn-name">seq_concat</span><span class="fn-module">string</span></a></li>
       <li class="function-item" data-name="seq_take"><a href="string.html#seq_take"><span class="fn-name">seq_take</span><span class="fn-module">string</span></a></li>
       <li class="function-item" data-name="seq_drop"><a href="string.html#seq_drop"><span class="fn-name">seq_drop</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_each"><a href="string.html#seq_each"><span class="fn-name">seq_each</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_map"><a href="string.html#seq_map"><span class="fn-name">seq_map</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_filter"><a href="string.html#seq_filter"><span class="fn-name">seq_filter</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_reduce"><a href="string.html#seq_reduce"><span class="fn-name">seq_reduce</span><span class="fn-module">string</span></a></li>
+      <li class="function-item" data-name="seq_zip_each"><a href="string.html#seq_zip_each"><span class="fn-name">seq_zip_each</span><span class="fn-module">string</span></a></li>
       <li class="function-item" data-name="to_cstr"><a href="string.html#to_cstr"><span class="fn-name">to_cstr</span><span class="fn-module">string</span></a></li>
       <li class="function-item" data-name="from_int"><a href="string.html#from_int"><span class="fn-name">from_int</span><span class="fn-module">string</span></a></li>
       <li class="function-item" data-name="from_long"><a href="string.html#from_long"><span class="fn-name">from_long</span><span class="fn-module">string</span></a></li>

--- a/docs/api/intarr.html
+++ b/docs/api/intarr.html
@@ -69,6 +69,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/io.html
+++ b/docs/api/io.html
@@ -96,6 +96,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/ipc.html
+++ b/docs/api/ipc.html
@@ -60,6 +60,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/json.html
+++ b/docs/api/json.html
@@ -109,6 +109,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/ksuid.html
+++ b/docs/api/ksuid.html
@@ -57,6 +57,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/list.html
+++ b/docs/api/list.html
@@ -67,6 +67,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/log.html
+++ b/docs/api/log.html
@@ -65,6 +65,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/longarr.html
+++ b/docs/api/longarr.html
@@ -69,6 +69,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/lzf.html
+++ b/docs/api/lzf.html
@@ -67,6 +67,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/map.html
+++ b/docs/api/map.html
@@ -70,6 +70,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/math.html
+++ b/docs/api/math.html
@@ -87,6 +87,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/mem.html
+++ b/docs/api/mem.html
@@ -150,6 +150,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/nanoid.html
+++ b/docs/api/nanoid.html
@@ -58,6 +58,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/net.html
+++ b/docs/api/net.html
@@ -119,6 +119,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/os.html
+++ b/docs/api/os.html
@@ -119,6 +119,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/path.html
+++ b/docs/api/path.html
@@ -58,6 +58,7 @@
     <li class="active"><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/regex.html
+++ b/docs/api/regex.html
@@ -101,6 +101,7 @@
     <li><a href="path.html">path</a></li>
     <li class="active"><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/signal.html
+++ b/docs/api/signal.html
@@ -67,6 +67,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li class="active"><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/snapshot.html
+++ b/docs/api/snapshot.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>snapshot - Aether</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="sidebar">
+  <div class="sidebar-header">
+    <h1><a href="index.html">Aether</a></h1>
+    <p class="tagline">Standard Library</p>
+  </div>
+  <input type="text" id="search" placeholder="Search snapshot..." onkeyup="searchModule()">
+  <h2>Exports</h2>
+  <ul class="function-nav">
+    <li><a href="#aether_snapshot_new">aether_snapshot_new</a></li>
+    <li><a href="#aether_snapshot_load">aether_snapshot_load</a></li>
+    <li><a href="#aether_snapshot_store">aether_snapshot_store</a></li>
+    <li><a href="#aether_snapshot_cas">aether_snapshot_cas</a></li>
+    <li><a href="#aether_snapshot_free">aether_snapshot_free</a></li>
+    <li><a href="#new">new</a></li>
+    <li><a href="#load">load</a></li>
+    <li><a href="#store">store</a></li>
+    <li><a href="#cas">cas</a></li>
+    <li><a href="#free">free</a></li>
+  </ul>
+  <hr>
+  <h2>Modules</h2>
+  <ul class="module-list">
+    <li><a href="actors.html">actors</a></li>
+    <li><a href="arena.html">arena</a></li>
+    <li><a href="audit.html">audit</a></li>
+    <li><a href="bignum.html">bignum</a></li>
+    <li><a href="bits.html">bits</a></li>
+    <li><a href="bytes.html">bytes</a></li>
+    <li><a href="capsicum.html">capsicum</a></li>
+    <li><a href="cas.html">cas</a></li>
+    <li><a href="casper.html">casper</a></li>
+    <li><a href="collections.html">collections</a></li>
+    <li><a href="config.html">config</a></li>
+    <li><a href="cryptography.html">cryptography</a></li>
+    <li><a href="dir.html">dir</a></li>
+    <li><a href="dl.html">dl</a></li>
+    <li><a href="file.html">file</a></li>
+    <li><a href="floatarr.html">floatarr</a></li>
+    <li><a href="fs.html">fs</a></li>
+    <li><a href="host.html">host</a></li>
+    <li><a href="http.html">http</a></li>
+    <li><a href="intarr.html">intarr</a></li>
+    <li><a href="io.html">io</a></li>
+    <li><a href="ipc.html">ipc</a></li>
+    <li><a href="json.html">json</a></li>
+    <li><a href="ksuid.html">ksuid</a></li>
+    <li><a href="list.html">list</a></li>
+    <li><a href="log.html">log</a></li>
+    <li><a href="longarr.html">longarr</a></li>
+    <li><a href="lzf.html">lzf</a></li>
+    <li><a href="map.html">map</a></li>
+    <li><a href="math.html">math</a></li>
+    <li><a href="mem.html">mem</a></li>
+    <li><a href="nanoid.html">nanoid</a></li>
+    <li><a href="net.html">net</a></li>
+    <li><a href="os.html">os</a></li>
+    <li><a href="path.html">path</a></li>
+    <li><a href="regex.html">regex</a></li>
+    <li><a href="signal.html">signal</a></li>
+    <li class="active"><a href="snapshot.html">snapshot</a></li>
+    <li><a href="strbuilder.html">strbuilder</a></li>
+    <li><a href="string.html">string</a></li>
+    <li><a href="tcp.html">tcp</a></li>
+    <li><a href="tsid.html">tsid</a></li>
+    <li><a href="ulid.html">ulid</a></li>
+    <li><a href="url.html">url</a></li>
+    <li><a href="uuid.html">uuid</a></li>
+    <li><a href="xml.html">xml</a></li>
+    <li><a href="zlib.html">zlib</a></li>
+  </ul>
+</nav>
+<main class="content">
+  <div class="module-header">
+    <h1>snapshot</h1>
+    <p class="module-desc">std.snapshot — copy-on-write snapshot cell for read-mostly shared data.</p>
+    <p class="import-line"><code>import std.snapshot</code></p>
+  </div>
+  <div class="functions" id="functions">
+    <div class="function" id="aether_snapshot_new" data-name="aether_snapshot_new">
+      <h3 class="function-name">aether_snapshot_new <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_snapshot_new(initial) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">initial: ptr</span></p>
+      <p class="doc">Create a cell pointing at `initial` (may be null). Returns the cell handle, or null on allocation failure / memory-cap exceeded. Does NOT take ownership of `initial`.</p>
+    </div>
+    <div class="function" id="aether_snapshot_load" data-name="aether_snapshot_load">
+      <h3 class="function-name">aether_snapshot_load <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_snapshot_load(cell) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr</span></p>
+      <p class="doc">Lock-free read: atomic acquire load of the current snapshot. Returns null for a null cell.</p>
+    </div>
+    <div class="function" id="aether_snapshot_store" data-name="aether_snapshot_store">
+      <h3 class="function-name">aether_snapshot_store <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_snapshot_store(cell, new_value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr, new_value: ptr</span></p>
+      <p class="doc">Publish `new_value` and return the displaced (old) snapshot. The writer now owns the returned pointer and must reclaim it only after a grace period (see the contract above). Null cell returns null.</p>
+    </div>
+    <div class="function" id="aether_snapshot_cas" data-name="aether_snapshot_cas">
+      <h3 class="function-name">aether_snapshot_cas <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_snapshot_cas(cell, expected, new_value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr, expected: ptr, new_value: ptr</span></p>
+      <p class="doc">Compare-and-swap. If the cell holds `expected`, swap in `new_value` and return 1; otherwise return 0 and leave the cell unchanged. On success the caller owns `expected` (reclaim after a grace period); on failure re-load and retry. Null cell returns 0.</p>
+    </div>
+    <div class="function" id="aether_snapshot_free" data-name="aether_snapshot_free">
+      <h3 class="function-name">aether_snapshot_free <span class="kind">extern</span></h3>
+      <pre class="usage"><code>aether_snapshot_free(cell)</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr</span></p>
+      <p class="doc">Free the cell itself. Does NOT free the snapshot it points at — that value is caller-owned. Null-safe.</p>
+    </div>
+    <div class="function" id="new" data-name="new">
+      <h3 class="function-name">new <span class="kind">fn</span></h3>
+      <pre class="usage"><code>new(initial) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">initial: ptr</span></p>
+      <p class="doc">snapshot.new(initial) — wrap an immutable value pointer in a cell.</p>
+    </div>
+    <div class="function" id="load" data-name="load">
+      <h3 class="function-name">load <span class="kind">fn</span></h3>
+      <pre class="usage"><code>load(cell) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr</span></p>
+      <p class="doc">snapshot.load(cell) — lock-free read of the current snapshot.</p>
+    </div>
+    <div class="function" id="store" data-name="store">
+      <h3 class="function-name">store <span class="kind">fn</span></h3>
+      <pre class="usage"><code>store(cell, new_value) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr, new_value: ptr</span></p>
+      <p class="doc">snapshot.store(cell, new_value) — publish `new_value`, returning the displaced snapshot for the writer to reclaim after a grace period.</p>
+    </div>
+    <div class="function" id="cas" data-name="cas">
+      <h3 class="function-name">cas <span class="kind">fn</span></h3>
+      <pre class="usage"><code>cas(cell, expected, new_value) <span class="arrow">-&gt;</span> int</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr, expected: ptr, new_value: ptr</span></p>
+      <p class="doc">snapshot.cas(cell, expected, new_value) — read-modify-write CAS; returns 1 on success, 0 on failure. Loop pattern (writer-actor): loop { cur = snapshot.load(cell) next = build_next_from(cur)   // pure, allocates `next` if snapshot.cas(cell, cur, next) == 1 { // `cur` is now displaced — reclaim it after a grace // period (e.g. defer one generation), NOT immediately. break } // lost the race: free our unused `next` and retry free_value(next) }</p>
+    </div>
+    <div class="function" id="free" data-name="free">
+      <h3 class="function-name">free <span class="kind">fn</span></h3>
+      <pre class="usage"><code>free(cell)</code></pre>
+      <p class="signature"><span class="sig-params">cell: ptr</span></p>
+      <p class="doc">snapshot.free(cell) — free the cell. Does NOT free the snapshots.</p>
+    </div>
+  </div>
+</main>
+<script src="search.js"></script>
+</body>
+</html>

--- a/docs/api/strbuilder.html
+++ b/docs/api/strbuilder.html
@@ -89,6 +89,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li class="active"><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/string.html
+++ b/docs/api/string.html
@@ -62,6 +62,11 @@
     <li><a href="#seq_concat">seq_concat</a></li>
     <li><a href="#seq_take">seq_take</a></li>
     <li><a href="#seq_drop">seq_drop</a></li>
+    <li><a href="#seq_each">seq_each</a></li>
+    <li><a href="#seq_map">seq_map</a></li>
+    <li><a href="#seq_filter">seq_filter</a></li>
+    <li><a href="#seq_reduce">seq_reduce</a></li>
+    <li><a href="#seq_zip_each">seq_zip_each</a></li>
     <li><a href="#to_cstr">to_cstr</a></li>
     <li><a href="#from_int">from_int</a></li>
     <li><a href="#from_long">from_long</a></li>
@@ -137,6 +142,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li class="active"><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>
@@ -402,6 +408,32 @@
       <h3 class="function-name">seq_drop <span class="kind">extern</span></h3>
       <pre class="usage"><code>seq_drop(s, n) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
       <p class="signature"><span class="sig-params">s: *StringSeq, n: int</span></p>
+    </div>
+    <div class="function" id="seq_each" data-name="seq_each">
+      <h3 class="function-name">seq_each <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_each(s, f)</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq, f: ptr</span></p>
+      <p class="doc">Closure-bearing combinators (#421 — multi-sequence iteration). Each takes an Aether closure as the per-element callback. The callback params are declared `ptr` so the codegen heap-BOXES the closure (`_aether_box_closure`) into the slot; the C runtime unboxes, invokes the body with the captured env as the implicit first argument, and frees the box (+ its env) when the walk completes — so a one-shot `string.seq_map(s, |x| ...)` does not leak the closure. All five are a single iterative spine walk: O(n) time, O(1) auxiliary stack (no recursion — that's the O(N^2)-&gt;O(N) point of the issue). string.seq_each(s, |x| { ... })          // side effects, per element string.seq_map(s, |x| -&gt; string)         // fresh seq, order preserved string.seq_filter(s, |x| -&gt; int)         // fresh seq of truthy elems string.seq_reduce(s, init, |acc, x| ...) // left fold, returns acc string.seq_zip_each(a, b, |x, y| { ... })// implicit zip to shorter `map`/`filter` return a fresh, caller-owned *StringSeq (reclaimed automatically at scope exit like any seq local). `reduce` returns the caller's accumulator (`ptr`). `each`/`zip_each` return nothing.</p>
+    </div>
+    <div class="function" id="seq_map" data-name="seq_map">
+      <h3 class="function-name">seq_map <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_map(s, f) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq, f: ptr</span></p>
+    </div>
+    <div class="function" id="seq_filter" data-name="seq_filter">
+      <h3 class="function-name">seq_filter <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_filter(s, pred) <span class="arrow">-&gt;</span> *StringSeq</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq, pred: ptr</span></p>
+    </div>
+    <div class="function" id="seq_reduce" data-name="seq_reduce">
+      <h3 class="function-name">seq_reduce <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_reduce(s, init, f) <span class="arrow">-&gt;</span> ptr</code></pre>
+      <p class="signature"><span class="sig-params">s: *StringSeq, init: ptr, f: ptr</span></p>
+    </div>
+    <div class="function" id="seq_zip_each" data-name="seq_zip_each">
+      <h3 class="function-name">seq_zip_each <span class="kind">extern</span></h3>
+      <pre class="usage"><code>seq_zip_each(a, b, f)</code></pre>
+      <p class="signature"><span class="sig-params">a: *StringSeq, b: *StringSeq, f: ptr</span></p>
     </div>
     <div class="function" id="to_cstr" data-name="to_cstr">
       <h3 class="function-name">to_cstr <span class="kind">extern</span></h3>

--- a/docs/api/tcp.html
+++ b/docs/api/tcp.html
@@ -68,6 +68,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li class="active"><a href="tcp.html">tcp</a></li>

--- a/docs/api/tsid.html
+++ b/docs/api/tsid.html
@@ -57,6 +57,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/ulid.html
+++ b/docs/api/ulid.html
@@ -57,6 +57,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/url.html
+++ b/docs/api/url.html
@@ -63,6 +63,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/uuid.html
+++ b/docs/api/uuid.html
@@ -58,6 +58,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/xml.html
+++ b/docs/api/xml.html
@@ -99,6 +99,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>

--- a/docs/api/zlib.html
+++ b/docs/api/zlib.html
@@ -72,6 +72,7 @@
     <li><a href="path.html">path</a></li>
     <li><a href="regex.html">regex</a></li>
     <li><a href="signal.html">signal</a></li>
+    <li><a href="snapshot.html">snapshot</a></li>
     <li><a href="strbuilder.html">strbuilder</a></li>
     <li><a href="string.html">string</a></li>
     <li><a href="tcp.html">tcp</a></li>


### PR DESCRIPTION
## Summary

The committed `docs/api/*.html` are generated from the stdlib `.ae` exports (via `make docs` → `tools/docgen`) and checked in by hand, so they drift whenever the stdlib gains exports without a regen. They'd gone stale.

Regenerated against the current stdlib — **no tool or content changes, purely `make docs` output brought back in sync**:

- adds newly-exported functions that were missing from the pages (e.g. string's `seq_each` / `seq_map` / `seq_filter` / `seq_reduce` / `seq_zip_each`)
- adds the `snapshot` module's page (`snapshot.html`), which the module nav already linked but had no committed page

48 files, +251/-1 (mostly one-line nav additions + the new page). Verified the generator builds and runs clean (`build/docgen std docs/api`).

Surfaced while health-checking the docs/benchmark/REPL toolchain. (The REPL and the docs generator both work as-is; the benchmark suite's Aether build fix is #968.)