### PR TITLE
fix(runtime,std): don't store a failed allocation and report success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Allocation-failure handling in a few registration helpers.** Several
+  functions stored a `strdup`/`malloc` result and reported success without
+  checking it, so under memory pressure they left a NULL in a live structure and
+  crashed later (a delayed fault, worse than a clean out-of-memory failure). Now
+  they allocate up front, store nothing on failure, and signal it:
+  `aether_vhost_register_host`, `aether_middleware_rewrite_add`, and
+  `aether_middleware_error_page_add` (a NULL host / rewrite prefix / error-page
+  body would crash the request or error path); `aether_shared_map_put` (a NULL
+  key crashes the next `strcmp`); and `aether_convert_type` (a NULL result was
+  dereferenced immediately). The normal (non-OOM) path is unchanged.
+
 ## [0.374.0]
 
 ### Added

--- a/runtime/aether_runtime_types.c
+++ b/runtime/aether_runtime_types.c
@@ -51,9 +51,10 @@ RuntimeValue* aether_convert_type(RuntimeValue* val, const char* target_type) {
     if (!val) return NULL;
     
     RuntimeValue* result = (RuntimeValue*)malloc(sizeof(RuntimeValue));
+    if (!result) return NULL;   // caller already handles a NULL result (see `!val` above)
     RuntimeTypeCode target_code = string_to_type_code(target_type);
     result->type = target_code;
-    
+
     // Convert from int
     if (val->type == RUNTIME_TYPE_INT) {
         if (target_code == RUNTIME_TYPE_FLOAT) {

--- a/runtime/aether_shared_map.c
+++ b/runtime/aether_shared_map.c
@@ -90,9 +90,13 @@ void aether_shared_map_put(AetherSharedMap* map, const char* key, const char* va
         }
     }
 
-    // Add new entry
+    // Add new entry. A NULL key (allocation failure) would crash the strcmp in
+    // every later get/put, so on failure leave the map unchanged. A NULL value
+    // is fine (get legitimately returns NULL for a present key with no value).
     if (map->count >= MAX_ENTRIES) return;
-    map->entries[map->count].key = strdup(key);
+    char* kdup = strdup(key);
+    if (!kdup) return;
+    map->entries[map->count].key = kdup;
     map->entries[map->count].value = value ? strdup(value) : NULL;
     map->count++;
 }

--- a/std/http/middleware/aether_middleware.c
+++ b/std/http/middleware/aether_middleware.c
@@ -557,7 +557,12 @@ int aether_vhost_register_host(AetherVhostMap* m, const char* host) {
         m->hosts = nh;
         m->cap = new_cap;
     }
-    m->hosts[m->count++] = strdup(host);
+    // Don't store a NULL on allocation failure and then report success: a NULL
+    // entry would crash the strcmp in aether_middleware_vhost on the next
+    // request. Leave the map unchanged and signal failure instead.
+    char* dup = strdup(host);
+    if (!dup) return -1;
+    m->hosts[m->count++] = dup;
     return 0;
 }
 
@@ -847,8 +852,13 @@ int aether_rewrite_add_rule(AetherRewriteOpts* o,
         o->rules = nr;
         o->cap = new_cap;
     }
-    o->rules[o->count].from_prefix = strdup(from_prefix);
-    o->rules[o->count].to_prefix = strdup(to_prefix);
+    // Allocate both strings up front; on failure store neither (a half-added
+    // rule with a NULL prefix would crash the rewrite path) and report failure.
+    char* fp = strdup(from_prefix);
+    char* tp = strdup(to_prefix);
+    if (!fp || !tp) { free(fp); free(tp); return -1; }
+    o->rules[o->count].from_prefix = fp;
+    o->rules[o->count].to_prefix = tp;
     o->rules[o->count].from_len = strlen(from_prefix);
     o->count++;
     return 0;
@@ -918,10 +928,16 @@ int aether_error_pages_register(AetherErrorPagesOpts* o,
         o->pages = np;
         o->cap = new_cap;
     }
+    // Allocate both strings up front; on failure store neither (a NULL body or
+    // content_type would crash when serving the custom error page) and report
+    // failure rather than leaving a corrupt page entry.
+    char* body_dup = strdup(body);
+    char* ct_dup = (content_type && *content_type)
+                       ? strdup(content_type) : strdup("text/html; charset=utf-8");
+    if (!body_dup || !ct_dup) { free(body_dup); free(ct_dup); return -1; }
     o->pages[o->count].status = status_code;
-    o->pages[o->count].body = strdup(body);
-    o->pages[o->count].content_type = content_type && *content_type
-        ? strdup(content_type) : strdup("text/html; charset=utf-8");
+    o->pages[o->count].body = body_dup;
+    o->pages[o->count].content_type = ct_dup;
     o->count++;
     return 0;
 }


### PR DESCRIPTION
## Summary

From a memory/malloc/performance/docs audit, this fixes the one class of genuine
allocation bugs found: helpers that **store a failed allocation and report
success**, leaving a NULL in a live structure that crashes later (a delayed
fault, worse than a clean out-of-memory failure).

## Fixed

| Function | Bug | Now |
|---|---|---|
| `aether_vhost_register_host` | `strdup(host)` stored, `return 0` on failure → NULL host crashes the next request's `strcmp` | allocate first, don't add the entry, return -1 |
| `aether_middleware_rewrite_add` | two `strdup`s stored, `return 0` → NULL prefix crashes the rewrite path | allocate both first, store neither on failure |
| `aether_middleware_error_page_add` | body/content-type `strdup`s stored, `return 0` → NULL crashes when serving the error page | allocate both first, store neither on failure |
| `aether_shared_map_put` | NULL key stored on failure → crashes the `strcmp` in every later get/put | leave the map unchanged (a NULL *value* stays legal) |
| `aether_convert_type` | `malloc` result dereferenced immediately without a NULL check | return NULL (callers already handle it) |

The normal (non-OOM) path is unchanged; existing behaviour is identical.

## Audit scope + what was left as-is (deliberately)

- **Leaks:** the `leaks(1)` gate and spot-checks are clean; the only allowances
  are documented third-party process-globals (OpenSSL). No fixable leaks found.
- **Other unchecked `strdup`s:** the remaining ones (path/os helpers) return NULL
  to a caller that treats it as an error, i.e. they fail *gracefully*. Hardening
  those adds churn without fixing a real crash, so they are left as-is.
- **Performance:** the audit surfaced linked-list symbol lookup, glob-import
  resolution, and callback-symbol lookup as linear-where-a-hash-could-be. These
  are core-infra refactors that warrant profiling evidence before changing, so
  they are intentionally out of this PR.
- **Docs:** the documentation cross-checked as accurate for shipped features. One
  flagged "stale" note (module-import aliases "do not yet resolve") was verified
  to be **correct** (aliased imports genuinely do not expose the module's
  functions yet), so the doc is left unchanged.

## Testing

Unit `232/232`, `.ae` suite `575/0`; the three changed C files compile
warning-free under `-Wall -Wextra -Werror`.
