### PR TITLE
feat: first-class enum types + enum-backed bit_set (#1044, #1046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **First-class `enum` types and enum-backed `bit_set` masks** (#1044, #1046).
+  Aether gains a real `enum` type — `enum Perm { Read, Write, Exec }` — lowering
+  to a C `int` and usable as a first-class value everywhere: variable
+  declarations (`Perm p = .Write`), function params and return types, struct
+  fields, `==` comparison, and `match` arms (`match p { Write -> ... }`), with
+  implicit selector syntax (`.Read`) wherever the enum type is known. On top of
+  it, `type Mask = bit_set[Perm]` gives an integer-backed set: literals use
+  enum members (`{ .Read, .Write }`) and lower to a `uint64_t` mask; `+`/`-`
+  and `+=`/`-=` are union/difference, `in`/`not_in` test membership,
+  `<`/`<=`/`>`/`>=` are strict/non-strict subset checks, and `card(mask)`
+  lowers to a popcount (a user-defined `card` function of your own is
+  unaffected). Zero runtime cost — an enum is an int, a bit_set is a uint64_t.
+  A `bit_set` over an enum with more than 64 members is a compile error (the
+  fixed 64-bit backing can't hold it); duplicate enum members are rejected.
+  V1 uses a fixed 64-bit backing width and implicit `0..N` member values;
+  explicit smaller widths (`bit_set[Perm; u16]`) and explicit member values
+  (`enum E { A = 5 }`) remain follow-ups. The first natural consumer is
+  capability/flag code (`std.capsicum`'s `R_*`/`F_*` masks) that currently
+  hand-rolls `0x0001`-style const blocks.
+
 ## [0.366.0]
 
 ### Added

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -548,6 +548,8 @@ static const char* type_name(Type* t) {
         case TYPE_MESSAGE:  return "message";
         case TYPE_ARRAY:    return "array";
         case TYPE_STRUCT:   return t->struct_name ? t->struct_name : "struct";
+        case TYPE_ENUM:     return t->struct_name ? t->struct_name : "enum";
+        case TYPE_BITSET:   return t->struct_name ? t->struct_name : "bit_set";
         case TYPE_FUNCTION:  return "closure";
         case TYPE_TUPLE:    return "tuple";
         case TYPE_OPTIONAL: return "optional";   // #340
@@ -572,6 +574,44 @@ static TypeKind wider_integer_kind(TypeKind a, TypeKind b) {
     if (a == TYPE_INT64 || b == TYPE_INT64) return TYPE_INT64;
     /* uint32/16/8 all fit int's value range for arithmetic. */
     return TYPE_INT;
+}
+
+static ASTNode* find_enum_def(SymbolTable* table, const char* enum_name) {
+    if (!enum_name) return NULL;
+    Symbol* sym = lookup_symbol(table, enum_name);
+    if (sym && sym->node && sym->node->type == AST_ENUM_DEF) return sym->node;
+    return NULL;
+}
+
+static ASTNode* find_enum_member(SymbolTable* table, const char* member,
+                                 const char** enum_name, int* index) {
+    if (!member) return NULL;
+    for (SymbolTable* scope = table; scope; scope = scope->parent) {
+        for (Symbol* s = scope->symbols; s; s = s->next) {
+            if (!s->node || s->node->type != AST_ENUM_DEF) continue;
+            for (int i = 0; i < s->node->child_count; i++) {
+                ASTNode* m = s->node->children[i];
+                if (m && m->value && strcmp(m->value, member) == 0) {
+                    if (enum_name) *enum_name = s->node->value;
+                    if (index) *index = i;
+                    return s->node;
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
+static int enum_has_member(ASTNode* enum_def, const char* member, int* index) {
+    if (!enum_def || !member) return 0;
+    for (int i = 0; i < enum_def->child_count; i++) {
+        ASTNode* m = enum_def->children[i];
+        if (m && m->value && strcmp(m->value, member) == 0) {
+            if (index) *index = i;
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /* #697: downward integer-width propagation.
@@ -1096,6 +1136,24 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
         case AST_LITERAL:
             return clone_type(expr->node_type);
 
+        case AST_ENUM_VALUE: {
+            const char* enum_name = NULL;
+            int idx = -1;
+            if (expr->node_type && expr->node_type->kind == TYPE_ENUM) {
+                return clone_type(expr->node_type);
+            }
+            if (find_enum_member(table, expr->value, &enum_name, &idx) && enum_name) {
+                Type* t = create_type(TYPE_ENUM);
+                t->struct_name = strdup(enum_name);
+                return t;
+            }
+            return create_type(TYPE_UNKNOWN);
+        }
+
+        case AST_BITSET_LITERAL:
+            return expr->node_type ? clone_type(expr->node_type)
+                                   : create_type(TYPE_UNKNOWN);
+
         case AST_NONE_LITERAL:
             // `none` — optional with as-yet-unknown inner; context pins the
             // concrete T (assignment / `??` / `==`). If already pinned, use it.
@@ -1381,6 +1439,15 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
              * than from a fixed symbol type. isolate(x) : Isolated[typeof x];
              * consume(iso) : the wrapped T (when iso is Isolated[T]). */
             if (expr->value && expr->child_count == 1) {
+                /* card(bit_set) popcount → int, but only when `card` isn't a
+                 * user function (which would shadow the builtin, #1046). */
+                if (strcmp(expr->value, "card") == 0 &&
+                    !lookup_symbol(table, "card")) {
+                    Type* a = infer_type(expr->children[0], table);
+                    int bs = (a && a->kind == TYPE_BITSET);
+                    if (a) free_type(a);
+                    if (bs) return create_type(TYPE_INT);
+                }
                 if (strcmp(expr->value, "isolate") == 0) {
                     Type* inner = infer_type(expr->children[0], table);
                     Type* iso = create_type(TYPE_ISOLATED);
@@ -1595,6 +1662,8 @@ Type* infer_binary_type(ASTNode* left, ASTNode* right, AeTokenType operator) {
         case TOKEN_LESS_EQUAL:
         case TOKEN_GREATER:
         case TOKEN_GREATER_EQUAL:
+        case TOKEN_IN:
+        case TOKEN_NOT_IN:
         case TOKEN_AND:
         case TOKEN_OR:
             return create_type(TYPE_BOOL);
@@ -1607,6 +1676,12 @@ Type* infer_binary_type(ASTNode* left, ASTNode* right, AeTokenType operator) {
     switch (operator) {
         case TOKEN_PLUS:
         case TOKEN_MINUS:
+            if (left_type->kind == TYPE_BITSET && right_type->kind == TYPE_BITSET &&
+                types_equal(left_type, right_type)) {
+                return clone_type(left_type);
+            }
+            // Fall through for non-bitset arithmetic.
+            /* FALLTHROUGH */
         case TOKEN_MULTIPLY:
         case TOKEN_DIVIDE:
         case TOKEN_MODULO:
@@ -1786,6 +1861,8 @@ AeTokenType get_token_type_from_string(const char* str) {
     if (strcmp(str, ">=") == 0) return TOKEN_GREATER_EQUAL;
     if (strcmp(str, "&&") == 0) return TOKEN_AND;
     if (strcmp(str, "||") == 0) return TOKEN_OR;
+    if (strcmp(str, "in") == 0) return TOKEN_IN;
+    if (strcmp(str, "not_in") == 0) return TOKEN_NOT_IN;
     if (strcmp(str, "=") == 0) return TOKEN_ASSIGN;
     if (strcmp(str, "!") == 0) return TOKEN_NOT;
     if (strcmp(str, "++") == 0) return TOKEN_INCREMENT;
@@ -2046,6 +2123,14 @@ static void resolve_distinct_types(ASTNode* program);
 // #914: resolve `type Name = A | B | C` references into TYPE_SUM.
 static void resolve_sum_types(ASTNode* program);
 static void sum_apply(Type* t, ASTNode* def);   // fill TYPE_SUM variant Types
+// #1046: resolve `type Name = bit_set[Enum]` references into TYPE_BITSET.
+static void resolve_bitset_types(ASTNode* program);
+static int pin_bitset_literal(ASTNode* lit, Type* bitset_type,
+                              SymbolTable* table);
+// #1044: rewrite bare TYPE_STRUCT{Name} use-sites into TYPE_ENUM when Name
+// is a declared enum, so enums work as first-class values (variable
+// declarations, params, struct fields, returns).
+static void resolve_enum_types(ASTNode* program);
 
 // #891: typecheck-time registry of @c_struct overlay names. Codegen has its
 // own field-level registry; the typechecker only needs the NAME set so an
@@ -2138,6 +2223,16 @@ int typecheck_program(ASTNode* program) {
     // TYPE_STRUCT{Name} use-sites into the real TYPE_SUM. Runs after distinct
     // resolution (a name is one or the other) and before any type-checking.
     resolve_sum_types(program);
+
+    // #1046: resolve `type Name = bit_set[Enum]` references.
+    resolve_bitset_types(program);
+
+    // #1044: rewrite bare TYPE_STRUCT{EnumName} annotations to TYPE_ENUM so
+    // enums are usable as first-class values. After bitset resolution (whose
+    // alias element is the enum name as a plain string, unaffected) and
+    // before type-checking, so every slot type agrees with the TYPE_ENUM a
+    // `.Member` value carries.
+    resolve_enum_types(program);
 
     // #891: collect @c_struct overlay names so `expr as *Name` casts and
     // member access typecheck against them (they have no struct symbol —
@@ -2423,6 +2518,46 @@ int typecheck_program(ASTNode* program) {
                 add_symbol(global_table, child->value, sum_type, 0, 0, 0);
                 Symbol* sum_sym = lookup_symbol(global_table, child->value);
                 if (sum_sym) sum_sym->node = child;
+                break;
+            }
+            case AST_ENUM_DEF: {
+                /* #1046: reject duplicate member names — a second `A` gets a
+                 * distinct index that find/has-member can never reach (its bit
+                 * is unsettable), so it's always a mistake. */
+                for (int mi = 0; mi < child->child_count; mi++) {
+                    ASTNode* ma = child->children[mi];
+                    if (!ma || !ma->value) continue;
+                    for (int mj = mi + 1; mj < child->child_count; mj++) {
+                        ASTNode* mb = child->children[mj];
+                        if (mb && mb->value && strcmp(ma->value, mb->value) == 0) {
+                            char msg[256];
+                            snprintf(msg, sizeof(msg),
+                                "duplicate member '%s' in enum '%s'",
+                                mb->value, child->value);
+                            type_error(msg, mb->line, mb->column);
+                        }
+                    }
+                }
+                Type* enum_type = create_type(TYPE_ENUM);
+                enum_type->struct_name = strdup(child->value);
+                add_symbol(global_table, child->value, enum_type, 0, 0, 0);
+                Symbol* enum_sym = lookup_symbol(global_table, child->value);
+                if (enum_sym) enum_sym->node = child;
+                break;
+            }
+            case AST_BITSET_TYPE_DEF: {
+                Type* bitset_type = child->node_type
+                                   ? clone_type(child->node_type)
+                                   : create_type(TYPE_BITSET);
+                if (!bitset_type->struct_name && child->value) {
+                    bitset_type->struct_name = strdup(child->value);
+                }
+                /* #1046 >64-member width guard lives in resolve_bitset_types
+                 * (a dedicated pass, so it's order-independent of where the
+                 * enum is declared relative to the bit_set alias). */
+                add_symbol(global_table, child->value, bitset_type, 0, 0, 0);
+                Symbol* bitset_sym = lookup_symbol(global_table, child->value);
+                if (bitset_sym) bitset_sym->node = child;
                 break;
             }
             case AST_MESSAGE_DEFINITION: {
@@ -2868,6 +3003,21 @@ int typecheck_node(ASTNode* node, SymbolTable* table) {
                         node->value ? node->value : "?", v->value);
                     type_error(msg, v->line, v->column);
                 }
+            }
+            return 1;
+        }
+        case AST_ENUM_DEF:
+            return 1;
+        case AST_BITSET_TYPE_DEF: {
+            if (!node->node_type || node->node_type->kind != TYPE_BITSET ||
+                !node->node_type->element_type ||
+                !find_enum_def(table, node->node_type->element_type->struct_name)) {
+                char msg[256];
+                snprintf(msg, sizeof(msg),
+                         "bit_set type '%s' must name an existing enum",
+                         node->value ? node->value : "?");
+                type_error(msg, node->line, node->column);
+                return 0;
             }
             return 1;
         }
@@ -3804,6 +3954,166 @@ static void resolve_sum_types(ASTNode* program) {
     sum_rewrite_ast(program, defs, ndefs);
 }
 
+// #1046 bit_set aliases. `type Mask = bit_set[Perm]` parses to
+// AST_BITSET_TYPE_DEF and use-sites parse as TYPE_STRUCT{Mask}; rewrite them
+// to TYPE_BITSET whose struct_name is the alias and whose element_type names
+// the enum. V1 always lowers to uint64_t.
+#define AETHER_MAX_BITSETS 256
+typedef struct { const char* name; const char* enum_name; } BitsetDef;
+
+static void bitset_apply(Type* t, BitsetDef* def) {
+    char* alias = strdup(def->name);
+    if (t->struct_name) free(t->struct_name);
+    t->kind = TYPE_BITSET;
+    t->struct_name = alias;
+    if (t->element_type) free_type(t->element_type);
+    t->element_type = create_type(TYPE_ENUM);
+    t->element_type->struct_name = strdup(def->enum_name);
+}
+
+static void bitset_rewrite_type(Type* t, BitsetDef* defs, int ndefs, int depth) {
+    if (!t || depth > 64) return;
+    if (t->kind == TYPE_STRUCT && t->struct_name && !t->distinct_name) {
+        for (int i = 0; i < ndefs; i++) {
+            if (strcmp(t->struct_name, defs[i].name) == 0) {
+                bitset_apply(t, &defs[i]);
+                break;
+            }
+        }
+    }
+    bitset_rewrite_type(t->element_type, defs, ndefs, depth + 1);
+    bitset_rewrite_type(t->return_type, defs, ndefs, depth + 1);
+    for (int i = 0; i < t->tuple_count; i++)
+        if (t->tuple_types) bitset_rewrite_type(t->tuple_types[i], defs, ndefs, depth + 1);
+    for (int i = 0; i < t->param_count; i++)
+        if (t->param_types) bitset_rewrite_type(t->param_types[i], defs, ndefs, depth + 1);
+}
+
+static void bitset_rewrite_ast(ASTNode* n, BitsetDef* defs, int ndefs) {
+    if (!n) return;
+    if (n->node_type) bitset_rewrite_type(n->node_type, defs, ndefs, 0);
+    for (int i = 0; i < n->child_count; i++)
+        bitset_rewrite_ast(n->children[i], defs, ndefs);
+}
+
+static void resolve_bitset_types(ASTNode* program) {
+    if (!program) return;
+    BitsetDef defs[AETHER_MAX_BITSETS];
+    int ndefs = 0;
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* c = program->children[i];
+        if (c && c->type == AST_BITSET_TYPE_DEF && c->value && c->node_type &&
+            c->node_type->kind == TYPE_BITSET && c->node_type->element_type &&
+            c->node_type->element_type->struct_name && ndefs < AETHER_MAX_BITSETS) {
+            defs[ndefs].name = c->value;
+            defs[ndefs].enum_name = c->node_type->element_type->struct_name;
+            ndefs++;
+
+            /* #1046 width guard: the backing is one uint64_t, so an enum with
+             * >64 members overflows — index 64+ shifts past the type width
+             * (UB + a -Wshift-count-overflow that fails -Werror CI). Reject
+             * here, order-independent of where the enum is declared. Find the
+             * enum def by scanning the program (no symbol table in this
+             * pass). Explicit backing widths are a follow-up. */
+            for (int j = 0; j < program->child_count; j++) {
+                ASTNode* e = program->children[j];
+                if (e && e->type == AST_ENUM_DEF && e->value &&
+                    strcmp(e->value, c->node_type->element_type->struct_name) == 0 &&
+                    e->child_count > 64) {
+                    char msg[256];
+                    snprintf(msg, sizeof(msg),
+                        "bit_set enum '%s' has %d members; the 64-bit backing "
+                        "supports at most 64", e->value, e->child_count);
+                    type_error(msg, c->line, c->column);
+                    break;
+                }
+            }
+        }
+    }
+    if (ndefs == 0) return;
+    bitset_rewrite_ast(program, defs, ndefs);
+}
+
+/* #1044: make enums first-class values. The parser lowers every bare
+ * named-type annotation (`c: Color`, `Color c = ...`, `-> Color`, a
+ * `Color` struct field) to TYPE_STRUCT{Color}, since it can't yet know
+ * Color is an enum. This pass — mirroring resolve_bitset_types — collects
+ * the declared enum names and rewrites those TYPE_STRUCT use-sites to
+ * TYPE_ENUM, so the slot type matches the TYPE_ENUM that a `.Member`
+ * value already carries (no more "type mismatch in initialization"), and
+ * codegen emits the enum's C type (int) rather than an undeclared
+ * `Color`. Runs after sum/distinct/bitset resolution (a name is exactly
+ * one of these) and before any type-checking. */
+#define AETHER_MAX_ENUMS 512
+typedef struct { const char* name; ASTNode* def; } EnumDefRef;
+
+static void enum_rewrite_type(Type* t, EnumDefRef* defs, int n, int depth) {
+    if (!t || depth > 16) return;
+    if (t->kind == TYPE_STRUCT && t->struct_name) {
+        for (int i = 0; i < n; i++) {
+            if (strcmp(t->struct_name, defs[i].name) == 0) {
+                t->kind = TYPE_ENUM;   /* struct_name stays = the enum name */
+                break;
+            }
+        }
+    }
+    enum_rewrite_type(t->element_type, defs, n, depth + 1);
+    enum_rewrite_type(t->return_type, defs, n, depth + 1);
+    for (int i = 0; i < t->tuple_count; i++)
+        enum_rewrite_type(t->tuple_types ? t->tuple_types[i] : NULL, defs, n, depth + 1);
+    for (int i = 0; i < t->param_count; i++)
+        enum_rewrite_type(t->param_types ? t->param_types[i] : NULL, defs, n, depth + 1);
+}
+
+/* Member index of `member` in enum `def`, or -1. */
+static int enum_def_member_index(ASTNode* def, const char* member) {
+    if (!def || !member) return -1;
+    for (int i = 0; i < def->child_count; i++) {
+        ASTNode* m = def->children[i];
+        if (m && m->value && strcmp(m->value, member) == 0) return i;
+    }
+    return -1;
+}
+
+static void enum_rewrite_ast(ASTNode* node, EnumDefRef* defs, int n) {
+    if (!node) return;
+    if (node->node_type) enum_rewrite_type(node->node_type, defs, n, 0);
+    /* Stamp every `.Member` value node with its integer index, resolved
+     * from the enum registry by name. Doing it here — not in a later
+     * typecheck pass — guarantees the index is present in EVERY position
+     * (return expressions, nested block bodies, tuple elements), not just
+     * the paths a given typecheck route happens to visit. Codegen reads
+     * `bit_width` for the emitted integer (#1044). A `.Member` whose node
+     * already carries a resolved index (from the bitset-literal path) is
+     * left alone; only an unresolved one (bit_width < 0 or the name maps
+     * to an index under some declared enum) is stamped. When exactly one
+     * enum defines the member, resolution is unambiguous. */
+    if (node->type == AST_ENUM_VALUE && node->value && node->bit_width < 0) {
+        for (int i = 0; i < n; i++) {
+            int idx = enum_def_member_index(defs[i].def, node->value);
+            if (idx >= 0) { node->bit_width = idx; break; }
+        }
+    }
+    for (int i = 0; i < node->child_count; i++)
+        enum_rewrite_ast(node->children[i], defs, n);
+}
+
+static void resolve_enum_types(ASTNode* program) {
+    if (!program) return;
+    EnumDefRef defs[AETHER_MAX_ENUMS];
+    int ndefs = 0;
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* c = program->children[i];
+        if (c && c->type == AST_ENUM_DEF && c->value && ndefs < AETHER_MAX_ENUMS) {
+            defs[ndefs].name = c->value;
+            defs[ndefs].def = c;
+            ndefs++;
+        }
+    }
+    if (ndefs == 0) return;
+    enum_rewrite_ast(program, defs, ndefs);
+}
+
 /* Fold every `__pure(fn)` node in the tree to a `true`/`false` bool literal. */
 static void resolve_purity_queries(ASTNode* node, ASTNode* program,
                                    const char** globals, int nglobals) {
@@ -4015,6 +4325,52 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 }
                 Type* init_type = infer_type(init, table);
 
+                Symbol* existing = stmt->value ? lookup_symbol(table, stmt->value) : NULL;
+                Type* bitset_target =
+                    (stmt->node_type && stmt->node_type->kind == TYPE_BITSET)
+                        ? stmt->node_type
+                        : ((existing && existing->type && existing->type->kind == TYPE_BITSET)
+                            ? existing->type : NULL);
+                if (init->type == AST_BITSET_LITERAL && bitset_target) {
+                    ASTNode* enum_def = bitset_target->element_type
+                                      ? find_enum_def(table, bitset_target->element_type->struct_name)
+                                      : NULL;
+                    int ok = 1;
+                    for (int bi = 0; bi < init->child_count; bi++) {
+                        ASTNode* item = init->children[bi];
+                        int member_idx = -1;
+                        if (!item || item->type != AST_ENUM_VALUE ||
+                            !enum_has_member(enum_def, item->value, &member_idx)) {
+                            ok = 0;
+                            char msg[256];
+                            snprintf(msg, sizeof(msg),
+                                     "bit_set literal member '.%s' is not in enum '%s'",
+                                     item && item->value ? item->value : "?",
+                                     bitset_target->element_type &&
+                                     bitset_target->element_type->struct_name
+                                         ? bitset_target->element_type->struct_name : "?");
+                            type_error(msg, init->line, init->column);
+                            break;
+                        }
+                        if (item->node_type) free_type(item->node_type);
+                        item->node_type = bitset_target->element_type
+                                        ? clone_type(bitset_target->element_type)
+                                        : create_type(TYPE_ENUM);
+                        if (item->annotation) free(item->annotation);
+                        item->annotation = bitset_target->element_type &&
+                                           bitset_target->element_type->struct_name
+                                         ? strdup(bitset_target->element_type->struct_name)
+                                         : NULL;
+                        item->bit_width = member_idx;
+                    }
+                    if (ok) {
+                        if (init->node_type) free_type(init->node_type);
+                        init->node_type = clone_type(bitset_target);
+                        if (init_type) free_type(init_type);
+                        init_type = clone_type(bitset_target);
+                    }
+                }
+
                 /* `const` is substitution-at-each-use: the compiler
                  * inlines the RHS expression at every reference. That
                  * works for literals but is silently wrong for
@@ -4075,7 +4431,6 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                  * binding is byte-typed, run the literal-range check
                  * before stmt->node_type gets overwritten with the int
                  * init type below. */
-                Symbol* existing = stmt->value ? lookup_symbol(table, stmt->value) : NULL;
                 if (existing && existing->type && existing->type->kind == TYPE_BYTE &&
                     byte_assignment_literal_out_of_range(init)) {
                     char msg[256];
@@ -4402,7 +4757,22 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 }
                 ASTNode* rhs = stmt->children[1];
                 typecheck_expression(rhs, table);
-                { Type* _t = infer_type(rhs, table); free_type(_t); }
+                Type* rhs_type = infer_type(rhs, table);
+                if (symbol->type && symbol->type->kind == TYPE_BITSET &&
+                    rhs && rhs->type == AST_BITSET_LITERAL) {
+                    pin_bitset_literal(rhs, symbol->type, table);
+                    if (rhs_type) free_type(rhs_type);
+                    rhs_type = clone_type(symbol->type);
+                }
+                if (symbol->type && symbol->type->kind == TYPE_BITSET &&
+                    (!rhs_type || rhs_type->kind != TYPE_BITSET ||
+                     !types_equal(symbol->type, rhs_type))) {
+                    type_error("bit_set compound assignment requires a matching bit_set RHS",
+                               stmt->line, stmt->column);
+                    if (rhs_type) free_type(rhs_type);
+                    return 0;
+                }
+                if (rhs_type) free_type(rhs_type);
                 if (stmt->node_type && stmt->node_type->kind == TYPE_UNKNOWN && symbol->type) {
                     free_type(stmt->node_type);
                     stmt->node_type = clone_type(symbol->type);
@@ -4753,6 +5123,41 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 element_type = create_type(TYPE_INT);
             }
 
+            /* #1044 match-on-enum: when the scrutinee is an enum, a bare
+             * identifier pattern (`Green ->`) names a member, not a
+             * variable. Rewrite it in place to an AST_ENUM_VALUE carrying
+             * the member index, so the existing enum-value typecheck/codegen
+             * (which emit the integer) apply and no undeclared C identifier
+             * leaks out. An unknown bare name under an enum scrutinee is a
+             * hard error rather than a silent capture. */
+            if (match_expr_type && match_expr_type->kind == TYPE_ENUM &&
+                match_expr_type->struct_name) {
+                ASTNode* enum_def = find_enum_def(table, match_expr_type->struct_name);
+                if (enum_def) {
+                    for (int ai = 1; ai < stmt->child_count; ai++) {
+                        ASTNode* a = stmt->children[ai];
+                        if (!a || a->type != AST_MATCH_ARM || a->child_count < 1) continue;
+                        ASTNode* pat = a->children[0];
+                        if (!pat || pat->type != AST_IDENTIFIER || !pat->value) continue;
+                        if (strcmp(pat->value, "_") == 0) continue;   // wildcard
+                        int midx = -1;
+                        if (enum_has_member(enum_def, pat->value, &midx)) {
+                            pat->type = AST_ENUM_VALUE;
+                            pat->bit_width = midx;
+                            if (pat->node_type) free_type(pat->node_type);
+                            pat->node_type = create_type(TYPE_ENUM);
+                            pat->node_type->struct_name = strdup(match_expr_type->struct_name);
+                        } else {
+                            char msg[256];
+                            snprintf(msg, sizeof(msg),
+                                     "'%s' is not a member of enum '%s'",
+                                     pat->value, match_expr_type->struct_name);
+                            type_error(msg, pat->line, pat->column);
+                        }
+                    }
+                }
+            }
+
             // #914 sum `match` bookkeeping: track variant coverage (for the
             // exhaustiveness check) and the scrutinee variable name (for
             // per-arm narrowing — `match s { Circle -> { s.r } }` narrows `s`
@@ -4948,6 +5353,34 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
     switch (expr->type) {
         case AST_BINARY_EXPRESSION:
             return typecheck_binary_expression(expr, table);
+
+        case AST_ENUM_VALUE: {
+            const char* enum_name = NULL;
+            int idx = -1;
+            if (!find_enum_member(table, expr->value, &enum_name, &idx) || !enum_name) {
+                char msg[256];
+                snprintf(msg, sizeof(msg), "unknown enum member '.%s'",
+                         expr->value ? expr->value : "?");
+                type_error(msg, expr->line, expr->column);
+                expr->node_type = create_type(TYPE_UNKNOWN);
+                return 0;
+            }
+            if (expr->node_type) free_type(expr->node_type);
+            expr->node_type = create_type(TYPE_ENUM);
+            expr->node_type->struct_name = strdup(enum_name);
+            if (expr->annotation) free(expr->annotation);
+            expr->annotation = strdup(enum_name);
+            expr->bit_width = idx;
+            return 1;
+        }
+
+        case AST_BITSET_LITERAL: {
+            for (int i = 0; i < expr->child_count; i++) {
+                typecheck_expression(expr->children[i], table);
+            }
+            if (!expr->node_type) expr->node_type = create_type(TYPE_UNKNOWN);
+            return 1;
+        }
             
         case AST_UNARY_EXPRESSION: {
             if (expr->child_count > 0) {
@@ -5143,6 +5576,24 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
         }
 
         case AST_FUNCTION_CALL:
+            /* `card(m)` is the bit_set popcount builtin ONLY when its single
+             * argument is a bit_set. Otherwise `card` is an ordinary name, so
+             * a user-defined `card(x: int)` resolves normally (#1046 review:
+             * the builtin must not hijack the identifier). */
+            if (expr->value && strcmp(expr->value, "card") == 0 &&
+                expr->child_count == 1 &&
+                !lookup_symbol(table, "card")) {
+                typecheck_expression(expr->children[0], table);
+                Type* arg = infer_type(expr->children[0], table);
+                int is_bitset = (arg && arg->kind == TYPE_BITSET);
+                if (arg) free_type(arg);
+                if (is_bitset) {
+                    expr->node_type = create_type(TYPE_INT);
+                    return 1;
+                }
+                /* not a bit_set and no user `card` — fall through to the
+                 * normal path so the undefined-function error is accurate. */
+            }
             return typecheck_function_call(expr, table);
             
         case AST_IDENTIFIER: {
@@ -5702,6 +6153,47 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
     }
 }
 
+static int pin_bitset_literal(ASTNode* lit, Type* bitset_type,
+                              SymbolTable* table) {
+    if (!lit || lit->type != AST_BITSET_LITERAL ||
+        !bitset_type || bitset_type->kind != TYPE_BITSET) return 0;
+    ASTNode* enum_def = bitset_type->element_type
+                      ? find_enum_def(table, bitset_type->element_type->struct_name)
+                      : NULL;
+    int ok = 1;
+    for (int i = 0; i < lit->child_count; i++) {
+        ASTNode* item = lit->children[i];
+        int member_idx = -1;
+        if (!item || item->type != AST_ENUM_VALUE ||
+            !enum_has_member(enum_def, item->value, &member_idx)) {
+            ok = 0;
+            char msg[256];
+            snprintf(msg, sizeof(msg),
+                     "bit_set literal member '.%s' is not in enum '%s'",
+                     item && item->value ? item->value : "?",
+                     bitset_type->element_type &&
+                     bitset_type->element_type->struct_name
+                         ? bitset_type->element_type->struct_name : "?");
+            type_error(msg, lit->line, lit->column);
+            break;
+        }
+        if (item->node_type) free_type(item->node_type);
+        item->node_type = bitset_type->element_type
+                        ? clone_type(bitset_type->element_type)
+                        : create_type(TYPE_ENUM);
+        if (item->annotation) free(item->annotation);
+        item->annotation = bitset_type->element_type &&
+                           bitset_type->element_type->struct_name
+                         ? strdup(bitset_type->element_type->struct_name)
+                         : NULL;
+        item->bit_width = member_idx;
+    }
+    if (!ok) return 0;
+    if (lit->node_type) free_type(lit->node_type);
+    lit->node_type = clone_type(bitset_type);
+    return 1;
+}
+
 int typecheck_binary_expression(ASTNode* expr, SymbolTable* table) {
     if (!expr || expr->type != AST_BINARY_EXPRESSION || expr->child_count < 2) return 0;
     
@@ -5715,6 +6207,54 @@ int typecheck_binary_expression(ASTNode* expr, SymbolTable* table) {
     Type* right_type = infer_type(right, table);
 
     AeTokenType operator = get_token_type_from_string(expr->value);
+
+    if ((operator == TOKEN_PLUS || operator == TOKEN_MINUS ||
+         operator == TOKEN_LESS || operator == TOKEN_LESS_EQUAL ||
+         operator == TOKEN_GREATER || operator == TOKEN_GREATER_EQUAL) &&
+        left_type && left_type->kind == TYPE_BITSET &&
+        right && right->type == AST_BITSET_LITERAL) {
+        pin_bitset_literal(right, left_type, table);
+        if (right_type) free_type(right_type);
+        right_type = clone_type(left_type);
+    }
+    if ((operator == TOKEN_PLUS || operator == TOKEN_MINUS ||
+         operator == TOKEN_LESS || operator == TOKEN_LESS_EQUAL ||
+         operator == TOKEN_GREATER || operator == TOKEN_GREATER_EQUAL) &&
+        right_type && right_type->kind == TYPE_BITSET &&
+        left && left->type == AST_BITSET_LITERAL) {
+        pin_bitset_literal(left, right_type, table);
+        if (left_type) free_type(left_type);
+        left_type = clone_type(right_type);
+    }
+
+    if ((operator == TOKEN_IN || operator == TOKEN_NOT_IN) &&
+        right_type && right_type->kind == TYPE_BITSET &&
+        left && left->type == AST_ENUM_VALUE) {
+        ASTNode* enum_def = right_type->element_type
+                          ? find_enum_def(table, right_type->element_type->struct_name)
+                          : NULL;
+        int member_idx = -1;
+        if (!enum_has_member(enum_def, left->value, &member_idx)) {
+            char msg[256];
+            snprintf(msg, sizeof(msg),
+                     "enum member '.%s' is not in bit_set enum '%s'",
+                     left->value ? left->value : "?",
+                     right_type->element_type && right_type->element_type->struct_name
+                         ? right_type->element_type->struct_name : "?");
+            type_error(msg, expr->line, expr->column);
+        }
+        if (left->node_type) free_type(left->node_type);
+        left->node_type = right_type->element_type
+                        ? clone_type(right_type->element_type)
+                        : create_type(TYPE_ENUM);
+        if (left->annotation) free(left->annotation);
+        left->annotation = right_type->element_type && right_type->element_type->struct_name
+                         ? strdup(right_type->element_type->struct_name)
+                         : NULL;
+        left->bit_width = member_idx >= 0 ? member_idx : 0;
+        if (left_type) free_type(left_type);
+        left_type = clone_type(left->node_type);
+    }
 
     // #340: equality with `none` / between optionals — `m == none`,
     // `none == m`, `a? == b?` all yield bool. Pin a bare `none` operand to the
@@ -5740,6 +6280,65 @@ int typecheck_binary_expression(ASTNode* expr, SymbolTable* table) {
             expr->node_type = create_type(TYPE_BOOL);
             return 1;
         }
+    }
+
+    if (operator == TOKEN_PLUS || operator == TOKEN_MINUS) {
+        if (left_type && right_type &&
+            (left_type->kind == TYPE_BITSET || right_type->kind == TYPE_BITSET)) {
+            if (!(left_type->kind == TYPE_BITSET && right_type->kind == TYPE_BITSET &&
+                  types_equal(left_type, right_type))) {
+                type_error("bit_set union/difference requires matching bit_set operands",
+                           expr->line, expr->column);
+                if (left_type) free_type(left_type);
+                if (right_type) free_type(right_type);
+                expr->node_type = create_type(TYPE_UNKNOWN);
+                return 0;
+            }
+            expr->node_type = clone_type(left_type);
+            free_type(left_type);
+            free_type(right_type);
+            return 1;
+        }
+    }
+
+    if (operator == TOKEN_IN || operator == TOKEN_NOT_IN) {
+        int ok = left_type && right_type &&
+                 left_type->kind == TYPE_ENUM &&
+                 right_type->kind == TYPE_BITSET &&
+                 right_type->element_type &&
+                 right_type->element_type->kind == TYPE_ENUM &&
+                 types_equal(left_type, right_type->element_type);
+        if (!ok) {
+            type_error("`in`/`not_in` requires `.EnumMember in bit_set[Enum]`",
+                       expr->line, expr->column);
+            if (left_type) free_type(left_type);
+            if (right_type) free_type(right_type);
+            expr->node_type = create_type(TYPE_BOOL);
+            return 0;
+        }
+        expr->node_type = create_type(TYPE_BOOL);
+        free_type(left_type);
+        free_type(right_type);
+        return 1;
+    }
+
+    if ((operator == TOKEN_LESS || operator == TOKEN_LESS_EQUAL ||
+         operator == TOKEN_GREATER || operator == TOKEN_GREATER_EQUAL) &&
+        left_type && right_type &&
+        (left_type->kind == TYPE_BITSET || right_type->kind == TYPE_BITSET)) {
+        if (!(left_type->kind == TYPE_BITSET && right_type->kind == TYPE_BITSET &&
+              types_equal(left_type, right_type))) {
+            type_error("bit_set subset comparisons require matching bit_set operands",
+                       expr->line, expr->column);
+            if (left_type) free_type(left_type);
+            if (right_type) free_type(right_type);
+            expr->node_type = create_type(TYPE_BOOL);
+            return 0;
+        }
+        expr->node_type = create_type(TYPE_BOOL);
+        free_type(left_type);
+        free_type(right_type);
+        return 1;
     }
 
     // Reject `string + string` at typecheck rather than emitting

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -210,6 +210,15 @@ const char* type_to_string(Type* type) {
                      type->element_type ? type_to_string(type->element_type) : "?");
             return buffer;
         }
+        case TYPE_ENUM:
+            return type->struct_name ? type->struct_name : "enum";
+        case TYPE_BITSET: {
+            static char buffer[256];
+            snprintf(buffer, sizeof(buffer), "bit_set[%s]",
+                     type->element_type && type->element_type->struct_name
+                         ? type->element_type->struct_name : "?");
+            return buffer;
+        }
         default: return "UNKNOWN";
     }
 }
@@ -239,6 +248,16 @@ int types_equal(Type* a, Type* b) {
 
     // #914 sum types are nominal: equal iff they name the same sum.
     if (a->kind == TYPE_SUM) {
+        if (!a->struct_name || !b->struct_name) return 0;
+        return strcmp(a->struct_name, b->struct_name) == 0;
+    }
+
+    if (a->kind == TYPE_ENUM) {
+        if (!a->struct_name || !b->struct_name) return 0;
+        return strcmp(a->struct_name, b->struct_name) == 0;
+    }
+
+    if (a->kind == TYPE_BITSET) {
         if (!a->struct_name || !b->struct_name) return 0;
         return strcmp(a->struct_name, b->struct_name) == 0;
     }
@@ -529,6 +548,10 @@ const char* ast_node_type_to_string(ASTNodeType type) {
         case AST_NULL_COALESCE: return "NULL_COALESCE";     // #340
         case AST_OPTIONAL_CHAIN: return "OPTIONAL_CHAIN";   // #340
         case AST_SUM_TYPE_DEF: return "SUM_TYPE_DEF";       // #914
+        case AST_ENUM_DEF: return "ENUM_DEF";
+        case AST_BITSET_TYPE_DEF: return "BITSET_TYPE_DEF";
+        case AST_ENUM_VALUE: return "ENUM_VALUE";
+        case AST_BITSET_LITERAL: return "BITSET_LITERAL";
         default: return "UNKNOWN";
     }
 }

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -224,6 +224,11 @@ typedef enum {
     // existing struct variants. value = the sum type name; each child is an
     // AST_IDENTIFIER naming a variant struct.
     AST_SUM_TYPE_DEF,
+    // #1046 enum-backed bit sets.
+    AST_ENUM_DEF,           // `enum Name { A, B }`; children are identifiers
+    AST_BITSET_TYPE_DEF,    // `type Mask = bit_set[Enum]`; child[0] enum id
+    AST_ENUM_VALUE,         // `.A` enum member expression; node_type pins enum
+    AST_BITSET_LITERAL,     // `{ .A, .B }`; children are AST_ENUM_VALUE
     // #913 error handler `expr or { … }` / `expr or default`. children[0] =
     // the fallible (value, err) expression; children[1] = the handler (a
     // block that yields a value or exits, or a bare default expression). `err`
@@ -278,13 +283,15 @@ typedef enum {
                         // name; `tuple_types[0..tuple_count)` are the variant
                         // Types (each TYPE_STRUCT). Lowers to a tagged union
                         // `{ <Name>_tag tag; union { ... } data; }`.
-    TYPE_ISOLATED       // #479 `Isolated[T]`, a compile-time-only, move-only
+    TYPE_ISOLATED,      // #479 `Isolated[T]`, a compile-time-only, move-only
                         // (linear) wrapper for actor message payloads.
                         // element_type is the wrapped T. Nominal (an Isolated
                         // is never assignable to a bare T or vice versa);
                         // lowers to T's C type with zero runtime cost. Appended
                         // at END to keep kind numbering stable (incremental
                         // builds need `make clean` after this edit).
+    TYPE_ENUM,          // #1046 enum value, lowers to int
+    TYPE_BITSET         // #1046 bit_set[Enum], lowers to uint64_t
 } TypeKind;
 
 typedef struct Type {

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1799,6 +1799,10 @@ const char* get_c_type(Type* type) {
              * lowers to the C type of the wrapped T with zero runtime cost
              * (mirrors distinct types); isolate()/consume() are no-ops. */
             return type->element_type ? get_c_type(type->element_type) : "void*";
+        case TYPE_ENUM:
+            return "int";
+        case TYPE_BITSET:
+            return "uint64_t";
         case TYPE_ARRAY: {
             static char buffers[4][256];
             static int buf_idx = 0;
@@ -1917,6 +1921,8 @@ static const char* get_abi_type(Type* type) {
         case TYPE_FLOAT32: return "float";
         case TYPE_BOOL:   return "int32_t";
         case TYPE_BYTE:   return "unsigned char";
+        case TYPE_ENUM:   return "int32_t";
+        case TYPE_BITSET: return "uint64_t";
         case TYPE_STRING: return "const char*";
         case TYPE_VOID:   return "void";
         case TYPE_PTR:    return "AetherValue*";
@@ -3496,7 +3502,8 @@ static void mangle_keyword_value_idents(ASTNode* node) {
         default:
             break;
     }
-    if (node->type == AST_SUM_TYPE_DEF) return;  // children are type names
+    if (node->type == AST_SUM_TYPE_DEF || node->type == AST_ENUM_DEF ||
+        node->type == AST_BITSET_TYPE_DEF) return;  // children are type names
     for (int i = 0; i < node->child_count; i++) {
         mangle_keyword_value_idents(node->children[i]);
     }
@@ -4823,6 +4830,11 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
             case AST_SUM_TYPE_DEF:
                 // #914: the tagged-union typedef was emitted in the hoisted
                 // type pass above; nothing to emit for the declaration here.
+                break;
+            case AST_ENUM_DEF:
+            case AST_BITSET_TYPE_DEF:
+                // #1046: enums/bit_set aliases lower to scalar values/types;
+                // no standalone C declaration is needed.
                 break;
             case AST_MAIN_FUNCTION:
                 generate_main_function(gen, child);

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2258,9 +2258,77 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 fprintf(gen->output, "))");
             }
             break;
+
+        case AST_ENUM_VALUE:
+            fprintf(gen->output, "%d", expr->bit_width >= 0 ? expr->bit_width : 0);
+            break;
+
+        case AST_BITSET_LITERAL: {
+            if (expr->child_count == 0) {
+                fprintf(gen->output, "0ULL");
+            } else {
+                fprintf(gen->output, "(");
+                for (int i = 0; i < expr->child_count; i++) {
+                    ASTNode* item = expr->children[i];
+                    if (i > 0) fprintf(gen->output, " | ");
+                    fprintf(gen->output, "(1ULL << %d)",
+                            item ? item->bit_width : 0);
+                }
+                fprintf(gen->output, ")");
+            }
+            break;
+        }
             
         case AST_BINARY_EXPRESSION:
             if (expr->child_count >= 2) {
+                if (expr->value && (strcmp(expr->value, "in") == 0 ||
+                                    strcmp(expr->value, "not_in") == 0)) {
+                    int neg = strcmp(expr->value, "not_in") == 0;
+                    if (neg) fprintf(gen->output, "!(");
+                    fprintf(gen->output, "(((");
+                    generate_expression(gen, expr->children[1]);
+                    fprintf(gen->output, ") >> (");
+                    generate_expression(gen, expr->children[0]);
+                    fprintf(gen->output, ")) & 1ULL)");
+                    if (neg) fprintf(gen->output, ")");
+                    break;
+                }
+
+                if (expr->value && expr->children[0]->node_type &&
+                    expr->children[0]->node_type->kind == TYPE_BITSET) {
+                    const char* op = NULL;
+                    if (strcmp(expr->value, "+") == 0) op = "|";
+                    else if (strcmp(expr->value, "-") == 0) op = "& ~";
+                    else if (strcmp(expr->value, "<=") == 0) op = "subset_le";
+                    else if (strcmp(expr->value, ">=") == 0) op = "subset_ge";
+                    else if (strcmp(expr->value, "<") == 0) op = "subset_lt";
+                    else if (strcmp(expr->value, ">") == 0) op = "subset_gt";
+                    if (op) {
+                        if (strncmp(op, "subset_", 7) == 0) {
+                            fprintf(gen->output, "({ uint64_t _bs_l = ");
+                            generate_expression(gen, expr->children[0]);
+                            fprintf(gen->output, "; uint64_t _bs_r = ");
+                            generate_expression(gen, expr->children[1]);
+                            fprintf(gen->output, "; ");
+                            if (strcmp(op, "subset_le") == 0)
+                                fprintf(gen->output, "((_bs_l & ~_bs_r) == 0)");
+                            else if (strcmp(op, "subset_ge") == 0)
+                                fprintf(gen->output, "((_bs_r & ~_bs_l) == 0)");
+                            else if (strcmp(op, "subset_lt") == 0)
+                                fprintf(gen->output, "(((_bs_l & ~_bs_r) == 0) && _bs_l != _bs_r)");
+                            else
+                                fprintf(gen->output, "(((_bs_r & ~_bs_l) == 0) && _bs_l != _bs_r)");
+                            fprintf(gen->output, "; })");
+                        } else {
+                            fprintf(gen->output, "(");
+                            generate_expression(gen, expr->children[0]);
+                            fprintf(gen->output, " %s ", op);
+                            generate_expression(gen, expr->children[1]);
+                            fprintf(gen->output, ")");
+                        }
+                        break;
+                    }
+                }
                 // #340: equality against `none` / between optionals. A struct
                 // `==` is invalid C, so compare the `has` flag (and value).
                 if (expr->value && (strcmp(expr->value, "==") == 0 ||
@@ -2534,6 +2602,17 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             break;
             
         case AST_FUNCTION_CALL:
+            /* card(bit_set) → popcount, but only when the arg is actually a
+             * bit_set; a user-defined card() emits as a normal call (#1046). */
+            if (expr->value && strcmp(expr->value, "card") == 0 &&
+                expr->child_count == 1 && expr->children[0] &&
+                expr->children[0]->node_type &&
+                expr->children[0]->node_type->kind == TYPE_BITSET) {
+                fprintf(gen->output, "__builtin_popcountll(");
+                generate_expression(gen, expr->children[0]);
+                fprintf(gen->output, ")");
+                break;
+            }
             /* heap.free(p) — counterpart to heap.new(T) (issue #564, #790).
              * A POD box owns no heap fields, so a plain free(p) reclaims it.
              * A box whose struct has string fields (#790) routes through the

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -5178,9 +5178,25 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                 }
 
                 if (is_state_var) {
-                    fprintf(gen->output, "self->%s %s ", stmt->value, op);
+                    if (stmt->node_type && stmt->node_type->kind == TYPE_BITSET &&
+                        strcmp(op, "+=") == 0) {
+                        fprintf(gen->output, "self->%s |= ", stmt->value);
+                    } else if (stmt->node_type && stmt->node_type->kind == TYPE_BITSET &&
+                               strcmp(op, "-=") == 0) {
+                        fprintf(gen->output, "self->%s &= ~", stmt->value);
+                    } else {
+                        fprintf(gen->output, "self->%s %s ", stmt->value, op);
+                    }
                 } else {
-                    fprintf(gen->output, "%s %s ", stmt->value, op);
+                    if (stmt->node_type && stmt->node_type->kind == TYPE_BITSET &&
+                        strcmp(op, "+=") == 0) {
+                        fprintf(gen->output, "%s |= ", stmt->value);
+                    } else if (stmt->node_type && stmt->node_type->kind == TYPE_BITSET &&
+                               strcmp(op, "-=") == 0) {
+                        fprintf(gen->output, "%s &= ~", stmt->value);
+                    } else {
+                        fprintf(gen->output, "%s %s ", stmt->value, op);
+                    }
                 }
                 generate_expression(gen, stmt->children[1]);
                 fprintf(gen->output, ";\n");

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -374,6 +374,7 @@ Token* read_identifier() {
     else if (strcmp(buffer, "null") == 0) token = create_token(TOKEN_NULL, buffer, current_line, current_column);
     else if (strcmp(buffer, "const") == 0) token = create_token(TOKEN_CONST, buffer, current_line, current_column);
     else if (strcmp(buffer, "in") == 0) token = create_token(TOKEN_IN, buffer, current_line, current_column);
+    else if (strcmp(buffer, "not_in") == 0) token = create_token(TOKEN_NOT_IN, buffer, current_line, current_column);
     else if (strcmp(buffer, "after") == 0) token = create_token(TOKEN_AFTER, buffer, current_line, current_column);
     else if (strcmp(buffer, "callback") == 0) token = create_token(TOKEN_CALLBACK, buffer, current_line, current_column);
     else if (strcmp(buffer, "hide") == 0) token = create_token(TOKEN_HIDE, buffer, current_line, current_column);
@@ -973,6 +974,7 @@ const char* token_type_to_string(AeTokenType type) {
         case TOKEN_NULL: return "NULL";
         case TOKEN_CALLBACK: return "CALLBACK";
         case TOKEN_IN: return "IN";
+        case TOKEN_NOT_IN: return "NOT_IN";
         case TOKEN_DOTDOT: return "DOTDOT";
         case TOKEN_DOTDOT_EQ: return "DOTDOT_EQ";
         case TOKEN_DOTDOT_LT: return "DOTDOT_LT";

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -293,6 +293,21 @@ static Type* parse_type_unsuffixed(Parser* parser) {
 
     Type* type = NULL;
 
+    if (token->type == TOKEN_IDENTIFIER && token->value &&
+        strcmp(token->value, "bit_set") == 0) {
+        advance_token(parser);  // bit_set
+        if (!expect_token(parser, TOKEN_LEFT_BRACKET)) return NULL;
+        Token* enum_name = expect_token(parser, TOKEN_IDENTIFIER);
+        if (!enum_name) return NULL;
+        if (!expect_token(parser, TOKEN_RIGHT_BRACKET)) return NULL;
+        Type* enum_type = create_type(TYPE_ENUM);
+        enum_type->struct_name = strdup(enum_name->value);
+        Type* bitset = create_type(TYPE_BITSET);
+        bitset->element_type = enum_type;
+        bitset->struct_name = strdup(enum_name->value);
+        return bitset;
+    }
+
     /* `const <type>` — a C-qualified type.  Parsed by recursing on the
      * unqualified type, then stamping a const-prefixed C spelling onto
      * `c_alias` so codegen emits the qualifier verbatim.  The `kind`
@@ -920,6 +935,45 @@ ASTNode* parse_closure_expression(Parser* parser) {
     return closure;
 }
 
+static ASTNode* parse_enum_value_expr(Parser* parser) {
+    Token* dot = peek_token(parser);
+    if (!dot || dot->type != TOKEN_DOT) return NULL;
+    advance_token(parser);
+    Token* name = expect_token(parser, TOKEN_IDENTIFIER);
+    if (!name) return NULL;
+    ASTNode* v = create_ast_node(AST_ENUM_VALUE, name->value, dot->line, dot->column);
+    /* -1 = index not yet resolved. The enum resolver (#1044) stamps the
+     * real member index by name; the -1 sentinel lets it distinguish an
+     * unresolved node from one legitimately resolved to index 0. */
+    if (v) v->bit_width = -1;
+    return v;
+}
+
+static ASTNode* parse_bitset_literal(Parser* parser) {
+    Token* open = peek_token(parser);
+    if (!open || open->type != TOKEN_LEFT_BRACE) return NULL;
+    advance_token(parser);
+
+    ASTNode* lit = create_ast_node(AST_BITSET_LITERAL, NULL, open->line, open->column);
+    if (!match_token(parser, TOKEN_RIGHT_BRACE)) {
+        do {
+            ASTNode* item = parse_enum_value_expr(parser);
+            if (!item) {
+                parser_error(parser, "bit_set literal entries must be enum members like `.Read`");
+                free_ast_node(lit);
+                return NULL;
+            }
+            add_child(lit, item);
+        } while (match_token(parser, TOKEN_COMMA));
+
+        if (!expect_token(parser, TOKEN_RIGHT_BRACE)) {
+            free_ast_node(lit);
+            return NULL;
+        }
+    }
+    return lit;
+}
+
 ASTNode* parse_primary_expression(Parser* parser) {
     Token* token = peek_token(parser);
     if (!token) return NULL;
@@ -935,6 +989,12 @@ ASTNode* parse_primary_expression(Parser* parser) {
     }
 
     switch (token->type) {
+        case TOKEN_DOT:
+            return parse_enum_value_expr(parser);
+
+        case TOKEN_LEFT_BRACE:
+            return parse_bitset_literal(parser);
+
         case TOKEN_NUMBER:
         case TOKEN_STRING_LITERAL:
         case TOKEN_TRUE:
@@ -2100,7 +2160,10 @@ int get_operator_precedence(AeTokenType type) {
         case TOKEN_CARET: return 4;   // bitwise XOR
         case TOKEN_AMPERSAND: return 5; // bitwise AND
         case TOKEN_EQUALS:
-        case TOKEN_NOT_EQUALS: return 6;
+        case TOKEN_NOT_EQUALS:
+        case TOKEN_IN:
+        case TOKEN_NOT_IN:
+            return 6;
         case TOKEN_LESS:
         case TOKEN_LESS_EQUAL:
         case TOKEN_GREATER:
@@ -5150,6 +5213,30 @@ ASTNode* parse_top_level_decl(Parser* parser) {
 
         ASTNode* node = NULL;
 
+        if (token->type == TOKEN_IDENTIFIER && token->value &&
+            strcmp(token->value, "enum") == 0) {
+            advance_token(parser);
+            Token* name = expect_token(parser, TOKEN_IDENTIFIER);
+            if (!name) return NULL;
+            if (!expect_token(parser, TOKEN_LEFT_BRACE)) return NULL;
+            ASTNode* edef = create_ast_node(AST_ENUM_DEF, name->value,
+                                            name->line, name->column);
+            if (!match_token(parser, TOKEN_RIGHT_BRACE)) {
+                do {
+                    Token* member = expect_token(parser, TOKEN_IDENTIFIER);
+                    if (!member) { free_ast_node(edef); return NULL; }
+                    add_child(edef, create_ast_node(AST_IDENTIFIER, member->value,
+                                                   member->line, member->column));
+                } while (match_token(parser, TOKEN_COMMA));
+                if (!expect_token(parser, TOKEN_RIGHT_BRACE)) {
+                    free_ast_node(edef);
+                    return NULL;
+                }
+            }
+            match_token(parser, TOKEN_SEMICOLON);
+            return edef;
+        }
+
         // #480: `type Name = distinct Base` — a zero-cost nominal type over
         // Base. `type` and `distinct` are contextual identifiers (usable as
         // names elsewhere); only the `type <ident> = distinct ...` shape here
@@ -5178,6 +5265,25 @@ ASTNode* parse_top_level_decl(Parser* parser) {
                     d->node_type = base;
                     match_token(parser, TOKEN_SEMICOLON);
                     return d;
+                }
+                if (dk && dk->type == TOKEN_IDENTIFIER && dk->value &&
+                    strcmp(dk->value, "bit_set") == 0) {
+                    Type* bitset_type = parse_type(parser);
+                    if (!bitset_type || bitset_type->kind != TYPE_BITSET ||
+                        !bitset_type->element_type ||
+                        !bitset_type->element_type->struct_name) {
+                        parser_error(parser, "expected `bit_set[Enum]` after `type Name =`");
+                        if (bitset_type) free_type(bitset_type);
+                        return NULL;
+                    }
+                    ASTNode* b = create_ast_node(AST_BITSET_TYPE_DEF,
+                                                 name->value, name->line, name->column);
+                    b->node_type = bitset_type;
+                    add_child(b, create_ast_node(AST_IDENTIFIER,
+                                                 bitset_type->element_type->struct_name,
+                                                 name->line, name->column));
+                    match_token(parser, TOKEN_SEMICOLON);
+                    return b;
                 }
                 // #914 sum/variant type: `type Name = A | B | C`. The variants
                 // are existing struct type names separated by `|`. At least two
@@ -5209,7 +5315,7 @@ ASTNode* parse_top_level_decl(Parser* parser) {
                     return sum;
                 }
                 parser_error(parser,
-                    "expected `distinct <type>` or a `|`-separated variant list "
+                    "expected `distinct <type>`, `bit_set[Enum]`, or a `|`-separated variant list "
                     "after `type Name =`");
                 return NULL;
             }

--- a/compiler/parser/tokens.h
+++ b/compiler/parser/tokens.h
@@ -45,7 +45,8 @@ typedef enum {
     TOKEN_EXTERN,           // 'extern' keyword for C FFI
     TOKEN_NULL,             // 'null' keyword for null pointer literal
     TOKEN_CONST,            // 'const' keyword for top-level constants
-    TOKEN_IN,               // 'in' keyword for range-based for loops
+    TOKEN_IN,               // 'in' keyword / membership operator
+    TOKEN_NOT_IN,           // 'not_in' membership operator
     TOKEN_AFTER,            // 'after' keyword for receive timeouts
     TOKEN_CALLBACK,         // 'callback' keyword for callback trailing blocks
     TOKEN_HIDE,             // 'hide' scope-level directive: blocks named outer bindings

--- a/tests/regression/test_issue1044_enums.ae
+++ b/tests/regression/test_issue1044_enums.ae
@@ -1,0 +1,63 @@
+// Regression for #1044: first-class enum types (the substrate #1046 needs).
+// Covers enums as values across every position the review found broken:
+// variable declarations, function params, return types, struct fields,
+// equality, and match — plus the non-first-index resolution bug (a
+// `return .Green` must emit index 1, not 0).
+
+import std.string
+
+enum Color { Red, Green, Blue }
+
+struct Paint { c: Color, coats: int }
+
+extern exit(code: int)
+
+fail(msg: string) { println(msg); exit(1) }
+
+// Return position — the case that emitted `return 0` for every member
+// before the enum-resolver stamped indices everywhere.
+next(c: Color) -> Color {
+    if c == .Red { return .Green }
+    if c == .Green { return .Blue }
+    return .Red
+}
+
+// Param + match on enum. Uses the assign-then-return idiom: `return
+// match {...}` as a bare expression is a pre-existing codegen bug
+// (garbage even for an int scrutinee), orthogonal to enums.
+name_of(c: Color) -> string {
+    r = match c {
+        Red   -> "red"
+        Green -> "green"
+        Blue  -> "blue"
+    }
+    return r
+}
+
+main() {
+    println("=== test_issue1044_enums ===")
+
+    // Variable declaration with a non-zero-index member.
+    Color a = .Blue
+    Color b = .Green
+    if a == .Blue == false { fail("FAIL: var decl .Blue") }
+    if b == .Green == false { fail("FAIL: var decl .Green") }
+    if a == b { fail("FAIL: distinct members compared equal") }
+
+    // Struct field of enum type.
+    Paint p = Paint{ c: .Green, coats: 2 }
+    if p.c == .Green == false { fail("FAIL: struct field enum") }
+    if p.c == .Red { fail("FAIL: struct field wrong match") }
+
+    // Return position: next(Red)=Green, next(Green)=Blue, next(Blue)=Red.
+    if next(.Red) == .Green == false { fail("FAIL: next(Red) != Green") }
+    if next(.Green) == .Blue == false { fail("FAIL: next(Green) != Blue") }
+    if next(.Blue) == .Red == false { fail("FAIL: next(Blue) != Red") }
+
+    // Match on enum, each arm (proves index 0/1/2 all resolve).
+    if string.equals(name_of(.Red), "red") != 1 { fail("FAIL: match Red") }
+    if string.equals(name_of(.Green), "green") != 1 { fail("FAIL: match Green") }
+    if string.equals(name_of(.Blue), "blue") != 1 { fail("FAIL: match Blue") }
+
+    println("=== test_issue1044_enums passed ===")
+}

--- a/tests/regression/test_issue1046_bit_set.ae
+++ b/tests/regression/test_issue1046_bit_set.ae
@@ -1,0 +1,43 @@
+// Regression for #1046: enum-backed bit_set masks.
+
+enum Perm { Read, Write, Exec }
+type Mask = bit_set[Perm]
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println(msg)
+    exit(1)
+}
+
+main() {
+    println("=== test_issue1046_bit_set ===")
+
+    Mask m = { .Read, .Write }
+    if .Read not_in m { fail("FAIL: Read missing") }
+    if .Exec in m { fail("FAIL: Exec unexpectedly present") }
+    if card(m) != 2 { fail("FAIL: initial card") }
+
+    m = m + { .Exec }
+    if .Exec not_in m { fail("FAIL: union did not add Exec") }
+    if card(m) != 3 { fail("FAIL: union card") }
+
+    m -= { .Write }
+    if .Write in m { fail("FAIL: -= did not remove Write") }
+    if card(m) != 2 { fail("FAIL: -= card") }
+
+    m += { .Write }
+    m = m - { .Read }
+    if .Read in m { fail("FAIL: difference did not remove Read") }
+    if .Write not_in m { fail("FAIL: += did not add Write") }
+
+    Mask rw = { .Read, .Write }
+    Mask all = { .Read, .Write, .Exec }
+    if rw <= all == false { fail("FAIL: subset <=") }
+    if all >= rw == false { fail("FAIL: superset >=") }
+    if rw < all == false { fail("FAIL: strict subset <") }
+    if all > rw == false { fail("FAIL: strict superset >") }
+    if all < all { fail("FAIL: strict self subset") }
+
+    println("=== test_issue1046_bit_set passed ===")
+}


### PR DESCRIPTION
Closes #1044. Closes #1046.

Delivers the tier-1 pairing from the Odin comparison: a real `enum` type usable as a first-class value, plus an integer-backed `bit_set` over it. #1044 (enums) is the substrate #1046 (bit_set) needs, so they land together.

## Enums (#1044)

```aether
enum Perm { Read, Write, Exec }

grant(p: Perm) -> Perm {          // param + return
    if p == .Read { return .Write }  // == and return-position values
    return p
}

struct Acl { owner: Perm }        // struct field
Perm p = .Write                   // variable decl, implicit selector
match p { Write -> "w"  _ -> "?" } // match arm
```

Lowers to a C `int`, zero runtime cost. Implemented via a `resolve_enum_types` typechecker pass that rewrites bare `TYPE_STRUCT{EnumName}` use-site annotations to `TYPE_ENUM` and stamps every `.Member` node with its integer index by name. Stamping in that pass (not a later typecheck route) is what makes indices correct in **every** position — the original commit emitted `return 0` for every member in return position because only some paths set the index.

## bit_set (#1046)

```aether
type Mask = bit_set[Perm]
Mask m = { .Read, .Write }
m += { .Exec }                    // union (also -, +=, -=)
if .Read in m { ... }             // in / not_in
n = card(m)                       // popcount
if rw <= m { ... }                // subset (<, <=, >, >=)
```

Lowers to a `uint64_t`; every op is integer arithmetic (`1ULL << idx`, `__builtin_popcountll`, bitwise). No allocation.

## Correctness (all found by an adversarial review of the initial commit; the single happy-path test caught none of them)

- **Enums weren't actually first-class** — var decls / params / fields / `==` / `match` all failed; only bit-index selectors worked. Fixed (the headline change above).
- **>64-member bit_set was silent UB** (index 64+ shifts past the uint64_t width, also a `-Wshift-count-overflow` that trips `-Werror` on CI) → now a clean compile error, in a pass that's order-independent of enum-vs-alias declaration order.
- **Duplicate enum members** silently accepted → rejected.
- **`card` hijacked any user function named `card`** → now only intercepts a bit_set argument.

## Scope / follow-ups

- V1: fixed 64-bit backing, implicit `0..N` member values. Explicit widths (`bit_set[Perm; u16]`) and explicit values (`enum E { A = 5 }`) are follow-ups.
- **#1054** (filed): `return match {...}` as a bare expression miscompiles — **pre-existing and independent of enums** (reproduces with a plain `int` scrutinee). The enum test uses the working assign-then-return idiom.

## Testing

- `tests/regression/test_issue1044_enums.ae` — enum values across every position, including the return-index regression.
- `tests/regression/test_issue1046_bit_set.ae` — full operator set.
- Clean build (`make clean` required — `TypeKind` gained `TYPE_ENUM`/`TYPE_BITSET`), C unit suite 231/231, full `.ae` suite 822/825 (the 3 are the known http/h2 network flakes that fail identically on `origin/main` on this box). `HARDEN=1 make ci` compiles clean — no format-security / stack-protector / `-Werror` issues in the compiler C.

Rebased onto `main` after Nic's ranged-match #1047 (v0.366.0) landed; code-independent of it (own AST nodes and `TypeKind`s, cherry-picked with only a trivial CHANGELOG overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)