### PR TITLE
fix(ffi,codegen): exact tuple-param type match + valid struct-pointer tuple typedef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,23 @@ next version number before tagging the release.
   stack garbage past the result (a success can read back as `-255`). `-> byte`
   reads exactly the one byte the ABI wrote.
 
+### Fixed
+
+- **FFI tuple-parameter type matching is now exact, and struct-pointer tuple
+  elements name a valid C type.** Two follow-ups to the #1062 tuple-value
+  parameter support, both surfaced by an adversarial review of that change:
+  - The value-form match compared only `TypeKind`, so a tuple value whose
+    element was an aliased scalar of the same kind (for example `(int, int)`
+    into an `(int8_t, int8_t)` parameter) type-checked and then failed with an
+    opaque C compile error. It now matches on the element's emitted C type name,
+    the same key codegen uses to name the `_tuple_*` struct, so the mismatch is
+    reported cleanly at type-check; matching aliases still pass.
+  - A tuple containing a struct-pointer element (`(*Node, int)`) generated the
+    invalid C identifier `_tuple_Node*_int`, so any use of such a tuple (extern
+    parameter, extern return, or a tuple literal) produced uncompilable output.
+    The tuple-typedef namer now sanitizes non-identifier characters the same way
+    the optional-type namer already does, yielding `_tuple_Node__int`.
+
 ## [0.389.0]
 
 ### Fixed

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -8,6 +8,12 @@
 #include "../aether_error.h"
 #include "../aether_module.h"
 
+// #1062: the canonical C-type-name renderer (codegen.c). The tuple-extern
+// argument check keys on the same C spelling codegen names `_tuple_*` typedefs
+// by, so an aliased scalar (int vs int8_t) or a differing pointer pointee is
+// rejected at type-check instead of deferring to an opaque C compile error.
+extern const char* get_c_type(Type* type);
+
 static int error_count = 0;
 static int warning_count = 0;
 // #891: query the @c_struct overlay name set (defined ~typecheck_program).
@@ -7185,15 +7191,22 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
                     int matches = at && at->kind == TYPE_TUPLE &&
                                   at->tuple_count == p->node_type->tuple_count;
                     for (int ei = 0; matches && ei < p->node_type->tuple_count; ei++) {
-                        TypeKind pk = p->node_type->tuple_types[ei]
-                                      ? p->node_type->tuple_types[ei]->kind : TYPE_UNKNOWN;
-                        TypeKind ak = (at->tuple_types && at->tuple_types[ei])
-                                      ? at->tuple_types[ei]->kind : TYPE_UNKNOWN;
-                        /* Element kinds must produce the same `_tuple_*` C
-                         * typedef. Allow an UNKNOWN arg element (an inference
-                         * gap) to defer to the C compiler rather than
-                         * over-reject a legitimate round-trip. */
-                        if (ak != pk && ak != TYPE_UNKNOWN) matches = 0;
+                        Type* pe = p->node_type->tuple_types[ei];
+                        Type* ae = at->tuple_types ? at->tuple_types[ei] : NULL;
+                        /* Match on the element's emitted C type name, which is
+                         * what codegen keys the `_tuple_*` typedef on, not just
+                         * its TypeKind: `int` and the aliased `int8_t`/`size_t`
+                         * share a kind but produce different C structs, and a
+                         * `ptr` differs from a typed `*Struct` by pointee. An
+                         * arg element with no inferred type (an inference gap)
+                         * is left to the C compiler rather than over-rejected,
+                         * preserving the earlier leniency. */
+                        if (!ae) continue;
+                        const char* pc = pe ? get_c_type(pe) : NULL;
+                        char* pcs = pc ? strdup(pc) : NULL;  /* get_c_type reuses a rotating static buffer */
+                        const char* ac = get_c_type(ae);
+                        if (!pcs || !ac || strcmp(pcs, ac) != 0) matches = 0;
+                        free(pcs);
                     }
                     if (at) free_type(at);
                     if (!matches) {

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1839,7 +1839,18 @@ const char* get_c_type(Type* type) {
                 else if (strcmp(elem, "void*") == 0) elem = "ptr";
                 else if (strcmp(elem, "unsigned char") == 0) elem = "byte";
                 else if (strcmp(elem, "long double") == 0) elem = "longdouble";
-                pos += snprintf(buffer + pos, 256 - pos, "_%s", elem);
+                // Any remaining non-identifier character (the `*` in a
+                // struct-pointer element like `Node*`, or an embedded space)
+                // would make an invalid C typedef name; map it to '_', the
+                // same sanitization the optional-type namer below applies.
+                if (pos < 255) buffer[pos++] = '_';
+                for (const char* e = elem; *e && pos < 255; e++) {
+                    char c = *e;
+                    int ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                             (c >= '0' && c <= '9') || c == '_';
+                    buffer[pos++] = ok ? c : '_';
+                }
+                buffer[pos] = '\0';
             }
             return buffer;
         }

--- a/tests/integration/extern_tuple_var_passthrough/test_extern_tuple_var_passthrough.sh
+++ b/tests/integration/extern_tuple_var_passthrough/test_extern_tuple_var_passthrough.sh
@@ -57,5 +57,49 @@ if "$AE" check "$tmpdir/badkind.ae" >"$tmpdir/badkind.log" 2>&1; then
     exit 1
 fi
 
-echo "  [PASS] extern_tuple_var_passthrough: tuple values (vars + call chains) cross the FFI by value; mismatches rejected"
+# Guard 3 (#1062 follow-up): an aliased-scalar tuple value whose element C type
+# differs from the parameter's is a TYPECHECK error, not a deferred C compile
+# error. `int` and `int8_t` are both TYPE_INT but produce different `_tuple_*`
+# structs, so the check must key on the emitted C type name, not just the kind.
+cat > "$tmpdir/badalias.ae" <<'AE'
+extern make_ii() -> (int, int)
+extern take_bytes(v: (int8_t, int8_t)) -> int
+main() { a = make_ii(); r = take_bytes(a); println("${r}") }
+AE
+if "$AE" check "$tmpdir/badalias.ae" >"$tmpdir/badalias.log" 2>&1; then
+    echo "  [FAIL] extern_tuple_var_passthrough: (int,int) value into (int8_t,int8_t) param passed typecheck"
+    exit 1
+fi
+if ! grep -q "tuple-typed" "$tmpdir/badalias.log"; then
+    echo "  [FAIL] extern_tuple_var_passthrough: alias-mismatch error lacks the tuple diagnostic"
+    exit 1
+fi
+
+# And the matching-alias case still type-checks (no over-rejection).
+cat > "$tmpdir/goodalias.ae" <<'AE'
+extern make_bb() -> (int8_t, int8_t)
+extern take_bytes(v: (int8_t, int8_t)) -> int
+main() { a = make_bb(); r = take_bytes(a); println("${r}") }
+AE
+if ! "$AE" check "$tmpdir/goodalias.ae" >"$tmpdir/goodalias.log" 2>&1; then
+    echo "  [FAIL] extern_tuple_var_passthrough: matching (int8_t,int8_t) value wrongly rejected"
+    sed 's/^/    /' "$tmpdir/goodalias.log" | head -5
+    exit 1
+fi
+
+# Guard 4 (#1062 follow-up): a tuple with a struct-pointer element produces a
+# valid C typedef identifier (the namer sanitizes `Node*` -> `Node_`), so the
+# generated C compiles rather than emitting an invalid `_tuple_Node*_int` name.
+cat > "$tmpdir/structptr.ae" <<'AE'
+struct Node { x: int }
+extern take_np(v: (*Node, int)) -> int
+main() { }
+AE
+if ! "$AE" build "$tmpdir/structptr.ae" -o "$tmpdir/structptr" >"$tmpdir/structptr.log" 2>&1; then
+    echo "  [FAIL] extern_tuple_var_passthrough: (*Node,int) tuple produced invalid C (namer not sanitized):"
+    sed 's/^/    /' "$tmpdir/structptr.log" | head -5
+    exit 1
+fi
+
+echo "  [PASS] extern_tuple_var_passthrough: tuple values cross by value; alias/shape mismatches rejected at type-check; struct-pointer tuples name a valid C typedef"
 exit 0


### PR DESCRIPTION
## Summary

Two follow-up fixes to #1062 (tuple-typed values at tuple extern params, merged in #1129), **both found by an independent adversarial review** of that change rather than by CI or my own tests. The review confirmed there is **no silent runtime miscompile** (the strongest thing it tried); these are the two real defects it did surface.

## Fix 1 (introduced by #1062): exact element type matching

The value-form match in #1129 compared only `TypeKind`. But codegen names the `_tuple_*` typedef by each element's **C spelling** (`get_c_type`, which returns `type->c_alias` for aliased scalars). So a tuple value whose element was an aliased scalar of the same kind was wrongly accepted, then failed downstream:

```aether
extern make_ii() -> (int, int)
extern take_bytes(v: (int8_t, int8_t)) -> int
main() { a = make_ii(); take_bytes(a) }     // #1129: type-checked, then cc error
                                            //   'passing _tuple_int_int to _tuple_int8_t_int8_t'
```

This contradicted the #1129 guarantee that "a value whose shape does not match is rejected at type-check." The check now keys on `get_c_type(element)` (the same name codegen uses), so `int` vs `int8_t` (and a `ptr` vs a typed `*Struct` pointee) is reported cleanly at type-check. **Matching aliases still pass** (`(int8_t,int8_t)` value into an `(int8_t,int8_t)` param round-trips and prints the right value).

## Fix 2 (pre-existing, reachable via #1062): valid struct-pointer tuple typedef

A tuple with a struct-pointer element emitted an invalid C identifier:

```c
typedef struct { Node* _0; int _1; } _tuple_Node*_int;   // '*' is not a valid identifier char
```

So `(*Node, int)` was uncompilable in **any** position (extern parameter, extern return, or a tuple literal), i.e. struct-pointer-in-tuple was effectively unusable. The tuple-typedef namer only remapped four specific spellings; it now sanitizes any remaining non-identifier character the same way the optional-type namer right below it already does, yielding `_tuple_Node__int`.

## Not fixed here (documented)

The review also found a **pre-existing, low-severity** issue unrelated to type matching: passing `_ctx` explicitly to a tuple-param extern misaligns the argument index (the `arg_base` logic assumes `_ctx` was auto-injected). It predates #1062, is niche, and needs the call-site injection logic reworked; left for a separate change.

## Verification

- Regression guards added to `tests/integration/extern_tuple_var_passthrough/`: alias mismatch rejected at type-check, matching alias accepted (no over-rejection), and a struct-pointer tuple compiles.
- Both defects reproduced on `main` before the fix and confirmed resolved after.
- `make test` 234/234, `make examples` 87/87, existing FFI integration tests (`extern_tuple_param`, `extern_tuple_return`, `extern_tuple_var_passthrough`) green, `-Werror` clean.
