### PR TITLE
feat(compiler): result-type error handling with `-> T!`, `or`, and `!` (#913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ next version number before tagging the release.
 
 ### Added
 
+- **Result-type error handling: `-> T!`, `or`, and `!`** (#913). `-> T!` names
+  the existing `(value, string)` result-tuple convention and adds ergonomic
+  sugar for the three things you do with a fallible call, with no hidden
+  machinery — `T!` *is* the `(T, string)` tuple, so the sugar and manual
+  destructuring interoperate freely.
+
+  - `return v` in a `T!` function auto-wraps to `(v, "")`; `return v, "msg"`
+    reports an error.
+  - `expr or default` yields the success value, or `default` on error.
+  - `expr or { ... }` runs a block on error with `err` bound to the message
+    (the block exits via `return`/`break`/`continue`/`panic`, like a `match`
+    arm's block body).
+  - `expr!` propagates: inside a `T!` function it returns `(zero, err)` on a
+    non-empty error slot; elsewhere it is unwrap-or-trap (panics, catchable
+    with `try`/`catch`).
+
+  ```aether
+  safe_divide(a: int, b: int) -> int! {
+      if b == 0 { return 0, "division by zero" }
+      return a / b
+  }
+
+  checked(x: int, d: int) -> int! {
+      return safe_divide(x, d)!        // propagate on error
+  }
+
+  main() {
+      q = safe_divide(10, 0) or -1     // q == -1
+      r = safe_divide(x, y) or {       // `err` bound; block exits
+          println("failed: ${err}")
+          return
+      }
+  }
+  ```
+
 - **Sum / variant types: `type Name = A | B | C` + exhaustive `match`** (#914).
   A tagged union over existing struct variants — "a value that is exactly one
   of N named alternatives." Completes `match` (which was literal-only) with the

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -1114,6 +1114,22 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
             return result;
         }
 
+        case AST_OR_ELSE: {
+            // #913: `fallible or handler` yields the fallible's success value
+            // type (the first slot of its (value, err) tuple).
+            if (expr->child_count < 1 || !expr->children[0])
+                return create_type(TYPE_UNKNOWN);
+            Type* operand = infer_type(expr->children[0], table);
+            Type* result = create_type(TYPE_UNKNOWN);
+            if (operand && operand->kind == TYPE_TUPLE &&
+                operand->tuple_count >= 1 && operand->tuple_types[0]) {
+                free_type(result);
+                result = clone_type(operand->tuple_types[0]);
+            }
+            if (operand) free_type(operand);
+            return result;
+        }
+
         case AST_NULL_LITERAL:
             return create_type(TYPE_PTR);
 
@@ -4737,6 +4753,38 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             if (expr->node_type) free_type(expr->node_type);
             expr->node_type = create_optional_type(ft ? ft : create_type(TYPE_UNKNOWN));
             free_type(o);
+            return 1;
+        }
+
+        case AST_OR_ELSE: {
+            // #913: `fallible or handler`. The LHS must be a fallible
+            // `(value, err)` / `T!` expression. A block handler runs when the
+            // error slot is non-empty (with `err` bound) and yields a value or
+            // exits; a bare expression is a default value. The whole
+            // expression's type is the success value type.
+            if (expr->child_count < 2) return 0;
+            typecheck_expression(expr->children[0], table);
+            Type* op = infer_type(expr->children[0], table);
+            if (!op || op->kind != TYPE_TUPLE || op->tuple_count < 2) {
+                type_error("`or` requires a fallible `(value, err)` / `T!` "
+                           "expression on its left", expr->line, expr->column);
+                if (op) free_type(op);
+                expr->node_type = create_type(TYPE_UNKNOWN);
+                return 0;
+            }
+            ASTNode* handler = expr->children[1];
+            if (handler && handler->type == AST_BLOCK) {
+                SymbolTable* h = create_symbol_table(table);
+                add_symbol(h, "err", create_type(TYPE_STRING), 0, 0, 0);
+                typecheck_statement(handler, h);
+                free_symbol_table(h);
+            } else if (handler) {
+                typecheck_expression(handler, table);
+            }
+            if (expr->node_type) free_type(expr->node_type);
+            expr->node_type = op->tuple_types[0] ? clone_type(op->tuple_types[0])
+                                                  : create_type(TYPE_UNKNOWN);
+            free_type(op);
             return 1;
         }
 

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -26,6 +26,7 @@ Type* create_type(TypeKind kind) {
      * must NOT inherit garbage from malloc. */
     type->is_fnptr = 0;
     type->compound_node = NULL;
+    type->is_result = 0;   /* #913 `T!` marker — must not inherit malloc garbage */
     return type;
 }
 

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -62,6 +62,16 @@ Type* create_tuple_type(int count, ...) {
     return type;
 }
 
+// #913 fallible result `T!`. Represented as the existing `(T, string)`
+// (value, err) tuple so it is ABI-interchangeable with the stdlib convention;
+// the `is_result` flag distinguishes it from a plain 2-tuple so `expr!`
+// propagates (not panics) in a result-returning function and `or {}` applies.
+Type* create_result_type(Type* inner) {
+    Type* t = create_tuple_type(2, inner, create_type(TYPE_STRING));
+    t->is_result = 1;
+    return t;
+}
+
 // #914 sum/variant type. `struct_name` holds the sum's name; the variant
 // Types are filled into `tuple_types[]` by the typechecker once the named
 // variant structs resolve. clone_type/free_type already handle both fields
@@ -287,6 +297,7 @@ Type* clone_type(Type* type) {
     }
     new_type->is_fnptr = type->is_fnptr;
     new_type->compound_node = type->compound_node;  // borrowed; AST owns it.
+    new_type->is_result = type->is_result;          // #913 `T!` marker
 
     return new_type;
 }

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -218,7 +218,12 @@ typedef enum {
     // #914 sum/variant types. `type Name = A | B | C` — a tagged union over
     // existing struct variants. value = the sum type name; each child is an
     // AST_IDENTIFIER naming a variant struct.
-    AST_SUM_TYPE_DEF
+    AST_SUM_TYPE_DEF,
+    // #913 error handler `expr or { … }` / `expr or default`. children[0] =
+    // the fallible (value, err) expression; children[1] = the handler (a
+    // block that yields a value or exits, or a bare default expression). `err`
+    // is bound inside a block handler.
+    AST_OR_ELSE
 } ASTNodeType;
 
 typedef enum {
@@ -311,6 +316,12 @@ typedef struct Type {
     // look up. NULL on all other types. Borrowed pointer (the AST owns
     // the storage), so don't free on type teardown.
     struct ASTNode* compound_node;
+    // #913: a fallible result type `T!`. Represented as the existing
+    // `(T, string)` (value, err) TUPLE so it is ABI-interchangeable with the
+    // stdlib convention; this flag marks it as a result so `expr!` PROPAGATES
+    // (rather than panics) inside a `T!`-returning function and so an `or {}`
+    // handler / the "must handle" check apply. 0 on a plain tuple.
+    int is_result;
 } Type;
 
 typedef struct ASTNode {
@@ -358,6 +369,7 @@ Type* create_optional_type(Type* inner);   // #340 `T?`
 Type* create_actor_ref_type(Type* actor_type);
 Type* create_tuple_type(int count, ...);  // create_tuple_type(2, type_a, type_b)
 Type* create_sum_type(const char* name);  // #914 `type Name = A | B | C`
+Type* create_result_type(Type* inner);    // #913 fallible `T!` -> (T, string)
 Type* create_function_type(int param_count, Type** param_types, Type* return_type);
 void free_type(Type* type);
 const char* type_to_string(Type* type);

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1776,6 +1776,50 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             break;
         }
 
+        case AST_OR_ELSE: {
+            /* #913: `fallible or handler`. Evaluate the (value, err) tuple
+             * once; on a non-empty error slot run the handler, else yield the
+             * value. A block handler runs its statements (with `err` bound) and
+             * is expected to exit (return/break/…) — matching the codebase's
+             * block-body convention; a bare expression handler is the default
+             * value. Single-eval via a GCC statement-expression. */
+            if (expr->child_count < 2) break;
+            ASTNode* fallible = expr->children[0];
+            ASTNode* handler = expr->children[1];
+            Type* tup = fallible->node_type;
+            if (!tup || tup->kind != TYPE_TUPLE || tup->tuple_count < 2 ||
+                !tup->tuple_types[0]) {
+                generate_expression(gen, fallible);   // malformed; already flagged
+                break;
+            }
+            const char* tuple_c = get_c_type(tup);
+            const char* val_c = get_c_type(tup->tuple_types[0]);
+            int err_idx = tup->tuple_count - 1;
+            static int oe_counter = 0;
+            int id = oe_counter++;
+            fprintf(gen->output, "({ %s _oe%d = ", tuple_c, id);
+            generate_expression(gen, fallible);
+            fprintf(gen->output, "; %s _oer%d;\nif (_oe%d._%d && _oe%d._%d[0]) {\n",
+                    val_c, id, id, err_idx, id, err_idx);
+            if (handler->type == AST_BLOCK) {
+                /* Block statements emit their own `#line` directives, which
+                 * must begin a line — hence the newlines bracketing them. */
+                fprintf(gen->output, "const char* err = _oe%d._%d; (void)err;\n",
+                        id, err_idx);
+                for (int j = 0; j < handler->child_count; j++) {
+                    generate_statement(gen, handler->children[j]);
+                }
+                fprintf(gen->output, "\n");
+            } else {
+                fprintf(gen->output, "_oer%d = ", id);
+                generate_expression(gen, handler);
+                fprintf(gen->output, ";\n");
+            }
+            fprintf(gen->output, "} else { _oer%d = _oe%d._0; } _oer%d; })",
+                    id, id, id);
+            break;
+        }
+
         case AST_TUPLE_UNWRAP: {
             /* `expr!` — unwrap-or-trap. Emit a GCC statement-expression
              * that evaluates the tuple once, panics if the trailing
@@ -1822,10 +1866,25 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             fprintf(gen->output, "({ %s _unw%d = ", tuple_c, uid);
             generate_expression(gen, operand);
             fprintf(gen->output, "; ");
-            fprintf(gen->output,
-                    "if (_unw%d._%d && _unw%d._%d[0]) "
-                    "aether_panic(_unw%d._%d); ",
-                    uid, err_idx, uid, err_idx, uid, err_idx);
+            /* #913: `expr!` on a (value, err) result. In a function whose
+             * return type is itself a result (`T!`), PROPAGATE — return the
+             * enclosing result with the error slot set (value slot zero-init),
+             * V-style one-char propagation. Otherwise keep the unwrap-or-PANIC
+             * semantics, so `expr!` in a non-result function is unchanged. The
+             * `return` inside the statement-expression returns from the
+             * enclosing function, which is exactly the propagation we want. */
+            if (gen->current_func_return_type &&
+                gen->current_func_return_type->is_result) {
+                fprintf(gen->output,
+                        "if (_unw%d._%d && _unw%d._%d[0]) return (%s){ ._1 = _unw%d._%d }; ",
+                        uid, err_idx, uid, err_idx,
+                        get_c_type(gen->current_func_return_type), uid, err_idx);
+            } else {
+                fprintf(gen->output,
+                        "if (_unw%d._%d && _unw%d._%d[0]) "
+                        "aether_panic(_unw%d._%d); ",
+                        uid, err_idx, uid, err_idx, uid, err_idx);
+            }
             fprintf(gen->output, "_unw%d._0; })", uid);
             break;
         }

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -3391,6 +3391,22 @@ static void emit_return_value(CodeGenerator* gen, ASTNode* stmt) {
         emit_sum_coerced(gen, stmt->children[0], gen->current_func_return_type);
         return;
     }
+    // #913: `return value` from a `T!` function wraps the success value into
+    // the `(value, "")` result tuple. An explicit `return value, "err"` is a
+    // 2-value return handled by the multi-return path and never reaches here;
+    // a value that is already the result tuple (forwarding another result)
+    // passes through unchanged.
+    if (gen->current_func_return_type &&
+        gen->current_func_return_type->is_result) {
+        ASTNode* v = stmt->children[0];
+        if (!(v->node_type && v->node_type->kind == TYPE_TUPLE)) {
+            fprintf(gen->output, "(%s){ ._0 = ",
+                    get_c_type(gen->current_func_return_type));
+            generate_expression(gen, v);
+            fprintf(gen->output, ", ._1 = \"\" }");
+            return;
+        }
+    }
     if (should_uniform_heap_return(gen, stmt)) {
         emit_uniform_heap_return_expr(gen, stmt->children[0]);
     } else {

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -275,6 +275,15 @@ Type* parse_type(Parser* parser) {
         advance_token(parser);
         t = create_optional_type(t);
     }
+    // #913: a postfix `!` makes the type a fallible result (`string!`,
+    // `int!`), symmetric with the `?` optional suffix above. In type position
+    // `!` is unambiguous (the unwrap/propagate `!` only appears in
+    // expressions). `T!` lowers to the existing `(T, string)` (value, err)
+    // tuple, so it interops with the stdlib convention.
+    if (peek_token(parser) && peek_token(parser)->type == TOKEN_EXCLAIM) {
+        advance_token(parser);
+        t = create_result_type(t);
+    }
     return t;
 }
 
@@ -1437,7 +1446,33 @@ static int operator_starts_newline(Parser* parser, Token* op) {
 }
 
 ASTNode* parse_expression(Parser* parser) {
-    return parse_binary_expression(parser, 0);
+    ASTNode* expr = parse_binary_expression(parser, 0);
+    if (!expr) return NULL;
+    // #913: postfix error handler `expr or { … }` / `expr or <default>`. `or`
+    // is a CONTEXTUAL keyword — still a valid identifier elsewhere (`byte or =
+    // …`) — recognised only here, in value position, on the same line (so a
+    // bare expression followed by a statement that happens to start with an
+    // `or`-named identifier stays two statements). The LHS is a fallible
+    // `(value, err)` / `T!` expression; the handler runs when the error slot
+    // is non-empty, binding `err`, and yields a value or exits (return/…).
+    Token* t = peek_token(parser);
+    if (t && t->type == TOKEN_IDENTIFIER && t->value &&
+        strcmp(t->value, "or") == 0 && !operator_starts_newline(parser, t)) {
+        advance_token(parser);  // consume contextual 'or'
+        ASTNode* handler;
+        Token* nx = peek_token(parser);
+        if (nx && nx->type == TOKEN_LEFT_BRACE) {
+            handler = parse_block(parser);
+        } else {
+            handler = parse_expression(parser);   // bare default value
+        }
+        if (!handler) return NULL;
+        ASTNode* oe = create_ast_node(AST_OR_ELSE, NULL, expr->line, expr->column);
+        add_child(oe, expr);
+        add_child(oe, handler);
+        return oe;
+    }
+    return expr;
 }
 
 ASTNode* parse_binary_expression(Parser* parser, int precedence) {

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -950,6 +950,54 @@ checked_op(x: int) -> {
 }
 ```
 
+#### The `T!` result type and `or` / `!` sugar (issue #913)
+
+`-> T!` is shorthand for the `(T, string)` result tuple above — it *names* the
+convention and unlocks ergonomic sugar for the three things you do with a
+fallible call. There is no hidden machinery: `T!` is the same tuple you can
+always destructure by hand, so the sugar and the manual form interoperate
+freely.
+
+```aether
+// `return v` auto-wraps to (v, ""); the error path is explicit.
+safe_divide(a: int, b: int) -> int! {
+    if b == 0 { return 0, "division by zero" }
+    return a / b
+}
+```
+
+**`expr or default` — use the value, or a fallback on error:**
+
+```aether
+q = safe_divide(10, 0) or -1      // q == -1
+```
+
+**`expr or { ... }` — run a block on error, with `err` bound to the message.**
+The block is expected to exit (like a `match` arm's block body): `return`,
+`break`, `continue`, or `panic`. For a computed fallback *value*, use the
+`or <expr>` form instead.
+
+```aether
+q = safe_divide(x, y) or {
+    println("math failed: ${err}")   // `err` is the error string
+    return
+}
+```
+
+**`expr!` — propagate the error.** Inside a function that itself returns `T!`,
+`!` returns `(zero, err)` to the caller when the error slot is non-empty, so an
+inner failure short-circuits without manual `if err != ""` plumbing:
+
+```aether
+checked_divide(x: int, d: int) -> int! {
+    return safe_divide(x, d)!   // forwards safe_divide's error unchanged
+}
+```
+
+Used outside a `T!` function, `expr!` is *unwrap-or-trap*: it panics on a
+non-empty error slot (catchable with `try`/`catch`). Both `!` and `or` accept
+any `(value, err)` tuple, not just `T!` returns.
+
 ### Function contracts: `requires` / `ensures` (issue #348)
 
 Eiffel-style runtime-checked preconditions and postconditions. Clauses appear after the typed return arrow and before the body; each is a single boolean expression, panic on violation.

--- a/examples/basics/error-handling.ae
+++ b/examples/basics/error-handling.ae
@@ -1,36 +1,44 @@
 // Error Handling with Result Types
 //
 // Aether uses Go-style multiple return values for error handling.
-// Functions that can fail return (value, error) tuples.
-// The error is a string: "" means no error, non-empty means failure.
+// Functions that can fail return (value, error) tuples. The error is a
+// string: "" means no error, non-empty means failure.
 //
-// Pattern: check error first, handle it (return/exit), then continue.
-// No else needed — keeps the code flat and readable.
+// The `-> T!` return type names that convention: it is exactly the
+// `(T, string)` result tuple, plus ergonomic sugar for the common cases:
+//   result   or default   -- use the value, or a fallback on error
+//   result   or { ... }    -- run a block (with `err` bound) on error
+//   result!                -- propagate the error up (or panic at top level)
+//
+// Under the hood there is no hidden machinery: `T!` is the same tuple you
+// can always destructure by hand. Pick whichever reads best.
 
-safe_divide(a: int, b: int) -> {
+import std.string
+
+// A fallible function. `return a / b` auto-wraps to `(a / b, "")`; the
+// error path returns an explicit message.
+safe_divide(a: int, b: int) -> int! {
     if b == 0 {
         return 0, "cannot divide by zero"
     }
-    return a / b, ""
+    return a / b
 }
 
-// Chain: propagate errors from inner calls
-checked_divide(input: int, divisor: int) -> {
+// Propagate with `!`: if safe_divide fails, checked_divide returns its
+// error unchanged — no manual `if err != ""` plumbing.
+checked_divide(input: int, divisor: int) -> int! {
     if input < 0 {
         return 0, "input must be non-negative"
     }
-    result, err = safe_divide(input, divisor)
-    if err != "" {
-        return 0, err
-    }
-    return result, ""
+    return safe_divide(input, divisor)!
 }
 
 main() {
     println("=== Error Handling Demo ===")
     println("")
 
-    // Basic pattern: check error, bail if needed, continue
+    // 1. Manual form — destructure the tuple and check the error.
+    //    Always available; nothing is hidden.
     result, err = safe_divide(10, 3)
     if err != "" {
         println("Error: ${err}")
@@ -38,34 +46,15 @@ main() {
     }
     println("10 / 3 = ${result}")
 
-    // Error case — handle and continue
-    _, err2 = safe_divide(10, 0)
-    if err2 != "" {
-        println("Caught: ${err2}")
+    // 2. `or default` — use the value, or a fallback when it fails.
+    quotient = safe_divide(10, 0) or -1
+    println("10 / 0 (or -1) = ${quotient}")
+
+    // 3. `or { ... }` — run a block on error, with `err` bound to the
+    //    message. Handy for logging before falling back or bailing.
+    safe = safe_divide(10, 0) or {
+        println("Caught: ${err}")
+        return
     }
-
-    // Discard error with _ when you know it won't fail
-    val, _ = safe_divide(42, 7)
-    println("42 / 7 = ${val}")
-
-    // Chained error propagation
-    v1, e1 = checked_divide(100, 5)
-    if e1 != "" {
-        println("Chain error: ${e1}")
-        exit(1)
-    }
-    println("checked 100/5 = ${v1}")
-
-    _, e2 = checked_divide(10, 0)
-    if e2 != "" {
-        println("Chain caught: ${e2}")
-    }
-
-    _, e3 = checked_divide(0 - 1, 5)
-    if e3 != "" {
-        println("Chain caught: ${e3}")
-    }
-
-    println("")
-    println("Done.")
+    println("unreachable when the divide fails: ${safe}")
 }

--- a/tests/regression/test_issue913_result_error_handling.ae
+++ b/tests/regression/test_issue913_result_error_handling.ae
@@ -1,0 +1,99 @@
+// Regression (#913): first-class error handling built on the `(value, err)`
+// tuple convention.
+//
+//   1. `-> T!` declares a fallible function whose ABI is the `(T, string)`
+//      result tuple. A bare `return v` auto-wraps to `(v, "")`; an explicit
+//      `return v, "msg"` reports an error.
+//   2. `expr!` inside a `T!` function propagates: on a non-empty error slot it
+//      returns `(zero, err)` from the caller instead of panicking.
+//   3. `expr or default` yields the success value, or `default` on error.
+//   4. `expr or { ... }` runs a block (with `err` bound to the error string)
+//      when the call fails; the block exits (here via `return`), forwarding a
+//      custom result.
+//
+// Self-asserting: prints FAIL + exits 1 on any mismatch, PASS at the end.
+
+import std.string
+
+extern exit(code: int)
+
+// (1) explicit (value, err) result + the error path
+parse_pos(x: int) -> int! {
+    if x < 0 {
+        return 0, "negative"
+    }
+    return x, ""
+}
+
+// (1b) single-value return auto-wraps to (value, "")
+half(x: int) -> int! {
+    return x / 2
+}
+
+// (2) `!` propagation: forwards parse_pos's error unchanged
+double_pos(x: int) -> int! {
+    let v = parse_pos(x)!
+    return v * 2, ""
+}
+
+// (4) block handler binds `err` and exits, forwarding a custom message
+describe(k: int) -> string! {
+    let v = parse_pos(k) or { return "", err }
+    if v == 0 {
+        return "zero", ""
+    }
+    return "ok", ""
+}
+
+main() {
+    // (1) success path: value used
+    let a = parse_pos(5) or 999
+    if a != 5 {
+        println("FAIL: parse_pos(5) or 999 = ${a}")
+        exit(1)
+    }
+
+    // (3) error path -> default value
+    let b = parse_pos(-3) or 999
+    if b != 999 {
+        println("FAIL: parse_pos(-3) or 999 = ${b}")
+        exit(1)
+    }
+
+    // (1b) auto-wrap success
+    let h = half(10) or -1
+    if h != 5 {
+        println("FAIL: half(10) or -1 = ${h}")
+        exit(1)
+    }
+
+    // (2) propagation, success
+    let c = double_pos(7) or -1
+    if c != 14 {
+        println("FAIL: double_pos(7) or -1 = ${c}")
+        exit(1)
+    }
+
+    // (2) propagation, error forwarded -> outer default
+    let d = double_pos(-2) or -1
+    if d != -1 {
+        println("FAIL: double_pos(-2) or -1 = ${d}")
+        exit(1)
+    }
+
+    // (4) block handler, success path (block not taken)
+    let s1 = describe(3) or "DEFAULT"
+    if string.equals(s1, "ok") != 1 {
+        println("FAIL: describe(3) or DEFAULT = ${s1}")
+        exit(1)
+    }
+
+    // (4) block handler, error path: describe forwards err "" then outer or
+    let s2 = describe(-1) or "DEFAULT"
+    if string.equals(s2, "DEFAULT") != 1 {
+        println("FAIL: describe(-1) or DEFAULT = ${s2}")
+        exit(1)
+    }
+
+    println("PASS: #913 result-error handling (T!, propagation, or-default, or-block)")
+}


### PR DESCRIPTION
## Summary

First-class error handling for Aether, built on the existing `(value, string)` result-tuple convention with no hidden machinery: `T!` *is* the `(T, string)` tuple, so the new sugar and manual destructuring interoperate freely, and `or` / `!` accept any `(value, err)` tuple.

### What's new

- **`-> T!` return type** — shorthand for the `(T, string)` result tuple. A bare `return v` auto-wraps to `(v, "")`; `return v, "msg"` reports an error.
- **`expr or default`** — yields the success value, or `default` on error.
- **`expr or { ... }`** — runs a block on error with `err` bound to the message; the block exits (`return`/`break`/`continue`/`panic`), matching the codebase's block-body convention. For a computed fallback *value*, use the `or <expr>` form.
- **`expr!`** — inside a `T!` function it propagates `(zero, err)` on a non-empty error slot; used elsewhere it stays unwrap-or-trap (panics, catchable with `try`/`catch`), so existing `!` uses are unchanged.

```aether
safe_divide(a: int, b: int) -> int! {
    if b == 0 { return 0, "division by zero" }
    return a / b
}

checked(x: int, d: int) -> int! {
    return safe_divide(x, d)!        // propagate on error
}

main() {
    q = safe_divide(10, 0) or -1     // q == -1
    r = safe_divide(x, y) or {       // `err` bound; block exits
        println("failed: ${err}")
        return
    }
}
```

## Implementation

- `create_result_type` — the `(T, string)` tuple plus an `is_result` marker (appended to `Type`), so a result is distinguishable from a plain 2-tuple.
- Parser: a postfix `!` type suffix (symmetric with `?` optional), and a contextual-`or` postfix in `parse_expression` (still a valid identifier elsewhere; recognised only in value position on the same line).
- Typechecker: `infer_type` / `typecheck_expression` for `AST_OR_ELSE` (binds `err` in a block handler; the expression's type is the success value type).
- Codegen: `T!` returns wrap the success value into `(v, "")`; `expr!` in a result function emits a propagating `return`; `or` lowers to a single-eval GCC statement-expression.

## Testing

- New self-asserting regression test `tests/regression/test_issue913_result_error_handling.ae` (T!, auto-wrap, propagation success+error, `or` default, `or {}` block with `err`).
- Refreshed `examples/basics/error-handling.ae` to show the manual form alongside the sugar.
- CHANGELOG and `docs/language-reference.md` updated in the same PR.
- **231/231** C unit tests, **798/798** `.ae` tests, **85/85** examples pass. Emitted C is warning-clean under `-Wall -Wextra -Werror`; the full compiler builds clean under `-Werror`; the regression test is leak-clean (`leaks --atExit`: 0 leaks).

Closes #913