### PR TITLE
docs(c3): record what shipping bitstruct taught us

### DIFF
--- a/docs/cross-references/c3.md
+++ b/docs/cross-references/c3.md
@@ -61,9 +61,11 @@ Two framing cautions before the details:
   convention, along the lines of C3's `fault` design (§4). Aether has already
   built most of the syntax and then bolted a weaker, stringly-typed convention
   beside it.
-- **Four cheap, high-value borrows:** `bitstruct` (§5) — which is the principled
-  fix for a bug class that has bitten this repo twice; `defer catch` / `defer
-  try` (§6); `@nodiscard` (§7); and `attrdef` user-defined attributes (§8).
+- **Four cheap, high-value borrows:** `bitstruct` (§5) — the principled fix for a
+  bug class that has bitten this repo twice, and **now shipped** (PR #1132),
+  though *not* as a straight copy: see §5.5 for why we rejected C3's
+  `@bigendian`; `defer catch` / `defer try` (§6); `@nodiscard` (§7); and
+  `attrdef` user-defined attributes (§8).
 - **One structural target that is not a language feature:** C3's stdlib is
   73,880 lines with **zero C files** (§3). That is the existence proof for
   Aether's "no externs, committed code must be Aether" rule.
@@ -95,7 +97,7 @@ Two framing cautions before the details:
 | UFCS | ✅ | ✅ |
 | `defer` | ✅ unconditional only | ✅ **plus `defer try` / `defer catch`** |
 | Distinct types | ✅ `type X = distinct int` | ✅ `typedef` (+ `inline` variant) |
-| Bitfields | ⚠️ extern-struct only, **always signed** | ✅ `bitstruct : uint { a : 0..2; }` |
+| Bitfields | ✅ **`bitstruct`** (shipped, §5) — plus the older extern-struct form, which is always signed | ✅ `bitstruct : uint { a : 0..2; }` |
 | `@nodiscard` | ✗ | ✅ |
 | User-defined attributes | ✗ | ✅ `attrdef` |
 | Interfaces | ✗ | ✅ (dynamic dispatch) |
@@ -131,10 +133,10 @@ This matters because "committed code must be Aether; no externs" is a standing
 project rule, and the standing objection is *"a systems stdlib obviously needs C
 for the low-level parts."* **C3 falsifies that objection at scale.**
 
-The two features that make it possible are exactly the two Aether lacks:
-**`bitstruct`** (§5), for the packed-struct and wire-protocol work that
-otherwise drives people to C, and **slices** (§10.4), for buffer manipulation
-without raw `char*` arithmetic. That is not a coincidence.
+The two features that make it possible are exactly the two Aether lacked:
+**`bitstruct`** (§5), for the packed-struct and wire-protocol work that otherwise
+drives people to C — **now shipped** — and **slices** (§10.4), for buffer
+manipulation without raw `char*` arithmetic. That is not a coincidence.
 
 > **Takeaway:** the C-in-`std/` ratio is a lagging indicator of *missing language
 > features*, not an inherent property of systems programming. Every candidate
@@ -284,6 +286,12 @@ In dependency order. Note how much Aether already has.
 
 ## 5. `bitstruct` — the best-designed feature in C3, and we have the bug it fixes
 
+> **✅ ADOPTED — shipped in [PR #1132](https://github.com/aether-lang-org/aether/pull/1132).**
+> Aether now has `bitstruct`. Two things in this section were revised by contact
+> with the implementation, and both are recorded below rather than quietly
+> edited away: we **rejected C3's `@bigendian`** (§5.5) and we **improved on
+> C3's inclusive-only ranges** (§5.4). The rest of the analysis held up.
+
 ### 5.1 Why this one is personal
 
 Aether's extern-struct bitfields **always emit as signed C `int`**, so every
@@ -311,20 +319,26 @@ C's `:n` bitfields are famously unusable for wire formats: signedness,
 allocation order, and straddling are all implementation-defined. C3 sidesteps all
 of it:
 
-- **Explicit container.** `bitstruct : uint` — you name the storage.
-- **Explicit inclusive ranges**, not widths. No "which end did the last field
-  finish at" arithmetic.
+- **Explicit container.** `bitstruct : uint` — you name the storage. ✅ *Adopted,
+  and made mandatory: Aether requires `uint8_t`/`uint16_t`/`uint32_t`/`uint64_t`,
+  so the width AND the unsignedness are both pinned by the declaration.*
+- **Explicit ranges**, not widths. No "which end did the last field finish at"
+  arithmetic. ✅ *Adopted — but see §5.4: C3's ranges are inclusive-only, and we
+  didn't copy that.*
 - **Explicit endianness.** `@bigendian` / `@littleendian` on the bitstruct force
   byte order *independent of the host*. The whole of `lib/std/core/bitorder.c3`
   is built from this — `bitstruct UIntBE : uint @bigendian { uint val : 0..31; }`
   — so a gzip header field is declared `UIntLE mtime;` and needs **no `ntohl`
-  call anywhere** (`lib/std/compression/gzip.c3:25-34`).
-- **Overlap is an error** unless you write `@overlap`.
-- **No implicit conversions** to or from the container.
+  call anywhere** (`lib/std/compression/gzip.c3:25-34`). ❌ **Rejected for
+  Aether — see §5.5. This was the biggest single revision to this document.**
+- **Overlap is an error** unless you write `@overlap`. ✅ *Adopted verbatim.*
+- **No implicit conversions** to or from the container. ✅ *Adopted — the
+  bitstruct is strictly nominal; crossing to the raw word is an explicit `as`.*
 - **Lowered to shift/mask on the container**, never to C bitfields — C3's own C
   header generator emits the container type
   (`src/compiler/headers.c:367-376`). *This is exactly how Aether would
   implement it*, and it is why the feature is trustworthy where C's is not.
+  ✅ *Adopted, and it is exactly how Aether did implement it.*
 
 ### 5.3 Compile-time reflection over bits (0.8.2)
 
@@ -333,13 +347,88 @@ of it:
 bitstruct's layout at compile time and fold to constants. Worth knowing about,
 but the core feature stands alone without it.
 
-### 5.4 Verdict
+### 5.4 Ranges: don't pick one, make the source say which
 
-**Strongest single recommendation in this document after §4.** It is
-self-contained, needs no type-system work, lowers trivially in a C backend, and
-it deletes both a known bug class and a chunk of the hand-written C in `std/`
-(§3). Adopt exclusive-or-inclusive ranges deliberately — C3 chose *inclusive*,
-which is a footgun for anyone arriving from Rust/Go/Python.
+C3 hardcodes **inclusive** ranges (`a : 0..2` is three bits) and leaves the
+reader to remember. That is a footgun for anyone arriving from Rust/Go/Python,
+where `0..2` is two elements.
+
+Aether didn't have to choose. It already had `..=` (inclusive) and `..<`
+(exclusive) as real lexer tokens, used by match-range case labels (#1047). So a
+bitstruct field says which it means, and the parser normalises both spellings to
+one internal `[lo, hi]` pair — codegen never has to know which was written:
+
+```aether
+bitstruct Flags : uint8_t {
+    kind: int 1..=3      // inclusive — bits 1,2,3
+    top:  int 5..<8      // exclusive — bits 5,6,7. Same three bits, either way.
+}
+```
+
+**The general lesson** — worth carrying into §10.4, where slices face the same
+question: when a borrowed feature forces an arbitrary convention on the reader,
+check whether the host language already has vocabulary that makes the convention
+explicit. Reaching for existing syntax beat importing C3's default.
+
+### 5.5 Endianness: rejected, because `std.mem` already owns it
+
+**This is the one place we concluded C3 is wrong for Aether**, and it is the most
+useful thing in this section, because the reasoning generalises.
+
+C3's `@bigendian` / `@littleendian` looked like the feature's biggest practical
+payoff (see the gzip example in §5.2). Aether deliberately **did not implement
+it**. There is no endianness annotation on an Aether bitstruct and no hidden
+byte-swapping on field access.
+
+The reason: **`std.mem` already owns byte order, and owns it well.** It has
+endian-explicit, unaligned-safe accessors — `mem.get_u16_be`, `mem.set_u32_le`,
+and the rest of the family — that go through `memcpy` + shifts and which every
+modern compiler folds to a **single load + `bswap`** (or a single load on a
+matching-endian target). See the header comment in `std/mem/aether_mem.c:428-442`,
+which spells out exactly that contract.
+
+So `@bigendian` would have been a **second** implementation of byte-swapping in
+the language, and a worse one, because it makes the swap *implicit*. That raises
+a question the annotation cannot answer cleanly:
+
+> Does the swap happen on **every field read**, or only **at the byte boundary**
+> when the word is serialised?
+
+Neither answer is good. Swapping per field read means a field access silently
+costs a `bswap`. Swapping at the boundary means the type is lying about when its
+representation changes. **This is precisely the class of "the layout does
+something you can't see" ambiguity that makes C bitfields untrustworthy in the
+first place** — which is the entire reason we adopted `bitstruct`. Importing
+`@bigendian` would have smuggled the disease in with the cure.
+
+**Bit layout and byte order are orthogonal concerns, and Aether keeps them
+apart.** A bitstruct says *which bits*; `std.mem` says *which byte order*. The
+composition is one visible line, and there is exactly one place a swap can
+happen:
+
+```aether
+hdr  = mem.get_u16_be(buf, 0) as DnsFlags    // byte order, THEN bit layout
+kind = hdr.opcode                            // pure shift/mask, no hidden swap
+mem.set_u16_be(buf, 0, hdr as uint16_t)      // ...and back out
+```
+
+**The generalisable lesson, and the reason this is worth writing down:** before
+adopting a feature from a survey like this one, check whether the *neighbouring
+stdlib* already solves the sub-problem the feature bundles in. C3 bundles byte
+order into `bitstruct` because C3's `bitstruct` predates a good answer elsewhere.
+Aether has a good answer elsewhere. **A borrowed feature should be cut down to
+the part the host language is actually missing** — copying its full surface area
+imports duplication and implicit behaviour along with the value. That test
+(*"what does our stdlib already own?"*) is worth applying to every remaining
+candidate in this document.
+
+### 5.6 Verdict
+
+**Strongest single recommendation in this document after §4** — and it shipped.
+Self-contained, no type-system work, lowers trivially in a C backend, and it kills
+a real bug class (Aether's extern-struct bitfields are always signed, so a stored
+`0b111` in a 3-bit field read back as `-1`; every unsigned read had to be
+hand-masked). Adopted with two deliberate divergences from C3, both above.
 
 ---
 
@@ -613,7 +702,7 @@ compiler rather than the docs:
 
 | # | Item | Size | Payoff |
 | --- | --- | --- | --- |
-| 1 | **`bitstruct`** (§5) | Small–medium | Kills a known bug class (signed bitfields); deletes C from `std/`; self-contained |
+| ~~1~~ | ~~**`bitstruct`** (§5)~~ | ✅ **SHIPPED** | PR #1132. Killed the signed-bitfield bug class. Adopted with two divergences from C3 (§5.4, §5.5) |
 | 2 | **`defer catch` / `defer try`** (§6) | Small | Fits `(value, err)` today; no dependencies |
 | 3 | **`@nodiscard`** (§7) | Tiny | Free leak guard |
 | 4 | **Compile-time `where`/contract folding** (§10.2) | Small | Concepts-like bounds without a macro system |
@@ -623,6 +712,15 @@ compiler rather than the docs:
 | 8 | Slices (§10.4) | Large | Needs a design pass against Aether's string model first |
 | — | Macros (§10.1) | — | **Decline.** The trailing-block DSL is the better answer |
 
-Items 1–5 are independent, each individually shippable, and together they would
-remove a meaningful fraction of the C in `std/` while closing a real bug class.
-Item 6 is the one worth a design discussion of its own.
+Items 2–5 are independent, each individually shippable, and together they would
+remove a meaningful fraction of the C in `std/`. Item 1 is done. Item 6 is the
+one worth a design discussion of its own.
+
+**A method note, learned from shipping item 1.** Do not port a borrowed feature's
+full surface area. Cut it down to the part the host language is genuinely
+missing, and check first whether the *neighbouring stdlib already owns* the
+sub-problems the feature bundles in — C3's `bitstruct` bundles byte order, but
+`std.mem` already owned that, so we dropped it (§5.5). The same test is worth
+applying to every item above: **what does Aether already have that makes part of
+this redundant?** Answering it before implementing is what kept `bitstruct` small
+and kept a second, implicit byte-swapping mechanism out of the language.


### PR DESCRIPTION
Follow-up to #1130 (the C3 cross-reference survey), now that `bitstruct` has actually shipped (#1132).

Two of §5's recommendations were **revised by contact with the code**. Both are recorded rather than quietly edited away — the point of a cross-reference doc is to save the next reader the walk, *including the parts of the path we backed out of*.

## 1. We rejected C3's `@bigendian` (new §5.5)

The survey called explicit endianness the feature's biggest practical payoff. **It isn't, for Aether** — and the reason generalises, which is why it's worth writing down.

`std.mem` **already owns byte order**: endian-explicit, unaligned-safe accessors (`get_u16_be`, `set_u32_le`, …) that every modern compiler folds to a single `load + bswap`. That's not an inference — it's the stated contract in `std/mem/aether_mem.c:428-442`.

So `@bigendian` would have been a **second** byte-swapping mechanism, and a worse one, because it makes the swap *implicit* and can't cleanly answer:

> Does the swap happen on **every field read**, or only **at the byte boundary** when the word is serialised?

Neither answer is good. And that "the layout does something you can't see" ambiguity is *exactly* the disease we adopted `bitstruct` to cure. Importing `@bigendian` would have smuggled it back in with the medicine.

Bit layout and byte order are orthogonal, and Aether keeps them apart. The composition is one visible line, with exactly one place a swap can happen:

```aether
hdr  = mem.get_u16_be(buf, 0) as DnsFlags    // byte order, THEN bit layout
kind = hdr.opcode                            // pure shift/mask, no hidden swap
```

**The generalisable lesson** (now in §5.5 and §13): before porting a borrowed feature, check whether the **neighbouring stdlib already owns a sub-problem the feature bundles in**, and cut the port down to the part the host language is genuinely missing. C3 bundles byte order into `bitstruct` because C3 lacked a good answer elsewhere. Aether has one. Copying a feature's full surface area imports duplication and implicit behaviour along with the value.

That test — *"what does our stdlib already own?"* — is worth applying to every remaining candidate in the document.

## 2. We improved on C3's inclusive-only ranges (new §5.4)

The survey said to "adopt exclusive-or-inclusive ranges **deliberately**" — C3 hardcodes inclusive (`0..2` is three bits) and leaves the reader to remember, which is a footgun for anyone arriving from Rust/Go/Python.

Aether didn't have to pick. It already had `..=` and `..<` as real lexer tokens, used by match-range case labels (#1047). So the **source says which it means**, and the parser normalises both spellings to one internal representation:

```aether
kind: int 1..=3      // inclusive — bits 1,2,3
top:  int 5..<8      // exclusive — bits 5,6,7. Same three bits, either way.
```

Same lesson applies to §10.4 (slices), which faces exactly this question.

## Housekeeping

Refreshes the §1 summary, the §2 feature table, the §3 "features Aether lacks" claim, and the §13 priority table, so the document stays internally consistent now that item 1 is done.

Docs-only — `[skip actions]` on the commit (not the PR title, so the release pipeline still runs on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)