### PR TITLE
feat(std): expose fds from std.file/std.net handles for Capsicum plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **stdlib descriptor accessors for Capsicum plumbing** (#1003). The opaque
+  stdlib handle types now expose their OS-level file descriptors:
+  `file.fd(handle)` / `fs.fd(handle)` for open files, `tcp.fd(sock)` and
+  `tcp.server_fd(server)` for sockets (raw externs `file_fd_raw`,
+  `tcp_fd_raw`, `tcp_server_fd_raw`). Closes the gap where
+  `capsicum.rights_limit()` / `fcntls_limit()` could only narrow descriptors
+  obtained from raw externs — the common open-through-the-stdlib case can now
+  narrow rights before `capsicum.enter()`. The fd is owned by the handle:
+  never `close()` it directly. New FreeBSD enforcement test
+  `tests/freebsd/rights_limit_stdlib_fd.ae` proves the flow end to end.
+- **Proof that `spawn_sandboxed` auto-contains Aether children on FreeBSD**
+  (#1003). The wiring itself shipped earlier (`AETHER_CAPSICUM=1` +
+  `capsicum_autosandbox.c`), but stale comments in `std.capsicum` still called
+  it "a later phase" and nothing exercised the composed path. Comments now
+  state the contract, and `tests/freebsd/spawn_capsicum_containment.sh`
+  asserts a spawned Aether child reports `capsicum.in_mode() == 1` without
+  ever calling `enter()` itself (`tests/freebsd/run.sh` now drives `.sh`
+  tests alongside the `.ae` ones).
+
 ## [0.357.0]
 
 ### Added

--- a/docs/aether_compared_to_capsicum.md
+++ b/docs/aether_compared_to_capsicum.md
@@ -649,8 +649,13 @@ children.
 **Limitation:** a self-sandboxed program must open everything it needs
 *before* `main()` runs, or accept that path access is gone. Wiring the
 grant list into pre-opened, `cap_rights_limit()`'d fds handed to the
-child is the remaining refinement, it needs std.file / std.net to
-expose their descriptors first.
+child is the remaining refinement. Its prerequisite landed with issue
+#1003: the stdlib handle types now expose their descriptors —
+`file.fd(handle)` / `fs.fd(handle)` for files, `tcp.fd(sock)` /
+`tcp.server_fd(server)` for sockets — so a program can open through
+the stdlib and narrow each descriptor with `capsicum.rights_limit()`
+before `capsicum.enter()` (exercised by
+`tests/freebsd/rights_limit_stdlib_fd.ae`).
 
 #### Phase 3: Audit Logging, **DONE**
 

--- a/std/capsicum/aether_capsicum.h
+++ b/std/capsicum/aether_capsicum.h
@@ -12,8 +12,10 @@
 //
 // These wrappers are intentionally minimal — they expose cap_enter,
 // cap_getmode, cap_rights_limit and cap_fcntls_limit so hand-written
-// Aether code can sandbox itself. Wiring Capsicum into spawn_sandboxed
-// transparently is a later phase (see docs/aether_compared_to_capsicum.md).
+// Aether code can sandbox itself. spawn_sandboxed is separately
+// auto-wired on FreeBSD via AETHER_CAPSICUM=1 + the startup hook in
+// runtime/sandbox/capsicum_autosandbox.c (see
+// docs/aether_compared_to_capsicum.md).
 //
 // Off FreeBSD every entry point is a stub returning AETHER_CAP_UNSUPPORTED
 // so portable Aether code can probe capsicum_available() and degrade.

--- a/std/capsicum/module.ae
+++ b/std/capsicum/module.ae
@@ -14,8 +14,11 @@
 //
 // This module is the hand-written entry point: code that wants OS-level
 // containment opens the fds it needs, limits each one, then enters
-// capability mode. Wiring Capsicum into spawn_sandboxed automatically is
-// a later phase — see docs/aether_compared_to_capsicum.md.
+// capability mode. spawn_sandboxed is ALSO auto-wired on FreeBSD: it
+// sets AETHER_CAPSICUM=1 in every child's environment, and an Aether
+// child cap_enter()s itself at startup (runtime/sandbox/
+// capsicum_autosandbox.c) — so a spawned Aether child is contained
+// without calling enter() by hand. See docs/aether_compared_to_capsicum.md.
 //
 // Portability: off FreeBSD every call returns CAP_UNSUPPORTED and
 // available() returns 0. Portable code should branch on available()
@@ -39,10 +42,14 @@
 //       // From here the kernel forbids opening any new path or socket.
 //   }
 //
-// rights_limit() takes a raw integer fd. Obtaining an fd from the
-// higher-level std.file / std.net handles is a follow-up once those
-// modules expose their descriptors; until then rights_limit() is most
-// useful with fds from raw externs or inherited descriptors.
+// rights_limit() takes a raw integer fd. The stdlib handle types
+// expose theirs (#1003): file.fd(handle) / fs.fd(handle) for files,
+// tcp.fd(sock) / tcp.server_fd(server) for sockets — so a descriptor
+// opened through the stdlib can be narrowed before enter():
+//
+//   handle, err = file.open("/var/db/app.db", "r")
+//   capsicum.rights_limit(file.fd(handle), capsicum.R_READ | capsicum.R_SEEK)
+//   capsicum.enter()
 
 exports (
     // Return codes

--- a/std/file/module.ae
+++ b/std/file/module.ae
@@ -11,8 +11,8 @@
 
 exports (
     file_open_raw, file_close, file_read_all_raw, file_write_raw,
-    file_exists, file_delete_raw, file_size_raw,
-    open, read, write, delete, size
+    file_exists, file_delete_raw, file_size_raw, file_fd_raw,
+    open, read, write, delete, size, fd
 )
 
 // Raw ptr/int externs (escape hatch).
@@ -23,6 +23,7 @@ extern file_write_raw(file: ptr, data: string, length: int) -> int
 extern file_exists(path: string) -> int
 extern file_delete_raw(path: string) -> int
 extern file_size_raw(path: string) -> int
+extern file_fd_raw(file: ptr) -> int
 
 // string_concat used to duplicate borrowed strings across free boundaries.
 extern string_concat(a: string, b: string) -> string
@@ -88,4 +89,15 @@ size(path: string) -> {
         return 0, "cannot stat file"
     }
     return s, ""
+}
+
+// The OS-level file descriptor inside an open handle, or -1 on a
+// null handle (#1003). Exists for capability plumbing: open through
+// the stdlib, then narrow the descriptor with
+// capsicum.rights_limit(file.fd(handle), ...) before capsicum.enter().
+// The fd is owned by the handle — do not close it directly; it is
+// released by file_close, which also frees the handle itself, so
+// never call fd() on a handle that has been closed.
+fd(handle: ptr) -> int {
+    return file_fd_raw(handle)
 }

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -11,6 +11,7 @@ File* file_open_raw(const char* p, const char* m) { (void)p; (void)m; return NUL
 char* file_read_all_raw(File* f) { (void)f; return NULL; }
 int file_write_raw(File* f, const char* d, int l) { (void)f; (void)d; (void)l; return 0; }
 int file_close(File* f) { (void)f; return 0; }
+int file_fd_raw(File* f) { (void)f; return -1; }
 int file_exists(const char* p) { (void)p; return 0; }
 int fs_path_exists(const char* p) { (void)p; return 0; }
 int file_delete_raw(const char* p) { (void)p; return 0; }
@@ -378,6 +379,21 @@ const char* fs_ftruncate_raw(File* file, long length) {
 
 /* fsync — flush kernel buffers to disk. Required after pwrite for
  * durability guarantees. POSIX fsync(2) / Windows _commit. */
+/* Expose the OS-level descriptor inside an open File (issue #1003).
+ * Exists so capability plumbing — capsicum.rights_limit() /
+ * fcntls_limit() before capsicum.enter() — can narrow a descriptor the
+ * program opened through the stdlib rather than a raw extern. The fd
+ * is owned by the handle: callers must not close() it, and it dies
+ * with file_close() — which also frees the File itself, so this must
+ * never be called on a closed handle (only on null, which returns -1).
+ * fflush first so the fd's view matches the FILE*'s buffered state. */
+int file_fd_raw(File* file) {
+    if (!file || !file->is_open) return -1;
+    FILE* fp = (FILE*)file->handle;
+    fflush(fp);
+    return fileno(fp);
+}
+
 const char* fs_fsync_raw(File* file) {
     if (!file || !file->is_open) return "invalid args";
     FILE* fp = (FILE*)file->handle;

--- a/std/fs/aether_fs.h
+++ b/std/fs/aether_fs.h
@@ -198,6 +198,11 @@ void        fs_release_pread(void);
 const char* fs_ftruncate_raw(File* file, long length);
 const char* fs_fsync_raw(File* file);
 
+// The OS-level descriptor inside an open File, or -1 if closed/invalid.
+// For capability plumbing (capsicum.rights_limit before capsicum.enter);
+// owned by the handle — do not close() it. Issue #1003.
+int         file_fd_raw(File* file);
+
 // Directory listing
 typedef struct {
     char** entries;

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -39,6 +39,7 @@ exports (
     fs_pwrite_raw, fs_pread_raw, fs_get_pread, fs_get_pread_length,
     fs_release_pread, fs_ftruncate_raw, fs_fsync_raw,
     pwrite, pread, ftruncate, fsync,
+    file_fd_raw, fd,
     fs_glob_raw, fs_glob_multi_raw,
     fs_walk_raw, fs_watch_open_raw,
     open, read, write, delete, size, mtime, exists,
@@ -251,6 +252,10 @@ extern fs_get_pread_length() -> int
 extern fs_release_pread()
 extern fs_ftruncate_raw(file: ptr, length: long) -> string
 extern fs_fsync_raw(file: ptr) -> string
+
+// Descriptor accessor (#1003). The OS-level fd inside an open handle,
+// or -1 if the handle is closed/invalid.
+extern file_fd_raw(file: ptr) -> int
 
 // Glob: match files by pattern. Raw externs return ptr, NULL on failure.
 extern fs_glob_raw(pattern: string) -> ptr
@@ -825,4 +830,15 @@ ftruncate(file: ptr, length: long) -> string {
 // Returns "" on success.
 fsync(file: ptr) -> string {
     return fs_fsync_raw(file)
+}
+
+// The OS-level file descriptor inside an open handle, or -1 on a
+// null handle (#1003). Exists for capability plumbing: open through
+// the stdlib, then narrow the descriptor with
+// capsicum.rights_limit(fs.fd(handle), ...) before capsicum.enter().
+// The fd is owned by the handle — do not close it directly; it is
+// released by file_close, which also frees the handle itself, so
+// never call fd() on a handle that has been closed.
+fd(file: ptr) -> int {
+    return file_fd_raw(file)
 }

--- a/std/net/aether_net.c
+++ b/std/net/aether_net.c
@@ -11,6 +11,8 @@ int tcp_close(TcpSocket* s) { (void)s; return 0; }
 TcpServer* tcp_listen_raw(int p) { (void)p; return NULL; }
 TcpSocket* tcp_accept_raw(TcpServer* s) { (void)s; return NULL; }
 int tcp_server_close(TcpServer* s) { (void)s; return 0; }
+int tcp_fd_raw(TcpSocket* s) { (void)s; return -1; }
+int tcp_server_fd_raw(TcpServer* s) { (void)s; return -1; }
 #else
 
 #include <stdlib.h>
@@ -227,6 +229,22 @@ int tcp_server_close(TcpServer* server) {
     close(server->fd);
     free(server);
     return 0;
+}
+
+/* Expose the OS-level descriptors inside the opaque socket handles
+ * (issue #1003). Exists so capability plumbing — capsicum.rights_limit()
+ * / fcntls_limit() before capsicum.enter() — can narrow a socket the
+ * program opened through the stdlib. The fd is owned by the handle:
+ * callers must not close() it; it dies with tcp_close /
+ * tcp_server_close. Returns -1 on a null/closed handle. */
+int tcp_fd_raw(TcpSocket* sock) {
+    if (!sock || !sock->connected) return -1;
+    return sock->fd;
+}
+
+int tcp_server_fd_raw(TcpServer* server) {
+    if (!server) return -1;
+    return server->fd;
 }
 
 #endif // AETHER_HAS_NETWORKING

--- a/std/net/aether_net.h
+++ b/std/net/aether_net.h
@@ -17,4 +17,10 @@ TcpServer* tcp_listen_raw(int port);
 TcpSocket* tcp_accept_raw(TcpServer* server);
 int tcp_server_close(TcpServer* server);
 
+// OS-level descriptor inside a handle, or -1 if null/closed. For
+// capability plumbing (capsicum.rights_limit before capsicum.enter);
+// owned by the handle — do not close() it. Issue #1003.
+int tcp_fd_raw(TcpSocket* sock);
+int tcp_server_fd_raw(TcpServer* server);
+
 #endif

--- a/std/net/module.ae
+++ b/std/net/module.ae
@@ -9,6 +9,7 @@
 exports (
     tcp_connect_raw, tcp_send_raw, tcp_receive_raw, tcp_close,
     tcp_listen_raw, tcp_accept_raw, tcp_server_close,
+    tcp_fd_raw, tcp_server_fd_raw,
     http_get_raw, http_post_raw, http_put_raw, http_delete_raw,
     http_response_free, http_response_status_code,
     http_response_body_str, http_response_headers_str,
@@ -43,6 +44,12 @@ extern tcp_close(sock: ptr) -> int
 extern tcp_listen_raw(port: int) -> ptr
 extern tcp_accept_raw(server: ptr) -> ptr
 extern tcp_server_close(server: ptr) -> int
+
+// Descriptor accessors (#1003). The OS-level fd inside a handle, or -1
+// if null/closed. For capability plumbing (capsicum.rights_limit before
+// capsicum.enter). Owned by the handle — never close() one directly.
+extern tcp_fd_raw(sock: ptr) -> int
+extern tcp_server_fd_raw(server: ptr) -> int
 
 // HTTP Client — raw ptr-returning externs (escape hatch).
 // Most callers should use the Go-style wrappers in std.http which provide

--- a/std/tcp/module.ae
+++ b/std/tcp/module.ae
@@ -7,7 +7,8 @@
 exports (
     tcp_connect_raw, tcp_send_raw, tcp_receive_raw, tcp_close,
     tcp_listen_raw, tcp_accept_raw, tcp_server_close,
-    connect, write, read, listen, accept
+    tcp_fd_raw, tcp_server_fd_raw,
+    connect, write, read, listen, accept, fd, server_fd
 )
 
 // Raw externs - escape hatch
@@ -18,6 +19,8 @@ extern tcp_close(sock: ptr) -> int
 extern tcp_listen_raw(port: int) -> ptr
 extern tcp_accept_raw(server: ptr) -> ptr
 extern tcp_server_close(server: ptr) -> int
+extern tcp_fd_raw(sock: ptr) -> int
+extern tcp_server_fd_raw(server: ptr) -> int
 
 // string_concat used to duplicate the borrowed receive buffer so the
 // caller's copy outlives the underlying malloc.
@@ -76,4 +79,21 @@ accept(server: ptr) -> {
         return null, "accept failed"
     }
     return sock, ""
+}
+
+// The OS-level descriptor inside a connected socket, or -1 if the
+// handle is null/closed (#1003). Exists for capability plumbing:
+// connect through the stdlib, then narrow the descriptor with
+// capsicum.rights_limit(tcp.fd(sock), ...) before capsicum.enter().
+// The fd is owned by the handle — do not close it directly; it is
+// released by tcp.close.
+fd(sock: ptr) -> int {
+    return tcp_fd_raw(sock)
+}
+
+// The OS-level listening descriptor inside a server handle, or -1 if
+// the handle is null (#1003). Same ownership rule: released by
+// tcp.server_close, never closed directly.
+server_fd(server: ptr) -> int {
+    return tcp_server_fd_raw(server)
 }

--- a/tests/freebsd/README.md
+++ b/tests/freebsd/README.md
@@ -19,8 +19,18 @@ platform.
   Casper channel **before** `capsicum.enter()`, then resolve `root → uid 0`
   **after** entry (impossible without Casper, since capability mode blocks
   `/etc/passwd`). Deterministic; no network.
+- **`rights_limit_stdlib_fd.ae`** — issue #1003 gap 1: opens `/etc/passwd`
+  through `std.file`, extracts the kernel descriptor with `file.fd(handle)`,
+  narrows it with `capsicum.rights_limit()`, enters capability mode, and
+  asserts the narrowed handle still reads while a fresh path-open is denied.
+- **`spawn_capsicum_containment.sh`** — issue #1003 gap 2: builds a real
+  parent+child pair and asserts a `spawn_sandboxed`-launched Aether child
+  lands in capability mode (`in_mode() == 1`) **without** its source ever
+  calling `capsicum.enter()` — i.e. the `AETHER_CAPSICUM=1` auto-wiring and
+  the `capsicum_autosandbox.c` startup hook actually compose.
 
-Each `.ae` exits **0 = pass, 1 = fail, 2 = skip (not FreeBSD)**.
+Each `.ae` (and `.sh` test) exits **0 = pass, 1 = fail, 2 = skip (not
+FreeBSD)**; `run.sh` drives both kinds.
 
 ## Running
 

--- a/tests/freebsd/rights_limit_stdlib_fd.ae
+++ b/tests/freebsd/rights_limit_stdlib_fd.ae
@@ -1,0 +1,84 @@
+// FreeBSD-only: capsicum.rights_limit() on a descriptor obtained from a
+// std.file handle via file.fd() (issue #1003). Run by tests/freebsd/run.sh;
+// NOT in the CI regression set (no FreeBSD runner).
+//
+// Proves the fd accessor returns the real kernel descriptor: narrowing it
+// succeeds; after capsicum.enter() the narrowed, already-open handle still
+// reads (READ|SEEK|FSTAT were retained) while a fresh path-open is denied.
+// This is the "open through the stdlib, then narrow rights before entering
+// capability mode" flow the accessor exists for.
+//
+// Exits 0 on success, 1 on any contract violation, 2 if run off FreeBSD
+// (the harness treats 2 as "skipped").
+
+import std.capsicum
+import std.os
+import std.file
+import std.string
+
+main() {
+    if string.equals(os.platform(), "freebsd") != 1 {
+        print("SKIP: not FreeBSD\n")
+        exit(2)
+    }
+    if capsicum.available() != 1 {
+        print("FAIL: available() != 1 on FreeBSD\n")
+        exit(1)
+    }
+
+    // Closed/invalid handles must report -1, not a stale descriptor.
+    if file.fd(null) != -1 {
+        print("FAIL: file.fd(null) != -1\n")
+        exit(1)
+    }
+
+    handle, err = file.open("/etc/passwd", "r")
+    if handle == null {
+        print("FAIL: cannot open /etc/passwd pre-entry (${err})\n")
+        exit(1)
+    }
+    fd = file.fd(handle)
+    if fd < 0 {
+        print("FAIL: file.fd() returned ${fd} for an open handle\n")
+        exit(1)
+    }
+    print("stdlib fd: ${fd}\n")
+
+    // Narrow the stdlib-opened descriptor. CAP_OK proves the int really
+    // is the kernel descriptor behind the handle.
+    r = capsicum.rights_limit(fd, capsicum.R_READ | capsicum.R_SEEK | capsicum.R_FSTAT)
+    if r != capsicum.CAP_OK {
+        print("FAIL: rights_limit(file.fd) returned ${r}, expected CAP_OK\n")
+        exit(1)
+    }
+
+    // Enter capability mode — irreversible from here.
+    r = capsicum.enter()
+    if r != capsicum.CAP_OK {
+        print("FAIL: enter() returned ${r}, expected CAP_OK\n")
+        exit(1)
+    }
+
+    // The narrowed, already-open descriptor must still read.
+    content = file.read_all_raw(handle)
+    if content == 0 {
+        print("FAIL: read via narrowed fd denied after enter()\n")
+        exit(1)
+    }
+    n = string.length(content)
+    if n < 1 {
+        print("FAIL: empty read via narrowed fd after enter()\n")
+        exit(1)
+    }
+    print("ok: read ${n} bytes via narrowed stdlib fd in capability mode\n")
+
+    // A fresh path-open must be denied (ECAPMODE).
+    h2, err2 = file.open("/etc/passwd", "r")
+    if h2 != null {
+        print("FAIL: opened a fresh path AFTER entering capability mode\n")
+        exit(1)
+    }
+    print("ok: fresh path open denied in capability mode (${err2})\n")
+    print("PASS: rights_limit on stdlib fd\n")
+    exit(0)
+}

--- a/tests/freebsd/run.sh
+++ b/tests/freebsd/run.sh
@@ -40,6 +40,23 @@ for t in "$ROOT"/tests/freebsd/*.ae; do
     esac
 done
 
+# Shell-driven tests (same 0/1/2 exit contract). Used where the test
+# must build its own binaries — e.g. spawn_capsicum_containment.sh,
+# which needs a real parent+child pair and the preload .so on disk.
+for t in "$ROOT"/tests/freebsd/*.sh; do
+    name=$(basename "$t" .sh)
+    case "$name" in run|nightly) continue ;; esac
+    printf '  [ .. ] %s\n' "$name"
+    out=$(AE="$AE" sh "$t" 2>&1)
+    rc=$?
+    case "$rc" in
+        0) echo "  [PASS] $name"; pass=$((pass+1)) ;;
+        2) echo "  [SKIP] $name (not FreeBSD)"; skip=$((skip+1)) ;;
+        *) echo "  [FAIL] $name (exit $rc)"; echo "$out" | sed 's/^/        /'
+           fail=$((fail+1)); failed_list="$failed_list $name" ;;
+    esac
+done
+
 echo
 echo "FreeBSD sandbox tests: $pass passed, $fail failed, $skip skipped"
 [ "$fail" -eq 0 ] || { echo "FAILED:$failed_list"; exit 1; }

--- a/tests/freebsd/spawn_capsicum_containment.sh
+++ b/tests/freebsd/spawn_capsicum_containment.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# tests/freebsd/spawn_capsicum_containment.sh — end-to-end proof that
+# spawn_sandboxed auto-wires Capsicum on FreeBSD (issue #1003, gap 2).
+#
+# Contract under test: spawn_sandboxed sets AETHER_CAPSICUM=1 in every
+# child's environment (runtime/sandbox/spawn_sandboxed_bsd.c), and an
+# Aether child self-enters capability mode at startup via the hook in
+# runtime/sandbox/capsicum_autosandbox.c — so a spawned Aether child is
+# kernel-contained WITHOUT its source ever calling capsicum.enter().
+#
+# Shape mirrors tests/integration/sandbox_toolchain: build the preload
+# .so and both binaries into a tmpdir, run the parent from there (the
+# preload is discovered next to the running binary), and assert on the
+# child's own report of its containment state.
+#
+# Exit: 0 = pass, 1 = fail, 2 = skip (not FreeBSD). Run by run.sh.
+set -u
+
+[ "$(uname -s 2>/dev/null)" = "FreeBSD" ] || { echo "SKIP: not FreeBSD"; exit 2; }
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+AE="${AE:-$ROOT/build/ae}"
+
+[ -x "$AE" ] || { echo "FAIL: ae not found at $AE"; exit 1; }
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Preload library: prefer the one the build produced; else compile it
+# the way the Makefile does on FreeBSD (dlopen/shm_open live in libc,
+# no -ldl -lrt).
+if [ -f "$ROOT/build/libaether_sandbox.so" ]; then
+    cp "$ROOT/build/libaether_sandbox.so" "$TMPDIR/"
+else
+    cc -shared -fPIC -o "$TMPDIR/libaether_sandbox.so" \
+        "$ROOT/runtime/libaether_sandbox_preload.c" 2>"$TMPDIR/preload-cc.log" || {
+        echo "FAIL: preload .so build failed:"; cat "$TMPDIR/preload-cc.log"; exit 1
+    }
+fi
+
+# The child NEVER calls capsicum.enter() itself — if it lands in
+# capability mode, spawn_sandboxed's auto-wiring put it there.
+cat > "$TMPDIR/child.ae" <<'AE'
+import std.capsicum
+import std.os
+extern println(s: string)
+main() {
+    m = capsicum.in_mode()
+    if m == 1 {
+        println("child-in-capability-mode")
+        exit(0)
+    }
+    println("child-NOT-contained mode=${m}")
+    exit(1)
+}
+AE
+
+cat > "$TMPDIR/parent.ae" <<AE
+import std.list
+extern println(s: string)
+main() {
+    g = list.new()
+    list.add(g, "env");     list.add(g, "*")
+    list.add(g, "fs_read"); list.add(g, "/*")
+    list.add(g, "native");  list.add(g, "*")
+    rc = spawn_sandboxed(g, "$TMPDIR/child", "unused")
+    println("rc=\${rc}")
+    list.free(g)
+}
+AE
+
+"$AE" build "$TMPDIR/child.ae" -o "$TMPDIR/child" >"$TMPDIR/child-build.log" 2>&1 || {
+    echo "FAIL: child build failed:"; tail -20 "$TMPDIR/child-build.log"; exit 1
+}
+"$AE" build "$TMPDIR/parent.ae" -o "$TMPDIR/parent" >"$TMPDIR/parent-build.log" 2>&1 || {
+    echo "FAIL: parent build failed:"; tail -20 "$TMPDIR/parent-build.log"; exit 1
+}
+
+cd "$TMPDIR" || exit 1
+./parent > out.log 2>&1
+cat out.log
+
+grep -q '^child-in-capability-mode$' out.log || {
+    echo "FAIL: spawned Aether child was not in capability mode"; exit 1
+}
+grep -q '^rc=0$' out.log || {
+    echo "FAIL: spawn_sandboxed did not return the child's success exit"; exit 1
+}
+echo "PASS: spawn_sandboxed auto-contains Aether children via Capsicum"
+exit 0


### PR DESCRIPTION
Closes #1003.

## Gap 1 — fd accessors (new code)

`capsicum.rights_limit()` / `fcntls_limit()` take a raw int fd, but the stdlib handle types kept theirs private, so rights could only be narrowed on descriptors from raw externs. This adds:

- `file.fd(handle)` / `fs.fd(handle)` — raw extern `file_fd_raw` (wraps `fileno`, flushes first so the fd's view matches the FILE*'s buffered state)
- `tcp.fd(sock)` / `tcp.server_fd(server)` — raw externs `tcp_fd_raw` / `tcp_server_fd_raw` (also exported from `std.net`)

Ownership contract: the fd belongs to the handle — never `close()` it directly; it is released by `file_close` / `tcp.close` / `tcp.server_close`. `file_close` frees the handle itself, so `fd()` must not be called after it (returns -1 only on a *null* handle).

## Gap 2 — spawn_sandboxed auto-wiring (already shipped; now stated + proven)

The issue's second gap had in fact already landed in ee155f2f: `spawn_sandboxed` on FreeBSD sets `AETHER_CAPSICUM=1` in every child's environment and an Aether child `cap_enter()`s itself at startup (`runtime/sandbox/capsicum_autosandbox.c`). But the `std.capsicum` module/header comments still called that wiring "a later phase" (which is presumably where the issue text came from), and nothing exercised the composed path. This PR fixes the stale comments and adds an end-to-end proof.

## Tests (run on the GhostBSD 2025 box, FreeBSD 14.3-RELEASE-p2 amd64)

- **`tests/freebsd/rights_limit_stdlib_fd.ae`** (new): opens `/etc/passwd` via `std.file`, narrows `file.fd(handle)` with `rights_limit(R_READ|R_SEEK|R_FSTAT)`, enters capability mode, asserts the narrowed handle still reads while a fresh path-open is denied.
- **`tests/freebsd/spawn_capsicum_containment.sh`** (new): builds a real parent+child pair; the `spawn_sandboxed`-launched Aether child reports `capsicum.in_mode() == 1` without ever calling `enter()` itself. `tests/freebsd/run.sh` now drives `.sh` tests alongside `.ae` ones.

```
FreeBSD sandbox enforcement tests — FreeBSD 14.3-RELEASE-p2 amd64
  [PASS] capsicum_enforce
  [PASS] casper_delegation
  [PASS] rights_limit_stdlib_fd
  [PASS] spawn_capsicum_containment
FreeBSD sandbox tests: 4 passed, 0 failed, 0 skipped
```

Also green: `tests/regression/test_capsicum_portability.ae` on both Linux and FreeBSD, full local `make test` (231/231), and an fd-accessor probe (file/fs/tcp/server fds, null-handle -1, `CAP_UNSUPPORTED` off FreeBSD) on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)