### PR TITLE
fix: const-qualify strstr for GCC 16 / glibc 2.43 (+ CHANGELOG hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,23 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.363.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
+
+## [current]
+
+### Fixed
+
+- **Release build (`make install`) on GCC 16 / glibc 2.43.** glibc 2.43's
+  const-preserving `strstr()` returns `const char*` for a `const char*` argument,
+  so assigning the result to a plain `char*` trips `-Werror=discarded-qualifiers`
+  on GCC 16 (in `lsp/aether_lsp.c` and `std/net/aether_http_server.c`). Both
+  results are read-only (pointer arithmetic and comparisons, never written
+  through), so they're now `const char*`. Backward-compatible: assigning the
+  plain-`char*` return of older glibc's `strstr` to a `const char*` is warning-
+  free on every compiler (verified on GCC 12.2 / glibc 2.36, Clang, and
+  mingw-w64).
 
 ## [0.384.0]
 
@@ -453,9 +467,6 @@ next version number before tagging the release.
   the remaining #996 follow-ups are single-file amalgamation and standalone
   runtime-source bundling. New coverage in `tests/integration/emit_csrc/`
   (well-formedness, functions/constants, capability provenance).
-**Workflow**: New changes go under `## [0.362.0]`. When a PR merges to
-`main`, the release pipeline automatically replaces `[current]` with the
-next version number before tagging the release.
 
 ## [0.362.0]
 

--- a/lsp/aether_lsp.c
+++ b/lsp/aether_lsp.c
@@ -13,7 +13,7 @@ static char* json_extract_string(const char* json, const char* key) {
     if (!json || !key) return NULL;
     char search[128];
     snprintf(search, sizeof(search), "\"%s\":", key);
-    char* start = strstr(json, search);
+    const char* start = strstr(json, search);
     if (!start) return NULL;
     start += strlen(search);
     while (*start == ' ' || *start == '\t') start++;

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -1292,7 +1292,7 @@ HttpRequest* http_parse_request_n(const char* buf, size_t len) {
     HttpRequest* req = (HttpRequest*)calloc(1, sizeof(HttpRequest));
 
     // Parse request line: METHOD /path HTTP/1.1
-    char* line_end = strstr(raw_request, "\r\n");
+    const char* line_end = strstr(raw_request, "\r\n");
     if (!line_end) {
         free(req);
         return NULL;


### PR DESCRIPTION
glibc 2.43's const-preserving `strstr()` returns `const char*` for a `const char*` argument, so assigning the result to a plain `char*` trips `-Werror=discarded-qualifiers` on GCC 16 — breaking the release build (`make install`) on Arch / newer toolchains. Two sites: `lsp/aether_lsp.c` (`json_extract_string`) and `std/net/aether_http_server.c` (`http_parse_request_n`). Both results are read-only (pointer arithmetic + comparisons, never written through), so they're now `const char*`.

## Backward-compatibility (verified, not assumed)

Adding `const` is safe in the *other* direction — assigning the plain-`char*` return of older glibc's `strstr` to a `const char*` variable is standard C, warning-free on every compiler. Proven on this **GCC 12.2.0 / glibc 2.36** box (older than the GCC 16/glibc 2.43 target):
- Both files compile clean with `-Werror -Wall -Wextra` on **GCC 12.2**, **Clang**, and **mingw-w64**.
- Full `make compiler stdlib EXTRA_CFLAGS=-Werror` succeeds.

## Completeness

Audited every other `char* = strstr(...)` site (~8). All have a non-const `char*` haystack (`malloc`'d / `char[]`), so their `strstr` returns `char*` even on glibc 2.43 and they don't trip GCC 16. The two patched here are the *only* const-haystack sites — the fix is complete.

## Also: CHANGELOG hygiene (folded in)

Since this adds a CHANGELOG entry anyway, it also fixes three pre-existing CHANGELOG issues found while reconciling entries:
- The top **Workflow** note said "New changes go under `## [0.363.0]`" — stale and self-contradictory (next line references `[current]`). Corrected to `## [current]`.
- No `## [current]` section existed after 0.384.0 released — added (now holding this fix's entry).
- A duplicate **Workflow** note buried mid-file inside `## [0.363.0]` (leftover from an old release cycle) — removed.

Reconciled all released versions 0.379–0.384 against merged PRs; every one already documents its work correctly, so no other missing content.

**Not `[skip actions]`** — touches `.c`, and the whole point is that it compiles under the `-Werror` toolchain matrix, so CI must run.

Fixes the GCC 16 release build.