### PR TITLE
docs: Chlipala-lens framing doc, LLM.md notes, CHANGELOG reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.331.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
-## [0.331.0]
+## [current]
+
+## [0.338.0]
 
 ### Added
 
@@ -47,6 +49,83 @@ next version number before tagging the release.
     no allocation, no vtable. Recursive shapes (trees, ASTs) work via explicit
     pointer fields (`left: *Tree`). v1 is monomorphic; generics are a follow-up.
 
+## [0.337.0]
+
+### Fixed
+
+- **macOS arm64: `ae build` couldn't link anything off a released package**
+  (#959). Three build-toolchain fixes:
+  - **Flat runtime-archive fallback.** `ae build` looked for the prebuilt
+    archive only at the canonical nested `lib/aether/libaether.a`. The macOS
+    arm64 v0.331/0.332 packages shipped it flat at `lib/libaether.a`, so the
+    lookup missed it and fell back to compiling an *incomplete* runtime source
+    list — every build, even hello-world, then failed to link (`Undefined
+    symbols ... _aether_io_poller_init`). `ae build` now falls back to the flat
+    archive before the source path; the complete archive links.
+  - **Version-agnostic homebrew link paths.** The link flags baked into `ae`
+    came from `pkg-config`, which on homebrew emits versioned
+    `-L/opt/homebrew/Cellar/<pkg>/<ver>/lib` paths — so `ld: library 'ssl' not
+    found` the moment a formula was upgraded. The build now rewrites those to
+    the version-agnostic `/opt/homebrew/opt/<pkg>/lib` symlinks homebrew keeps
+    current. No-op on non-homebrew layouts.
+  - **Corrupt-archive guard on install.** `ae version install` now validates
+    that the extracted `libaether.a` is a well-formed `ar` archive of plausible
+    size, catching the interrupted/partial extract that left a truncated
+    archive (undefined symbols) and a broken install with no hint at the cause.
+
+## [0.336.0]
+
+### Changed
+
+- **`LLM.md` operational additions** (#912) — rebuild/test table, build-safety
+  notes, ask-first thresholds, and the codegen tag-and-grep debugging recipe.
+  Documentation only; no compiler, stdlib, or runtime behaviour change.
+
+## [0.335.0]
+
+### Fixed
+
+- **`ae check` now catches over-/under-applying an extern; `from_cstr` survives
+  an `AetherString*`** (#952). Two "`ae check` passes but the program then
+  crashes or fails in gcc" gaps:
+  - **Arity of extern functions wasn't checked.** Calling the zero-arg
+    `math.deg_to_rad()` constant as `math.deg_to_rad(x)` (and the sibling
+    `math.pi`/`tau`/`e`/`rad_to_deg` constants) passed `ae check` and surfaced
+    only as a raw gcc "too many arguments" error. Extern arity is now validated
+    in Aether terms, honoring variadic externs (`f(named, ...)`, both the
+    `extern` and `@extern("c")` forms) and `_ctx`-first builder externs. The
+    fix also wires each imported extern's AST node into its symbol — like
+    entry-file externs already were — so the existing extern arg-type checks
+    apply across module boundaries too.
+  - **`string.from_cstr` segfaulted on an owned-list value.** A string stored
+    with `list.add_string_owned` (which keeps the 24-byte `AetherString`
+    header) and read back via `list.get` was an `AetherString*`, not a raw
+    `char*`; `from_cstr` read the header bytes as character data and copied
+    garbage or crashed. `from_cstr` now routes its argument through the
+    magic-header-aware accessor, so the round-trip is correct for either an
+    `AetherString*` or a plain C string (and is NULL-safe).
+
+## [0.334.0]
+
+### Fixed
+
+- **`ae build` now fails on an imported module's compile error** (#953). `ae
+  build` accepted an entry program whose *imported* module did not compile —
+  the parser's error recovery dropped the offending construct (e.g. an invalid
+  `@` annotation lowering to a bare `return x`), so the merged AST type-checked
+  clean and codegen produced a working binary from non-compiling source, while
+  `ae check` correctly reported the error. The two disagreed on validity, and a
+  build's exit code couldn't be trusted (it bit a mutation-testing driver that
+  rebuilds an imported SUT). The entry file's own parse errors were already
+  gated, but the global error count was not re-checked after module
+  orchestration — which is where imported modules are parsed. Both `build` and
+  `check` now fail (non-zero, no binary) when any module they pull in carries an
+  error. A clean import is unaffected (the gate keys on the error count).
+
+## [0.333.0]
+
+### Added
+
 - **Optionals: `T?` with `none`, `!`, `??`, `?.`, and `match`** (#340). A
   first-class optional type for "maybe a value," complementing the `(value,
   err)` result convention (which stays the tool for *fallible* operations).
@@ -72,59 +151,9 @@ next version number before tagging the release.
     message type) or with `match` pattern arms. See the
     [language reference](docs/language-reference.md#optionals).
 
+## [0.332.0]
+
 ### Fixed
-
-- **macOS arm64: `ae build` couldn't link anything off a released package**
-  (#959). Three build-toolchain fixes:
-  - **Flat runtime-archive fallback.** `ae build` looked for the prebuilt
-    archive only at the canonical nested `lib/aether/libaether.a`. The macOS
-    arm64 v0.331/0.332 packages shipped it flat at `lib/libaether.a`, so the
-    lookup missed it and fell back to compiling an *incomplete* runtime source
-    list — every build, even hello-world, then failed to link (`Undefined
-    symbols ... _aether_io_poller_init`). `ae build` now falls back to the flat
-    archive before the source path; the complete archive links.
-  - **Version-agnostic homebrew link paths.** The link flags baked into `ae`
-    came from `pkg-config`, which on homebrew emits versioned
-    `-L/opt/homebrew/Cellar/<pkg>/<ver>/lib` paths — so `ld: library 'ssl' not
-    found` the moment a formula was upgraded. The build now rewrites those to
-    the version-agnostic `/opt/homebrew/opt/<pkg>/lib` symlinks homebrew keeps
-    current. No-op on non-homebrew layouts.
-  - **Corrupt-archive guard on install.** `ae version install` now validates
-    that the extracted `libaether.a` is a well-formed `ar` archive of plausible
-    size, catching the interrupted/partial extract that left a truncated
-    archive (undefined symbols) and a broken install with no hint at the cause.
-- **`ae build` now fails on an imported module's compile error** (#953). `ae
-  build` accepted an entry program whose *imported* module did not compile —
-  the parser's error recovery dropped the offending construct (e.g. an invalid
-  `@` annotation lowering to a bare `return x`), so the merged AST type-checked
-  clean and codegen produced a working binary from non-compiling source, while
-  `ae check` correctly reported the error. The two disagreed on validity, and a
-  build's exit code couldn't be trusted (it bit a mutation-testing driver that
-  rebuilds an imported SUT). The entry file's own parse errors were already
-  gated, but the global error count was not re-checked after module
-  orchestration — which is where imported modules are parsed. Both `build` and
-  `check` now fail (non-zero, no binary) when any module they pull in carries an
-  error. A clean import is unaffected (the gate keys on the error count).
-
-- **`ae check` now catches over-/under-applying an extern; `from_cstr` survives
-  an `AetherString*`** (#952). Two "`ae check` passes but the program then
-  crashes or fails in gcc" gaps:
-  - **Arity of extern functions wasn't checked.** Calling the zero-arg
-    `math.deg_to_rad()` constant as `math.deg_to_rad(x)` (and the sibling
-    `math.pi`/`tau`/`e`/`rad_to_deg` constants) passed `ae check` and surfaced
-    only as a raw gcc "too many arguments" error. Extern arity is now validated
-    in Aether terms, honoring variadic externs (`f(named, ...)`, both the
-    `extern` and `@extern("c")` forms) and `_ctx`-first builder externs. The
-    fix also wires each imported extern's AST node into its symbol — like
-    entry-file externs already were — so the existing extern arg-type checks
-    apply across module boundaries too.
-  - **`string.from_cstr` segfaulted on an owned-list value.** A string stored
-    with `list.add_string_owned` (which keeps the 24-byte `AetherString`
-    header) and read back via `list.get` was an `AetherString*`, not a raw
-    `char*`; `from_cstr` read the header bytes as character data and copied
-    garbage or crashed. `from_cstr` now routes its argument through the
-    magic-header-aware accessor, so the round-trip is correct for either an
-    `AetherString*` or a plain C string (and is NULL-safe).
 
 - **Heredoc closing-marker rule: no more silent truncation** (#922). A heredoc
   body line that merely read like the closing marker could close the heredoc
@@ -140,6 +169,10 @@ next version number before tagging the release.
   leading-whitespace / least-indented line, like Ruby's squiggly `<<~`). Docs
   (`LLM.md`, language-reference) corrected — they wrongly claimed "column 0
   only," which the lexer never enforced.
+
+## [0.331.0]
+
+### Fixed
 
 - **Qualified type name `mod.Type` accepted in type positions** (#946). A
   module-qualified name was accepted as a value/call (`lib.mk(...)`, #878) but

--- a/LLM.md
+++ b/LLM.md
@@ -332,20 +332,14 @@ workaround — they cover cases a porter often hand-rolls.
 
 ## Working with downstream users
 
-- **svn-aether port (avn)** (`~/scm/subversion/subversion/` locally;
-  GitHub: anthropic/avn — sibling claude works there) is the biggest
-  real-world consumer. Port is methodical C → Aether, one-leaf-per-
-  commit. Downstream finds the gaps before anyone else — every
-  cross-`import` typer issue (struct visibility, selective-import
-  propagation, 128-decl cap) was filed by avn before showing up
-  anywhere else.
-- **aether-ui** (`https://github.com/aether-lang-org/aether-ui`) —
-  cross-platform widget toolkit (GTK4 / AppKit / Win32) with an
+- **aether-ui** (`https://github.com/aether-lang-org/aether-ui` locally: ../aether-ui) 
+  — cross-platform widget toolkit (GTK4 / AppKit / Win32) with an
   AetherUIDriver HTTP test server. Was `contrib/aether_ui/` in this
   repo until the spin-out; now consumes Aether the same way external
   users do (install + `$(ae cflags)`). Useful reference for the
   embedded-DSL pattern: the toolkit's surface IS a closure-DSL.
-- **aeb** (`https://github.com/aether-lang-org/aeb`) — multi-package
+- **aeb** (`https://github.com/aether-lang-org/aeb` locally: ../aeb) 
+  — multi-package
   build system, the second of three ecosystem siblings (language / build
   runner / orchestrator). Reads `share/aether/MANIFEST` to discover
   link-suitable runtime/stdlib `.c` files and orchestrates per-package
@@ -353,7 +347,8 @@ workaround — they cover cases a porter often hand-rolls.
   (`docs/install-layout.md`) was carved out specifically to support aeb
   without forcing it to guess via `find -name '*.c'`. If you're touching
   install-layout / shipped source / link contract, ping aeb side.
-- **aeo** (`https://github.com/aether-lang-org/aeo`) — the third sibling:
+- **aeo** (`https://github.com/aether-lang-org/aeo` - locally: ../aeo) 
+  — the third major sibling:
   an infrastructure orchestrator that stands up / tears down a dependency-
   ordered tree of VMs + containers (FreeBSD jail/bhyve, Linux
   podman·docker/KVM) from one Aether composition (`aeo up|status|down|
@@ -361,11 +356,48 @@ workaround — they cover cases a porter often hand-rolls.
   *built by* aeb and shells *to* aeb across a plain artifact+CLI seam. Its
   compose surface is the `config IS code` closure-DSL applied to live
   infra — the canonical proof the DSL pitch works beyond config files.
-- **aeocha** (`https://github.com/aether-lang-org/aeocha`) — BDD-style
-  test framework for Aether (`describe` / `it` / `before_each` /
+- **aeocha** (`https://github.com/aether-lang-org/aeocha` locally: ../aeocha)
+  — BDD-style test framework for Aether (`describe` / `it` / `before_each` /
   `after_each` via trailing blocks + closures, Cuppa-inspired). The
   reference consumer of the trailing-block/closure DSL for a test surface;
   look here for a worked example of the `builder`-shaped API in anger.
+  There is a co-located mutation testing facility too.
+- **svn-aether port (avn)** (`https://github.com/aether-lang-org/avn` locally: ../avn) 
+  — is a big
+  real-world consumer. Port is methodical C → Aether, one-leaf-per-
+  commit. Downstream finds the gaps before anyone else — every
+  cross-`import` typer issue (struct visibility, selective-import
+  propagation, 128-decl cap) was filed by avn before showing up
+  anywhere else. As much as anything it was used to shake out
+  missing features and bugs for Aether.
+- **mquickjs-port** (`https://github.com/aether-lang-org/mquickjs-port` locally: ../mquickjs-port)
+  — a full C→Aether port of Bellard & Gordon's
+  MicroQuickJS (ES5-subset embedded JS engine, tracing GC, ~10 kB RAM). The
+  end state is pure Aether: `mquickjs.c` deleted entirely, every engine leaf
+  now an `ae/*.ae` file, built with `aeb`, tested via the `c.tests` runner.
+  This is the extern-removal / no-C-consumers exemplar the memory notes keep
+  referencing — it drove the hardest low-level features (const arrays for the
+  atoms table, signed-bitfield emission, shift-width and `as int`-narrowing
+  fixes, the `--audit-mem` accessor-width check). `migration_assessment.md` 
+  and `ae/PORT_STATUS.md` were used in the port but could be out of date. 
+  Known pre-existing engine bugs live in
+  [[project_mquickjs_known_bugs]] (e.g. `Math.random()` returns -1, baseline
+  too — not caught by `make test`). `dtoa.c` stays C by decision ([[feedback_dtoa_stays_c]]).
+- **servirtium-vcr** (`https://github.com/servirtium/servirtium-vcr` locally: ../servirtium-vcr)
+   — record/replay for HTTP service tests in the
+  [Servirtium](https://servirtium.dev) markdown-tape format, as a **one-engine-
+  many-thin-bindings** monorepo. The engine is a single pure-Aether module
+  (`core/vcr.ae` + `core/embed.ae` C-ABI) built once as `libservirtium_vcr.so`
+  via `ae build --emit=lib` on top of the stdlib (HTTP server, regex, zlib,
+  crypto); 17+ language bindings (Go/cgo, Python/ctypes, Java·Panama, Ruby·
+  Fiddle, Rust, Node·koffi, Haskell, Elixir/Erlang-NIF, …, plus the JVM family
+  over the Java jar) are thin FFI wrappers over that one artifact, so they
+  can't drift — cross-language Servirtium compatibility is a build-time
+  guarantee, not a test target. The canonical proof of the `--emit=lib` +
+  auto-generated-SDK story at scale, and the reference for how a downstream
+  wires many FFI consumers through one `aeb` run. Aether-side entry is
+  `import core.vcr` — it's a separate repo, not part of `std.http` (the
+  HTTP-client idiom above says the same).
 - **Feature request flow that works**: downstream writes a spec
   (e.g. `import_typer_at_scale.md`, `exprt_structs.md`,
   `stdlib_wish.md`), Aether implements, downstream adopts within the

--- a/docs/chlipala-lens.md
+++ b/docs/chlipala-lens.md
@@ -1,0 +1,190 @@
+# Aether Through Chlipala's Lens
+
+A framing writeup reading Aether against Adam Chlipala's *"The Expensive
+Fictions of Low-Level Programming Languages"* (Jun 2026,
+[stng.substack.com](https://stng.substack.com/p/the-expensive-fictions-of-low-level)).
+It is a *framing*
+document, not a spec — the goal is to place Aether honestly on the two axes the
+essay uses to judge languages, and to name the two research directions that
+would let Aether actually engage the half of the critique it currently ducks.
+
+Like `docs/v-language-inspiration.md` and `docs/moonbit-feature-survey.md`,
+this separates the genuine alignment from the wishful, and it is deliberately
+unflattering where the language deserves it.
+
+## What Chlipala is actually arguing
+
+The naive reading — "C bad, high-level good" — is *not* his claim, and Aether
+is vulnerable to being praised for the wrong reasons. His argument runs on two
+axes for judging a notation used in automated program search:
+
+1. **Tractability of search** — can we describe systems succinctly and
+   manipulate them algebraically?
+2. **Control over the final program's hardware behaviour** — can we spell out
+   every last detail of harnessing the hardware?
+
+His indictment of C and Rust is that they score *poorly on both*: too low-level
+to manipulate cleanly, yet too high-level to expose the real performance model.
+And the specific "fictions" he names are precise:
+
+- **The sequential-instruction fiction** — code reads as one-instruction-at-a-
+  time while the hardware is a spatial fabric where *everything is always
+  running*.
+- **The flat-shared-memory fiction** — one uniform address space, when real
+  access cost is a function of *locality and topology* and requires global
+  reasoning to predict.
+
+The through-line: these fictions make **performance opaque**, and opaque
+performance makes **program search intractable**, because a correct-by-
+construction search cannot use "will this run fast on the real fabric?" as a
+fitness function. His refinement diagram runs from abstract-notation-at-top to
+hardware-detail-at-bottom, and *most of the essay is a complaint about the
+bottom.*
+
+## The uncomfortable starting point
+
+**Aether compiles to C.** By construction it sits *downstream* of exactly the
+model the essay indicts. It cannot claim to have escaped the two fictions,
+because its backend *is* the "1970s hardware model." Any honest placement has
+to start there rather than around it.
+
+So on his two axes:
+
+### Axis 2 (hardware control): Aether is *further from* the fabric than C
+
+This is the counterintuitive part. Aether is not a lower-level language than C —
+it is C *plus* abstractions that move away from the fabric:
+
+- RAII-via-codegen,
+- ref-counted / arena-owned strings,
+- closures lowered to plain C functions,
+- `heap.new` boxing that adopts and frees string fields.
+
+Every one of those is a layer between the source and the emitted instructions.
+Aether exposes **no locality model at the language level**, no topology, no
+notion in the *source* that memory access cost is nonuniform. On the essay's
+own terms, a search choosing among Aether variants has *less* insight into cost
+than one choosing among C variants, because refcount traffic, arena lifetimes,
+and codegen'd cleanup all sit in the gap. Chlipala's "even simple improvements
+require nonlocal changes" problem is **amplified** by a compile-to-C layer, not
+relieved.
+
+The one real qualifier: the *runtime* is topology-aware even though the
+*language* is not — see the actor section below.
+
+### Axis 1 (search tractability): a genuine story, but a *different* one
+
+This is where Aether has a defensible answer — but it lives near the **top and
+middle** of his refinement diagram, which is the half he spends the least time
+on. It is important to claim the right win rather than the flattering one.
+
+- **The trailing-block / `builder` DSL and `config IS code`** are a succinct-
+  notation play — "notations that let us describe complex systems succinctly and
+  manipulate algebraically." The call site reads like a config file while the
+  body is full Aether underneath (see `docs/config-is-code.md`,
+  `docs/closures-and-builder-dsl.md`). That is precisely his axis-1 virtue,
+  expressed at the requirements/config altitude — *not* at the codegen altitude
+  he cares most about.
+
+- **The capability / effect system is the most Chlipala-aligned thing in the
+  language**, and it should be foregrounded. His actual research program (he is
+  the Bedrock / Fiat-Crypto / verified-compilation person) is *correct-by-
+  construction via machine-checked specification*. Aether's compile-time effect
+  tags (`@pure`, `@no_fs`, `@no_net`, `@no_os`), the `--emit=lib --with=`
+  capability gate, `@scoped` escape analysis, and `distinct` types are a
+  **lightweight, gradual** version of exactly that discipline: invariants turned
+  into things the compiler *rejects programs for violating*. A search generating
+  Aether can use "does it typecheck under `@no_fs`?" as a real, cheap fitness
+  signal — verification-as-fitness-function, at the safety-property level.
+
+## Where the critique bites Aether specifically
+
+Three places worth naming rather than papering over:
+
+### 1. Aether's guarantees are *safety*, not *functionality*
+
+The capability system proves *a program cannot touch the filesystem*; it does
+not prove *the program meets its spec*. Chlipala's premise is search where "a
+tool might give up but will never return an incorrect program" — full
+functional correctness. Aether's `where`-contracts are **runtime** panics
+(`precondition violation: b != 0 in divide`), not static proofs. A violation is
+caught at execution — which is exactly what a correct-by-construction search
+*cannot* rely on. To play in his world, those contracts would need to be
+*discharged statically* (SMT / refinement-type style). They currently are not.
+This is the single largest gap between Aether's marketing-adjacent story ("the
+compiler checks your invariants") and Chlipala's bar ("the compiler proves your
+program correct or refuses it").
+
+### 2. The performance model is fully implicit — and the C layer widens the gap
+
+Covered above under axis 2. The point bears repeating because it is the crux:
+inserting a compile-to-C stage between the search's candidate and the emitted
+instructions makes the *cost of a candidate less predictable*, not more. This is
+the opposite of what a self-improving search wants from its target language.
+
+### 3. The actor model is the one place Aether *could* answer the sequential
+fiction — and half-does
+
+Chlipala explicitly praises models that "reveal hardware topology" (MPI) even
+while noting they are painful. Aether's `message` / `receive` / `spawn` is a
+*logical* concurrency model — no shared mutable state, message-passing — which
+answers the *correctness* worry the sequential fiction creates (data races) but
+says nothing at the **language** level about *placement*: which node runs which
+actor, how far a message travels.
+
+The nuance the first draft of this document got wrong: the **runtime already
+carries the topology Aether's source hides.** The multicore scheduler is
+NUMA-aware (`runtime/aether_numa.*`, `docs/numa-support.md`) — it detects the
+node topology and places work to keep memory accesses local. So the fiction is
+half-broken *underneath* the language even though the language surface still
+presents flat, placeless actors.
+
+That is the design opening. If actor handles carried **affinity/locality as a
+first-class, source-visible property**, and the scheduler surfaced its placement
+decisions back to the program (or to a search process), Aether would have a
+principled, *language-level* answer to fiction #1 — a genuine move down-and-
+across his diagram rather than a restatement of the C model. The runtime
+plumbing is already there; what's missing is exposing it in the type/effect
+system the way capabilities are exposed.
+
+## The two research directions this points at
+
+1. **Static discharge of `where`-contracts.** Move preconditions from runtime
+   panics toward compile-time proof obligations (refinement types / an SMT
+   backend), so a contract becomes something a correct-by-construction search
+   can *rely on* rather than *discover at runtime*. This is the path from
+   "safety-checked" to Chlipala's "correct or refused."
+
+2. **Topology-visible actors.** Lift the NUMA-aware scheduler's placement model
+   into the language: affinity as a first-class property of actor handles,
+   placement decisions legible to the program and to an optimizing search. This
+   is the path from "logical concurrency over a hidden fabric" to "concurrency
+   over a fabric the notation can reason about."
+
+## The one-line verdict
+
+Aether is a strong answer to the *half* of Chlipala's critique he spends the
+*least* time on — succinct, algebraically-manipulable, machine-checkable
+notation, via the DSL layer and the capability/effect system — and **not an
+answer** to the half he spends the *most* time on: the sequential-execution and
+flat-memory performance fictions, because it compiles to C and adopts C's cost
+model verbatim (its NUMA-aware runtime notwithstanding, because that awareness
+is not yet visible to the source).
+
+Marketing Aether as "a better low-level language for the AI-search era" invites
+exactly the rebuttal the essay pre-loads. Marketing it as **"a high-tractability
+specification-and-capability layer that happens to emit native code"** is both
+more defensible and more true — and it names the two concrete moves (static
+`where`-contracts; topology-visible actors) that would let Aether actually
+engage the performance half of the argument.
+
+## See also
+
+- `docs/config-is-code.md`, `docs/closures-and-builder-dsl.md` — the succinct-
+  notation / axis-1 story.
+- `docs/emit-lib.md`, `docs/hide-and-seal.md`, `docs/distinct-types.md` — the
+  capability / effect surface.
+- `docs/numa-support.md`, `docs/actor-concurrency.md` — the runtime topology
+  awareness the language does not yet surface.
+- `docs/v-language-inspiration.md`, `docs/moonbit-feature-survey.md` — sibling
+  "read another design through Aether's lens" writeups.


### PR DESCRIPTION
Doc-only branch, three files.

## `docs/chlipala-lens.md` (new)
Reads Aether against Adam Chlipala's *"The Expensive Fictions of Low-Level
Programming Languages"*. Places the language honestly on his two axes
(search-tractability / hardware-control), owns that compiling-to-C inherits
both performance fictions, credits the capability/effect system + trailing-block
DSL as the genuine axis-1 win, and names two research directions (static
`where`-contracts; topology-visible actors over the existing NUMA scheduler)
that would let Aether engage the performance half. Sibling to
`v-language-inspiration.md` / `moonbit-feature-survey.md`. Verified factual
claims against CHANGELOG `[0.331.0]`.

## `LLM.md`
- Fill in the **mquickjs-port** and **servirtium-vcr** downstream entries
  (drawn from each repo's README/migration doc, not from memory).
- Fix aeo "second" → "third" ecosystem sibling.
- Clarify the `core.vcr` import note (drop the nonexistent `std.http.server.vcr`
  phrasing).

## `CHANGELOG.md`
Reconstruct the missing `0.332.0`–`0.338.0` sections. The top was a mislabeled
`[0.331.0]` grab-bag holding content that actually shipped across seven later
releases, while those versions had no sections at all — the release pipeline
had no `[current]` heading to rename, so each release recorded nothing.
Redistributed existing entries under the correct version heading (verified via
`git tag --contains`), reduced `[0.331.0]` to its one genuine entry (`mod.Type`,
\#946), added a fresh `## [current]` at top, and fixed the workflow comment so
future releases get renamed correctly. Prose unchanged — only reheaded and
reordered newest-first.

Branch commits carry `[skip actions]` (doc-only, no compiler/std/runtime touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)