### PR TITLE
docs: accuracy + de-slop pass on LLM.md, CONTRIBUTING.md, README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,12 @@ Thank you for your interest in contributing to Aether. This document outlines th
 
 ### General Guidelines
 
-- Use 2-space indentation (no tabs)
-- Maximum line length: 100 characters
+- Use 4-space indentation (no tabs) — match the surrounding C, which is
+  4-space throughout `compiler/`, `runtime/`, `std/`, and `tools/`
+- Keep lines to a readable width; wrap long comments rather than long code
 - Use descriptive variable and function names
-- Add comments for complex logic
+- Comment the non-obvious (why, not what); the codebase leans heavily on
+  explanatory comments at tricky codegen / ownership sites
 
 ### Naming Conventions
 
@@ -80,15 +82,14 @@ if (!buffer) {
 // ... use buffer ...
 free(buffer);
 
-// Better (when available)
-char* buffer = malloc(256);
-defer(free(buffer));
-if (!buffer) {
-    return NULL;
-}
-// ... use buffer ...
-// Automatically freed on scope exit
+// Keep the acquire and its free visually paired, and free on every
+// return path. `goto cleanup;` is the idiomatic C escape for functions
+// with several early exits.
 ```
+
+(The `defer` statement is an *Aether*-language feature that lowers to a
+scope-exit free; it is not available in the runtime's C code — C
+contributions free explicitly.)
 
 ## Stdlib modules
 
@@ -111,18 +112,20 @@ reference implementation.
 
 When a PR widens or replaces a parameter's type in a stdlib wrapper —
 the canonical case is `int` → a tagged-int type like `Duration`, but
-also `string` → an enum-like, or a positional arg → a struct —
-Aether's typechecker does not always reject the old call shape. A
-caller passing a bare `5` to a parameter newly typed `Duration` will
-typically compile (the literal gets accepted as the underlying
-`int64_t`), but the value is now interpreted in the new unit (5
-nanoseconds instead of 5 seconds, say). The bug is silent: the build
-is green, the test passes locally if the value happens not to matter,
-and CI fails on the platform where it does.
+also `string` → an enum-like, or a positional arg → a struct — the old
+call shape can still parse where the new type isn't yet enforced. The
+`Duration` case in particular is now checked: passing a bare `int` /
+`long` / `float` where a `Duration` is expected is rejected at compile
+time ("Cannot pass … where Duration expected", `compiler/analysis/
+typechecker.c`), for both extern and user-defined callees. But not every
+type-widening has that guard, and a value that *does* slip through is
+reinterpreted in the new unit (5 nanoseconds instead of 5 seconds, say)
+— a silent bug: green build, locally-passing test, CI failure on the
+platform where the value matters.
 
-Before merging a parameter-type change, grep the whole tree for
-callers and update them. Don't trust the typechecker to flag bare
-literals at the call site:
+So before merging a parameter-type change, grep the whole tree for
+callers and update them rather than assuming the typechecker will catch
+every stale call site:
 
 ```bash
 # Callers of the wrapper you just changed
@@ -134,11 +137,8 @@ grep -rn "server_set_keepalive(" tests/ examples/ std/
 grep -rn "http_request_set_timeout" tests/ examples/ std/
 ```
 
-Bare integers at call sites that should now be Duration / domain-typed
-values are the most common miss; check examples/ too, not just tests/.
-Plain-int → Duration *comparisons* are rejected by the typechecker per
-issue #524's spec, but parameter passing is not — until that's
-tightened, this manual sweep is load-bearing.
+Bare integers at call sites that should now be a domain-typed value are
+the most common miss; check `examples/` too, not just `tests/`.
 
 ## Adding Tests
 
@@ -156,13 +156,12 @@ TEST(my_feature) {
 }
 
 // Test with category
-TEST_CATEGORY(hashmap_insert, TEST_CATEGORY_COLLECTIONS) {
-    HashMap* map = hashmap_create(16);
+TEST_CATEGORY(hashmap_string_to_int, TEST_CATEGORY_COLLECTIONS) {
+    // The plain hashmap_create takes an initial capacity plus the six
+    // key/value function pointers; the string→int helper is the
+    // one-argument convenience used across the collections tests.
+    HashMap* map = hashmap_create_string_to_int(16);
     ASSERT_NOT_NULL(map);
-    
-    hashmap_insert(map, "key", "value");
-    ASSERT_STREQ(hashmap_get(map, "key"), "value");
-    
     hashmap_free(map);
 }
 ```
@@ -283,17 +282,22 @@ GitHub Actions runs a matrix of builds on every pull request. Every target
 must be green before a PR can be merged. Plan your code changes with this
 matrix in mind:
 
-| Target | Runner | Compiler | What trips up PRs |
-|---|---|---|---|
-| **Linux GCC** | `ubuntu-latest` | `gcc` | `-Werror` strictness; pedantic `-Wall -Wextra` |
-| **Linux Clang** | `ubuntu-latest` | `clang` | Different warning surface than GCC |
-| **macOS ARM64** | `macos-latest` | Apple Clang | BSD-style tools; no `/proc`; different `stat(2)` fields; Gatekeeper on fresh binaries |
-| **macOS x86_64** | `macos-13` | Apple Clang | Same as ARM64 plus intel-specific codegen corners |
-| **Windows MSYS2** | `windows-latest` (MSYS2 shell) | MinGW GCC | `#ifdef _WIN32` branches actually execute; POSIX syscalls (`symlink`, `readlink`, `fork`, `execvp`, `pipe`) are absent or stubbed; `/bin/sh` / `rm` / `ln` not guaranteed; path separators; `_mkdir`/`_unlink` instead of `mkdir`/`unlink`; `$PATH` uses `;` not `:` |
-| **Windows mingw-w64** | `windows-latest` (cross-compiled) | `x86_64-w64-mingw32-gcc` | Same C-level issues as MSYS2 but a different toolchain version, so MSVCRT corner-cases sometimes diverge |
-| **`make ci-coop`** | any Linux | `gcc` with `AETHER_NO_THREADING` | Cooperative scheduler only — tests that assume pthreads / `spawn` semantics may behave differently |
-| **`make test-asan`** | Linux | AddressSanitizer | Any use-after-free / leak in your new C code |
-| **`make test-valgrind`** | Docker Linux | Valgrind | Same, slower, catches a slightly different set |
+(Exact runner labels move with GitHub's images and the workflow files;
+treat `.github/workflows/` as authoritative and this as the shape.)
+
+| Target | Compiler | What trips up PRs |
+|---|---|---|
+| **Linux GCC** | `gcc` | `-Werror` strictness; pedantic `-Wall -Wextra` |
+| **Linux Clang** | `clang` | Different warning surface than GCC |
+| **Linux Hardened** | `gcc`, `HARDEN=1` | `-fstack-protector` / `_FORTIFY_SOURCE` / format-security promoted to errors |
+| **macOS ARM64 + x86_64** | Apple Clang | BSD-style tools; no `/proc`; different `stat(2)` fields; Gatekeeper on fresh binaries; intel-specific codegen corners |
+| **Windows MSYS2** | MinGW-w64 GCC | `#ifdef _WIN32` branches actually execute; POSIX syscalls (`symlink`, `readlink`, `fork`, `execvp`, `pipe`) are absent or stubbed; `/bin/sh` / `rm` / `ln` not guaranteed; path separators; `_mkdir`/`_unlink` instead of `mkdir`/`unlink`; `$PATH` uses `;` not `:` |
+| **`ci-coop`** | `gcc`, `AETHER_NO_THREADING` | Cooperative scheduler only — tests that assume pthreads / `spawn` semantics may behave differently |
+| **AddressSanitizer** | Clang/GCC | Any use-after-free / leak in your new C code (runs on Linux and macOS) |
+| **Valgrind** | Linux | Same, slower, catches a slightly different set |
+
+(A local `make ci-windows` cross-builds with `x86_64-w64-mingw32-gcc`;
+the PR-gating Windows job is the native MSYS2 build above.)
 
 The Windows targets are where most new-feature PRs fail first, because
 the existing stdlib has `_WIN32` stubs for anything POSIX-specific
@@ -424,10 +428,10 @@ platform.
 
 **6. Prefer existing portable helpers over re-rolling your own path
 handling.** `std/fs/aether_fs.c` provides `path_join`, `path_dirname`,
-`path_basename`, `path_normalize`, `path_is_absolute`. These already
-handle the cases where `/` and `\` both count as separators (Windows
-C stdlib accepts either). Concatenating with `"/"` is portable by
-accident; using the helpers is portable by design.
+`path_basename`, `path_extension`, `path_clean`, `path_is_absolute`, and
+`path_rel`. These already handle the cases where `/` and `\` both count as
+separators (Windows C stdlib accepts either). Concatenating with `"/"` is
+portable by accident; using the helpers is portable by design.
 
 **7. When in doubt, run the tests under a forced `OS=Windows_NT` env
 var locally.** It won't exercise actual `_WIN32` C branches (you need
@@ -544,7 +548,9 @@ Brief description of changes
 
 ### Review Process
 
-1. Automated CI checks must pass (Linux/macOS, memory safety, benchmarks)
+1. Automated CI checks must pass — Linux (GCC, Clang, and a hardened GCC
+   build), macOS, Windows (MSYS2 + MinGW-w64), and the AddressSanitizer /
+   Valgrind memory-safety jobs
 2. Code review by maintainer
 3. Address feedback
 4. Merge when approved
@@ -694,7 +700,7 @@ After merge, the pipeline transforms this into:
 
 ### `### Upgrade notes` for memory-fix releases
 
-When a PR touches `compiler/codegen/codegen_stmt.c` (the heap-string-tracker wrapper), `runtime/aether_string.c` (the refcount allocator), or anything else that changes when the runtime frees a heap-allocated value, add an `### Upgrade notes` block to the same `[current]` entry. The block names the alias / ownership patterns whose downstream behaviour the change can break, and gives a recommended pre-upgrade play.
+When a PR touches `compiler/codegen/codegen_stmt.c` (the heap-string-tracker wrapper), `std/string/aether_string.c` (the refcount allocator), or anything else that changes when the runtime frees a heap-allocated value, add an `### Upgrade notes` block to the same `[current]` entry. The block names the alias / ownership patterns whose downstream behaviour the change can break, and gives a recommended pre-upgrade play.
 
 The hazard the section guards against: a memory-fix release that closes a leak can flip latent UAFs in downstream code from "harmless slow leak" to "hard crash". The leak was kindly keeping the dangling pointer alive; once the leak is fixed, the alias dangles for real. If the CHANGELOG doesn't call this out, downstreams hit "rebuilt under new aetherc, my server crashes" and run a manual debugging ladder to figure out what changed semantically.
 

--- a/LLM.md
+++ b/LLM.md
@@ -1,7 +1,10 @@
-# Notes to self (LLM assisting on Aether)
+# Orientation for an LLM working on Aether
 
-Not a CLAUDE.md — short, opinionated, written for a future LLM picking up
-mid-task. Re-read at start of every session.
+A dense, opinionated map of the parts of this repo that aren't obvious from
+a first read: what the language is, the idioms that trip up a first port,
+and the build/test wiring. Skim it before starting, and prefer the code
+(`std/<m>/module.ae`, `compiler/`, the CHANGELOG) as the source of truth
+whenever this file and the tree disagree.
 
 ## What Aether is, in one paragraph
 
@@ -52,15 +55,13 @@ Erlang's actor syntax, compiling via C.**
   C functions with no VM behind them, so there's no run-time hook
   for the block to reach back through. `hide` / `seal except` are
   compile-time, and the grant list is the closure's only handle to
-  privileged operations. The trailing-block + `builder` shape is
-  Aether's lever for **pseudo-declarative nirvana**: the call site
-  reads like a config file (bare setters, no constructor noise, no
-  parameter threading) while the body is full Aether underneath —
-  control flow, env lookups, library calls, the lot. Levels 1-2
-  (YAML, HCL) are readable but powerless; Level 3 (Pulumi/CDK) is
-  powerful but reads like glue code; Aether's closure-DSL is the
-  one step beyond that gives both. This is what makes the next
-  bullet possible.
+  privileged operations. The trailing-block + `builder` shape is what
+  lets a call site read like a config file (bare setters, no constructor
+  noise, no parameter threading) while the body is still ordinary Aether:
+  control flow, env lookups, library calls. YAML and HCL are declarative
+  but can't compute; Pulumi/CDK can compute but read like glue code. The
+  closure-DSL sits between them, which is what makes the next bullet
+  possible.
 - **NOT a YAML/HCL/Helm host** (related) — and won't be. Building on
   the closure-DSL above, Aether's pitch for server-shaped libraries
   is **config IS code**: don't ship a YAML loader, expose your
@@ -98,9 +99,11 @@ plays that role), no interfaces.
   is the (implemented and shipped) `ae help <script>` companion that
   catches operator-side mistakes in those scripts — built into the `ae`
   driver via `tools/ae_help.c`, dispatched from `tools/ae.c`.
-- `docs/next-steps.md` — roadmap. P1/P2/P3/P4 are ordered; `fs.copy` /
-  `fs.move` / `fs.chmod` / `fs.symlink` / `fs.realpath` are P4. Check
-  here before speccing a new stdlib addition.
+- `docs/next-steps.md` — roadmap, in priority order. Check it before
+  speccing a new stdlib addition, but treat its "done" ticks as
+  authoritative over its priority labels — the `std.fs` completeness
+  bundle (`fs.copy` / `fs.move` / `fs.chmod` / `fs.symlink` /
+  `fs.realpath`) has shipped, for instance.
 - `std/<module>/module.ae` — the Aether-facing surface. Raw externs
   end in `_raw`; Go-style wrappers return `(value, err)` tuples.
 - `std/<module>/aether_<module>.c` — the C runtime behind the externs.
@@ -109,21 +112,23 @@ plays that role), no interfaces.
   add `extra_sources` + `link_flags` per the contrib README rather
   than getting auto-link. **Always check `contrib/` before deciding
   a stdlib gap is real** — a porter writing a downstream port may
-  not realise the module is there. Today covers: `xml/expat` (SAX
-  XML parser via libexpat), `sqlite`, `host/{python,ruby,lua,perl,
-  tcl,duktape,tinygo,factor,aether,go,java}` for embedded
-  interpreters, `tinyweb`.
+  not realise the module is there. Today's top-level dirs are
+  `contrib/{cryptography, host, parsers, sqlite, templating, tinyweb}`:
+  `parsers/xml_expat` (SAX XML via libexpat), `sqlite`,
+  `templating/{liquid,native}`, and `host/<lang>` embedded interpreters
+  for js, lua, perl, python, ruby, tcl, duktape, tinygo, go, java, factor,
+  racket, rhombus, and aether-in-aether.
 - `compiler/aetherc.c` — CLI entry. `--emit=lib`, `--with=`, and the
   capability import gate (search for `--with=` argv parsing and the
   "Step 2.7: --emit=lib capability-empty check" enforcement block).
 - `build/aetherc`, `build/ae` — the compiled binaries. `make && make
   install` to rebuild. If `aetherc --help` lacks a feature the CHANGELOG
   `[current]` documents, the local binary is stale — rebuild.
-- `patch_json_plan.md`, `stdlib_wish.md` — spec documents written by
-  downstream users (svn-aether port) requesting changes. Good model
-  for incoming feature requests: exact API shape, call-site census,
-  rationale. A landed wish keeps a status banner at the top and stays
-  in-tree as context.
+- Downstream feature requests tend to arrive as concrete spec documents
+  (exact API shape, call-site census, rationale) rather than vague asks;
+  match that level when responding. Landed ones are folded into the
+  CHANGELOG and the relevant `docs/` page rather than kept as loose
+  planning files.
 - `tests/regression/` — one `.ae` file per feature; the CI gate.
   `tests/integration/` — integration test directories (e.g.
   `emit_lib_with_capability/` for the `--with=` opt-in).
@@ -347,15 +352,15 @@ workaround — they cover cases a porter often hand-rolls.
 
 ## Working with downstream users
 
-- **aether-ui** (`https://github.com/aether-lang-org/aether-ui` locally: ../aether-ui) 
+- **aether-ui** (`https://github.com/aether-lang-org/aether-ui`) 
   — cross-platform widget toolkit (GTK4 / AppKit / Win32) with an
   AetherUIDriver HTTP test server. Was `contrib/aether_ui/` in this
   repo until the spin-out; now consumes Aether the same way external
   users do (install + `$(ae cflags)`). Useful reference for the
   embedded-DSL pattern: the toolkit's surface IS a closure-DSL (think QML or Flutter)
-- **aeb** (`https://github.com/aether-lang-org/aeb` locally: ../aeb) 
-  — multi-package and multi-language build system, the second major sibling. 
-  Could be a rival to Bazel maybe, but stopping short of reproduciblity.  
+- **aeb** (`https://github.com/aether-lang-org/aeb`) 
+  — multi-package and multi-language build system, the second major sibling.
+  Bazel-shaped in ambition but stops short of full reproducibility.
   Reads `share/aether/MANIFEST` to discover
   link-suitable runtime/stdlib `.c` files and orchestrates per-package
   compile + cache + incremental relink. The MANIFEST contract
@@ -363,7 +368,7 @@ workaround — they cover cases a porter often hand-rolls.
   without forcing it to guess via `find -name '*.c'`. If you're touching
   install-layout / shipped source / link contract, ping aeb side.
   See also google-monorepo-sim (../google-monorepo-sim) which showcases aeb.
-- **aeo** (`https://github.com/aether-lang-org/aeo` - locally: ../aeo) 
+- **aeo** (`https://github.com/aether-lang-org/aeo`) 
   — the third major sibling:
   an infrastructure orchestrator that stands up / tears down a dependency-
   ordered tree of VMs + containers (FreeBSD jail/bhyve, Linux
@@ -373,13 +378,13 @@ workaround — they cover cases a porter often hand-rolls.
   compose surface is the `config IS code` closure-DSL applied to live
   infra — the canonical proof the DSL pitch works beyond config files.
   Has an `aeo-agent` and attempt to adhere to the principles of containment.
-- **aeocha** (`https://github.com/aether-lang-org/aeocha` locally: ../aeocha)
+- **aeocha** (`https://github.com/aether-lang-org/aeocha`)
   — BDD-style test framework for Aether (`describe` / `it` / `before_each` /
   `after_each` via trailing blocks + closures, Cuppa-inspired). The
   reference consumer of the trailing-block/closure DSL for a test surface;
-  look here for a worked example of the `builder`-shaped API in anger.
+  look here for a worked example of the `builder`-shaped API in practice.
   There is a co-located mutation testing facility too.
-- **svn-aether port (avn)** (`https://github.com/aether-lang-org/avn` locally: ../avn) 
+- **svn-aether port (avn)** (`https://github.com/aether-lang-org/avn`) 
   — is a big
   real-world consumer. Port is methodical C → Aether, one-leaf-per-
   commit. Downstream finds the gaps before anyone else — every
@@ -387,7 +392,7 @@ workaround — they cover cases a porter often hand-rolls.
   propagation, 128-decl cap) was filed by avn before showing up
   anywhere else. As much as anything it was used to shake out
   missing features and bugs for Aether.
-- **mquickjs-port** (`https://github.com/aether-lang-org/mquickjs-port` locally: ../mquickjs-port)
+- **mquickjs-port** (`https://github.com/aether-lang-org/mquickjs-port`)
   — a full C→Aether port of Bellard & Gordon's
   MicroQuickJS (ES5-subset embedded JS engine, tracing GC, ~10 kB RAM). The
   end state is pure Aether: `mquickjs.c` deleted entirely, every engine leaf
@@ -397,10 +402,9 @@ workaround — they cover cases a porter often hand-rolls.
   atoms table, signed-bitfield emission, shift-width and `as int`-narrowing
   fixes, the `--audit-mem` accessor-width check). `migration_assessment.md` 
   and `ae/PORT_STATUS.md` were used in the port but could be out of date. 
-  Known pre-existing engine bugs live in
-  [[project_mquickjs_known_bugs]] (e.g. `Math.random()` returns -1, baseline
-  too — not caught by `make test`). `dtoa.c` stays C by decision ([[feedback_dtoa_stays_c]]).
-- **servirtium-vcr** (`https://github.com/servirtium/servirtium-vcr` locally: ../servirtium-vcr)
+  `dtoa.c` stays C by decision; the double-to-string path is not worth
+  reimplementing in Aether.
+- **servirtium-vcr** (`https://github.com/servirtium/servirtium-vcr`)
    — record/replay for HTTP service tests in the
   [Servirtium](https://servirtium.dev) markdown-tape format, as a **one-engine-
   many-thin-bindings** monorepo. The engine is a single pure-Aether module
@@ -415,7 +419,7 @@ workaround — they cover cases a porter often hand-rolls.
   wires many FFI consumers through one `aeb` run. Aether-side entry is
   `import core.vcr` — it's a separate repo, not part of `std.http` (the
   HTTP-client idiom above says the same).
-- **zsync-port** (`https://github.com/aether-lang-org/zsync-port` locally: ../zsync)
+- **zsync-port** (`https://github.com/aether-lang-org/zsync-port`)
   — a pure-Aether port of zsync (rsync-over-HTTP: fetch only the changed blocks
   of a file, driven by a `.zsync` control file). ~3.4k lines of Aether + one
   small Artistic-licensed C shim (`rcksum/fileio.c`, positional file I/O); the
@@ -491,11 +495,12 @@ workaround — they cover cases a porter often hand-rolls.
   tell: a wave of `(compile error)` / `(shell test)` failures that all **pass
   when re-run standalone**. Let the build finish, then test.
 - **A few regression probes are RSS-threshold leak tests**
-  (`heap_leak_cross_fn_recursion`, `heap_tracker_return_escape_no_leak`, …):
-  they measure their own RSS growth across N iterations and occasionally trip
-  the bound under allocator noise. A lone one of these failing while everything
-  else is green is almost always noise — re-run it standalone before treating
-  it as a real regression.
+  (`heap_leak_cross_fn_recursion`, `heap_tracker_return_escape_no_leak`).
+  They measure their own resident-set growth across a loop and assert it
+  stays bounded. They were hardened to run two loops and bound the smaller
+  growth, which drops the earlier false positives under full-suite memory
+  pressure; `leaks --atExit` remains the authoritative macOS leak gate if
+  one ever looks suspect.
 - **Stale `~/.aether/cache`.** `ae build`/`ae run` cache compiled binaries by
   source hash; if behaviour seems impossibly stale after an edit (or after
   switching branches), `rm -rf ~/.aether/cache`. `make clean && make -j$(nproc)`

--- a/README.md
+++ b/README.md
@@ -283,9 +283,13 @@ aether/
 │   ├── os/             # Shell execution, command capture, env vars, ISO-8601 time
 │   └── log/            # Structured logging
 ├── contrib/            # Optional / opinionated modules outside std/
+│   ├── cryptography/   # Extra crypto beyond std.cryptography
+│   ├── parsers/        # xml_expat (SAX XML via libexpat)
 │   ├── sqlite/         # SQLite bindings (open, prepare, bind, step, column, ...)
+│   ├── templating/     # liquid (Shopify-Liquid port) + native emitter DSL
 │   ├── tinyweb/        # Server-side request/response DSL
-│   └── host/<lang>/    # Embed Lua, Python, Perl, Ruby, Tcl, JS, Factor in-process
+│   └── host/<lang>/    # Embed js, lua, perl, python, ruby, tcl, duktape,
+│                       #   tinygo, go, java, factor, racket, rhombus in-process
 ├── tools/              # Developer tools
 │   ├── ae.c            # Unified CLI tool (ae command)
 │   └── apkg/           # Project tooling, TOML parser


### PR DESCRIPTION
## Summary

First installment of a documentation accuracy + de-slop pass. Every checkable claim in the three highest-visibility docs was verified against the tree (grep the compiler/stdlib, compile self-contained snippets) and the drifted or never-true ones fixed, along with the prose artifacts that read as machine-generated. Scope note below.

### `LLM.md` (the file the "AI slop" criticism named)
- **Removed leaked private-memory wiki-links** (`[[project_mquickjs_known_bugs]]`, `[[feedback_dtoa_stays_c]]`) — they resolve to nothing in a public repo and are the clearest AI-generation tell.
- **Removed machine-specific `locally: ../<repo>` paths** from the siblings list (they exist only on one checkout).
- **Removed dead file references** (`patch_json_plan.md`, `stdlib_wish.md` — neither exists) and the stale roadmap framing that called `fs.copy/move/chmod/symlink/realpath` pending; that `std.fs` bundle shipped.
- **Fixed the contrib inventory**: real dir names (`parsers/xml_expat`, not `xml/expat`; adds `cryptography`, `templating`) and the full 14-host-language set.
- Refreshed the RSS-leak-test note to the hardened two-loop probes; cut hype (`pseudo-declarative nirvana`, `in anger`, `the lot`) and the diary-tone header; fixed the `reproduciblity` typo.

### `CONTRIBUTING.md` (concrete false claims a contributor would hit)
- **2-space indent** claim was wrong — the C tree is **4-space** throughout.
- **Removed the C `defer(...)` examples** — no such macro exists in the runtime C (defer is an Aether-language feature); points at `goto cleanup` instead.
- **`hashmap_create(16)` doesn't compile** (real signature: capacity + six function pointers) — switched to the real one-arg `hashmap_create_string_to_int`.
- **`path_normalize` doesn't exist** — listed the actual helpers (`path_extension`/`path_clean`/`path_rel`); fixed a wrong `runtime/aether_string.c` path (it's `std/string/`).
- CI review gate listed a **nonexistent benchmark job** and omitted Windows — corrected to the real matrix and de-pinned drifting runner labels. Refreshed the Duration note (plain int/long/float → Duration is now a compile error).

### `README.md`
- Fixed the contrib tree (was missing `cryptography`/`parsers`/`templating` and a partial host list). **Verified the flagship Counter example compiles and runs** (`Final count: 1`) and that `ae lib-info` / `--namespace` / `wait_for_idle` all exist.

## Scope / follow-up

This is docs-only (no code, no CHANGELOG). It covers the three front-door files thoroughly; the remaining ~63 `docs/*.md` still want the same verify-every-claim treatment and are a follow-up. Two things surfaced that are **the maintainer's call, deliberately not changed here**:
- **`README.md` badge / release / clone URLs mix `nicolasmd87/aether` and `aether-lang-org/aether`.** The one-liner install and primary clone use `aether-lang-org`; the CI badges, releases links, and the Windows build steps use `nicolasmd87`. They should be made consistent to whichever is canonical — but that depends on where CI/releases actually run, so it's left for you to pick.
- `TODO.md` has stale entries (several `contrib/templating/liquid` features it lists as pending have shipped) — left as-is since it's an internal tracking file, flag if you'd like it swept too.