### PR TITLE
feat(types): flow-sensitive optional narrowing, no-panic null safety (#1068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ next version number before tagging the release.
 
 ### Added
 
+- **Flow-sensitive optional narrowing** (#1068). A none-check on an optional
+  variable narrows it in the guarded branch: inside `if x != none { ... }` (and
+  the `else` of `if x == none { ... } else { ... }`), `x` is its inner type `T`
+  and is used directly, without the `!` force-unwrap, and the runtime none-check
+  is elided (presence is proven by the guard). It is a pure compile-time analysis
+  with zero runtime cost, turning a class of `!`-unwrap panics into
+  statically-guaranteed-safe accesses. The narrowed value flows through
+  expressions, field access, and function arguments; nested guards narrow their
+  own innermost block. Narrowing is refused, soundly, when the branch rebinds the
+  variable or uses it with an optional-only operator (`== none`, `!= none`, `!`,
+  `??`, `?.`). New regression: `tests/regression/test_optional_narrowing.ae`;
+  docs in `language-reference.md`.
+
 - **Length-aware TCP I/O** (#1078). `std.tcp` now exposes
   `tcp.write_n(sock, data, length)` and `tcp.read_n(sock, max)` on top of
   `tcp_send_n_raw` / `tcp_receive_n_raw`, so TCP relays can send and

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -4245,6 +4245,99 @@ static int tc_loop_label_in_scope(const char* label) {
     return 0;
 }
 
+// #1068 flow-sensitive optional narrowing.
+//
+// If a condition is a none-check on an optional variable, the guarded branch can
+// treat that variable as its inner type `T` (used without the `!` force-unwrap)
+// and the runtime none-check is elided (presence is proven by the guard). This
+// is a pure compile-time analysis with zero runtime cost.
+//
+// `optional_narrow_target` recognizes `x != none` / `none != x` (narrow the THEN
+// branch) and `x == none` / `none == x` (narrow the ELSE branch). It returns the
+// optional variable's identifier node (borrowed) and sets *narrow_then; else
+// NULL. The condition is already typechecked, so the identifier carries its
+// TYPE_OPTIONAL node_type.
+static ASTNode* optional_narrow_target(ASTNode* cond, int* narrow_then) {
+    if (!cond || cond->type != AST_BINARY_EXPRESSION || !cond->value ||
+        cond->child_count < 2) return NULL;
+    int is_ne = strcmp(cond->value, "!=") == 0;
+    int is_eq = strcmp(cond->value, "==") == 0;
+    if (!is_ne && !is_eq) return NULL;
+    ASTNode* a = cond->children[0];
+    ASTNode* b = cond->children[1];
+    ASTNode* var = NULL;
+    if (a && a->type == AST_IDENTIFIER && b && b->type == AST_NONE_LITERAL) var = a;
+    else if (b && b->type == AST_IDENTIFIER && a && a->type == AST_NONE_LITERAL) var = b;
+    if (!var || !var->value) return NULL;
+    if (!var->node_type || var->node_type->kind != TYPE_OPTIONAL ||
+        !var->node_type->element_type ||
+        var->node_type->element_type->kind == TYPE_UNKNOWN) return NULL;
+    *narrow_then = is_ne ? 1 : 0;   // `!= none` -> then present; `== none` -> else
+    return var;
+}
+
+// Would narrowing `name` to its inner type be UNSAFE anywhere in subtree `n`?
+// Narrowing changes `name` from `T?` to `T` inside the branch, so it must be
+// refused (branch typechecked unchanged) when the branch:
+//   - rebinds `name` (assignment / re-declaration), it could become `none`;
+//   - uses `name` in a none-comparison (`name == none` / `name != none`);
+//   - uses `name` as the operand of an optional-only operator: `!` (unwrap),
+//     `??` (null-coalesce), or `?.` (optional chain).
+// Each of those needs the optional form of `name`, which narrowing removes.
+// Conservative but sound (and the innermost none-check still narrows its own
+// block via recursion). Does not descend into nested function/actor bodies.
+static int narrow_unsafe(ASTNode* n, const char* name) {
+    if (!n || !name) return 0;
+    if (n->type == AST_FUNCTION_DEFINITION || n->type == AST_ACTOR_DEFINITION) return 0;
+    // Rebind.
+    if ((n->type == AST_ASSIGNMENT || n->type == AST_VARIABLE_DECLARATION) &&
+        n->value && strcmp(n->value, name) == 0) return 1;
+    // `name` as the operand of an optional-only operator (`!` / `??` / `?.`).
+    if ((n->type == AST_TUPLE_UNWRAP || n->type == AST_NULL_COALESCE ||
+         n->type == AST_OPTIONAL_CHAIN) && n->child_count >= 1) {
+        ASTNode* c = n->children[0];
+        if (c && c->type == AST_IDENTIFIER && c->value && strcmp(c->value, name) == 0)
+            return 1;
+    }
+    // `name == none` / `name != none` (either operand order).
+    if (n->type == AST_BINARY_EXPRESSION && n->value &&
+        (strcmp(n->value, "==") == 0 || strcmp(n->value, "!=") == 0) &&
+        n->child_count >= 2) {
+        ASTNode* a = n->children[0], *b = n->children[1];
+        int a_var = a && a->type == AST_IDENTIFIER && a->value && strcmp(a->value, name) == 0;
+        int b_var = b && b->type == AST_IDENTIFIER && b->value && strcmp(b->value, name) == 0;
+        int a_none = a && a->type == AST_NONE_LITERAL;
+        int b_none = b && b->type == AST_NONE_LITERAL;
+        if ((a_var && b_none) || (b_var && a_none)) return 1;
+    }
+    for (int i = 0; i < n->child_count; i++)
+        if (narrow_unsafe(n->children[i], name)) return 1;
+    return 0;
+}
+
+// Mark every read of `name` in `n` as a narrowed-optional access, so codegen
+// emits `name.val` (the present inner value) rather than the `ae_opt` struct.
+// Only reached when `name` is not rebound in the branch, so every occurrence is
+// a read of the proven-present optional. Does not cross a nested function/actor
+// boundary.
+static void mark_optional_narrowed(ASTNode* n, const char* name, Type* inner) {
+    if (!n || !name) return;
+    if (n->type == AST_FUNCTION_DEFINITION || n->type == AST_ACTOR_DEFINITION) return;
+    if (n->type == AST_IDENTIFIER && n->value && strcmp(n->value, name) == 0) {
+        if (n->annotation) free(n->annotation);
+        n->annotation = strdup("__opt_narrowed");
+        // Pin the node's type to the inner T so any pass that reads node_type
+        // (e.g. the var-declaration type-join for `y = x`) sees the narrowed
+        // type, not the optional. Codegen uses the annotation to emit `x.val`.
+        if (inner) {
+            if (n->node_type) free_type(n->node_type);
+            n->node_type = clone_type(inner);
+        }
+    }
+    for (int i = 0; i < n->child_count; i++)
+        mark_optional_narrowed(n->children[i], name, inner);
+}
+
 int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
     if (!stmt) return 0;
 
@@ -4769,6 +4862,8 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
         }
 
         case AST_IF_STATEMENT: {
+            ASTNode* narrow_var = NULL;
+            int narrow_then = 1;
             if (stmt->child_count >= 1) {
                 ASTNode* condition = stmt->children[0];
                 typecheck_expression(condition, table);
@@ -4780,11 +4875,30 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                     return 0;
                 }
                 free_type(cond_type);
+                // #1068 detect an optional none-check to narrow one branch.
+                narrow_var = optional_narrow_target(condition, &narrow_then);
             }
-            
-            // Type check then and else branches
+
+            // Type check then (child 1) and else (child 2) branches. The branch
+            // that the guard proves present narrows the optional variable to its
+            // inner type `T` in a child scope (so `x.field` / `foo(x)` typecheck
+            // without `!`), unless the variable is rebound in that branch.
             for (int i = 1; i < stmt->child_count; i++) {
-                typecheck_statement(stmt->children[i], table);
+                ASTNode* branch = stmt->children[i];
+                int is_then = (i == 1);
+                int narrow_this = narrow_var && branch &&
+                                  ((is_then && narrow_then) || (!is_then && !narrow_then)) &&
+                                  !narrow_unsafe(branch, narrow_var->value);
+                if (narrow_this) {
+                    Type* inner = narrow_var->node_type->element_type;
+                    SymbolTable* nt = create_symbol_table(table);
+                    add_symbol(nt, narrow_var->value, clone_type(inner), 0, 0, 0);
+                    mark_optional_narrowed(branch, narrow_var->value, inner);
+                    typecheck_statement(branch, nt);
+                    free_symbol_table(nt);
+                } else {
+                    typecheck_statement(branch, table);
+                }
             }
             return 1;
         }

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2034,6 +2034,14 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
 
         case AST_IDENTIFIER:
             if (!expr->value) { fprintf(gen->output, "/* NULL identifier */0"); break; }
+            // #1068 flow-narrowed optional: inside `if x != none { ... }` the
+            // typechecker marked this read of `x` as narrowed, so emit the inner
+            // value `x.val` of the `ae_opt` struct. Presence is proven by the
+            // guard, so there is NO runtime none-check (zero cost).
+            if (expr->annotation && strcmp(expr->annotation, "__opt_narrowed") == 0) {
+                fprintf(gen->output, "%s.val", expr->value);
+                break;
+            }
             // Source-location intrinsics (#265) — `__LINE__` / `__FILE__` /
             // `__func__` substitute literal AST-node line, source-file path,
             // and C-side function name (which mirrors the Aether function

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -1212,6 +1212,35 @@ let label: string = match maybe {
 }
 ```
 
+### Narrowing
+
+A none-check on an optional variable **narrows** it in the guarded branch: inside
+`if x != none { ... }` (and the `else` of `if x == none { ... } else { ... }`),
+`x` is its inner type `T` and is used directly, without the `!` force-unwrap.
+Presence is proven by the guard, so the runtime none-check is elided, this is a
+compile-time analysis with zero runtime cost:
+
+```aether
+find(id: int) -> User?
+
+let u: User? = find(42)
+if u != none {
+    println(u.name)        // no `!`, `u` is a User here
+    greet(u)              // passed by value as User
+}
+```
+
+Narrowing is refused (soundly, the branch is unchanged) when the guarded branch
+reassigns the variable, or uses it with an optional-only operator (`== none`,
+`!= none`, `!`, `??`, or `?.`), since those need the optional form. A nested
+guard on the same variable still narrows its own innermost block.
+
+The narrowed value flows through expressions, field access, and function
+arguments. Assigning the narrowed variable *directly* to a pre-existing variable
+(`existing = x`) is one spot the inner type does not yet propagate (the outer
+variable keeps its optional type); use an expression (`existing = x + 0`) or a
+fresh `let` binding there.
+
 ### Functions
 
 Optionals flow through parameters and return types. A bare `T` (or `none`) is implicitly wrapped at the call site and in `return`:

--- a/tests/regression/test_optional_narrowing.ae
+++ b/tests/regression/test_optional_narrowing.ae
@@ -1,0 +1,83 @@
+// Regression: #1068 flow-sensitive optional narrowing. Inside `if x != none {}`
+// (and the `else` of `if x == none {} else {}`) the optional `x: T?` is usable
+// as its inner `T` without the `!` force-unwrap, and the none-check is elided
+// (presence is proven by the guard), so it is zero runtime cost. Narrowing is
+// refused, soundly, when the branch rebinds `x` or uses it with an optional-only
+// operator (`== none`, `!=`, `!`, `??`, `?.`); the innermost guard still narrows.
+import std.io
+
+struct P { x: int, y: int }
+dist(p: P) -> int { return p.x + p.y }
+
+check_int(got: int, want: int, lbl: string) -> int {
+    if got != want { println("FAIL ${lbl}: ${got} != ${want}"); return 1 }
+    return 0
+}
+
+main() {
+    var fails = 0
+
+    // then-branch narrowing: `a` used as int in an expression, no `!`
+    let a: int? = 5
+    var av = -1
+    if a != none {
+        av = a + 10          // a narrowed to int
+    }
+    fails = fails + check_int(av, 15, "then-branch value")
+
+    // else-branch narrowing on `== none`
+    let b: int? = 7
+    var bv = -1
+    if b == none {
+        bv = 0
+    } else {
+        bv = b * 2           // b narrowed in the else
+    }
+    fails = fails + check_int(bv, 14, "else-branch value")
+
+    // the guard genuinely gates the block
+    let c: int? = none
+    var entered = 0
+    if c != none {
+        entered = 1          // not reached
+    }
+    fails = fails + check_int(entered, 0, "none gates block")
+
+    // struct optional: field access and pass-by-value, both narrowed
+    let op: P? = P { x: 3, y: 4 }
+    var sum = -1
+    var viafn = -1
+    if op != none {
+        sum = op.x + op.y    // op.x -> op.val.x
+        viafn = dist(op)     // op -> op.val (by value)
+    }
+    fails = fails + check_int(sum, 7, "struct field narrowed")
+    fails = fails + check_int(viafn, 7, "struct arg narrowed")
+
+    // nested guard on the same variable (outer defers, inner narrows)
+    let d: int? = 9
+    var dv = -1
+    if d != none {
+        if d != none {
+            dv = d + 0       // narrowed int
+        }
+    }
+    fails = fails + check_int(dv, 9, "nested guard")
+
+    // narrowed value drives a nested condition without `!`
+    let e: int? = 3
+    var ev = 0
+    if e != none {
+        if e > 2 {           // e narrowed to int for the comparison
+            ev = 1
+        }
+    }
+    fails = fails + check_int(ev, 1, "narrowed in nested condition")
+
+    if fails == 0 {
+        println("PASS: optional_narrowing")
+    } else {
+        println("FAILED: ${fails}")
+        exit(1)
+    }
+}


### PR DESCRIPTION
## Summary

Flow-sensitive narrowing for optionals: a none-check on an optional variable now
lets the guarded branch use that variable as its inner type `T`, without the `!`
force-unwrap, and elides the runtime none-check (presence is proven by the
guard). A pure compile-time analysis with **zero runtime cost**, turning a class
of `!`-unwrap panics into statically-guaranteed-safe accesses.

Closes #1068.

## What it does

```aether
find(id: int) -> User?

let u: User? = find(42)
if u != none {
    println(u.name)   // no `!`; `u` is a User here
    greet(u)          // passed as User (the inner value)
}
```

- `if x != none { ... }` narrows `x` to `T` in the then-branch.
- `if x == none { ... } else { ... }` narrows `x` to `T` in the else-branch.
- Emitted C uses the `.val` of the `ae_opt` struct directly, with **no**
  `if (!x.has) aether_panic(...)` check inside the guard (the `!` operator
  elsewhere still emits its runtime check, unchanged).

## Soundness

Narrowing is refused (the branch is typechecked unchanged) when the guarded
branch:
- rebinds the variable (it could become `none` again), or
- uses it with an optional-only operator (`== none`, `!= none`, `!`, `??`, `?.`),
  which need the optional form.

A nested guard on the same variable still narrows its own innermost block. The
`.ae` suite (575) and examples (87) confirm no existing code changes behaviour.

## Implementation

Localized to `typechecker.c` (the `AST_IF_STATEMENT` handler + three helpers) and
one branch in `codegen_expr.c`'s `AST_IDENTIFIER` case:
- `optional_narrow_target` detects the guard shape and which branch is proven
  present.
- The proven branch is typechecked in a child scope where the variable is rebound
  to its inner type, and each narrowed read is marked so codegen emits `x.val`.
- `narrow_unsafe` implements the soundness bail above.

## Scope / known edge

Narrowing flows through expressions, field access, and function arguments.
Assigning the narrowed variable *directly* to a pre-existing variable
(`existing = x`) is one spot the inner type does not yet propagate, the outer
variable keeps its optional type (a pre-existing var-type-join behaviour, not
introduced here); use an expression (`existing = x + 0`) or a fresh `let`. This
is documented in `language-reference.md` and is a natural follow-up.

## Testing

- New `tests/regression/test_optional_narrowing.ae`: then/else narrowing, struct
  field access and pass-by-value, nested guards, narrowed use in a nested
  condition, and the guard gating the block.
- Unit `232/232`, `.ae` suite `575/0`, examples `87/0`; `typechecker.c` and
  `codegen_expr.c` compile warning-free under `-Wall -Wextra -Werror`.
- Verified the generated C: narrowed reads emit `x.val` with no panic check; the
  guard condition still emits the `.has` presence test; `!` elsewhere is
  unchanged.
