### PR TITLE
fix(runtime,std): allocation-failure hardening and two lifetime leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Two memory leaks on the normal (non-OOM) path.** `http_route_matches`
+  allocated fresh `param_keys`/`param_values` arrays on every call and only the
+  last call's pair was ever freed, so a server with more than one route leaked
+  the two arrays (plus their strings) for every candidate route tried before the
+  match, and for every route on a 404, on ordinary traffic. It now frees the
+  previous call's params first (which also clears stale params an earlier failed
+  pattern left behind). `scheduler_release_pooled` never freed an actor's
+  lazily-allocated same-core `spsc_queue`, leaking a multi-KB buffer for every
+  actor that had flushed a same-core batch; it is now reclaimed on teardown (a
+  reused pooled slot re-allocates lazily).
+
+- **Allocation-failure hardening across the runtime and standard library.** A
+  sweep for the "store a failed allocation, report success, crash later" class
+  (a delayed fault far from the failed alloc, worse than a clean out-of-memory
+  failure) plus self-overwriting `realloc`s that leak the original and then
+  dereference NULL. Fixes span: the cooperative and multicore schedulers (actor
+  table, per-core I/O map, send-batch buffer with a direct-send fallback), NUMA
+  init (falls back to single-node instead of a NULL cpu-to-node map), the
+  cooperative message send (fails loudly like the threaded path rather than
+  dispatching a NULL payload), actor tracing; the HTTP/1.1 server (request
+  header arrays, response create, `set_header`/`add_header`, route params and
+  bound, route and middleware registration, accept-thread context), the HTTP
+  client redirect follower, the HTTP/2 request builder, the middleware factories
+  (session-auth, rate-limit bucket, static-file opts, request-header add), the
+  proxy Prometheus exporter (an OOM-path escape-buffer leak), and runtime type
+  conversion. The normal path is unchanged; every fix degrades gracefully or
+  fails cleanly under memory pressure.
+
+### Documentation
+
+- **Closure capture semantics corrected.** `closures-and-builder-dsl.md` and
+  `closures-and-lifetimes.md` claimed closures capture by value and that a
+  mutation like `count = count + 1` is not visible to the enclosing scope. The
+  compiler actually heap-promotes a captured variable a closure assigns to, so
+  the outer binding and the closure share one cell and writes are visible both
+  ways (the Ruby/Groovy model, asserted by
+  `tests/syntax/test_closure_mutable_capture_probe.ae`). The docs now describe
+  this and scope ref cells to state that isn't a plain captured local.
+
+- **Corrected several doc claims contradicted by the compiler/stdlib** (each
+  reproduced against a freshly built compiler): the `as` primitive cast is
+  documented as not parsing, but the #480 value cast means `n as int` and other
+  numeric casts compile and run (non-numeric casts like `buf as string` parse
+  and are rejected at type-check with `E0200`), `language-reference.md`;
+  `io.stderr_write` / `io.stdout_write` take one argument, not two (length is
+  computed internally), `stdlib-reference.md`; and the `std.tcp` write function
+  is `tcp.write`, not `tcp.send` (`send` is a reserved keyword),
+  `stdlib-api.md`.
+
 ## [0.377.0]
 
 ### Added

--- a/docs/closures-and-builder-dsl.md
+++ b/docs/closures-and-builder-dsl.md
@@ -569,9 +569,17 @@ _aether_ctx_pop();                                  // 3. pop
 
 ## Ref Cells, Shared Mutable State for Closures
 
-Aether closures capture variables by value. This means a closure that does
-`count = count + 1` modifies its own copy, not the original. For callbacks
-that need shared mutable state (like UI event handlers), use **ref cells**:
+Aether heap-promotes a captured variable that a closure **assigns to**: the
+enclosing binding and every closure capturing it then share one heap cell, so
+`count = count + 1` inside a closure is visible to the outer scope and to
+sibling closures (the Ruby/Groovy model). A simple named local needs no ref
+cell to share mutable state this way. A capture the closure only reads stays a
+cheap aliased copy.
+
+**Ref cells** are for shared mutable state that isn't a plain captured local:
+a value passed explicitly as a `ptr` argument to callbacks (UI event
+handlers), threaded through a struct field, or handed across an actor
+boundary:
 
 ```aether
 count = ref(0)           // heap-allocated mutable cell

--- a/docs/closures-and-lifetimes.md
+++ b/docs/closures-and-lifetimes.md
@@ -55,10 +55,14 @@ and writes through `_env->name` directly. Scope analysis distinguishes
 captures from fresh body-locals while honouring Python-style `x = expr`
 shadowing: if the RHS does not read `x`, treat `x` as a fresh local.
 
-**Semantics preserved:** closures capture by value (as documented in
-`docs/closures-and-builder-dsl.md`). Mutations inside a closure mutate the
-env's copy, which persists across calls, but are not visible to the
-enclosing scope. Shared mutable state still requires ref cells.
+**Resulting semantics:** a read-only capture stays an aliased copy (zero
+cost). A capture the closure *assigns to* is heap-promoted, so the enclosing
+binding and the closure env share one heap cell and writes are visible in both
+directions (the Ruby/Groovy model, verified by
+`tests/syntax/test_closure_mutable_capture_probe.ae`). A simple named local
+therefore needs no ref cell to share mutable state; ref cells remain useful for
+state that isn't a plain captured local (an explicit `ptr` argument, a struct
+field, or an actor boundary). See `docs/closures-and-builder-dsl.md`.
 
 ### 3. Escaping-closure use-after-free
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -244,7 +244,7 @@ Aether has **no general-purpose cast operator**. The `as` keyword is reserved fo
 - `expr as fn(T1, T2, ...) -> R` function-pointer cast (call a stored pointer with type checking; see [§ Function-pointer parameters](#function-pointer-parameters-fnt1-t2---r) below)
 - `expr as T[]` typed-array view cast (reinterpret a raw pointer as a `T[]`)
 
-`buf as string`, `n as int`, `p as ptr` and similar primitive casts **do not parse**, after `as`, the parser accepts only `*StructName`, `fn(...) -> R`, or `T[]`. Convert between primitives this way instead:
+After `as` the parser also accepts a primitive **value cast** (#480): `n as int` and other numeric casts compile and run, and a cast between a distinct type and its base type is allowed too. Casts the type system can't justify (for example `buf as string` or `p as ptr`) still parse, but are rejected at type-check with `E0200`, use a named helper for those. The `*StructName`, `fn(...) -> R`, and `T[]` forms remain available. Other primitive conversions:
 
 | From → To | How |
 |---|---|
@@ -1604,7 +1604,7 @@ main() {
 
 The cast is a view, not an allocation, the operand pointer's lifetime is the caller's problem (the same contract as raw `extern` interaction). Reach for this only when the storage is C-allocated and Aether wants to manipulate fields. For Aether-owned data, use the normal struct-literal form (`Point { x: 1, y: 2 }`) so refcounting and lifetime tracking apply.
 
-**`as` accepts `*StructName`, `fn(...) -> R`, or `T[]` there is no general-purpose primitive cast.** After `as` the parser accepts a struct overlay (`*` then a struct name), a function-pointer cast (`fn(T1, T2, ...) -> R`), or a typed-array view (`T[]`). Forms like `buf as string`, `n as int`, `raw as ptr` do not parse. For converting between primitive types, see the [Casting between types](#casting-between-types) table above, most conversions are either implicit (Aether's type system inserts the necessary cast in the generated C) or use a named helper (`string.from_int`, `string.from_long`, …).
+**`as` accepts a primitive value cast (#480), a struct overlay (`*StructName`), a function-pointer cast (`fn(...) -> R`), or a typed-array view (`T[]`).** A value cast like `n as int` (numeric to numeric, or between a distinct type and its base) compiles and runs. Non-numeric casts such as `buf as string` or `raw as ptr` parse but are rejected at type-check with `E0200`. For converting between primitive types, see the [Casting between types](#casting-between-types) table above, most conversions are either implicit (Aether's type system inserts the necessary cast in the generated C) or use a named helper (`string.from_int`, `string.from_long`, …).
 
 The `as` keyword is the same token used for `import x as y` aliasing; the two parses don't collide because import-aliasing is recognised only inside `import` statements. Full semantics (operand type rules, error cases, the shared-token interaction) are in [c-interop.md § Struct overlay on raw pointers](c-interop.md#struct-overlay-on-raw-pointers-structname-and-expr-as-structname).
 

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -30,7 +30,7 @@ Functions are called using **namespace-style syntax**: `namespace.function()`
 | `import std.json` | `json` | `json.parse(str)`, `json.create_object()` |
 | `import std.cryptography` | `cryptography` | `cryptography.sha256_hex(data, n)`, `cryptography.base64_encode(data, n)` |
 | `import std.http` | `http` | `http.get(url)`, `http.server_create(port)` |
-| `import std.tcp` | `tcp` | `tcp.connect(host, port)`, `tcp.send(sock, data)` |
+| `import std.tcp` | `tcp` | `tcp.connect(host, port)`, `tcp.write(sock, data)` |
 | `import std.list` | `list` | `list.new()`, `list.add(l, item)` |
 | `import std.map` | `map` | `map.new()`, `map.put(m, key, val)` |
 | `import std.math` | `math` | `math.sqrt(x)`, `math.sin(x)` |

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -1913,8 +1913,8 @@ main() {
 - `io.print_float(value)` - Print float
 
 **Unbuffered fd writes (crash-trace use case):**
-- `io.stderr_write(data, length)` → `int` - Write `length` bytes to fd 2 directly, bypassing stdio buffering. Returns the byte count actually written, or -1 on error. Loops on partial writes; retries `EINTR` on POSIX. `data` may contain NULs (binary-safe). Reach for this when output must reach the terminal / pipe before the process aborts, `println` and `io.print` are line-buffered on tty and block-buffered when piped, so the last few lines reliably get lost during a crash.
-- `io.stdout_write(data, length)` → `int` - Same shape as `stderr_write` but writes to fd 1. Useful for shell-pipe-friendly tools that need each record flushed before the next stage reads.
+- `io.stderr_write(data)` → `int` - Write `data` to fd 2 directly (length computed internally with `string.length`), bypassing stdio buffering. Returns the byte count actually written, or -1 on error. Loops on partial writes; retries `EINTR` on POSIX. Reach for this when output must reach the terminal / pipe before the process aborts, `println` and `io.print` are line-buffered on tty and block-buffered when piped, so the last few lines reliably get lost during a crash.
+- `io.stdout_write(data)` → `int` - Same shape as `stderr_write` but writes to fd 1. Useful for shell-pipe-friendly tools that need each record flushed before the next stage reads.
 
 **File-descriptor lifecycle and bulk fd I/O:**
 - `io.fd_open_read(path)` → `(int, string)` - Open `path` for reading (POSIX `O_RDONLY` / Win `_O_RDONLY | _O_BINARY`). Returns `(fd, "")` on success, `(-1, error)` on failure.

--- a/runtime/actors/aether_send_message.c
+++ b/runtime/actors/aether_send_message.c
@@ -188,9 +188,15 @@ static inline void AETHER_HOT aether_send_message_sync(ActorBase* actor, void* m
     // The just-sent message will be processed later by scheduler_wait(),
     // by which time the caller's stack frame may be gone.
     void* heap_copy = malloc(message_size);
-    if (heap_copy) {
-        memcpy(heap_copy, message_data, message_size);
+    if (!heap_copy) {
+        // Delivering a NULL payload would crash the handler (or, for a
+        // single-int message, silently run it on zeroed data). Match the
+        // threaded path below and fail loudly rather than corrupt state.
+        fprintf(stderr, "aether: malloc(%zu) failed for msg type %d to actor %d\n",
+                message_size, *(int*)message_data, actor->id);
+        abort();
     }
+    memcpy(heap_copy, message_data, message_size);
     msg.payload_ptr = heap_copy;
 #endif
 

--- a/runtime/aether_numa.c
+++ b/runtime/aether_numa.c
@@ -159,6 +159,12 @@ aether_numa_topology_t aether_numa_init(void) {
             for (int cpu = 0; cpu < topo.num_cpus; cpu++) {
                 topo.cpu_to_node[cpu] = numa_node_of_cpu(cpu);
             }
+        } else {
+            // Couldn't build the CPU->node map: disable NUMA rather than report
+            // it available with a NULL map that aether_numa_node_of_cpu would
+            // dereference. Falls back to single-node (plain malloc) allocation.
+            topo.available = false;
+            topo.num_nodes = 1;
         }
     } else {
         topo.num_nodes = 1;

--- a/runtime/aether_runtime_types.c
+++ b/runtime/aether_runtime_types.c
@@ -64,6 +64,7 @@ RuntimeValue* aether_convert_type(RuntimeValue* val, const char* target_type) {
             char buffer[32];
             snprintf(buffer, sizeof(buffer), "%lld", (long long)val->value.int_val);
             result->value.string_val = strdup(buffer);
+            if (!result->value.string_val) { free(result); return NULL; }
             return result;
         } else if (target_code == RUNTIME_TYPE_BOOL) {
             result->value.bool_val = val->value.int_val != 0;
@@ -80,6 +81,7 @@ RuntimeValue* aether_convert_type(RuntimeValue* val, const char* target_type) {
             char buffer[32];
             snprintf(buffer, sizeof(buffer), "%f", val->value.float_val);
             result->value.string_val = strdup(buffer);
+            if (!result->value.string_val) { free(result); return NULL; }
             return result;
         } else if (target_code == RUNTIME_TYPE_BOOL) {
             result->value.bool_val = val->value.float_val != 0.0;
@@ -112,13 +114,14 @@ RuntimeValue* aether_convert_type(RuntimeValue* val, const char* target_type) {
             return result;
         } else if (target_code == RUNTIME_TYPE_STRING) {
             result->value.string_val = strdup(val->value.bool_val ? "true" : "false");
+            if (!result->value.string_val) { free(result); return NULL; }
             return result;
         }
     }
     
-    // No conversion possible - return copy
-    free(result);
-    result = (RuntimeValue*)malloc(sizeof(RuntimeValue));
+    // No conversion possible - return a copy of the input unchanged. Reuse the
+    // already-allocated (and NULL-checked) result rather than free+malloc again,
+    // which would reintroduce an unchecked allocation dereferenced right below.
     *result = *val;
     return result;
 }

--- a/runtime/scheduler/aether_scheduler_coop.c
+++ b/runtime/scheduler/aether_scheduler_coop.c
@@ -47,6 +47,13 @@ void scheduler_init(int cores) {
     memset(&schedulers[0], 0, sizeof(Scheduler));
     schedulers[0].core_id = 0;
     schedulers[0].actors = calloc(MAX_ACTORS_PER_CORE, sizeof(ActorBase*));
+    if (!schedulers[0].actors) {
+        // The scheduler cannot run any actor without this table; leaving it NULL
+        // with a non-zero capacity would crash scheduler_register_actor on the
+        // first spawn. Fail loudly at init instead of a delayed NULL deref.
+        fprintf(stderr, "aether: failed to allocate cooperative scheduler actor table\n");
+        abort();
+    }
     schedulers[0].actor_count = 0;
     schedulers[0].capacity = MAX_ACTORS_PER_CORE;
 

--- a/runtime/scheduler/multicore_scheduler.c
+++ b/runtime/scheduler/multicore_scheduler.c
@@ -1002,7 +1002,10 @@ void scheduler_init(int cores) {
             fprintf(stderr, "WARNING: I/O poller init failed for core %d\n", i);
         }
         schedulers[i].io_map = calloc(AETHER_IO_MAX_FDS, sizeof(AetherIoEntry));
-        schedulers[i].io_map_capacity = AETHER_IO_MAX_FDS;
+        // On failure leave the capacity at 0 so scheduler_io_register grows the
+        // map lazily (realloc from NULL) on first use, instead of writing through
+        // a NULL map that a non-zero capacity would let it index directly.
+        schedulers[i].io_map_capacity = schedulers[i].io_map ? AETHER_IO_MAX_FDS : 0;
         schedulers[i].io_registered_count = 0;
     }
 }
@@ -1374,7 +1377,9 @@ void scheduler_deregister_actor(ActorBase* actor) {
 
 // Grow io_map to accommodate fd. Returns 0 on success, -1 on failure.
 static int scheduler_io_map_grow(Scheduler* sched, int fd) {
-    int new_cap = sched->io_map_capacity;
+    // Start from at least 1 so a zero capacity (initial map allocation failed)
+    // grows normally instead of looping forever on new_cap *= 2.
+    int new_cap = sched->io_map_capacity > 0 ? sched->io_map_capacity : 1;
     while (new_cap <= fd) new_cap *= 2;
 
     AetherIoEntry* new_map = realloc(sched->io_map, (size_t)new_cap * sizeof(AetherIoEntry));
@@ -1699,6 +1704,7 @@ static AETHER_TLS BatchSendBuffer* g_batch_buffer = NULL;
 void scheduler_send_batch_start(void) {
     if (!g_batch_buffer) {
         g_batch_buffer = calloc(1, sizeof(BatchSendBuffer));
+        if (!g_batch_buffer) return;  // OOM: batching stays off, callers fall back
     }
     g_batch_buffer->count = 0;
     memset(g_batch_buffer->by_core, 0, sizeof(g_batch_buffer->by_core));
@@ -1717,6 +1723,12 @@ void scheduler_send_batch_add(ActorBase* actor, Message msg) {
     // BATCH PATH: Multi-actor fan-out optimization
     if (!g_batch_buffer) {
         scheduler_send_batch_start();
+        if (!g_batch_buffer) {
+            // Batch buffer couldn't be allocated: deliver directly so the
+            // message is never dropped. Batching is only a throughput optimization.
+            mailbox_send(&actor->mailbox, msg);
+            return;
+        }
     }
 
     // If buffer is full, flush first
@@ -1890,6 +1902,16 @@ void scheduler_release_pooled(ActorBase* actor) {
 
     // Track actor count for inline mode auto-detection
     aether_on_actor_terminate();
+
+    // Reclaim the lazily-allocated same-core SPSC queue (owned solely by this
+    // actor, calloc'd by ensure_spsc_queue / send_buffer_flush). Neither
+    // teardown path below frees it, so without this every actor that ever
+    // flushed a same-core batch leaks its multi-KB queue. A pooled slot that is
+    // reused re-allocates lazily, since both allocators re-check for NULL.
+    if (actor->spsc_queue) {
+        free(actor->spsc_queue);
+        actor->spsc_queue = NULL;
+    }
 
     int core = atomic_load_explicit(&actor->assigned_core, memory_order_relaxed);
     if (core >= 0 && core < num_cores && schedulers[core].actor_pool) {

--- a/runtime/utils/aether_tracing.c
+++ b/runtime/utils/aether_tracing.c
@@ -65,11 +65,15 @@ void tracing_add_actor(int actor_id) {
         }
     }
     
-    // Add actor
-    global_tracing.traced_actor_ids = (int*)realloc(
+    // Add actor. Grow through a temp so a failed realloc keeps the existing
+    // array (and doesn't leak it) instead of overwriting it with NULL and then
+    // dereferencing that NULL on the store below.
+    int* grown = (int*)realloc(
         global_tracing.traced_actor_ids,
         (global_tracing.traced_actor_count + 1) * sizeof(int)
     );
+    if (!grown) return;
+    global_tracing.traced_actor_ids = grown;
     global_tracing.traced_actor_ids[global_tracing.traced_actor_count++] = actor_id;
 }
 

--- a/std/http/middleware/aether_middleware.c
+++ b/std/http/middleware/aether_middleware.c
@@ -308,6 +308,9 @@ AetherSessionAuthOpts* aether_session_auth_opts_new(const char* cookie_name,
     AetherSessionAuthOpts* o = (AetherSessionAuthOpts*)calloc(1, sizeof(AetherSessionAuthOpts));
     if (!o) return NULL;
     o->cookie_name = strdup(cookie_name);
+    // cookie_name is compared on every request; a NULL would crash that lookup.
+    // (redirect_url is optional, so a NULL there is a valid "no redirect".)
+    if (!o->cookie_name) { free(o); return NULL; }
     o->redirect_url = (redirect_url && *redirect_url) ? strdup(redirect_url) : NULL;
     o->verify = verify;
     o->verifier_user_data = verifier_user_data;
@@ -488,6 +491,13 @@ int aether_middleware_rate_limit(HttpRequest* req, HttpServerResponse* res, void
             return 1;  /* fail open on OOM */
         }
         bucket->key = strdup(keybuf);
+        if (!bucket->key) {
+            // A NULL key would crash the strcmp bucket lookup on the next
+            // request; drop the bucket and fail open like the calloc path above.
+            free(bucket);
+            pthread_mutex_unlock(&o->lock);
+            return 1;  /* fail open on OOM */
+        }
         bucket->tokens = (double)o->max_requests;
         bucket->last_refill = now;
         if (prev) prev->next = bucket;
@@ -756,6 +766,14 @@ AetherStaticOpts* aether_static_opts_new(const char* url_prefix, const char* roo
     if (!o) return NULL;
     o->url_prefix = strdup(url_prefix ? url_prefix : "");
     o->root = strdup(root);
+    // A NULL url_prefix would crash the strlen just below; a NULL root would
+    // crash path resolution when serving. Bail cleanly instead.
+    if (!o->url_prefix || !o->root) {
+        free(o->url_prefix);
+        free(o->root);
+        free(o);
+        return NULL;
+    }
     o->prefix_len = strlen(o->url_prefix);
     return o;
 }
@@ -992,9 +1010,13 @@ static int request_append_header(HttpRequest* req,
     char** nv = (char**)realloc(req->header_values, (size_t)(n + 1) * sizeof(char*));
     if (!nv) return -1;
     req->header_values = nv;
-    req->header_keys[n]   = strdup(name);
-    req->header_values[n] = strdup(value);
-    if (!req->header_keys[n] || !req->header_values[n]) return -1;
+    char* kd = strdup(name);
+    char* vd = strdup(value);
+    // Store only if both copies succeed; returning with just one stored (the
+    // old code) leaked it, since header_count wasn't advanced to cover index n.
+    if (!kd || !vd) { free(kd); free(vd); return -1; }
+    req->header_keys[n]   = kd;
+    req->header_values[n] = vd;
     req->header_count = n + 1;
     return 0;
 }

--- a/std/http/proxy/aether_proxy_metrics.c
+++ b/std/http/proxy/aether_proxy_metrics.c
@@ -114,6 +114,12 @@ char* aether_proxy_pool_metrics_text(AetherProxyPool* pool) {
     }
     pthread_mutex_unlock(&pool->lock);
 
+    /* Single escape scratch pointer at function scope. The per-loop
+     * declarations left a live `esc` leaked whenever an EMIT hit OOM and
+     * jumped to `oom:` before its free; a hoisted pointer (NULLed after each
+     * free) lets the oom path reclaim it. */
+    char* esc = NULL;
+
     /* requests_total — broken down by status class so a Grafana
      * dashboard can sum {class="5xx"} for an error-rate panel
      * without re-aggregating. */
@@ -121,40 +127,40 @@ char* aether_proxy_pool_metrics_text(AetherProxyPool* pool) {
     EMIT("# TYPE aether_proxy_upstream_requests_total counter\n");
     for (int i = 0; i < n; i++) {
         AetherUpstream* u = snap[i];
-        char* esc = prom_label_escape(u->base_url);
+        esc = prom_label_escape(u->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_requests_total{upstream=\"%s\",class=\"2xx\"} %ld\n", esc, atomic_load(&u->metric_requests_2xx));
         EMIT("aether_proxy_upstream_requests_total{upstream=\"%s\",class=\"3xx\"} %ld\n", esc, atomic_load(&u->metric_requests_3xx));
         EMIT("aether_proxy_upstream_requests_total{upstream=\"%s\",class=\"4xx\"} %ld\n", esc, atomic_load(&u->metric_requests_4xx));
         EMIT("aether_proxy_upstream_requests_total{upstream=\"%s\",class=\"5xx\"} %ld\n", esc, atomic_load(&u->metric_requests_5xx));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     EMIT("# HELP aether_proxy_upstream_transport_errors_total Transport-class failures (DNS, connect, TLS).\n");
     EMIT("# TYPE aether_proxy_upstream_transport_errors_total counter\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_transport_errors_total{upstream=\"%s\"} %ld\n", esc, atomic_load(&snap[i]->metric_transport_errors));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     EMIT("# HELP aether_proxy_upstream_timeouts_total Upstream calls that exceeded the request timeout.\n");
     EMIT("# TYPE aether_proxy_upstream_timeouts_total counter\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_timeouts_total{upstream=\"%s\"} %ld\n", esc, atomic_load(&snap[i]->metric_timeouts));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     EMIT("# HELP aether_proxy_upstream_retries_total Idempotent retries fired against this upstream.\n");
     EMIT("# TYPE aether_proxy_upstream_retries_total counter\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_retries_total{upstream=\"%s\"} %ld\n", esc, atomic_load(&snap[i]->metric_retries));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     /* Latency: emit sum + count so dashboards can compute average
@@ -163,55 +169,55 @@ char* aether_proxy_pool_metrics_text(AetherProxyPool* pool) {
     EMIT("# HELP aether_proxy_upstream_latency_ms_sum Sum of upstream call durations in ms.\n");
     EMIT("# TYPE aether_proxy_upstream_latency_ms_sum counter\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_latency_ms_sum{upstream=\"%s\"} %ld\n", esc, atomic_load(&snap[i]->metric_latency_sum_ms));
-        free(esc);
+        free(esc); esc = NULL;
     }
     EMIT("# HELP aether_proxy_upstream_latency_ms_count Count of upstream calls observed.\n");
     EMIT("# TYPE aether_proxy_upstream_latency_ms_count counter\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_latency_ms_count{upstream=\"%s\"} %ld\n", esc, atomic_load(&snap[i]->metric_latency_count));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     /* Gauges. */
     EMIT("# HELP aether_proxy_upstream_inflight Concurrent in-flight requests on this upstream.\n");
     EMIT("# TYPE aether_proxy_upstream_inflight gauge\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_inflight{upstream=\"%s\"} %d\n", esc, atomic_load(&snap[i]->inflight));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     EMIT("# HELP aether_proxy_upstream_healthy 1 if the active health check considers the upstream up.\n");
     EMIT("# TYPE aether_proxy_upstream_healthy gauge\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_healthy{upstream=\"%s\"} %d\n", esc, atomic_load(&snap[i]->healthy));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     EMIT("# HELP aether_proxy_upstream_breaker_state 0=closed, 1=open, 2=half_open.\n");
     EMIT("# TYPE aether_proxy_upstream_breaker_state gauge\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_breaker_state{upstream=\"%s\"} %d\n", esc, atomic_load(&snap[i]->cb_state));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     EMIT("# HELP aether_proxy_upstream_draining 1 if the upstream is in active drain mode.\n");
     EMIT("# TYPE aether_proxy_upstream_draining gauge\n");
     for (int i = 0; i < n; i++) {
-        char* esc = prom_label_escape(snap[i]->base_url);
+        esc = prom_label_escape(snap[i]->base_url);
         if (!esc) goto oom;
         EMIT("aether_proxy_upstream_draining{upstream=\"%s\"} %d\n", esc, atomic_load(&snap[i]->draining));
-        free(esc);
+        free(esc); esc = NULL;
     }
 
     /* Pool-level counters. */
@@ -236,6 +242,7 @@ char* aether_proxy_pool_metrics_text(AetherProxyPool* pool) {
     return buf.data;
 
 oom:
+    free(esc);
     free(snap);
     free(buf.data);
     return NULL;

--- a/std/http/server/h2/aether_h2.c
+++ b/std/http/server/h2/aether_h2.c
@@ -502,6 +502,9 @@ static HttpRequest* request_from_stream(AetherH2Stream* str) {
     HttpRequest* req = calloc(1, sizeof(HttpRequest));
     if (!req) return NULL;
     req->method        = dup_str(str->method ? str->method : "GET");
+    /* method is dereferenced by route dispatch (strcmp); a NULL here would be a
+     * delayed crash far from this alloc, so fail the request build now. */
+    if (!req->method) { free(req); return NULL; }
     /* Per RFC 7540, the :path pseudo-header is the request-target
      * which embeds the query string. The HTTP/1.1 parser splits at
      * '?' to populate path + query_string separately, and downstream
@@ -562,6 +565,10 @@ static HttpRequest* request_from_stream(AetherH2Stream* str) {
                 req->header_keys[i]   = malloc(klen + 1);
                 req->header_values[i] = malloc(vlen + 1);
                 if (!req->header_keys[i] || !req->header_values[i]) {
+                    /* One of the pair failed: free the other so it doesn't leak
+                     * (header_count won't cover this un-incremented slot). */
+                    free(req->header_keys[i]);   req->header_keys[i] = NULL;
+                    free(req->header_values[i]); req->header_values[i] = NULL;
                     p = eol + 2; continue;
                 }
                 memcpy(req->header_keys[i], p, klen);

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -1764,6 +1764,10 @@ HttpResponse* http_send_raw(HttpRequest* req) {
     /* If redirects aren't enabled, return the first response as-is. */
     if (req->max_redirects <= 0) return resp;
 
+    /* No URL to resolve redirects against (strdup(NULL) below would be UB),
+     * so there is nothing to follow: return the first response as-is. */
+    if (!req->url) return resp;
+
     /* Track visited URLs for loop detection. Bounded by max_redirects
      * + 1 (the original URL). Static array is fine — max_redirects is
      * expected to be small (typically 5-10). */
@@ -1775,6 +1779,13 @@ HttpResponse* http_send_raw(HttpRequest* req) {
 
     int hops_remaining = req->max_redirects;
     char* current_url = strdup(req->url);
+    if (!current_url || !visited[0]) {
+        // Can't follow redirects without a copy of the starting URL; return the
+        // first response as-is rather than dereferencing a NULL current_url below.
+        free(current_url);
+        free(visited[0]);
+        return resp;
+    }
 
     while (hops_remaining > 0 && resp && resp->status_code >= 300 && resp->status_code < 400) {
         const char* hdrs = resp->headers ? string_to_cstr(resp->headers) : "";

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -1359,7 +1359,14 @@ HttpRequest* http_parse_request_n(const char* buf, size_t len) {
     req->header_keys = (char**)malloc(sizeof(char*) * 50);
     req->header_values = (char**)malloc(sizeof(char*) * 50);
     req->header_count = 0;
-    
+    // If either array failed to allocate, drop both and skip storing headers
+    // (the loop below still runs to advance past them to the body) rather than
+    // writing strdup results through a NULL array pointer.
+    if (!req->header_keys || !req->header_values) {
+        free(req->header_keys);   req->header_keys = NULL;
+        free(req->header_values); req->header_values = NULL;
+    }
+
     const char* header_start = line_end + 2;
     while (1) {
         line_end = strstr(header_start, "\r\n");
@@ -1377,7 +1384,7 @@ HttpRequest* http_parse_request_n(const char* buf, size_t len) {
         header_line[line_len] = '\0';
         
         char* colon = strchr(header_line, ':');
-        if (colon && req->header_count < 50) {
+        if (colon && req->header_count < 50 && req->header_keys && req->header_values) {
             *colon = '\0';
             char* key = header_line;
             char* value = colon + 1;
@@ -1385,9 +1392,18 @@ HttpRequest* http_parse_request_n(const char* buf, size_t len) {
             // Trim whitespace from value
             while (*value == ' ') value++;
 
-            req->header_keys[req->header_count] = strdup(key);
-            req->header_values[req->header_count] = strdup(value);
-            req->header_count++;
+            // Store only if both copies succeed; a NULL key/value would later
+            // crash header lookup (strcasecmp) or serialization (strlen).
+            char* kd = strdup(key);
+            char* vd = strdup(value);
+            if (kd && vd) {
+                req->header_keys[req->header_count] = kd;
+                req->header_values[req->header_count] = vd;
+                req->header_count++;
+            } else {
+                free(kd);
+                free(vd);
+            }
         }
         
         header_start = line_end + 2;
@@ -1571,6 +1587,7 @@ void http_request_free(HttpRequest* req) {
 // Response building
 HttpServerResponse* http_response_create() {
     HttpServerResponse* res = (HttpServerResponse*)calloc(1, sizeof(HttpServerResponse));
+    if (!res) return NULL;
     res->status_code = 200;
     res->status_text = strdup("OK");
     res->header_keys = (char**)malloc(sizeof(char*) * 50);
@@ -1616,16 +1633,23 @@ void http_response_set_header(HttpServerResponse* res, const char* key, const ch
     // Check if header exists, update it
     for (int i = 0; i < res->header_count; i++) {
         if (strcasecmp(res->header_keys[i], key) == 0) {
+            char* vd = strdup(value);
+            if (!vd) return;  // keep the existing value rather than free-to-NULL
             free(res->header_values[i]);
-            res->header_values[i] = strdup(value);
+            res->header_values[i] = vd;
             return;
         }
     }
 
-    // Add new header (max 50)
+    // Add new header (max 50). Store only if both copies succeed; a NULL key
+    // would crash the strcasecmp above on the next call, a NULL value the
+    // serializer's strlen.
     if (res->header_count >= 50) return;
-    res->header_keys[res->header_count] = strdup(key);
-    res->header_values[res->header_count] = strdup(value);
+    char* kd = strdup(key);
+    char* vd = strdup(value);
+    if (!kd || !vd) { free(kd); free(vd); return; }
+    res->header_keys[res->header_count] = kd;
+    res->header_values[res->header_count] = vd;
     res->header_count++;
 }
 
@@ -1669,8 +1693,11 @@ void http_response_add_header(HttpServerResponse* res, const char* key, const ch
         if (!res->header_keys || !res->header_values) return;
     }
     if (res->header_count >= 50) return;
-    res->header_keys[res->header_count] = strdup(key);
-    res->header_values[res->header_count] = strdup(value);
+    char* kd = strdup(key);
+    char* vd = strdup(value);
+    if (!kd || !vd) { free(kd); free(vd); return; }
+    res->header_keys[res->header_count] = kd;
+    res->header_values[res->header_count] = vd;
     res->header_count++;
 }
 
@@ -1873,8 +1900,17 @@ const char* http_status_text(int code) {
 // Routing
 void http_server_add_route(HttpServer* server, const char* method, const char* path, HttpHandler handler, void* user_data) {
     HttpRoute* route = (HttpRoute*)malloc(sizeof(HttpRoute));
+    if (!route) return;
     route->method = strdup(method);
     route->path_pattern = strdup(path);
+    // A NULL method/path_pattern would crash route matching's strcmp; drop the
+    // half-built route rather than register it.
+    if (!route->method || !route->path_pattern) {
+        free(route->method);
+        free(route->path_pattern);
+        free(route);
+        return;
+    }
     route->handler = handler;
     route->user_data = user_data;
     route->next = server->routes;
@@ -1899,6 +1935,7 @@ void http_server_delete(HttpServer* server, const char* path, HttpHandler handle
 
 void http_server_use_middleware(HttpServer* server, HttpMiddleware middleware, void* user_data) {
     HttpMiddlewareNode* node = (HttpMiddlewareNode*)malloc(sizeof(HttpMiddlewareNode));
+    if (!node) return;
     node->middleware = middleware;
     node->user_data = user_data;
     node->next = NULL;
@@ -2397,47 +2434,76 @@ void http_server_use_response_transformer(HttpServer* server,
 
 // Route matching with parameter extraction
 int http_route_matches(const char* pattern, const char* path, HttpRequest* req) {
+    // Free any params captured by a previous candidate-route check on this
+    // request. A route table tries each pattern in turn until one matches, so
+    // without this every non-matching (and every partially-matching) route
+    // leaks the two arrays plus their strings, since http_request_free only
+    // reclaims the final call's set. Doing it before the exact-match return
+    // also clears stale params a failed earlier pattern left behind.
+    if (req->param_keys) {
+        for (int i = 0; i < req->param_count; i++) free(req->param_keys[i]);
+        free(req->param_keys);
+        req->param_keys = NULL;
+    }
+    if (req->param_values) {
+        for (int i = 0; i < req->param_count; i++) free(req->param_values[i]);
+        free(req->param_values);
+        req->param_values = NULL;
+    }
+    req->param_count = 0;
+
     // Exact match
     if (strcmp(pattern, path) == 0) {
         return 1;
     }
-    
+
     // Pattern matching with parameters
     const char* p = pattern;
     const char* u = path;
-    
+
     // Allocate space for params
     req->param_keys = (char**)malloc(sizeof(char*) * 10);
     req->param_values = (char**)malloc(sizeof(char*) * 10);
     req->param_count = 0;
-    
+    if (!req->param_keys || !req->param_values) {
+        free(req->param_keys);   req->param_keys = NULL;
+        free(req->param_values); req->param_values = NULL;
+        return 0;
+    }
+
     while (*p && *u) {
         if (*p == ':') {
             // Parameter segment
             p++; // Skip ':'
-            
+
             // Extract parameter name
             const char* param_start = p;
             while (*p && *p != '/') p++;
-            
+
             int param_name_len = p - param_start;
-            char* param_name = (char*)malloc(param_name_len + 1);
-            strncpy(param_name, param_start, param_name_len);
-            param_name[param_name_len] = '\0';
-            
+
             // Extract parameter value from URL
             const char* value_start = u;
             while (*u && *u != '/') u++;
-            
+
             int value_len = u - value_start;
+
+            // The arrays hold at most 10 params; a pattern with more would
+            // overflow them. Treat that as a non-match rather than corrupt heap.
+            if (req->param_count >= 10) return 0;
+
+            char* param_name = (char*)malloc(param_name_len + 1);
             char* value = (char*)malloc(value_len + 1);
+            if (!param_name || !value) { free(param_name); free(value); return 0; }
+            strncpy(param_name, param_start, param_name_len);
+            param_name[param_name_len] = '\0';
             strncpy(value, value_start, value_len);
             value[value_len] = '\0';
-            
+
             req->param_keys[req->param_count] = param_name;
             req->param_values[req->param_count] = value;
             req->param_count++;
-            
+
         } else if (*p == '*') {
             // Wildcard - matches anything remaining
             return 1;
@@ -3629,6 +3695,13 @@ int http_server_start_raw(HttpServer* server) {
 
         for (int i = 1; i < n_threads; i++) {
             AcceptThreadCtx* ctx = malloc(sizeof(AcceptThreadCtx));
+            if (!ctx) {
+                // The join loop below assumes exactly n_threads accept threads;
+                // continuing with a NULL ctx would write through NULL here and
+                // leave a never-created thread to join. Fail loudly instead.
+                fprintf(stderr, "aether: failed to allocate accept-thread context\n");
+                abort();
+            }
             ctx->server = server;
             ctx->listen_fd = server->accept_listen_fds[i];
             ctx->poller = &server->accept_pollers[i];


### PR DESCRIPTION
## Summary

A second audit pass over runtime and stdlib memory handling, following the merged allocation-failure work in #1084. It fixes two real leaks on the ordinary execution path and hardens the "store a failed allocation, report success, crash later" class across the runtime and standard library, plus a set of verified documentation corrections.

## Leaks fixed (normal, non-OOM path)

- **`http_route_matches` leaked per request.** It allocated fresh `param_keys`/`param_values` arrays on every call, but only the last call's pair was ever freed. A server with more than one route therefore leaked the two arrays (and their strings) for every candidate route tried before the match, and for every route on a 404, on ordinary traffic. It now frees the previous call's params first, which also clears stale params a failed earlier pattern left behind.
- **`scheduler_release_pooled` leaked an actor's `spsc_queue`.** The lazily-allocated same-core SPSC queue (a multi-KB buffer) was never freed on teardown, so every actor that had flushed a same-core batch leaked it. It is now reclaimed on teardown; a reused pooled slot re-allocates lazily.

## Allocation-failure hardening

The "store a failed allocation, report success, then crash later" pattern produces a delayed fault far from the failed alloc, worse to diagnose than a clean out-of-memory failure. This also covers self-overwriting `realloc`s that leak the original allocation and then dereference NULL. Sites hardened:

- **Runtime:** cooperative and multicore schedulers (actor table, per-core I/O map with a zero-capacity grow guard, send-batch buffer with a direct-send fallback), NUMA init (falls back to single-node instead of a NULL cpu-to-node map), cooperative message send (fails loudly like the threaded path instead of dispatching a NULL payload), actor tracing.
- **Standard library:** the HTTP/1.1 server (request header arrays, response create, `set_header`/`add_header`, route params plus a bound, route and middleware registration, accept-thread context), the HTTP client redirect follower, the HTTP/2 request builder, the middleware factories (session-auth, rate-limit bucket, static-file opts, request-header add), the proxy Prometheus exporter (an OOM-path escape-buffer leak), and runtime type conversion.

The normal path is unchanged; each site degrades gracefully or fails cleanly under memory pressure.

## Documentation

Verified against a freshly built compiler:
- Closure capture semantics: a captured variable a closure assigns to is heap-promoted and shared with the enclosing scope (the Ruby/Groovy model, asserted by `tests/syntax/test_closure_mutable_capture_probe.ae`), not captured by value. `closures-and-builder-dsl.md` and `closures-and-lifetimes.md` corrected.
- The `as` primitive value cast (#480): `n as int` and other numeric casts parse and run; non-numeric casts parse and are rejected at type-check with E0200. `language-reference.md` corrected.
- `io.stderr_write` / `io.stdout_write` take one argument, not two. `stdlib-reference.md` corrected.
- The `std.tcp` write function is `tcp.write`, not `tcp.send`. `stdlib-api.md` corrected.

## Validation

- `make test`: 232/232 unit tests pass.
- `make examples`: 87/87 pass.
- Full ASan + LeakSanitizer suite: 232/232, zero sanitizer reports.
- `-Werror` clean across every changed file.

## Deliberately out of scope (tracked for follow-up)

The audit surfaced items that are likely code bugs rather than doc errors, so they are left for dedicated fixes rather than papered over here:
- The compiler codegen/parser assume-success allocation convention (compile-time OOM is fatal by design; the growth reallocs there are already checked).
- A top-level arrow clause with a trailing `;` fails to parse though the docs say semicolons are optional (likely a parser fix).
- `--emit-header` emits a near-empty header (the content emitters are dead code) and the documented `spawn_X(void)` signature differs from the real `spawn_X(int preferred_core)` (a c-embedding code fix).
- Mixing the `exports (...)` list with per-function `export` prints an error but does not fail the build, despite being documented as a hard error (a compiler enforcement fix).
