### PR TITLE
fix(std.tcp): full-duplex readiness — poll primitive + non-fatal read-timeout (#1092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.tcp` readiness primitives — `tcp.poll` / `tcp.poll2`** (#1092). Thin
+  `poll(2)` wrappers that wait for a socket (or two sockets at once) to become
+  readable with a caller-supplied timeout, without reading and without touching
+  the socket's connected flag. `poll2` is the primitive a full-duplex relay (a
+  CONNECT tunnel / TCP splice) needs to service whichever direction speaks
+  next; blocking `read_n` from one thread of control cannot express that.
+
+### Fixed
+
+- **`std.tcp` read-timeout no longer masquerades as a connection close**
+  (#1092). `tcp_receive_raw`/`tcp_receive_n_raw` collapsed every `recv <= 0`
+  into a single "closed or failed" branch that also marked the socket
+  permanently dead — so a quiet-but-alive direction (a peer idle for the 30 s
+  `SO_RCVTIMEO` window, normal on a long-lived tunnel) tore the connection down
+  mid-stream. Would-block / timeout (`EAGAIN`/`EWOULDBLOCK`/`WSAETIMEDOUT`) is
+  now distinguished: `read_n` returns a distinct `"timeout"` sentinel and
+  leaves the socket connected for a retry; only an orderly FIN or a hard error
+  is treated as a terminal close.
+
 ## [0.378.0]
 
 ### Fixed

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -808,12 +808,22 @@ It is no longer part of the Aether stdlib. See [`docs/http-vcr.md`](http-vcr.md)
 - `tcp.write_n(sock, data, length)` → `(int, string)` - Length-aware write for binary payloads
 - `tcp.read(sock, max_bytes)` → `(string, string)` - Text-shaped read, return `(data, err)`
 - `tcp.read_n(sock, max_bytes)` → `(string, int, string)` - Binary-safe read, return `(bytes, length, err)`
+- `tcp.poll(sock, timeout_ms)` → `(bool, string)` - Wait for readability. `(true, "")` = a following `read_n` won't block, `(false, "")` = timeout, `(false, err)` = closed/failed. `timeout_ms`: `-1` blocks, `0` polls, `>0` waits that many ms.
+- `tcp.poll2(a, b, timeout_ms)` → `(bool, bool, string)` - Wait on two sockets at once (the full-duplex relay primitive); each flag is true when that side is readable, both may be true.
 - `tcp.listen(port)` → `(ptr, string)` - Create listening socket
 - `tcp.accept(server)` → `(ptr, string)` - Accept connection
 - `tcp.close(sock)` - Close socket (infallible)
 - `tcp.server_close(server)` - Close server socket
 
-Raw externs: `tcp_connect_raw`, `tcp_send_raw`, `tcp_send_n_raw`, `tcp_receive_raw`, `tcp_receive_n_raw`, `tcp_listen_raw`, `tcp_accept_raw`.
+> **Timeout vs. close (#1092).** A quiet-but-alive peer (recv-timeout /
+> would-block) is *not* a close: `tcp.read_n` returns the distinct
+> `"timeout"` error and leaves the socket connected so you can retry or
+> `tcp.poll` it. Only an orderly FIN or a hard error returns `"connection
+> closed or receive failed"`. A full-duplex relay must branch on the
+> `"timeout"` sentinel rather than collapsing all non-empty errors into
+> "closed."
+
+Raw externs: `tcp_connect_raw`, `tcp_send_raw`, `tcp_send_n_raw`, `tcp_receive_raw`, `tcp_receive_n_raw`, `tcp_listen_raw`, `tcp_accept_raw`, `tcp_poll_raw`, `tcp_poll2_raw`.
 
 ### Reactor-Pattern Async I/O (`await_io`)
 

--- a/std/net/aether_net.c
+++ b/std/net/aether_net.c
@@ -21,11 +21,14 @@ int tcp_server_close(TcpServer* s) { (void)s; return 0; }
 int tcp_fd_raw(TcpSocket* s) { (void)s; return -1; }
 int tcp_server_fd_raw(TcpServer* s) { (void)s; return -1; }
 TcpSocket* tcp_socket_from_fd_owned(int fd) { (void)fd; return NULL; }
+int tcp_poll_raw(TcpSocket* s, int t) { (void)s; (void)t; return -1; }
+int tcp_poll2_raw(TcpSocket* a, TcpSocket* b, int t) { (void)a; (void)b; (void)t; return -1; }
 #else
 
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>   /* snprintf (getaddrinfo port string) */
+#include <errno.h>   /* EAGAIN/EWOULDBLOCK: idle-peer vs. closed-peer recv */
 
 #ifdef _WIN32
     #include <winsock2.h>
@@ -41,7 +44,23 @@ TcpSocket* tcp_socket_from_fd_owned(int fd) { (void)fd; return NULL; }
     #include <netdb.h>
     #include <unistd.h>
     #include <arpa/inet.h>
+    #include <poll.h>
 #endif
+
+/* recv returned <= 0: distinguish "peer idle, socket still alive"
+ * (SO_RCVTIMEO fired, or a nonblocking socket with nothing buffered) from
+ * "peer closed / hard error". A 30 s quiet window on a long-lived tunnel is
+ * normal and must NOT tear the connection down — see issue #1092. Returns 1
+ * for would-block/timeout/interrupt, 0 for a genuine close-or-error. Only
+ * meaningful when `received < 0`; an orderly FIN is received == 0. */
+static int net_recv_wouldblock(void) {
+#ifdef _WIN32
+    int err = WSAGetLastError();
+    return err == WSAEWOULDBLOCK || err == WSAETIMEDOUT;
+#else
+    return errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR;
+#endif
+}
 
 struct TcpSocket {
     int fd;
@@ -157,7 +176,15 @@ char* tcp_receive_raw(TcpSocket* sock, int max_bytes) {
 
     if (received <= 0) {
         aether_caps_free(buffer, (size_t)max_bytes + 1);
-        sock->connected = 0;
+        /* Idle peer (recv-timeout / would-block) is not a close: leave the
+         * socket connected so the caller can retry (#1092). Only a genuine
+         * FIN (received == 0) or hard error marks it dead. This text path
+         * still collapses both to NULL — callers needing to tell idle from
+         * closed must use tcp_receive_n_raw, whose "timeout" sentinel is
+         * distinct. */
+        if (!(received < 0 && net_recv_wouldblock())) {
+            sock->connected = 0;
+        }
         return NULL;
     }
 
@@ -184,7 +211,17 @@ TcpReceiveResult tcp_receive_n_raw(TcpSocket* sock, int max_bytes) {
     int received = recv(sock->fd, buffer, max_bytes, 0);
     if (received <= 0) {
         aether_caps_free(buffer, (size_t)max_bytes);
-        sock->connected = 0;
+        /* Split the failure branch (#1092): a would-block / recv-timeout means
+         * "peer idle, try again" — return the distinct "timeout" sentinel and
+         * KEEP the socket connected. Only an orderly FIN (received == 0) or a
+         * hard error is a real close that marks the socket dead. Collapsing
+         * these (the old behaviour) tore down full-duplex tunnels the first
+         * time either direction went quiet for 30 s. */
+        if (received < 0 && net_recv_wouldblock()) {
+            out._2 = "timeout";
+        } else {
+            sock->connected = 0;
+        }
         return out;
     }
 
@@ -312,6 +349,76 @@ TcpSocket* tcp_socket_from_fd_owned(int fd) {
     sock->fd = fd;
     sock->connected = 1;
     return sock;
+}
+
+/* Readiness primitives (#1092). A full-duplex relay must wait on both
+ * directions at once and service whichever becomes readable; blocking
+ * read_n from one thread of control cannot express that. These wrap
+ * poll(2) directly — the smallest surface that unblocks a CONNECT-tunnel
+ * byte pump without entangling std.tcp with the scheduler's actor poller.
+ *
+ * timeout_ms: -1 blocks indefinitely, 0 polls, >0 waits that many ms.
+ * On Windows, WSAPoll has the same shape for connected TCP sockets. */
+#ifdef _WIN32
+    #define AE_POLLFD  WSAPOLLFD
+    #define ae_poll    WSAPoll
+    #define ae_nfds_t  ULONG
+#else
+    #define AE_POLLFD  struct pollfd
+    #define ae_poll    poll
+    #define ae_nfds_t  nfds_t
+#endif
+
+/* Wait until a single socket is readable. Returns 1 if readable (data or
+ * EOF pending — a following recv distinguishes them), 0 on timeout, -1 on
+ * a null/closed handle or poll error. Does NOT read and does NOT alter the
+ * socket's connected flag. */
+int tcp_poll_raw(TcpSocket* sock, int timeout_ms) {
+    if (!sock || !sock->connected) return -1;
+    AE_POLLFD pfd;
+    pfd.fd = sock->fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    int rc = ae_poll(&pfd, (ae_nfds_t)1, timeout_ms);
+    if (rc < 0) {
+        if (net_recv_wouldblock()) return 0;   /* EINTR: treat as no-event */
+        return -1;
+    }
+    if (rc == 0) return 0;                      /* timeout */
+    return (pfd.revents & (POLLIN | POLLHUP | POLLERR)) ? 1 : 0;
+}
+
+/* Wait until either of two sockets is readable — the relay primitive.
+ * Returns a bitmask: bit 0 (1) = `a` readable, bit 1 (2) = `b` readable
+ * (both bits may be set). 0 on timeout. -1 if both handles are
+ * null/closed or on a poll error. A null/closed handle on one side is
+ * simply not watched, so a half-open relay still waits on the live side. */
+int tcp_poll2_raw(TcpSocket* a, TcpSocket* b, int timeout_ms) {
+    AE_POLLFD pfds[2];
+    int idx_a = -1, idx_b = -1;
+    ae_nfds_t n = 0;
+    if (a && a->connected) {
+        pfds[n].fd = a->fd; pfds[n].events = POLLIN; pfds[n].revents = 0;
+        idx_a = (int)n; n++;
+    }
+    if (b && b->connected) {
+        pfds[n].fd = b->fd; pfds[n].events = POLLIN; pfds[n].revents = 0;
+        idx_b = (int)n; n++;
+    }
+    if (n == 0) return -1;
+
+    int rc = ae_poll(pfds, n, timeout_ms);
+    if (rc < 0) {
+        if (net_recv_wouldblock()) return 0;   /* EINTR: caller re-polls */
+        return -1;
+    }
+    if (rc == 0) return 0;                      /* timeout */
+
+    int ready = 0;
+    const short mask = POLLIN | POLLHUP | POLLERR;
+    if (idx_a >= 0 && (pfds[idx_a].revents & mask)) ready |= 1;
+    if (idx_b >= 0 && (pfds[idx_b].revents & mask)) ready |= 2;
+    return ready;
 }
 
 #endif // AETHER_HAS_NETWORKING

--- a/std/net/aether_net.h
+++ b/std/net/aether_net.h
@@ -34,4 +34,16 @@ int tcp_server_fd_raw(TcpServer* server);
 // Ownership transfers to the returned TcpSocket; tcp_close closes it.
 TcpSocket* tcp_socket_from_fd_owned(int fd);
 
+// Readiness primitives for full-duplex relaying (#1092). Wrap poll(2);
+// neither reads nor mutates the socket's connected flag.
+//
+// tcp_poll_raw:  1 = readable (data or EOF pending), 0 = timeout,
+//                -1 = null/closed handle or poll error. timeout_ms:
+//                -1 blocks, 0 polls, >0 waits that many milliseconds.
+// tcp_poll2_raw: wait on two sockets at once; returns a bitmask
+//                (1 = a readable, 2 = b readable, 3 = both), 0 on
+//                timeout, -1 if both are null/closed or on poll error.
+int tcp_poll_raw(TcpSocket* sock, int timeout_ms);
+int tcp_poll2_raw(TcpSocket* a, TcpSocket* b, int timeout_ms);
+
 #endif

--- a/std/net/module.ae
+++ b/std/net/module.ae
@@ -10,7 +10,7 @@ exports (
     tcp_connect_raw, tcp_send_raw, tcp_send_n_raw,
     tcp_receive_raw, tcp_receive_n_raw, tcp_close,
     tcp_listen_raw, tcp_accept_raw, tcp_server_close,
-    tcp_fd_raw, tcp_server_fd_raw,
+    tcp_fd_raw, tcp_server_fd_raw, tcp_poll_raw, tcp_poll2_raw,
     http_get_raw, http_post_raw, http_put_raw, http_delete_raw,
     http_response_free, http_response_status_code,
     http_response_body_str, http_response_headers_str,
@@ -53,6 +53,12 @@ extern tcp_server_close(server: ptr) -> int
 // capsicum.enter). Owned by the handle — never close() one directly.
 extern tcp_fd_raw(sock: ptr) -> int
 extern tcp_server_fd_raw(server: ptr) -> int
+
+// Readiness primitives for full-duplex relaying (#1092). poll2 waits on
+// two sockets at once and returns a bitmask (1 = a, 2 = b, 3 = both),
+// 0 on timeout, -1 on error. Neither reads nor closes the sockets.
+extern tcp_poll_raw(sock: ptr, timeout_ms: int) -> int
+extern tcp_poll2_raw(a: ptr, b: ptr, timeout_ms: int) -> int
 
 // HTTP Client — raw ptr-returning externs (escape hatch).
 // Most callers should use the Go-style wrappers in std.http which provide

--- a/std/tcp/module.ae
+++ b/std/tcp/module.ae
@@ -8,8 +8,9 @@ exports (
     tcp_connect_raw, tcp_send_raw, tcp_send_n_raw,
     tcp_receive_raw, tcp_receive_n_raw, tcp_close,
     tcp_listen_raw, tcp_accept_raw, tcp_server_close,
-    tcp_fd_raw, tcp_server_fd_raw,
-    connect, write, write_n, read, read_n, listen, accept, fd, server_fd
+    tcp_fd_raw, tcp_server_fd_raw, tcp_poll_raw, tcp_poll2_raw,
+    connect, write, write_n, read, read_n, listen, accept, fd, server_fd,
+    poll, poll2
 )
 
 // Raw externs - escape hatch
@@ -24,6 +25,8 @@ extern tcp_accept_raw(server: ptr) -> ptr
 extern tcp_server_close(server: ptr) -> int
 extern tcp_fd_raw(sock: ptr) -> int
 extern tcp_server_fd_raw(server: ptr) -> int
+extern tcp_poll_raw(sock: ptr, timeout_ms: int) -> int
+extern tcp_poll2_raw(a: ptr, b: ptr, timeout_ms: int) -> int
 
 // string_concat used to duplicate the borrowed receive buffer so the
 // caller's copy outlives the underlying malloc.
@@ -82,8 +85,47 @@ read(sock: ptr, max_bytes: int) -> {
 // byte buffer stored in a length-aware AetherString. The returned
 // length is authoritative; callers should pass it to length-aware
 // consumers rather than re-derive length with strlen-shaped APIs.
+//
+// Error discipline (#1092): a quiet-but-alive peer (recv-timeout /
+// would-block) returns ("", 0, "timeout") and leaves the socket
+// connected — retry or poll, do NOT treat it as a close. Only an
+// orderly FIN or a hard error returns "connection closed or receive
+// failed"; that is the terminal state. A full-duplex relay must branch
+// on the "timeout" sentinel rather than collapsing all non-empty errors
+// into "closed."
 read_n(sock: ptr, max_bytes: int) -> {
     return tcp_receive_n_raw(sock, max_bytes)
+}
+
+// Wait until `sock` is readable, up to timeout_ms (-1 blocks, 0 polls,
+// >0 waits that many ms). Returns (true, "") when a subsequent read_n
+// will not block, (false, "") on timeout, (false, error) if the handle
+// is closed or poll failed. Neither reads nor closes the socket — pair
+// it with read_n to build a nonblocking loop over a single direction.
+poll(sock: ptr, timeout_ms: int) -> {
+    rc = tcp_poll_raw(sock, timeout_ms)
+    if rc < 0 {
+        return false, "poll failed"
+    }
+    if rc == 0 {
+        return false, ""
+    }
+    return true, ""
+}
+
+// Wait on two sockets at once — the full-duplex relay primitive. Returns
+// (a_ready, b_ready, "") where each flag is true when that side is
+// readable (both may be true); (false, false, "") on timeout;
+// (false, false, error) if both handles are closed or poll failed.
+// Service whichever side is ready with read_n, then re-poll.
+poll2(a: ptr, b: ptr, timeout_ms: int) -> {
+    rc = tcp_poll2_raw(a, b, timeout_ms)
+    if rc < 0 {
+        return false, false, "poll failed"
+    }
+    a_ready = (rc & 1) != 0
+    b_ready = (rc & 2) != 0
+    return a_ready, b_ready, ""
 }
 
 // Listen on a port. Returns (server, "") on success, (null, error) on

--- a/tests/integration/tcp_poll_fullduplex/client.ae
+++ b/tests/integration/tcp_poll_fullduplex/client.ae
@@ -1,0 +1,95 @@
+// Client side of the #1092 full-duplex readiness regression.
+//
+// Exercises the two fixes:
+//   1. tcp.poll — wait for the server-speaks-first greeting via a
+//      readiness primitive instead of a blind blocking read.
+//   2. poll-then-timeout is non-fatal — a poll that times out must leave
+//      the socket connected so a later read on the SAME socket succeeds.
+//   3. tcp.poll2 — with one busy and one idle socket, poll2 reports only
+//      the busy side ready.
+
+import std.tcp
+import std.string
+
+extern exit(code: int)
+
+const PORT = 18292
+
+fail(msg: string) {
+    println("  [FAIL] ${msg}")
+    exit(1)
+}
+
+make_payload() -> string {
+    // "a\0b" — embedded NUL, must survive the length-aware round-trip.
+    nul = string.from_char(0)
+    a = string.concat_wrapped("a", nul)
+    return string.concat_wrapped(a, "b")
+}
+
+// Retry connect until the server's listen socket is up. The server's
+// READY line is block-buffered to a pipe and may never flush, so the
+// client self-synchronizes rather than waiting on a log grep.
+connect_retry() -> ptr {
+    tries = 0
+    while tries < 100 {
+        sock, cerr = tcp.connect("127.0.0.1", PORT)
+        if cerr == "" {
+            return sock
+        }
+        sleep(100)
+        tries = tries + 1
+    }
+    fail("connect: server never came up after 100 tries")
+    return null
+}
+
+main() {
+    // Connect both sockets up front: the server accepts the busy one, then
+    // blocks on a second accept for the idle one before it speaks. `sock`
+    // is the busy connection (first accepted), `idle` the quiet one.
+    sock = connect_retry()
+    idle, ierr = tcp.connect("127.0.0.1", PORT)
+    if ierr != "" { fail("connect idle: ${ierr}") }
+
+    // --- Fix 1 & 2: poll returns ready for the greeting; a preceding
+    // idle poll window must not have killed the socket. Poll with a
+    // generous timeout; the server greets after both accepts complete.
+    ready, perr = tcp.poll(sock, 3000)
+    if perr != "" { fail("poll greeting: ${perr}") }
+    if ready == false { fail("poll timed out waiting for greeting") }
+
+    greeting, grerr = tcp.read(sock, 64)
+    if grerr != "" { fail("read greeting (socket died across poll?): ${grerr}") }
+    if string.contains(greeting, "GREETING") == 0 {
+        fail("greeting mismatch: ${greeting}")
+    }
+
+    // --- Fix 3: poll2(busy, idle) must report the busy side only. Send a
+    // frame on `sock` so the server echoes it and it becomes readable;
+    // the idle peer is accepted but silent, so it must stay not-ready.
+    payload = make_payload()
+    _, werr = tcp.write_n(sock, payload, 3)
+    if werr != "" { fail("write payload: ${werr}") }
+
+    a_ready, b_ready, p2err = tcp.poll2(sock, idle, 2000)
+    if p2err != "" { fail("poll2: ${p2err}") }
+    if a_ready == false { fail("poll2: busy side not reported ready") }
+    if b_ready == true { fail("poll2: idle side wrongly reported ready") }
+
+    // The echoed frame must round-trip byte-exact including the NUL.
+    echo, n, rerr = tcp.read_n(sock, 128)
+    if rerr != "" { fail("read echo: ${rerr}") }
+    if n != 3 { fail("echo length: got ${n}, expected 3") }
+    b0 = string.char_at_n(echo, n, 0)
+    b1 = string.char_at_n(echo, n, 1)
+    b2 = string.char_at_n(echo, n, 2)
+    if b0 != 97 { fail("echo[0]: got ${b0}, expected 97") }
+    if b1 != 0  { fail("echo[1]: got ${b1}, expected 0 (NUL)") }
+    if b2 != 98 { fail("echo[2]: got ${b2}, expected 98") }
+
+    tcp.close(idle)
+    tcp.close(sock)
+    println("  [OK] tcp full-duplex readiness (#1092)")
+    exit(0)
+}

--- a/tests/integration/tcp_poll_fullduplex/server.ae
+++ b/tests/integration/tcp_poll_fullduplex/server.ae
@@ -1,0 +1,81 @@
+// Server side of the #1092 full-duplex readiness regression.
+//
+// It accepts TWO connections:
+//   - the "busy" one: it SPEAKS FIRST (greeting before any read), then
+//     echoes one length-aware frame. A half-duplex "client speaks, then
+//     server replies" relay stalls on the speaks-first shape; a
+//     poll-driven client does not.
+//   - the "idle" one: accepted and held open, but never written to, so
+//     the client has a genuinely quiet-but-alive peer to prove poll2
+//     reports it NOT ready.
+//
+// listen happens in main() so the client's connect-retry has a socket to
+// hit; the blocking accept/serve runs in an actor off the main thread.
+
+import std.tcp
+import std.string
+
+extern exit(code: int)
+
+const PORT = 18292
+
+message Serve { server: ptr }
+
+actor SrvActor {
+    state s = 0
+    receive {
+        Serve(server) -> {
+            s = server
+
+            // First accept = the busy connection.
+            busy, aerr = tcp.accept(server)
+            if aerr != "" {
+                println("FAIL: accept busy: ${aerr}")
+                exit(1)
+            }
+
+            // Second accept = the idle connection. Held open, never
+            // written to, so it stays quiet with a live peer.
+            idle, ierr = tcp.accept(server)
+            if ierr != "" {
+                println("FAIL: accept idle: ${ierr}")
+                exit(1)
+            }
+
+            // Speak first on the busy socket — no read before this write.
+            _, gwerr = tcp.write(busy, "GREETING")
+            if gwerr != "" {
+                println("FAIL: write greeting: ${gwerr}")
+                exit(1)
+            }
+
+            // Then echo one frame back, length-aware (survives NULs).
+            bytes, n, rerr = tcp.read_n(busy, 128)
+            if rerr == "" {
+                tcp.write_n(busy, bytes, n)
+            }
+
+            // Keep the idle peer alive until the client has finished its
+            // poll2 assertion, then tear everything down.
+            sleep(3000)
+            tcp.close(idle)
+            tcp.close(busy)
+            tcp.server_close(server)
+        }
+    }
+}
+
+main() {
+    server, lerr = tcp.listen(PORT)
+    if lerr != "" {
+        println("FAIL: listen: ${lerr}")
+        exit(1)
+    }
+    println("READY")
+
+    a = spawn(SrvActor())
+    a ! Serve { server: server }
+
+    sleep(60000)
+    exit(0)
+}

--- a/tests/integration/tcp_poll_fullduplex/test_tcp_poll_fullduplex.sh
+++ b/tests/integration/tcp_poll_fullduplex/test_tcp_poll_fullduplex.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Regression for #1092: std.tcp exposes a readiness primitive (poll/poll2)
+# and a recv-timeout no longer masquerades as a connection close. Together
+# these let a poll-driven client service a server-speaks-first stream that
+# a half-duplex relay would stall on.
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP-WIN] tcp_poll_fullduplex - socket-heavy TCP behaviour is covered by POSIX matrix"
+        exit 0
+        ;;
+esac
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMPDIR="$(mktemp -d)"
+AETHER_CACHE_DIR="$TMPDIR/cache"
+export AETHER_CACHE_DIR
+SRV_PID=""
+cleanup() {
+    if [ -n "$SRV_PID" ]; then
+        # `ae run` compiles then forks the built binary into a child that
+        # holds the listen socket, so killing the wrapper alone orphans it
+        # (and leaks the fixed port for the next run). Kill the whole
+        # process group where setsid gave us one (Linux); on macOS/BSD
+        # setsid is usually absent, so also pkill any process whose argv
+        # names this test's server.ae as a portable belt-and-braces reap.
+        kill -- "-$SRV_PID" 2>/dev/null || kill "$SRV_PID" 2>/dev/null || true
+        wait "$SRV_PID" 2>/dev/null || true
+        if command -v pkill >/dev/null 2>&1; then
+            pkill -f "$SCRIPT_DIR/server.ae" 2>/dev/null || true
+        fi
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Start the server as its own process-group leader so cleanup can reap the
+# forked child too. setsid puts it in a fresh session/pgid == its pid.
+if command -v setsid >/dev/null 2>&1; then
+    setsid sh -c 'AETHER_HOME="$1" exec "$2" run "$3"' _ "$ROOT" "$AE" "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+else
+    AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+fi
+SRV_PID=$!
+
+# No READY-grep or port probe: the server's stdout is block-buffered to
+# this pipe while it blocks in accept(), and a probe connect would steal
+# the single accept slot. Instead the CLIENT self-synchronizes — it
+# retries connect() until the listen socket is up (see client.ae). We
+# only guard against the server dying before the client can connect.
+sleep 0.5
+if ! kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "  [FAIL] server died during startup:"
+    head -30 "$TMPDIR/srv.log"
+    exit 1
+fi
+
+AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/client.ae" >"$TMPDIR/client.out" 2>&1 || {
+    echo "  [FAIL] client exited non-zero:"
+    cat "$TMPDIR/client.out"
+    echo "--- server log ---"
+    head -30 "$TMPDIR/srv.log"
+    exit 1
+}
+
+cat "$TMPDIR/client.out"

--- a/tests/runtime/test_runtime_net.c
+++ b/tests/runtime/test_runtime_net.c
@@ -6,6 +6,7 @@
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <unistd.h>
+#include <fcntl.h>
 #endif
 
 TEST_CATEGORY(socket_null_handling, TEST_CATEGORY_NETWORK) {
@@ -86,6 +87,93 @@ TEST_CATEGORY(tcp_binary_nul_roundtrip, TEST_CATEGORY_NETWORK) {
     ASSERT_EQ('\0', data[1]);
     ASSERT_EQ('B', data[2]);
     string_release(got._0);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+// #1092: a recv that would block (nonblocking socket with nothing
+// buffered, or SO_RCVTIMEO firing) must be reported as a distinct
+// "timeout" and must NOT mark the socket dead. Collapsing it into the
+// close branch tears down a quiet-but-alive tunnel direction.
+TEST_CATEGORY(tcp_receive_timeout_is_not_fatal, TEST_CATEGORY_NETWORK) {
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+    // Make the read end nonblocking so recv returns EAGAIN immediately
+    // rather than waiting on the 30 s SO_RCVTIMEO.
+    int flags = fcntl(fds[1], F_GETFL, 0);
+    ASSERT_TRUE(flags >= 0);
+    ASSERT_EQ(0, fcntl(fds[1], F_SETFL, flags | O_NONBLOCK));
+
+    TcpSocket right = { fds[1], 1 };
+
+    // Nothing sent yet: recv would block. Expect the timeout sentinel and
+    // an intact connected flag.
+    TcpReceiveResult idle = tcp_receive_n_raw(&right, 16);
+    ASSERT_NULL(idle._0);
+    ASSERT_EQ(0, idle._1);
+    ASSERT_STREQ("timeout", idle._2);
+    ASSERT_EQ(1, right.connected);   // still alive — the crux of #1092
+
+    // The same socket must still work: send then read succeeds.
+    TcpSocket left = { fds[0], 1 };
+    const char payload[3] = { 'x', '\0', 'y' };
+    errno = 0;
+    int sent = tcp_send_n_raw(&left, payload, 3);
+    if (sent < 0 && errno == EPERM) {
+        printf("  SKIP tcp_receive_timeout_is_not_fatal: send denied by sandbox\n");
+        close(fds[0]); close(fds[1]);
+        return;
+    }
+    ASSERT_EQ(3, sent);
+
+    TcpReceiveResult got = tcp_receive_n_raw(&right, 16);
+    ASSERT_NOT_NULL(got._0);
+    ASSERT_EQ(3, got._1);
+    ASSERT_STREQ("", got._2);
+    string_release(got._0);
+
+    // A genuine peer close (FIN) IS fatal: connected goes to 0.
+    close(fds[0]);
+    TcpReceiveResult closed = tcp_receive_n_raw(&right, 16);
+    ASSERT_NULL(closed._0);
+    ASSERT_EQ(0, right.connected);
+
+    close(fds[1]);
+}
+
+// #1092: readiness primitives. poll reports timeout vs ready without
+// reading; poll2 reports which of two sockets is readable as a bitmask.
+TEST_CATEGORY(tcp_poll_readiness, TEST_CATEGORY_NETWORK) {
+    // Null/closed handles are an error, not a silent timeout.
+    ASSERT_EQ(-1, tcp_poll_raw(NULL, 0));
+    ASSERT_EQ(-1, tcp_poll2_raw(NULL, NULL, 0));
+
+    int fds[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+    TcpSocket a = { fds[0], 1 };
+    TcpSocket b = { fds[1], 1 };
+
+    // Nothing buffered: poll times out (0) with a short deadline.
+    ASSERT_EQ(0, tcp_poll_raw(&b, 50));
+
+    // poll2 with both idle also times out.
+    ASSERT_EQ(0, tcp_poll2_raw(&a, &b, 50));
+
+    // Send from a->b: b becomes readable, a does not.
+    const char one = 'Z';
+    errno = 0;
+    int sent = tcp_send_n_raw(&a, &one, 1);
+    if (sent < 0 && errno == EPERM) {
+        printf("  SKIP tcp_poll_readiness: send denied by sandbox\n");
+        close(fds[0]); close(fds[1]);
+        return;
+    }
+    ASSERT_EQ(1, sent);
+
+    ASSERT_EQ(1, tcp_poll_raw(&b, 1000));       // b readable
+    ASSERT_EQ(2, tcp_poll2_raw(&a, &b, 1000));  // bit 1 (b) only
 
     close(fds[0]);
     close(fds[1]);


### PR DESCRIPTION
## Description

Fixes #1092. `std.tcp` could only express **half-duplex** stream relaying. A bidirectional byte pump — a CONNECT tunnel / TCP splice where either side may speak first or stream continuously — was not expressible through the stdlib without silent data loss, due to two independent defects in `std/net/aether_net.c`. This PR fixes both (issue's Option A, the more generally useful path).

### 1. No readiness primitive → added `tcp.poll` / `tcp.poll2`

Only blocking `read_n`/`write_n` existed, so there was no way to wait on **both** fds at once and service whichever becomes readable. Added:

- `tcp.poll(sock, timeout_ms) → (bool, string)` — wait for one socket to become readable.
- `tcp.poll2(a, b, timeout_ms) → (bool, bool, string)` — wait on two sockets at once (the full-duplex relay primitive).

Both are thin `poll(2)` wrappers (`WSAPoll` on Windows); they neither read nor touch the socket's `connected` flag. `timeout_ms`: `-1` blocks, `0` polls, `>0` waits that many ms.

> The issue suggested wrapping `runtime/io/aether_poller_*.c`, but those are the **orphaned** poller hub that `make install` deletes; the active poller (`runtime/scheduler/`) is actor-mailbox-coupled. A direct `poll(2)` is the smallest correct surface and needs no new link wiring.

### 2. Read-timeout masqueraded as EOF, and was fatal → now non-fatal + distinguishable

Every `recv <= 0` collapsed into one branch that marked the socket **permanently dead**. So a quiet-but-alive direction (a peer idle for the fixed 30 s `SO_RCVTIMEO` window — normal on a long-lived tunnel) tore the connection down mid-stream. Now split:

- would-block / recv-timeout (`EAGAIN`/`EWOULDBLOCK`/`EINTR`; `WSAETIMEDOUT` on Windows) → `read_n` returns a distinct **`"timeout"`** sentinel and **keeps the socket connected** for a retry.
- only an orderly FIN (`recv == 0`) or a hard error is terminal.

## Type of Change
- [x] Bug fix
- [x] New feature (readiness primitive)

## Testing
- [x] **C unit** (`tests/runtime/test_runtime_net.c`): `tcp_receive_timeout_is_not_fatal` (nonblocking `socketpair` proves timeout ≠ close, socket survives, real FIN *is* fatal) and `tcp_poll_readiness` (poll/poll2 timeout-vs-ready, bitmask, null-handle → -1). **234/234 C tests pass**, including under `HARDEN=1`.
- [x] **Integration** (`tests/integration/tcp_poll_fullduplex/`): a **server-speaks-first** stream serviced by a poll-driven client + a genuinely-idle second peer; asserts `poll2` reports the busy side only and a NUL-bearing frame round-trips byte-exact. Passes; re-runnable.
- [x] Neighbour regression `http_server_connect_tunnel` (#1086) still green.

## Cross-platform anticipation
- **Windows**: `aether_net.c` cross-compiles clean under `x86_64-w64-mingw32-gcc -Werror`; `WSAPoll`/`WSAPOLLFD`/`POLLIN`/`POLLHUP`/`POLLERR`/`ULONG` all declare and link (no `_WIN32_WINNT` override needed on modern mingw-w64). `net_recv_wouldblock()` reads `WSAGetLastError()` on Windows, `errno` on POSIX. `AETHER_HAS_NETWORKING=0` stub path updated. The integration test **skips on Windows** and self-synchronizes (client retries `connect`) rather than grepping a block-buffered READY line.
- **macOS/BSD**: `poll(2)`, `POLLHUP`/`POLLERR`, `nfds_t`, `AF_UNIX` socketpair, `fcntl(O_NONBLOCK)` are all POSIX-portable. The test's cleanup guards `setsid` (Linux-only) with a `pkill -f` fallback so the forked `ae run` child is reaped without a fixed-port leak.

## Docs
- `CHANGELOG.md` under `[current]` (Added + Fixed).
- `docs/stdlib-api.md`: `tcp.poll`/`tcp.poll2` entries + a timeout-vs-close discipline note.

## Checklist
- [x] Code follows style guidelines (4-space C, explanatory comments at the tricky sites)
- [x] Self-review completed
- [x] Documentation updated
- [x] Pure Aether module surface, no new C consumers
