### PR TITLE
fix(modules): selective stdlib import no longer suppresses transitively-used wrappers (#1097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Selective import of a stdlib module no longer suppresses instantiation of
+  wrappers used transitively by an imported library** (#1097). When the
+  top-level unit did `import std.tcp (connect)` — a *selective* import that
+  omitted a tuple wrapper (`poll2` / `read_n` / `write_n`) — and an imported
+  library used that wrapper internally, the omitted wrapper was never
+  code-generated: its call site degraded to an undefined `tcp_poll2` and the
+  build failed at the *library's* source location. The cross-module merge's
+  transitive-dependency pass skipped any module that was also a direct import,
+  on the assumption the main loop had fully merged it; but a *selective* direct
+  import merges only its named subset. The transitive pass now recognises a
+  module that is both a direct import and a transitive dependency, and merges
+  the remaining exports the library needs (dedup guards keep the already-merged
+  subset a no-op). This makes a partial `std.tcp` import behave like the
+  no-import case, which already merged the full surface transitively. The
+  bare-name selective restriction on user code is unchanged.
+
 ## [0.379.0]
 
 ### Added

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -2326,6 +2326,14 @@ void module_merge_into_program(ASTNode* program) {
     {
         // Collect direct imports as the BFS frontier.
         const char* visited[256];
+        // #1097: was this module reached as a *transitive dependency* of some
+        // other module (as opposed to only being a direct top-level import)?
+        // A direct import merged only its selected subset in the main loop, so
+        // a module that is ALSO transitively needed must have its remaining
+        // exports merged here — otherwise a wrapper the top-level import
+        // omitted (`poll2`) but a library uses stays un-instantiated and its
+        // call site degrades to an undefined `<ns>_<name>`.
+        int reached_transitively[256];
         int visited_count = 0;
         const char* queue[256];
         int q_head = 0, q_tail = 0;
@@ -2334,12 +2342,15 @@ void module_merge_into_program(ASTNode* program) {
             ASTNode* child = program->children[i];
             if (!child || child->type != AST_IMPORT_STATEMENT || !child->value) continue;
             if (visited_count >= 256) break;
+            reached_transitively[visited_count] = 0;
             visited[visited_count++] = child->value;
             if (q_tail < 256) queue[q_tail++] = child->value;
         }
 
         // BFS: for each enqueued module, look at its `imports` list and
-        // enqueue any not yet visited.
+        // enqueue any not yet visited. A dep discovered here is marked
+        // reached-transitively even if it was already seeded as a direct
+        // import (#1097) — that's the union signal the merge below needs.
         while (q_head < q_tail) {
             const char* mod_path = queue[q_head++];
             AetherModule* mod = module_find(mod_path);
@@ -2350,22 +2361,37 @@ void module_merge_into_program(ASTNode* program) {
                 if (!dep) continue;
                 int seen = 0;
                 for (int v = 0; v < visited_count; v++) {
-                    if (strcmp(visited[v], dep) == 0) { seen = 1; break; }
+                    if (strcmp(visited[v], dep) == 0) {
+                        // Already visited — but now we know it's also a
+                        // transitive dep, so record that (a direct selective
+                        // import seeded it with the flag clear). #1097.
+                        reached_transitively[v] = 1;
+                        seen = 1;
+                        break;
+                    }
                 }
                 if (seen) continue;
                 if (visited_count >= 256) break;
+                reached_transitively[visited_count] = 1;
                 visited[visited_count++] = dep;
                 if (q_tail < 256) queue[q_tail++] = dep;
             }
         }
 
-        // For each transitively-reachable module that wasn't a direct
-        // user import, merge its exported functions and constants the
-        // same way the main loop merged direct imports.
+        // For each transitively-reachable module, merge its exported functions
+        // and constants the same way the main loop merged direct imports.
         for (int v = 0; v < visited_count; v++) {
             const char* dep_path = visited[v];
 
-            // Skip direct imports — they were merged above.
+            // Skip modules that are *only* a direct user import — the main
+            // loop already merged them (its selective filter is the intended
+            // user-facing scope). But a direct import that is ALSO a
+            // transitive dependency of another merged module must fall
+            // through: the main loop merged only its selected subset, and the
+            // library needs the rest. The clone dedup guards below
+            // (program_has_function / _const / _struct) make re-merging the
+            // already-cloned subset a no-op, so this only adds the missing
+            // transitively-used exports. #1097.
             int is_direct = 0;
             for (int i = 0; i < orig_count; i++) {
                 ASTNode* child = program->children[i];
@@ -2375,7 +2401,7 @@ void module_merge_into_program(ASTNode* program) {
                     break;
                 }
             }
-            if (is_direct) continue;
+            if (is_direct && !reached_transitively[v]) continue;
 
             AetherModule* dep_mod = module_find(dep_path);
             if (!dep_mod || !dep_mod->ast) continue;
@@ -2408,10 +2434,26 @@ void module_merge_into_program(ASTNode* program) {
             // qualified calls) BUT skip the user-explicit registry
             // (so user code can't accidentally call into the
             // transitively-pulled-in namespace it never imported).
-            ASTNode* synth_import = create_ast_node(AST_IMPORT_STATEMENT,
-                                                   dep_path, 0, 0);
-            synth_import->annotation = strdup("synthetic");
-            insert_child_at(program, synth_import, insert_idx++);
+            // #1097: a direct-but-also-transitive dep already carries a
+            // user-written import for this path, so the namespace is already
+            // registered — don't add a redundant synthetic node for it. Only
+            // inject the synthetic import when the program has no import of
+            // this path yet (the pure-transitive case #243 targeted).
+            int has_import_of_dep = 0;
+            for (int p = 0; p < program->child_count; p++) {
+                ASTNode* pc = program->children[p];
+                if (pc && pc->type == AST_IMPORT_STATEMENT && pc->value &&
+                    strcmp(pc->value, dep_path) == 0) {
+                    has_import_of_dep = 1;
+                    break;
+                }
+            }
+            if (!has_import_of_dep) {
+                ASTNode* synth_import = create_ast_node(AST_IMPORT_STATEMENT,
+                                                       dep_path, 0, 0);
+                synth_import->annotation = strdup("synthetic");
+                insert_child_at(program, synth_import, insert_idx++);
+            }
 
             for (int j = 0; j < mod_ast->child_count; j++) {
                 ASTNode* decl = unwrap_export(mod_ast->children[j]);

--- a/tests/integration/issue1097_selective_transitive_wrapper/lib/relaylib/module.ae
+++ b/tests/integration/issue1097_selective_transitive_wrapper/lib/relaylib/module.ae
@@ -1,0 +1,14 @@
+// relaylib uses the tuple-returning std.tcp wrappers internally. It is
+// imported by a top-level unit that selectively imports std.tcp WITHOUT
+// naming poll2/read_n/write_n — the #1097 case that used to fail because
+// the omitted wrappers were not instantiated for this transitive use.
+import std.tcp (poll2, read_n, write_n)
+exports (splicey)
+splicey(a: ptr, b: ptr, mx: int) -> string {
+    ar, br, e = poll2(a, b, 100)
+    if e != "" { return e }
+    d, n, r = read_n(a, mx)
+    if r != "" { return r }
+    w, we = write_n(b, d, n)
+    return we
+}

--- a/tests/integration/issue1097_selective_transitive_wrapper/main.ae
+++ b/tests/integration/issue1097_selective_transitive_wrapper/main.ae
@@ -1,0 +1,14 @@
+// Top-level unit selectively imports std.tcp naming ONLY connect — it
+// never names poll2/read_n/write_n, which are used only via relaylib.
+// Before #1097's fix this failed with "Undefined function 'tcp_poll2'";
+// the selective import wrongly shadowed the transitive full-merge that a
+// no-import build already did correctly.
+import std.tcp (connect)
+import relaylib (splicey)
+
+main() {
+    // null args make splice() error-return immediately; we only care that
+    // the program COMPILES — the omitted wrappers must be instantiated.
+    _ = splicey(null, null, 16)
+    println("ok")
+}

--- a/tests/integration/issue1097_selective_transitive_wrapper/test_issue1097_selective_transitive_wrapper.sh
+++ b/tests/integration/issue1097_selective_transitive_wrapper/test_issue1097_selective_transitive_wrapper.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Regression for #1097: a selective `import std.tcp (connect)` in the top-level
+# unit must NOT suppress instantiation of the tuple wrappers (poll2/read_n/
+# write_n) that an imported library uses transitively.
+#
+# Before the fix the transitive cross-module merge skipped std.tcp entirely
+# once it was a *direct* (selective) import, so the omitted wrappers were never
+# cloned and relaylib's call sites degraded to an undefined `tcp_poll2`. A build
+# with NO top-level std.tcp import already worked (std.tcp reached only
+# transitively → full merge), so a partial import was wrongly *stronger* than no
+# import. This test pins the "partial import" case to build.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Run from the test dir so `import relaylib` resolves against ./relaylib/.
+cd "$SCRIPT_DIR"
+
+ACTUAL="$TMPDIR/actual.txt"
+if ! AETHER_HOME="$ROOT" "$AE" run main.ae >"$ACTUAL" 2>"$TMPDIR/err.log"; then
+    echo "  [FAIL] ae run main.ae exited non-zero — selective import suppressed a"
+    echo "         transitively-used std.tcp wrapper (regression of #1097)"
+    head -15 "$TMPDIR/err.log"
+    exit 1
+fi
+
+ACTUAL_TXT=$(cat "$ACTUAL")
+if [ "$ACTUAL_TXT" != "ok" ]; then
+    echo "  [FAIL] expected 'ok', got '$ACTUAL_TXT'"
+    exit 1
+fi
+
+echo "  [PASS] issue1097: selective std.tcp import doesn't suppress transitive wrapper instantiation"


### PR DESCRIPTION
## Description

Fixes #1097. A **selective** import of a stdlib module in the top-level unit suppressed instantiation of *omitted* wrappers that an imported library used **transitively**, so the build failed with `Undefined function 'tcp_poll2'` pointing at the library.

### Root cause

`module_merge_into_program`'s transitive cross-module merge (the #243 BFS) **skips any module that is a direct import**, on the assumption the main merge loop already merged it in full. That holds for a *bare* import, but a **selective** direct import merges only its named subset. So a module that was **both** a direct selective import **and** a transitive dependency of an imported library had its unselected-but-transitively-used exports dropped.

This is exactly why the issue's cases behaved as they did:
- **P1 (no top-level `std.tcp` import)** → `std.tcp` reached only transitively → BFS merges its whole surface → **builds**.
- **P2 (`import std.tcp (connect)`)** → `std.tcp` is now a direct selective import → BFS skips it → omitted wrappers never instantiated → **fails**.
- **P3 (full import)** → main loop merges the named wrappers → **builds**.

So a partial import was strictly *stronger* than no import.

### Fix

Track whether each BFS-visited module was reached as a **transitive dependency** (not merely seeded as a direct import). A module that is both a direct import and a transitive dep now falls through to the transitive merge. The existing clone-dedup guards (`program_has_function` / `_const` / `_struct`) make re-merging the already-selected subset a no-op, so only the missing transitively-used exports are added. The synthetic-import injection is guarded so a direct import (namespace already registered) doesn't get a redundant node.

### Behaviour

- A partial `std.tcp` import now matches the no-import case (full transitive merge) — the issue's first "Expected" bullet (union of what every module uses).
- **The bare-name selective restriction on *user* code is unchanged**: `poll2(...)` as a bare call in a file that imported only `connect` still fails. Qualified `tcp.poll2(...)` remains export-gated (poll2 *is* exported) — the documented selective-import semantics (the per-import-form filter was deliberately removed from the typechecker; see `is_export_blocked`).

## Type of Change
- [x] Bug fix

## Testing
- [x] **Regression test** `tests/integration/issue1097_selective_transitive_wrapper` (the exact P2 case). Verified it **fails on the pristine compiler** with `Undefined function 'tcp_poll2'` and **passes** with the fix. Library lives under `lib/` so the harness's `*/lib/*` prune excludes it from standalone-build discovery; `main.ae` builds via `./lib` auto-resolution.
- [x] Reproduced P1/P2/P3 from the issue — all three build after the fix.
- [x] Full import suite green in isolation: selective_import, selective_import_merge_order, selective_import_shadow, issue870_selective_import_merge, transitive_import, transitive_module_import, module_reexport, glob_import(+cross_module,+tuple_return), bare_fn_cross_module, ufcs_cross_module, cross_module_actor, pure_module(+mixed).
- [x] 234/234 C unit tests pass.
- [x] Verified the bare-name gate (negative case) and the qualified-call export gate both still behave correctly.

> Note: a shared-`~/.aether/cache` parallel `make test-ae` run showed a batch of unrelated `aetherc returned -1` crashes (emit_lib/glob_import/liquid/http) — these are cache-contention artifacts under `-P 12`, not this change: every one passes in isolation (verified with per-test `AETHER_CACHE_DIR`). The only other reds are the known-flaky `http_server_h2` 50-stream stress and a pre-existing untracked `test_issue1046_bit_set.ae`, neither related.

## Cross-platform
- Pure C control-flow change in `compiler/aether_module.c` — no `_WIN32`/platform code, no new stdlib symbols, no `long`/`ssize_t`/typedef hazards. `int` arrays + `strcmp` only.
- Builds clean under `-Werror`, `HARDEN=1`, and `x86_64-w64-mingw32-gcc -Werror`.

## Checklist
- [x] Code follows style guidelines (4-space C, explanatory comment at the tricky merge site)
- [x] Self-review completed
- [x] Regression test added (bug fix = regression test)
- [x] CHANGELOG updated under `[current]`
