### PR TITLE
fix(codegen): mangle value identifiers that are C reserved keywords (#976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **Identifiers that are C reserved keywords now compile** (#976). A value
+  named `short`, `register`, `signed`, `unsigned`, `volatile`, `static`,
+  `double`, … is a valid Aether identifier but not a valid C one, so codegen
+  emitted `int short = 3;` and the C compiler rejected it — `ae check` passed
+  but `ae build` failed, with an error that pointed into the `.ae` file but
+  showed C source. Codegen now rewrites such value identifiers to a safe C
+  spelling (`ae_<name>`) once on the AST, consistently across declarations,
+  references, parameters, loop variables, reassignment, tuple destructuring,
+  and heap-string tracking. (Names that are *Aether* keywords, e.g. `int` /
+  `struct`, are still reported at check time with a rename hint.)
+
 - **`client.response_body()` now returns an OWNED string — safe to read after
   `response_free()`.** The body was a pointer *borrowed* from the response, so a
   caller that freed the response before reading the body got garbage or a crash

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1626,6 +1626,52 @@ const char* safe_c_name(const char* name) {
     return buf;
 }
 
+// #976: is `name` a C reserved keyword (as opposed to a libc symbol)?
+// These are the names that cannot be a C identifier AT ALL — a variable,
+// parameter, or struct field spelled this way is a hard C syntax error, not
+// a link-time collision. A perfectly ordinary Aether identifier (`short`,
+// `long`, `char`, `default`) lands here and must be mangled in codegen so it
+// still compiles. Includes C89/C99/C11 keywords plus the common
+// header-provided keywords/macros (`bool`/`true`/`false` from <stdbool.h>,
+// C23 spellings) that the generated prelude may pull in.
+int is_c_keyword(const char* name) {
+    if (!name) return 0;
+    static const char* kw[] = {
+        // C89
+        "auto", "break", "case", "char", "const", "continue", "default", "do",
+        "double", "else", "enum", "extern", "float", "for", "goto", "if",
+        "int", "long", "register", "return", "short", "signed", "sizeof",
+        "static", "struct", "switch", "typedef", "union", "unsigned", "void",
+        "volatile", "while",
+        // C99 / C11
+        "inline", "restrict",
+        "_Alignas", "_Alignof", "_Atomic", "_Bool", "_Complex", "_Generic",
+        "_Imaginary", "_Noreturn", "_Static_assert", "_Thread_local",
+        // <stdbool.h> / C23 spellings that behave as keywords/macros
+        "bool", "true", "false", "nullptr", "typeof", "typeof_unqual",
+        "alignas", "alignof", "static_assert", "thread_local", "constexpr",
+        NULL
+    };
+    for (int i = 0; kw[i]; i++) {
+        if (strcmp(name, kw[i]) == 0) return 1;
+    }
+    return 0;
+}
+
+// #976: mangle a value/variable identifier that is a C keyword to a valid C
+// identifier. Non-keywords pass through unchanged, so normal code is emitted
+// verbatim and only the (previously broken) keyword names are rewritten. The
+// `ae_` prefix matches safe_c_name's convention. Must be applied at EVERY
+// site that emits this value's C name (declaration, reference, parameter,
+// capture field, loop var, …) so the spelling stays consistent.
+const char* safe_value_name(const char* name) {
+    if (!name) return name;
+    if (!is_c_keyword(name)) return name;
+    static char buf[280];
+    snprintf(buf, sizeof(buf), "ae_%s", name);
+    return buf;
+}
+
 const char* get_c_type(Type* type) {
     if (!type) {
         AetherError w = {NULL, NULL, 0, 0, "internal: NULL type in codegen, defaulting to int",
@@ -3198,9 +3244,53 @@ static const char* find_first_reply_msg(ASTNode* node) {
     return NULL;
 }
 
+// #976: a value identifier that is a C reserved keyword (`short`, `int`,
+// `char`, `default`, …) is a valid Aether identifier but an invalid C one, so
+// emitting it verbatim breaks the C compile even though `ae check` passed.
+// Rather than thread the mangler through the ~100 codegen sites that emit a
+// variable's name (declarations, references, params, and derived temporaries
+// like `_heap_<name>` / `_seqheap_<name>` / `<name>_len`), rewrite the name
+// ONCE on the AST before codegen: every site then reads the already-safe name
+// and stays consistent by construction.
+//
+// Only value-binding / value-reference node types are rewritten:
+//   - AST_IDENTIFIER          — reads, and assignment/destructure lvalues
+//   - AST_VARIABLE_DECLARATION — locals, for-loop vars, params
+//   - AST_PATTERN_VARIABLE     — match bindings, pattern params
+// Function names live on AST_FUNCTION_CALL->value / the function node and go
+// through safe_c_name at emission with the same `ae_` prefix, so a keyword
+// used as a function stays consistent too. Struct/message field names are
+// their own node types (AST_STRUCT_FIELD / AST_MESSAGE_FIELD / on
+// AST_MEMBER_ACCESS->value) and are left alone. AST_SUM_TYPE_DEF's children
+// are variant TYPE names, not values, so its subtree is skipped.
+static void mangle_keyword_value_idents(ASTNode* node) {
+    if (!node) return;
+    if ((node->type == AST_IDENTIFIER ||
+         node->type == AST_VARIABLE_DECLARATION ||
+         node->type == AST_PATTERN_VARIABLE) &&
+        node->value && is_c_keyword(node->value)) {
+        const char* safe = safe_value_name(node->value);
+        if (safe && safe != node->value) {
+            char* dup = strdup(safe);
+            if (dup) {
+                free(node->value);
+                node->value = dup;
+            }
+        }
+    }
+    if (node->type == AST_SUM_TYPE_DEF) return;  // children are type names
+    for (int i = 0; i < node->child_count; i++) {
+        mangle_keyword_value_idents(node->children[i]);
+    }
+}
+
 void generate_program(CodeGenerator* gen, ASTNode* program) {
     if (!program || program->type != AST_PROGRAM) return;
     gen->program = program;
+    // #976: rewrite C-keyword value identifiers to a valid C spelling before
+    // any codegen pass reads their names (must run before escape analysis and
+    // emission, which both key off the identifier names).
+    mangle_keyword_value_idents(program);
     // Note: `gen->program` is the source of truth for the
     // structural-escape-analysis lookup (issue #405). Setting it
     // here means every per-fn codegen pass beyond this point can

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -20,6 +20,13 @@ const char* get_c_type(Type* type);
 const char* const_array_elem_c_type(Type* t);
 int is_c_reserved_word(const char* name);
 const char* safe_c_name(const char* name);
+// #976: mangle a VALUE/variable identifier that is a C reserved keyword
+// (`short`, `int`, `char`, …) so it emits as a valid C identifier. Unlike
+// safe_c_name (which also renames libc symbols for functions), this touches
+// keywords ONLY — a local named `open` is a valid C identifier and must keep
+// its spelling. Returns a static buffer; use before the next call.
+int is_c_keyword(const char* name);
+const char* safe_value_name(const char* name);
 const char* get_c_operator(const char* aether_op);
 void generate_type(CodeGenerator* gen, Type* type);
 void emit_fnptr_decl(CodeGenerator* gen, Type* sig, const char* name);

--- a/tests/regression/test_issue976_c_keyword_idents.ae
+++ b/tests/regression/test_issue976_c_keyword_idents.ae
@@ -1,0 +1,90 @@
+// Regression (#976): an identifier that is a C reserved keyword (`short`,
+// `register`, `signed`, `unsigned`, `volatile`, `static`, `double`, …) is a
+// perfectly valid Aether identifier but an invalid C one. Before the fix it
+// was emitted verbatim, so `ae check` passed but the C compile failed
+// (`int short = 3;` → "expected identifier"). Codegen now mangles such value
+// identifiers to a valid C spelling consistently across declaration,
+// reference, parameters, loop variables, reassignment, tuple destructuring,
+// and heap-string tracking.
+//
+// Self-asserting: FAIL + exit 1 on mismatch, PASS at the end. Leak-clean.
+
+import std.string
+
+extern exit(code: int)
+
+check(name: string, got: int, want: int) {
+    if got != want {
+        println("FAIL: ${name} = ${got}, expected ${want}")
+        exit(1)
+    }
+}
+
+// keyword as a parameter name, referenced in the body
+add_one(short: int) -> int {
+    return short + 1
+}
+
+// keyword params + loop var + accumulator + reassignment
+sum_to(register: int) -> int {
+    double = 0
+    signed = 0
+    while signed < register {
+        double = double + signed
+        signed = signed + 1
+    }
+    return double
+}
+
+// keyword-named heap-string local, returned (exercises _heap_<name> tracking)
+join2(short: string, register: string) -> string {
+    unsigned = string.concat(short, register)
+    return unsigned
+}
+
+// keyword names as tuple-destructure targets come from here
+pair() -> (int, string) {
+    return 42, "answer"
+}
+
+main() {
+    // locals: declaration + reference + nested expression
+    short = 3
+    unsigned = 4
+    volatile = short * unsigned + 1
+    check("volatile", volatile, 13)
+
+    // reassignment of a keyword-named local
+    static = 1
+    static = static + 9
+    check("static", static, 10)
+
+    // keyword parameter + loop function
+    check("add_one", add_one(41), 42)
+    check("sum_to", sum_to(5), 10)
+
+    // tuple destructure into keyword-named targets
+    signed, double = pair()
+    check("destructure int", signed, 42)
+    if string.equals(double, "answer") != 1 {
+        println("FAIL: destructure string = ${double}")
+        exit(1)
+    }
+
+    // heap-string round trip through keyword-named locals
+    if string.equals(join2("ab", "cd"), "abcd") != 1 {
+        println("FAIL: join2")
+        exit(1)
+    }
+
+    // heap string reassigned through a keyword-named local
+    char = "x"
+    char = string.concat(char, "y")
+    char = string.concat(char, "z")
+    if string.equals(char, "xyz") != 1 {
+        println("FAIL: char reassign = ${char}")
+        exit(1)
+    }
+
+    println("PASS: #976 C-keyword value identifiers compile and run")
+}


### PR DESCRIPTION
## Summary

An identifier whose name is a C reserved keyword — `short`, `register`, `signed`, `unsigned`, `volatile`, `static`, `double`, … — is a valid Aether identifier but not a valid C one. Codegen emitted it verbatim, so a perfectly ordinary variable made the C compile fail even though `ae check` passed:

```aether
main() {
    short = 3          // valid Aether …
    println(short)
}
// ae build: `int short = 3;` → error: expected identifier or '('
```

Same "front-end accepts, build breaks" class as #952 / #953, and the deferred C-keyword half of #880 (which handled the *Aether*-keyword value names `ptr`/`byte`/`func`/`state`/`after`). Found building aether-lang-org/aefyles (`short = model.short_path(...)`).

## Fix

A pre-codegen AST pass (`mangle_keyword_value_idents`, run at the top of `generate_program`) rewrites value-binding / value-reference identifiers whose name is a C keyword to `ae_<name>`. Doing it **once on the AST** — rather than threading a mangler through the ~100 sites that emit a variable's name (declarations, references, params, and derived temporaries `_heap_<name>` / `_seqheap_<name>` / `<name>_len`) — keeps every site consistent **by construction**.

Scope is deliberately precise:
- Rewrites only `AST_IDENTIFIER`, `AST_VARIABLE_DECLARATION`, `AST_PATTERN_VARIABLE` `->value` (reads, assignment/destructure lvalues, locals, for-loop vars, params, match bindings). Params are already one of those node types.
- **Function names** live on `AST_FUNCTION_CALL->value` / the function node and go through `safe_c_name` at emission with the same `ae_` prefix — so a keyword used as a function stays consistent (no double-mangling).
- **Struct/message field names** are their own node types (`AST_STRUCT_FIELD` / `AST_MESSAGE_FIELD`, and on `AST_MEMBER_ACCESS->value`) — left untouched.
- `AST_SUM_TYPE_DEF`'s children are variant *type* names — its subtree is skipped.

`is_c_keyword` is **keyword-only** (unlike `safe_c_name`, it does not rename libc symbols), so a local named `open` keeps its valid-C spelling. Names that are *Aether* keywords (`int`, `struct`, …) remain rejected at check time with a rename hint.

## Testing

New regression test `test_issue976_c_keyword_idents.ae` covering keyword names as: locals (decl + reference + nested expr), parameters, loop variables, reassignment, tuple-destructure targets, and heap-string round-trips (exercising the `_heap_<name>` tracking). Verified the emitted C mangles consistently (`int ae_short = 3;`, `_heap_ae_unsigned`, …).

**231/231** C unit tests, **803/803** `.ae` tests, **86/86** examples pass. Codegen compiles clean under `-Werror`; the generated C compiles and the test is `leaks --atExit`-clean. The AST pass is global (touches every program's codegen) and the full suite confirms no regression.

Closes #976