### PR TITLE
fix(std/fs): widen file size/mtime surfaces to 64-bit end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **std.fs file sizes and mtimes are 64-bit end-to-end** (#1021). Every size
+  surface was a 32-bit C `int`, so files >= 2 GiB reported wrapped-negative
+  sizes (a disk-usage tool under-counts exactly the files that dominate disk
+  usage). Widened in place: `file_size_raw`, `fs_get_stat_size`, and the
+  `fs.size` / `file.size` / `fs.file_stat` wrappers now speak `long`
+  (C `int64_t`); mtimes (`file_mtime`, `file_mtime_raw`, `fs_get_stat_mtime`,
+  `fs.mtime`, `file_stat`'s slot) widened in the same pass (Y2038). On
+  Windows the stat calls moved to `_stati64` — plain `_stat` carries a
+  32-bit `st_size` — and the positional-I/O family (`fs_pwrite_raw` /
+  `fs_pread_raw` / `fs_ftruncate_raw`) now defines its offsets/returns as
+  `int64_t` with `_fseeki64`, matching the `int64_t` prototypes the compiler
+  emits for Aether `long` externs (plain C `long` is 32-bit on LLP64, so the
+  old definitions were an ABI mismatch there). Regression test creates a
+  sparse 2 GiB + 5 file and asserts every surface reports the true value.
+  Wrapper note: the Go-style tuple wrappers keep their `(value, err)` shape,
+  but their success arm now returns first — the first `return` statement
+  pins the inferred tuple slot types, and the int-literal error arm would
+  otherwise narrow the size slot back to 32-bit.
+
 ## [0.358.0]
 
 ### Added

--- a/std/file/module.ae
+++ b/std/file/module.ae
@@ -22,7 +22,9 @@ extern file_read_all_raw(file: ptr) -> string
 extern file_write_raw(file: ptr, data: string, length: int) -> int
 extern file_exists(path: string) -> int
 extern file_delete_raw(path: string) -> int
-extern file_size_raw(path: string) -> int
+// Size in bytes, as `long` (#1021): the old int surface wrapped files
+// >= 2 GiB to a negative value. Returns -1 on stat failure.
+extern file_size_raw(path: string) -> long
 extern file_fd_raw(file: ptr) -> int
 
 // string_concat used to duplicate borrowed strings across free boundaries.
@@ -81,14 +83,19 @@ delete(path: string) -> {
     return ""
 }
 
-// Return the size of the file at `path` in bytes.
+// Return the size of the file at `path` in bytes, as `long` (#1021 —
+// files >= 2 GiB used to wrap negative through the old int surface).
 // Returns (size, "") on success, (0, error) on failure.
+//
+// The success arm returns FIRST: the first `return` statement pins the
+// inferred tuple slot types, so the `long`-typed arm must come before
+// the int-literal error arm or the size slot narrows back to int.
 size(path: string) -> {
     s = file_size_raw(path)
-    if s < 0 {
-        return 0, "cannot stat file"
+    if s >= 0 {
+        return s, ""
     }
-    return s, ""
+    return 0, "cannot stat file"
 }
 
 // The OS-level file descriptor inside an open handle, or -1 on a

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -15,8 +15,8 @@ int file_fd_raw(File* f) { (void)f; return -1; }
 int file_exists(const char* p) { (void)p; return 0; }
 int fs_path_exists(const char* p) { (void)p; return 0; }
 int file_delete_raw(const char* p) { (void)p; return 0; }
-int file_size_raw(const char* p) { (void)p; return -1; }
-int file_mtime(const char* p) { (void)p; return 0; }
+int64_t file_size_raw(const char* p) { (void)p; return -1; }
+int64_t file_mtime(const char* p) { (void)p; return 0; }
 int dir_exists(const char* p) { (void)p; return 0; }
 int dir_create_raw(const char* p) { (void)p; return 0; }
 int dir_delete_raw(const char* p) { (void)p; return 0; }
@@ -32,15 +32,15 @@ int fs_write_atomic_raw(const char* p, const char* d, int l) {
     (void)p; (void)d; (void)l; return 0;
 }
 int fs_rename_raw(const char* f, const char* t) { (void)f; (void)t; return 0; }
-int fs_stat_raw(const char* p, int* k, int* s, int* m) {
+int fs_stat_raw(const char* p, int* k, int64_t* s, int64_t* m) {
     (void)p;
     if (k) *k = 0; if (s) *s = 0; if (m) *m = 0;
     return 0;
 }
 int fs_try_stat(const char* p) { (void)p; return 0; }
-int fs_get_stat_kind(void)  { return 0; }
-int fs_get_stat_size(void)  { return 0; }
-int fs_get_stat_mtime(void) { return 0; }
+int     fs_get_stat_kind(void)  { return 0; }
+int64_t fs_get_stat_size(void)  { return 0; }
+int64_t fs_get_stat_mtime(void) { return 0; }
 char* fs_read_binary_raw(const char* p, int* n) {
     (void)p; if (n) *n = 0; return NULL;
 }
@@ -82,12 +82,12 @@ int path_is_absolute(const char* p) { (void)p; return 0; }
 char* path_clean(const char* p) { (void)p; return NULL; }
 int path_is_within_base(const char* base, const char* target) { (void)base; (void)target; return 0; }
 char* path_rel(const char* base, const char* target) { (void)base; (void)target; return NULL; }
-long fs_pwrite_raw(File* f, const char* d, int l, long o) { (void)f; (void)d; (void)l; (void)o; return -1; }
-int fs_pread_raw(File* f, int l, long o) { (void)f; (void)l; (void)o; return 0; }
+int64_t fs_pwrite_raw(File* f, const char* d, int l, int64_t o) { (void)f; (void)d; (void)l; (void)o; return -1; }
+int fs_pread_raw(File* f, int l, int64_t o) { (void)f; (void)l; (void)o; return 0; }
 const char* fs_get_pread(void) { return ""; }
 int fs_get_pread_length(void) { return 0; }
 void fs_release_pread(void) {}
-const char* fs_ftruncate_raw(File* f, long l) { (void)f; (void)l; return "fs unavailable"; }
+const char* fs_ftruncate_raw(File* f, int64_t l) { (void)f; (void)l; return "fs unavailable"; }
 const char* fs_fsync_raw(File* f) { (void)f; return "fs unavailable"; }
 DirList* dir_list_raw(const char* p) { (void)p; return NULL; }
 int dir_list_count(DirList* l) { (void)l; return 0; }
@@ -260,8 +260,10 @@ int file_close(File* file) {
 #include <errno.h>
 
 /* Returns bytes written on success, -1 on error. Loops on short
- * writes. `offset` is a byte position from start-of-file. */
-long fs_pwrite_raw(File* file, const char* data, int length, long offset) {
+ * writes. `offset` is a byte position from start-of-file.
+ * int64_t (not C `long`) so the definition matches the prototype the
+ * compiler emits for an Aether `long` extern on LLP64 (#1021). */
+int64_t fs_pwrite_raw(File* file, const char* data, int length, int64_t offset) {
     if (!file || !file->is_open || !data || length < 0 || offset < 0) return -1;
     FILE* fp = (FILE*)file->handle;
     fflush(fp);
@@ -273,14 +275,15 @@ long fs_pwrite_raw(File* file, const char* data, int length, long offset) {
         /* Windows has no pwrite — emulate with seek + write. NOT
          * thread-safe across handles (the seek changes the file
          * position for the whole handle); fine for the single-
-         * threaded port-server case the issue addresses. */
-        if (fseek(fp, offset + (long)total, SEEK_SET) != 0) return -1;
+         * threaded port-server case the issue addresses. _fseeki64
+         * because plain fseek takes a 32-bit long on Windows. */
+        if (_fseeki64(fp, offset + (int64_t)total, SEEK_SET) != 0) return -1;
         size_t w = fwrite(data + total, 1, (size_t)length - total, fp);
         if (w == 0) return -1;
         total += w;
 #else
         ssize_t w = pwrite(fd, data + total, (size_t)length - total,
-                           (off_t)(offset + (long)total));
+                           (off_t)(offset + (int64_t)total));
         if (w < 0) {
             if (errno == EINTR) continue;
             return -1;
@@ -289,7 +292,7 @@ long fs_pwrite_raw(File* file, const char* data, int length, long offset) {
         total += (size_t)w;
 #endif
     }
-    return (long)total;
+    return (int64_t)total;
 }
 
 /* TLS slot for the pread split-accessor — mirrors fs_get_read_binary.
@@ -321,7 +324,7 @@ int fs_get_pread_length(void) {
 
 /* Returns 1 on success (TLS slot has up-to-length bytes; partial
  * EOF reads are still success), 0 on failure. */
-int fs_pread_raw(File* file, int length, long offset) {
+int fs_pread_raw(File* file, int length, int64_t offset) {
     release_pread_locked();
     if (!file || !file->is_open || length < 0 || offset < 0) return 0;
     FILE* fp = (FILE*)file->handle;
@@ -336,7 +339,7 @@ int fs_pread_raw(File* file, int length, long offset) {
     size_t total = 0;
     while (total < (size_t)length) {
 #ifdef _WIN32
-        if (fseek(fp, offset + (long)total, SEEK_SET) != 0) {
+        if (_fseeki64(fp, offset + (int64_t)total, SEEK_SET) != 0) {
             aether_caps_free(buf, alloc); return 0;
         }
         size_t r = fread(buf + total, 1, (size_t)length - total, fp);
@@ -344,7 +347,7 @@ int fs_pread_raw(File* file, int length, long offset) {
         total += r;
 #else
         ssize_t r = pread(fd, buf + total, (size_t)length - total,
-                          (off_t)(offset + (long)total));
+                          (off_t)(offset + (int64_t)total));
         if (r < 0) {
             if (errno == EINTR) continue;
             aether_caps_free(buf, alloc); return 0;
@@ -363,7 +366,7 @@ int fs_pread_raw(File* file, int length, long offset) {
  * extends with zero bytes when length > current size; SHOULD work
  * the same way on Windows via _chsize_s. Returns "" on success or
  * an error message. */
-const char* fs_ftruncate_raw(File* file, long length) {
+const char* fs_ftruncate_raw(File* file, int64_t length) {
     if (!file || !file->is_open || length < 0) return "invalid args";
     FILE* fp = (FILE*)file->handle;
     fflush(fp);
@@ -447,33 +450,50 @@ int file_delete_raw(const char* path) {
     return remove(path) == 0 ? 1 : 0;
 }
 
-int file_size_raw(const char* path) {
+/* 64-bit stat shim (#1021). The size/mtime surfaces below return
+ * int64_t — the C spelling of an Aether `long` extern (LLP64-safe;
+ * plain C `long` is 32-bit on Windows). On POSIX, stat/lstat already
+ * fill a 64-bit off_t/time_t on every platform we build. On Windows
+ * the CRT's plain _stat carries a 32-bit st_size, so files >= 2 GiB
+ * wrap — _stati64 is the 64-bit-size spelling. (No lstat on the
+ * Windows CRT; fs_stat_raw's symlink branch is POSIX-only anyway.) */
+#ifdef _WIN32
+typedef struct _stati64 aether_stat64_t;
+#define aether_stat64(p, st)  _stati64((p), (st))
+#define aether_lstat64(p, st) _stati64((p), (st))
+#else
+typedef struct stat aether_stat64_t;
+#define aether_stat64(p, st)  stat((p), (st))
+#define aether_lstat64(p, st) lstat((p), (st))
+#endif
+
+int64_t file_size_raw(const char* path) {
     if (!path) return 0;
     if (!aether_sandbox_check("fs_read", path)) return 0;
 
-    struct stat st;
-    if (stat(path, &st) != 0) return -1;
-    return (int)st.st_size;
+    aether_stat64_t st;
+    if (aether_stat64(path, &st) != 0) return -1;
+    return (int64_t)st.st_size;
 }
 
-int file_mtime(const char* path) {
+int64_t file_mtime(const char* path) {
     if (!path) return 0;
 
-    struct stat st;
-    if (stat(path, &st) != 0) return 0;
-    return (int)st.st_mtime;
+    aether_stat64_t st;
+    if (aether_stat64(path, &st) != 0) return 0;
+    return (int64_t)st.st_mtime;
 }
 
 // Like file_mtime but distinguishes "stat failed" (returns -1) from
 // "file's mtime happens to be 0" (returns 0 — the Unix epoch). The
 // older `file_mtime` collapses both into 0, swallowing the error.
 // Aether-side callers should prefer `fs.mtime` (Go-style result tuple).
-int file_mtime_raw(const char* path) {
+int64_t file_mtime_raw(const char* path) {
     if (!path) return -1;
 
-    struct stat st;
-    if (stat(path, &st) != 0) return -1;
-    return (int)st.st_mtime;
+    aether_stat64_t st;
+    if (aether_stat64(path, &st) != 0) return -1;
+    return (int64_t)st.st_mtime;
 }
 
 // Directory operations
@@ -784,7 +804,7 @@ int fs_rename_raw(const char* from, const char* to) {
 #define FS_STAT_KIND_OTHER   4
 
 int fs_stat_raw(const char* path, int* out_kind,
-                int* out_size, int* out_mtime) {
+                int64_t* out_size, int64_t* out_mtime) {
     if (!path) {
         if (out_kind)  *out_kind  = 0;
         if (out_size)  *out_size  = 0;
@@ -798,14 +818,14 @@ int fs_stat_raw(const char* path, int* out_kind,
         return 0;
     }
 
-    struct stat st;
+    aether_stat64_t st;
 #ifndef _WIN32
-    if (lstat(path, &st) != 0) {
+    if (aether_lstat64(path, &st) != 0) {
 #else
-    // Windows CRT has no lstat; stat follows symlinks, but Windows
+    // Windows CRT has no lstat; _stati64 follows symlinks, but Windows
     // symlinks already go through a different code path we stub out
     // (fs_is_symlink returns 0). Good enough for v1.
-    if (stat(path, &st) != 0) {
+    if (aether_stat64(path, &st) != 0) {
 #endif
         if (out_kind)  *out_kind  = 0;
         if (out_size)  *out_size  = 0;
@@ -823,8 +843,8 @@ int fs_stat_raw(const char* path, int* out_kind,
     else                           kind = FS_STAT_KIND_OTHER;
 
     if (out_kind)  *out_kind  = kind;
-    if (out_size)  *out_size  = (int)st.st_size;
-    if (out_mtime) *out_mtime = (int)st.st_mtime;
+    if (out_size)  *out_size  = (int64_t)st.st_size;
+    if (out_mtime) *out_mtime = (int64_t)st.st_mtime;
     return 1;
 }
 
@@ -838,12 +858,13 @@ int fs_stat_raw(const char* path, int* out_kind,
 #else
   #define AETHER_FS_TLS
 #endif
-static AETHER_FS_TLS int s_last_kind  = 0;
-static AETHER_FS_TLS int s_last_size  = 0;
-static AETHER_FS_TLS int s_last_mtime = 0;
+static AETHER_FS_TLS int     s_last_kind  = 0;
+static AETHER_FS_TLS int64_t s_last_size  = 0;
+static AETHER_FS_TLS int64_t s_last_mtime = 0;
 
 int fs_try_stat(const char* path) {
-    int k = 0, sz = 0, mt = 0;
+    int k = 0;
+    int64_t sz = 0, mt = 0;
     int ok = fs_stat_raw(path, &k, &sz, &mt);
     if (!ok) {
         s_last_kind = 0; s_last_size = 0; s_last_mtime = 0;
@@ -853,9 +874,9 @@ int fs_try_stat(const char* path) {
     return 1;
 }
 
-int fs_get_stat_kind(void)  { return s_last_kind;  }
-int fs_get_stat_size(void)  { return s_last_size;  }
-int fs_get_stat_mtime(void) { return s_last_mtime; }
+int     fs_get_stat_kind(void)  { return s_last_kind;  }
+int64_t fs_get_stat_size(void)  { return s_last_size;  }
+int64_t fs_get_stat_mtime(void) { return s_last_mtime; }
 
 char* fs_read_binary_raw(const char* path, int* out_len) {
     if (out_len) *out_len = 0;

--- a/std/fs/aether_fs.h
+++ b/std/fs/aether_fs.h
@@ -2,6 +2,7 @@
 #define AETHER_FS_H
 
 #include <stddef.h>
+#include <stdint.h>   // int64_t — 64-bit size/mtime/offset surfaces (#1021)
 
 // ---- Structured-error kinds (pilot — issue #392) ----
 //
@@ -44,8 +45,13 @@ int file_exists(const char* path);
  * existing — matches POSIX `test -e`. */
 int fs_path_exists(const char* path);
 int file_delete_raw(const char* path);
-int file_size_raw(const char* path);
-int file_mtime(const char* path);
+// Size in bytes / mtime in Unix epoch seconds. int64_t end-to-end
+// (#1021): files >= 2 GiB used to wrap negative through the old int
+// surfaces, and 32-bit mtimes hit Y2038. int64_t (not C `long`) so the
+// definition matches the int64_t prototype the compiler emits for an
+// Aether `long` extern even on LLP64 (Windows).
+int64_t file_size_raw(const char* path);
+int64_t file_mtime(const char* path);
 
 // Directory operations
 int dir_exists(const char* path);
@@ -116,7 +122,7 @@ int fs_rename_raw(const char* from, const char* to);
 // Returns 1 on success, 0 on failure (missing path, stat error).
 // On failure all three out-params are zeroed.
 int fs_stat_raw(const char* path, int* out_kind,
-                int* out_size, int* out_mtime);
+                int64_t* out_size, int64_t* out_mtime);
 
 // Split-accessor pair for Aether callers that don't want to pass C
 // out-parameters. fs_try_stat caches the most recent stat result in
@@ -130,9 +136,9 @@ int fs_stat_raw(const char* path, int* out_kind,
 //       mtime = fs_get_stat_mtime()
 //   }
 int fs_try_stat(const char* path);
-int fs_get_stat_kind(void);
-int fs_get_stat_size(void);
-int fs_get_stat_mtime(void);
+int     fs_get_stat_kind(void);
+int64_t fs_get_stat_size(void);
+int64_t fs_get_stat_mtime(void);
 
 // Read the entire file at `path` into a newly malloc'd buffer.
 // Sibling of file_read_all_raw that is length-aware and binary-safe:
@@ -190,12 +196,12 @@ char* path_rel(const char* base, const char* target);
 // file_open_raw with a mode that admits both read and write ("r+",
 // "w+", "a+"). Loops on short transfers; EINTR-safe on POSIX;
 // _chsize_s / _commit on Windows.
-long        fs_pwrite_raw(File* file, const char* data, int length, long offset);
-int         fs_pread_raw(File* file, int length, long offset);
+int64_t     fs_pwrite_raw(File* file, const char* data, int length, int64_t offset);
+int         fs_pread_raw(File* file, int length, int64_t offset);
 const char* fs_get_pread(void);
 int         fs_get_pread_length(void);
 void        fs_release_pread(void);
-const char* fs_ftruncate_raw(File* file, long length);
+const char* fs_ftruncate_raw(File* file, int64_t length);
 const char* fs_fsync_raw(File* file);
 
 // The OS-level descriptor inside an open File, or -1 if closed/invalid.

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -97,19 +97,21 @@ extern file_exists(path: string) -> int
 // Matches POSIX `test -e`.
 extern fs_path_exists(path: string) -> int
 extern file_delete_raw(path: string) -> int
-extern file_size_raw(path: string) -> int
+// Size in bytes, as `long` (#1021): the old int surface wrapped files
+// >= 2 GiB to a negative value. Returns -1 on stat failure.
+extern file_size_raw(path: string) -> long
 
 // Get file modification time as a Unix timestamp. Infallible — returns
 // 0 for missing files, null paths, or stat failure. Kept as a raw
 // extern with no Go-style wrapper because callers already use the 0
-// sentinel for "no mtime".
-extern file_mtime(path: string) -> int
+// sentinel for "no mtime". `long` since #1021 (Y2038-safe).
+extern file_mtime(path: string) -> long
 // `file_mtime_raw` returns the file's mtime as Unix epoch seconds, or
 // -1 if stat failed. Use this rather than `file_mtime` when you need
 // to distinguish "1970-01-01 epoch file" from "stat failed" — the
 // older `file_mtime` collapses both into 0. The `fs.mtime` wrapper
 // below builds the standard (value, err) tuple on top of it.
-extern file_mtime_raw(path: string) -> int
+extern file_mtime_raw(path: string) -> long
 
 // Directory operations - raw externs
 extern dir_exists(path: string) -> int
@@ -154,8 +156,10 @@ extern fs_rename_raw(from: string, to: string) -> int
 // Pair is thread-local so back-to-back calls on one thread are safe.
 extern fs_try_stat(path: string) -> int
 extern fs_get_stat_kind() -> int
-extern fs_get_stat_size() -> int
-extern fs_get_stat_mtime() -> int
+// size/mtime are `long` (#1021): 64-bit sizes (no >= 2 GiB wrap) and
+// Y2038-safe mtimes.
+extern fs_get_stat_size() -> long
+extern fs_get_stat_mtime() -> long
 
 // Split-accessor binary read: fs_try_read_binary reads the file into
 // a TLS-owned buffer; fs_get_read_binary / fs_get_read_binary_length
@@ -340,14 +344,19 @@ delete(path: string) -> {
     return ""
 }
 
-// Return the size of the file at `path` in bytes.
+// Return the size of the file at `path` in bytes, as `long` (#1021 —
+// files >= 2 GiB used to wrap negative through the old int surface).
 // Returns (size, "") on success, (0, error) on failure.
+//
+// The success arm returns FIRST: the first `return` statement pins the
+// inferred tuple slot types, so the `long`-typed arm must come before
+// the int-literal error arm or the size slot narrows back to int.
 size(path: string) -> {
     s = file_size_raw(path)
-    if s < 0 {
-        return 0, "cannot stat file"
+    if s >= 0 {
+        return s, ""
     }
-    return s, ""
+    return 0, "cannot stat file"
 }
 
 // Return the file's mtime as Unix epoch seconds.
@@ -355,12 +364,13 @@ size(path: string) -> {
 // "stat failed" from "file's mtime is 0" (which the older `file_mtime`
 // extern collapses into a single sentinel). Prefer this wrapper for
 // new code; `file_mtime` stays for back-compat.
+// Success arm first — same tuple-slot-inference constraint as `size`.
 mtime(path: string) -> {
     m = file_mtime_raw(path)
-    if m < 0 {
-        return 0, "cannot stat file"
+    if m >= 0 {
+        return m, ""
     }
-    return m, ""
+    return 0, "cannot stat file"
 }
 
 // Does anything exist at `path`? Returns 1 for any kind of
@@ -593,12 +603,21 @@ rename(from: string, to: string) -> {
 //
 // Cheaper than the existing file_exists + fs_is_symlink + size +
 // file_mtime quartet when callers need more than one field.
+// Two inference constraints keep size/mtime `long` here (#1021):
+// the getters are bound to locals (a call expression directly inside
+// a tuple return types as int; a variable carries the extern's
+// declared long), and the success arm returns first (the first
+// `return` pins the tuple slot types). The getters all return 0 after
+// a failed fs_try_stat, so binding them before the ok-check is safe.
 file_stat(path: string) -> {
     ok = fs_try_stat(path)
-    if ok == 0 {
-        return 0, 0, 0, "cannot stat path"
+    kind = fs_get_stat_kind()
+    size = fs_get_stat_size()
+    mtime = fs_get_stat_mtime()
+    if ok != 0 {
+        return kind, size, mtime, ""
     }
-    return fs_get_stat_kind(), fs_get_stat_size(), fs_get_stat_mtime(), ""
+    return 0, 0, 0, "cannot stat path"
 }
 
 // Binary-safe file read. Preserves embedded NULs and reports the
@@ -787,12 +806,14 @@ rel(base: string, target: string) -> string {
 // This is the "scatter-write" primitive — reconstructing a file from
 // blocks fetched out of order (rsync, zsync, parallel downloads,
 // sparse-file build). For sequential append, `fs.write` is simpler.
+// Success arm first — same tuple-slot-inference constraint as `size`
+// (the count slot is `long`).
 pwrite(file: ptr, data: string, length: int, offset: long) -> {
     n = fs_pwrite_raw(file, data, length, offset)
-    if n < 0 {
-        return -1, "pwrite failed"
+    if n >= 0 {
+        return n, ""
     }
-    return n, ""
+    return -1, "pwrite failed"
 }
 
 // Positional binary-safe read. Reads up to `length` bytes from

--- a/tests/regression/test_fs_size_64bit.ae
+++ b/tests/regression/test_fs_size_64bit.ae
@@ -1,0 +1,90 @@
+// Regression test for #1021: file sizes and mtimes are 64-bit end-to-end.
+//
+// The old surfaces were 32-bit C int all the way through, so a file
+// >= 2 GiB reported a wrapped-negative size from fs.size / file.size /
+// fs.file_stat, and mtimes would hit Y2038. This creates a SPARSE file
+// just past the 2 GiB wrap point (ftruncate extends without writing
+// data blocks on every filesystem we run CI on; NTFS moves EOF without
+// zero-filling) and asserts every size surface reports the true value.
+
+import std.fs
+import std.file
+import std.io
+
+main() {
+    print("=== std.fs 64-bit sizes / mtimes (#1021) ===\n\n")
+
+    // Pick a scratch dir — /tmp on POSIX, TEMP/TMPDIR elsewhere. A bare
+    // "/tmp" resolves to C:\tmp via fopen on Windows and isn't created,
+    // so fs.open(w+) fails there (matches the other std.fs tests' idiom).
+    tmp = io.getenv("TMPDIR")
+    if tmp == 0 { tmp = io.getenv("TEMP") }
+    if tmp == 0 { tmp = "/tmp" }
+    path = "${tmp}/aether_test_size64.bin"
+    fs.delete(path)
+
+    // 2 GiB + 5 bytes: 2147483653 — wraps to -2147483643 through a
+    // 32-bit int boundary. Any negative or small-positive readback
+    // means a narrowing crept back in somewhere.
+    big = 2147483653
+
+    f, ferr = fs.open(path, "w+")
+    if ferr != "" {
+        print("FAIL open: ${ferr}\n"); exit(1)
+    }
+    terr = fs.ftruncate(f, big)
+    file_close(f)
+    if terr != "" {
+        // A filesystem that refuses a 2 GiB sparse extend (FAT32 tmp
+        // dir, quota'd CI) is an environment limit, not a regression.
+        print("SKIP: cannot create 2GiB sparse file (${terr})\n")
+        fs.delete(path)
+        exit(0)
+    }
+
+    // Surface 1: fs.size (rides file_size_raw)
+    sz, serr = fs.size(path)
+    if serr != "" {
+        print("FAIL fs.size: ${serr}\n"); fs.delete(path); exit(1)
+    }
+    if sz != big {
+        print("FAIL fs.size: expected ${big}, got ${sz}\n"); fs.delete(path); exit(1)
+    }
+    print("PASS fs.size = ${sz}\n")
+
+    // Surface 2: file.size (std.file alias, same raw extern)
+    sz2, serr2 = file.size(path)
+    if serr2 != "" || sz2 != big {
+        print("FAIL file.size: expected ${big}, got ${sz2} (${serr2})\n")
+        fs.delete(path); exit(1)
+    }
+    print("PASS file.size = ${sz2}\n")
+
+    // Surface 3: fs.file_stat's size slot (rides fs_get_stat_size)
+    kind, sz3, mt, sterr = fs.file_stat(path)
+    if sterr != "" || kind != 1 {
+        print("FAIL file_stat: kind=${kind} err=${sterr}\n"); fs.delete(path); exit(1)
+    }
+    if sz3 != big {
+        print("FAIL file_stat size: expected ${big}, got ${sz3}\n"); fs.delete(path); exit(1)
+    }
+    print("PASS file_stat size = ${sz3}\n")
+
+    // mtime sanity on the same stat: a real current timestamp, not
+    // wrapped/zero. (Y2038 proper can't be asserted without setting a
+    // future mtime; the type widening is shared with the size path.)
+    if mt < 1500000000 {
+        print("FAIL file_stat mtime looks wrong: ${mt}\n"); fs.delete(path); exit(1)
+    }
+    print("PASS file_stat mtime = ${mt}\n")
+
+    // Surface 4: fs.mtime (rides file_mtime_raw)
+    mt2, merr = fs.mtime(path)
+    if merr != "" || mt2 < 1500000000 {
+        print("FAIL fs.mtime: got ${mt2} (${merr})\n"); fs.delete(path); exit(1)
+    }
+    print("PASS fs.mtime = ${mt2}\n")
+
+    fs.delete(path)
+    print("\n=== All #1021 64-bit size/mtime tests passed ===\n")
+}


### PR DESCRIPTION
Closes #1021.

## What

Every file-size surface in `std.fs` was a 32-bit C `int`, so files ≥ 2 GiB reported wrapped-negative sizes. Widened **in place** (option 1 from the issue — the narrowing guard turns any downstream int-stuffing into a loud failure rather than a silent wrap), with mtime widened in the same pass (the issue's Y2038 same-pass candidate):

- `file_size_raw`, `file_mtime`, `file_mtime_raw` → `int64_t` / Aether `long`
- `fs_stat_raw`'s size/mtime out-params, the TLS stat cache, `fs_get_stat_size` / `fs_get_stat_mtime` → `int64_t`
- `fs.size` / `file.size` / `fs.mtime` / `fs.file_stat` tuple slots now carry `long`
- Windows: stat calls moved to `_stati64` — plain `_stat` carries a 32-bit `st_size`, so the widening would have been a no-op there

## Same-boundary LLP64 correction

The compiler emits `int64_t` prototypes for Aether `long` externs, but `fs_pwrite_raw` / `fs_pread_raw` / `fs_ftruncate_raw` (#640) were *defined* with C `long` offsets/returns — an ABI mismatch on Windows (LLP64, C `long` is 32-bit). They're now defined as `int64_t`, with `_fseeki64` replacing `fseek` in the Windows emulation paths.

## Tuple-inference pitfalls the new test caught (both were real wraps)

1. A wrapper's **first `return` statement pins the inferred tuple slot types**. `size()`'s error arm (`return 0, "cannot stat file"`) came first, so the success arm's `long` narrowed back to int. The Go-style wrappers keep their exact `(value, err)` contracts but their success arm now returns first, with a comment stating the constraint.
2. A **call expression directly inside a tuple return types as int** even when the extern is declared `-> long`; a variable carries the declared type. `file_stat` now binds the three getters to locals before returning.

Worth noting for a compiler follow-up — both behaviors silently narrow where E0200 loudly guards plain assignments.

## Tests

- New `tests/regression/test_fs_size_64bit.ae`: creates a **sparse** 2 GiB + 5 byte file (`ftruncate`, no data blocks written) and asserts `fs.size`, `file.size`, and `fs.file_stat` all report 2147483653, plus mtime sanity through both stat paths. Skips cleanly on filesystems that refuse the sparse extend.
- Full local suite green (231/231); all pre-existing fs/file/mtime/stat/positional-IO regression tests pass unchanged — the widening is invisible to existing callers except that big values are now correct.

Downstream note: aevg's GrandPerspective port can drop its clamp-to-0 workaround once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)