### PR TITLE
feat(types): enum-indexed arrays [E]T (#1044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Enum-indexed arrays, `[E]T`** (follow-up to #1044). A fixed array with one
+  slot per member of enum `E`, indexed by an `E` value instead of a raw integer:
+  `const LABELS: [Dir]string = ["north","east","south","west"]; LABELS[Dir.E]`.
+  Sized at compile time to the enum's member range (`0 ..= max value`) and
+  lowered to a plain C array, so there is zero runtime cost and no bounds check
+  is needed (the index is a sealed enum value). A positional literal supplies one
+  value per member in declaration order and the count must match; indexing with a
+  raw `int`, a mismatched value count, or a non-enum index type are compile
+  errors. Supported for local variables and top-level `const`; array-typed
+  parameters and empty `[]` initialisers share the pre-existing fixed-size-array
+  limitations and are a separate follow-up. New regression:
+  `tests/regression/test_enum_indexed_array.ae`; docs in `language-reference.md`.
+
 ## [0.372.0]
 
 ### Added

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -2249,6 +2249,27 @@ static int coerce_bare_enum_member(ASTNode* expr, Type* expected, SymbolTable* t
     return 1;
 }
 
+// #1044 enum-indexed arrays: the C array slot count for `[E]T`, i.e. the max
+// member value + 1 (values follow the same implicit `previous + 1` / explicit
+// integer-literal rule as codegen's emit_enum_typedef). Returns 0 if the enum
+// is unknown. A non-literal explicit value (`A = 1 << 2`) is not evaluated here;
+// enum-indexed arrays require integer-literal member values, so those size to
+// their literal text via the same path C uses.
+static int enum_slot_count(const char* ename) {
+    ASTNode* def = enum_def_lookup(ename);
+    if (!def) return 0;
+    int cur = 0, maxv = -1;
+    for (int i = 0; i < def->child_count; i++) {
+        ASTNode* m = def->children[i];
+        if (!m || m->type != AST_ENUM_MEMBER) continue;
+        if (m->child_count > 0 && m->children[0] && m->children[0]->value)
+            cur = atoi(m->children[0]->value);
+        if (cur > maxv) maxv = cur;
+        cur++;
+    }
+    return maxv + 1;
+}
+
 static int is_c_struct_name(const char* name) {
     if (!name) return 0;
     for (int i = 0; i < g_c_struct_name_count; i++)
@@ -4019,6 +4040,10 @@ static void enum_rewrite_type(Type* t, const char** names, int n, int depth) {
         for (int i = 0; i < n; i++)
             if (strcmp(t->struct_name, names[i]) == 0) { t->kind = TYPE_ENUM; break; }
     }
+    // #1044 enum-indexed array `[E]T`: now that the enum is known, size the
+    // array to its member range (the parser left array_size = -1).
+    if (t->kind == TYPE_ARRAY && t->index_enum_name && t->array_size < 0)
+        t->array_size = enum_slot_count(t->index_enum_name);
     enum_rewrite_type(t->element_type, names, n, depth + 1);
     enum_rewrite_type(t->return_type, names, n, depth + 1);
     for (int i = 0; i < t->tuple_count; i++)
@@ -4524,6 +4549,33 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                     free_type(init_type);
                     type_error("Type mismatch in variable initialization", stmt->line, stmt->column);
                     return 0;
+                }
+                // #1044 enum-indexed array `[E]T`: the index type must be a real
+                // enum, and a literal initializer supplies one value per member,
+                // in declaration order (an empty `[]` zero-initialises every
+                // slot).
+                if (stmt->node_type && stmt->node_type->kind == TYPE_ARRAY &&
+                    stmt->node_type->index_enum_name) {
+                    const char* en = stmt->node_type->index_enum_name;
+                    if (!is_enum_type_name(en)) {
+                        char msg[256];
+                        snprintf(msg, sizeof(msg),
+                            "enum-indexed array `[%s]...` requires `%s` to be an enum",
+                            en, en);
+                        type_error(msg, stmt->line, stmt->column);
+                        return 0;
+                    }
+                    if (init && init->type == AST_ARRAY_LITERAL &&
+                        init->child_count > 0 &&
+                        init->child_count != stmt->node_type->array_size) {
+                        char msg[256];
+                        snprintf(msg, sizeof(msg),
+                            "enum-indexed array `[%s]...` needs %d values (one per "
+                            "member, in order), got %d",
+                            en, stmt->node_type->array_size, init->child_count);
+                        type_error(msg, stmt->line, stmt->column);
+                        return 0;
+                    }
                 }
                 /* #340: re-binding an already-declared optional local
                  * (`z = 5` / `z = none` after `let z: int? = ...`) adopts the
@@ -5844,9 +5896,25 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             if (expr->child_count >= 2) {
                 typecheck_expression(expr->children[0], table);
                 typecheck_expression(expr->children[1], table);
+                Type* arr_type = expr->children[0]->node_type;
                 Type* idx_type = infer_type(expr->children[1], table);
-                if (idx_type && idx_type->kind != TYPE_INT && idx_type->kind != TYPE_INT64
-                    && idx_type->kind != TYPE_UNKNOWN) {
+                if (arr_type && arr_type->kind == TYPE_ARRAY && arr_type->index_enum_name) {
+                    // Index must be a value of the array's index enum, not a raw int.
+                    if (idx_type && idx_type->kind != TYPE_UNKNOWN &&
+                        !(idx_type->kind == TYPE_ENUM && idx_type->struct_name &&
+                          strcmp(idx_type->struct_name, arr_type->index_enum_name) == 0)) {
+                        char error_msg[256];
+                        snprintf(error_msg, sizeof(error_msg),
+                                 "index into `[%s]...` must be a %s value, got %s",
+                                 arr_type->index_enum_name, arr_type->index_enum_name,
+                                 type_name(idx_type));
+                        type_error(error_msg, expr->line, expr->column);
+                    }
+                } else if (idx_type && idx_type->kind != TYPE_INT &&
+                           idx_type->kind != TYPE_INT64 &&
+                           idx_type->kind != TYPE_UNKNOWN &&
+                           idx_type->kind != TYPE_ENUM) {
+                    // Ordinary array: an integer index (an enum is int-backed).
                     char error_msg[256];
                     snprintf(error_msg, sizeof(error_msg),
                              "Array index must be an integer, got %s",
@@ -5856,7 +5924,6 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                 if (idx_type) free_type(idx_type);
 
                 // Propagate element type from the array expression.
-                Type* arr_type = expr->children[0]->node_type;
                 if (arr_type && arr_type->kind == TYPE_ARRAY && arr_type->element_type &&
                     (!expr->node_type || expr->node_type->kind == TYPE_UNKNOWN)) {
                     if (expr->node_type) free_type(expr->node_type);

--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -13,6 +13,7 @@ Type* create_type(TypeKind kind) {
     type->struct_name = NULL;
     type->c_alias = NULL;
     type->distinct_name = NULL;
+    type->index_enum_name = NULL;   // #1044 enum-indexed array marker
     type->tuple_types = NULL;
     type->tuple_count = 0;
     type->tuple_heap_flags = NULL;
@@ -121,6 +122,9 @@ void free_type(Type* type) {
         if (type->distinct_name) {
             free(type->distinct_name);
         }
+        if (type->index_enum_name) {
+            free(type->index_enum_name);
+        }
         if (type->tuple_types) {
             for (int i = 0; i < type->tuple_count; i++) {
                 free_type(type->tuple_types[i]);
@@ -171,9 +175,16 @@ const char* type_to_string(Type* type) {
         }
         case TYPE_ARRAY: {
             static char buffer[256];
-            snprintf(buffer, sizeof(buffer), "%s[%d]", 
-                    type_to_string(type->element_type), 
-                    type->array_size);
+            if (type->index_enum_name) {
+                // #1044 enum-indexed array `[E]T`
+                snprintf(buffer, sizeof(buffer), "[%s]%s",
+                        type->index_enum_name,
+                        type->element_type ? type_to_string(type->element_type) : "?");
+            } else {
+                snprintf(buffer, sizeof(buffer), "%s[%d]",
+                        type_to_string(type->element_type),
+                        type->array_size);
+            }
             return buffer;
         }
         case TYPE_ACTOR_REF: {
@@ -275,6 +286,13 @@ int types_equal(Type* a, Type* b) {
         return types_equal(a->return_type, b->return_type);
     }
 
+    // #1044 enum-indexed arrays are distinguished by their index enum: a
+    // `[Dir]string` is neither a plain `string[]` nor a `[Color]string`.
+    if (a->index_enum_name || b->index_enum_name) {
+        if (!a->index_enum_name || !b->index_enum_name) return 0;
+        if (strcmp(a->index_enum_name, b->index_enum_name) != 0) return 0;
+    }
+
     return types_equal(a->element_type, b->element_type);
 }
 
@@ -296,6 +314,9 @@ Type* clone_type(Type* type) {
     }
     if (type->distinct_name) {
         new_type->distinct_name = strdup(type->distinct_name);
+    }
+    if (type->index_enum_name) {
+        new_type->index_enum_name = strdup(type->index_enum_name);
     }
 
     if (type->tuple_types && type->tuple_count > 0) {

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -338,6 +338,12 @@ typedef struct Type {
     // or a distinct type vs its base, are NOT compatible without an explicit
     // `as` cast, even when `kind` matches. NULL for every non-distinct type.
     char* distinct_name;
+    // #1044 enum-indexed array `[E]T`: when non-NULL on a TYPE_ARRAY, the array
+    // has one slot per member of enum `index_enum_name` and is indexed by an
+    // `E` value (`labels[Dir.North]`), not a raw int. `element_type` is the
+    // element T; `array_size` is the slot count (max member value + 1). NULL for
+    // an ordinary integer-indexed array. Zero runtime cost (a plain C array).
+    char* index_enum_name;
     // Tuple support (multiple return values)
     struct Type** tuple_types;  // Array of element types (NULL if not tuple)
     int tuple_count;            // Number of tuple elements (0 if not tuple)

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -293,6 +293,34 @@ static Type* parse_type_unsuffixed(Parser* parser) {
 
     Type* type = NULL;
 
+    // #1044 enum-indexed array `[E]T`: a leading `[` introduces the index enum,
+    // then the element type. The array has one slot per member of enum E and is
+    // indexed by an E value (`labels[Dir.North]`). Ordinary arrays keep the
+    // postfix `T[N]` / `T[]` form handled after the switch below. The size is
+    // filled in from E by resolve_enum_types once the enum definition is known.
+    if (token->type == TOKEN_LEFT_BRACKET) {
+        advance_token(parser);  // consume '['
+        Type* index_enum = parse_type(parser);
+        if (!index_enum) {
+            parser_error(parser,
+                "expected an enum name inside `[...]` for an enum-indexed array");
+            return NULL;
+        }
+        if (!expect_token(parser, TOKEN_RIGHT_BRACKET)) { free_type(index_enum); return NULL; }
+        Type* elem = parse_type(parser);
+        if (!elem) {
+            parser_error(parser,
+                "expected an element type after `[E]` for an enum-indexed array, e.g. [Dir]string");
+            free_type(index_enum);
+            return NULL;
+        }
+        Type* arr = create_array_type(elem, -1);  // size resolved at typecheck
+        if (index_enum->struct_name)
+            arr->index_enum_name = strdup(index_enum->struct_name);
+        free_type(index_enum);
+        return arr;
+    }
+
     /* `const <type>` — a C-qualified type.  Parsed by recursing on the
      * unqualified type, then stamping a const-prefixed C spelling onto
      * `c_alias` so codegen emits the qualifier verbatim.  The `kind`

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -1308,7 +1308,27 @@ A real binding always wins: if a variable named `North` is in scope, `North`
 refers to it, not the member. A bare name that is not a member of the expected
 enum stays an ordinary "undefined variable" error.
 
-Deliberately deferred to a follow-up: enum-indexed arrays (`[Direction]string`).
+### Enum-indexed arrays
+
+`[E]T` is a fixed array with exactly one slot per member of enum `E`, indexed by
+an `E` value rather than a raw integer. It is sized at compile time to the enum's
+member range and lowers to a plain C array (zero runtime cost):
+
+```aether
+enum Dir { N, E, S, W }
+const LABELS: [Dir]string = ["north", "east", "south", "west"]  // one per member
+
+LABELS[Dir.E]        // "east", indexed by the enum member
+var t: [Dir]string = ["n", "e", "s", "w"]
+t[Dir.N] = "NORTH"   // element assignment
+```
+
+A positional literal supplies one value per member in declaration order; the
+count must match. The index must be a value of `E` (a raw `int` is rejected), so
+the type keeps the table and its keys in lockstep. With explicit member values
+the array spans `0 ..= max value`, so a sparse enum reserves the intervening
+slots. Array-typed function parameters and empty `[]` initialisers share the
+current fixed-size-array limitations and are a separate follow-up.
 
 ## Bit Sets
 

--- a/tests/regression/test_enum_indexed_array.ae
+++ b/tests/regression/test_enum_indexed_array.ae
@@ -1,0 +1,60 @@
+// Regression: #1044 enum-indexed arrays. `[E]T` is a fixed array with one slot
+// per member of enum E, indexed by an E value (not a raw int). Sized to the
+// enum's member range at compile time; a plain C array, zero runtime cost.
+//   let labels: [Dir]string = ["n", "e", "s", "w"]   // one value per member
+//   labels[Dir.North]                                 // indexed by the enum
+// Compile-error paths (wrong value count, non-enum index type, raw-int index)
+// are checked out-of-band. Local vars and top-level `const` with positional
+// init are supported; array-typed parameters and empty `[]` init share the
+// pre-existing fixed-size-array limitations and are not exercised here.
+import std.io
+
+enum Dir { N, E, S, W }
+enum Level { Low = 1, Mid = 5, High = 9 }   // explicit, sparse values
+
+// top-level const lookup table
+const LABELS: [Dir]string = ["north", "east", "south", "west"]
+
+check_str(got: string, want: string, lbl: string) -> int {
+    if got != want { println("FAIL ${lbl}: got ${got} want ${want}"); return 1 }
+    return 0
+}
+check_int(got: int, want: int, lbl: string) -> int {
+    if got != want { println("FAIL ${lbl}: ${got} != ${want}"); return 1 }
+    return 0
+}
+
+main() {
+    var fails = 0
+
+    // read a const lookup table by enum member
+    fails = fails + check_str(LABELS[Dir.N], "north", "const N")
+    fails = fails + check_str(LABELS[Dir.W], "west", "const W")
+
+    // local table, indexed by an enum-typed variable
+    let labels: [Dir]string = ["n", "e", "s", "w"]
+    let d = Dir.S
+    fails = fails + check_str(labels[d], "s", "var index")
+
+    // element assignment
+    var t: [Dir]string = ["n", "e", "s", "w"]
+    t[Dir.N] = "NORTH"
+    fails = fails + check_str(t[Dir.N], "NORTH", "assign N")
+    fails = fails + check_str(t[Dir.E], "e", "unchanged E")
+
+    // sparse explicit values: the array spans 0..max member value (High = 9),
+    // so it has 10 slots; indexing by the members lands on the right ones
+    var scores: [Level]int = [0,0,0,0,0,0,0,0,0,0]
+    scores[Level.Low] = 10
+    scores[Level.High] = 90
+    fails = fails + check_int(scores[Level.Low], 10, "Low")
+    fails = fails + check_int(scores[Level.High], 90, "High")
+    fails = fails + check_int(scores[Level.Mid], 0, "Mid untouched")
+
+    if fails == 0 {
+        println("PASS: enum_indexed_array")
+    } else {
+        println("FAILED: ${fails}")
+        exit(1)
+    }
+}


### PR DESCRIPTION
## Summary

Adds enum-indexed arrays, `[E]T`: a fixed array with exactly one slot per member
of enum `E`, indexed by an `E` value instead of a raw integer.

Follow-up to #1044.

## What it does

```aether
enum Dir { N, E, S, W }
const LABELS: [Dir]string = ["north", "east", "south", "west"]   // one per member

LABELS[Dir.E]                    // "east", indexed by the enum member
var t: [Dir]string = ["n","e","s","w"]
t[Dir.N] = "NORTH"               // element read/write
```

Sized at compile time to the enum's member range (`0 ..= max member value`) and
lowered to a plain C array, so there is zero runtime cost and no bounds check is
needed (the index is a sealed enum value):

```c
const char* LABELS[4] = {"north", "east", "south", "west"};
... LABELS[Dir_E] ...
```

## Design

- **Type**: a new field `index_enum_name` on `TYPE_ARRAY` (Option A), so ordinary
  integer-indexed arrays are completely untouched. `create_type` inits it NULL;
  `clone_type` / `free_type` / `types_equal` / `type_to_string` handle it.
- **Parser**: the prefix `[E]T` form in `parse_type_unsuffixed` (ordinary arrays
  keep the postfix `T[N]` / `T[]` form).
- **Resolve**: `resolve_enum_types` sizes the array from the enum member range
  once the enum definition is known.
- **Typecheck**: rejects a raw-`int` index (the index must be a value of `E`), a
  non-enum index type, and a positional literal whose value count does not match
  the member count, each with a clear error.
- **Codegen**: reuses the existing array declaration + access machinery; the
  enum member lowers to its C constant (`Dir_E`), which is a valid array index.

## Scope

Supported for local variables and top-level `const` with a positional literal
initializer, indexed by a member (`arr[Dir.North]`). Array-typed function
parameters and empty `[]` initialisers hit the same pre-existing fixed-size-array
limitations (a plain `int[4]` parameter and `int[4] = []` fail identically today)
and are left to a separate follow-up. Keyed initialisers (`{ North: "N", ... }`)
and the bare-member index (`arr[North]`) are natural future enhancements.

## Testing

- New `tests/regression/test_enum_indexed_array.ae`: const + local tables,
  index by member and by enum-typed variable, element assignment, and sparse
  explicit member values. Compile-error paths (wrong count, non-enum index,
  raw-int index) verified out-of-band.
- Unit `231/231`, `.ae` suite `573/0`, examples `87/0`; `ast.c`, `parser.c`, and
  `typechecker.c` compile warning-free under `-Wall -Wextra -Werror`.

Docs: new "Enum-indexed arrays" subsection in `language-reference.md`; the item
is removed from the enum deferred list.
