### PR TITLE
feat(types): enum match completeness, bare-name arms + exhaustiveness (#1044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Enum `match` completeness** (follow-up to #1044). A `match` on an enum now
+  accepts bare-name arms (`Red ->`, not only the qualified `Color.Red ->`),
+  resolving the member against the scrutinee's enum, and is exhaustiveness-
+  checked: a match that covers every member needs no `_`, while a non-exhaustive
+  match with no `_` is a compile error naming the missing members (the same
+  guarantee sum types already give). Previously a non-exhaustive enum match fell
+  through and yielded an uninitialized result, and a bare member name failed as
+  an "undeclared identifier" at C-compile time. Both are scoped to enum-scrutinee
+  matches; numeric, string, sum, optional, and ranged matches are untouched. New
+  regression: `tests/regression/test_enum_match_completeness.ae`; docs in
+  `language-reference.md`.
+
 ## [0.370.0]
 
 ### Fixed

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -5018,6 +5018,17 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
             for (int z = 0; z < 64; z++) sum_covered[z] = 0;
             int sum_wildcard = 0;
 
+            // #1044 enum `match` bookkeeping (mirrors the sum path): resolve
+            // bare-name arms (`Red ->`) to the enum constant and track member
+            // coverage for the exhaustiveness check. Only engages when the
+            // scrutinee is a TYPE_ENUM, so every other match shape is untouched.
+            int enum_match = (match_expr_type && match_expr_type->kind == TYPE_ENUM);
+            const char* enum_name = enum_match ? match_expr_type->struct_name : NULL;
+            ASTNode* enum_def = enum_name ? enum_def_lookup(enum_name) : NULL;
+            int enum_covered[64];
+            for (int z = 0; z < 64; z++) enum_covered[z] = 0;
+            int enum_wildcard = 0;
+
             // Type check each match arm
             for (int i = 1; i < stmt->child_count; i++) {
                 ASTNode* arm = stmt->children[i];
@@ -5123,6 +5134,59 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                     }
                 }
 
+                // #1044 enum `match`: an arm pattern is an enum member, written
+                // qualified (`Color.Red`, already lowered to the constant
+                // `Color_Red` by resolve_enum_types) or bare (`Red`). Resolve a
+                // bare member to the constant here (so codegen emits
+                // `_match_val == Color_Red`), reject non-members with a clear
+                // error, and record coverage for the exhaustiveness check. `_`
+                // is the catch-all.
+                if (enum_match && enum_def && pattern) {
+                    int is_wild = (pattern->node_type &&
+                                   pattern->node_type->kind == TYPE_WILDCARD) ||
+                                  (pattern->value && strcmp(pattern->value, "_") == 0);
+                    if (is_wild) {
+                        enum_wildcard = 1;
+                    } else if ((pattern->type == AST_IDENTIFIER ||
+                                pattern->type == AST_PATTERN_VARIABLE) && pattern->value) {
+                        size_t elen = strlen(enum_name);
+                        const char* mem = NULL;
+                        int bare = 0;
+                        if (enum_has_member(enum_name, pattern->value)) {
+                            mem = pattern->value;                 // bare `Member`
+                            bare = 1;
+                        } else if (strncmp(pattern->value, enum_name, elen) == 0 &&
+                                   pattern->value[elen] == '_' &&
+                                   enum_has_member(enum_name, pattern->value + elen + 1)) {
+                            mem = pattern->value + elen + 1;      // lowered `Enum_Member`
+                        }
+                        if (!mem) {
+                            char msg[256];
+                            snprintf(msg, sizeof(msg),
+                                "'%s' is not a member of enum '%s'",
+                                pattern->value, enum_name ? enum_name : "?");
+                            type_error(msg, pattern->line, pattern->column);
+                        } else {
+                            for (int mi = 0; mi < enum_def->child_count && mi < 64; mi++) {
+                                ASTNode* mn = enum_def->children[mi];
+                                if (mn && mn->type == AST_ENUM_MEMBER && mn->value &&
+                                    strcmp(mn->value, mem) == 0) { enum_covered[mi] = 1; break; }
+                            }
+                            if (bare) {
+                                // Lower the bare member to the enum constant so
+                                // codegen compares against `Enum_Member`.
+                                char qualified[512];
+                                snprintf(qualified, sizeof(qualified), "%s_%s",
+                                         enum_name, mem);
+                                free(pattern->value);
+                                pattern->value = strdup(qualified);
+                                if (pattern->node_type) free_type(pattern->node_type);
+                                pattern->node_type = clone_type(match_expr_type);
+                            }
+                        }
+                    }
+                }
+
                 // Type check the arm body in the new scope. A match-as-
                 // expression arm has an EXPRESSION body (an identifier,
                 // literal, call, interpolation, ...); typecheck_statement only
@@ -5176,6 +5240,33 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                         "non-exhaustive match on sum type '%s': missing variant%s "
                         "%s. Add an arm for each, or a `_` wildcard.",
                         match_expr_type->struct_name ? match_expr_type->struct_name : "?",
+                        nmiss > 1 ? "s" : "", missing);
+                    type_error(msg, stmt->line, stmt->column);
+                }
+            }
+
+            // #1044 enum exhaustiveness: every member must be handled unless a
+            // `_` catches the rest (mirrors the sum-type check). This turns a
+            // non-exhaustive enum match, which otherwise falls through and
+            // yields an uninitialized result, into a compile error.
+            if (enum_match && enum_def && !enum_wildcard) {
+                char missing[256]; int mp = 0, nmiss = 0;
+                for (int mi = 0; mi < enum_def->child_count && mi < 64; mi++) {
+                    ASTNode* mn = enum_def->children[mi];
+                    if (!mn || mn->type != AST_ENUM_MEMBER || !mn->value) continue;
+                    if (enum_covered[mi]) continue;
+                    if (nmiss > 0 && mp < (int)sizeof(missing))
+                        mp += snprintf(missing + mp, sizeof(missing) - mp, ", ");
+                    if (mp < (int)sizeof(missing))
+                        mp += snprintf(missing + mp, sizeof(missing) - mp, "%s", mn->value);
+                    nmiss++;
+                }
+                if (nmiss > 0) {
+                    char msg[360];
+                    snprintf(msg, sizeof(msg),
+                        "non-exhaustive match on enum '%s': missing member%s "
+                        "%s. Add an arm for each, or a `_` wildcard.",
+                        enum_name ? enum_name : "?",
                         nmiss > 1 ? "s" : "", missing);
                     type_error(msg, stmt->line, stmt->column);
                 }

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -1266,29 +1266,34 @@ if d == Direction.East { ... }  // compare (nominal: same enum only)
 ```
 
 An enum is used like any other type, on parameters, returns, and locals, and is
-matched with qualified arms:
+matched with member arms. Inside a `match` on an enum the member may be written
+qualified (`Direction.North`) or bare (`North`), since the scrutinee already
+fixes the enum:
 
 ```aether
 label(d: Direction) -> string {
     return match d {
-        Direction.North -> "N"
-        Direction.East  -> "E"
-        _               -> "?"
+        North -> "N"
+        East  -> "E"
+        South -> "S"
+        West  -> "W"
     }
 }
 ```
 
+An enum `match` is **exhaustive-checked**: if it covers every member, no `_` arm
+is needed (as above); if a member is left uncovered and there is no `_`, it is a
+compile error naming the missing members (the same guarantee sum types give). A
+`_` arm still catches the rest when you want a default.
+
 Because an enum is integer-backed, its members interconvert with integer scalars
 (`x: int = Errno.Perm` gives `13`; `code == Errno.NotFound` compares as ints),
-but two **different** enums are never compatible with each other. A qualified
-match arm compares against the member's constant, so a `match` on an enum needs
-a `_` arm unless every member value is covered.
+but two **different** enums are never compatible with each other.
 
 Deliberately deferred to a follow-up (they need context-type propagation that
 Aether does not yet thread to every use site): the implicit selector `.North`
-(inferring the enum from the expected type), bare-name match arms (`North ->`),
-enum-indexed arrays (`[Direction]string`), and enum-match exhaustiveness
-checking.
+(inferring the enum from the expected type) in expression position, and
+enum-indexed arrays (`[Direction]string`).
 
 ## Bit Sets
 

--- a/tests/regression/test_enum_match_completeness.ae
+++ b/tests/regression/test_enum_match_completeness.ae
@@ -1,0 +1,71 @@
+// Regression: #1044 enum `match` completeness follow-ups.
+//   - bare-name arms: `Red ->` resolves to the enum member (not only the
+//     qualified `Color.Red ->`).
+//   - exhaustiveness: a match on an enum that covers every member needs no `_`;
+//     a non-exhaustive match with no `_` is a compile error (checked out-of-band
+//     since a regression test can only exercise programs that compile).
+// Both are scoped to enum-scrutinee matches; numeric/string/sum/optional
+// matches are untouched.
+import std.io
+
+enum Color { Red, Green, Blue }
+enum Dir { N, E, S, W }
+
+check_str(got: string, want: string, lbl: string) -> int {
+    if got != want { println("FAIL ${lbl}: got ${got} want ${want}"); return 1 }
+    return 0
+}
+
+// bare-name arms, exhaustive, NO wildcard needed
+name(c: Color) -> string {
+    g = match c {
+        Red -> "red"
+        Green -> "green"
+        Blue -> "blue"
+    }
+    return g
+}
+
+// mixed qualified + bare + wildcard
+kind(c: Color) -> string {
+    g = match c {
+        Color.Red -> "warm"
+        Green -> "cool"
+        _ -> "other"
+    }
+    return g
+}
+
+// bare-name arms inside a `return match` (combines #1054 + this)
+arrow(d: Dir) -> string {
+    return match d {
+        N -> "^"
+        E -> ">"
+        S -> "v"
+        W -> "<"
+    }
+}
+
+main() {
+    var fails = 0
+
+    fails = fails + check_str(name(Color.Red), "red", "name Red")
+    fails = fails + check_str(name(Color.Green), "green", "name Green")
+    fails = fails + check_str(name(Color.Blue), "blue", "name Blue")
+
+    fails = fails + check_str(kind(Color.Red), "warm", "kind Red")
+    fails = fails + check_str(kind(Color.Green), "cool", "kind Green")
+    fails = fails + check_str(kind(Color.Blue), "other", "kind Blue")
+
+    fails = fails + check_str(arrow(Dir.N), "^", "arrow N")
+    fails = fails + check_str(arrow(Dir.E), ">", "arrow E")
+    fails = fails + check_str(arrow(Dir.S), "v", "arrow S")
+    fails = fails + check_str(arrow(Dir.W), "<", "arrow W")
+
+    if fails == 0 {
+        println("PASS: enum_match_completeness")
+    } else {
+        println("FAILED: ${fails}")
+        exit(1)
+    }
+}


### PR DESCRIPTION
## Summary

Completes the enum `match` experience from first-class enums (#1044). A `match`
whose scrutinee is an enum now supports bare-name arms and is exhaustiveness-
checked.

Follow-up to #1044.

## Bare-name arms

The member may be written qualified or bare, since the scrutinee fixes the enum:

```aether
enum Color { Red, Green, Blue }

name(c: Color) -> string {
    return match c {
        Red   -> "red"      // was: only `Color.Red ->` worked
        Green -> "green"
        Blue  -> "blue"
    }
}
```

A bare member is lowered to the enum constant (`Color_Red`), so codegen is
unchanged. A bare name that is not a member of the scrutinee's enum is now a
clear `'Purple' is not a member of enum 'Color'` error, instead of a downstream
`undeclared identifier` failure from the C compiler.

## Exhaustiveness

An enum `match` that covers every member needs no `_`; a non-exhaustive match
with no `_` is a compile error naming the missing members, the same guarantee
sum types already give:

```
error: non-exhaustive match on enum 'Color': missing member Blue.
       Add an arm for each, or a `_` wildcard.
```

Previously a non-exhaustive enum match fell through and returned an
uninitialized result (silent garbage). A `_` arm still provides a default.

## Scope

Both behaviours are gated on a `TYPE_ENUM` scrutinee, so numeric, string, sum,
optional, and ranged/multi-value matches are untouched. They work in expression,
return (`return match ...`), and statement position. The implementation mirrors
the existing sum-type coverage tracking and exhaustiveness check in
`typecheck_statement`'s `AST_MATCH_STATEMENT` case.

## Testing

- New `tests/regression/test_enum_match_completeness.ae` (bare / qualified /
  mixed / wildcard arms across expression, return, and statement positions).
- Unit `231/231`, `.ae` suite `572/0`, examples `87/0`; `typechecker.c` compiles
  warning-free under `-Wall -Wextra -Werror`.
- Compile-error paths verified out-of-band: non-exhaustive match, and a
  non-member bare arm.

Docs: the two items are removed from the "deferred" list in the Enums section of
`language-reference.md`, which now documents bare-name arms and exhaustiveness.
