### PR TITLE
feat(types): bit_set[E], a zero-cost set of enum members (#1046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Bit sets, `bit_set[E]`** (#1046). A set of members of an enum, backed by a
+  single unsigned 64-bit word (one bit per member, at the member's enum value),
+  so every operation is a bitwise op with zero runtime cost. Construct with a set
+  literal, `bit_set[Perm]{ Perm.Read, Perm.Write }` (bare member names and the
+  empty set `bit_set[Perm]{}` also work); operate with `in` (membership), `+`
+  (union), `-` (difference), `<=` / `>=` (subset / superset), `==` / `!=`
+  (equality), and `card(s)` (cardinality, a `popcount`). A bit set is nominal and
+  strictly typed: it never implicitly converts to or from an integer, and two
+  bit sets interoperate only when they are over the same enum; members must lie
+  in `0..63`. Usable as a local, parameter, return type, and struct field. `in`
+  is now also an expression operator (the range-`for` header still consumes its
+  own `in` first, so loops are unaffected). New regression:
+  `tests/regression/test_bit_set.ae`; docs in `language-reference.md`.
+
+### Fixed
+
+- A parametric type used as a **function return type**, `-> Name[T] { ... }`
+  (e.g. `bit_set[E]`, `Isolated[T]`), was mis-parsed: the return-type
+  disambiguator only recognized a bare or dotted name before the body brace, so a
+  `[...]` group hid the block body and the signature fell through to the arrow-
+  expression path, producing a spurious top-level parse error. The disambiguator
+  now scans the balanced bracket group, fixing bracketed return types generally.
+
 ## [0.368.0]
 
 ### Added

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -930,6 +930,14 @@ int is_type_compatible(Type* from, Type* to) {
         return is_integer_scalar(other);
     }
 
+    // #1046 bit_set is strictly nominal: never an int, never another enum's
+    // set. If either side is a bit_set, both must be bit_sets over the same
+    // enum (types_equal compares the element enums nominally).
+    if (from->kind == TYPE_BITSET || to->kind == TYPE_BITSET) {
+        return from->kind == TYPE_BITSET && to->kind == TYPE_BITSET &&
+               types_equal(from, to);
+    }
+
     // Exact match
     if (types_equal(from, to)) return 1;
 
@@ -1229,6 +1237,13 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
         case AST_SIZEOF:
         case AST_OFFSETOF:
             // Compile-time layout builtins; both lower to a C int.
+            return create_type(TYPE_INT);
+
+        case AST_BITSET_LITERAL:   // #1046 `bit_set[E]{...}`; the parser set the
+            return expr->node_type ? clone_type(expr->node_type)  // TYPE_BITSET.
+                                   : create_type(TYPE_UNKNOWN);
+
+        case AST_BITSET_CARD:      // #1046 `card(s)`; cardinality is an int.
             return create_type(TYPE_INT);
 
         case AST_VA_START:
@@ -1637,6 +1652,36 @@ Type* infer_binary_type(ASTNode* left, ASTNode* right, AeTokenType operator) {
     Type* left_type = left ? left->node_type : NULL;
     Type* right_type = right ? right->node_type : NULL;
 
+    // #1046 bit_set operators. A bit_set is nominal (never an int), so any
+    // operator touching one is resolved here before the generic numeric/
+    // comparison rules; a mismatch returns TYPE_UNKNOWN (a clean type error).
+    //   member in set   -> bool   (left enum member, right same-enum bit_set)
+    //   set + set        -> set    (union)
+    //   set - set        -> set    (difference)
+    //   set <= / >= set  -> bool   (subset / superset)
+    //   set == / != set  -> bool   (equality)
+    if (operator == TOKEN_IN) {
+        if (left_type && right_type && right_type->kind == TYPE_BITSET &&
+            left_type->kind == TYPE_ENUM && right_type->element_type &&
+            types_equal(left_type, right_type->element_type)) {
+            return create_type(TYPE_BOOL);
+        }
+        return create_type(TYPE_UNKNOWN);
+    }
+    if ((left_type && left_type->kind == TYPE_BITSET) ||
+        (right_type && right_type->kind == TYPE_BITSET)) {
+        int both_same = left_type && right_type &&
+                        left_type->kind == TYPE_BITSET &&
+                        right_type->kind == TYPE_BITSET &&
+                        types_equal(left_type, right_type);
+        if (operator == TOKEN_PLUS || operator == TOKEN_MINUS)
+            return both_same ? clone_type(left_type) : create_type(TYPE_UNKNOWN);
+        if (operator == TOKEN_LESS_EQUAL || operator == TOKEN_GREATER_EQUAL ||
+            operator == TOKEN_EQUALS || operator == TOKEN_NOT_EQUALS)
+            return both_same ? create_type(TYPE_BOOL) : create_type(TYPE_UNKNOWN);
+        return create_type(TYPE_UNKNOWN);   // any other op on a bit_set is invalid
+    }
+
     // Duration comparisons are only valid against another Duration.
     if (operator == TOKEN_EQUALS || operator == TOKEN_NOT_EQUALS ||
         operator == TOKEN_LESS || operator == TOKEN_LESS_EQUAL ||
@@ -1859,6 +1904,7 @@ AeTokenType get_token_type_from_string(const char* str) {
     if (strcmp(str, "~") == 0) return TOKEN_TILDE;
     if (strcmp(str, "<<") == 0) return TOKEN_LSHIFT;
     if (strcmp(str, ">>") == 0) return TOKEN_RSHIFT;
+    if (strcmp(str, "in") == 0) return TOKEN_IN;  // #1046 bit_set membership
 
     return TOKEN_ERROR;
 }
@@ -5381,6 +5427,52 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             // posture of the `as *Struct` cast.
             expr->node_type = create_type(TYPE_INT);
             return 1;
+
+        case AST_BITSET_LITERAL: {
+            // #1046 `bit_set[E]{ E.A, E.B }`. The element type must resolve to an
+            // enum (resolve_enum_types rewrites TYPE_STRUCT{E} -> TYPE_ENUM), and
+            // every member must belong to that same enum. The members were
+            // normalized to `E.Member` at parse time and rewritten to the enum
+            // constant `E_Member` (node_type TYPE_ENUM{E}) by enum resolution.
+            Type* bs = expr->node_type;
+            Type* elem = bs ? bs->element_type : NULL;
+            if (!elem || elem->kind != TYPE_ENUM) {
+                type_error("bit_set element type must be an enum, e.g. bit_set[Color]",
+                           expr->line, expr->column);
+                return 0;
+            }
+            for (int i = 0; i < expr->child_count; i++) {
+                ASTNode* m = expr->children[i];
+                // Members were resolved to enum constants (node_type TYPE_ENUM)
+                // by resolve_enum_types; just validate they name this enum.
+                if (!m->node_type || m->node_type->kind != TYPE_ENUM ||
+                    !types_equal(m->node_type, elem)) {
+                    char msg[256];
+                    snprintf(msg, sizeof(msg),
+                        "bit_set member must be a value of enum '%s'",
+                        elem->struct_name ? elem->struct_name : "?");
+                    type_error(msg, m->line, m->column);
+                    return 0;
+                }
+            }
+            return 1;
+        }
+
+        case AST_BITSET_CARD: {
+            // #1046 `card(s)`: s must be a bit_set; the count is an int.
+            if (expr->child_count < 1) return 0;
+            typecheck_expression(expr->children[0], table);
+            Type* at = infer_type(expr->children[0], table);
+            if (!at || at->kind != TYPE_BITSET) {
+                type_error("card() requires a bit_set argument", expr->line, expr->column);
+                if (at) free_type(at);
+                expr->node_type = create_type(TYPE_INT);
+                return 0;
+            }
+            free_type(at);
+            expr->node_type = create_type(TYPE_INT);
+            return 1;
+        }
 
         case AST_VA_START:
             // No children; opaque va_list cookie (ptr).

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -50,6 +50,15 @@ Type* create_actor_ref_type(Type* actor_type) {
     return type;
 }
 
+// #1046 `bit_set[E]`, a set of members of enum `element_enum`, backed by an
+// unsigned 64-bit word. `element_enum` is adopted (not cloned). Nominal;
+// clone_type/free_type handle element_type generically.
+Type* create_bitset_type(Type* element_enum) {
+    Type* type = create_type(TYPE_BITSET);
+    type->element_type = element_enum;
+    return type;
+}
+
 Type* create_tuple_type(int count, ...) {
     Type* type = create_type(TYPE_TUPLE);
     type->tuple_count = count;
@@ -209,6 +218,12 @@ const char* type_to_string(Type* type) {
         case TYPE_ISOLATED: {
             static char buffer[256];
             snprintf(buffer, sizeof(buffer), "Isolated[%s]",
+                     type->element_type ? type_to_string(type->element_type) : "?");
+            return buffer;
+        }
+        case TYPE_BITSET: {
+            static char buffer[256];
+            snprintf(buffer, sizeof(buffer), "bit_set[%s]",
                      type->element_type ? type_to_string(type->element_type) : "?");
             return buffer;
         }

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -241,9 +241,19 @@ typedef enum {
     // (incremental builds need `make clean` after this edit).
     AST_ENUM_DEFINITION,    // `enum Name { A, B = 5, C }`. `value` = enum name;
                             // children are AST_ENUM_MEMBER nodes in source order.
-    AST_ENUM_MEMBER         // one member. `value` = member name; children[0] (if
+    AST_ENUM_MEMBER,        // one member. `value` = member name; children[0] (if
                             // present) is the explicit value expression, else the
                             // value is previous + 1 (first defaults to 0).
+    // #1046 bit_set. Appended at END to keep node numbering stable (incremental
+    // builds need `make clean` after this edit).
+    AST_BITSET_LITERAL,     // `bit_set[E]{ E.A, E.B }`. `node_type` is the
+                            // TYPE_BITSET; children are the member expressions
+                            // (each an AST_MEMBER_ACCESS `E.Member`, normalized
+                            // from bare `Member` at parse time). Empty braces
+                            // (`bit_set[E]{}`) yield the empty set (0 children).
+    AST_BITSET_CARD         // `card(s)`, the cardinality (popcount) of a
+                            // bit_set. children[0] is the bit_set expression;
+                            // lowers to `__builtin_popcountll`. Result is int.
 } ASTNodeType;
 
 typedef enum {
@@ -292,12 +302,21 @@ typedef enum {
                         // lowers to T's C type with zero runtime cost. Appended
                         // at END to keep kind numbering stable (incremental
                         // builds need `make clean` after this edit).
-    TYPE_ENUM           // #1044 first-class enum. `struct_name` = enum name.
+    TYPE_ENUM,          // #1044 first-class enum. `struct_name` = enum name.
                         // A named set of integer constants; lowers to a C
                         // `typedef enum { Name_Member = v, ... } Name;` with
                         // zero runtime cost. Nominal (compares equal only to the
                         // same-named enum; interconverts with int only via the
                         // rules in is_type_compatible). Appended at END.
+    TYPE_BITSET         // #1046 `bit_set[E]`, a set of enum members backed by an
+                        // unsigned 64-bit word. element_type is the member enum
+                        // (a TYPE_ENUM). Each member occupies the bit at its enum
+                        // value (members must lie in 0..63). Nominal: a bit_set is
+                        // never an int, and two bit_sets match only when their
+                        // element enums match. Lowers to `unsigned long long` with
+                        // zero runtime cost; set ops become bitwise ops. Appended
+                        // at END to keep kind numbering stable (incremental builds
+                        // need `make clean` after this edit).
 } TypeKind;
 
 typedef struct Type {
@@ -406,6 +425,7 @@ Type* create_optional_type(Type* inner);   // #340 `T?`
 Type* create_actor_ref_type(Type* actor_type);
 Type* create_tuple_type(int count, ...);  // create_tuple_type(2, type_a, type_b)
 Type* create_sum_type(const char* name);  // #914 `type Name = A | B | C`
+Type* create_bitset_type(Type* element_enum);  // #1046 `bit_set[E]`
 Type* create_result_type(Type* inner);    // #913 fallible `T!` -> (T, string)
 Type* create_function_type(int param_count, Type** param_types, Type* return_type);
 void free_type(Type* type);

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1808,6 +1808,11 @@ const char* get_c_type(Type* type) {
              * lowers to the C type of the wrapped T with zero runtime cost
              * (mirrors distinct types); isolate()/consume() are no-ops. */
             return type->element_type ? get_c_type(type->element_type) : "void*";
+        case TYPE_BITSET:
+            /* #1046: bit_set[E] is a set of enum members backed by an unsigned
+             * 64-bit word (one bit per member, at the member's enum value).
+             * Set operations lower to bitwise ops; zero runtime cost. */
+            return "unsigned long long";
         case TYPE_ARRAY: {
             static char buffers[4][256];
             static int buf_idx = 0;

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1972,6 +1972,35 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             }
             break;
 
+        case AST_BITSET_LITERAL:
+            // #1046 `bit_set[E]{ E.A, E.B }` → `((1ULL<<E_A) | (1ULL<<E_B))`.
+            // Each member is the enum constant (= its bit position); the empty
+            // set is `0ULL`. Fully constant-foldable by the C compiler.
+            if (expr->child_count == 0) {
+                fprintf(gen->output, "0ULL");
+            } else {
+                fprintf(gen->output, "(");
+                for (int i = 0; i < expr->child_count; i++) {
+                    if (i > 0) fprintf(gen->output, " | ");
+                    fprintf(gen->output, "(1ULL << (");
+                    generate_expression(gen, expr->children[i]);
+                    fprintf(gen->output, "))");
+                }
+                fprintf(gen->output, ")");
+            }
+            break;
+
+        case AST_BITSET_CARD:
+            // #1046 `card(s)` → popcount of the backing word.
+            if (expr->child_count >= 1) {
+                fprintf(gen->output, "((int)__builtin_popcountll((unsigned long long)(");
+                generate_expression(gen, expr->children[0]);
+                fprintf(gen->output, ")))");
+            } else {
+                fprintf(gen->output, "/* malformed card */0");
+            }
+            break;
+
         case AST_VA_START:
             // The variadic function's prologue declared `va_list __ae_va`
             // and called va_start. This expression just yields its
@@ -2261,6 +2290,56 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             
         case AST_BINARY_EXPRESSION:
             if (expr->child_count >= 2) {
+                // #1046 bit_set operators lower to bitwise ops on the backing
+                // `unsigned long long`. Handled before the generic paths since a
+                // bit_set must never fall through to numeric `<=`/`-` semantics.
+                // `==`/`!=` are left to the default integer compare (which is
+                // exactly set equality). Subset/superset bind each operand once
+                // via a statement-expression so a side-effecting operand (e.g. a
+                // call returning a set) is evaluated exactly once.
+                if (expr->value) {
+                    ASTNode* L = expr->children[0];
+                    ASTNode* R = expr->children[1];
+                    int l_bs = L->node_type && L->node_type->kind == TYPE_BITSET;
+                    int r_bs = R->node_type && R->node_type->kind == TYPE_BITSET;
+                    if (strcmp(expr->value, "in") == 0 && r_bs) {
+                        // member in set -> test the member's bit
+                        fprintf(gen->output, "((((");
+                        generate_expression(gen, R);
+                        fprintf(gen->output, ") >> (");
+                        generate_expression(gen, L);
+                        fprintf(gen->output, ")) & 1ULL) != 0)");
+                        break;
+                    }
+                    if (l_bs || r_bs) {
+                        if (strcmp(expr->value, "+") == 0) {          // union
+                            fprintf(gen->output, "(");
+                            generate_expression(gen, L);
+                            fprintf(gen->output, " | ");
+                            generate_expression(gen, R);
+                            fprintf(gen->output, ")");
+                            break;
+                        }
+                        if (strcmp(expr->value, "-") == 0) {          // difference
+                            fprintf(gen->output, "(");
+                            generate_expression(gen, L);
+                            fprintf(gen->output, " & ~(");
+                            generate_expression(gen, R);
+                            fprintf(gen->output, "))");
+                            break;
+                        }
+                        if (strcmp(expr->value, "<=") == 0 ||
+                            strcmp(expr->value, ">=") == 0) {         // subset/superset
+                            int subset = strcmp(expr->value, "<=") == 0;
+                            fprintf(gen->output, "({ unsigned long long _a = (");
+                            generate_expression(gen, L);
+                            fprintf(gen->output, "); unsigned long long _b = (");
+                            generate_expression(gen, R);
+                            fprintf(gen->output, "); (_a & _b) == %s; })", subset ? "_a" : "_b");
+                            break;
+                        }
+                    }
+                }
                 // #340: equality against `none` / between optionals. A struct
                 // `==` is invalid C, so compare the `has` flag (and value).
                 if (expr->value && (strcmp(expr->value, "==") == 0 ||

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -586,6 +586,26 @@ static Type* parse_type_unsuffixed(Parser* parser) {
                     }
                     type = create_type(TYPE_ISOLATED);
                     type->element_type = inner;
+                } else if (strcmp(token->value, "bit_set") == 0 &&
+                           peek_token(parser) &&
+                           peek_token(parser)->type == TOKEN_LEFT_BRACKET) {
+                    /* #1046: bit_set[E], a set of members of enum E backed by an
+                     * unsigned 64-bit word. The identifier was consumed at case
+                     * entry, so peek is `[`. The element type resolves to a
+                     * TYPE_ENUM (via resolve_enum_types); it lowers to
+                     * `unsigned long long` with zero runtime cost. */
+                    advance_token(parser);  // consume '['
+                    Type* elem = parse_type(parser);
+                    if (!elem) {
+                        parser_error(parser,
+                            "bit_set requires an enum type parameter, e.g. bit_set[Color]");
+                        return NULL;
+                    }
+                    if (!expect_token(parser, TOKEN_RIGHT_BRACKET)) {
+                        free_type(elem);
+                        return NULL;
+                    }
+                    type = create_bitset_type(elem);
                 } else if (strcmp(token->value, "cstring") == 0) {
                     /* `cstring` — a string whose emitted C type is the
                      * mutable `char*` (Aether's plain `string` emits
@@ -1109,6 +1129,82 @@ ASTNode* parse_primary_expression(Parser* parser) {
                     ASTNode* node = create_ast_node(AST_VA_END, NULL, line, column);
                     node->node_type = create_type(TYPE_VOID);
                     add_child(node, cookie);
+                    return node;
+                }
+            }
+            // #1046 bit_set set literal: `bit_set[E]{ E.A, E.B }` (also the
+            // bare-member form `{ A, B }`, and the empty set `bit_set[E]{}`).
+            // Intercepted on the `bit_set[` shape only, so user code may still
+            // name things `bit_set` elsewhere (same non-reserving treatment as
+            // sizeof). Each element is normalized to an AST_MEMBER_ACCESS
+            // `E.Member` so the enum-resolution pass lowers it to `E_Member`.
+            {
+                Token* after = peek_ahead(parser, 1);
+                if (after && after->type == TOKEN_LEFT_BRACKET && token->value &&
+                    strcmp(token->value, "bit_set") == 0) {
+                    int line = token->line, column = token->column;
+                    advance_token(parser);                       // consume 'bit_set'
+                    advance_token(parser);                       // consume '['
+                    Type* elem = parse_type(parser);
+                    if (!elem) {
+                        parser_error(parser,
+                            "bit_set requires an enum type parameter, e.g. bit_set[Color]{ Color.Red }");
+                        return NULL;
+                    }
+                    if (!expect_token(parser, TOKEN_RIGHT_BRACKET)) { free_type(elem); return NULL; }
+                    if (!expect_token(parser, TOKEN_LEFT_BRACE)) { free_type(elem); return NULL; }
+                    const char* enum_name = elem->struct_name;  // element enum's name
+                    ASTNode* lit = create_ast_node(AST_BITSET_LITERAL, NULL, line, column);
+                    lit->node_type = create_bitset_type(elem);
+                    if (!match_token(parser, TOKEN_RIGHT_BRACE)) {
+                        do {
+                            Token* first = expect_token(parser, TOKEN_IDENTIFIER);
+                            if (!first) { free_ast_node(lit); return NULL; }
+                            const char* base_name;   // enum name for this element
+                            const char* member_name; // member name
+                            if (peek_token(parser) && peek_token(parser)->type == TOKEN_DOT) {
+                                advance_token(parser);            // consume '.'
+                                Token* mem = expect_token(parser, TOKEN_IDENTIFIER);
+                                if (!mem) { free_ast_node(lit); return NULL; }
+                                base_name = first->value;         // qualified: E.Member
+                                member_name = mem->value;
+                            } else {
+                                if (!enum_name) {
+                                    parser_error(parser,
+                                        "bare set member needs an enum element type, e.g. bit_set[Color]{ Red }");
+                                    free_ast_node(lit);
+                                    return NULL;
+                                }
+                                base_name = enum_name;            // bare: Member
+                                member_name = first->value;
+                            }
+                            ASTNode* ma = create_ast_node(AST_MEMBER_ACCESS, member_name,
+                                                          first->line, first->column);
+                            ASTNode* base = create_ast_node(AST_IDENTIFIER, base_name,
+                                                            first->line, first->column);
+                            add_child(ma, base);
+                            add_child(lit, ma);
+                        } while (match_token(parser, TOKEN_COMMA));
+                        if (!expect_token(parser, TOKEN_RIGHT_BRACE)) { free_ast_node(lit); return NULL; }
+                    }
+                    return lit;
+                }
+            }
+            // #1046 card(s), cardinality (popcount) of a bit_set. Intercepted on
+            // the `card(` call shape only (same non-reserving treatment as sizeof).
+            {
+                Token* after = peek_ahead(parser, 1);
+                if (after && after->type == TOKEN_LEFT_PAREN && token->value &&
+                    strcmp(token->value, "card") == 0) {
+                    int line = token->line, column = token->column;
+                    advance_token(parser);                       // consume 'card'
+                    if (!expect_token(parser, TOKEN_LEFT_PAREN)) return NULL;
+                    ASTNode* arg = parse_expression(parser);
+                    if (!arg) return NULL;
+                    if (!expect_token(parser, TOKEN_RIGHT_PAREN)) { free_ast_node(arg); return NULL; }
+                    ASTNode* node = create_ast_node(AST_BITSET_CARD, NULL, line, column);
+                    node->node_type = create_type(TYPE_INT);
+                    add_child(node, arg);
                     return node;
                 }
             }
@@ -2104,7 +2200,11 @@ int get_operator_precedence(AeTokenType type) {
         case TOKEN_LESS:
         case TOKEN_LESS_EQUAL:
         case TOKEN_GREATER:
-        case TOKEN_GREATER_EQUAL: return 7;
+        case TOKEN_GREATER_EQUAL:
+        case TOKEN_IN: return 7;  // #1046 `member in bit_set` membership test.
+                                  // A leading `IDENT in` in a for-header is
+                                  // consumed by parse_for_loop before reaching
+                                  // here, so range loops are unaffected.
         case TOKEN_LSHIFT:
         case TOKEN_RSHIFT: return 8;  // shift operators
         case TOKEN_PLUS:
@@ -4598,6 +4698,41 @@ ASTNode* parse_function_definition(Parser* parser) {
                         (c_abi_alias_kind(peek->value, &alias_k) ||
                          strcmp(peek->value, "longdouble") == 0)) {
                         is_typed_return = 1;
+                        break;
+                    }
+                    // A parametric return type `-> Name[T] { ... }` (e.g.
+                    // `bit_set[Color]`, `Isolated[T]`). The bare-name branch
+                    // below only looks one token ahead for `{`, so a `[...]`
+                    // group between the name and `{` hid the block body and the
+                    // signature fell through to the `-> expr` path (which then
+                    // mis-parsed the function body). Scan the balanced bracket
+                    // group; a `{` after the closing `]` (that isn't a struct-
+                    // literal head) marks a typed return with a block body. An
+                    // arrow-expr body like `-> arr[i]` has no trailing `{`, so
+                    // it stays an expression. (Fixes bracketed return types
+                    // generally, not just bit_set.)
+                    if (peek_ahead(parser, 1) &&
+                        peek_ahead(parser, 1)->type == TOKEN_LEFT_BRACKET) {
+                        int off = 1, depth = 0, guard = 0;
+                        while (peek_ahead(parser, off) && guard++ < 256) {
+                            AeTokenType tt = peek_ahead(parser, off)->type;
+                            if (tt == TOKEN_LEFT_BRACKET) depth++;
+                            else if (tt == TOKEN_RIGHT_BRACKET) {
+                                depth--;
+                                if (depth == 0) { off++; break; }
+                            }
+                            off++;
+                        }
+                        // `off` now points just past the closing `]`.
+                        Token* after_br = peek_ahead(parser, off);
+                        if (after_br && after_br->type == TOKEN_LEFT_BRACE) {
+                            Token* ab = peek_ahead(parser, off + 1);
+                            Token* af = peek_ahead(parser, off + 2);
+                            int looks_like_struct_literal =
+                                ab && ab->type == TOKEN_IDENTIFIER &&
+                                af && af->type == TOKEN_COLON;
+                            if (!looks_like_struct_literal) is_typed_return = 1;
+                        }
                         break;
                     }
                     // #946: a qualified return type `-> mod.Name { ... }`

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -1290,6 +1290,58 @@ Aether does not yet thread to every use site): the implicit selector `.North`
 enum-indexed arrays (`[Direction]string`), and enum-match exhaustiveness
 checking.
 
+## Bit Sets
+
+A **bit set** is a set of members of an enum, `bit_set[E]`. It is backed by a
+single unsigned 64-bit word (one bit per member, at the member's enum value), so
+every set operation is a bitwise operation with zero runtime cost.
+
+```aether
+enum Perm { Read, Write, Exec }
+
+let a = bit_set[Perm]{ Perm.Read, Perm.Write }   // a two-member set
+let b = bit_set[Perm]{ Write, Exec }             // bare member names also work
+let empty = bit_set[Perm]{}                       // the empty set
+```
+
+Inside a `bit_set[E]{ ... }` literal each element is a member of `E`, written
+qualified (`Perm.Read`) or bare (`Read`). The type is written the same way it is
+constructed, so a set is used like any other type, on locals, parameters, return
+types, and struct fields:
+
+```aether
+grant(base: bit_set[Perm]) -> bit_set[Perm] {
+    return base + bit_set[Perm]{ Perm.Exec }
+}
+
+struct File { name: string, perms: bit_set[Perm] }
+```
+
+The operators:
+
+| Operation      | Syntax            | Result       | Lowers to        |
+|----------------|-------------------|--------------|------------------|
+| membership     | `Perm.Read in a`  | `bool`       | `(a >> Read) & 1`|
+| union          | `a + b`           | `bit_set[E]` | `a \| b`         |
+| difference     | `a - b`           | `bit_set[E]` | `a & ~b`         |
+| subset         | `a <= b`          | `bool`       | `(a & b) == a`   |
+| superset       | `a >= b`          | `bool`       | `(a & b) == b`   |
+| equality       | `a == b` / `!=`   | `bool`       | `a == b`         |
+| cardinality    | `card(a)`         | `int`        | `popcount(a)`    |
+
+```aether
+let u = a + b                         // union
+let d = a - b                         // difference (members of a not in b)
+if Perm.Exec in u { ... }             // membership test
+if a <= u { ... }                     // is a a subset of u?
+let n = card(u)                       // how many members are set
+```
+
+A bit set is **nominal** and strictly typed: it never implicitly converts to or
+from an integer, and two bit sets interoperate only when they are over the same
+enum. Members must have values in `0..63` (the width of the backing word). `card`
+is a reserved call form, like `sizeof`, and applies only to a bit set.
+
 ## Sum / Variant Types
 
 A **sum type** is a value that is exactly one of N named struct variants:

--- a/tests/regression/test_bit_set.ae
+++ b/tests/regression/test_bit_set.ae
@@ -1,0 +1,91 @@
+// Regression: #1046 bit_set — a set of enum members backed by an unsigned
+// 64-bit word (one bit per member, at the member's enum value).
+//   bit_set[E]                 the type (parametric over an enum E)
+//   bit_set[E]{ E.A, E.B }     a set literal (also bare `{ A, B }`, empty `{}`)
+//   member in set              membership          -> bool
+//   set + set                  union               -> set
+//   set - set                  difference          -> set
+//   set <= set / set >= set    subset / superset   -> bool
+//   set == set / set != set    equality            -> bool
+//   card(set)                  cardinality         -> int
+// All operations lower to bitwise ops on the backing word (zero runtime cost).
+enum Perm { Read, Write, Exec }                 // 0, 1, 2
+enum Flag { Lo = 1, Mid = 8, Hi = 40 }          // explicit, sparse values
+
+import std.io
+
+check_int(got: int, want: int, lbl: string) -> int {
+    if got != want { println("FAIL ${lbl}: ${got} != ${want}"); return 1 }
+    return 0
+}
+check_bool(got: bool, want: bool, lbl: string) -> int {
+    if got == want { return 0 }
+    println("FAIL ${lbl}")
+    return 1
+}
+
+// bit_set as a parameter and as a return type
+with_exec(s: bit_set[Perm]) -> bit_set[Perm] {
+    return s + bit_set[Perm]{ Perm.Exec }
+}
+
+struct Caps {
+    name: string
+    perms: bit_set[Perm]
+}
+
+main() {
+    var fails = 0
+
+    let a = bit_set[Perm]{ Perm.Read, Perm.Write }
+    let b = bit_set[Perm]{ Perm.Write, Perm.Exec }
+
+    // cardinality of literals + the empty set
+    fails = fails + check_int(card(a), 2, "card a")
+    fails = fails + check_int(card(bit_set[Perm]{}), 0, "card empty")
+    fails = fails + check_int(card(bit_set[Perm]{ Read, Write, Exec }), 3, "card bare full")
+
+    // membership
+    fails = fails + check_bool(Perm.Read in a, true, "Read in a")
+    fails = fails + check_bool(Perm.Exec in a, false, "Exec not in a")
+
+    // union / difference
+    let u = a + b
+    fails = fails + check_int(card(u), 3, "card union")
+    let d = a - b
+    fails = fails + check_int(card(d), 1, "card diff")
+    fails = fails + check_bool(Perm.Read in d, true, "Read in diff")
+    fails = fails + check_bool(Perm.Write in d, false, "Write not in diff")
+
+    // subset / superset
+    fails = fails + check_bool(a <= u, true, "a subset u")
+    fails = fails + check_bool(u <= a, false, "u not subset a")
+    fails = fails + check_bool(u >= a, true, "u superset a")
+
+    // equality (order-independent) / inequality
+    let a2 = bit_set[Perm]{ Perm.Write, Perm.Read }
+    fails = fails + check_bool(a == a2, true, "a equals a2")
+    fails = fails + check_bool(a == b, false, "a not equal b")
+
+    // explicit, sparse enum values place bits at the value (Hi = bit 40)
+    let f = bit_set[Flag]{ Flag.Lo, Flag.Hi }
+    fails = fails + check_int(card(f), 2, "card flags")
+    fails = fails + check_bool(Flag.Hi in f, true, "Hi in f")
+    fails = fails + check_bool(Flag.Mid in f, false, "Mid not in f")
+
+    // bit_set as a parameter and return type
+    fails = fails + check_int(card(with_exec(a)), 3, "card with_exec")
+    fails = fails + check_bool(Perm.Exec in with_exec(a), true, "Exec added")
+
+    // bit_set as a struct field
+    let c = Caps { name: "root", perms: bit_set[Perm]{ Perm.Read, Perm.Exec } }
+    fails = fails + check_int(card(c.perms), 2, "card caps")
+    fails = fails + check_bool(Perm.Exec in c.perms, true, "Exec in caps")
+
+    if fails == 0 {
+        println("PASS: bit_set")
+    } else {
+        println("FAILED: ${fails}")
+        exit(1)
+    }
+}


### PR DESCRIPTION
## Summary

Adds `bit_set[E]`, a set of members of an enum backed by a single unsigned
64-bit word (one bit per member, at the member's enum value). Every set
operation lowers to a bitwise op, so a bit set has zero runtime cost and the
same footprint as an integer.

Closes #1046.

## Surface

```aether
enum Perm { Read, Write, Exec }

let a = bit_set[Perm]{ Perm.Read, Perm.Write }   // set literal
let b = bit_set[Perm]{ Write, Exec }             // bare member names
let empty = bit_set[Perm]{}                       // the empty set
```

| Operation    | Syntax           | Result       | Lowers to           |
|--------------|------------------|--------------|---------------------|
| membership   | `Perm.Read in a` | `bool`       | `(a >> Read) & 1`   |
| union        | `a + b`          | `bit_set[E]` | `a \| b`            |
| difference   | `a - b`          | `bit_set[E]` | `a & ~b`            |
| subset       | `a <= b`         | `bool`       | `(a & b) == a`      |
| superset     | `a >= b`         | `bool`       | `(a & b) == b`      |
| equality     | `a == b` / `!=`  | `bool`       | `a == b`            |
| cardinality  | `card(a)`        | `int`        | `__builtin_popcountll` |

A bit set is nominal and strictly typed: it never implicitly converts to or
from an integer, and two bit sets interoperate only when they are over the same
enum. Members must lie in `0..63` (the width of the backing word). Usable as a
local, parameter, return type, and struct field.

`in` becomes an expression operator. The range-`for` header consumes its own
`in` before general expression parsing, so `for i in 0..n` is unaffected
(verified against the examples and the `.ae` suite).

## Also fixed

A parametric type used as a function return type, `-> Name[T] { ... }` (e.g.
`bit_set[E]`, `Isolated[T]`), was mis-parsed: the return-type disambiguator
recognized only a bare or dotted name before the body brace, so a `[...]` group
hid the block body and the signature fell through to the arrow-expression path,
producing a spurious top-level parse error. The disambiguator now scans the
balanced bracket group, fixing bracketed return types generally (`Isolated[T]`
returns now parse too).

## Implementation

- New `TYPE_BITSET` (nominal, `element_type` = the enum; lowers to
  `unsigned long long`) and AST nodes `AST_BITSET_LITERAL` / `AST_BITSET_CARD`.
- Parser: `bit_set[E]` in type position, `bit_set[E]{ ... }` literals (members
  normalized to `E.Member` so enum resolution lowers them to the enum constant),
  and `card(...)` and `in` as call/operator forms.
- Typechecker: nominal compatibility, member/element validation, operator typing.
- Codegen: the bitwise lowerings above; subset/superset bind each operand once
  via a statement-expression (no double evaluation of a side-effecting operand).

## Testing

- New `tests/regression/test_bit_set.ae` (literals, empty/bare forms, all
  operators, sparse explicit enum values, param/return/struct-field use).
- Unit `231/231`, `.ae` suite `570/0`, examples `87/0`.
- Generated C and all changed compiler sources compile warning-free under
  `-Wall -Wextra -Werror`; the compiled test reports `0 leaks`.
- Error paths rejected with clear messages (wrong-enum member, non-enum element,
  `card` on a non-set, int-to-set assignment, mixed-enum operators).

Docs: new Bit Sets section in `docs/language-reference.md`.
