### PR TITLE
feat(std.bits): wrapping_add64 / wrapping_mul64 (defined modulo-2^64) + F3 port asks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.bits.wrapping_add64` / `wrapping_mul64`** — defined modulo-2^64 add and
+  multiply. Aether's `long` is signed `int64_t` and native `a * b` overflow is
+  undefined behaviour (a `-fsanitize=undefined` build traps on it) even though
+  2's-complement wrap "happens to work" at `-O2`; these compute in the unsigned
+  domain so the wrap is defined and optimiser-proof. They join the existing
+  unsigned 64-bit helpers (`udiv64` / `urem64` / `ucmp64`). Motivated by ports
+  of C tools whose on-disk / wire format depends on defined unsigned overflow —
+  e.g. F3's fill/verify LCG `x = x * 4294967311 + 17`.
+
 ## [0.380.0]
 
 ### Fixed

--- a/asks/binary-buffer-streaming-ergonomics.md
+++ b/asks/binary-buffer-streaming-ergonomics.md
@@ -1,0 +1,103 @@
+# Ask: Binary Buffer and Streaming Ergonomics
+
+## Request
+
+Two small additions to the binary I/O path, so a fixed-size block reader can
+avoid a per-block copy and read little-endian integers straight out of a
+streamed buffer:
+
+1. `fs.pread_into(file, buf: bytes, len, offset) -> (int, string)` — read up to
+   `len` bytes at `offset` directly into an existing `std.bytes` buffer,
+   returning `(n, err)`. The point is to reuse one buffer across a validation
+   loop instead of allocating a fresh string per block.
+2. Little-endian readers on `std.bytes.cursor` (`read_le_u16/u32/u64`) to match
+   the existing big-endian readers, since binary formats are frequently LE.
+
+A documented recipe using existing APIs is an acceptable substitute for (2) if a
+cursor extension isn't wanted.
+
+## Motivation
+
+F3 reads and writes repeated 512-byte sectors (`SECTOR_SIZE`,
+`src/f3write.c` / `src/f3read.c`). The read path regenerates the LCG sequence and
+compares it against each sector, in a tight loop over the whole device.
+
+### What already works (verified against the in-progress port)
+
+Most of what a block reader/writer needs is **already present**, so this ask is
+deliberately narrow. In `src/f3core/module.ae`:
+
+- **EOF vs. short read vs. I/O error is already distinguishable.** `read_h2w_file`
+  branches on `fs.pread`'s `(payload, n, err)` return: `err != ""` is an I/O
+  error, `n == 0` is EOF (break), `n != SECTOR_SIZE` is a short sector. No new
+  API is needed for this — an earlier version of this ask listed it as a gap; it
+  is not one.
+- **Little-endian integer access on a buffer already exists.** `std.bytes` has
+  both `set_le64` and `get_le64` (and the 16/32 variants). The port's write path
+  uses `bytes.new` → `set_le64` → `finish`, which is clean. The port's read path
+  currently hand-rolls an LE64 decode from a string byte-by-byte
+  (`bytes_from_string_check`, assembling `b0 | (b1<<8) | …`); that is
+  **unnecessary** — `bytes.copy_from_string` followed by `bytes.get_le64` does
+  the same thing with the stdlib accessor.
+
+### The actual gap
+
+`fs.pread` returns a length-bearing **string**. To use `bytes.get_le64` on the
+read-back, you must first copy that string into a `bytes` buffer
+(`bytes.copy_from_string`) — a **copy per sector** in the hottest loop in the
+tool. That copy is the only real inefficiency: everything else composes.
+
+- `fs.pread_into(file, buf, len, offset)` removes it: read straight into a
+  reusable `bytes` buffer, then `bytes.get_le64` in place. One buffer for the
+  whole device.
+- `std.bytes.cursor` is the natural "walk the sector's u64s" abstraction, but it
+  only offers **big-endian** readers (`read_be_u16/u32/u64`). F3's format is
+  little-endian, so the cursor can't be used as-is. LE readers would let the
+  validation loop read successive u64s with bounds-checked cursor advances
+  instead of manual index arithmetic.
+
+Neither is a correctness blocker — the string + `copy_from_string` +
+`get_le64` recipe is correct today (and binary-safe: `fs.pread` returns a
+length-bearing string, so embedded NULs survive). This ask is purely about
+removing the per-block copy and giving LE formats a first-class streaming
+reader.
+
+## Possible Shape
+
+```aether
+// One reusable buffer for the whole validation loop:
+buf = bytes.new(512)
+loop {
+    n, err = fs.pread_into(file, buf, 512, offset)
+    if err != "" { return io_error }
+    if n == 0 { break }            // EOF
+    if n != 512 { return short }   // short sector
+    v0 = bytes.get_le64(buf, 0)    // no per-sector copy
+    // …validate the sector's u64 sequence in place…
+    offset = offset + 512
+}
+```
+
+## Acceptance Criteria
+
+- A pure-Aether fixed-size block reader can process repeated blocks **without a
+  per-block string→bytes copy** (via `pread_into` into a reused buffer).
+- Fixed-size reads continue to distinguish EOF (`n == 0`), short read
+  (`0 < n < len`), and I/O error (`err != ""`) — this already holds for
+  `fs.pread` and must hold for `pread_into` too.
+- LE integer reads compose with `std.bytes` (`get_le16/32/64` on the buffer, and
+  ideally `read_le_*` on a cursor).
+- Tests include embedded NUL bytes (a sector whose payload contains `0x00`
+  bytes must round-trip) and a repeated fixed-size block read/validate loop over
+  several sectors, asserting the copy-free path yields the same result as the
+  existing `pread` + `copy_from_string` recipe.
+
+## Notes for the implementer
+
+- `pread_into` is a thin sibling of the existing `fs.pread` extern in
+  `std/fs/`, differing only in that it writes into a caller-owned
+  `AetherBytes*` rather than allocating a new length-bearing string. Bounds:
+  clamp `len` to the buffer capacity.
+- The cursor LE readers mirror `bytes_cursor_read_be_u{16,32,64}` in
+  `std/bytes/cursor/` with the byte order reversed; same EOF-returns-null,
+  cursor-unchanged contract.

--- a/asks/wrapping-64-bit-arithmetic.md
+++ b/asks/wrapping-64-bit-arithmetic.md
@@ -1,0 +1,91 @@
+# Ask: Wrapping 64-bit Arithmetic Helpers
+
+## Request
+
+Add explicit 64-bit wrapping arithmetic helpers to `std.bits`:
+
+```aether
+bits.wrapping_add64(a: long, b: long) -> long
+bits.wrapping_mul64(a: long, b: long) -> long
+```
+
+The helpers perform modulo-2^64 arithmetic and return the resulting 64-bit bit
+pattern as `long`. They are the defined-overflow siblings of the unsigned
+64-bit operations `std.bits` already exposes (`aether_bits_udiv64`,
+`urem64`, `ucmp64`), and should be implemented the same way — thin externs over
+`aether_bits_*` C functions that compute in `uint64_t`.
+
+## Motivation
+
+F3's fill/verify core is a linear-congruential generator whose every sector is
+a run of these values written as little-endian `uint64`
+(`src/libutils.c:219-221`, `fill_buffer_with_block` / `validate_buffer_with_block`):
+
+```c
+static inline uint64_t next_random_number(uint64_t random_number)
+{
+    return random_number * 4294967311ULL + 17;
+}
+```
+
+This arithmetic **is** the on-disk validation format: `f3write` fills each
+512-byte sector with the sequence, `f3read` regenerates it and compares. It has
+to be bit-exact or the tool is wrong.
+
+### What actually needs fixing (verified, not assumed)
+
+The original version of this ask claimed a faithful port "either needs a C shim
+or must change the file format." That is **not** true, and the correction
+matters:
+
+- Aether's native `long * long + long` already produces the **bit-identical**
+  modulo-2^64 result as C's `uint64_t`. Verified empirically: seeding at 512 and
+  iterating the LCG 20 times (well past 2^64 wrap) gives Aether
+  `-8007105390423481696`, which is the same 64 bits as C's
+  `10439638683286069920` — only the signed-vs-unsigned *display* differs. F3
+  writes these as raw LE64 bytes (`bytes.set_le64`), so the interpretation is
+  irrelevant; the bytes match.
+
+So this is **not** a "the port is impossible without it" ask. The real reason to
+add the helpers is **defined behavior**:
+
+- Aether `long` lowers to signed `int64_t`, and signed overflow in C is
+  **undefined behavior**. Aether does not emit `-fwrapv`. The native-multiply
+  approach gets the right bytes at `-O2` today only by luck of 2's-complement
+  wrap; an optimizer is free to miscompile it, and a UBSan build **traps** on it
+  (confirmed: `runtime error: signed integer overflow: … cannot be represented
+  in type 'long int'`). Aether ships a UBSan test path (`-fsanitize=undefined`),
+  so a port that relies on signed-overflow wrap is a latent CI failure.
+
+`wrapping_mul64` / `wrapping_add64` express the intent correctly — defined
+modulo-2^64, computed in `uint64_t` on the C side — so the port is UBSan-clean
+and optimizer-proof rather than depending on undefined behavior that happens to
+work.
+
+### Current port state (why this is stalled work, not hypothetical)
+
+The in-progress port (`src/f3core/module.ae`) currently **fakes the format**:
+`sector_payload` writes the offset then fills the rest of the sector with zeros
+instead of the LCG sequence, and `validate_sector` checks for zeros to match.
+That is precisely the "change the file format" outcome, adopted as a placeholder
+because the RNG core isn't ported yet. These helpers unblock porting the real
+`fill_buffer_with_block` / `validate_buffer_with_block`.
+
+## Acceptance Criteria
+
+- `std.bits` exports `wrapping_add64` and `wrapping_mul64`, each a thin wrapper
+  over an `aether_bits_*` extern that computes in `uint64_t`.
+- Behavior is modulo 2^64 on all supported targets, and is **defined** — a
+  `-fsanitize=undefined` build of the emitted C does not trap.
+- Tests cover overflow boundaries: values around `LONG_MAX`, `-1`
+  (all-bits-set), multiplication by large constants (e.g. `4294967311`), and a
+  multi-step LCG iteration asserted bit-for-bit against a `uint64_t` reference.
+- The helpers can be used from pure Aether code without custom C sources.
+
+## Notes for the implementer
+
+- Mirror the existing `aether_bits_udiv64` shape in `std/bits/aether_bits.c` and
+  its extern in `std/bits/module.ae`; add the friendly wrappers alongside
+  `lsr64` etc.
+- A one-line C body suffices: `return (int64_t)((uint64_t)a * (uint64_t)b);` and
+  `return (int64_t)((uint64_t)a + (uint64_t)b);`.

--- a/std/bits/aether_bits.h
+++ b/std/bits/aether_bits.h
@@ -44,4 +44,11 @@ long long aether_bits_urem64(long long a, long long b);
 /* Unsigned compare of two 64-bit values. Returns -1 / 0 / 1. */
 int aether_bits_ucmp64(long long a, long long b);
 
+/* Wrapping (defined modulo-2^64) add / multiply. Carry the low 64 bits
+ * like C's `uint64_t`, computed in `unsigned long long` so the overflow
+ * is defined rather than the undefined behaviour a native signed `long`
+ * multiply would invoke. */
+long long aether_bits_wrapping_add64(long long a, long long b);
+long long aether_bits_wrapping_mul64(long long a, long long b);
+
 #endif

--- a/std/bits/module.ae
+++ b/std/bits/module.ae
@@ -24,6 +24,7 @@ exports (
     clz32, clz64,
     udiv32, urem32, udiv64, urem64,
     ucmp64,
+    wrapping_add64, wrapping_mul64,
     aether_bits_lsr32, aether_bits_lsr64,
     aether_bits_rotr32, aether_bits_rotl32,
     aether_bits_rotr64, aether_bits_rotl64,
@@ -31,7 +32,8 @@ exports (
     aether_bits_clz32, aether_bits_clz64,
     aether_bits_udiv32, aether_bits_urem32,
     aether_bits_udiv64, aether_bits_urem64,
-    aether_bits_ucmp64
+    aether_bits_ucmp64,
+    aether_bits_wrapping_add64, aether_bits_wrapping_mul64
 )
 
 // ---- Raw externs ----
@@ -50,6 +52,8 @@ extern aether_bits_urem32(a: int, b: int) -> int
 extern aether_bits_udiv64(a: long, b: long) -> long
 extern aether_bits_urem64(a: long, b: long) -> long
 extern aether_bits_ucmp64(a: long, b: long) -> int
+extern aether_bits_wrapping_add64(a: long, b: long) -> long
+extern aether_bits_wrapping_mul64(a: long, b: long) -> long
 
 // ---- Friendly wrappers ----
 
@@ -110,4 +114,17 @@ urem64(a: long, b: long) -> long {
 // Unsigned compare of two 64-bit values. Returns -1 / 0 / 1.
 ucmp64(a: long, b: long) -> int {
     return aether_bits_ucmp64(a, b)
+}
+
+// Wrapping (defined modulo-2^64) add / multiply. Carry the low 64 bits
+// like C's `uint64` — computed in the unsigned domain so the overflow is
+// *defined*, unlike a native `a * b` on `long`, which is signed-overflow
+// UB (a `-fsanitize=undefined` build traps on it). Reach for these when
+// an on-disk / wire format depends on defined unsigned overflow, e.g. an
+// LCG like `x = x * 4294967311 + 17`.
+wrapping_add64(a: long, b: long) -> long {
+    return aether_bits_wrapping_add64(a, b)
+}
+wrapping_mul64(a: long, b: long) -> long {
+    return aether_bits_wrapping_mul64(a, b)
 }

--- a/std/collections/aether_bits.c
+++ b/std/collections/aether_bits.c
@@ -133,3 +133,21 @@ int aether_bits_ucmp64(long long a, long long b) {
     if (ua > ub) return 1;
     return 0;
 }
+
+/* ---- Wrapping (defined modulo-2^64) arithmetic ----
+ * Add / multiply that carry the low 64 bits, matching C's `uint64_t`
+ * semantics. Aether's `long` is signed `long long`, and signed overflow
+ * is undefined behaviour in C (a `-fsanitize=undefined` build traps on
+ * it), so a native `a * b` that overflows is UB even though 2's-complement
+ * wrap "happens to work" at -O2. Computing in `unsigned long long` makes
+ * the wrap defined and optimiser-proof. Used by ports of C tools that
+ * rely on defined unsigned overflow as part of an on-disk format (e.g.
+ * F3's LCG `random_number * 4294967311ULL + 17`). */
+
+long long aether_bits_wrapping_add64(long long a, long long b) {
+    return (long long)((unsigned long long)a + (unsigned long long)b);
+}
+
+long long aether_bits_wrapping_mul64(long long a, long long b) {
+    return (long long)((unsigned long long)a * (unsigned long long)b);
+}

--- a/tests/regression/test_bits.ae
+++ b/tests/regression/test_bits.ae
@@ -75,6 +75,36 @@ main() {
     if bits.ucmp64(1, 0xFFFFFFFFFFFFFFFF) != -1 { print("FAIL ucmp64 small<huge\n"); fails = fails + 1 }
     if bits.ucmp64(42, 42) != 0 { print("FAIL ucmp64 eq\n"); fails = fails + 1 }
 
+    // ---- wrapping (defined modulo-2^64) add / multiply ----
+    // Non-overflowing base cases.
+    if bits.wrapping_add64(2, 3) != 5 { print("FAIL wrap_add small\n"); fails = fails + 1 }
+    if bits.wrapping_mul64(6, 7) != 42 { print("FAIL wrap_mul small\n"); fails = fails + 1 }
+    // Add that wraps past 2^64: 0xFFFF...FF + 1 == 0.
+    if bits.wrapping_add64(0xFFFFFFFFFFFFFFFF, 1) != 0 { print("FAIL wrap_add wrap-to-0\n"); fails = fails + 1 }
+    // 0xFFFF...FF is unsigned (2^64 - 1); + 2 wraps to 1.
+    if bits.wrapping_add64(0xFFFFFFFFFFFFFFFF, 2) != 1 { print("FAIL wrap_add wrap-to-1\n"); fails = fails + 1 }
+    // Multiply that wraps: (2^63) * 2 == 2^64 == 0 (mod 2^64).
+    if bits.wrapping_mul64(0x8000000000000000, 2) != 0 { print("FAIL wrap_mul msb*2\n"); fails = fails + 1 }
+    // (2^64 - 1) * (2^64 - 1) == 1 (mod 2^64), the (-1)*(-1) identity.
+    if bits.wrapping_mul64(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF) != 1 { print("FAIL wrap_mul (-1)^2\n"); fails = fails + 1 }
+    // Multiply by a large constant that forces overflow on the 2nd step.
+    if bits.wrapping_mul64(0x0000000100000000, 0x0000000100000000) != 0 { print("FAIL wrap_mul 2^32*2^32\n"); fails = fails + 1 }
+
+    // ---- F3 LCG golden value ----
+    // F3's on-disk fill/verify is `x = x * 4294967311 + 17`, seeded at the
+    // sector offset. Iterating 20 times from seed 512 must land on the exact
+    // uint64 modulo-2^64 result C produces (10439638683286069920, which is
+    // -8007105390423481696 read as signed int64). Proves the wrapping helpers
+    // give bit-exact interop, not just internal consistency.
+    long r = 512
+    long mult = 4294967311
+    li = 0
+    while li < 20 {
+        r = bits.wrapping_add64(bits.wrapping_mul64(r, mult), 17)
+        li = li + 1
+    }
+    if r != -8007105390423481696 { print("FAIL F3 LCG golden: got ${r}\n"); fails = fails + 1 }
+
     if fails == 0 {
         print("PASS: std.bits\n")
     } else {


### PR DESCRIPTION
## Description

Implements the `std.bits` wrapping-arithmetic ask (#1101) and lands the two
rewritten `asks/` docs behind the F3 (fight-flash-fraud) port. Bundled as **one
PR to conserve CI minutes** per request.

### Code: `std.bits.wrapping_add64` / `wrapping_mul64` (#1101)

Defined modulo-2^64 add and multiply, computed in `unsigned long long`.

Aether's `long` is signed `int64_t`, so a native `a * b` that overflows is
**undefined behaviour** — a `-fsanitize=undefined` build traps on it, even though
2's-complement wrap produces the right bytes at `-O2`. These helpers make the
wrap **defined and optimiser-proof**. They're the natural siblings of the
existing `udiv64` / `urem64` / `ucmp64` externs and follow the same
thin-wrapper-over-`aether_bits_*` shape.

**Motivation:** F3's on-disk fill/verify format is the LCG
`x = x * 4294967311 + 17` (`src/libutils.c`). A faithful port needs defined
unsigned overflow to stay UBSan-clean; the in-progress port currently fakes the
format with zeros because it had no wrapping multiply.

### Docs: two `asks/` rewrites (verified against the F3 source)

- `asks/wrapping-64-bit-arithmetic.md` — corrected motivation. The original said
  a port "needs a C shim or must change the file format"; not true — native
  multiply already gives bit-exact bytes. The real reason is
  **defined/UBSan-clean** behaviour. (Implemented by this PR.)
- `asks/binary-buffer-streaming-ergonomics.md` — **downgraded** from "can't do
  binary I/O" to a narrow ask. EOF/short/error distinction and LE getters
  already exist; the genuine gap is a per-sector string→bytes copy
  (`fs.pread_into`) and little-endian cursor readers. Proposal only, tracked as
  **#1102** — no code in this PR.

## Type of Change
- [x] New feature (`std.bits` helpers)
- [x] Documentation (asks)

## Testing
- [x] `tests/regression/test_bits.ae` extended: overflow boundaries (add
  wrap-to-0/1, `2^63*2`, `(-1)*(-1)`, `2^32*2^32`) **plus an F3 LCG golden
  value** — 20 iterations from seed 512 asserted bit-exact against C's `uint64`
  result (`10439638683286069920` == `-8007105390423481696` as signed int64),
  proving interop, not just self-consistency.
- [x] **UBSan-clean verified**: `ae build` with `-fsanitize=undefined` runs the
  LCG loop without a signed-overflow trap (the whole point vs. native multiply,
  which *does* trap).
- [x] 234/234 C unit tests pass.

## Cross-platform
- `std/collections/aether_bits.c` change is one-line unsigned casts — no
  platform code, no `long`/typedef hazards (uses `long long` per the file's
  existing width convention).
- Clean under `-Werror`, `HARDEN=1` stdlib, and `x86_64-w64-mingw32-gcc -Werror`.

## Checklist
- [x] Code follows style guidelines (matches the udiv64/ucmp64 idiom)
- [x] Self-review completed
- [x] New feature → new test (bit-exact golden vector + UBSan check)
- [x] CHANGELOG updated under `[current]`

Closes #1101. Refs #1102 (companion binary-buffer ask, no code here).
