### PR TITLE
docs: add C3 cross-reference survey

### DIFF
--- a/docs/cross-references/c3.md
+++ b/docs/cross-references/c3.md
@@ -1,0 +1,628 @@
+<!-- Cross-reference: C3 vs. Aether comparison (full menu of features to consider/skip). -->
+<!-- Kept alongside the code so the comparison stays discoverable for future contributors. -->
+
+# C3 vs. Aether, feature comparison for cross-pollination
+
+> **Status:** Design-exploration survey (July 2026). A record of what was considered from C3 and what, if anything, is worth adopting into Aether. Not a roadmap; nothing here is a commitment.
+>
+> Source project: C3, https://github.com/c3lang/c3c — surveyed against the in-tree snapshot at `../c3c/`, version **0.8.3**.
+
+This survey is written for Aether's maintainers, weighing what, if anything,
+from C3 is worth porting. It compares C3 against Aether **as it actually is in
+this repo** — verified against `compiler/` and `tests/`, not just `LLM.md`,
+which has drifted (see §12).
+
+It is intentionally detailed enough that an Aether implementer can read **only
+this file** and start designing a port of any individual feature without
+re-reading C3's source. `file:line` references point into `../c3c/`.
+
+---
+
+## 1. Framing: the closest sibling in this series
+
+**Aether** is a Go-ergonomics / capability-disciplined / actor-flavoured systems
+language that compiles to C, with two emit modes (`--emit=exe`, `--emit=lib`)
+and an `LD_PRELOAD` libc sandbox. The differentiator is **safety-of-host**:
+making it cheap to embed untrusted Aether inside C, Python, Java, Ruby.
+
+**C3** (Christoffer Lerno, `c3lang/c3c`) is an **evolution of C** compiling via
+LLVM. Its design principles are worth quoting, because they are almost exactly
+Aether's:
+
+> - Procedural "get things done"-type of language.
+> - Try to stay close to C — only change what's really necessary.
+> - C ABI compatibility and excellent C integration.
+> - Data is inert.
+> - **Avoid "big ideas" & the "more is better" fallacy.**
+> - Introduce some higher level conveniences where the value is great.
+
+Fir and Zym were "what can a very different language teach us." C3 is the
+**closest sibling**: a language that made nearly the same bet, is ten years
+further down the road, and has a much larger standard library. That makes the
+comparison unusually actionable — C3 has already shipped production answers to
+questions Aether currently has open, and has *deliberately declined* several
+things Aether might be tempted by.
+
+Two framing cautions before the details:
+
+- **C3's naming has churned.** `@extern` was renamed to **`@cname`** (and the
+  old spelling removed); `distinct` was renamed to **`typedef`**; `module
+  foo(<Type>)` is now `module foo <Type>;`. Older blog posts and LLM training
+  data will be wrong. Everything below reflects 0.8.3.
+- **The release notes oversell one feature.** C3 0.8.2 advertises `own` / `init`
+  / `drop` parameter annotations, which sound like ownership tracking. They are
+  written to the AST and read **only by the documentation generator**
+  (`src/compiler/docgen.c:141-146`). There is no borrow checking, no move
+  checking, and **no destructors at all** in C3. See §9.
+
+**The short answer up front:**
+
+- **One large win:** unify Aether's `T?` optional with its `(value, err)`
+  convention, along the lines of C3's `fault` design (§4). Aether has already
+  built most of the syntax and then bolted a weaker, stringly-typed convention
+  beside it.
+- **Four cheap, high-value borrows:** `bitstruct` (§5) — which is the principled
+  fix for a bug class that has bitten this repo twice; `defer catch` / `defer
+  try` (§6); `@nodiscard` (§7); and `attrdef` user-defined attributes (§8).
+- **One structural target that is not a language feature:** C3's stdlib is
+  73,880 lines with **zero C files** (§3). That is the existence proof for
+  Aether's "no externs, committed code must be Aether" rule.
+- **Several explicit do-not-copies** (§10), headed by C3's macro system — the
+  largest single piece of complexity in the language, and the one Aether's
+  trailing-block DSL already substitutes for at far lower cost.
+- **Two places Aether is already ahead** (§11): `@c_import`, and getting the C
+  ABI for free by emitting C.
+
+---
+
+## 2. Side-by-side at a glance
+
+| Dimension | Aether | C3 |
+| --- | --- | --- |
+| Family | Imperative, Go-shaped | Imperative, C-shaped |
+| Backend | **C** | **LLVM** (+ experimental C backend) |
+| Compiler size | ~46k lines C | ~80k lines C |
+| Stdlib | 21.7k `.ae` + **29.6k C** | 73.9k `.c3` + **0 C** |
+| Error handling | `(value, err)` string convention **and** a separate `T?` | **Unified** `T?` carrying a `fault` |
+| Optionals | ✅ `T?` / `none` / `!` / `??` / `?.` | ✅ `T?` — but it carries the error |
+| Generics | ✗ | Module-level type params, monomorphised |
+| Slices | ✗ | `T[]` fat pointer `{ptr,len}`, bounds-checked |
+| Macros | ✗ (trailing-block DSL instead) | Large semantic macro system |
+| Compile-time reflection | ✗ | Extensive (`$typeof`, `.membersof`, `$foreach`) |
+| Static-if | ✅ `when` | ✅ `$if` / `@if` |
+| Contracts | ✅ `where` on params (runtime) | ✅ `@require`/`@ensure` — **also compile-time** |
+| Sum types | ✅ with exhaustiveness | ✗ (enums with associated values) |
+| UFCS | ✅ | ✅ |
+| `defer` | ✅ unconditional only | ✅ **plus `defer try` / `defer catch`** |
+| Distinct types | ✅ `type X = distinct int` | ✅ `typedef` (+ `inline` variant) |
+| Bitfields | ⚠️ extern-struct only, **always signed** | ✅ `bitstruct : uint { a : 0..2; }` |
+| `@nodiscard` | ✗ | ✅ |
+| User-defined attributes | ✗ | ✅ `attrdef` |
+| Interfaces | ✗ | ✅ (dynamic dispatch) |
+| Allocators | ⚠️ RAII-via-codegen, ref-counted strings | ✅ pluggable + temp-arena `@pool()` |
+| Destructors / RAII | ✅ | ✗ **none** |
+| `@c_import` | ✅ | ✗ |
+| Actors / concurrency | ✅ first-class | ✗ threads + atomics |
+| Sandboxing | ✅ three layers | ✗ |
+| Effect tags / purity | ✅ `@pure`, `@no_fs`, … | ⚠️ `@pure` only |
+
+**The headline:** the two languages agree on philosophy to a startling degree.
+Where they differ, C3 has gone further on *type-system and stdlib machinery*
+(generics, slices, reflection, allocators, bitstruct), and Aether has gone
+further on *isolation, concurrency, and safety* (sandbox, actors, effect tags,
+RAII, `--emit=lib`). **Neither is a superset.** The borrow list is therefore
+mostly "machinery"; the do-not-borrow list is mostly "big ideas C3 itself warns
+against".
+
+---
+
+## 3. The thing to steal that isn't a feature: a stdlib with no C in it
+
+**Fact:** `find ../c3c/lib -name '*.c' -o -name '*.h'` returns **zero files**.
+
+C3's entire 73,880-line standard library — `std::io`, `std::net`, sockets,
+threads, atomics, compression (deflate, gzip, qoi), crypto, JSON — is written in
+C3, reaching libc through `extern fn` declarations exactly the way Aether does.
+
+Aether today: **21,673 lines of `.ae` against 29,617 lines of C** in `std/`.
+More than half of the standard library, by line count, is C.
+
+This matters because "committed code must be Aether; no externs" is a standing
+project rule, and the standing objection is *"a systems stdlib obviously needs C
+for the low-level parts."* **C3 falsifies that objection at scale.**
+
+The two features that make it possible are exactly the two Aether lacks:
+**`bitstruct`** (§5), for the packed-struct and wire-protocol work that
+otherwise drives people to C, and **slices** (§10.4), for buffer manipulation
+without raw `char*` arithmetic. That is not a coincidence.
+
+> **Takeaway:** the C-in-`std/` ratio is a lagging indicator of *missing language
+> features*, not an inherent property of systems programming. Every candidate
+> below should be judged primarily on **how much C it lets us delete.**
+
+---
+
+## 4. The big one: unify `T?` with `(value, err)`
+
+### 4.1 Where Aether stands
+
+Aether has **two parallel, incompatible error mechanisms**:
+
+1. **`T?` optionals** (`LLM.md:313-326`) — `let m: int? = 69`, `none`, `m ?? d`,
+   `v?.field`, `match m { none -> … some(v) -> … }`. Deliberately scoped to the
+   *"present or absent"* axis.
+2. **Go-style `(value, err)`** — `fs.write_atomic(path, data, len) -> string`,
+   where **empty string = success, non-empty = error message**. `LLM.md:151`
+   says: *"Don't 'improve' the convention, it's consistent across all of `std`."*
+
+So Aether already built ~80% of the optional syntax — `!`, `??`, `?.`, `match` —
+and then routed all *fallible* operations through a stringly-typed side channel.
+The costs of that split:
+
+- **Boilerplate at every call site.** A tuple destructure plus `if err != ""`.
+- **No exhaustiveness, no identity.** Errors are strings. You cannot `switch` on
+  them, cannot compare them reliably, cannot enumerate them.
+- **A string compare on every success path.**
+- **Two things to learn** where one would do.
+
+### 4.2 What C3 proves
+
+C3's `int?` is **one mechanism for both axes**. The design is unusually
+well-suited to Aether's C backend, and it is *not* a tagged union:
+
+**An Optional is a (value, fault) pair kept in two separate storage slots.** The
+`fault` is a **pointer-width integer** that is `0` when there is no error, and
+otherwise holds the **address of a link-time symbol** whose contents are the
+error's name string.
+
+```c3
+faultdef INVALID_PARAMETERS, FILE_OPEN_FAILED, INVALID_DATA;   // qoi.c3:46
+```
+
+Each `faultdef` name becomes a global constant `@mod.NAME` initialised to the
+string `"mod::NAME"` (`src/compiler/llvm_codegen.c:1322-1347`), and the fault
+*value* is `ptrtoint @mod.NAME` (`llvm_codegen_expr.c:4801-4806`).
+
+**Three consequences, all of which Aether wants:**
+
+- **Cross-module composition is free.** Fault identity is a linker symbol, so a
+  fault declared in a library and one declared in your app coexist with no
+  registry, no error-code space, no ordinal allocation, no `From<E>` conversion.
+  `err == io::EOF` is an integer compare against the library's symbol address.
+- **Zero-cost error values.** 8 bytes, no allocation, no boxing. Compare with
+  Go's `error`, a 16-byte interface that usually costs a heap allocation.
+- **`fault` prints itself** — the value *is* a pointer to its name string, so
+  `"%s"` works with no runtime type tables.
+
+**The ABI rewrite is the whole trick** (`src/compiler/abi/c_abi.c:250-269`):
+
+| C3 signature | Lowered C signature |
+| --- | --- |
+| `fn int foo()` | `int foo(void)` |
+| `fn void? foo()` | `fault foo(void)` — returns the fault; `0` = ok |
+| `fn int? foo()` | `fault foo(int* out)` — **out-param prepended** |
+
+This lowers *directly* into C. C3's own header generator already emits exactly
+that shape for C consumers (`src/compiler/headers.c:298-319`), using
+`typedef void* c3fault_t`.
+
+### 4.3 The ergonomics, which are the actual point
+
+Real C3 stdlib code (`lib/std/compression/qoi.c3:71-103`):
+
+```c3
+char[] output = encode(tmem, input, desc)!;               // propagate on failure
+file::save(filename, output)!;                            // same, on a void call
+char[] data = file::load_temp(filename) ?? FILE_OPEN_FAILED~!;  // substitute, then propagate
+```
+
+Against Aether's current shape, that is one character (`!`) versus a destructure
+and a four-line `if err != ""` block — *at every call site.*
+
+The operator set, all of which Aether already has spellings for:
+
+| Form | Meaning |
+| --- | --- |
+| `foo()!` | Propagate the fault to my caller (requires my return be optional) |
+| `foo()!!` | Panic if failed (the `main`/test escape hatch) |
+| `foo() ?? v` | Use `v` if failed |
+| `foo() ?? OTHER~` | **Translate** the fault, then keep going |
+| `if (try v = foo())` | Bind on success |
+| `if (catch err = foo())` | Bind the fault on failure |
+| `FAULT~` | Produce a fault-state optional (`~` is C3's "raise") |
+
+Two safety properties Aether's string convention cannot have:
+
+1. **You cannot forget to check.** Every optional-producing expression must be
+   consumed by exactly one of `!`, `!!`, `??`, a `try`/`catch` conditional, an
+   assignment to an optional, or an explicit `(void)` cast. Anything else is a
+   compile error (`sema_expr.c:12806`). In Go — and in Aether today — dropping
+   the error compiles fine.
+2. **You cannot read the value without checking.** `int?` is a *different type*
+   from `int`. The only way to the `int` is through one of the forms above. On
+   the fault path the value slot is left `undef` — which is *safe precisely
+   because* the type system forbids reading it.
+
+There is also **flow-sensitive narrowing**: `if (catch err = x) { return err~; }`
+unwraps `x` to plain `int` for the rest of the scope, implemented as a scoped
+shadow declaration (`sema_name_resolution.c:1352-1360`) — zero runtime cost.
+
+### 4.4 What Aether would need
+
+In dependency order. Note how much Aether already has.
+
+1. **A `fault` scalar.** Pointer-width; `0` = none; otherwise the address of a
+   link-time-unique constant descriptor. **This is the load-bearing decision** —
+   get it right and cross-module composition falls out of the linker.
+2. **Make `T?` carry it.** Aether's `T?` already exists; `none` becomes "fault
+   slot is 0", and a fault-state optional is the new case.
+3. **The ABI rewrite:** `T? f(args)` → `fault f(T* out, args)`. Straightforward
+   in a C backend.
+4. **An "ambient catch" in codegen** — a `(fault_slot, target_block)` pair pushed
+   and popped around any construct that can absorb a fault. Every
+   optional-producing expression emits: *check fault → on fault, store and jump
+   to the ambient target.* That single invariant makes `!`, `!!`, `??`,
+   `if (try)`, and `if (catch)` all fall out as ~40-line functions differing only
+   in what they install as the target.
+5. **Mandatory-consumption checking** in the type checker.
+
+### 4.5 The honest cost
+
+- **Faults are identities, not payloads.** A C3 fault carries *no data* — you
+  cannot attach "which file, what errno". Aether's error *strings* can. If a
+  port wants payloads, that is a genuine extension beyond C3, and the sharpest
+  design tension in C3's model.
+- **No exhaustiveness.** Because there is one `fault` type, a function can return
+  any fault from any module. C3's `@return?` contract documents the set but
+  **only checks literal returns, not propagated ones** (there is a `TODO` at
+  `sema_stmts.c:490-513`). It is a lint, not an effect system.
+- **`(value, err)` is load-bearing across all of `std`.** This is the single
+  largest change proposed in this document and would touch every stdlib
+  signature. It is worth costing seriously before starting.
+
+---
+
+## 5. `bitstruct` — the best-designed feature in C3, and we have the bug it fixes
+
+### 5.1 Why this one is personal
+
+Aether's extern-struct bitfields **always emit as signed C `int`**, so every
+unsigned-field read has to be hand-masked with `& ((1<<N)-1)`. That has bitten
+this project more than once and is recorded as a standing gotcha.
+
+C3's `bitstruct` is the principled fix, and it is *simple*:
+
+```c3
+bitstruct BitField : char        // explicit backing type — REQUIRED
+{
+    uint a : 0..2;               // explicit, INCLUSIVE bit range
+    uint b : 4..6;
+    bool c : 7;
+}
+```
+
+The compiler **errors if you omit the backing type**
+(`test/test_suite/bitstruct/bitstruct_general.c3:6`). Members must be integers,
+booleans, or enums.
+
+### 5.2 What makes it trustworthy
+
+C's `:n` bitfields are famously unusable for wire formats: signedness,
+allocation order, and straddling are all implementation-defined. C3 sidesteps all
+of it:
+
+- **Explicit container.** `bitstruct : uint` — you name the storage.
+- **Explicit inclusive ranges**, not widths. No "which end did the last field
+  finish at" arithmetic.
+- **Explicit endianness.** `@bigendian` / `@littleendian` on the bitstruct force
+  byte order *independent of the host*. The whole of `lib/std/core/bitorder.c3`
+  is built from this — `bitstruct UIntBE : uint @bigendian { uint val : 0..31; }`
+  — so a gzip header field is declared `UIntLE mtime;` and needs **no `ntohl`
+  call anywhere** (`lib/std/compression/gzip.c3:25-34`).
+- **Overlap is an error** unless you write `@overlap`.
+- **No implicit conversions** to or from the container.
+- **Lowered to shift/mask on the container**, never to C bitfields — C3's own C
+  header generator emits the container type
+  (`src/compiler/headers.c:367-376`). *This is exactly how Aether would
+  implement it*, and it is why the feature is trustworthy where C's is not.
+
+### 5.3 Compile-time reflection over bits (0.8.2)
+
+`.bitoffset` and `.bitsize` are compile-time constants on each member
+(`src/compiler/sema_expr.c:5720-5733`), so a generic serialiser can walk a
+bitstruct's layout at compile time and fold to constants. Worth knowing about,
+but the core feature stands alone without it.
+
+### 5.4 Verdict
+
+**Strongest single recommendation in this document after §4.** It is
+self-contained, needs no type-system work, lowers trivially in a C backend, and
+it deletes both a known bug class and a chunk of the hand-written C in `std/`
+(§3). Adopt exclusive-or-inclusive ranges deliberately — C3 chose *inclusive*,
+which is a footgun for anyone arriving from Rust/Go/Python.
+
+---
+
+## 6. `defer catch` / `defer try` — cheap, and it fits `(value, err)` exactly
+
+Aether's `defer` is **unconditional only** (verified: `compiler/parser/parser.c:3563`).
+C3 has four forms:
+
+```c3
+defer            cleanup();    // always
+defer try        commit();     // only on the SUCCESS path
+defer catch      rollback();   // only on the ERROR path
+defer (catch err) log(err);    // error path, binding the in-flight fault
+```
+
+Which buys you a **transaction in three lines** (`on_stack_allocator.c:148-152`):
+
+```c3
+Chunk* chunk = alloc::alloc_try(backing, Chunk)!;
+defer catch alloc::free(backing, chunk);   // roll back if we bail
+defer try   self.chunk = chunk;            // publish only if we succeed
+chunk.data = backing.acquire(size, init_type, alignment)!;   // this ! may bail
+```
+
+**The implementation detail Aether should copy.** C3 does *not* keep a runtime
+defer stack, and does not use `__attribute__((cleanup))`. Semantic analysis
+**inlines the defer body at every exit point**, maintaining **two chains** —
+`cleanup` (success) and `cleanup_fail` (error) — and filtering by whether each
+defer is `is_try` / `is_catch` (`src/compiler/semantic_analyser.c:76-95`,
+`sema_stmts.c:466-482`). Zero runtime cost; the price is code duplication at
+each exit.
+
+That maps **perfectly** onto Aether's `(value, err)` returns, today, with no
+other change: the `err != ""` return path *is* C3's `cleanup_fail` chain. This is
+a small, self-contained, high-value addition and it does not depend on §4.
+
+---
+
+## 7. `@nodiscard` — the cheapest ownership guard there is
+
+C3 puts `@nodiscard` on **every allocating function** (`lib/std/core/alloc.c3:54,
+62, 77, …`). Dropping an owning return value on the floor is then a compile
+error. Aether has no equivalent (verified).
+
+Zero runtime cost, tiny implementation, catches a real leak class. Given that
+Aether has RAII-via-codegen, the payoff is smaller than in C3 — but it is still
+close to free, and it also guards non-memory resources (fds, locks, handles).
+
+---
+
+## 8. `attrdef` — user-defined attributes
+
+C3 lets you define attributes that expand to lists of built-in ones, with
+parameters, composition, and `@if` guards (`src/compiler/parse_global.c:2505-2554`):
+
+```c3
+attrdef @MathLibc(name) = @cname(name), @link(env::POSIX, "m");   // lib/std/math/math.c3:9
+```
+used as:
+```c3
+extern fn double _atan(double x) @MathLibc("atan");
+```
+
+One line bundles "set the C symbol name" and "conditionally link `-lm`". They
+compose recursively (cycle-checked), take arbitrary compile-time expressions as
+arguments, and can themselves be conditional:
+
+```c3
+attrdef @ReadOnly @if(env::LINUX) = @section(".rodata");
+attrdef @ReadOnly @if(env::WIN32) = @section(".rdata$");
+```
+
+Aether has no user-defined attributes. This is a modest, well-contained feature
+that pays for itself in any codebase with repeated attribute boilerplate — which
+`std/`, with its extern-heavy C bindings, certainly is.
+
+---
+
+## 9. Ownership: where C3 is *behind*, and the release notes mislead
+
+C3 0.8.2's notes say: *"Add `own`, `init` and `drop` parameter annotations."*
+That sounds like ownership tracking. **It is not.**
+
+The flags are parsed into `Decl.var.{own,init,drop}_param`
+(`src/compiler/sema_decls.c:3996-4023`) and then read by **exactly one place in
+the entire compiler**: the documentation generator
+(`src/compiler/docgen.c:141-146`). There is:
+
+- **no borrow checking**
+- **no move checking**
+- **no ownership transfer analysis**
+- **no destructors, and no RAII of any kind**
+
+(By contrast, the sibling annotations `[in]` / `[out]` / `[inout]` and the `&`
+non-null prefix *are* enforced.)
+
+C3's actual ownership discipline is **manual and lexical**: `defer` + `defer
+catch` + `@pool()` + `@nodiscard`, with an `X.init()` / `X.free()` convention.
+The `own`/`init`/`drop` annotations stake out syntax for a future analysis pass
+that does not exist yet.
+
+**Aether's RAII-via-codegen is genuinely ahead here.** This section exists mainly
+so nobody reads C3's release notes and concludes otherwise.
+
+---
+
+## 10. Considered and *not* recommended
+
+### 10.1 The macro system — the main thing to decline
+
+C3's semantic macro system is the **largest single source of complexity in the
+language**, and it exists mainly to serve C3's *other* big feature, module-level
+generics. It is not one construct but **22 distinct compile-time forms** — a
+whole second evaluation language layered over the runtime one:
+
+```
+$if $else $endif  $for $foreach $endforeach  $switch $case $default $endswitch
+$assert $error $echo  $typeof $defined $eval $feature $stringify $vaarg
+$checks $include $exec $embed
+```
+
+plus `macro` declarations, `@body` trailing-block parameters, and `.membersof`
+reflection.
+
+Aether already has the two things macros are usually reached for:
+
+- **Static-if** — Aether's compile-time `when` (`docs/when-static-if.md`) covers
+  what `$if` does.
+- **Compile-time DSL / code shaping** — Aether's **trailing-block + `builder`**
+  form is a *better* answer for the config/DSL use case, because the block is
+  ordinary Aether (control flow, imports, library calls) rather than a
+  second, weaker meta-language. That is the "config is code" thesis and it is a
+  genuine differentiator; a macro system would undercut it.
+
+Adopting C3's macros would import a whole second evaluation model. Against C3's
+own principle — *"avoid 'big ideas' and the 'more is better' fallacy"* —
+this is the one to decline.
+
+**But note one idea worth lifting out of it (§10.2).**
+
+### 10.2 …except: `@require` as a *compile-time* constraint
+
+C3's `@require` does double duty. On a macro, it is evaluated at the **call site**
+and, if the predicate constant-folds to false, it is a **compile error with a
+custom message** (`sema_stmts.c:415-444`):
+
+```c3
+<*
+ @require $defined(*ptr = passthru) : "Pointer and passthru must match"
+ @require @kindof(passthru) == VECTOR : "Expected passthru to be a vector"
+*>
+macro masked_load(ptr, bool[<*>] mask, passthru)      // lib/std/core/mem.c3:49-55
+```
+
+That is **C++ concepts / Rust trait bounds, achieved without a type system for
+them** — the contract *is* the bound. Aether's `where` contracts are runtime-only.
+Making Aether's contracts fold at compile time when their operands are known —
+erroring rather than trapping — is a small change with real payoff, and it does
+not require adopting macros.
+
+(Both languages agree on the runtime half: C3's asserts vanish entirely under
+`--safe=no`, exactly as Aether's do under `--no-contracts`.)
+
+### 10.3 Generics — desirable, but the biggest single project here
+
+C3's model is *module-level*: `module std::collections::list <Type>;` parameterises
+an entire namespace, instantiated as `List{int}` and monomorphised
+(`lib/std/collections/list.c3:4`). It is elegant, and it is what lets C3's stdlib
+be C-free.
+
+It is also the largest thing in this document. Aether has no generics at all;
+adding them touches the parser, type checker, name resolution, and codegen.
+Worth doing eventually — the `std/` collections are the obvious first customer —
+but it should be scoped as a project, not a feature, and §4/§5/§6 all deliver
+value without it.
+
+### 10.4 Slices — wanted, but blocked behind a bigger decision
+
+`T[]` as a `{ptr, len}` fat pointer with bounds checking
+(`src/compiler/llvm_codegen_type.c:340-346`) is unambiguously good, and it is the
+other half of why C3's stdlib needs no C.
+
+Two notes for a port:
+- **Do not make slices ABI-transparent to C.** C3 doesn't: it keeps a separate
+  NUL-terminated `ZString` (`= inline char*`) for the C boundary and converts
+  explicitly. That is the right call for a C-targeting language.
+- **C3's `arr[1..3]` is *inclusive*.** Aether should almost certainly use
+  exclusive-end (Go/Rust/Python) and note the divergence loudly.
+
+The reason this isn't a top recommendation is that slices interact heavily with
+Aether's existing string model (ref-counted / arena-owned) and with generics.
+It needs a design pass first, not a port.
+
+### 10.5 Allocators / `@pool()` — good ideas, wrong shape for Aether
+
+C3's signature memory idiom is a thread-local temp arena plus a scoped pool:
+
+```c3
+fn String format(Allocator allocator, String fmt, args...) => @pool()
+{
+    DString str = dstring::temp_with_capacity(...);
+    str.appendf(fmt, ...args);
+    return str.copy_str(allocator);   // copy the ONE survivor out; pool reclaims the rest
+}
+```
+
+Notably, **`@pool()` is a library macro, not a compiler feature** — it is just
+`push_pool()` + `defer pop_pool()` (`lib/std/core/mem.c3:647-655`).
+
+Aether's ref-counted/arena strings occupy a *different point in the design
+space*, and C3's model leans on macros and generics that §10.1/§10.3 decline. But
+three specific tricks are worth stealing independently of the allocator model:
+
+- **ASAN poison/unpoison on every arena bump** (`temp_allocator.c3:249`).
+  Arenas otherwise silently defeat the sanitizer — and this repo's CI has an
+  ASan/LSan gate that would benefit.
+- **VM-reserved arena with `protect_unused_pages`** — turns "returned a pointer
+  into a dead arena" from silent corruption into a deterministic SIGSEGV.
+- **Refcount memory ordering:** `RELAXED` retain, `RELEASE` decrement, `ACQUIRE`
+  fence before destroy (`lib/std/core/refcount.c3:59-69`). Textbook-correct;
+  worth checking Aether's ref-counted strings against it.
+
+### 10.6 Interfaces
+
+C3 has `interface` with dynamic dispatch — but it implements it as a **linear
+search through a linked list of `{fn_ptr, selector}` nodes per call**
+(`llvm_codegen_expr.c:5483-5495`), Objective-C style, not a vtable. It buys
+retroactive implementation at the cost of dispatch speed, and C3 hides the cost
+by making hot paths macros. If Aether ever wants interfaces, use a plain vtable
+pointer; don't copy this.
+
+---
+
+## 11. Where Aether is already ahead
+
+Worth stating plainly, because the surrounding sections are a long list of things
+to borrow:
+
+- **`@c_import`.** Aether can import a struct's layout directly from a C header
+  (`compiler/parser/parser.c:4267`, three integration tests). **C3 has no
+  equivalent** — no `@c_import`, no `#include`, no libclang integration. You
+  hand-write `.c3i` interface files. This is a real capability advantage.
+- **The C ABI comes free.** C3 hand-maintains **seven per-target C ABI
+  classifiers** (`src/compiler/abi/c_abi_x64.c`, `_win64`, `_aarch64`, `_riscv`,
+  `_wasm`, …) — a reimplementation of Clang's `TargetInfo`. Aether emits C and
+  the host compiler does it. That is a structural advantage of the C backend and
+  it should be defended.
+- **RAII / destructors** — C3 has none (§9).
+- **Sum types with exhaustiveness** — C3 has enums with associated values, but no
+  true sum type and no exhaustiveness checking over one.
+- **Actors, the sandbox, effect tags, `--emit=lib`** — no C3 analogue at all.
+  These are Aether's differentiators and nothing in this document should be
+  allowed to erode them.
+
+---
+
+## 12. Documentation drift found while writing this
+
+`LLM.md` is out of date in at least one respect, discovered by checking the
+compiler rather than the docs:
+
+- **Contracts already exist.** `requires` / `ensures` are parsed
+  (`compiler/parser/parser.c:4625, 4878`) and emitted
+  (`emit_contract_preconditions`, issue #348), and `LLM.md:335` documents `where`
+  clauses — but the feature list at the top of `LLM.md` doesn't mention them, and
+  there are **no `tests/syntax/` tests named for contracts**. Worth a look.
+
+---
+
+## 13. Recommendation, in priority order
+
+| # | Item | Size | Payoff |
+| --- | --- | --- | --- |
+| 1 | **`bitstruct`** (§5) | Small–medium | Kills a known bug class (signed bitfields); deletes C from `std/`; self-contained |
+| 2 | **`defer catch` / `defer try`** (§6) | Small | Fits `(value, err)` today; no dependencies |
+| 3 | **`@nodiscard`** (§7) | Tiny | Free leak guard |
+| 4 | **Compile-time `where`/contract folding** (§10.2) | Small | Concepts-like bounds without a macro system |
+| 5 | **`attrdef`** (§8) | Small | Removes extern-binding boilerplate |
+| 6 | **Unify `T?` with `(value, err)`** (§4) | **Large** | The single biggest ergonomic + safety win available — but touches every `std/` signature |
+| 7 | Generics (§10.3) | **Very large** | Prerequisite for a C-free stdlib; scope as a project |
+| 8 | Slices (§10.4) | Large | Needs a design pass against Aether's string model first |
+| — | Macros (§10.1) | — | **Decline.** The trailing-block DSL is the better answer |
+
+Items 1–5 are independent, each individually shippable, and together they would
+remove a meaningful fraction of the C in `std/` while closing a real bug class.
+Item 6 is the one worth a design discussion of its own.


### PR DESCRIPTION
Adds `docs/cross-references/c3.md`, alongside the existing `fir.md` / `flint.md` / `gcp-aether.md` / `zym.md`.

Docs-only — `[skip actions]` on the branch commit (not in the PR title, so the release pipeline still runs on merge).

## Why C3 is worth a survey

C3 (`c3lang/c3c`, surveyed at 0.8.3) is the **closest sibling** in this series so far. Fir and Zym were "what can a very different language teach us." C3 made nearly the same bet as Aether — evolve C, keep the C ABI, don't be Rust, *"avoid big ideas and the more-is-better fallacy"* — and is ten years further down the road with a much larger standard library. So the comparison is unusually actionable, and the **don't-copy** list matters as much as the borrow list.

Claims are verified against `../c3c` source and against this repo's `compiler/` and `tests/` — not against `LLM.md`, which has drifted.

## Headline findings

**The big one: Aether's two error mechanisms should be one.** Aether already has `T?` optionals (`none`, `!`, `??`, `?.`, `match`) and then routes every *fallible* operation through a separate stringly-typed `(value, err)` convention. C3 proves the two axes can be a single mechanism: its `T?` carries a `fault` — a pointer-width integer holding *the address of a link-time symbol*, zero = no error. Cross-module error composition then falls out of the linker for free (no registry, no error-code space, no `From<E>`), and the ABI rewrite `T? f(args)` → `fault f(T* out, args)` drops straight into a C backend. Biggest ergonomic and safety win available — but it touches every `std/` signature, so the doc scopes it as a design discussion rather than a task.

**`bitstruct` is the top actionable recommendation.** It's the principled fix for a bug class that has bitten this repo more than once: Aether's extern-struct bitfields always emit as signed C `int`, forcing hand-masking of every unsigned read. C3's design — mandatory explicit backing type, explicit bit ranges, explicit `@bigendian`/`@littleendian`, lowered to shift/mask and **never** to a C bitfield — is self-contained, needs no type-system work, and lowers trivially in a C backend.

**Three more small, independent, individually shippable borrows:** `defer catch` / `defer try` (fits `(value, err)` *today*, no dependencies), `@nodiscard`, and `attrdef`.

**Decline the macro system.** It's 22 distinct compile-time constructs — a whole second evaluation language — and Aether's trailing-block DSL is the better answer for the use case it serves. But one idea is worth lifting out of it: C3's `@require` **constant-folds into a compile error** with a custom message, which is concepts-like bounds with no type system for them.

## Two places the source contradicts the marketing

Recorded so nobody has to rediscover them:

- **C3's `own`/`init`/`drop` "ownership" annotations (0.8.2) are documentation only.** They're written to the AST and read by exactly one place in the compiler — the doc generator. No borrow checking, no move checking, and **C3 has no destructors at all**. Aether's RAII-via-codegen is genuinely ahead.
- **C3's stdlib is 73,880 lines with zero `.c` files** (verified). Aether's `std/` is 21.7k `.ae` against 29.6k C. That's the existence proof for the no-externs rule — and the two features that make it possible are precisely `bitstruct` and slices. Not a coincidence.

Also worth knowing if you read older C3 material: `@extern` was renamed to `@cname`, and `distinct` to `typedef`.

## Incidental find

`LLM.md`'s feature list omits that `requires`/`ensures` contracts **already exist** (parser + codegen, issue #348), and there are no `tests/syntax/` tests named for them. Noted in §12; not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)