### PR TITLE
docs(changelog): fix stale workflow note + restore [current], drop stray duplicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.363.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
 
 ## [0.384.0]
 
@@ -453,9 +455,6 @@ next version number before tagging the release.
   the remaining #996 follow-ups are single-file amalgamation and standalone
   runtime-source bundling. New coverage in `tests/integration/emit_csrc/`
   (well-formedness, functions/constants, capability provenance).
-**Workflow**: New changes go under `## [0.362.0]`. When a PR merges to
-`main`, the release pipeline automatically replaces `[current]` with the
-next version number before tagging the release.
 
 ## [0.362.0]
 


### PR DESCRIPTION
Pure CHANGELOG hygiene, no content entries changed.

- The top **Workflow** note said "New changes go under `## [0.363.0]`" — stale and self-contradictory (its next line says the pipeline replaces `[current]`). Corrected to `## [current]`.
- No `## [current]` section existed after 0.384.0 released — added the empty section so the next change has a home and the release pipeline has its replace target.
- A duplicate **Workflow** note had been pasted mid-file, buried inside the `## [0.363.0]` section (between its emit_csrc entry and `## [0.362.0]`), left by an old release cycle. Removed.

Reconciled every released version 0.379–0.384 against the merged PRs — all already document their work correctly (#1092, #1097, ae fmt #1100, wrapping64 #1103, set_cafile #1107/#1110). The only genuinely missing entry was the GCC 16 strstr fix, which is handled on its own branch (`fix/gcc16-const-strstr-qualifiers`) where its code lives.

Docs-only.