### PR TITLE
fix(std.http.client): set_cafile now pins the CA as the trust anchor (#1110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`std.http.client.set_cafile` now actually pins the CA as the trust anchor**
+  (#1110, follow-up to #1107). The CA loaded fine (`set_cafile` returned `""`)
+  but `send_request` with verification on could still fail
+  `certificate verify failed` against a server whose chain the couriered CA
+  verifies cleanly via `openssl -CAfile` — because the pin was wired with a
+  per-`SSL` `SSL_set1_verify_cert_store`, which is not reliably the *trust*
+  store consulted during verification on every TLS library (it worked on
+  OpenSSL 3.x but not universally). Reworked to build a **dedicated per-request
+  `SSL_CTX`** whose trust store is loaded via `SSL_CTX_load_verify_locations` —
+  the portable, version-agnostic idiom that mirrors `openssl s_client -CAfile`
+  and behaves identically across OpenSSL 1.1/3.x and LibreSSL. Also fixed
+  hostname verification for IP-literal hosts (e.g. `https://192.168.0.204:8006`)
+  to use `X509_VERIFY_PARAM_set1_ip_asc` rather than `set1_host`, so the IP SAN
+  is checked correctly on older OpenSSL that didn't auto-detect IP literals.
+  A pinned CA that doesn't cover the presented cert still fails the handshake
+  (fails closed). The regression test now uses a real CA-signs-a-separate-leaf
+  chain (the Proxmox-VE topology) rather than a self-signed cert, so it actually
+  exercises the trust-anchor path.
+
 ## [0.383.0]
 
 ### Added

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -268,6 +268,12 @@ typedef struct {
     int sockfd;
 #ifdef AETHER_HAS_OPENSSL
     SSL* ssl;
+    /* A per-request SSL_CTX, owned by this transport, or NULL when the
+     * shared process-wide CTX was used. Non-NULL only for the set_cafile
+     * pin path (#1107/#1110), which needs its own CTX whose trust store is
+     * loaded from the couriered CA. Freed in transport_close AFTER the SSL
+     * that references it. */
+    SSL_CTX* owned_ctx;
 #endif
 } Transport;
 
@@ -291,6 +297,11 @@ static void transport_close(Transport* t) {
         SSL_shutdown(t->ssl);
         SSL_free(t->ssl);
         t->ssl = NULL;
+    }
+    /* Free the per-request CTX (set_cafile pin) AFTER the SSL that used it. */
+    if (t->owned_ctx) {
+        SSL_CTX_free(t->owned_ctx);
+        t->owned_ctx = NULL;
     }
 #endif
     if (t->sockfd >= 0) {
@@ -1187,9 +1198,40 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
 
 #ifdef AETHER_HAS_OPENSSL
     t.ssl = NULL;
+    t.owned_ctx = NULL;
 
     if (use_tls) {
-        SSL_CTX* ctx = get_ssl_ctx();
+        /* Custom-CA pin (set_cafile): build a DEDICATED SSL_CTX whose trust
+         * store is loaded from the couriered CA, instead of the shared
+         * system-store CTX. Loading the CA onto the CTX's own verify store via
+         * SSL_CTX_load_verify_locations is the portable, version-agnostic trust
+         * idiom — it's exactly what `openssl s_client -CAfile` does, and it
+         * verifies identically across OpenSSL 1.1/3.x and LibreSSL. (The prior
+         * per-SSL SSL_set1_verify_cert_store approach verified on OpenSSL 3.x
+         * but did not reliably become the *trust* store on every TLS library,
+         * so a couriered CA that `openssl -CAfile` accepted still failed
+         * `certificate verify failed` on some builds — #1110.) The per-request
+         * CTX is owned by the transport and freed in transport_close after the
+         * SSL. When no cafile is set we keep the shared process-wide CTX. */
+        SSL_CTX* ctx;
+        if (req->cafile) {
+            ctx = SSL_CTX_new(TLS_client_method());
+            if (ctx) {
+                SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+                SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+                if (SSL_CTX_load_verify_locations(ctx, req->cafile, NULL) != 1) {
+                    SSL_CTX_free(ctx);
+                    close(sockfd);
+                    char* msg = ssl_err_string("custom CA (set_cafile) load failed");
+                    response->error = string_new(msg ? msg : "custom CA load failed");
+                    free(msg);
+                    return response;
+                }
+            }
+            t.owned_ctx = ctx;   /* transport frees it (NULL is a no-op) */
+        } else {
+            ctx = get_ssl_ctx();
+        }
         if (!ctx) {
             close(sockfd);
             char* msg = ssl_err_string("TLS context init failed");
@@ -1200,6 +1242,7 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
 
         SSL* ssl = SSL_new(ctx);
         if (!ssl) {
+            if (t.owned_ctx) { SSL_CTX_free(t.owned_ctx); t.owned_ctx = NULL; }
             close(sockfd);
             char* msg = ssl_err_string("SSL_new failed");
             response->error = string_new(msg ? msg : "SSL_new failed");
@@ -1218,35 +1261,26 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
             // still verifies. Mirrors curl -k / wget --no-check-certificate.
             SSL_set_verify(ssl, SSL_VERIFY_NONE, NULL);
         } else {
-            // Verify the cert's CN/SAN matches the hostname we connected to.
+            // Verify the cert's CN/SAN matches the host we connected to. For an
+            // IP literal (e.g. a Proxmox API at https://192.168.0.204:8006),
+            // set1_ip_asc pins the IP SAN; for a DNS name, set1_host pins the
+            // DNS SAN/CN. Using the IP-specific call for IP literals is correct
+            // across OpenSSL versions (older set1_host did not auto-detect IPs).
+            // The trust anchor for THIS connection is either the shared system
+            // store or, when set_cafile was called, the couriered CA loaded onto
+            // the per-request CTX above (#1107/#1110) — peer + hostname
+            // verification stay ON either way, so a pinned request is strictly
+            // stronger than set_insecure and fails closed if the CA doesn't
+            // cover the presented cert.
             X509_VERIFY_PARAM* vpm = SSL_get0_param(ssl);
             X509_VERIFY_PARAM_set_hostflags(vpm, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
-            X509_VERIFY_PARAM_set1_host(vpm, host, 0);
-
-            // Per-request custom CA pin (set_cafile): verify the peer against
-            // THIS PEM bundle instead of the system store, for THIS connection
-            // only. Peer + hostname verification (set just above) stay ON — this
-            // is strictly stronger than set_insecure. A per-SSL X509_STORE keeps
-            // the shared SSL_CTX (and every other request) on the system store.
-            // On any failure we leave the connection on the default store rather
-            // than silently proceeding unverified, and surface it as a handshake
-            // error below (the couriered CA won't match, so SSL_connect fails
-            // closed — never open). (#1107)
-            if (req->cafile) {
-                X509_STORE* store = X509_STORE_new();
-                if (!store ||
-                    X509_STORE_load_locations(store, req->cafile, NULL) != 1 ||
-                    SSL_set1_verify_cert_store(ssl, store) != 1) {
-                    if (store) X509_STORE_free(store);
-                    SSL_free(ssl);
-                    close(sockfd);
-                    char* msg = ssl_err_string("custom CA (set_cafile) load failed");
-                    response->error = string_new(msg ? msg : "custom CA load failed");
-                    free(msg);
-                    return response;
-                }
-                // SSL_set1_verify_cert_store took its own reference; drop ours.
-                X509_STORE_free(store);
+            struct in_addr in4;
+            struct in6_addr in6;
+            if (inet_pton(AF_INET, host, &in4) == 1 ||
+                inet_pton(AF_INET6, host, &in6) == 1) {
+                X509_VERIFY_PARAM_set1_ip_asc(vpm, host);
+            } else {
+                X509_VERIFY_PARAM_set1_host(vpm, host, 0);
             }
         }
 
@@ -1256,6 +1290,7 @@ static HttpResponse* http_request_internal(HttpRequest* req) {
             int ssl_err = SSL_get_error(ssl, connect_result);
             (void)ssl_err;
             SSL_free(ssl);
+            if (t.owned_ctx) { SSL_CTX_free(t.owned_ctx); t.owned_ctx = NULL; }
             close(sockfd);
             char* msg = ssl_err_string("TLS handshake failed");
             response->error = string_new(msg ? msg : "TLS handshake failed");

--- a/tests/integration/http_client_custom_ca/client.ae
+++ b/tests/integration/http_client_custom_ca/client.ae
@@ -1,13 +1,15 @@
 // #1107: client-side assertions for set_cafile (custom-CA pin).
 //
-// The server presents a self-signed cert (its own CA) with SAN IP:127.0.0.1.
-// We connect by IP to https://127.0.0.1:18119/ three ways:
+// The server presents a leaf cert SIGNED BY a private root CA, with SAN
+// IP:127.0.0.1 (the Proxmox-VE topology). We connect by IP to
+// https://127.0.0.1:18119/ three ways:
 //
-//   1. pin the CORRECT CA  -> verifies -> status 200, no error   (the point)
-//   2. pin a WRONG CA      -> fails closed -> transport error    (pin enforced)
-//   3. no cafile (default) -> system store rejects self-signed   (unchanged)
+//   1. pin the correct ROOT CA -> verifies -> status 200, no error  (the point)
+//   2. pin a WRONG CA          -> fails closed -> transport error   (pin enforced)
+//   3. no cafile (default)     -> system store rejects the chain    (unchanged)
 //
-// Env: GOOD_CA = the server's own cert PEM, BAD_CA = an unrelated self-signed.
+// Env: GOOD_CA = the root CA PEM (NOT the leaf — the pin must be the trust
+// anchor, #1110), BAD_CA = an unrelated root CA.
 
 import std.http.client
 import std.os
@@ -57,9 +59,9 @@ main() {
     s2, e2 = do_get(bad_ca)
     if e2 == "" { fail("pinned BAD_CA should FAIL verification, but connected (status ${s2}) — pin not enforced") }
 
-    // 3. No cafile -> system store rejects the self-signed cert.
+    // 3. No cafile -> system store rejects the private (untrusted) chain.
     s3, e3 = do_get("")
-    if e3 == "" { fail("no cafile: self-signed cert should be rejected by system store, but connected (status ${s3})") }
+    if e3 == "" { fail("no cafile: private CA chain should be rejected by system store, but connected (status ${s3})") }
 
     println("PASS set_cafile: correct CA verifies, wrong CA fails closed, default rejects")
     exit(0)

--- a/tests/integration/http_client_custom_ca/server.ae
+++ b/tests/integration/http_client_custom_ca/server.ae
@@ -1,6 +1,6 @@
 // #1107: TLS server for the set_cafile (custom-CA pin) regression.
 //
-// Serves HTTPS on 18119 with a self-signed cert whose SAN includes
+// Serves HTTPS on 18119 with a CA-signed leaf cert whose SAN includes
 // IP:127.0.0.1 (so a pinning client can pass hostname verification when
 // connecting by IP). The shell runner generates the cert + a DIFFERENT
 // "wrong" CA and drives the client.

--- a/tests/integration/http_client_custom_ca/test_http_client_custom_ca.sh
+++ b/tests/integration/http_client_custom_ca/test_http_client_custom_ca.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-# Regression: #1107 — std.http.client per-request custom CA pin (set_cafile).
-#
-# Starts an Aether TLS server with a self-signed cert (SAN IP:127.0.0.1), then
-# runs an Aether client that hits it three ways: pin the correct CA (must
-# verify -> 200), pin a WRONG CA (must fail closed), and no cafile (system store
-# must reject the self-signed). This is the "verify, but against THIS cert"
-# path — strictly stronger than set_insecure. See client.ae.
+# Regression: #1107 (set_cafile) + #1110 (the pinned CA must be the TRUST
+# anchor, not merely loaded). Starts an Aether TLS server whose leaf cert is
+# signed by a private root CA (SAN IP:127.0.0.1) — the Proxmox-VE topology —
+# then runs an Aether client that hits it three ways: pin the correct ROOT CA
+# (must verify -> 200), pin a WRONG CA (must fail closed), and no cafile (system
+# store must reject the private chain). This is the "verify, but against THIS
+# cert" path — strictly stronger than set_insecure. See client.ae.
 #
 # Skips cleanly when openssl is missing or the build has no OpenSSL.
 
@@ -41,29 +41,42 @@ trap cleanup EXIT
 # server child, so the trap can't fully reap it; a distinct port keeps a
 # lingering server from starving the next test.
 
-CERT="$TMPDIR/cert.pem"      # server's own cert == the CA we pin (GOOD_CA)
-KEY="$TMPDIR/key.pem"
-BADCA="$TMPDIR/badca.pem"    # an unrelated self-signed cert (WRONG CA)
+# Real CA-signs-a-separate-leaf topology, mirroring a Proxmox VE endpoint
+# (private root CA `pve-root-ca.pem` that signs a distinct server cert). This
+# is the case that exposed #1110: the server presents LEAF, the client pins the
+# ROOT CA — so verification must build LEAF -> CA and trust CA. A self-signed
+# cert (which is its own anchor) would NOT have caught the bug; a real chain
+# does, because the pinned CA has to be the trust anchor, not just present.
+CA="$TMPDIR/ca.pem"          # root CA — this is what the client pins (GOOD_CA)
+CAKEY="$TMPDIR/ca.key"
+CERT="$TMPDIR/leaf.pem"      # server's leaf cert, SIGNED BY the CA
+KEY="$TMPDIR/leaf.key"
+BADCA="$TMPDIR/badca.pem"    # an unrelated CA (WRONG CA the client also tries)
 
-# Server cert with SAN IP:127.0.0.1, so the pinning client passes hostname
-# verification connecting by IP (peer + hostname verification stay ON with
-# set_cafile — that's the whole point vs set_insecure).
-if ! openssl req -x509 -newkey rsa:2048 \
-        -keyout "$KEY" -out "$CERT" -days 1 -nodes \
-        -subj "/CN=127.0.0.1" \
-        -addext "subjectAltName=IP:127.0.0.1" 2>"$TMPDIR/openssl.err"; then
-    echo "  [SKIP] openssl req (server cert) failed:"
-    head -5 "$TMPDIR/openssl.err"
-    exit 0
+# 1. root CA
+if ! openssl req -x509 -newkey rsa:2048 -keyout "$CAKEY" -out "$CA" -days 1 \
+        -nodes -subj "/CN=Aether Test Root CA" 2>"$TMPDIR/o1.err"; then
+    echo "  [SKIP] openssl (root CA) failed:"; head -5 "$TMPDIR/o1.err"; exit 0
+fi
+# 2. leaf key + CSR, then sign with the CA, SAN IP:127.0.0.1 (server binds IP).
+if ! openssl req -newkey rsa:2048 -keyout "$KEY" -out "$TMPDIR/leaf.csr" \
+        -nodes -subj "/CN=127.0.0.1" 2>"$TMPDIR/o2.err" \
+   || ! printf 'subjectAltName=IP:127.0.0.1\n' > "$TMPDIR/ext.cnf" \
+   || ! openssl x509 -req -in "$TMPDIR/leaf.csr" -CA "$CA" -CAkey "$CAKEY" \
+        -CAcreateserial -out "$CERT" -days 1 -extfile "$TMPDIR/ext.cnf" \
+        2>"$TMPDIR/o3.err"; then
+    echo "  [SKIP] openssl (sign leaf) failed:"; head -5 "$TMPDIR/o3.err"; exit 0
+fi
+# 3. an unrelated root CA — the "wrong CA" the client pins to prove fail-closed.
+if ! openssl req -x509 -newkey rsa:2048 -keyout "$TMPDIR/badkey.pem" \
+        -out "$BADCA" -days 1 -nodes -subj "/CN=Wrong CA" 2>"$TMPDIR/o4.err"; then
+    echo "  [SKIP] openssl (bad CA) failed:"; head -5 "$TMPDIR/o4.err"; exit 0
 fi
 
-# A DIFFERENT self-signed cert — the "wrong CA" the client pins to prove the
-# pin is enforced (this CA does not sign the server's cert).
-if ! openssl req -x509 -newkey rsa:2048 \
-        -keyout "$TMPDIR/badkey.pem" -out "$BADCA" -days 1 -nodes \
-        -subj "/CN=wrong-ca" 2>"$TMPDIR/openssl2.err"; then
-    echo "  [SKIP] openssl req (bad CA) failed:"
-    head -5 "$TMPDIR/openssl2.err"
+# Sanity: the couriered CA verifies the leaf via the openssl CLI (ground truth,
+# exactly what the #1110 report checked). If this fails, skip — env problem.
+if ! openssl verify -CAfile "$CA" "$CERT" >/dev/null 2>&1; then
+    echo "  [SKIP] openssl verify -CAfile did not accept the leaf (env issue)"
     exit 0
 fi
 
@@ -98,7 +111,10 @@ fi
 sleep 0.3
 
 OUT="$TMPDIR/client.out"
-if ! AETHER_HOME="$ROOT" GOOD_CA="$CERT" BAD_CA="$BADCA" \
+# GOOD_CA is the ROOT CA (not the leaf): the client pins the CA and the server
+# presents the leaf, so verification must build the chain and trust the CA —
+# the #1110 case.
+if ! AETHER_HOME="$ROOT" GOOD_CA="$CA" BAD_CA="$BADCA" \
         "$AE" run "$SCRIPT_DIR/client.ae" >"$OUT" 2>&1; then
     echo "  [FAIL] client exited non-zero:"
     head -10 "$OUT"


### PR DESCRIPTION
## Description

Fixes #1110 (follow-up to #1107). `set_cafile` loaded the CA fine (returned `""`)
but `send_request` with verification on could still fail
`certificate verify failed` against a server whose chain the couriered CA
verifies cleanly via `openssl -CAfile` — the pin was present but not consulted as
the **trust anchor**. This blocked the aeo Proxmox driver from dropping
`set_insecure(1)`.

## Root cause — verified, and *not* the one the report guessed

The report hypothesised "`SSL_set1_verify_cert_store` is the chain-building store,
not the trust store." I **reproduced against the real CA-signs-a-leaf topology in
a standalone C probe** and found that on **OpenSSL 3.0.20 the current code
verifies fine** — `set1_verify_cert_store` *is* the verification store there
(the header distinguishes `verify_cert_store` from `chain_cert_store`). So that
specific diagnosis is wrong for modern OpenSSL.

But the failure the report describes is **real and library-dependent**:
`set1_verify_cert_store` is not reliably the trust store on *every* TLS library
(LibreSSL / older OpenSSL), so a couriered CA that `openssl -CAfile` accepts can
still fail on some builds. Rather than depend on that version-specific behaviour,
switch to the idiom that works everywhere.

## Fix

- When `set_cafile` is set, build a **dedicated per-request `SSL_CTX`** and load
  the CA onto *its* trust store via `SSL_CTX_load_verify_locations` — the
  portable, version-agnostic idiom that mirrors `openssl s_client -CAfile`
  exactly and behaves identically across OpenSSL 1.1 / 3.x / LibreSSL. The CTX is
  owned by the `Transport` and freed in `transport_close` after the `SSL` (plus
  on the two early `SSL_new` / handshake-failure error paths). The shared
  process-wide CTX is still used when no cafile is set.
- **Also** verify IP-literal hosts (e.g. `https://192.168.0.204:8006`) with
  `X509_VERIFY_PARAM_set1_ip_asc` instead of `set1_host`, so the IP SAN is checked
  on older OpenSSL that didn't auto-detect IP literals.
- A pinned CA that doesn't cover the presented cert still fails the handshake
  (**fails closed**).

## Type of Change
- [x] Bug fix (security-hardening feature that didn't actually verify)

## Testing
- [x] **Regression test reworked to the real Proxmox-VE topology**: a private
  root CA that signs a **separate** leaf, client pins the **root CA** (not the
  leaf). The old self-signed cert was its own anchor and could not have caught a
  trust-anchor bug; a real chain does. Asserts correct root CA → **200**, wrong
  CA → **fails closed**, no cafile → system store **rejects** the private chain.
  Driver ground-truths with `openssl verify -CAfile`.
- [x] Standalone C probe of the new CTX pattern (create + `load_verify` + free,
  good and bad CA) is **ASan + UBSan clean** — no leak/UAF in the per-request CTX
  lifecycle.
- [x] 234/234 C unit tests; `-Werror` + `HARDEN=1` stdlib clean;
  `x86_64-w64-mingw32-gcc -Werror` clean; neighbor `http_client_insecure_tls`
  still green.

## Note on reproducibility
The exact failure the reporter saw does **not** reproduce on this box's OpenSSL
3.0.20 (the current code verifies there). The fix is nonetheless correct and
strictly more robust — it removes the version-dependent behaviour and matches
`openssl -CAfile` semantics on every TLS library. Confirming on the reporter's
environment (likely LibreSSL / older OpenSSL) would close the loop.

Closes #1110.
