### PR TITLE
fix(std): read-to-EOF for /proc & unseekable files (#1116) + fs.statvfs (#1117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`io.read_file` / `fs.read` no longer silently return `""` for `/proc`,
+  `/sys`, pipes, and sockets** (#1116). Both sized their buffer from
+  `fseek(SEEK_END)` / `ftell`, which reports `0` for any `/proc` or `/sys`
+  seq-file (and is meaningless for unseekable fds), so they returned an empty
+  string with **no error** — silent data loss on a common operation (reading a
+  pseudo-file). They now keep the fast size-based path for regular seekable
+  files and fall back to a grow-and-read-to-EOF loop when the size is 0 or the
+  fd isn't seekable. A genuine read error surfaces as an error/NULL, not `""`.
+
+### Added
+
+- **`fs.statvfs(path) -> (total, free, avail, err)`** (#1117). Exact filesystem
+  byte counts for the filesystem containing `path`, via POSIX `statvfs(2)`
+  (portable across Linux/macOS/BSD). `avail` is `f_bavail` — the space usable by
+  an unprivileged process, the value you want for "how much can I actually write
+  here" (e.g. auto-filling a write range: `end = avail / file_size`). Replaces
+  shelling out to `df` and parsing columns; sits alongside `fs.size` /
+  `fs.file_stat`. Windows (no `statvfs`) returns the error branch.
+
 ## [0.385.0]
 
 ### Fixed

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -206,11 +206,12 @@ main() {
 
 ### File Operations (Go-style)
 
-- `file.read(path)` → `(string, string)` - Read entire file (opens, reads, closes)
+- `file.read(path)` → `(string, string)` - Read entire file (opens, reads, closes). Handles `/proc`/`/sys` seq-files and unseekable fds via a read-to-EOF fallback (a size-0 `ftell` no longer silently returns `""`).
 - `file.write(path, content)` → `string` - Write content, return error string
 - `file.open(path, mode)` → `(ptr, string)` - Low-level open (caller must `file.close`)
 - `file.close(handle)` - Close a file handle
 - `file.size(path)` → `(int, string)` - Get file size in bytes
+- `fs.statvfs(path)` → `(total, free, avail, err)` - Filesystem byte counts (POSIX `statvfs`) for the fs containing `path`. `avail` is space usable by a non-root process (`f_bavail`) — use it for "how much can I actually write" (`end = avail / file_size`). Portable Linux/macOS/BSD; Windows returns the error branch.
 - `file.delete(path)` → `string` - Delete a file, return error string
 - `file.exists(path)` → `int` - 1 if exists, 0 otherwise (infallible predicate)
 

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -41,6 +41,10 @@ int fs_try_stat(const char* p) { (void)p; return 0; }
 int     fs_get_stat_kind(void)  { return 0; }
 int64_t fs_get_stat_size(void)  { return 0; }
 int64_t fs_get_stat_mtime(void) { return 0; }
+int fs_try_statvfs(const char* p) { (void)p; return 0; }
+int64_t fs_get_statvfs_total(void) { return 0; }
+int64_t fs_get_statvfs_free(void)  { return 0; }
+int64_t fs_get_statvfs_avail(void) { return 0; }
 char* fs_read_binary_raw(const char* p, int* n) {
     (void)p; if (n) *n = 0; return NULL;
 }
@@ -111,6 +115,7 @@ void fs_watch_close(void* w) { (void)w; }
 #include <sys/types.h>
 #ifndef _WIN32
 #include <unistd.h>
+#include <sys/statvfs.h>     // statvfs() for fs_try_statvfs (#1117)
 #endif
 
 #ifdef _WIN32
@@ -197,25 +202,62 @@ File* file_open_raw(const char* path, const char* mode) {
     return file;
 }
 
+/* Grow-and-read an open stream to EOF into a caller-owned, NUL-terminated
+ * buffer. Used as the fallback when the fast size-based path can't work:
+ * `/proc` and `/sys` seq-files report size 0 from ftell, and pipes/sockets
+ * aren't seekable at all — the size-based path would silently return an empty
+ * string. Returns NULL on OOM. Cap-aware via aether_caps_realloc; the caller
+ * frees the result with plain libc free per the caller-owned-return contract
+ * (#1116). */
+static char* read_stream_to_eof(FILE* fp) {
+    size_t cap = 65536;   /* one page-ish chunk; grows as needed */
+    size_t len = 0;
+    char* buffer = (char*)aether_caps_malloc(cap);
+    if (!buffer) return NULL;
+    for (;;) {
+        if (len + 4096 > cap) {
+            size_t new_cap = cap * 2;
+            char* grown = (char*)aether_caps_realloc(buffer, cap, new_cap);
+            if (!grown) { aether_caps_free(buffer, cap); return NULL; }
+            buffer = grown;
+            cap = new_cap;
+        }
+        size_t n = fread(buffer + len, 1, cap - len - 1, fp);
+        len += n;
+        if (n == 0) break;   /* EOF or error; ferror check below */
+    }
+    if (ferror(fp)) { aether_caps_free(buffer, cap); return NULL; }
+    buffer[len] = '\0';
+    return buffer;
+}
+
 char* file_read_all_raw(File* file) {
     if (!file || !file->is_open) return NULL;
 
     FILE* fp = (FILE*)file->handle;
-    fseek(fp, 0, SEEK_END);
-    long size = ftell(fp);
-    if (size < 0) return NULL;
-    fseek(fp, 0, SEEK_SET);
 
-    /* Cap-aware (#343): file size is OS-supplied and unbounded.
-     * Caller frees with plain libc free per the caller-owned-return
-     * contract — counter drifts up on this path, same as
-     * string_concat. */
-    char* buffer = (char*)aether_caps_malloc((size_t)size + 1);
-    if (!buffer) return NULL;
-    size_t read = fread(buffer, 1, (size_t)size, fp);
-    buffer[read] = '\0';
-
-    return buffer;
+    /* Fast path for regular, seekable files: size the buffer from the file
+     * length and read once. Fall through to the EOF loop when the file isn't
+     * seekable (pipe/socket) or reports size 0 (any /proc or /sys seq-file) —
+     * the old code returned an empty string with no error in those cases
+     * (#1116, the /proc/self/mountinfo silent-truncation bug). */
+    if (fseek(fp, 0, SEEK_END) == 0) {
+        long size = ftell(fp);
+        if (size > 0 && fseek(fp, 0, SEEK_SET) == 0) {
+            /* Cap-aware (#343): file size is OS-supplied and unbounded.
+             * Caller frees with plain libc free per the caller-owned-return
+             * contract — counter drifts up on this path, same as
+             * string_concat. */
+            char* buffer = (char*)aether_caps_malloc((size_t)size + 1);
+            if (!buffer) return NULL;
+            size_t read = fread(buffer, 1, (size_t)size, fp);
+            buffer[read] = '\0';
+            return buffer;
+        }
+        /* size <= 0 or re-seek failed: rewind (best-effort) and stream. */
+        fseek(fp, 0, SEEK_SET);
+    }
+    return read_stream_to_eof(fp);
 }
 
 int file_write_raw(File* file, const char* data, int length) {
@@ -877,6 +919,39 @@ int fs_try_stat(const char* path) {
 int     fs_get_stat_kind(void)  { return s_last_kind;  }
 int64_t fs_get_stat_size(void)  { return s_last_size;  }
 int64_t fs_get_stat_mtime(void) { return s_last_mtime; }
+
+/* statvfs (#1117): exact filesystem byte counts for the filesystem containing
+ * `path`. Split try/get pair, same TLS pattern as fs_try_stat, so the Aether
+ * wrapper reads three int64 fields without C out-params. total/free/avail are
+ * bytes; `avail` is the space usable by an unprivileged process (f_bavail),
+ * which is the one callers usually want for "how much can I actually write".
+ * Not available on Windows (no statvfs) — stubbed there to return 0/failure. */
+static AETHER_FS_TLS int64_t s_vfs_total = 0;
+static AETHER_FS_TLS int64_t s_vfs_free  = 0;
+static AETHER_FS_TLS int64_t s_vfs_avail = 0;
+
+int fs_try_statvfs(const char* path) {
+    s_vfs_total = 0; s_vfs_free = 0; s_vfs_avail = 0;
+    if (!path) return 0;
+#ifdef _WIN32
+    (void)path;
+    return 0;   /* no statvfs on Windows; caller gets the error branch */
+#else
+    struct statvfs st;
+    if (statvfs(path, &st) != 0) return 0;
+    /* f_frsize is the fundamental block size for the byte math; fall back to
+     * f_bsize if a platform reports frsize as 0. */
+    uint64_t unit = st.f_frsize ? (uint64_t)st.f_frsize : (uint64_t)st.f_bsize;
+    s_vfs_total = (int64_t)((uint64_t)st.f_blocks * unit);
+    s_vfs_free  = (int64_t)((uint64_t)st.f_bfree  * unit);
+    s_vfs_avail = (int64_t)((uint64_t)st.f_bavail * unit);
+    return 1;
+#endif
+}
+
+int64_t fs_get_statvfs_total(void) { return s_vfs_total; }
+int64_t fs_get_statvfs_free(void)  { return s_vfs_free;  }
+int64_t fs_get_statvfs_avail(void) { return s_vfs_avail; }
 
 char* fs_read_binary_raw(const char* path, int* out_len) {
     if (out_len) *out_len = 0;

--- a/std/fs/aether_fs.h
+++ b/std/fs/aether_fs.h
@@ -140,6 +140,16 @@ int     fs_get_stat_kind(void);
 int64_t fs_get_stat_size(void);
 int64_t fs_get_stat_mtime(void);
 
+// statvfs (#1117): exact filesystem byte counts for the fs containing `path`.
+// Same split try/get shape as fs_try_stat. total/free/avail are bytes; avail
+// is space usable by an unprivileged process (f_bavail). fs_try_statvfs
+// returns 0 on failure (incl. Windows, which has no statvfs) with all getters
+// reading 0.
+int fs_try_statvfs(const char* path);
+int64_t fs_get_statvfs_total(void);
+int64_t fs_get_statvfs_free(void);
+int64_t fs_get_statvfs_avail(void);
+
 // Read the entire file at `path` into a newly malloc'd buffer.
 // Sibling of file_read_all_raw that is length-aware and binary-safe:
 // the returned buffer contains exactly the file's bytes (including

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -30,6 +30,8 @@ exports (
     fs_symlink_raw, fs_readlink_raw, fs_is_symlink, fs_unlink_raw,
     fs_write_binary_raw, fs_write_atomic_raw, fs_rename_raw,
     fs_try_stat, fs_get_stat_kind, fs_get_stat_size, fs_get_stat_mtime,
+    fs_try_statvfs, fs_get_statvfs_total, fs_get_statvfs_free, fs_get_statvfs_avail,
+    statvfs,
     fs_try_read_binary, fs_get_read_binary, fs_get_read_binary_length,
     fs_release_read_binary, fs_read_binary_tuple,
     dir_list_count, dir_list_get, dir_list_kind, dir_list_free,
@@ -160,6 +162,14 @@ extern fs_get_stat_kind() -> int
 // Y2038-safe mtimes.
 extern fs_get_stat_size() -> long
 extern fs_get_stat_mtime() -> long
+
+// Split-accessor statvfs (#1117): fs_try_statvfs first, then read the
+// three byte-count getters. All `long` (exact bytes, 64-bit). Thread-local
+// like the stat pair. fs_try_statvfs returns 0 on failure (incl. Windows).
+extern fs_try_statvfs(path: string) -> int
+extern fs_get_statvfs_total() -> long
+extern fs_get_statvfs_free() -> long
+extern fs_get_statvfs_avail() -> long
 
 // Split-accessor binary read: fs_try_read_binary reads the file into
 // a TLS-owned buffer; fs_get_read_binary / fs_get_read_binary_length
@@ -618,6 +628,28 @@ file_stat(path: string) -> {
         return kind, size, mtime, ""
     }
     return 0, 0, 0, "cannot stat path"
+}
+
+// Exact filesystem byte counts for the filesystem containing `path` (#1117).
+// Returns (total, free, avail, "") on success, (0, 0, 0, error) on failure.
+// `avail` (POSIX f_bavail) is the space usable by an unprivileged process —
+// the one you want for "how much can I actually write here" (e.g. auto-filling
+// a write range: `end = avail / file_size`). POSIX statvfs(2); portable across
+// Linux/macOS/BSD. Not available on Windows (returns the error branch there).
+//
+// Same `long`-inference discipline as file_stat (#1021): bind the getters to
+// locals so they keep their `long` type, and return the success arm first so
+// the first `return` pins the tuple slots to long. The getters all read 0
+// after a failed fs_try_statvfs, so binding them before the ok-check is safe.
+statvfs(path: string) -> {
+    ok    = fs_try_statvfs(path)
+    total = fs_get_statvfs_total()
+    free  = fs_get_statvfs_free()
+    avail = fs_get_statvfs_avail()
+    if ok != 0 {
+        return total, free, avail, ""
+    }
+    return 0, 0, 0, "cannot statvfs path"
 }
 
 // Binary-safe file read. Preserves embedded NULs and reports the

--- a/std/io/aether_io.c
+++ b/std/io/aether_io.c
@@ -110,28 +110,60 @@ void io_print_float(double value) {
 }
 
 // File I/O
+/* Grow-and-read an open stream to EOF into a caller-owned, NUL-terminated
+ * buffer. Fallback for when the size-based path can't work: `/proc` and `/sys`
+ * seq-files report size 0 from ftell, pipes/sockets aren't seekable — the
+ * size-based path would silently return an empty string (#1116). Returns NULL
+ * on OOM or a read error. Cap-aware; caller frees with plain libc free. */
+static char* io_read_stream_to_eof(FILE* fp) {
+    size_t cap = 65536;
+    size_t len = 0;
+    char* buffer = (char*)aether_caps_malloc(cap);
+    if (!buffer) return NULL;
+    for (;;) {
+        if (len + 4096 > cap) {
+            size_t new_cap = cap * 2;
+            char* grown = (char*)aether_caps_realloc(buffer, cap, new_cap);
+            if (!grown) { aether_caps_free(buffer, cap); return NULL; }
+            buffer = grown;
+            cap = new_cap;
+        }
+        size_t n = fread(buffer + len, 1, cap - len - 1, fp);
+        len += n;
+        if (n == 0) break;
+    }
+    if (ferror(fp)) { aether_caps_free(buffer, cap); return NULL; }
+    buffer[len] = '\0';
+    return buffer;
+}
+
 char* io_read_file_raw(const char* path) {
     if (!path) return NULL;
 
     FILE* file = fopen(path, "rb");
     if (!file) return NULL;
 
-    // Get file size
-    fseek(file, 0, SEEK_END);
-    long size = ftell(file);
-    if (size < 0) { fclose(file); return NULL; }
-    fseek(file, 0, SEEK_SET);
-
-    // Read file. Cap-aware (#343): file size is OS-supplied and
-    // unbounded; gate the allocation. The caller frees with plain
-    // libc `free()` per the caller-owned-return contract — the
-    // counter drifts up on the cold path, same as string_concat.
-    char* buffer = (char*)aether_caps_malloc((size_t)size + 1);
-    if (!buffer) { fclose(file); return NULL; }
-    size_t read = fread(buffer, 1, size, file);
-    buffer[read] = '\0';
+    /* Fast path for regular, seekable files: size the buffer and read once.
+     * Fall through to the EOF loop when the file isn't seekable (pipe/socket)
+     * or reports size 0 (any /proc or /sys seq-file) — the old code returned
+     * an empty string with no error there (#1116, the /proc silent-truncation
+     * bug). Cap-aware (#343): OS-supplied size is gated; caller frees with
+     * plain libc free() per the caller-owned-return contract. */
+    char* buffer = NULL;
+    if (fseek(file, 0, SEEK_END) == 0) {
+        long size = ftell(file);
+        if (size > 0 && fseek(file, 0, SEEK_SET) == 0) {
+            buffer = (char*)aether_caps_malloc((size_t)size + 1);
+            if (!buffer) { fclose(file); return NULL; }
+            size_t read = fread(buffer, 1, (size_t)size, file);
+            buffer[read] = '\0';
+            fclose(file);
+            return buffer;
+        }
+        fseek(file, 0, SEEK_SET);   /* best-effort rewind before streaming */
+    }
+    buffer = io_read_stream_to_eof(file);
     fclose(file);
-
     return buffer;
 }
 

--- a/tests/regression/test_read_proc_and_statvfs.ae
+++ b/tests/regression/test_read_proc_and_statvfs.ae
@@ -1,0 +1,60 @@
+// Regression: #1116 (io.read_file / fs.read no longer silently return "" for
+// /proc seq-files) and #1117 (fs.statvfs exact byte counts).
+//
+// Linux-only: /proc and statvfs. Skips cleanly elsewhere (macOS lacks /proc;
+// Windows has neither) so it stays green across the POSIX matrix.
+
+import std.io
+import std.fs
+import std.os
+import std.string
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    // /proc is Linux-specific; if it isn't there, there's nothing to regress.
+    if fs.exists("/proc/self/status") == 0 {
+        println("SKIP: no /proc (non-Linux) — read-to-EOF path not exercised here")
+        return
+    }
+
+    // --- #1116: io.read_file on a seq-file whose ftell() reports size 0.
+    // Before the fix this returned "" with no error (silent truncation).
+    status, err = io.read_file("/proc/self/status")
+    if err != "" { fail("io.read_file /proc/self/status errored: ${err}") }
+    if string.length(status) == 0 { fail("io.read_file /proc/self/status returned empty (#1116 regressed)") }
+    // Every /proc/<pid>/status has a "Name:" line — prove we got real content.
+    if string.contains(status, "Name:") == 0 { fail("io.read_file content missing 'Name:' — got a partial read?") }
+
+    // --- #1116 via the fs.read (open → file_read_all → close) path too.
+    fstatus, ferr = fs.read("/proc/self/status")
+    if ferr != "" { fail("fs.read /proc/self/status errored: ${ferr}") }
+    if string.length(fstatus) == 0 { fail("fs.read /proc/self/status returned empty (#1116 regressed)") }
+
+    // Regular files must still work via the fast size-based path.
+    reg, rerr = io.read_file("tests/regression/test_read_proc_and_statvfs.ae")
+    if rerr != "" { fail("io.read_file on a regular file errored: ${rerr}") }
+    if string.length(reg) == 0 { fail("io.read_file on a regular file returned empty") }
+
+    // --- #1117: fs.statvfs on the root filesystem — sane byte counts.
+    long total = 0
+    long free = 0
+    long avail = 0
+    total, free, avail, verr = fs.statvfs("/")
+    if verr != "" { fail("fs.statvfs / errored: ${verr}") }
+    if total <= 0 { fail("statvfs total should be > 0, got ${total}") }
+    if avail < 0 { fail("statvfs avail should be >= 0, got ${avail}") }
+    if avail > total { fail("statvfs avail (${avail}) should be <= total (${total})") }
+    if free > total { fail("statvfs free (${free}) should be <= total (${total})") }
+
+    // A bad path should surface an error, not silent zeros passed off as success.
+    _, _, _, berr = fs.statvfs("/no/such/path/definitely/not/here")
+    if berr == "" { fail("fs.statvfs on a missing path should error") }
+
+    println("PASS read-proc-eof + statvfs (#1116, #1117)")
+}


### PR DESCRIPTION
## Description

Two F3 (Fight Flash Fraud) port asks, **bundled into one PR** to conserve CI minutes. Closes #1116 and #1117. (#1118 — mount/block-device enumeration — is filed as an issue only: lower-priority, app-flavored, deferred.)

## #1116 — silent data-loss bug (the important one)

`io.read_file` (`io_read_file_raw`) and `fs.read` (`file_read_all_raw`) sized their buffer from `fseek(SEEK_END)` / `ftell`. For any `/proc` or `/sys` seq-file `ftell` returns **0** (not `<0`), and pipes/sockets aren't seekable at all — so both **silently returned an empty string with no error**. This is the `/proc/self/mountinfo` read that made the F3 port's drive enumeration return nothing.

**Fix:** keep the fast size-based path for regular seekable files; when `fseek`/`ftell` can't give a usable size (size 0, or unseekable), fall back to a grow-and-read-to-EOF loop. A genuine read error now surfaces as NULL/error, not `""`. These are text-shaped `char*` APIs, so the EOF loop is NUL-terminated (fine for `/proc`/`/sys` text; binary reads use the length-aware `_n` / `pread` APIs).

## #1117 — `fs.statvfs`

```
fs.statvfs(path) -> (total_bytes, free_bytes, avail_bytes, err)
```
Exact filesystem byte counts via POSIX `statvfs(2)`. `avail` is `f_bavail` (space usable by a non-root process) — the value you want for "how much can I actually write" (`end = avail / file_size`). Split try/get pair with TLS storage, same shape + `long`-inference discipline as `file_stat` (#1021). Portable Linux/macOS/BSD; Windows (no `statvfs`) returns the error branch (stubbed under `_WIN32`).

## Testing
- **Regression test** (`tests/regression/test_read_proc_and_statvfs.ae`): reads `/proc/self/status` via **both** `io.read_file` and `fs.read` (asserts non-empty + contains `Name:` — would fail on the old silent-truncation code), confirms a regular file still reads via the fast path, and checks `fs.statvfs("/")` returns sane counts (`total>0`, `0<=avail<=total`, `free<=total`) + errors on a bad path. Linux-guarded (skips cleanly on non-`/proc` platforms).
- **Cross-checked correctness**: `fs.statvfs("/")` returns byte-identical values to `df -B1 /` (total `403514413056`, avail `53385162752`).
- 234/234 C unit tests; `-Werror` + `HARDEN=1` stdlib clean; both `.c` files cross-compile clean under `x86_64-w64-mingw32-gcc -Werror` (the `statvfs` `#ifdef _WIN32` stub).

## Docs
`docs/stdlib-api.md` (fs.statvfs entry + note on the read-to-EOF fallback) and `CHANGELOG.md` `[current]`.

Closes #1116, closes #1117.
