### PR TITLE
fix(codegen): free heap-backed string? locals at scope exit

### DIFF
--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -509,6 +509,12 @@ CodeGenerator* create_code_generator(FILE* output) {
     gen->seq_var_count = 0;
     gen->escaped_seq_vars = NULL;
     gen->escaped_seq_var_count = 0;
+    // `string?` heap-ownership tracking — same zero-init requirement as
+    // the seq registry above (field-initialised, not calloc'd).
+    gen->opt_str_vars = NULL;
+    gen->opt_str_var_count = 0;
+    gen->escaped_opt_str_vars = NULL;
+    gen->escaped_opt_str_var_count = 0;
     // Ask/reply type map
     gen->reply_type_map = NULL;
     gen->reply_type_count = 0;
@@ -588,6 +594,7 @@ void free_code_generator(CodeGenerator* gen) {
         }
         clear_heap_string_vars(gen);
     clear_seq_vars(gen);
+    clear_opt_str_vars(gen);
         clear_escaped_string_vars(gen);
         clear_try_clobbered_vars(gen);  /* Issue #501 follow-up */
         if (gen->message_registry) {
@@ -857,6 +864,62 @@ void clear_seq_vars(CodeGenerator* gen) {
     gen->escaped_seq_var_count = 0;
 }
 
+/* ---- `string?` (optional-of-string) heap registry ----
+ * Parallel to the seq registry above, but frees `<name>.val` (guarded by
+ * both the `_heapopt_<name>` ownership flag and the struct's `.has` bit)
+ * via aether_heap_str_free. See the header comment on `opt_str_vars`. */
+int is_opt_str_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return 0;
+    for (int i = 0; i < gen->opt_str_var_count; i++) {
+        if (strcmp(gen->opt_str_vars[i], var_name) == 0) return 1;
+    }
+    return 0;
+}
+
+void mark_opt_str_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return;
+    if (is_opt_str_var(gen, var_name)) return;
+    char** nv = realloc(gen->opt_str_vars, sizeof(char*) * (gen->opt_str_var_count + 1));
+    if (!nv) return;
+    gen->opt_str_vars = nv;
+    gen->opt_str_vars[gen->opt_str_var_count++] = strdup(var_name);
+}
+
+int is_escaped_opt_str_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return 0;
+    for (int i = 0; i < gen->escaped_opt_str_var_count; i++) {
+        if (strcmp(gen->escaped_opt_str_vars[i], var_name) == 0) return 1;
+    }
+    return 0;
+}
+
+void mark_escaped_opt_str_var(CodeGenerator* gen, const char* var_name) {
+    if (!gen || !var_name) return;
+    if (is_escaped_opt_str_var(gen, var_name)) return;
+    char** nv = realloc(gen->escaped_opt_str_vars,
+                        sizeof(char*) * (gen->escaped_opt_str_var_count + 1));
+    if (!nv) return;
+    gen->escaped_opt_str_vars = nv;
+    gen->escaped_opt_str_vars[gen->escaped_opt_str_var_count++] = strdup(var_name);
+}
+
+void clear_opt_str_vars(CodeGenerator* gen) {
+    if (!gen) return;
+    if (gen->opt_str_vars) {
+        for (int i = 0; i < gen->opt_str_var_count; i++) free(gen->opt_str_vars[i]);
+        free(gen->opt_str_vars);
+    }
+    gen->opt_str_vars = NULL;
+    gen->opt_str_var_count = 0;
+    if (gen->escaped_opt_str_vars) {
+        for (int i = 0; i < gen->escaped_opt_str_var_count; i++)
+            free(gen->escaped_opt_str_vars[i]);
+        free(gen->escaped_opt_str_vars);
+    }
+    gen->escaped_opt_str_vars = NULL;
+    gen->escaped_opt_str_var_count = 0;
+}
+
 /* Return-escape sibling. See the header comment on
  * `return_escaped_string_vars` for the two-set rationale. */
 int is_return_escaped_string_var(CodeGenerator* gen, const char* var_name) {
@@ -1077,6 +1140,28 @@ static int try_emit_seq_exit_free(CodeGenerator* gen, ASTNode* deferred) {
     return 1;
 }
 
+/* `string?` scope-exit free carrier. Annotation: "opt_str_exit_free:<name>".
+ * Frees the optional's `.val` buffer when the slot both currently owns a
+ * heap allocation (`_heapopt_<name>`, set from is_heap_string_expr on the
+ * coerced RHS) AND is present (`.has`). aether_heap_str_free dispatches on
+ * the AetherString magic header, so a borrowed literal would be a no-op
+ * even if it slipped through — but the flag guard keeps it precise. The
+ * flag/`.has` reset keeps a re-emitted drain (multiple return sites)
+ * idempotent. */
+static int try_emit_opt_str_exit_free(CodeGenerator* gen, ASTNode* deferred) {
+    if (!deferred || !deferred->annotation) return 0;
+    const char* prefix = "opt_str_exit_free:";
+    size_t plen = strlen(prefix);
+    if (strncmp(deferred->annotation, prefix, plen) != 0) return 0;
+    const char* name = deferred->annotation + plen;
+    if (!*name) return 0;
+    print_indent(gen);
+    fprintf(gen->output,
+            "/* deferred */ if (_heapopt_%s && %s.has) { aether_heap_str_free((void*)%s.val); %s.val = NULL; %s.has = 0; _heapopt_%s = 0; }\n",
+            name, name, name, name, name, name);
+    return 1;
+}
+
 /* Struct-destructor defer carrier (#465). Annotation:
  *   "struct_destroy:<varname>:<StructName>"
  * Pushed by the struct-local-declaration site in codegen_stmt.c
@@ -1161,6 +1246,7 @@ static void emit_deferred_one(CodeGenerator* gen, int i) {
 
     if (!try_emit_heap_string_exit_free(gen, deferred) &&
         !try_emit_seq_exit_free(gen, deferred) &&
+        !try_emit_opt_str_exit_free(gen, deferred) &&
         !try_emit_struct_destroy(gen, deferred)) {
         print_indent(gen);
         fprintf(gen->output, "/* deferred%s */ ",
@@ -3481,6 +3567,7 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
     clear_declared_vars(gen);  // Reset for main function
     clear_heap_string_vars(gen);
     clear_seq_vars(gen);
+    clear_opt_str_vars(gen);
     clear_escaped_string_vars(gen);
     clear_try_clobbered_vars(gen);  /* Issue #501 follow-up */
     // Reset defer state for main function and enter scope
@@ -3554,8 +3641,10 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
             mark_try_clobbered_vars(gen, main->children[0]);
             hoist_heap_string_trackers(gen, main->children[0]);
             hoist_seq_trackers(gen, main->children[0]);
+            hoist_opt_str_trackers(gen, main->children[0]);
             mark_escaped_heap_string_vars(gen, main->children[0]);
             mark_escaped_seq_vars(gen, main->children[0]);
+            mark_escaped_opt_str_vars(gen, main->children[0]);
             /* Mirror the regular-function path in
              * codegen_func.c::generate_function_definition: push a
              * function-exit defer-free for every non-escaped
@@ -3573,6 +3662,7 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main) {
              * a buffer the user already released manually. */
             push_heap_string_exit_free_defers(gen, main->children[0]);
             push_seq_exit_free_defers(gen, main->children[0]);
+            push_opt_str_exit_free_defers(gen, main->children[0]);
         }
         generate_statement(gen, main->children[0]);
         gen->current_promoted_captures = prev_promoted;

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -441,6 +441,22 @@ typedef struct {
     char** escaped_seq_vars;
     int escaped_seq_var_count;
 
+    // `string?` (optional-of-string) locals whose `.val` may own a heap
+    // allocation. Parallel to heap_string_vars, but the value is a by-value
+    // `ae_opt_string` struct (`{ int has; const char* val; }`), so the free
+    // targets `<name>.val` guarded by `<name>.has`. The struct's `.has` bit
+    // alone can't tell a heap `.val` from a borrowed literal, so a
+    // `_heapopt_<name>` flag tracks ownership exactly like `_heap_<name>`
+    // does for bare strings — set from is_heap_string_expr on the coerced
+    // initializer/reassignment RHS. The prior `.val` is freed on reassign
+    // and at scope exit via aether_heap_str_free. escaped_opt_str_vars
+    // suppresses the exit-free when the optional is `return`ed (the caller
+    // owns the buffer).
+    char** opt_str_vars;
+    int opt_str_var_count;
+    char** escaped_opt_str_vars;
+    int escaped_opt_str_var_count;
+
     // Ask/reply type map: request message name -> reply message name.
     // Built by scanning actor receive handlers for reply statements.
     struct ReplyTypeEntry {

--- a/compiler/codegen/codegen_actor.c
+++ b/compiler/codegen/codegen_actor.c
@@ -240,6 +240,7 @@ void generate_actor_definition(CodeGenerator* gen, ASTNode* actor) {
                         clear_declared_vars(gen);
                         clear_heap_string_vars(gen);
     clear_seq_vars(gen);
+    clear_opt_str_vars(gen);
                         print_line(gen, "%s* _pattern = (%s*)_msg_data;", pattern->value, pattern->value);
                         mark_var_declared(gen, "_pattern");
 

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -1052,6 +1052,7 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
     clear_declared_vars(gen);  // Reset for each function
     clear_heap_string_vars(gen);
     clear_seq_vars(gen);
+    clear_opt_str_vars(gen);
     clear_escaped_string_vars(gen);
     clear_try_clobbered_vars(gen);  /* Issue #501 follow-up — per-fn set */
 
@@ -1264,6 +1265,10 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             // refcount-decrement scope-exit free (parallel to the
             // heap-string passes immediately around this).
             hoist_seq_trackers(gen, body);
+            // `string?` locals: hoist their _heapopt flags + function-
+            // scope decl, mark escapes, and push the scope-exit free of
+            // the owned `.val` buffer (parallel to the seq passes).
+            hoist_opt_str_trackers(gen, body);
             // Mark heap-string vars that escape via call argument or
             // closure capture. The wrapper at codegen_stmt.c:1611
             // skips its `free(_tmp_old)` for escaped vars to avoid
@@ -1272,6 +1277,7 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             // cost of leaking the value over the function's lifetime.
             mark_escaped_heap_string_vars(gen, body);
             mark_escaped_seq_vars(gen, body);
+            mark_escaped_opt_str_vars(gen, body);
             // Push a function-exit defer-free for every non-escaped
             // hoisted heap-string var (#420 follow-up). The
             // wrapper-on-reassignment frees the previous value on
@@ -1282,6 +1288,7 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
             // every explicit return.
             push_heap_string_exit_free_defers(gen, body);
             push_seq_exit_free_defers(gen, body);
+            push_opt_str_exit_free_defers(gen, body);
         }
         // If body is a block, it handles its own scope
         // If not a block, we still need to generate the statements
@@ -1684,6 +1691,7 @@ void generate_combined_function(CodeGenerator* gen, ASTNode** clauses, int claus
     clear_declared_vars(gen);
     clear_heap_string_vars(gen);
     clear_seq_vars(gen);
+    clear_opt_str_vars(gen);
     clear_try_clobbered_vars(gen);  /* Issue #501 follow-up — per-fn set */
 
     // Generate each clause as an if/else-if branch

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -57,6 +57,11 @@ void mark_seq_var(CodeGenerator* gen, const char* var_name);
 void clear_seq_vars(CodeGenerator* gen);
 int is_escaped_seq_var(CodeGenerator* gen, const char* var_name);
 void mark_escaped_seq_var(CodeGenerator* gen, const char* var_name);
+int is_opt_str_var(CodeGenerator* gen, const char* var_name);
+void mark_opt_str_var(CodeGenerator* gen, const char* var_name);
+void clear_opt_str_vars(CodeGenerator* gen);
+int is_escaped_opt_str_var(CodeGenerator* gen, const char* var_name);
+void mark_escaped_opt_str_var(CodeGenerator* gen, const char* var_name);
 /* Classifier: does the expression produce an OWNED *StringSeq (a fresh
  * ref the caller must free), vs a borrowed spine pointer (seq_tail)?
  * Defined in codegen_stmt.c. */
@@ -217,6 +222,11 @@ void push_heap_string_exit_free_defers(CodeGenerator* gen, ASTNode* body);
 void hoist_seq_trackers(CodeGenerator* gen, ASTNode* body);
 void mark_escaped_seq_vars(CodeGenerator* gen, ASTNode* body);
 void push_seq_exit_free_defers(CodeGenerator* gen, ASTNode* body);
+
+/* `string?` heap-ownership lifecycle (parallel to the seq passes). */
+void hoist_opt_str_trackers(CodeGenerator* gen, ASTNode* body);
+void mark_escaped_opt_str_vars(CodeGenerator* gen, ASTNode* body);
+void push_opt_str_exit_free_defers(CodeGenerator* gen, ASTNode* body);
 
 /* Actor generation (codegen_actor.c) */
 void generate_actor_definition(CodeGenerator* gen, ASTNode* actor);

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1749,6 +1749,19 @@ static void collect_heap_string_var_names(CodeGenerator* gen, ASTNode* node,
          * value persists for the process lifetime, mirroring the
          * scalar/#701 model. This matches how hoist_loop_vars and the
          * if-branch hoists already skip module globals by name. */
+        /* An optional-typed LHS (`b: string? = <string>`) is an
+         * `ae_opt_string`, NOT a bare `const char*`. Without this guard
+         * the initializer-type check below grabs it (the RHS is
+         * TYPE_STRING), hoists a `const char* b`, and the optional
+         * decl-site then assigns an `ae_opt_string` struct into that
+         * `char*` slot — a C type error. Optional-of-string locals are
+         * owned exclusively by the opt-str registry
+         * (collect_opt_str_var_names); skip them here. */
+        if (node->node_type && node->node_type->kind == TYPE_OPTIONAL) {
+            for (int i = 0; i < node->child_count; i++)
+                collect_heap_string_var_names(gen, node->children[i], names, count, cap);
+            return;
+        }
         // Decide whether this declaration's LHS deserves a tracker.
         // Bare `_` is a per-use discard, never a tracked variable —
         // skipped here so a string-typed `_` destructure slot doesn't
@@ -1936,6 +1949,117 @@ void hoist_seq_trackers(CodeGenerator* gen, ASTNode* body) {
         if (is_promoted_capture(gen, name)) continue;
         print_indent(gen);
         fprintf(gen->output, "StringSeq* %s = NULL;\n", name);
+        mark_var_declared(gen, name);
+    }
+}
+
+/* True for a `string?` type: an optional wrapping a bare string. The
+ * heap-ownership tracking only applies to string payloads (scalar
+ * optionals like `int?` carry no allocation). */
+static int is_opt_string_type(Type* t) {
+    return t && t->kind == TYPE_OPTIONAL &&
+           t->element_type && t->element_type->kind == TYPE_STRING;
+}
+
+/* Does the RHS of a `string? = <rhs>` assignment produce an optional
+ * whose `.val` is a freshly-owned heap buffer this slot must free?
+ *
+ * Two provenance cases, mirroring emit_optional_coerced:
+ *   - WRAP (a bare string value coerced into the optional): owned iff
+ *     the value is a heap producer (is_heap_string_expr).
+ *   - PASSTHROUGH (the RHS is already a `string?`): owned only when it
+ *     is a function call returning `string?` — the callee transfers
+ *     ownership of `.val` to us (its return-escape suppression means it
+ *     will NOT free the buffer). An identifier passthrough (`o = other`)
+ *     is an alias, NOT an ownership transfer: treating it as owned would
+ *     double-free when both locals' exit-frees fire, so it stays
+ *     unowned and the source local frees it. Other optional-yielding
+ *     shapes (`??`, `?.`, match-expr) may borrow, so also unowned —
+ *     conservative: never double-frees, at worst leaks a rare case. */
+static int is_heap_opt_string_rhs(CodeGenerator* gen, ASTNode* rhs) {
+    if (!rhs) return 0;
+    if (rhs->type == AST_NONE_LITERAL) return 0;
+    /* A bare identifier RHS — `b = a` where `a` names a heap-string or
+     * another opt-str local — is an ALIAS, not an ownership transfer:
+     * the source local already owns the buffer and will free it. Taking
+     * ownership here too would double-free. Leave `b` unowned; the
+     * source's tracker reclaims the buffer. (True ownership arrives only
+     * via a fresh producer — a call or a heap-string expression that
+     * isn't itself a tracked slot.) */
+    if (rhs->type == AST_IDENTIFIER && rhs->value &&
+        (is_heap_string_var(gen, rhs->value) || is_opt_str_var(gen, rhs->value))) {
+        return 0;
+    }
+    if (rhs->node_type && rhs->node_type->kind == TYPE_OPTIONAL) {
+        return rhs->type == AST_FUNCTION_CALL;
+    }
+    return is_heap_string_expr(gen, rhs);
+}
+
+/* Collect `string?` local declaration names (parallel to
+ * collect_seq_var_names). Keyed on the LHS or initializer carrying a
+ * `string?` type. */
+static void collect_opt_str_var_names(CodeGenerator* gen, ASTNode* node,
+                                      const char** names, int* count, int cap) {
+    if (!node || *count >= cap) return;
+    if (node->type == AST_VARIABLE_DECLARATION && node->value &&
+        strcmp(node->value, "_") != 0 &&
+        !is_module_global_var(gen, node->value)) {
+        int is_opt = is_opt_string_type(node->node_type);
+        if (!is_opt && node->child_count > 0 && node->children[0] &&
+            is_opt_string_type(node->children[0]->node_type)) {
+            is_opt = 1;
+        }
+        if (is_opt) {
+            int already = 0;
+            for (int i = 0; i < *count; i++)
+                if (strcmp(names[i], node->value) == 0) { already = 1; break; }
+            if (!already && *count < cap) names[(*count)++] = node->value;
+        }
+    }
+    for (int i = 0; i < node->child_count; i++)
+        collect_opt_str_var_names(gen, node->children[i], names, count, cap);
+}
+
+/* Hoist `int _heapopt_<name> = 0;` + the function-scope `ae_opt_string
+ * <name> = (ae_opt_string){0};` declaration for every `string?` local,
+ * mirroring hoist_seq_trackers. Function-scope hoisting lets the
+ * scope-exit defer-free always reference the slot, and routes every
+ * assignment (including the first) through the reassignment path so the
+ * ownership flag is maintained and the prior `.val` is freed. */
+void hoist_opt_str_trackers(CodeGenerator* gen, ASTNode* body) {
+    if (!body || !gen) return;
+    const char* names[256];
+    int count = 0;
+    collect_opt_str_var_names(gen, body, names, &count, 256);
+    for (int i = 0; i < count; i++) {
+        const char* name = names[i];
+        if (!is_opt_str_var(gen, name)) {
+            print_indent(gen);
+            fprintf(gen->output,
+                    "int _heapopt_%s = 0; (void)_heapopt_%s;\n", name, name);
+            mark_opt_str_var(gen, name);
+        }
+        if (is_var_declared(gen, name)) continue;
+        /* Actor state vars (accessed via self->name), env captures and
+         * promoted captures don't live as a plain function-scope
+         * `ae_opt_string` — skip the C-var hoist for them, exactly as
+         * hoist_seq_trackers / hoist_heap_string_trackers do. */
+        if (gen->current_actor) {
+            int is_state = 0;
+            for (int s = 0; s < gen->state_var_count; s++)
+                if (gen->actor_state_vars[s] &&
+                    strcmp(gen->actor_state_vars[s], name) == 0) { is_state = 1; break; }
+            if (is_state) continue;
+        }
+        int is_env_cap = 0;
+        for (int e = 0; e < gen->current_env_capture_count; e++)
+            if (gen->current_env_captures[e] &&
+                strcmp(gen->current_env_captures[e], name) == 0) { is_env_cap = 1; break; }
+        if (is_env_cap) continue;
+        if (is_promoted_capture(gen, name)) continue;
+        print_indent(gen);
+        fprintf(gen->output, "ae_opt_string %s = (ae_opt_string){0};\n", name);
         mark_var_declared(gen, name);
     }
 }
@@ -2338,6 +2462,37 @@ static int is_nonstoring_builtin(const char* fn) {
            strcmp(fn, "_aether_safe_str") == 0;
 }
 
+/* Does argument position `arg_idx` of `call` escape — i.e. might the
+ * callee store the pointer beyond the call? Shared by the heap-string
+ * and `string?` escape walks so both apply identical precision (a
+ * read-only `string`/`string?` param does NOT escape, which is what
+ * keeps `string.length(s)` and `sink(opt)` from leaking; a `ptr`/
+ * unknown/`@retain` param does). Encapsulates the type-kind check, the
+ * non-storing-builtin allowlist, the visible-body interprocedural walk,
+ * and the extern-retain annotation. */
+static int call_arg_position_escapes(CodeGenerator* gen, ASTNode* call,
+                                     int arg_idx) {
+    if (!call) return 1;
+    char fn_norm[256];
+    const char* fn = call->value
+        ? codegen_normalise_callee(call->value, fn_norm, sizeof(fn_norm))
+        : NULL;
+    if (fn && is_nonstoring_builtin(fn)) return 0;
+    if (fn && is_retain_extern_param(gen, fn, arg_idx)) return 1;
+    if (callee_has_visible_body(gen, call->value)) {
+        /* Visible body → the body-walk is authoritative (sees through
+         * read-only accessors, ignores self-assignment `p = p`). */
+        return callee_param_escapes_via_body(gen, call->value, arg_idx, 0);
+    }
+    /* No visible body (extern / unknown): a `string`-typed param looks
+     * read-only to call_arg_escapes, but a storing wrapper lets it
+     * escape — keep both the kind check and the (no-body → 0) body
+     * walk so unknown callees stay conservatively escaped. */
+    TypeKind k = lookup_callee_param_kind(gen, call->value, arg_idx);
+    return call_arg_escapes(k) ||
+           callee_param_escapes_via_body(gen, call->value, arg_idx, 0);
+}
+
 static void escape_inspect_call_args(CodeGenerator* gen, ASTNode* call,
                                       const char* consumed_lhs) {
     if (!call) return;
@@ -2347,60 +2502,15 @@ static void escape_inspect_call_args(CodeGenerator* gen, ASTNode* call,
         ASTNode* arg = call->children[i];
         if (!arg) continue;
         if (arg->type == AST_IDENTIFIER && arg->value) {
-            /* Bare identifier in argument position. */
+            /* Bare identifier in argument position. See
+             * call_arg_position_escapes for the escape rationale
+             * (read-only string/scalar params don't escape; ptr/
+             * unknown/@retain do). */
             if (is_heap_string_var(gen, arg->value) &&
                 (consumed_lhs == NULL ||
                  strcmp(arg->value, consumed_lhs) != 0)) {
-                /* Type-based escape: only mark escaped if the callee's
-                 * matching parameter is `ptr` (storage likely) or
-                 * unknown (safe-default). Read-only scalar/string
-                 * parameters don't escape — that's the precision that
-                 * keeps `string.length(s)` from leaking.
-                 *
-                 * Exception: a parameter explicitly annotated `@retain`
-                 * tells the walker the function stores the pointer
-                 * beyond the call (string_list_add, map_put_raw's
-                 * key, etc.). Mark escaped regardless of TypeKind so
-                 * the function-exit defer-free skips the free —
-                 * otherwise the stored copy would dangle. The
-                 * lookup is dot-normalised internally so it works
-                 * for both bare and namespaced call sites
-                 * (e.g. `collections.string_list_add` and
-                 * `string_list_add` resolve to the same registry
-                 * entry). */
-                char fn_norm[256];
-                const char* fn = call->value
-                    ? codegen_normalise_callee(call->value, fn_norm, sizeof(fn_norm))
-                    : NULL;
-                if (fn && is_nonstoring_builtin(fn)) {
-                    /* Provably non-storing (print family) — not an
-                     * escape; leave the variable freeable so its
-                     * reassignment-free wrapper fires. */
-                } else if (fn && is_retain_extern_param(gen, fn, i)) {
+                if (call_arg_position_escapes(gen, call, i)) {
                     mark_escaped_string_var(gen, arg->value);
-                } else if (callee_has_visible_body(gen, call->value)) {
-                    /* Visible body → the body-walk is authoritative
-                     * (it sees through read-only accessors and ignores
-                     * self-assignment `p = p`). Trust it instead of the
-                     * conservative call_arg_escapes, so a heap local
-                     * passed to a non-storing user shim (a no-op-free
-                     * stub, an assert helper) stays freeable and its
-                     * reassignment-free / scope-exit free fires.
-                     * Mirrors the arg-drain gate in codegen_expr.c. */
-                    if (callee_param_escapes_via_body(gen, call->value, i, 0)) {
-                        mark_escaped_string_var(gen, arg->value);
-                    }
-                } else {
-                    TypeKind k = lookup_callee_param_kind(gen, call->value, i);
-                    /* No visible body (extern / unknown): a `string`-typed
-                     * param looks read-only to call_arg_escapes, but a
-                     * storing wrapper lets it escape — keep both the
-                     * conservative kind check and the (no-body → 0) body
-                     * walk so unknown callees stay conservatively escaped. */
-                    if (call_arg_escapes(k) ||
-                        callee_param_escapes_via_body(gen, call->value, i, 0)) {
-                        mark_escaped_string_var(gen, arg->value);
-                    }
                 }
             }
         } else {
@@ -2712,6 +2822,125 @@ void push_seq_exit_free_defers(CodeGenerator* gen, ASTNode* body) {
         if (is_promoted_capture(gen, name)) continue;
         char annot[300];
         snprintf(annot, sizeof(annot), "seq_exit_free:%s", name);
+        ASTNode* carrier = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
+                                            body->line, body->column);
+        if (carrier) {
+            if (carrier->annotation) free(carrier->annotation);
+            carrier->annotation = strdup(annot);
+            push_defer(gen, carrier);
+        }
+    }
+}
+
+/* Escape pre-pass for `string?` locals. Unlike the two-channel
+ * heap-string analysis, a `string?` uses a SINGLE escape set: any
+ * ownership departure — `return`, capture by a closure, a raw store
+ * into a struct field / array element, or being passed to any function
+ * (which may stash the `.val` pointer) — suppresses the scope-exit
+ * free entirely. This is conservative (an in-loop-reassigned optional
+ * that also escapes keeps its intermediate buffers to scope exit
+ * rather than freeing them at each reassign), but it can never
+ * double-free a buffer the recipient still holds. The RHS-of-own-
+ * assignment exception (`o = f(o)`) keeps a self-referential rebind
+ * from marking itself escaped. */
+static void opt_str_escape_walk(CodeGenerator* gen, ASTNode* node,
+                                const char* consumed_lhs) {
+    if (!node) return;
+    if (node->type == AST_RETURN_STATEMENT) {
+        for (int i = 0; i < node->child_count; i++) {
+            ASTNode* c = node->children[i];
+            if (c && c->type == AST_IDENTIFIER && c->value &&
+                is_opt_str_var(gen, c->value)) {
+                mark_escaped_opt_str_var(gen, c->value);
+            } else {
+                opt_str_escape_walk(gen, c, consumed_lhs);
+            }
+        }
+        return;
+    }
+    if (node->type == AST_VARIABLE_DECLARATION && node->value &&
+        node->child_count > 0) {
+        for (int i = 0; i < node->child_count; i++)
+            opt_str_escape_walk(gen, node->children[i], node->value);
+        return;
+    }
+    /* Non-trivial store `s.field = opt` / `arr[i] = opt`: the write
+     * target outlives this activation, so a `string?` on the RHS
+     * escapes. */
+    if (node->type == AST_BINARY_EXPRESSION && node->value &&
+        strcmp(node->value, "=") == 0 && node->child_count == 2) {
+        ASTNode* lhs = node->children[0];
+        ASTNode* rhs = node->children[1];
+        if (lhs && lhs->type != AST_IDENTIFIER) {
+            if (rhs && rhs->type == AST_IDENTIFIER && rhs->value &&
+                is_opt_str_var(gen, rhs->value)) {
+                mark_escaped_opt_str_var(gen, rhs->value);
+            }
+            opt_str_escape_walk(gen, lhs, NULL);
+            opt_str_escape_walk(gen, rhs, NULL);
+            return;
+        }
+    }
+    if (node->type == AST_CLOSURE) {
+        for (int i = 0; i < node->child_count; i++)
+            opt_str_escape_walk(gen, node->children[i], NULL);
+        return;
+    }
+    if (node->type == AST_FUNCTION_CALL) {
+        for (int i = 0; i < node->child_count; i++) {
+            ASTNode* a = node->children[i];
+            if (a && a->type == AST_IDENTIFIER && a->value &&
+                is_opt_str_var(gen, a->value)) {
+                if (consumed_lhs && strcmp(a->value, consumed_lhs) == 0) continue;
+                /* Same parameter-aware precision as the heap-string walk:
+                 * a `string?` passed by value to a read-only callee (its
+                 * param only read, like `sink(x: string?)`) does NOT
+                 * escape — the recipient sees a copy of the `{has,val}`
+                 * struct and, unless it stores `.val`, our exit-free may
+                 * still reclaim it. Only a genuine storing sink escapes. */
+                if (call_arg_position_escapes(gen, node, i)) {
+                    mark_escaped_opt_str_var(gen, a->value);
+                }
+            } else {
+                opt_str_escape_walk(gen, a, consumed_lhs);
+            }
+        }
+        return;
+    }
+    if (node->type == AST_FUNCTION_DEFINITION ||
+        node->type == AST_BUILDER_FUNCTION) {
+        return;
+    }
+    for (int i = 0; i < node->child_count; i++)
+        opt_str_escape_walk(gen, node->children[i], consumed_lhs);
+}
+
+void mark_escaped_opt_str_vars(CodeGenerator* gen, ASTNode* body) {
+    if (!gen || !body) return;
+    opt_str_escape_walk(gen, body, NULL);
+}
+
+/* Scope-exit defer-free for non-escaped `string?` locals (parallel to
+ * push_seq_exit_free_defers). The carrier annotation
+ * `opt_str_exit_free:<name>` is recognised by try_emit_opt_str_exit_free. */
+void push_opt_str_exit_free_defers(CodeGenerator* gen, ASTNode* body) {
+    if (!gen || !body) return;
+    if (gen->opt_str_var_count <= 0) return;
+    for (int i = 0; i < gen->opt_str_var_count; i++) {
+        const char* name = gen->opt_str_vars[i];
+        if (!name) continue;
+        if (is_escaped_opt_str_var(gen, name)) continue;
+        int is_env_cap = 0;
+        for (int e = 0; e < gen->current_env_capture_count; e++) {
+            if (gen->current_env_captures[e] &&
+                strcmp(gen->current_env_captures[e], name) == 0) {
+                is_env_cap = 1; break;
+            }
+        }
+        if (is_env_cap) continue;
+        if (is_promoted_capture(gen, name)) continue;
+        char annot[300];
+        snprintf(annot, sizeof(annot), "opt_str_exit_free:%s", name);
         ASTNode* carrier = create_ast_node(AST_EXPRESSION_STATEMENT, NULL,
                                             body->line, body->column);
         if (carrier) {
@@ -3731,7 +3960,40 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             // don't understand the `ae_opt_<T>` tagged-struct wrap.
             if (stmt->value && strcmp(stmt->value, "_") != 0 &&
                 stmt->node_type && stmt->node_type->kind == TYPE_OPTIONAL) {
+                /* `string?` heap-ownership: the local is registered by
+                 * hoist_opt_str_trackers, so is_var_declared is already
+                 * true here and this always takes the assign-only branch.
+                 * On reassignment the PREVIOUS `.val` (if this slot owns
+                 * a heap buffer) must be freed before the overwrite, and
+                 * the `_heapopt_<name>` flag re-set from the RHS's
+                 * heap-ness — exactly the bare-string reassignment
+                 * wrapper, adapted to the `{has,val}` struct. */
+                int is_opt_str = is_opt_str_var(gen, stmt->value);
+                int rhs_is_heap = is_opt_str && stmt->child_count > 0 &&
+                                  stmt->children[0] &&
+                                  is_heap_opt_string_rhs(gen, stmt->children[0]);
                 print_indent(gen);
+                if (is_opt_str) {
+                    /* Free the prior owned buffer, then assign the new
+                     * value, then update the ownership flag. A single
+                     * temp captures the old struct so the RHS (which may
+                     * read the same slot, e.g. `o = o ?? x`) evaluates
+                     * against the un-freed value. */
+                    fprintf(gen->output, "{ ae_opt_string _opt_old_%s = %s; ",
+                            stmt->value, stmt->value);
+                    fprintf(gen->output, "%s = ", stmt->value);
+                    if (stmt->child_count > 0 && stmt->children[0]) {
+                        emit_optional_coerced(gen, stmt->children[0], stmt->node_type);
+                    } else {
+                        fprintf(gen->output, "(%s){0}", get_c_type(stmt->node_type));
+                    }
+                    fprintf(gen->output,
+                            "; if (_heapopt_%s && _opt_old_%s.has) aether_heap_str_free((void*)_opt_old_%s.val);",
+                            stmt->value, stmt->value, stmt->value);
+                    fprintf(gen->output, " _heapopt_%s = %d; }\n",
+                            stmt->value, rhs_is_heap ? 1 : 0);
+                    break;
+                }
                 if (!is_var_declared(gen, stmt->value)) {
                     fprintf(gen->output, "%s %s", get_c_type(stmt->node_type), stmt->value);
                     mark_var_declared(gen, stmt->value);

--- a/tests/regression/test_optional_heap_leak.ae
+++ b/tests/regression/test_optional_heap_leak.ae
@@ -1,0 +1,90 @@
+// Regression: a heap-backed `string?` local leaked its `.val` buffer at
+// scope exit and on reassignment. `ae_opt_string` lowers to a by-value
+// `{ int has; const char* val; }`; the optional decl/assign path emitted
+// no heap tracker and no scope-exit free (unlike a bare `string` local),
+// so every `let a: string? = <heap>` in a loop lost its buffer. The fix
+// adds a `_heapopt_<name>` ownership tracker (parallel to `_heap_<name>`
+// for bare strings): the prior `.val` is freed on reassignment and at
+// scope exit, with the usual escape suppression so a `return`ed or
+// stored optional is NOT freed by the producer.
+//
+// This test has no asserts about the leak itself — the leak is invisible
+// to program output. Its value is under the leak-detection CI gates
+// (valgrind on Linux, `leaks` on macOS): before the fix it lost
+// 32 bytes/iteration; after, it is leak-clean. The asserts here only
+// pin the observable BEHAVIOUR (values survive the ownership plumbing).
+
+import std.string
+
+extern exit(code: int)
+
+// Heap producer returning `string?` — `.val` is a fresh AetherString.
+mk(i: int) -> string? {
+    return string.concat("v-", string.from_int(i))
+}
+
+// A `string?` local that is RETURNED: the caller owns the buffer, so
+// this function's scope-exit free must be suppressed (else the caller's
+// pointer dangles — a use-after-free, not a leak).
+forward(i: int) -> string? {
+    let a: string? = mk(i)
+    return a
+}
+
+// A `string?` passed by value to a read-only callee: the recipient sees
+// a copy of `{has,val}` and only reads it, so the caller's exit-free
+// still reclaims the buffer (mirrors bare-string `string.length(s)`).
+peek(x: string?) -> int {
+    let s = x ?? ""
+    return string.length(s)
+}
+
+main() {
+    let mut fails = 0
+    let mut n = 0
+    let mut total = 0
+
+    while n < 40 {
+        // Reassign-in-loop: each iteration's prior `.val` is freed by the
+        // reassignment wrapper; the final one by the scope-exit free.
+        let a: string? = mk(n)
+        let s = a ?? "MISSING"
+        if string.length(s) < 3 {
+            fails = fails + 1
+        }
+
+        // Return-escape path: forward() hands us an owned optional.
+        let r: string? = forward(n)
+        let rs = r ?? "MISSING"
+        if string.length(rs) < 3 {
+            fails = fails + 1
+        }
+
+        // Pass-to-read-only-callee path.
+        total = total + peek(a)
+
+        // Alias path: a heap `string` local wrapped into a `string?`.
+        // Both `h` (bare-string tracker) and `b` (opt-str tracker) would
+        // otherwise claim the same buffer and double-free at scope exit;
+        // the alias is treated as non-owning so only `h` frees it.
+        let h = string.concat("h-", string.from_int(n))
+        let b: string? = h
+        let bs = b ?? "MISSING"
+        if string.length(bs) < 3 {
+            fails = fails + 1
+        }
+
+        n = n + 1
+    }
+
+    if total <= 0 {
+        println("FAIL: peek accumulated nothing")
+        fails = fails + 1
+    }
+
+    if fails != 0 {
+        println("optional-heap-leak: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_optional_heap_leak")
+}


### PR DESCRIPTION
## Problem

A heap-backed `string?` local leaked its `.val` buffer on reassignment and at scope exit. `ae_opt_string` lowers to a by-value `{ int has; const char* val; }`, and the optional decl/assign path emitted **no heap tracker and no free** — unlike a bare `string` local. So every `let a: string? = <heap>` lost its buffer:

```
==…== definitely lost: 1,600 bytes in 50 blocks
```

(std/ uses zero optionals, so this never surfaced in the stdlib — but it's a real per-use leak for application code.)

## Fix

Adds an **opt-str heap registry** parallel to the existing `*StringSeq` registry:

- A `_heapopt_<name>` ownership flag (the struct's `.has` bit alone can't distinguish a heap `.val` from a borrowed literal), set from `is_heap_string_expr` on the coerced RHS.
- The prior `.val` is freed on reassignment and at scope exit via `aether_heap_str_free`, with escape suppression so a `return`ed or stored optional is **not** freed by the producer (no dangle).
- The bare-string call-arg escape decision is factored into a shared `call_arg_position_escapes` helper, so `string?` gets the **same parameter-aware precision** — a `string?` passed to a read-only callee (`peek(x: string?)`) is still reclaimed by the caller, exactly like `string.length(s)`.

## Two pre-existing bugs surfaced & fixed

1. `let b: string? = <heap string local>` mis-declared `b` as `const char*` (the heap-string collector grabbed the optional because its RHS was `TYPE_STRING`), then assigned an `ae_opt_string` struct into that slot — a straight **miscompile**. The heap-string collector now excludes optional-typed LHS.
2. That same alias shape then **double-freed** once both trackers claimed the buffer; a bare-identifier RHS is now treated as a non-owning alias (the source local frees it).

## Verification

Leak-clean under valgrind (0 bytes lost, 0 errors) across every path:
- reassign-in-loop
- return-escape (no dangle)
- pass-to-read-only-callee
- alias (`string? = heap string`)

New regression test `tests/regression/test_optional_heap_leak.ae` covers each. `make ci` green on all optional tests (`test_issue340_optionals`, `test_optional_hygiene`, `test_optional_heap_leak`). The only CI failures are unrelated: one stray untracked WIP file (`test_issue1046_bit_set.ae`) and the pre-forgiven flaky h2/port-bind shell tests.

## Out of scope (separate pre-existing gaps)

Optionals in **struct fields** don't compile at all today (the field lowers to `int`), and **actor-handler** scope-exit frees aren't wired (same as seq). Both are untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TUeb6FUn9xeeBwe1Pu8Lr