### PR TITLE
fix(std.tcp): add length-aware binary I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Length-aware TCP I/O** (#1078). `std.tcp` now exposes
+  `tcp.write_n(sock, data, length)` and `tcp.read_n(sock, max)` on top of
+  `tcp_send_n_raw` / `tcp_receive_n_raw`, so TCP relays can send and
+  receive byte buffers with embedded NULs without strlen truncation. The
+  read side returns `(bytes, length, err)` using a length-bearing
+  AetherString, matching the binary-safe stdlib pattern used by
+  `fs.read_binary`.
+
 ## [0.373.0]
 
 ### Added

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -804,14 +804,16 @@ It is no longer part of the Aether stdlib. See [`docs/http-vcr.md`](http-vcr.md)
 > the `send_raw`/`receive_raw` naming.
 
 - `tcp.connect(host, port)` → `(ptr, string)` - Connect, return `(socket, err)`
-- `tcp.write(sock, data)` → `(int, string)` - Write, return `(bytes, err)`
-- `tcp.read(sock, max_bytes)` → `(string, string)` - Read, return `(data, err)`
+- `tcp.write(sock, data)` → `(int, string)` - Text-shaped write, return `(bytes, err)`
+- `tcp.write_n(sock, data, length)` → `(int, string)` - Length-aware write for binary payloads
+- `tcp.read(sock, max_bytes)` → `(string, string)` - Text-shaped read, return `(data, err)`
+- `tcp.read_n(sock, max_bytes)` → `(string, int, string)` - Binary-safe read, return `(bytes, length, err)`
 - `tcp.listen(port)` → `(ptr, string)` - Create listening socket
 - `tcp.accept(server)` → `(ptr, string)` - Accept connection
 - `tcp.close(sock)` - Close socket (infallible)
 - `tcp.server_close(server)` - Close server socket
 
-Raw externs: `tcp_connect_raw`, `tcp_send_raw`, `tcp_receive_raw`, `tcp_listen_raw`, `tcp_accept_raw`.
+Raw externs: `tcp_connect_raw`, `tcp_send_raw`, `tcp_send_n_raw`, `tcp_receive_raw`, `tcp_receive_n_raw`, `tcp_listen_raw`, `tcp_accept_raw`.
 
 ### Reactor-Pattern Async I/O (`await_io`)
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -1613,14 +1613,16 @@ main() {
 
 **Functions (Go-style):**
 - `tcp.connect(host, port)` → `(ptr, string)` - Connect, return `(socket, err)`
-- `tcp.write(sock, data)` → `(int, string)` - Write bytes, return `(bytes_sent, err)`
-- `tcp.read(sock, max)` → `(string, string)` - Read bytes, return `(data, err)`
+- `tcp.write(sock, data)` → `(int, string)` - Write text-shaped data, return `(bytes_sent, err)`. Uses the legacy strlen-shaped raw send; use `tcp.write_n` for binary payloads.
+- `tcp.write_n(sock, data, length)` → `(int, string)` - Length-aware write, return `(bytes_sent, err)`. Sends exactly the caller-supplied byte prefix, preserving embedded NUL bytes.
+- `tcp.read(sock, max)` → `(string, string)` - Read text-shaped data, return `(data, err)`. Use `tcp.read_n` for binary payloads.
+- `tcp.read_n(sock, max)` → `(string, int, string)` - Binary-safe read, return `(bytes, length, err)`. The returned length is authoritative for payloads with embedded NUL bytes.
 - `tcp.listen(port)` → `(ptr, string)` - Create server socket
 - `tcp.accept(server)` → `(ptr, string)` - Accept connection
 - `tcp.close(sock)` - Close socket (infallible)
 - `tcp.server_close(server)` - Close server socket
 
-Raw externs: `tcp_connect_raw`, `tcp_send_raw`, `tcp_receive_raw`, `tcp_listen_raw`, `tcp_accept_raw`.
+Raw externs: `tcp_connect_raw`, `tcp_send_raw`, `tcp_send_n_raw`, `tcp_receive_raw`, `tcp_receive_n_raw`, `tcp_listen_raw`, `tcp_accept_raw`.
 
 ### Reactor-pattern async I/O (`await_io`)
 

--- a/std/net/aether_net.c
+++ b/std/net/aether_net.c
@@ -2,11 +2,18 @@
 #include "../../runtime/config/aether_optimization_config.h"
 #include "../../runtime/aether_sandbox.h"
 #include "../../runtime/aether_resource_caps.h"
+#include "../string/aether_string.h"
 
 #if !AETHER_HAS_NETWORKING
 TcpSocket* tcp_connect_raw(const char* h, int p) { (void)h; (void)p; return NULL; }
 int tcp_send_raw(TcpSocket* s, const char* d) { (void)s; (void)d; return -1; }
+int tcp_send_n_raw(TcpSocket* s, const char* d, int n) { (void)s; (void)d; (void)n; return -1; }
 char* tcp_receive_raw(TcpSocket* s, int m) { (void)s; (void)m; return NULL; }
+TcpReceiveResult tcp_receive_n_raw(TcpSocket* s, int m) {
+    (void)s; (void)m;
+    TcpReceiveResult out = { NULL, 0, "net unavailable" };
+    return out;
+}
 int tcp_close(TcpSocket* s) { (void)s; return 0; }
 TcpServer* tcp_listen_raw(int p) { (void)p; return NULL; }
 TcpSocket* tcp_accept_raw(TcpServer* s) { (void)s; return NULL; }
@@ -128,6 +135,14 @@ int tcp_send_raw(TcpSocket* sock, const char* data) {
     return sent;
 }
 
+int tcp_send_n_raw(TcpSocket* sock, const char* data, int length) {
+    if (!sock || !sock->connected || !data || length < 0) return -1;
+    if (length == 0) return 0;
+
+    int sent = send(sock->fd, data, (size_t)length, 0);
+    return sent;
+}
+
 char* tcp_receive_raw(TcpSocket* sock, int max_bytes) {
     if (!sock || !sock->connected || max_bytes <= 0) return NULL;
 
@@ -147,6 +162,42 @@ char* tcp_receive_raw(TcpSocket* sock, int max_bytes) {
 
     buffer[received] = '\0';
     return buffer;
+}
+
+TcpReceiveResult tcp_receive_n_raw(TcpSocket* sock, int max_bytes) {
+    TcpReceiveResult out;
+    out._0 = NULL;
+    out._1 = 0;
+    out._2 = "connection closed or receive failed";
+
+    if (!sock || !sock->connected || max_bytes <= 0) {
+        return out;
+    }
+
+    char* buffer = (char*)aether_caps_malloc((size_t)max_bytes);
+    if (!buffer) {
+        out._2 = "allocation failed";
+        return out;
+    }
+
+    int received = recv(sock->fd, buffer, max_bytes, 0);
+    if (received <= 0) {
+        aether_caps_free(buffer, (size_t)max_bytes);
+        sock->connected = 0;
+        return out;
+    }
+
+    AetherString* wrapped = string_new_with_length(buffer, (size_t)received);
+    aether_caps_free(buffer, (size_t)max_bytes);
+    if (!wrapped) {
+        out._2 = "allocation failed";
+        return out;
+    }
+
+    out._0 = (void*)wrapped;
+    out._1 = received;
+    out._2 = "";
+    return out;
 }
 
 int tcp_close(TcpSocket* sock) {

--- a/std/net/aether_net.h
+++ b/std/net/aether_net.h
@@ -5,11 +5,18 @@
 
 typedef struct TcpSocket TcpSocket;
 typedef struct TcpServer TcpServer;
+typedef struct TcpReceiveResult {
+    void* _0;
+    int _1;
+    const char* _2;
+} TcpReceiveResult;
 
 // TCP Client
 TcpSocket* tcp_connect_raw(const char* host, int port);
 int tcp_send_raw(TcpSocket* sock, const char* data);
+int tcp_send_n_raw(TcpSocket* sock, const char* data, int length);
 char* tcp_receive_raw(TcpSocket* sock, int max_bytes);
+TcpReceiveResult tcp_receive_n_raw(TcpSocket* sock, int max_bytes);
 int tcp_close(TcpSocket* sock);
 
 // TCP Server

--- a/std/net/module.ae
+++ b/std/net/module.ae
@@ -7,7 +7,8 @@
 // - http_server_* : HTTP server operations
 
 exports (
-    tcp_connect_raw, tcp_send_raw, tcp_receive_raw, tcp_close,
+    tcp_connect_raw, tcp_send_raw, tcp_send_n_raw,
+    tcp_receive_raw, tcp_receive_n_raw, tcp_close,
     tcp_listen_raw, tcp_accept_raw, tcp_server_close,
     tcp_fd_raw, tcp_server_fd_raw,
     http_get_raw, http_post_raw, http_put_raw, http_delete_raw,
@@ -37,7 +38,9 @@ exports (
 // TCP Client - raw externs (escape hatch)
 extern tcp_connect_raw(host: string, port: int) -> ptr
 extern tcp_send_raw(sock: ptr, data: string) -> int
+extern tcp_send_n_raw(sock: ptr, data: string, length: int) -> int
 extern tcp_receive_raw(sock: ptr, max_bytes: int) -> string
+extern tcp_receive_n_raw(sock: ptr, max_bytes: int) -> (string @heap, int, string)
 extern tcp_close(sock: ptr) -> int
 
 // TCP Server - raw externs

--- a/std/tcp/module.ae
+++ b/std/tcp/module.ae
@@ -5,16 +5,19 @@
 // The implementations are in std/net/aether_net.c.
 
 exports (
-    tcp_connect_raw, tcp_send_raw, tcp_receive_raw, tcp_close,
+    tcp_connect_raw, tcp_send_raw, tcp_send_n_raw,
+    tcp_receive_raw, tcp_receive_n_raw, tcp_close,
     tcp_listen_raw, tcp_accept_raw, tcp_server_close,
     tcp_fd_raw, tcp_server_fd_raw,
-    connect, write, read, listen, accept, fd, server_fd
+    connect, write, write_n, read, read_n, listen, accept, fd, server_fd
 )
 
 // Raw externs - escape hatch
 extern tcp_connect_raw(host: string, port: int) -> ptr
 extern tcp_send_raw(sock: ptr, data: string) -> int
+extern tcp_send_n_raw(sock: ptr, data: string, length: int) -> int
 extern tcp_receive_raw(sock: ptr, max_bytes: int) -> string
+extern tcp_receive_n_raw(sock: ptr, max_bytes: int) -> (string @heap, int, string)
 extern tcp_close(sock: ptr) -> int
 extern tcp_listen_raw(port: int) -> ptr
 extern tcp_accept_raw(server: ptr) -> ptr
@@ -50,8 +53,22 @@ write(sock: ptr, data: string) -> {
     return n, ""
 }
 
+// Length-aware socket write. Writes exactly the caller-supplied byte
+// prefix, so embedded NUL bytes in `data` do not truncate the send.
+// Returns the OS send(2) byte count; callers that require full-buffer
+// delivery should loop until `length` bytes have been accepted.
+write_n(sock: ptr, data: string, length: int) -> {
+    n = tcp_send_n_raw(sock, data, length)
+    if n < 0 {
+        return 0, "send failed"
+    }
+    return n, ""
+}
+
 // Read up to max_bytes from a socket. Returns (data, "") on success,
-// ("", error) on transport failure or connection close.
+// ("", error) on transport failure or connection close. This text
+// wrapper copies with string_concat and is strlen-shaped; use read_n
+// when the payload may contain embedded NUL bytes.
 read(sock: ptr, max_bytes: int) -> {
     data = tcp_receive_raw(sock, max_bytes)
     if data == null {
@@ -59,6 +76,14 @@ read(sock: ptr, max_bytes: int) -> {
     }
     data_copy = string_concat(data, "")
     return data_copy, ""
+}
+
+// Binary-safe read. Returns (bytes, length, "") on success, with the
+// byte buffer stored in a length-aware AetherString. The returned
+// length is authoritative; callers should pass it to length-aware
+// consumers rather than re-derive length with strlen-shaped APIs.
+read_n(sock: ptr, max_bytes: int) -> {
+    return tcp_receive_n_raw(sock, max_bytes)
 }
 
 // Listen on a port. Returns (server, "") on success, (null, error) on

--- a/tests/runtime/test_runtime_net.c
+++ b/tests/runtime/test_runtime_net.c
@@ -1,12 +1,27 @@
 #include "test_harness.h"
 #include "../../std/net/aether_net.h"
+#include "../../std/string/aether_string.h"
+#include <errno.h>
+
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
 
 TEST_CATEGORY(socket_null_handling, TEST_CATEGORY_NETWORK) {
     int result = tcp_send_raw(NULL, NULL);
     ASSERT_EQ(-1, result);
 
+    result = tcp_send_n_raw(NULL, NULL, 0);
+    ASSERT_EQ(-1, result);
+
     char* received = tcp_receive_raw(NULL, 1024);
     ASSERT_NULL(received);
+
+    TcpReceiveResult received_n = tcp_receive_n_raw(NULL, 1024);
+    ASSERT_NULL(received_n._0);
+    ASSERT_EQ(0, received_n._1);
+    ASSERT_STRNE("", received_n._2);
 
     result = tcp_close(NULL);
     ASSERT_EQ(-1, result);
@@ -33,3 +48,46 @@ TEST_CATEGORY(server_create_invalid_port, TEST_CATEGORY_NETWORK) {
     TcpServer* server = tcp_listen_raw(-1);
     ASSERT_NULL(server);
 }
+
+#ifndef _WIN32
+// Mirror the private runtime layout so this unit test can wrap a POSIX
+// socketpair without depending on a bindable TCP port.
+struct TcpSocket {
+    int fd;
+    int connected;
+};
+
+TEST_CATEGORY(tcp_binary_nul_roundtrip, TEST_CATEGORY_NETWORK) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+    TcpSocket left = { fds[0], 1 };
+    TcpSocket right = { fds[1], 1 };
+
+    const char payload[3] = { 'A', '\0', 'B' };
+    errno = 0;
+    int sent = tcp_send_n_raw(&left, payload, 3);
+    if (sent < 0) {
+        if (errno == EPERM) {
+            printf("  SKIP tcp_binary_nul_roundtrip: socket send denied by sandbox\n");
+            close(fds[0]);
+            close(fds[1]);
+            return;
+        }
+    }
+    ASSERT_EQ(3, sent);
+
+    TcpReceiveResult got = tcp_receive_n_raw(&right, 16);
+    ASSERT_NOT_NULL(got._0);
+    ASSERT_EQ(3, got._1);
+
+    const char* data = aether_string_data(got._0);
+    ASSERT_EQ('A', data[0]);
+    ASSERT_EQ('\0', data[1]);
+    ASSERT_EQ('B', data[2]);
+    string_release(got._0);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+#endif

--- a/tests/syntax/test_tcp_tuple.ae
+++ b/tests/syntax/test_tcp_tuple.ae
@@ -13,5 +13,19 @@ main() {
     if sock != null {
         tcp.close(sock)
     }
+    _, werr = tcp.write_n(null, "A", 1)
+    if werr == "" {
+        println("FAIL: write_n(null) should error")
+        exit(1)
+    }
+    _, n, rerr = tcp.read_n(null, 16)
+    if rerr == "" {
+        println("FAIL: read_n(null) should error")
+        exit(1)
+    }
+    if n != 0 {
+        println("FAIL: read_n(null) length should be 0")
+        exit(1)
+    }
     println("tcp tuple wrappers ok")
 }


### PR DESCRIPTION
## Summary
- add length-aware TCP raw externs: `tcp_send_n_raw` and `tcp_receive_n_raw`
- expose `tcp.write_n(sock, data, length)` and `tcp.read_n(sock, max) -> (bytes, length, err)`
- document the binary-safe API and add runtime/syntax coverage for embedded-NUL handling

Closes #1078.

## Testing
- `make test` passed: 232 passed, 0 failed
- `HARDEN=1 make test` passed: 232 passed, 0 failed
- `AETHER_CACHE_DIR=/tmp/aether-cache ./build/ae run tests/syntax/test_tcp_tuple.ae` passed
- `make ci` ran to completion: 827 passed, 5 failed
  - HTTP shell failures on this Chromebook: `integration_http_client_forward_proxy_test_http_client_forward_proxy`, `integration_http_h2_concurrent_dispatch_test_http_h2_concurrent_dispatch`, `integration_http_reverse_proxy_pool_test_http_reverse_proxy_pool`, `integration_http_server_h2_test_http_server_h2`
  - unrelated pre-existing untracked regression file: `tests/regression/test_issue1046_bit_set.ae`