### PR TITLE
fix(codegen): mangle struct/message field names that are C keywords (#976 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ next version number before tagging the release.
 
 ## [0.344.0]
 
+### Fixed
+
+- **Codegen mangles struct/message FIELD names that collide with C keywords**
+  (follow-up to #976). #976 fixed value identifiers; this completes the class
+  for field names. A field named `register`, `signed`, `unsigned`, `volatile`,
+  `static`, `double`, … now compiles instead of emitting `int register;` in the
+  generated struct. The AST pre-pass rewrites the whole field namespace
+  consistently — the field declaration, the struct/message constructor field,
+  the field read (`x.field`), and receive-pattern bindings — so declaration and
+  use never diverge.
+
+  ```aether
+  struct Point { register: int  signed: int }   // was: invalid C
+  message Bump { volatile: int }
+  ```
+
 ## [0.343.0]
 
 ### Fixed

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -3253,30 +3253,52 @@ static const char* find_first_reply_msg(ASTNode* node) {
 // ONCE on the AST before codegen: every site then reads the already-safe name
 // and stays consistent by construction.
 //
-// Only value-binding / value-reference node types are rewritten:
-//   - AST_IDENTIFIER          — reads, and assignment/destructure lvalues
-//   - AST_VARIABLE_DECLARATION — locals, for-loop vars, params
-//   - AST_PATTERN_VARIABLE     — match bindings, pattern params
+// Rewritten node types, grouped by namespace — each namespace's declaration,
+// initializer, reference, and pattern all read `->value`, so renaming every
+// member of the group keeps that namespace internally consistent:
+//   values — AST_IDENTIFIER (reads, assignment/destructure lvalues),
+//            AST_VARIABLE_DECLARATION (locals, for-loop vars, params),
+//            AST_PATTERN_VARIABLE (match bindings, pattern params)
+//   fields — AST_STRUCT_FIELD / AST_MESSAGE_FIELD (declarations),
+//            AST_ASSIGNMENT (struct/message constructor field — the parser
+//              builds every AST_ASSIGNMENT as a constructor field-init; a
+//              plain reassignment is an AST_VARIABLE_DECLARATION, so this node
+//              type always carries a field name, never an lvalue),
+//            AST_FIELD_INIT (the other constructor field-init shape),
+//            AST_PATTERN_FIELD (receive-pattern field bindings),
+//            AST_MEMBER_ACCESS (field reads `x.field`)
 // Function names live on AST_FUNCTION_CALL->value / the function node and go
 // through safe_c_name at emission with the same `ae_` prefix, so a keyword
-// used as a function stays consistent too. Struct/message field names are
-// their own node types (AST_STRUCT_FIELD / AST_MESSAGE_FIELD / on
-// AST_MEMBER_ACCESS->value) and are left alone. AST_SUM_TYPE_DEF's children
-// are variant TYPE names, not values, so its subtree is skipped.
+// used as a function stays consistent too. AST_SUM_TYPE_DEF's children are
+// variant TYPE names, not values, so its subtree is skipped. Module-qualified
+// and method calls are folded to AST_FUNCTION_CALL during parsing, so by
+// codegen an AST_MEMBER_ACCESS is a genuine field read (its non-keyword
+// property accessors — durations, optionals — never match is_c_keyword).
 static void mangle_keyword_value_idents(ASTNode* node) {
     if (!node) return;
-    if ((node->type == AST_IDENTIFIER ||
-         node->type == AST_VARIABLE_DECLARATION ||
-         node->type == AST_PATTERN_VARIABLE) &&
-        node->value && is_c_keyword(node->value)) {
-        const char* safe = safe_value_name(node->value);
-        if (safe && safe != node->value) {
-            char* dup = strdup(safe);
-            if (dup) {
-                free(node->value);
-                node->value = dup;
+    switch (node->type) {
+        case AST_IDENTIFIER:
+        case AST_VARIABLE_DECLARATION:
+        case AST_PATTERN_VARIABLE:
+        case AST_STRUCT_FIELD:
+        case AST_MESSAGE_FIELD:
+        case AST_ASSIGNMENT:
+        case AST_FIELD_INIT:
+        case AST_PATTERN_FIELD:
+        case AST_MEMBER_ACCESS:
+            if (node->value && is_c_keyword(node->value)) {
+                const char* safe = safe_value_name(node->value);
+                if (safe && safe != node->value) {
+                    char* dup = strdup(safe);
+                    if (dup) {
+                        free(node->value);
+                        node->value = dup;
+                    }
+                }
             }
-        }
+            break;
+        default:
+            break;
     }
     if (node->type == AST_SUM_TYPE_DEF) return;  // children are type names
     for (int i = 0; i < node->child_count; i++) {

--- a/tests/regression/test_c_keyword_field_names.ae
+++ b/tests/regression/test_c_keyword_field_names.ae
@@ -1,0 +1,56 @@
+// Regression (follow-up to #976): struct and message FIELD names that are C
+// reserved keywords (`register`, `signed`, `unsigned`, `volatile`, `static`,
+// `double`, …) are valid Aether identifiers but invalid C ones. Codegen now
+// mangles them consistently across the field declaration, struct/message
+// construction, field reads, and reassignment — so `struct P { register: int }`
+// compiles instead of emitting `int register;`.
+//
+// Self-asserting for the (synchronous) struct paths; the actor section proves
+// the message-field declaration + send + receive-binding paths compile and run.
+
+import std.string
+
+extern exit(code: int)
+
+struct Point { register: int  signed: int }
+
+message Bump { volatile: int  static: int }
+message Done {}
+
+actor Counter {
+    state total = 0
+    receive {
+        Bump(volatile, static) -> {
+            total = total + volatile + static
+        }
+        Done -> {
+            println(total)          // 3+4 + 10+20 = 37
+        }
+    }
+}
+
+main() {
+    // struct: literal construction, field read, field reassignment
+    p = Point { register: 10, signed: 20 }
+    if p.register + p.signed != 30 {
+        println("FAIL: Point read = ${p.register + p.signed}")
+        exit(1)
+    }
+    p.register = p.register + 5
+    if p.register != 15 {
+        println("FAIL: Point reassign = ${p.register}")
+        exit(1)
+    }
+    if p.register + p.signed != 35 {
+        println("FAIL: Point total = ${p.register + p.signed}")
+        exit(1)
+    }
+
+    // message fields: declaration + send + positional receive binding
+    c = spawn(Counter())
+    c ! Bump { volatile: 3, static: 4 }
+    c ! Bump { volatile: 10, static: 20 }
+    c ! Done {}
+
+    println("PASS: C-keyword field names (struct + message) compile and run")
+}


### PR DESCRIPTION
## Summary

Completes the C-keyword identifier class. #976 (merged) fixed **value** identifiers — locals, params, match bindings — via a pre-codegen AST rename. It deliberately left **field** names out because they span more nodes that must mangle together. This follow-up extends the same pass to the field namespace, so a struct or message field named after a C keyword compiles instead of emitting invalid C:

```aether
struct Point  { register: int  signed: int }   // was: `int register;` → C error
message Bump  { volatile: int }
```

## How

The field namespace is rewritten as a group in `mangle_keyword_value_idents`, so a field's declaration and every use stay consistent:

- `AST_STRUCT_FIELD` / `AST_MESSAGE_FIELD` — the field declaration.
- `AST_ASSIGNMENT` — the struct/message **constructor** field. The parser only ever builds `AST_ASSIGNMENT` as a constructor field-init (a plain reassignment is an `AST_VARIABLE_DECLARATION`), so this node type always carries a field name, never an lvalue — safe to rewrite unconditionally.
- `AST_FIELD_INIT` — the other constructor field-init shape.
- `AST_PATTERN_FIELD` — receive-pattern field bindings.
- `AST_MEMBER_ACCESS` — field reads `x.field`. Module-qualified and method calls are folded to `AST_FUNCTION_CALL` during parsing, so by codegen a member access is a genuine field read; its non-keyword property accessors (durations, optionals) never match `is_c_keyword`.

## Testing

New regression test `test_c_keyword_field_names.ae`: a struct with keyword fields (literal construction, field read, reassignment) and an actor whose message has keyword fields (declaration + send + positional receive binding).

**231/231** C unit, **804/804** `.ae`, **86/86** examples pass — the field-namespace additions (`AST_ASSIGNMENT` / `AST_MEMBER_ACCESS` are global) break no existing struct/message/pattern test. Codegen clean under `-Werror`; leak-clean.

Follow-up to #976.