### PR TITLE
feat(fs,bytes): fs.pread_into + little-endian bytes.cursor readers (#1102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`fs.pread_into` and little-endian `std.bytes.cursor` readers** (#1102), for
+  copy-free fixed-size block reading of binary files. `fs.pread_into(file, buf,
+  len, offset)` reads up to `len` bytes at `offset` straight into an existing
+  `std.bytes` buffer (clamped to its capacity), sets the buffer's length to the
+  count read, and returns `(n, err)` with the same EOF (`n == 0`) / short-read
+  (`0 < n < len`) / I/O-error (`err != ""`) distinction as `fs.pread`. A
+  fixed-size block reader reuses one buffer across the whole file instead of
+  allocating a fresh string per block; the packed integers are then read in
+  place (`bytes.get_le64`) or walked with a cursor. `std.bytes.cursor` gains
+  `read_le_u16` / `read_le_u32` / `read_le_u64` alongside the existing big-endian
+  readers (same end-of-buffer contract: returns `-1` with the cursor unchanged),
+  so little-endian on-disk formats stream as cleanly as big-endian wire formats.
+  Exercised by `tests/regression/test_fs_pread_into.ae`.
+
 ## [0.398.0]
 
 ### Fixed

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -308,6 +308,8 @@ out = bytes.finish(b, 6)                  // "ABABAB"
 - `bytes.finish(b, length)` → `string` - Hand off to refcounted AetherString; buffer is consumed
 - `bytes.free(b)` - Discard without finishing (idempotent on null)
 
+**Streaming binary reads without a per-block copy (#1102).** A fixed-size block reader (walking 512-byte sectors of a device, say) can read straight into a reused `std.bytes` buffer instead of allocating a fresh string per block: `fs.pread_into(file, buf, len, offset)` reads up to `len` bytes at `offset` directly into `buf` (clamped to its capacity), sets `buf`'s length to the count read, and returns `(n, err)` with the same EOF (`n == 0`) / short-read (`0 < n < len`) / I/O-error (`err != ""`) distinction as `fs.pread`. The packed integers are then read in place with `bytes.get_le64` etc., or walked with a cursor. `std.bytes.cursor` offers both byte orders, `read_be_u16/32/64` and `read_le_u16/32/64` (each returns `-1` and leaves the cursor unchanged at end-of-buffer), so little-endian on-disk formats stream as cleanly as big-endian wire formats.
+
 The build-then-walk pattern needed by binary-codec encoders (svndiff and similar) is what `bytes.get` / `bytes.{set,get}_le32` are for, accumulate packed-int ops into the same buffer via `set_le32` at known offsets, then walk and read each back at finish time:
 
 ```aether

--- a/std/bytes/aether_bytes.c
+++ b/std/bytes/aether_bytes.c
@@ -66,6 +66,24 @@ int aether_bytes_length(AetherBytes* b) {
     return (int)b->length;
 }
 
+int aether_bytes_capacity(AetherBytes* b) {
+    if (!b) return -1;
+    return (int)b->capacity;
+}
+
+void* aether_bytes_data(AetherBytes* b) {
+    if (!b || b->capacity == 0) return NULL;
+    return b->data;
+}
+
+int aether_bytes_set_length(AetherBytes* b, int length) {
+    if (!b) return -1;
+    if (length < 0) length = 0;
+    if ((size_t)length > b->capacity) length = (int)b->capacity;
+    b->length = (size_t)length;
+    return length;
+}
+
 int aether_bytes_set(AetherBytes* b, int index, int byte) {
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 1;

--- a/std/bytes/aether_bytes.h
+++ b/std/bytes/aether_bytes.h
@@ -40,6 +40,25 @@ AetherBytes* aether_bytes_new(int initial_capacity);
 /* Number of bytes the buffer logically contains. -1 if `b` is NULL. */
 int aether_bytes_length(AetherBytes* b);
 
+/* Reserved capacity in bytes (always >= length). -1 if `b` is NULL.
+ * Distinct from length: a buffer created with `aether_bytes_new(512)`
+ * has capacity 512 and length 0. */
+int aether_bytes_capacity(AetherBytes* b);
+
+/* Pointer to the buffer's mutable storage, for zero-copy I/O: a caller
+ * can `read(2)`/`pread(2)` directly into the reserved region (up to
+ * `capacity` bytes) and then publish the byte count with
+ * `aether_bytes_set_length`, avoiding a read-into-temp-then-copy. NULL if
+ * `b` is NULL or its capacity is 0. BORROWED and short-lived: the pointer
+ * is invalidated by any call that may reallocate the buffer (`set`,
+ * `copy_from_*`) and by `aether_bytes_free` / `aether_bytes_finish`. */
+void* aether_bytes_data(AetherBytes* b);
+
+/* Set the buffer's logical length, clamped to [0, capacity]. Used to
+ * publish how many bytes a direct write into `aether_bytes_data`'s region
+ * actually produced. Returns the resulting length, or -1 if `b` is NULL. */
+int aether_bytes_set_length(AetherBytes* b, int length);
+
 /* Write a single byte at `index`. Grows the buffer if needed. The
  * logical length advances to max(length, index + 1) — gaps between
  * the previous tail and `index` are zero-filled. No-op if `b` is

--- a/std/bytes/cursor/aether_bytes_cursor.c
+++ b/std/bytes/cursor/aether_bytes_cursor.c
@@ -70,6 +70,39 @@ long long bytes_cursor_read_be_u64(BytesCursor* c) {
     return (long long)v;
 }
 
+int bytes_cursor_read_le_u16(BytesCursor* c) {
+    if (!c || c->pos + 2 > c->len) return -1;
+    int lo = aether_bytes_get(c->bytes, c->pos);
+    int hi = aether_bytes_get(c->bytes, c->pos + 1);
+    if (lo < 0 || hi < 0) return -1;
+    c->pos += 2;
+    return (hi << 8) | lo;
+}
+
+int bytes_cursor_read_le_u32(BytesCursor* c) {
+    if (!c || c->pos + 4 > c->len) return -1;
+    unsigned int v = 0;
+    for (int i = 0; i < 4; i++) {
+        int b = aether_bytes_get(c->bytes, c->pos + i);
+        if (b < 0) return -1;
+        v |= (unsigned int)b << (8 * i);
+    }
+    c->pos += 4;
+    return (int)v;
+}
+
+long long bytes_cursor_read_le_u64(BytesCursor* c) {
+    if (!c || c->pos + 8 > c->len) return -1;
+    unsigned long long v = 0;
+    for (int i = 0; i < 8; i++) {
+        int b = aether_bytes_get(c->bytes, c->pos + i);
+        if (b < 0) return -1;
+        v |= (unsigned long long)b << (8 * i);
+    }
+    c->pos += 8;
+    return (long long)v;
+}
+
 AetherBytes* bytes_cursor_read_slice(BytesCursor* c, int n) {
     if (!c || n < 0 || c->pos + n > c->len) return NULL;
     AetherBytes* out = aether_bytes_new(n);

--- a/std/bytes/cursor/aether_bytes_cursor.h
+++ b/std/bytes/cursor/aether_bytes_cursor.h
@@ -42,6 +42,17 @@ int bytes_cursor_read_be_u32(BytesCursor* c);
  * than 8 bytes remain (cursor left unchanged). */
 long long bytes_cursor_read_be_u64(BytesCursor* c);
 
+/* Little-endian counterparts of the big-endian readers above: read a
+ * 16/32/64-bit value least-significant-byte-first and advance by 2/4/8.
+ * Same contract, returns -1 (cursor unchanged) when fewer than that many
+ * bytes remain. The 32-bit read returns the bit pattern in an `int`
+ * (top bit becomes the sign bit, as with aether_bytes_get_le32). For
+ * little-endian on-disk formats these let a validation loop walk the
+ * buffer with bounds-checked cursor reads instead of manual indexing. */
+int bytes_cursor_read_le_u16(BytesCursor* c);
+int bytes_cursor_read_le_u32(BytesCursor* c);
+long long bytes_cursor_read_le_u64(BytesCursor* c);
+
 /* Read the next `n` bytes into a freshly-allocated AetherBytes and
  * advance by `n`. Returns NULL if fewer than `n` bytes remain (cursor
  * left unchanged), `n` is negative, or allocation fails. The caller

--- a/std/bytes/cursor/module.ae
+++ b/std/bytes/cursor/module.ae
@@ -21,10 +21,12 @@ exports (
     bytes_cursor_new,
     bytes_cursor_read_u8,
     bytes_cursor_read_be_u16, bytes_cursor_read_be_u32, bytes_cursor_read_be_u64,
+    bytes_cursor_read_le_u16, bytes_cursor_read_le_u32, bytes_cursor_read_le_u64,
     bytes_cursor_read_slice,
     bytes_cursor_remaining, bytes_cursor_peek, bytes_cursor_eof,
     bytes_cursor_pos, bytes_cursor_seek, bytes_cursor_free,
-    new, read_u8, read_be_u16, read_be_u32, read_be_u64, read_slice,
+    new, read_u8, read_be_u16, read_be_u32, read_be_u64,
+    read_le_u16, read_le_u32, read_le_u64, read_slice,
     remaining, peek, eof, pos, seek, free
 )
 
@@ -47,6 +49,14 @@ extern bytes_cursor_read_be_u32(c: ptr) -> int
 // Read a big-endian 64-bit value, advancing by 8. -1 if fewer than 8
 // bytes remain (cursor unchanged).
 extern bytes_cursor_read_be_u64(c: ptr) -> long
+
+// Little-endian counterparts: read a 16/32/64-bit value least-significant
+// byte first, advancing by 2/4/8. Same contract as the big-endian readers
+// (-1, cursor unchanged, when too few bytes remain). For little-endian
+// on-disk formats.
+extern bytes_cursor_read_le_u16(c: ptr) -> int
+extern bytes_cursor_read_le_u32(c: ptr) -> int
+extern bytes_cursor_read_le_u64(c: ptr) -> long
 
 // Read the next `n` bytes into a fresh AetherBytes, advancing by `n`.
 // Returns null if fewer than `n` bytes remain (cursor unchanged), `n`
@@ -106,6 +116,22 @@ read_be_u32(c: ptr) -> int {
 // Read a big-endian 64-bit value, advancing by 8. -1 if too few bytes.
 read_be_u64(c: ptr) -> long {
     return bytes_cursor_read_be_u64(c)
+}
+
+// Read a little-endian 16-bit value, advancing by 2. -1 if too few bytes.
+read_le_u16(c: ptr) -> int {
+    return bytes_cursor_read_le_u16(c)
+}
+
+// Read a little-endian 32-bit value (as an int bit pattern), advancing by
+// 4. -1 if too few bytes.
+read_le_u32(c: ptr) -> int {
+    return bytes_cursor_read_le_u32(c)
+}
+
+// Read a little-endian 64-bit value, advancing by 8. -1 if too few bytes.
+read_le_u64(c: ptr) -> long {
+    return bytes_cursor_read_le_u64(c)
 }
 
 // Read the next `n` bytes into a fresh AetherBytes (caller owns it),

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -4,6 +4,7 @@
 #include "../../runtime/aether_sandbox.h"
 #include "../../runtime/aether_resource_caps.h"
 #include "../string/aether_string.h"
+#include "../bytes/aether_bytes.h"   /* fs_pread_into_raw fills a caller's bytes buffer (#1102) */
 
 #if !AETHER_HAS_FILESYSTEM
 // Stubs when filesystem is unavailable (WASM, embedded)
@@ -88,6 +89,7 @@ int path_is_within_base(const char* base, const char* target) { (void)base; (voi
 char* path_rel(const char* base, const char* target) { (void)base; (void)target; return NULL; }
 int64_t fs_pwrite_raw(File* f, const char* d, int l, int64_t o) { (void)f; (void)d; (void)l; (void)o; return -1; }
 int fs_pread_raw(File* f, int l, int64_t o) { (void)f; (void)l; (void)o; return 0; }
+int fs_pread_into_raw(File* f, AetherBytes* b, int l, int64_t o) { (void)f; (void)b; (void)l; (void)o; return -1; }
 const char* fs_get_pread(void) { return ""; }
 int fs_get_pread_length(void) { return 0; }
 void fs_release_pread(void) {}
@@ -402,6 +404,56 @@ int fs_pread_raw(File* file, int length, int64_t offset) {
     g_pread_cap = alloc;
     g_pread_len = (int)total;
     return 1;
+}
+
+/* Zero-copy sibling of fs_pread_raw (#1102): read up to `length` bytes at
+ * `offset` directly into the caller's `buf` storage, clamped to the
+ * buffer's capacity, then publish the count as its logical length. A
+ * fixed-size block reader can reuse one buffer across a loop instead of
+ * allocating a fresh string per block. Returns the byte count (>= 0; 0 =
+ * EOF, 0 < n < length = short read), or -1 on invalid args / I/O error;
+ * on error the buffer is left empty. */
+int fs_pread_into_raw(File* file, AetherBytes* buf, int length, int64_t offset) {
+    if (!buf) return -1;
+    if (!file || !file->is_open || length < 0 || offset < 0) {
+        aether_bytes_set_length(buf, 0);
+        return -1;
+    }
+    int cap = aether_bytes_capacity(buf);
+    if (cap < 0) { return -1; }
+    if (length > cap) length = cap;          /* clamp to buffer capacity */
+    aether_bytes_set_length(buf, 0);         /* empty until success publishes the count */
+    if (length == 0) return 0;
+
+    unsigned char* dst = (unsigned char*)aether_bytes_data(buf);
+    if (!dst) return -1;
+
+    FILE* fp = (FILE*)file->handle;
+    fflush(fp);
+    int fd = fileno(fp);
+    if (fd < 0) return -1;
+
+    size_t total = 0;
+    while (total < (size_t)length) {
+#ifdef _WIN32
+        if (_fseeki64(fp, offset + (int64_t)total, SEEK_SET) != 0) return -1;
+        size_t r = fread(dst + total, 1, (size_t)length - total, fp);
+        if (r == 0) break;  /* EOF or error: return what we have (short read is success). */
+        total += r;
+#else
+        ssize_t r = pread(fd, dst + total, (size_t)length - total,
+                          (off_t)(offset + (int64_t)total));
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            aether_bytes_set_length(buf, 0);
+            return -1;
+        }
+        if (r == 0) break;  /* EOF: short read is success per the contract. */
+        total += (size_t)r;
+#endif
+    }
+    aether_bytes_set_length(buf, (int)total);
+    return (int)total;
 }
 
 /* ftruncate — set file length to `length` bytes. POSIX truncate(2)

--- a/std/fs/aether_fs.h
+++ b/std/fs/aether_fs.h
@@ -208,6 +208,12 @@ char* path_rel(const char* base, const char* target);
 // _chsize_s / _commit on Windows.
 int64_t     fs_pwrite_raw(File* file, const char* data, int length, int64_t offset);
 int         fs_pread_raw(File* file, int length, int64_t offset);
+/* Zero-copy positional read into a caller-owned std.bytes buffer (#1102):
+ * fills up to `length` bytes at `offset` (clamped to the buffer's capacity)
+ * and sets its logical length. Returns the count read (0 = EOF, short read =
+ * 0 < n < length), or -1 on error (buffer left empty). */
+struct AetherBytes;
+int         fs_pread_into_raw(File* file, struct AetherBytes* buf, int length, int64_t offset);
 const char* fs_get_pread(void);
 int         fs_get_pread_length(void);
 void        fs_release_pread(void);

--- a/std/fs/module.ae
+++ b/std/fs/module.ae
@@ -38,9 +38,9 @@ exports (
     path_join, path_dirname, path_basename, path_extension, path_is_absolute,
     path_clean, path_is_within_base, path_rel,
     clean, is_within_base, rel, join_clean, first_element,
-    fs_pwrite_raw, fs_pread_raw, fs_get_pread, fs_get_pread_length,
+    fs_pwrite_raw, fs_pread_raw, fs_pread_into_raw, fs_get_pread, fs_get_pread_length,
     fs_release_pread, fs_ftruncate_raw, fs_fsync_raw,
-    pwrite, pread, ftruncate, fsync,
+    pwrite, pread, pread_into, ftruncate, fsync,
     file_fd_raw, fd,
     fs_glob_raw, fs_glob_multi_raw,
     fs_walk_raw, fs_watch_open_raw,
@@ -261,6 +261,7 @@ extern path_rel(base: string, target: string) -> string
 // Positional I/O (#640).
 extern fs_pwrite_raw(file: ptr, data: string, length: int, offset: long) -> long
 extern fs_pread_raw(file: ptr, length: int, offset: long) -> int
+extern fs_pread_into_raw(file: ptr, buf: ptr, length: int, offset: long) -> int
 extern fs_get_pread() -> string
 extern fs_get_pread_length() -> int
 extern fs_release_pread()
@@ -866,6 +867,26 @@ pread(file: ptr, length: int, offset: long) -> {
     owned = string_new_with_length(raw, n)
     fs_release_pread()
     return owned, n, ""
+}
+
+// Read up to `length` bytes at `offset` directly into the existing
+// std.bytes buffer `buf` (a `bytes` handle), clamped to the buffer's
+// capacity, with no per-call allocation or copy. After the call `buf`
+// holds the bytes read and its length is the returned count, so
+// bytes.get_le64 / a bytes.cursor can read them in place. This is the
+// copy-free sibling of `pread` for a reused fixed-size block buffer
+// (#1102): reuse one buffer across a loop instead of allocating a fresh
+// string per block.
+//
+// Returns (n, err): `n` is the byte count (n == 0 = EOF, 0 < n < length =
+// short read), `err` is "" on success or a message on I/O error. Same
+// EOF / short-read / error distinction as `pread`.
+pread_into(file: ptr, buf: ptr, length: int, offset: long) -> (int, string) {
+    n = fs_pread_into_raw(file, buf, length, offset)
+    if n < 0 {
+        return 0, "pread_into failed"
+    }
+    return n, ""
 }
 
 // Set the file length to `length` bytes. Extends with zero bytes if

--- a/tests/regression/test_fs_pread_into.ae
+++ b/tests/regression/test_fs_pread_into.ae
@@ -1,0 +1,111 @@
+// Regression test for #1102: fs.pread_into (zero-copy positional read into a
+// reused std.bytes buffer) and the little-endian std.bytes.cursor readers.
+//
+// A fixed-size block reader reuses one buffer across the whole file instead of
+// allocating a fresh string per block, reads little-endian integers in place
+// with bytes.get_le64 and a cursor's read_le_*, and still distinguishes EOF,
+// short read, and I/O error. The copy-free path must match the existing
+// pread + copy_from_string recipe.
+
+import std.fs
+import std.bytes
+import std.bytes.cursor
+import std.io
+
+main() {
+    print("=== fs.pread_into + LE cursor (#1102) ===\n\n")
+
+    // Scratch dir idiom shared with the other std.fs tests.
+    tmp = io.getenv("TMPDIR")
+    if tmp == 0 { tmp = io.getenv("TEMP") }
+    if tmp == 0 { tmp = "/tmp" }
+    path = "${tmp}/aether_test_pread_into.bin"
+    fs.delete(path)
+
+    // Five little-endian u64s (40 bytes). Two carry embedded NUL bytes so the
+    // binary-safe path is exercised.
+    src = bytes.new(40)
+    bytes.set_le64(src, 0, 1)
+    bytes.set_le64(src, 8, 256)                   // 0x0100: low byte 0x00 then 0x01
+    bytes.set_le64(src, 16, 72057594037927936)    // 2^56: seven 0x00 bytes then 0x01
+    bytes.set_le64(src, 24, -1)                    // all 0xFF
+    bytes.set_le64(src, 32, 305419896)             // 0x12345678
+    data = bytes.finish(src, 40)                   // consumes src
+    werr = fs.write_binary(path, data, 40)
+    if werr != "" { print("FAIL write_binary: ${werr}\n"); exit(1) }
+
+    f, ferr = fs.open(path, "r+")
+    if ferr != "" { print("FAIL open: ${ferr}\n"); exit(1) }
+
+    // One 16-byte buffer, reused for every block below (no per-block alloc).
+    blk = bytes.new(16)
+
+    // Block 0 at offset 0: full 16-byte read.
+    n0, e0 = fs.pread_into(f, blk, 16, 0)
+    if e0 != "" { print("FAIL block0 err: ${e0}\n"); exit(1) }
+    if n0 != 16 { print("FAIL block0 n=${n0}, want 16\n"); exit(1) }
+    if bytes.get_le64(blk, 0) != 1 { print("FAIL block0 v0\n"); exit(1) }
+    if bytes.get_le64(blk, 8) != 256 { print("FAIL block0 v1 (embedded NUL)\n"); exit(1) }
+    print("PASS pread_into full block, in-place get_le64\n")
+
+    // Block 1 at offset 16: reuse the SAME buffer, read with a LE cursor.
+    n1, e1 = fs.pread_into(f, blk, 16, 16)
+    if e1 != "" || n1 != 16 { print("FAIL block1 n=${n1} err=${e1}\n"); exit(1) }
+    c, cerr = cursor.new(blk)
+    if cerr != "" { print("FAIL cursor.new: ${cerr}\n"); exit(1) }
+    if cursor.read_le_u64(c) != 72057594037927936 { print("FAIL cursor le64 #0\n"); exit(1) }
+    if cursor.read_le_u64(c) != -1 { print("FAIL cursor le64 #1\n"); exit(1) }
+    if cursor.read_le_u64(c) != -1 { print("FAIL cursor should be exhausted\n"); exit(1) }
+    if cursor.pos(c) != 16 { print("FAIL cursor advanced on failed read\n"); exit(1) }
+    cursor.free(c)
+    print("PASS reused buffer, cursor read_le_u64\n")
+
+    // Block at offset 32: only 8 bytes remain -> short read (0 < n < len).
+    n2, e2 = fs.pread_into(f, blk, 16, 32)
+    if e2 != "" { print("FAIL short-read err: ${e2}\n"); exit(1) }
+    if n2 != 8 { print("FAIL short read n=${n2}, want 8\n"); exit(1) }
+    if bytes.get_le64(blk, 0) != 305419896 { print("FAIL short-read value\n"); exit(1) }
+    print("PASS short read reports n=8\n")
+
+    // Read at EOF (offset 40): n == 0, no error.
+    n3, e3 = fs.pread_into(f, blk, 16, 40)
+    if e3 != "" { print("FAIL eof err: ${e3}\n"); exit(1) }
+    if n3 != 0 { print("FAIL eof n=${n3}, want 0\n"); exit(1) }
+    print("PASS EOF reports n=0\n")
+
+    // len is clamped to the buffer capacity: ask for more than 16, still get 16.
+    n4, e4 = fs.pread_into(f, blk, 999, 0)
+    if e4 != "" { print("FAIL clamp err: ${e4}\n"); exit(1) }
+    if n4 != 16 { print("FAIL clamp n=${n4}, want 16 (buffer capacity)\n"); exit(1) }
+    print("PASS len clamped to buffer capacity\n")
+
+    // Copy-free path matches the pread + copy_from_string recipe byte-for-byte.
+    payload, pn, perr = fs.pread(f, 16, 0)
+    if perr != "" || pn != 16 { print("FAIL recipe pread: n=${pn} err=${perr}\n"); exit(1) }
+    recipe = bytes.new(16)
+    bytes.copy_from_string(recipe, 0, payload, 16)
+    fs.pread_into(f, blk, 16, 0)
+    if bytes.get_le64(blk, 0) != bytes.get_le64(recipe, 0) { print("FAIL recipe mismatch @0\n"); exit(1) }
+    if bytes.get_le64(blk, 8) != bytes.get_le64(recipe, 8) { print("FAIL recipe mismatch @8\n"); exit(1) }
+    print("PASS copy-free path matches pread + copy_from_string\n")
+
+    // LE cursor 16/32-bit readers over a hand-built buffer.
+    small = bytes.new(6)
+    bytes.set_le16(small, 0, 4660)          // 0x1234
+    bytes.set_le32(small, 2, 287454020)     // 0x11223344
+    sc, scerr = cursor.new(small)
+    if scerr != "" { print("FAIL small cursor.new\n"); exit(1) }
+    if cursor.read_le_u16(sc) != 4660 { print("FAIL le16\n"); exit(1) }
+    if cursor.read_le_u32(sc) != 287454020 { print("FAIL le32\n"); exit(1) }
+    if cursor.read_le_u16(sc) != -1 { print("FAIL le16 past end\n"); exit(1) }
+    if cursor.pos(sc) != 6 { print("FAIL le16 cursor moved on failed read\n"); exit(1) }
+    cursor.free(sc)
+    print("PASS cursor read_le_u16 / read_le_u32\n")
+
+    fs.file_close(f)
+    fs.delete(path)
+    bytes.free(blk)
+    bytes.free(recipe)
+    bytes.free(small)
+    print("\nAll pread_into + LE cursor checks passed.\n")
+}


### PR DESCRIPTION
## Summary

Closes #1102. Two small, self-contained additions to the binary I/O path so a fixed-size block reader can avoid a per-block copy and read little-endian integers straight out of a streamed buffer, the two gaps the F3 (Fight Flash Fraud) port hit.

## 1. `fs.pread_into` (copy-free positional read)

```aether
n, err = fs.pread_into(file, buf, len, offset)
```

Reads up to `len` bytes at `offset` **directly into an existing `std.bytes` buffer** (clamped to its capacity), sets the buffer's length to the count read, and returns `(n, err)` with the **same EOF (`n == 0`) / short-read (`0 < n < len`) / I/O-error (`err != ""`) distinction as `fs.pread`**. A fixed-size block reader reuses one buffer across the whole file instead of allocating a fresh string per block:

```aether
blk = bytes.new(512)
loop:
    n, err = fs.pread_into(file, blk, 512, off)   // no per-block alloc
    // read packed ints in place: bytes.get_le64(blk, i) or a cursor
```

Where `fs.pread` returns a length-bearing string (forcing a string->bytes copy per block before `bytes.get_le64`), `pread_into` removes that copy. It is the zero-copy sibling of the existing `fs_pread_raw`: same platform read loop (POSIX `pread(2)`, EINTR-safe; Windows `_fseeki64`+`fread`), writing into the caller's buffer.

Backed by three new byte-buffer primitives in `std.bytes` (`aether_bytes_capacity` / `aether_bytes_data` / `aether_bytes_set_length`) so `fs` can read straight into the buffer's storage. These are the standard reserve/commit zero-copy pattern (cf. Rust `spare_capacity_mut`+`set_len`); no raw data pointer is exposed to Aether code.

## 2. Little-endian `std.bytes.cursor` readers

`read_le_u16` / `read_le_u32` / `read_le_u64`, mirroring the existing big-endian readers with the same contract (return `-1` and leave the cursor unchanged at end-of-buffer). Little-endian on-disk formats can now walk a buffer with bounds-checked cursor reads instead of manual index arithmetic, just like big-endian wire formats.

## Verification

`tests/regression/test_fs_pread_into.ae` (runs standalone in the `.ae` suite, cross-platform temp path) covers every acceptance criterion:
- reused-buffer block reads with no per-block allocation,
- in-place `bytes.get_le64` and cursor `read_le_u16/u32/u64`,
- embedded NUL bytes survive,
- short read (`n=8`), EOF (`n=0`), and `len` clamped to buffer capacity,
- byte-for-byte match with the existing `pread` + `copy_from_string` recipe.

`make test` 234/234, `make examples` 87/87, `stdlib` `-Werror` clean, and `leaks --atExit` reports **0 leaks** on the reused-buffer hot path.
