### PR TITLE
fix(codegen): free the discarded error slot in `f() or { … }`

### DIFF
--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2096,6 +2096,21 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             int err_idx = tup->tuple_count - 1;
             static int oe_counter = 0;
             int id = oe_counter++;
+            /* The trailing error slot is discarded on BOTH paths — on the
+             * error path the handler consumes it (as `err`) then it is
+             * dead; on the success path it is the `""` success sentinel.
+             * When the fallible's error position is classified HEAP, every
+             * return (both paths) was wrapped in `aether_uniform_heap_str`
+             * (emit_tuple_return_position), so the slot is always a
+             * malloc-owned pointer — an AetherString or a plain malloc'd
+             * copy — and leaks unless freed. `aether_heap_str_free`
+             * reclaims both shapes. When the error position is NON-heap
+             * (e.g. `string.to_long`'s raw literal "invalid long"), the
+             * slot is a `.rodata` literal and must NOT be freed — so gate
+             * the free on the SAME static classification the `v, e = f()`
+             * destructure site uses for `_heap_e`, keeping the two forms
+             * consistent. */
+            int err_slot_heap = or_fallible_error_slot_is_heap(gen, fallible);
             fprintf(gen->output, "({ %s _oe%d = ", tuple_c, id);
             generate_expression(gen, fallible);
             fprintf(gen->output, "; %s _oer%d;\nif (_oe%d._%d && _oe%d._%d[0]) {\n",
@@ -2137,8 +2152,29 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 generate_expression(gen, handler);
                 fprintf(gen->output, ";\n");
             }
-            fprintf(gen->output, "} else { _oer%d = _oe%d._0; } _oer%d; })",
-                    id, id, id);
+            /* Error path done: `err` (the error slot) is now dead — free it
+             * if statically heap. The value slot `_oe._0` is left alone: on
+             * this path it was the failed call's value (often a null/empty
+             * sentinel), and whether it is heap-owned and safe to reclaim is
+             * the caller's classification concern, not the `or` lowering's;
+             * a blind free here risks the failed-call value aliasing the
+             * handler's own result. Freeing only the always-discarded error
+             * slot is the safe, sufficient fix. */
+            if (err_slot_heap) {
+                fprintf(gen->output, "aether_heap_str_free((void*)_oe%d._%d);\n",
+                        id, err_idx);
+            }
+            /* Success path: yield the value slot as the result (must NOT be
+             * freed — it is what the expression evaluates to); free only the
+             * discarded success-sentinel error slot, again only when heap. */
+            if (err_slot_heap) {
+                fprintf(gen->output,
+                        "} else { _oer%d = _oe%d._0; aether_heap_str_free((void*)_oe%d._%d); } _oer%d; })",
+                        id, id, id, err_idx, id);
+            } else {
+                fprintf(gen->output, "} else { _oer%d = _oe%d._0; } _oer%d; })",
+                        id, id, id);
+            }
             break;
         }
 

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -72,6 +72,10 @@ int is_seq_owning_expr(CodeGenerator* gen, ASTNode* expr);
  * temp lifetime wrap (ArgDrainSub) to detect heap-returning
  * function calls in argument position. */
 int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr);
+/* Whether the discarded error slot of an `or`-expression's fallible is a
+ * heap-owned string the `or` lowering must release (vs a raw literal it
+ * must not free). See the definition in codegen_stmt.c. */
+int or_fallible_error_slot_is_heap(CodeGenerator* gen, ASTNode* fallible);
 
 /* Returns 1 if some `AST_VARIABLE_DECLARATION` for `var_name` inside
  * `node` assigns it from a heap-string source (`is_heap_string_expr`

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1671,6 +1671,35 @@ static int function_def_returns_heap_at(CodeGenerator* gen, ASTNode* fn_def,
     return result;
 }
 
+/* Is the error (last) slot of `fallible` a heap-owned string that the
+ * `or` lowering must release when it discards it? True only when the
+ * fallible is a call to a user function whose error position is
+ * classified heap by `function_def_returns_heap_at` — in which case
+ * emit_tuple_return_position wrapped EVERY return (including the `""`
+ * success sentinel) in `aether_uniform_heap_str`, so the slot is always
+ * a malloc-owned pointer, uniformly freeable. When the error position is
+ * non-heap (e.g. `string.to_long` returning the raw literal "invalid
+ * long"), the slot is a `.rodata` literal and must NOT be freed. This is
+ * exactly the gate the `v, e = f()` destructure site uses to decide
+ * `_heap_e`, so the `or` and destructure forms stay consistent. Callees
+ * with no resolvable definition (externs, unknowns) are conservatively
+ * treated as non-heap — matching the destructure default. */
+int or_fallible_error_slot_is_heap(CodeGenerator* gen, ASTNode* fallible) {
+    if (!fallible || fallible->type != AST_FUNCTION_CALL || !fallible->value ||
+        !gen || !gen->program) {
+        return 0;
+    }
+    Type* tup = fallible->node_type;
+    if (!tup || tup->kind != TYPE_TUPLE || tup->tuple_count < 2) return 0;
+    int err_idx = tup->tuple_count - 1;
+    char fn_norm[256];
+    const char* fn = codegen_normalise_callee(fallible->value, fn_norm,
+                                              sizeof(fn_norm));
+    ASTNode* callee = find_function_definition_by_name(gen->program, fn);
+    if (!callee) return 0;
+    return function_def_returns_heap_at(gen, callee, err_idx);
+}
+
 /* Emit one position of a multi-value `return e0, e1, ...`. When the
  * enclosing function classifies tuple position `j` as a heap-string
  * position (`function_def_returns_heap_at`), route that position's

--- a/tests/regression/test_or_block_error_slot_leak.ae
+++ b/tests/regression/test_or_block_error_slot_leak.ae
@@ -1,0 +1,64 @@
+// Regression: `f() or { … }` leaked the discarded error string. The `or`
+// lowering (codegen_expr.c AST_OR_ELSE) evaluates the fallible's
+// `(value, err)` tuple once, then on the error path binds `err` for the
+// handler and on the success path yields the value — but never released
+// the trailing error slot on EITHER path. Stdlib fallibles build that
+// slot with `string_concat(...)` (a heap AetherString), so every
+// `json.parse(bad) or { … }` leaked its error message, and every
+// successful `json.stringify(v) or { … }` leaked its heap `""` success
+// sentinel.
+//
+// Fixed by releasing the error slot before yielding, on both paths, via
+// `string_release` — which is literal-safe (is_aether_string
+// short-circuits on the first non-magic byte), so a plain-literal error
+// slot (e.g. string.to_long's "invalid long", or a bare "" sentinel) is
+// a clean no-op and only a heap AetherString is refcount-decremented.
+//
+// No output asserts the leak (it is invisible to the program); the test's
+// value is under the leak-detection CI gates (valgrind + macOS `leaks`).
+// The asserts pin the observable behaviour so the paths actually run.
+//
+// NOTE: this covers the ERROR-SLOT leak. A separate value-slot leak —
+// `s = f() or { … }` not heap-tracking the yielded value when the paths
+// have heterogeneous ownership (heap success value vs literal handler
+// default) — is a distinct, harder problem (needs uniform-heap boxing of
+// the `or` result) tracked separately; it is deliberately not exercised
+// here so this test stays leak-gate-clean.
+
+import std.json
+import std.string
+
+extern exit(code: int)
+
+main() {
+    fails = 0
+    n = 0
+
+    while n < 40 {
+        // Error path: a failed parse's heap error string is discarded by
+        // the `or` handler. Was leaked; now released.
+        bad = json.parse("{ not valid") or { null }
+        if bad != null { println("FAIL: bad parse should yield null via or"); fails = fails + 1 }
+
+        // Success path: a valid parse; the heap "" success sentinel in the
+        // error slot is discarded. Was leaked; now released. The value is
+        // freed explicitly (json.free) — that path is already correct.
+        ok = json.parse("{\"k\":1}") or { null }
+        if ok == null { println("FAIL: good parse should yield value via or"); fails = fails + 1 }
+        if ok != null { json.free(ok) }
+
+        // Literal-error fallible through `or`: string.to_long's error is a
+        // literal ("invalid long"), so string_release must no-op on it (no
+        // invalid free / crash). Exercises the literal-safe path.
+        v = string.to_long("not a number") or { -1 }
+        if v != -1 { println("FAIL: to_long bad should yield -1 via or"); fails = fails + 1 }
+
+        n = n + 1
+    }
+
+    if fails != 0 {
+        println("or-block-error-slot-leak: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_or_block_error_slot_leak")
+}


### PR DESCRIPTION
## Problem

The `or` lowering evaluated a fallible's `(value, err)` tuple once, ran the handler (error path) or yielded the value (success path), but **never freed the discarded error slot** on either path. So:

- `json.parse(bad) or { … }` leaked its heap error message, and
- `json.parse(ok) or { … }` leaked the heap `""` success sentinel.

Reproduced: 1 leak per iteration under valgrind.

## Why it's subtle

The error slot has **three physical shapes with no runtime discriminator**:

| # | shape | example | safe free |
|---|-------|---------|-----------|
| 1 | heap AetherString | `json.parse` failure (`string_concat`) | `string_release` / `aether_heap_str_free` |
| 2 | plain malloc'd C string | the `""` success sentinel (`aether_uniform_heap_str(is_heap=0)` copies the literal) | `free` / `aether_heap_str_free` |
| 3 | raw `.rodata` literal | `string.to_long`'s `"invalid long"` | **must not free** |

No single runtime primitive is safe on all three — `string_release` leaks (2), `aether_heap_str_free` faults on (3).

## Fix

Gate the free on the **same static classification the `v, e = f()` destructure site uses**: `function_def_returns_heap_at(callee, err_idx)`.

- When the error position is **heap**, `emit_tuple_return_position` has already wrapped *every* return (both paths) in `aether_uniform_heap_str`, so the slot is uniformly malloc-owned → `aether_heap_str_free` reclaims shapes (1) and (2).
- When **non-heap**, the slot is always a literal (3) → left alone.

`or` and destructure now agree by construction. New helper `or_fallible_error_slot_is_heap` (codegen_stmt.c) is the single decision point.

## Verification

Leak-clean under valgrind across all three shapes (0 lost, 0 invalid-free); all existing `or`-block suites pass. New regression `tests/regression/test_or_block_error_slot_leak.ae` exercises each path in a loop.

CI failures on the branch are pre-existing/unrelated: stray untracked `test_issue1046_bit_set.ae`, and the pre-forgiven flaky h2/port-bind shell tests.

## Scope / follow-ups

Covers the **error-slot** leak. Two adjacent, harder gaps left for separate work:
1. The `or`-**result value slot** is not heap-tracked when the success value is heap but the handler default is a literal (heterogeneous per-path ownership — needs uniform-heap boxing of the result).
2. An `or` whose fallible is a **raw `@heap` extern** (not a user fn) conservatively does not free (leak, never crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TUeb6FUn9xeeBwe1Pu8Lr