### PR TITLE
feat(std): dir_list_kind (readdir d_type) + stable string_list sort (#966, #967)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ next version number before tagging the release.
 
 ## [0.339.0]
 
+### Added
+
+- **`std.collections`: stable `string_list` sort** (#967). `string_list_sort_lex(list)`
+  sorts ascending byte-wise; `string_list_sort(list, cmp)` sorts by a comparator
+  closure `|a: string, b: string| { ... }` (negative / 0 / positive, like `strcmp`).
+  Both are stable and reorder the backing slots only — no element is copied or
+  freed — so they remove the get/set aliasing footgun of a hand-rolled swap (a
+  naive adjacent swap frees a slot another borrowed pointer still aliases,
+  silently corrupting entries).
+
+  ```aether
+  string_list_sort_lex(names)
+  string_list_sort(names, |a: string, b: string| {
+      return string.length(a) - string.length(b)   // shortest first, stable
+  })
+  ```
+
+- **`std.fs`: `dir_list_kind` exposes readdir's `d_type`** (#966). A directory
+  listing now carries each entry's file kind (1 file / 2 dir / 3 symlink /
+  4 other; 0 unknown), read straight from `readdir`'s `d_type` (Windows'
+  `dwFileAttributes`) — the same encoding `file_stat` returns. Telling files
+  from directories no longer costs an N-entry `stat(2)` sweep; a file browser
+  or tree walk gets it from the single `readdir`.
+
+  ```aether
+  list, err = dir.list(path)
+  kind = dir.list_kind(list, i)   // 2 == directory, no stat needed
+  ```
+
 ## [0.338.0]
 
 ### Added

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -111,6 +111,23 @@ Plain string literals pass through unchanged — `string_retain` is a no-op on v
 - `string_list_remove(list, index)` - Remove + release the entry
 - `string_list_clear(list)` - Drop every entry, keep the backing alloc
 - `string_list_free(list)` - Release every entry then free
+- `string_list_sort_lex(list)` - Stable ascending lexicographic (byte-wise) sort, in place
+- `string_list_sort(list, cmp)` - Stable in-place sort by a comparator closure `|a: string, b: string| { ... }` returning negative / 0 / positive (like `strcmp`)
+
+Both sorts reorder the backing slots only — no element is copied or freed — so they sidestep the get/set aliasing trap of a hand-rolled swap (`string_list_get` returns the slot's internal pointer; a naive adjacent swap would free a slot another borrowed pointer still aliases). Issue #967.
+
+```aether
+names = string_list_new()
+string_list_add(names, "Charlie")
+string_list_add(names, "alice")
+string_list_add(names, "Bob")
+
+string_list_sort_lex(names)                 // "Bob", "Charlie", "alice" (ASCII order)
+
+string_list_sort(names, |a: string, b: string| {
+    return string.length(a) - string.length(b)   // shortest first, stable
+})
+```
 
 For a similar `string_map`, file an issue — same pattern would apply. Issue #274.
 
@@ -599,10 +616,18 @@ main() {
         if err != "" { println("mkdir failed: ${err}") }
     }
 
-    // List contents
+    // List contents, with each entry's kind straight from readdir's d_type
+    // (no per-entry stat needed).
     list, lerr = dir.list(".")
     if lerr == "" {
-        // Process list with dir.list_count / dir.list_get...
+        n = dir.list_count(list)
+        i = 0
+        while i < n {
+            name = dir.list_get(list, i)
+            kind = dir.list_kind(list, i)      // 1 file / 2 dir / 3 symlink / 4 other / 0 unknown
+            if kind == 2 { println("[dir]  ${name}") }
+            i = i + 1
+        }
         dir.list_free(list)
     }
 
@@ -615,10 +640,13 @@ main() {
 - `dir.create(path)` → `string` - Create directory, return error string
 - `dir.delete(path)` → `string` - Delete empty directory, return error string
 - `dir.list(path)` → `(ptr, string)` - List contents (caller must `dir.list_free`)
+- `dir.list_count(list)` → `int` - Number of entries
+- `dir.list_get(list, index)` → `string` - Entry name at `index`
+- `dir.list_kind(list, index)` → `int` - Entry's file kind from readdir's `d_type`, avoiding a `stat(2)` per entry: 1 = file, 2 = directory, 3 = symlink (target not followed), 4 = other; 0 = unknown (the filesystem didn't report a type — stat that entry to resolve it). Same encoding as `file_stat`'s kind. Issue #966.
 - `dir.exists(path)` - 1 if a **directory** is at `path`, 0 otherwise. Returns 0 for regular files, even if they exist — see `fs.exists` for the path-agnostic check.
 - `dir.list_free(list)` - Free directory listing
 
-Raw externs: `dir_create_raw`, `dir_delete_raw`, `dir_list_raw`.
+Raw externs: `dir_create_raw`, `dir_delete_raw`, `dir_list_raw`, `dir_list_count`, `dir_list_get`, `dir_list_kind`, `dir_list_free`.
 
 ### Paths (`std.path`)
 

--- a/examples/stdlib/dir-listing.ae
+++ b/examples/stdlib/dir-listing.ae
@@ -1,0 +1,89 @@
+// Directory listing — sorted, with per-entry kind (issues #966, #967).
+// Run with: ae run examples/stdlib/dir-listing.ae
+//
+// The pattern behind a file browser or a `du`-style walk:
+//   - dir.list_kind(list, i) reports each entry's type straight from
+//     readdir's d_type (1 file / 2 dir / 3 symlink / 4 other; 0 unknown),
+//     so you skip a stat(2) per entry just to draw a folder-vs-file icon.
+//   - string_list_sort_lex / string_list_sort give a stable order without
+//     hand-rolling a sort (and its get/set aliasing footgun).
+
+import std.dir
+import std.file
+import std.collections
+import std.string
+
+main() {
+    print("=== Directory Listing Demo ===\n\n")
+
+    base = "/tmp/aether_dir_listing_demo"
+    _c = dir.create(base)
+    _s = dir.create("${base}/src")
+    wa = file.write("${base}/README.md", "readme")
+    wb = file.write("${base}/main.ae", "main")
+    wc = file.write("${base}/config.toml", "cfg")
+    if wa != "" {
+        println("(skipping: scratch dir not writable: ${wa})")
+        return
+    }
+
+    // List once. Read each entry's kind from the same sweep — no stat.
+    listing, lerr = dir.list(base)
+    if lerr != "" {
+        println("list failed: ${lerr}")
+        return
+    }
+
+    names = string_list_new()
+    n = dir.list_count(listing)
+    i = 0
+    while i < n {
+        name = dir.list_get(listing, i)
+        string_list_add(names, name)
+        i = i + 1
+    }
+
+    // Sort the names lexicographically for a stable display order.
+    string_list_sort_lex(names)
+
+    println("Entries (sorted), with kind from d_type:")
+    j = 0
+    m = string_list_size(names)
+    while j < m {
+        entry = string_list_get(names, j)
+        // Re-derive the kind for this name from the original listing.
+        kind = 0
+        k = 0
+        while k < n {
+            if string.equals(dir.list_get(listing, k), entry) == 1 {
+                kind = dir.list_kind(listing, k)
+            }
+            k = k + 1
+        }
+        label = "file"
+        if kind == 2 { label = "dir " }
+        if kind == 3 { label = "link" }
+        println("  [${label}] ${entry}")
+        j = j + 1
+    }
+
+    // Sort by descending name length via a comparator closure.
+    string_list_sort(names, |a: string, b: string| {
+        return string.length(b) - string.length(a)
+    })
+    println("")
+    println("Longest name: ${string_list_get(names, 0)}")
+
+    string_list_free(names)
+    dir.list_free(listing)
+
+    // Cleanup.
+    _ra = file.delete("${base}/README.md")
+    _rb = file.delete("${base}/main.ae")
+    _rc = file.delete("${base}/config.toml")
+    _rs = dir.delete("${base}/src")
+    _rd = dir.delete(base)
+
+    println("")
+    println("Done.")
+}

--- a/std/collections/aether_stringlist.c
+++ b/std/collections/aether_stringlist.c
@@ -128,3 +128,108 @@ void string_list_free(StringList* list) {
     }
     aether_caps_free(list, sizeof(StringList));
 }
+
+/* #967: sort support.
+ *
+ * The reorder strategy sidesteps the get/set aliasing footgun (issue
+ * #967): `string_list_get` hands back the slot's internal pointer and a
+ * naive adjacent-swap frees a slot that another borrowed pointer still
+ * aliases. Instead we snapshot the borrowed element pointers into a
+ * scratch array, sort the scratch (a permutation of the same pointers),
+ * then write them back with `list_set` — which only overwrites the slot
+ * pointer (never frees). No element is copied or freed, so the pointer
+ * set is preserved exactly: no leak, no double-free, no read-after-free.
+ */
+
+/* Layout-compatible view of the codegen's boxed `_AeClosure`
+ * (see std/collections/aether_stringseq.c and codegen.c's prologue):
+ *     typedef struct { void (*fn)(void); void* env; } _AeClosure;
+ * `env` is the implicit first argument to `fn`. */
+typedef struct { void (*fn)(void); void* env; } AeStrListClosure;
+
+/* Free a boxed comparator closure — the callee owns it, matching the
+ * seq-combinator convention. NULL-safe. */
+static void sl_closure_free(void* box) {
+    if (!box) return;
+    AeStrListClosure* clo = (AeStrListClosure*)box;
+    if (clo->env) free(clo->env);
+    free(box);
+}
+
+/* Stable top-down merge sort of borrowed pointers, invoking the Aether
+ * comparator. Taking the left run on a tie (`cmp <= 0`) preserves the
+ * input order of equal elements — the stability the issue asks for. */
+static void sl_msort(const char** a, const char** tmp, int lo, int hi,
+                     int (*cmp)(void*, const char*, const char*), void* env) {
+    if (hi - lo <= 1) return;
+    int mid = lo + (hi - lo) / 2;
+    sl_msort(a, tmp, lo, mid, cmp, env);
+    sl_msort(a, tmp, mid, hi, cmp, env);
+    int i = lo, j = mid, k = lo;
+    while (i < mid && j < hi) {
+        if (cmp(env, a[i] ? a[i] : "", a[j] ? a[j] : "") <= 0)
+            tmp[k++] = a[i++];
+        else
+            tmp[k++] = a[j++];
+    }
+    while (i < mid) tmp[k++] = a[i++];
+    while (j < hi)  tmp[k++] = a[j++];
+    for (int x = lo; x < hi; x++) a[x] = tmp[x];
+}
+
+void string_list_sort(StringList* list, void* cmp_box) {
+    if (!list || !list->items || !cmp_box) {
+        sl_closure_free(cmp_box);   /* still own the box on the error path */
+        return;
+    }
+    int n = list_size(list->items);
+    if (n <= 1) { sl_closure_free(cmp_box); return; }
+
+    AeStrListClosure clo = *(AeStrListClosure*)cmp_box;
+    int (*cmp)(void*, const char*, const char*) =
+        (int (*)(void*, const char*, const char*))clo.fn;
+
+    size_t bytes = (size_t)n * sizeof(const char*);
+    const char** snap = (const char**)aether_caps_malloc(bytes);
+    const char** tmp  = (const char**)aether_caps_malloc(bytes);
+    if (!snap || !tmp) {
+        if (snap) aether_caps_free(snap, bytes);
+        if (tmp)  aether_caps_free(tmp, bytes);
+        sl_closure_free(cmp_box);
+        return;
+    }
+
+    for (int i = 0; i < n; i++)
+        snap[i] = (const char*)list_get_raw(list->items, i);
+    sl_msort(snap, tmp, 0, n, cmp, clo.env);
+    for (int i = 0; i < n; i++)
+        list_set(list->items, i, (void*)snap[i]);
+
+    aether_caps_free(snap, bytes);
+    aether_caps_free(tmp, bytes);
+    sl_closure_free(cmp_box);
+}
+
+/* strcmp over borrowed element pointers, for qsort. Equal elements are
+ * byte-identical strings, so qsort's instability is unobservable here. */
+static int sl_cmp_lex(const void* pa, const void* pb) {
+    const char* a = *(const char* const*)pa;
+    const char* b = *(const char* const*)pb;
+    return strcmp(a ? a : "", b ? b : "");
+}
+
+void string_list_sort_lex(StringList* list) {
+    if (!list || !list->items) return;
+    int n = list_size(list->items);
+    if (n <= 1) return;
+
+    size_t bytes = (size_t)n * sizeof(const char*);
+    const char** snap = (const char**)aether_caps_malloc(bytes);
+    if (!snap) return;
+    for (int i = 0; i < n; i++)
+        snap[i] = (const char*)list_get_raw(list->items, i);
+    qsort(snap, (size_t)n, sizeof(const char*), sl_cmp_lex);
+    for (int i = 0; i < n; i++)
+        list_set(list->items, i, (void*)snap[i]);
+    aether_caps_free(snap, bytes);
+}

--- a/std/collections/aether_stringlist.h
+++ b/std/collections/aether_stringlist.h
@@ -51,4 +51,17 @@ void string_list_clear(StringList* list);
 /* Release every entry then free the list. Idempotent on null. */
 void string_list_free(StringList* list);
 
+/* #967: stable in-place sort by a caller-supplied comparator closure
+ * `fn(string, string) -> int` (negative / 0 / positive for a<b / a==b /
+ * a>b, like strcmp). `cmp_box` is a codegen-boxed `_AeClosure` passed as
+ * a ptr; this function OWNS it and frees it before returning (matching
+ * the seq-combinator convention). Reorders the backing pointers only —
+ * no element is copied or freed — so it sidesteps the get/set aliasing
+ * trap of a hand-rolled swap. No-op (box still freed) on null / OOM. */
+void string_list_sort(StringList* list, void* cmp_box);
+
+/* #967: stable in-place ascending lexicographic (byte-wise `strcmp`)
+ * sort — the common case, no closure needed. No-op on null. */
+void string_list_sort_lex(StringList* list);
+
 #endif

--- a/std/collections/module.ae
+++ b/std/collections/module.ae
@@ -19,6 +19,7 @@ exports (
     intarr_fill, intarr_free,
     string_list_new, string_list_add, string_list_get, string_list_set,
     string_list_size, string_list_remove, string_list_clear, string_list_free,
+    string_list_sort, string_list_sort_lex,
     list_add, list_get,
     map_put, map_get, map_keys
 )
@@ -113,6 +114,12 @@ extern string_list_size(list: ptr) -> int
 extern string_list_remove(list: ptr, index: int)
 extern string_list_clear(list: ptr)
 extern string_list_free(list: ptr)
+// #967: stable sort. `cmp` is a comparator closure `fn(string, string) -> int`
+// (negative / 0 / positive, like strcmp), passed as a boxed closure (ptr).
+// Reorders slots only — safe against the get/set aliasing trap. sort_lex is
+// the closure-free ascending-lexicographic common case.
+extern string_list_sort(list: ptr, cmp: ptr)
+extern string_list_sort_lex(list: ptr)
 
 // ---- Go-style wrappers ----
 

--- a/std/dir/module.ae
+++ b/std/dir/module.ae
@@ -5,13 +5,16 @@
 
 exports (
     dir_exists, dir_create_raw, dir_delete_raw, dir_list_raw, dir_list_free,
-    create, delete, list
+    create, delete, list, list_count, list_get, list_kind
 )
 
 extern dir_exists(path: string) -> int
 extern dir_create_raw(path: string) -> int
 extern dir_delete_raw(path: string) -> int
 extern dir_list_raw(path: string) -> ptr
+extern dir_list_count(list: ptr) -> int
+extern dir_list_get(list: ptr, index: int) -> string
+extern dir_list_kind(list: ptr, index: int) -> int
 extern dir_list_free(list: ptr)
 
 // Create a directory. Returns "" on success, error on failure.
@@ -41,4 +44,22 @@ list(path: string) -> {
         return null, "cannot list directory"
     }
     return result, ""
+}
+
+// Number of entries in a listing.
+list_count(l: ptr) -> int {
+    return dir_list_count(l)
+}
+
+// Name of entry `index` (empty on out-of-range).
+list_get(l: ptr, index: int) -> string {
+    return dir_list_get(l, index)
+}
+
+// #966: file kind of entry `index`, straight from readdir's d_type — no
+// stat(2) per entry. Same encoding as file_stat's kind: 1 = file, 2 = dir,
+// 3 = symlink (target not followed), 4 = other; 0 = unknown (the filesystem
+// didn't report a type — stat that entry to resolve it).
+list_kind(l: ptr, index: int) -> int {
+    return dir_list_kind(l, index)
 }

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -91,6 +91,7 @@ const char* fs_fsync_raw(File* f) { (void)f; return "fs unavailable"; }
 DirList* dir_list_raw(const char* p) { (void)p; return NULL; }
 int dir_list_count(DirList* l) { (void)l; return 0; }
 const char* dir_list_get(DirList* l, int i) { (void)l; (void)i; return NULL; }
+int dir_list_kind(DirList* l, int i) { (void)l; (void)i; return 0; }
 void dir_list_free(DirList* l) { (void)l; }
 DirList* fs_glob_raw(const char* p) { (void)p; return NULL; }
 DirList* fs_glob_multi_raw(void* l) { (void)l; return NULL; }
@@ -1733,6 +1734,36 @@ static char* fs_caps_strdup(const char* s) {
     return p;
 }
 
+/* #966: map readdir's d_type to fs_stat_raw's kind encoding
+ * (1 file / 2 dir / 3 symlink / 4 other), 0 when the FS doesn't report
+ * one (DT_UNKNOWN) so the caller stats only those. */
+#ifndef _WIN32
+static int fs_dtype_to_kind(unsigned char dt) {
+#ifdef DT_DIR
+    switch (dt) {
+        case DT_REG:  return FS_STAT_KIND_FILE;
+        case DT_DIR:  return FS_STAT_KIND_DIR;
+        case DT_LNK:  return FS_STAT_KIND_SYMLINK;
+        case DT_FIFO:
+        case DT_SOCK:
+        case DT_CHR:
+        case DT_BLK:  return FS_STAT_KIND_OTHER;
+        default:      return 0;   /* DT_UNKNOWN or unrecognised */
+    }
+#else
+    (void)dt;
+    return 0;   /* platform lacks d_type; caller falls back to stat */
+#endif
+}
+#else
+/* #966: same mapping from Windows' dwFileAttributes. */
+static int fs_winattr_to_kind(DWORD attr) {
+    if (attr & FILE_ATTRIBUTE_REPARSE_POINT) return FS_STAT_KIND_SYMLINK;
+    if (attr & FILE_ATTRIBUTE_DIRECTORY)     return FS_STAT_KIND_DIR;
+    return FS_STAT_KIND_FILE;
+}
+#endif
+
 // Directory listing
 DirList* dir_list_raw(const char* path) {
     if (!path) return NULL;
@@ -1745,6 +1776,7 @@ DirList* dir_list_raw(const char* path) {
     list->entries = NULL;
     list->count = 0;
     list->capacity = 0;
+    list->kinds = NULL;   /* #966 */
 
     #ifdef _WIN32
     WIN32_FIND_DATAA find_data;
@@ -1770,11 +1802,19 @@ DirList* dir_list_raw(const char* path) {
                     (size_t)new_cap * sizeof(char*));
                 if (!new_entries) break;
                 list->entries = new_entries;
+                /* #966: grow the parallel kinds array in lock-step. */
+                int* new_kinds = (int*)aether_caps_realloc(
+                    list->kinds, (size_t)cap * sizeof(int),
+                    (size_t)new_cap * sizeof(int));
+                if (!new_kinds) break;
+                list->kinds = new_kinds;
                 cap = new_cap;
                 list->capacity = new_cap;
             }
             char* name_copy = fs_caps_strdup(find_data.cFileName);
             if (!name_copy) break;
+            list->kinds[list->count] =                                   /* #966 */
+                fs_winattr_to_kind(find_data.dwFileAttributes);
             list->entries[list->count++] = name_copy;
         }
     } while (FindNextFileA(hFind, &find_data));
@@ -1795,11 +1835,18 @@ DirList* dir_list_raw(const char* path) {
                     (size_t)new_cap * sizeof(char*));
                 if (!new_entries) break;
                 list->entries = new_entries;
+                /* #966: grow the parallel kinds array in lock-step. */
+                int* new_kinds = (int*)aether_caps_realloc(
+                    list->kinds, (size_t)cap * sizeof(int),
+                    (size_t)new_cap * sizeof(int));
+                if (!new_kinds) break;
+                list->kinds = new_kinds;
                 cap = new_cap;
                 list->capacity = new_cap;
             }
             char* name_copy = fs_caps_strdup(entry->d_name);
             if (!name_copy) break;
+            list->kinds[list->count] = fs_dtype_to_kind(entry->d_type);  /* #966 */
             list->entries[list->count++] = name_copy;
         }
     }
@@ -1819,6 +1866,14 @@ const char* dir_list_get(DirList* list, int index) {
     return list->entries[index];
 }
 
+/* #966: file kind of entry `index`, from readdir's d_type. Out-of-range
+ * or a list built before kinds were tracked reports 0 (unknown), so a
+ * caller can safely fall back to stat. */
+int dir_list_kind(DirList* list, int index) {
+    if (!list || !list->kinds || index < 0 || index >= list->count) return 0;
+    return list->kinds[index];
+}
+
 void dir_list_free(DirList* list) {
     if (!list) return;
 
@@ -1830,6 +1885,9 @@ void dir_list_free(DirList* list) {
     }
     if (list->entries)
         aether_caps_free(list->entries, (size_t)list->capacity * sizeof(char*));
+    /* #966: the parallel kinds array is `capacity` ints. */
+    if (list->kinds)
+        aether_caps_free(list->kinds, (size_t)list->capacity * sizeof(int));
     aether_caps_free(list, sizeof(DirList));
 }
 
@@ -1981,6 +2039,7 @@ DirList* fs_glob_raw(const char* pattern) {
     result->entries = NULL;
     result->count = 0;
     result->capacity = 0;
+    result->kinds = NULL;   /* #966: globs carry no d_type; kind stays unknown */
 
 #ifdef _WIN32
     // Check for ** (recursive glob)
@@ -2090,6 +2149,7 @@ DirList* fs_glob_multi_raw(void* pattern_list) {
     result->entries = NULL;
     result->count = 0;
     result->capacity = 0;
+    result->kinds = NULL;   /* #966: globs carry no d_type; kind stays unknown */
 
     int n = list_size(pattern_list);
     for (int i = 0; i < n; i++) {

--- a/std/fs/aether_fs.h
+++ b/std/fs/aether_fs.h
@@ -207,11 +207,23 @@ typedef struct {
      * size; the per-entry strdup'd names are freed via strlen at
      * dir_list_free time. */
     int capacity;
+    /* #966: per-entry file kind (parallel to `entries`), read straight
+     * from readdir's `d_type` / Windows `dwFileAttributes` so callers
+     * can distinguish files from directories without a stat(2) per entry.
+     * Same encoding as fs_stat_raw's out_kind: 0 unknown, 1 file, 2 dir,
+     * 3 symlink, 4 other. 0 when the filesystem doesn't report a type
+     * (DT_UNKNOWN) — the caller then stats only those. Allocated to
+     * `capacity` ints alongside `entries`. */
+    int* kinds;
 } DirList;
 
 DirList* dir_list_raw(const char* path);
 int dir_list_count(DirList* list);
 const char* dir_list_get(DirList* list, int index);
+// #966: file kind of entry `index` (0 unknown / 1 file / 2 dir /
+// 3 symlink / 4 other), from readdir's d_type. Turns an O(N)-syscall
+// "stat every entry" directory read into a single readdir sweep.
+int dir_list_kind(DirList* list, int index);
 void dir_list_free(DirList* list);
 
 // Glob: match files by pattern (e.g., "src/**/*.c")

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -32,7 +32,7 @@ exports (
     fs_try_stat, fs_get_stat_kind, fs_get_stat_size, fs_get_stat_mtime,
     fs_try_read_binary, fs_get_read_binary, fs_get_read_binary_length,
     fs_release_read_binary, fs_read_binary_tuple,
-    dir_list_count, dir_list_get, dir_list_free,
+    dir_list_count, dir_list_get, dir_list_kind, dir_list_free,
     path_join, path_dirname, path_basename, path_extension, path_is_absolute,
     path_clean, path_is_within_base, path_rel,
     clean, is_within_base, rel, join_clean, first_element,
@@ -221,6 +221,12 @@ extern fs_chmod_raw(path: string, mode: int) -> (int, int, string)
 
 extern dir_list_count(list: ptr) -> int
 extern dir_list_get(list: ptr, index: int) -> string
+// #966: file kind of entry `index`, straight from readdir's d_type — no
+// stat(2) needed. Same encoding as file_stat's kind: 1 = regular file,
+// 2 = directory, 3 = symlink (target not followed), 4 = other (fifo /
+// socket / device). 0 = unknown: the filesystem didn't report a type
+// (rare) — stat that entry to resolve it.
+extern dir_list_kind(list: ptr, index: int) -> int
 extern dir_list_free(list: ptr)
 
 // Path utilities - pure functions, never fail

--- a/tests/integration/heap_leak_cross_fn_recursion/probe.ae
+++ b/tests/integration/heap_leak_cross_fn_recursion/probe.ae
@@ -25,11 +25,24 @@ main() {
         return
     }
 
-    // Warm-up.
-    _w = dirwalk.rebuild_dir(3, 5)
-    if string.length(_w) < 100 {
-        println("FAIL: warm-up too short: ${string.length(_w)}")
-        exit(1)
+    // Warm-up LOOP. A single call leaves the allocator's arenas to grow
+    // *inside* the measured loop, and max_rss (a page-granular high-water
+    // mark that never decreases) then misattributes that one-time arena
+    // growth as per-call leakage — a false positive that made this test
+    // flaky on macOS (~500-768 KB of pure fragmentation). Running enough
+    // warm-up iterations first lets the arenas reach steady state before
+    // rss0 is sampled, so rss1 - rss0 reflects genuine per-call retention.
+    // (`leaks --atExit` independently confirms 0 leaked bytes; this test's
+    // job is to catch the O(N^2) retained-buffer *growth* the codegen fix
+    // addressed, which would dwarf the threshold regardless.)
+    w = 0
+    while w < 300 {
+        _wv = dirwalk.rebuild_dir(3, 5)
+        if string.length(_wv) < 100 {
+            println("FAIL: warm-up too short: ${string.length(_wv)}")
+            exit(1)
+        }
+        w = w + 1
     }
 
     rss0 = getrusage_max_rss_kb()

--- a/tests/regression/test_issue966_dir_list_kind.ae
+++ b/tests/regression/test_issue966_dir_list_kind.ae
@@ -1,0 +1,88 @@
+// Regression (#966): fs.dir_list_kind exposes readdir's d_type, so a caller
+// can tell files from directories from symlinks without a stat(2) per entry.
+//
+// Kind encoding (same as file_stat's kind): 0 unknown, 1 file, 2 dir,
+// 3 symlink, 4 other.
+//
+// Builds a scratch tree (a regular file, a subdirectory, and a symlink),
+// lists it, and asserts each entry's kind. Self-asserting: FAIL + exit 1 on
+// mismatch, PASS at the end. Cleans up.
+
+import std.fs (*)
+import std.string
+
+extern exit(code: int)
+
+main() {
+    base = "/tmp/ae_issue966_probe"
+
+    // Fresh tree — returns captured so the generated C has no discarded-
+    // value warning.
+    _cd = create_dir(base)
+    _cs = create_dir("${base}/subdir")
+    werr = write("${base}/file.txt", "hi")
+    if werr != "" {
+        // A sandboxed / read-only environment can't host the probe. Skip
+        // rather than fail — the C accessor is exercised elsewhere too.
+        println("SKIP dir_list_kind: cannot write probe (${werr})")
+        return
+    }
+    // Symlink is best-effort: some filesystems / platforms disallow it.
+    lerr = symlink("${base}/file.txt", "${base}/link")
+    have_symlink = 0
+    if lerr == "" {
+        have_symlink = 1
+    }
+
+    dl, derr = list_dir(base)
+    if derr != "" {
+        println("FAIL list_dir: ${derr}")
+        exit(1)
+    }
+
+    saw_file = 0
+    saw_dir = 0
+    saw_link = 0
+    n = dir_list_count(dl)
+    i = 0
+    while i < n {
+        name = dir_list_get(dl, i)
+        kind = dir_list_kind(dl, i)
+        if string.equals(name, "file.txt") == 1 {
+            if kind == 1 { saw_file = 1 }        // 1 = regular file
+        }
+        if string.equals(name, "subdir") == 1 {
+            if kind == 2 { saw_dir = 1 }         // 2 = directory
+        }
+        if string.equals(name, "link") == 1 {
+            if kind == 3 { saw_link = 1 }        // 3 = symlink
+        }
+        i = i + 1
+    }
+    dir_list_free(dl)
+
+    if saw_file != 1 {
+        println("FAIL: file.txt not reported as file (kind 1)")
+        exit(1)
+    }
+    if saw_dir != 1 {
+        println("FAIL: subdir not reported as dir (kind 2)")
+        exit(1)
+    }
+    if have_symlink == 1 {
+        if saw_link != 1 {
+            println("FAIL: link not reported as symlink (kind 3)")
+            exit(1)
+        }
+    }
+
+    // Cleanup (best-effort).
+    _u1 = unlink("${base}/file.txt")
+    if have_symlink == 1 {
+        _u2 = unlink("${base}/link")
+    }
+    _dd = delete_dir("${base}/subdir")
+    _db = delete_dir(base)
+
+    println("PASS: #966 dir_list_kind (file / dir / symlink from d_type)")
+}

--- a/tests/regression/test_issue967_string_list_sort.ae
+++ b/tests/regression/test_issue967_string_list_sort.ae
@@ -1,0 +1,92 @@
+// Regression (#967): std.collections string_list sort.
+//
+//   - string_list_sort_lex(L)     stable ascending lexicographic (strcmp)
+//   - string_list_sort(L, cmp)    stable sort by a comparator closure
+//                                 `fn(string, string) -> int`
+//
+// Both reorder the backing slots only (no element copied or freed), so the
+// get/set aliasing trap the issue describes cannot occur. Self-asserting:
+// prints FAIL + exits 1 on mismatch, PASS at the end. Leak-clean: the list
+// owns its element copies and frees them in string_list_free.
+
+import std.collections
+import std.string
+
+extern exit(code: int)
+
+// Read the whole list back as "a,b,c,".
+joined(L: ptr) -> string {
+    out = ""
+    n = string_list_size(L)
+    i = 0
+    while i < n {
+        out = string.concat(out, string_list_get(L, i))
+        out = string.concat(out, ",")
+        i = i + 1
+    }
+    return out
+}
+
+main() {
+    L = string_list_new()
+    string_list_add(L, "banana")
+    string_list_add(L, "apple")
+    string_list_add(L, "cherry")
+    string_list_add(L, "apple")   // duplicate — exercises stability
+
+    // 1. lexicographic
+    string_list_sort_lex(L)
+    got = joined(L)
+    if string.equals(got, "apple,apple,banana,cherry,") != 1 {
+        println("FAIL sort_lex: ${got}")
+        exit(1)
+    }
+
+    // 2. comparator closure: by length descending, then the 6-length ones
+    //    first. banana(6), cherry(6) before apple(5), apple(5).
+    string_list_sort(L, |a: string, b: string| {
+        return string.length(b) - string.length(a)
+    })
+    first = string_list_get(L, 0)
+    second = string_list_get(L, 1)
+    if string.length(first) != 6 {
+        println("FAIL sort(cmp): first length ${string.length(first)}")
+        exit(1)
+    }
+    if string.length(second) != 6 {
+        println("FAIL sort(cmp): second length ${string.length(second)}")
+        exit(1)
+    }
+
+    // 3. stability: sort_lex leaves equal keys in input order. Build a fresh
+    //    list where every element is equal under a constant comparator; the
+    //    order must be untouched.
+    S = string_list_new()
+    string_list_add(S, "one")
+    string_list_add(S, "two")
+    string_list_add(S, "three")
+    string_list_sort(S, |a: string, b: string| {
+        return 0        // all "equal" — a stable sort preserves input order
+    })
+    order = joined(S)
+    if string.equals(order, "one,two,three,") != 1 {
+        println("FAIL stability: ${order}")
+        exit(1)
+    }
+
+    // 4. empty and single-element lists are no-ops (must not crash).
+    E = string_list_new()
+    string_list_sort_lex(E)
+    string_list_sort(E, |a: string, b: string| { return 0 })
+    string_list_add(E, "solo")
+    string_list_sort_lex(E)
+    if string.equals(string_list_get(E, 0), "solo") != 1 {
+        println("FAIL single-element")
+        exit(1)
+    }
+
+    string_list_free(L)
+    string_list_free(S)
+    string_list_free(E)
+    println("PASS: #967 string_list_sort / sort_lex (closure, stability, edges)")
+}


### PR DESCRIPTION
## Summary

Two `std` gaps found building a file browser, bundled with a flaky-test fix.

### #966 — `std.fs` / `std.dir`: expose readdir's `d_type`

A directory listing now carries each entry's file **kind** (1 file / 2 dir / 3 symlink / 4 other; 0 unknown), read straight from `readdir`'s `d_type` (Windows' `dwFileAttributes`) via a parallel `kinds` array on `DirList` — the same encoding `file_stat` returns. Telling files from directories no longer costs an N-entry `stat(2)` sweep; a file browser or tree walk gets it from the single `readdir`.

- `dir_list_kind(list, i)` (raw extern, `std.fs`) / `dir.list_kind(list, i)` (`std.dir` wrapper).
- Also **completes `std.dir`** with `list_count` / `list_get` wrappers — the listing API was incomplete (you could `dir.list()` but not iterate the result via `dir.*`; the reference docs described functions that didn't exist).

```aether
list, err = dir.list(path)
kind = dir.list_kind(list, i)   // 2 == directory, no stat needed
```

### #967 — `std.collections`: stable `string_list` sort

- `string_list_sort_lex(list)` — stable ascending byte-wise.
- `string_list_sort(list, cmp)` — stable, by a comparator closure `|a: string, b: string| { ... }` (negative / 0 / positive, like `strcmp`).

Both reorder the backing slots only (no element copied or freed), removing the get/set aliasing footgun of a hand-rolled swap: `string_list_get` returns the slot's internal pointer, so a naive adjacent swap frees a slot another borrowed pointer still aliases, silently corrupting entries.

```aether
string_list_sort(names, |a: string, b: string| {
    return string.length(a) - string.length(b)   // shortest first, stable
})
```

### Flaky-test fix (bundled)

`heap_leak_cross_fn_recursion`'s RSS-growth check used a single warm-up call, letting allocator arenas grow *inside* the measured loop; `max_rss` (a page-granular high-water mark) then misattributed that one-time growth as per-call leakage (~500-768 KB of pure fragmentation on macOS, intermittently tripping the 256 KB threshold). A warm-up **loop** reaches allocator steady state before sampling, so growth is a stable 0 KB. `leaks --atExit` independently confirms 0 leaked bytes; the test still catches the O(N²) retained-buffer growth it was written for.

## Safety

- Every `DirList` allocation site (including glob results) initializes the new `kinds` field, so `dir_list_free` never frees garbage.
- The sort frees the comparator closure box on every path (including error/empty), and its scratch buffers; the pointer set is a permutation, so no leak / double-free / read-after-free.

## Testing

- New self-asserting regression tests: `test_issue966_dir_list_kind.ae` (file / dir / symlink), `test_issue967_string_list_sort.ae` (lexicographic, closure comparator, stability, empty/single edges).
- New `examples/stdlib/dir-listing.ae` showing the file-browser pattern (sorted listing with per-entry kind).
- `docs/stdlib-reference.md` and `CHANGELOG.md` updated in this PR.
- **231/231** C unit tests, **800/800** `.ae` tests, **86/86** examples pass. Stdlib C compiles clean under `-Werror`; both features are `leaks --atExit`-clean.

Closes #966
Closes #967