### PR TITLE
feat(match): ranged and multi-value match/switch case labels (#1047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Ranged and multi-value `match` / `switch` cases** (#1047). A case label can
+  now be an inclusive range `lo..=hi`, a half-open range `lo..<hi` (consistent
+  with the exclusive `for i in 0..5`), or a comma-list of values and ranges in
+  one arm: `match score { 90..=100 -> "A"  80..<90 -> "B"  60, 61, 62 -> "D"  _
+  -> "F" }`. Ranges are over integer ordinals; a ranged arm lowers to a plain
+  `x >= lo && x <= hi` comparison in the branch chain (no runtime, no
+  allocation). In a C-style `switch`, a comma-list lowers to several `case`
+  labels sharing a body, and a switch containing any range is lowered to an
+  equivalent if-else chain (safe because Aether's `switch` has no fall-through).
+  Existing single-literal cases are unaffected. New operators `..=` / `..<`;
+  new regression `tests/regression/test_ranged_match_cases.ae`; docs in
+  `language-reference.md`.
+
 ## [0.364.0]
 
 ### Added

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -228,7 +228,15 @@ typedef enum {
     // the fallible (value, err) expression; children[1] = the handler (a
     // block that yields a value or exits, or a bare default expression). `err`
     // is bound inside a block handler.
-    AST_OR_ELSE
+    AST_OR_ELSE,
+    // #1047 match/switch case-label selectors. Appended at END to keep node
+    // numbering stable (incremental builds need `make clean` after this edit).
+    AST_MATCH_RANGE,        // `lo..=hi` / `lo..<hi` in a case label. children[0]
+                            // = lo, children[1] = hi. `annotation` is
+                            // "inclusive" (..=) or "halfopen" (..<).
+    AST_MATCH_ALT           // comma-listed alternatives in one case label
+                            // (`1, 2, 5..=9`). Each child is a selector: a
+                            // literal expression or an AST_MATCH_RANGE.
 } ASTNodeType;
 
 typedef enum {

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -444,6 +444,68 @@ static int try_emit_series_collapse(CodeGenerator* gen, ASTNode* while_node) {
     return 1;
 }
 
+/* #1047: emit the boolean condition that a case selector matches `val_var`.
+ * Handles a single value (== , or string_equals for strings), an inclusive
+ * (`lo..=hi`) / half-open (`lo..<hi`) range, and a comma-list of these (OR).
+ * Shared by match arms and the ranged-switch if-chain lowering. */
+static void emit_selector_condition(CodeGenerator* gen, ASTNode* sel,
+                                    const char* val_var, int is_string) {
+    if (!sel) { fprintf(gen->output, "0"); return; }
+    if (sel->type == AST_MATCH_ALT) {
+        fprintf(gen->output, "(");
+        for (int i = 0; i < sel->child_count; i++) {
+            if (i > 0) fprintf(gen->output, " || ");
+            emit_selector_condition(gen, sel->children[i], val_var, is_string);
+        }
+        fprintf(gen->output, ")");
+        return;
+    }
+    if (sel->type == AST_MATCH_RANGE && sel->child_count >= 2) {
+        int inclusive = sel->annotation && strcmp(sel->annotation, "inclusive") == 0;
+        fprintf(gen->output, "(%s >= ", val_var);
+        generate_expression(gen, sel->children[0]);
+        fprintf(gen->output, " && %s %s ", val_var, inclusive ? "<=" : "<");
+        generate_expression(gen, sel->children[1]);
+        fprintf(gen->output, ")");
+        return;
+    }
+    if (is_string) {
+        fprintf(gen->output, "(%s && string_equals(%s, ", val_var, val_var);
+        generate_expression(gen, sel);
+        fprintf(gen->output, "))");
+    } else {
+        fprintf(gen->output, "(%s == ", val_var);
+        generate_expression(gen, sel);
+        fprintf(gen->output, ")");
+    }
+}
+
+/* #1047: does this case selector contain a range (directly, or as an element
+ * of a comma-list)? A C `switch` can't express a range, so a switch with any
+ * ranged case is lowered to an if-else chain instead. */
+static int selector_has_range(ASTNode* sel) {
+    if (!sel) return 0;
+    if (sel->type == AST_MATCH_RANGE) return 1;
+    if (sel->type == AST_MATCH_ALT) {
+        for (int i = 0; i < sel->child_count; i++)
+            if (sel->children[i] && sel->children[i]->type == AST_MATCH_RANGE) return 1;
+    }
+    return 0;
+}
+
+/* #1047: the C type of a switch/match scrutinee, for the temp that a lowered
+ * if-chain compares against. Mirrors the match `_match_val` typing. */
+static const char* scrutinee_c_type(ASTNode* expr) {
+    Type* t = expr ? expr->node_type : NULL;
+    if (!t) return "int";
+    if (t->kind == TYPE_STRING || t->kind == TYPE_PTR) return "const char*";
+    if (t->kind == TYPE_FLOAT)      return "double";
+    if (t->kind == TYPE_LONGDOUBLE) return "long double";
+    if (t->kind == TYPE_INT64)      return "int64_t";
+    if (t->kind == TYPE_BOOL)       return "bool";
+    return "int";
+}
+
 static void generate_list_pattern_condition(CodeGenerator* gen, ASTNode* pattern,
                                             const char* len_name,
                                             int is_seq_match) {
@@ -5556,23 +5618,18 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                             print_indent(gen);
                             fprintf(gen->output, "if (");
                         }
-                        // Use _match_val (temp) instead of re-evaluating match_expr
+                        // Use _match_val (temp) instead of re-evaluating
+                        // match_expr. emit_selector_condition (#1047) handles a
+                        // single value, an inclusive/half-open range, or a
+                        // comma-list. For strings it uses string_equals (NULL
+                        // -safe, magic-aware: _match_val may be a magic
+                        // AetherString, so a raw strcmp would compare the struct
+                        // header; the NULL guard makes a NULL scrutinee match no
+                        // pattern).
                         Type* mexpr_type = match_expr->node_type;
-                        if (mexpr_type && mexpr_type->kind == TYPE_STRING) {
-                            // NULL-safe, magic-aware: _match_val may be a magic
-                            // AetherString (string ops / concat now return
-                            // magic), so a raw strcmp would compare the struct
-                            // header. string_equals dispatches on the header
-                            // (binary-safe memcmp); keep the NULL guard so a
-                            // NULL scrutinee matches no pattern.
-                            fprintf(gen->output, "_match_val && string_equals(_match_val, ");
-                            generate_expression(gen, pattern);
-                            fprintf(gen->output, ")) {\n");
-                        } else {
-                            fprintf(gen->output, "_match_val == ");
-                            generate_expression(gen, pattern);
-                            fprintf(gen->output, ") {\n");
-                        }
+                        int mexpr_is_string = mexpr_type && mexpr_type->kind == TYPE_STRING;
+                        emit_selector_condition(gen, pattern, "_match_val", mexpr_is_string);
+                        fprintf(gen->output, ") {\n");
                     }
 
                     indent(gen);
@@ -5611,32 +5668,97 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             }
             break;
 
-        case AST_SWITCH_STATEMENT:
-            fprintf(gen->output, "switch (");
-            if (stmt->child_count > 0) {
-                generate_expression(gen, stmt->children[0]);
-            }
-            fprintf(gen->output, ") {\n");
-            
-            indent(gen);
+        case AST_SWITCH_STATEMENT: {
+            // #1047: a C `switch` can't express a ranged case (`case 1..=5:`).
+            // Aether's switch has no fall-through (each case auto-breaks), so it
+            // is semantically identical to an if-else chain. When any case is
+            // ranged, lower the whole switch to an if-chain (comparing a temp
+            // scrutinee via emit_selector_condition); plain / comma-list-only
+            // switches keep the C `switch` for readable output.
+            int needs_chain = 0;
             for (int i = 1; i < stmt->child_count; i++) {
-                generate_statement(gen, stmt->children[i]);
+                ASTNode* c = stmt->children[i];
+                if (c && c->type == AST_CASE_STATEMENT && c->child_count > 0 &&
+                    !(c->value && strcmp(c->value, "default") == 0) &&
+                    selector_has_range(c->children[0])) { needs_chain = 1; break; }
+            }
+
+            if (!needs_chain) {
+                fprintf(gen->output, "switch (");
+                if (stmt->child_count > 0) generate_expression(gen, stmt->children[0]);
+                fprintf(gen->output, ") {\n");
+                indent(gen);
+                for (int i = 1; i < stmt->child_count; i++)
+                    generate_statement(gen, stmt->children[i]);
+                unindent(gen);
+                print_line(gen, "}");
+                break;
+            }
+
+            // Ranged switch -> if-else chain.
+            ASTNode* sexpr = stmt->child_count > 0 ? stmt->children[0] : NULL;
+            int is_str = sexpr && sexpr->node_type && sexpr->node_type->kind == TYPE_STRING;
+            print_line(gen, "{");
+            indent(gen);
+            print_indent(gen);
+            fprintf(gen->output, "%s _switch_val = ", scrutinee_c_type(sexpr));
+            if (sexpr) generate_expression(gen, sexpr);
+            else fprintf(gen->output, "0");
+            fprintf(gen->output, ";\n");
+
+            ASTNode* default_case = NULL;
+            int emitted = 0;
+            for (int i = 1; i < stmt->child_count; i++) {
+                ASTNode* c = stmt->children[i];
+                if (!c || c->type != AST_CASE_STATEMENT) continue;
+                int is_default = (c->value && strcmp(c->value, "default") == 0);
+                if (is_default) { default_case = c; continue; }
+                print_indent(gen);
+                fprintf(gen->output, emitted ? "else if (" : "if (");
+                emit_selector_condition(gen, c->children[0], "_switch_val", is_str);
+                fprintf(gen->output, ") {\n");
+                indent(gen);
+                for (int j = 1; j < c->child_count; j++) generate_statement(gen, c->children[j]);
+                unindent(gen);
+                print_line(gen, "}");
+                emitted = 1;
+            }
+            if (default_case) {
+                print_indent(gen);
+                fprintf(gen->output, emitted ? "else {\n" : "{\n");
+                indent(gen);
+                for (int j = 0; j < default_case->child_count; j++)
+                    generate_statement(gen, default_case->children[j]);
+                unindent(gen);
+                print_line(gen, "}");
             }
             unindent(gen);
-            
             print_line(gen, "}");
             break;
+        }
             
         case AST_CASE_STATEMENT: {
             int is_default = (stmt->value && strcmp(stmt->value, "default") == 0);
             if (is_default) {
                 print_line(gen, "default:");
             } else {
-                fprintf(gen->output, "case ");
-                if (stmt->child_count > 0) {
-                    generate_expression(gen, stmt->children[0]);
+                // #1047: a comma-list case (`case 7, 8, 9:`) lowers to one C
+                // `case` label per value, sharing the body (no fall-through in
+                // between, Aether auto-breaks after the shared body). A ranged
+                // case never reaches here (AST_SWITCH_STATEMENT diverts a switch
+                // with any range to an if-chain).
+                ASTNode* sel = stmt->child_count > 0 ? stmt->children[0] : NULL;
+                if (sel && sel->type == AST_MATCH_ALT) {
+                    for (int a = 0; a < sel->child_count; a++) {
+                        fprintf(gen->output, "case ");
+                        generate_expression(gen, sel->children[a]);
+                        fprintf(gen->output, ":\n");
+                    }
+                } else {
+                    fprintf(gen->output, "case ");
+                    if (sel) generate_expression(gen, sel);
+                    fprintf(gen->output, ":\n");
                 }
-                fprintf(gen->output, ":\n");
             }
 
             indent(gen);

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -835,6 +835,16 @@ Token* next_token() {
                     advance();
                     return create_token(TOKEN_DOTDOTDOT, "...", current_line, current_column);
                 }
+                /* #1047: `..=` inclusive and `..<` half-open range operators for
+                 * match/switch case labels. Plain `..` stays exclusive (for). */
+                if (peek() == '=') {
+                    advance();
+                    return create_token(TOKEN_DOTDOT_EQ, "..=", current_line, current_column);
+                }
+                if (peek() == '<') {
+                    advance();
+                    return create_token(TOKEN_DOTDOT_LT, "..<", current_line, current_column);
+                }
                 return create_token(TOKEN_DOTDOT, "..", current_line, current_column);
             }
             return create_token(TOKEN_DOT, ".", current_line, current_column);
@@ -964,6 +974,8 @@ const char* token_type_to_string(AeTokenType type) {
         case TOKEN_CALLBACK: return "CALLBACK";
         case TOKEN_IN: return "IN";
         case TOKEN_DOTDOT: return "DOTDOT";
+        case TOKEN_DOTDOT_EQ: return "DOTDOT_EQ";
+        case TOKEN_DOTDOT_LT: return "DOTDOT_LT";
         case TOKEN_DOTDOTDOT: return "DOTDOTDOT";
         case TOKEN_CONST: return "CONST";
         case TOKEN_TRY: return "TRY";

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -2910,6 +2910,49 @@ ASTNode* parse_switch_statement(Parser* parser) {
     return switch_stmt;
 }
 
+// #1047: parse one match/switch case selector element: a single value, or a
+// range `lo..=hi` (inclusive) / `lo..<hi` (half-open). Returns the bare value
+// expression, or an AST_MATCH_RANGE with children [lo, hi] and annotation
+// "inclusive"/"halfopen".
+static ASTNode* parse_one_selector(Parser* parser) {
+    ASTNode* lo = parse_expression(parser);
+    if (!lo) return NULL;
+    Token* t = peek_token(parser);
+    if (t && (t->type == TOKEN_DOTDOT_EQ || t->type == TOKEN_DOTDOT_LT)) {
+        int inclusive = (t->type == TOKEN_DOTDOT_EQ);
+        advance_token(parser);  // consume ..= / ..<
+        ASTNode* hi = parse_expression(parser);
+        if (!hi) return NULL;
+        ASTNode* range = create_ast_node(AST_MATCH_RANGE, NULL, lo->line, lo->column);
+        range->annotation = strdup(inclusive ? "inclusive" : "halfopen");
+        add_child(range, lo);
+        add_child(range, hi);
+        return range;
+    }
+    return lo;
+}
+
+// #1047: parse a full case selector: one element, or a comma-list of elements
+// (`1, 2, 5..=9`). A single element returns bare (backward compatible); a list
+// returns an AST_MATCH_ALT whose children are the elements. Stops at the arm
+// terminator (`->` / `:`), so the arm-separator comma is untouched.
+static ASTNode* parse_case_selector(Parser* parser) {
+    ASTNode* first = parse_one_selector(parser);
+    if (!first) return NULL;
+    if (!peek_token(parser) || peek_token(parser)->type != TOKEN_COMMA) {
+        return first;  // single value / single range
+    }
+    ASTNode* alt = create_ast_node(AST_MATCH_ALT, NULL, first->line, first->column);
+    add_child(alt, first);
+    while (peek_token(parser) && peek_token(parser)->type == TOKEN_COMMA) {
+        advance_token(parser);  // consume ','
+        ASTNode* nxt = parse_one_selector(parser);
+        if (!nxt) return NULL;
+        add_child(alt, nxt);
+    }
+    return alt;
+}
+
 ASTNode* parse_case_statement(Parser* parser) {
     if (match_token(parser, TOKEN_DEFAULT)) {
         if (!expect_token(parser, TOKEN_COLON)) return NULL;
@@ -2940,7 +2983,7 @@ ASTNode* parse_case_statement(Parser* parser) {
     }
     
     if (match_token(parser, TOKEN_CASE)) {
-        ASTNode* value = parse_expression(parser);
+        ASTNode* value = parse_case_selector(parser);  // #1047: value / range / comma-list
         if (!value) return NULL;
         if (!expect_token(parser, TOKEN_COLON)) return NULL;
         
@@ -3059,7 +3102,9 @@ ASTNode* parse_match_case(Parser* parser) {
     } else {
         // Expression pattern (literal, identifier, etc.) — includes the
         // `none` arm, which parse_expression yields as AST_NONE_LITERAL.
-        pattern = parse_expression(parser);
+        // #1047: also accepts a range (`lo..=hi` / `lo..<hi`) and a comma-list
+        // of values/ranges in one arm.
+        pattern = parse_case_selector(parser);
         if (!pattern) return NULL;
     }
     

--- a/compiler/parser/tokens.h
+++ b/compiler/parser/tokens.h
@@ -111,7 +111,9 @@ typedef enum {
     TOKEN_XOR_ASSIGN,       // '^='
     TOKEN_LSHIFT_ASSIGN,    // '<<='
     TOKEN_RSHIFT_ASSIGN,    // '>>='
-    TOKEN_DOTDOT,           // '..' range operator
+    TOKEN_DOTDOT,           // '..' range operator (exclusive, as in `for i in 0..5`)
+    TOKEN_DOTDOT_EQ,        // '..=' inclusive range in match/switch case labels (#1047)
+    TOKEN_DOTDOT_LT,        // '..<' half-open range in match/switch case labels (#1047)
     TOKEN_DOTDOTDOT,        // '...' varargs marker (extern only, v1)
 
     // Delimiters

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -700,6 +700,41 @@ match (command) {
 }
 ```
 
+### Ranged and multi-value cases
+
+A `match` arm (and a `switch` case) can match a **range** of ordinal values or a
+**comma-separated list** of values and ranges, instead of a single literal:
+
+```aether
+grade = match score {
+    90..=100   -> "A"     // ..= inclusive:  90 through 100
+    80..<90    -> "B"     // ..< half-open:  80 through 89 (excludes 90)
+    70..<80    -> "C"
+    60, 61, 62 -> "D"     // comma-list of values
+    _          -> "F"
+}
+```
+
+- `..=` is an **inclusive** range (both ends match); `..<` is **half-open**
+  (the high end is excluded), consistent with the exclusive `for i in 0..5`.
+- Comma-separated elements in one arm match if **any** of them matches, and each
+  element may itself be a value or a range: `97..=122, 65..=90 -> "letter"`.
+- Ranges are over integer ordinals (`int`, `long`, `byte`). Aether has no
+  character literals, so a character class matches the byte's integer value,
+  e.g. from `string.char_at`:
+
+```aether
+kind = match string.char_at(s, i) {
+    97..=122, 65..=90 -> "letter"   // a-z, A-Z
+    48..=57           -> "digit"    // 0-9
+    _                 -> "other"
+}
+```
+
+A ranged arm lowers to a plain comparison (`x >= lo && x <= hi`) in the branch
+chain, with no runtime support and no allocation. Existing single-literal arms
+are unaffected.
+
 ### List Pattern Matching
 
 Arrays can be matched with list patterns. Requires a corresponding `_len` variable:
@@ -756,11 +791,27 @@ switch (month) {
 }
 ```
 
+Aether's `switch` has **no fall-through**: each case auto-breaks after its body.
+Cases also accept comma-lists and ranges, the same as `match` arms:
+
+```aether
+switch code {
+case 200, 201, 204: kind = "success";
+case 300..<400:     kind = "redirect";   // ranged case (lowered to an if-chain)
+case 400..<500:     kind = "client-error";
+default:            kind = "other";
+}
+```
+
+A comma-list case lowers to several C `case` labels sharing one body; a `switch`
+containing any ranged case is lowered to an equivalent if-else chain (safe
+because there is no fall-through to preserve).
+
 ### Switch vs Match
 
 | Feature | `switch` | `match` |
 |---------|----------|---------|
-| Pattern types | Integer/string literals | Literals, lists, wildcards |
+| Pattern types | Literals, ranges, comma-lists | Literals, ranges, comma-lists, lists, wildcards |
 | Binding | No | Yes (captures variables) |
 | Use case | Simple dispatch | Pattern destructuring |
 

--- a/tests/regression/test_ranged_match_cases.ae
+++ b/tests/regression/test_ranged_match_cases.ae
@@ -1,0 +1,92 @@
+// Regression: #1047 ranged and multi-value match/switch cases.
+//   ..=  inclusive range      ..<  half-open range
+//   comma-listed values/ranges in one arm
+// Aether has no char literals, so ranges are over integer ordinals (an int
+// from string.char_at, a byte, etc.). Boundaries are checked explicitly:
+// inclusive includes the high end, half-open excludes it.
+import std.io
+
+// match as an expression (assigned), inclusive + half-open + multi-value.
+grade(s: int) -> string {
+    g = match s {
+        90..=100   -> "A"
+        80..<90    -> "B"
+        70..<80    -> "C"
+        60, 61, 62 -> "D"
+        _          -> "F"
+    }
+    return g
+}
+
+// match on a byte value (int code), comma-listed ranges in one arm.
+classify(ch: int) -> string {
+    c = match ch {
+        97..=122, 65..=90 -> "letter"
+        48..=57           -> "digit"
+        _                 -> "other"
+    }
+    return c
+}
+
+// C-style switch: multi-value labels + ranged cases (lowered to an if-chain).
+bucket(n: int) -> string {
+    r = "other"
+    switch n {
+    case 1, 2, 3:
+        r = "low"
+    case 10..=20:
+        r = "mid"
+    case 30..<40:
+        r = "high"
+    default:
+        r = "other"
+    }
+    return r
+}
+
+check(got: string, want: string, label: string) -> int {
+    if got != want {
+        println("FAIL ${label}: got ${got} want ${want}")
+        return 1
+    }
+    return 0
+}
+
+main() {
+    var fails = 0
+
+    // inclusive boundaries: 90 and 100 are A; 89 is B; 101 is F.
+    fails = fails + check(grade(90), "A", "grade 90 lo-incl")
+    fails = fails + check(grade(100), "A", "grade 100 hi-incl")
+    fails = fails + check(grade(101), "F", "grade 101 over")
+    // half-open: 80..<90 includes 80 and 89 but NOT 90 (that is A).
+    fails = fails + check(grade(89), "B", "grade 89 hi-halfopen")
+    fails = fails + check(grade(80), "B", "grade 80 lo")
+    fails = fails + check(grade(72), "C", "grade 72")
+    // comma-list
+    fails = fails + check(grade(61), "D", "grade 61 multi")
+    fails = fails + check(grade(63), "F", "grade 63 gap")
+    fails = fails + check(grade(40), "F", "grade 40 wild")
+
+    // char-class via int codes, comma-listed ranges
+    fails = fails + check(classify(109), "letter", "classify m")   // 'm'
+    fails = fails + check(classify(66), "letter", "classify B")    // 'B'
+    fails = fails + check(classify(52), "digit", "classify 4")     // '4'
+    fails = fails + check(classify(36), "other", "classify $")     // '$'
+
+    // switch
+    fails = fails + check(bucket(2), "low", "bucket multi")
+    fails = fails + check(bucket(10), "mid", "bucket incl-lo")
+    fails = fails + check(bucket(20), "mid", "bucket incl-hi")
+    fails = fails + check(bucket(30), "high", "bucket halfopen-lo")
+    fails = fails + check(bucket(39), "high", "bucket halfopen-hi")
+    fails = fails + check(bucket(40), "other", "bucket halfopen-excl")
+    fails = fails + check(bucket(99), "other", "bucket default")
+
+    if fails == 0 {
+        println("PASS: ranged_match_cases")
+    } else {
+        println("FAILED: ${fails}")
+        exit(1)
+    }
+}


### PR DESCRIPTION
## Summary

A `match` arm or `switch` case can now be an **inclusive range** `lo..=hi`, a **half-open range** `lo..<hi`, or a **comma-list** of values and ranges in one arm, instead of a single literal. Purely additive: existing single-literal cases are unaffected.

```aether
grade = match score {
    90..=100   -> "A"     // ..= inclusive:  90 through 100
    80..<90    -> "B"     // ..< half-open:  80 through 89
    60, 61, 62 -> "D"     // comma-list
    _          -> "F"
}

switch code {
case 200, 201, 204: kind = "success";
case 300..<400:     kind = "redirect";   // ranged case
default:            kind = "other";
}
```

Closes #1047 (Odin comparison, Tier 1). `..=` is inclusive, `..<` is half-open (consistent with the exclusive `for i in 0..5`).

## Implementation

- **Lexer**: new `..=` (`TOKEN_DOTDOT_EQ`) and `..<` (`TOKEN_DOTDOT_LT`) operators; plain `..` stays exclusive.
- **AST**: two new node types, appended at the end of the node enum: `AST_MATCH_RANGE` (children `[lo, hi]`, `annotation` = `inclusive`/`halfopen`) and `AST_MATCH_ALT` (comma-list; each child is a value or a range).
- **Parser**: a shared `parse_case_selector` helper feeds both `parse_match_case` and `parse_case_statement`, so `match` and `switch` get the feature from one place. A single value still parses to a bare literal (backward compatible).
- **Codegen**: a ranged/multi arm lowers to a plain comparison chain via a shared `emit_selector_condition` (`x >= lo && x <= hi` inclusive, `x >= lo && x < hi` half-open, OR across a comma-list) with no runtime and no allocation. `match` already emits an if-chain, so ranges slot in directly. A C `switch` cannot express a range, and Aether's `switch` has **no fall-through**, so a comma-list lowers to several `case` labels sharing a body, and a switch containing any range is lowered to an equivalent if-else chain (semantically identical because there is no fall-through to preserve).

Ranges are over integer ordinals (`int`/`long`/`byte`). Aether has no character literals, so a character class uses the byte's integer value (e.g. from `string.char_at`), documented in the language reference.

## Verification

- New `tests/regression/test_ranged_match_cases.ae`: inclusive vs half-open **boundary** checks (90 and 100 match `90..=100`; 89 matches `80..<90` but 90 does not), comma-lists, match-as-expression, and `switch` multi-value + ranged cases. Self-asserting, exits 0.
- Emitted C confirmed: `(_match_val >= 90 && _match_val <= 100)`, half-open `< 90`, multi-value `((_match_val == 60) || (_match_val == 61) || ...)`.
- Gates: `make clean` build; unit **231**; examples **87/87**; `.ae` suite **823/823** (new test passes, **zero regressions** across all existing match/switch tests); `-Werror -Wall -Wextra` clean on the changed files.

Closes #1047