### PR TITLE
test(https_client): skip when the network is unavailable, not fail CI

### DIFF
--- a/tests/regression/test_https_client.ae
+++ b/tests/regression/test_https_client.ae
@@ -26,6 +26,22 @@ main() {
             println("SKIP https: build has no OpenSSL support (${err})")
             return
         }
+        // Offline / DNS-blocked runner (a CI runner with no network, or a
+        // transient resolver hiccup): a live-endpoint probe must not fail the
+        // build when the host is simply unreachable. Treat resolve / connect /
+        // unreachable errors as a skip, the same posture as the OpenSSL-absent
+        // and AETHER_SKIP_NETWORK guards above.
+        net_down = string.contains(err, "resolv")
+        if net_down == 0 { net_down = string.contains(err, "unreachable") }
+        if net_down == 0 { net_down = string.contains(err, "could not connect") }
+        if net_down == 0 { net_down = string.contains(err, "Could not connect") }
+        if net_down == 0 { net_down = string.contains(err, "connection refused") }
+        if net_down == 0 { net_down = string.contains(err, "Connection refused") }
+        if net_down == 0 { net_down = string.contains(err, "timed out") }
+        if net_down == 1 {
+            println("SKIP https: network unavailable (${err})")
+            return
+        }
         println("FAIL: http.get returned error: ${err}")
         exit(1)
     }


### PR DESCRIPTION
## Problem

`tests/regression/test_https_client.ae` probes a live endpoint (`https://example.com`). On an offline or DNS-blocked CI runner, `http.get` returns `could not resolve host` and the test **hard-fails the build** (`exit 1`):

```
--- regression_test_https_client (runtime error, exit 1) ---
Test: https://example.com/ responds with 'Example Domain'
FAIL: http.get returned error: could not resolve host
Aether Tests: 817 passed, 1 failed, 818 total
```

That is a flaky, environment-dependent failure (the runner had no working DNS on that attempt), not a defect in the HTTPS client. It has intermittently reddened main CI and re-runs just gamble on the runner's network.

## Fix

Treat resolve / connect / unreachable errors on the `example.com` probe as a **skip**, exactly the posture the test already takes for a build without OpenSSL and for `AETHER_SKIP_NETWORK`. A live-endpoint probe must not fail the build when the host is simply unreachable.

## Verification

- With network: the test still passes (`PASS: TLS handshake + response body OK`, exit 0).
- Against an unresolvable host (offline simulation): the new skip path fires and the test exits 0 (`SKIP https: network unavailable (could not resolve host)`) instead of failing.
- The bogus-host assertion later in the test is unaffected: it is reached only when the network is up (the `example.com` probe succeeded), and it still asserts an error as before.

Scope is limited to the skip predicate on the first probe; no behavior change when the network is available.