### PR TITLE
fix(codegen): heap-track the value of `s = f() or { … }`

### DIFF
--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2010,7 +2010,8 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
      * lifetime is managed by the wrap. */
     if (expr->type == AST_FUNCTION_CALL ||
         expr->type == AST_STRING_INTERP ||
-        expr->type == AST_CLOSURE) {
+        expr->type == AST_CLOSURE ||
+        expr->type == AST_OR_ELSE) {
         const char* sub = arg_drain_lookup(expr);
         if (sub) {
             fprintf(gen->output, "%s", sub);
@@ -2111,6 +2112,20 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
              * destructure site uses for `_heap_e`, keeping the two forms
              * consistent. */
             int err_slot_heap = or_fallible_error_slot_is_heap(gen, fallible);
+            /* Uniform-heap boxing of the RESULT: when the success value
+             * slot is a heap string, the success path yields a malloc-owned
+             * pointer but the handler's default (`"" `, a literal) is not —
+             * heterogeneous ownership the caller's single `_heap_<lhs>`
+             * tracker can't represent, so it leaked the success value. Box
+             * the handler's value through `aether_uniform_heap_str(_, 0)`
+             * (malloc-copies a literal, passes a heap value through) so BOTH
+             * paths yield a uniformly malloc-owned pointer; then the
+             * AST_OR_ELSE case in is_heap_string_expr classifies the whole
+             * expression heap and the caller frees it at scope exit. Only
+             * for a string result whose value slot is statically heap. */
+            int box_val = (tup->tuple_types[0] &&
+                           tup->tuple_types[0]->kind == TYPE_STRING &&
+                           or_fallible_value_slot_is_heap(gen, fallible));
             fprintf(gen->output, "({ %s _oe%d = ", tuple_c, id);
             generate_expression(gen, fallible);
             fprintf(gen->output, "; %s _oer%d;\nif (_oe%d._%d && _oe%d._%d[0]) {\n",
@@ -2139,27 +2154,45 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 if (last >= 0 && handler->children[last] &&
                     handler->children[last]->type == AST_EXPRESSION_STATEMENT &&
                     handler->children[last]->child_count > 0) {
+                    ASTNode* hv = handler->children[last]->children[0];
+                    /* is_heap flag = whether hv is ALREADY heap: a heap
+                     * value passes through uniform_heap_str untouched
+                     * (must NOT re-copy — that would leak the original);
+                     * a literal is malloc-copied. */
+                    int hv_heap = is_heap_string_expr(gen, hv);
                     print_indent(gen);
                     fprintf(gen->output, "_oer%d = ", id);
-                    generate_expression(gen, handler->children[last]->children[0]);
+                    if (box_val) fprintf(gen->output, "aether_uniform_heap_str((const char*)(");
+                    generate_expression(gen, hv);
+                    if (box_val) fprintf(gen->output, "), %d)", hv_heap ? 1 : 0);
                     fprintf(gen->output, ";\n");
                 } else if (last >= 0 && handler->children[last]) {
                     generate_statement(gen, handler->children[last]);
                 }
                 fprintf(gen->output, "\n");
             } else {
+                int hv_heap = is_heap_string_expr(gen, handler);
                 fprintf(gen->output, "_oer%d = ", id);
+                if (box_val) fprintf(gen->output, "aether_uniform_heap_str((const char*)(");
                 generate_expression(gen, handler);
+                if (box_val) fprintf(gen->output, "), %d)", hv_heap ? 1 : 0);
                 fprintf(gen->output, ";\n");
             }
-            /* Error path done: `err` (the error slot) is now dead — free it
-             * if statically heap. The value slot `_oe._0` is left alone: on
-             * this path it was the failed call's value (often a null/empty
-             * sentinel), and whether it is heap-owned and safe to reclaim is
-             * the caller's classification concern, not the `or` lowering's;
-             * a blind free here risks the failed-call value aliasing the
-             * handler's own result. Freeing only the always-discarded error
-             * slot is the safe, sufficient fix. */
+            /* Error path done. Free the discarded slots the handler
+             * replaced:
+             *   - the error slot `err`, now dead, if statically heap;
+             *   - the failed call's VALUE slot `_oe._0`, when it is a
+             *     uniformly-heap string (box_val): the handler produced a
+             *     fresh `_oer` value, so `_oe._0` (the failed call's own
+             *     value, itself uniform-heap-wrapped — e.g. json's
+             *     `("", err)` empty sentinel) is genuinely discarded and
+             *     non-aliasing here, so it must be reclaimed. Without
+             *     box_val the value slot's ownership is unknown, so it is
+             *     left alone (as before). */
+            if (box_val) {
+                fprintf(gen->output, "aether_heap_str_free((void*)_oe%d._0);\n",
+                        id);
+            }
             if (err_slot_heap) {
                 fprintf(gen->output, "aether_heap_str_free((void*)_oe%d._%d);\n",
                         id, err_idx);
@@ -4268,8 +4301,15 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                              * call returned. Observed as ~34 byte/call
                              * leak on `outer(string_returning_call("seed-${i}"))`
                              * shape; 100k iterations grew RSS by 3.3 MB. */
+                            /* AST_OR_ELSE included: `f(g() or { … })`
+                             * yields a uniformly-heap string (the `or`
+                             * lowering boxes both paths) with no consumer,
+                             * so it leaks in argument position exactly like
+                             * a bare heap-returning call. is_heap_string_expr
+                             * classifies it, so drain it the same way. */
                             if (arg->type != AST_FUNCTION_CALL &&
-                                arg->type != AST_STRING_INTERP) continue;
+                                arg->type != AST_STRING_INTERP &&
+                                arg->type != AST_OR_ELSE) continue;
                             if (arg_drain_lookup(arg)) continue;
                             if (!is_heap_string_expr(gen, arg)) continue;
                             /* @retain parameter: callee stores the

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -76,6 +76,10 @@ int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr);
  * heap-owned string the `or` lowering must release (vs a raw literal it
  * must not free). See the definition in codegen_stmt.c. */
 int or_fallible_error_slot_is_heap(CodeGenerator* gen, ASTNode* fallible);
+/* Whether an `or`-expression's fallible value slot (position 0) is a
+ * heap-owned string — gates uniform-heap boxing of the `or` result so
+ * the yielded value is freed at scope exit. See codegen_stmt.c. */
+int or_fallible_value_slot_is_heap(CodeGenerator* gen, ASTNode* fallible);
 
 /* Returns 1 if some `AST_VARIABLE_DECLARATION` for `var_name` inside
  * `node` assigns it from a heap-string source (`is_heap_string_expr`

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -800,11 +800,38 @@ int is_seq_owning_expr(CodeGenerator* gen, ASTNode* expr) {
     return 0;
 }
 
+int or_fallible_value_slot_is_heap(CodeGenerator* gen, ASTNode* fallible);
+
 int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
     if (!expr) return 0;
 
     // String interpolation (non-printf mode) allocates via _aether_interp.
     if (expr->type == AST_STRING_INTERP) {
+        return 1;
+    }
+
+    /* `fallible or handler` whose result is a string and whose success
+     * value slot is heap: the `or` lowering boxes the handler's default
+     * via aether_uniform_heap_str so BOTH paths yield a malloc-owned
+     * pointer, making the whole expression uniformly heap. Classifying it
+     * here sets the caller's `_heap_<lhs>` tracker so the yielded value is
+     * freed at scope exit (the `v, e = f()` destructure form already frees
+     * the value via its own tracker; without this the `or` form leaked
+     * it). Must stay in lock-step with the boxing in the AST_OR_ELSE
+     * codegen — both gate on or_fallible_value_slot_is_heap. */
+    /* The `or`-node's own node_type is not reliably stamped in every
+     * position (e.g. a `return f() or { … }` node can reach here with a
+     * NULL node_type), so derive string-ness from the fallible's VALUE
+     * slot type (`tuple_types[0]`) rather than the `or`-node itself —
+     * that is the type the expression actually yields, and it is what
+     * or_fallible_value_slot_is_heap already keys on. */
+    if (expr->type == AST_OR_ELSE && expr->child_count >= 1 &&
+        expr->children[0] && expr->children[0]->node_type &&
+        expr->children[0]->node_type->kind == TYPE_TUPLE &&
+        expr->children[0]->node_type->tuple_count >= 2 &&
+        expr->children[0]->node_type->tuple_types[0] &&
+        expr->children[0]->node_type->tuple_types[0]->kind == TYPE_STRING &&
+        or_fallible_value_slot_is_heap(gen, expr->children[0])) {
         return 1;
     }
 
@@ -1671,33 +1698,55 @@ static int function_def_returns_heap_at(CodeGenerator* gen, ASTNode* fn_def,
     return result;
 }
 
-/* Is the error (last) slot of `fallible` a heap-owned string that the
- * `or` lowering must release when it discards it? True only when the
- * fallible is a call to a user function whose error position is
- * classified heap by `function_def_returns_heap_at` — in which case
- * emit_tuple_return_position wrapped EVERY return (including the `""`
- * success sentinel) in `aether_uniform_heap_str`, so the slot is always
- * a malloc-owned pointer, uniformly freeable. When the error position is
- * non-heap (e.g. `string.to_long` returning the raw literal "invalid
- * long"), the slot is a `.rodata` literal and must NOT be freed. This is
- * exactly the gate the `v, e = f()` destructure site uses to decide
- * `_heap_e`, so the `or` and destructure forms stay consistent. Callees
- * with no resolvable definition (externs, unknowns) are conservatively
- * treated as non-heap — matching the destructure default. */
-int or_fallible_error_slot_is_heap(CodeGenerator* gen, ASTNode* fallible) {
+/* Is tuple `position` of `fallible`'s result classified heap by
+ * `function_def_returns_heap_at`? Shared by the `or` lowering's
+ * error-slot free (position = last) and its value-slot uniform-heap
+ * boxing (position 0). True only when the fallible is a call to a
+ * resolvable user function — for such a function
+ * emit_tuple_return_position wrapped EVERY return at that position in
+ * `aether_uniform_heap_str`, so the slot is uniformly malloc-owned.
+ * Callees with no resolvable definition (externs, unknowns) are
+ * conservatively non-heap, matching the `v, e = f()` destructure
+ * default. */
+static int or_fallible_slot_is_heap(CodeGenerator* gen, ASTNode* fallible,
+                                    int position) {
     if (!fallible || fallible->type != AST_FUNCTION_CALL || !fallible->value ||
         !gen || !gen->program) {
         return 0;
     }
     Type* tup = fallible->node_type;
     if (!tup || tup->kind != TYPE_TUPLE || tup->tuple_count < 2) return 0;
-    int err_idx = tup->tuple_count - 1;
+    if (position < 0 || position >= tup->tuple_count) return 0;
     char fn_norm[256];
     const char* fn = codegen_normalise_callee(fallible->value, fn_norm,
                                               sizeof(fn_norm));
     ASTNode* callee = find_function_definition_by_name(gen->program, fn);
     if (!callee) return 0;
-    return function_def_returns_heap_at(gen, callee, err_idx);
+    return function_def_returns_heap_at(gen, callee, position);
+}
+
+/* Is the error (last) slot of `fallible` a heap-owned string that the
+ * `or` lowering must release when it discards it? When true,
+ * emit_tuple_return_position wrapped every return (including the `""`
+ * success sentinel) in `aether_uniform_heap_str`, so the slot is always
+ * malloc-owned; when false (e.g. `string.to_long` returning the raw
+ * literal "invalid long") the slot is a `.rodata` literal that must NOT
+ * be freed. Same gate the `v, e = f()` destructure site uses for
+ * `_heap_e`, keeping the two forms consistent. */
+int or_fallible_error_slot_is_heap(CodeGenerator* gen, ASTNode* fallible) {
+    Type* tup = fallible ? fallible->node_type : NULL;
+    if (!tup || tup->kind != TYPE_TUPLE || tup->tuple_count < 2) return 0;
+    return or_fallible_slot_is_heap(gen, fallible, tup->tuple_count - 1);
+}
+
+/* Is the VALUE (position 0) slot of `fallible` a heap-owned string? Used
+ * by the `or` lowering to decide uniform-heap boxing of the result: when
+ * the success value is heap, the `or`-expression is classified heap (so
+ * the caller's `_heap_<lhs>` tracker frees it at scope exit) and the
+ * handler's non-heap default is boxed via `aether_uniform_heap_str` so
+ * BOTH paths yield a uniformly malloc-owned pointer. */
+int or_fallible_value_slot_is_heap(CodeGenerator* gen, ASTNode* fallible) {
+    return or_fallible_slot_is_heap(gen, fallible, 0);
 }
 
 /* Emit one position of a multi-value `return e0, e1, ...`. When the

--- a/tests/regression/test_or_result_value_leak.ae
+++ b/tests/regression/test_or_result_value_leak.ae
@@ -1,0 +1,81 @@
+// Regression: `s = f() or { … }` leaked the yielded value when the
+// fallible's success value slot is a heap string but the handler default
+// is a literal. The paths have heterogeneous ownership — success yields a
+// malloc-owned pointer, the handler default is a `.rodata` literal — which
+// the caller's single `_heap_<s>` tracker can't represent, so the `or`
+// result was classified non-heap and the success value never freed.
+//
+// Fix (uniform-heap boxing): when the success value slot is statically
+// heap (function_def_returns_heap_at position 0), the `or` lowering boxes
+// the handler's value through `aether_uniform_heap_str` — passing an
+// already-heap handler value through untouched, malloc-copying a literal —
+// so BOTH paths yield a uniformly malloc-owned pointer. The AST_OR_ELSE
+// case in is_heap_string_expr then classifies the expression heap so the
+// caller frees it at scope exit. The failed call's own (discarded) value
+// slot is freed on the error path. The `v, e = f()` destructure form
+// already froze the value via its tracker; this brings `or` in line.
+//
+// No output asserts the leak (invisible to the program); the value is
+// under the leak-detection CI gates. Asserts pin the observable behaviour
+// so every path runs.
+
+import std.json
+import std.string
+
+extern exit(code: int)
+
+// Returning an `or`-expression: the function's result is heap (the value
+// slot is uniform-heap), so the caller must free it. Exercises the
+// single-value return-heap classifier's AST_OR_ELSE path.
+forward(j: ptr) -> string {
+    return json.stringify(j) or { "none" }
+}
+
+main() {
+    fails = 0
+    n = 0
+
+    while n < 40 {
+        j, _ = json.parse("{\"k\":${n}}")
+
+        // Success value heap, handler default a LITERAL. Was leaked.
+        s1 = json.stringify(j) or { "" }
+        if string.length(s1) < 3 { println("FAIL: stringify or-literal too short"); fails = fails + 1 }
+
+        // Error path taken (get_string on a non-string errors), handler
+        // default a LITERAL — boxed default must be freed, failed call's
+        // own value slot must be freed.
+        s2 = json.get_string(j) or { "default" }
+        if s2 != "default" { println("FAIL: get_string or-default = ${s2}"); fails = fails + 1 }
+
+        // Error path taken, handler yields a HEAP value (string.concat) —
+        // must pass through the box untouched (no re-copy leak of the
+        // original), and be freed at scope exit.
+        s3 = json.get_string(j) or { string.concat("hv-", string.from_int(n)) }
+        if string.length(s3) < 3 { println("FAIL: get_string or-heap too short"); fails = fails + 1 }
+
+        // Block-form handler with a heap trailing value on the error path.
+        s4 = json.get_string(j) or { let m = "blk"; string.concat(m, "!") }
+        if s4 != "blk!" { println("FAIL: block-handler = ${s4}"); fails = fails + 1 }
+
+        // `or`-result passed DIRECTLY as a call argument (no bound local):
+        // the heap temporary must be drained by the argument-lifetime wrap,
+        // and the fallible must be evaluated exactly once.
+        if string.length(json.stringify(j) or { "" }) < 3 {
+            println("FAIL: or-result-as-arg too short"); fails = fails + 1
+        }
+
+        // `or`-result RETURNED from a function, then held by the caller.
+        s5 = forward(j)
+        if string.length(s5) < 3 { println("FAIL: returned or-result too short"); fails = fails + 1 }
+
+        json.free(j)
+        n = n + 1
+    }
+
+    if fails != 0 {
+        println("or-result-value-leak: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_or_result_value_leak")
+}


### PR DESCRIPTION
Companion to #1159 (which freed the discarded **error** slot). This fixes the `or`-**result value** leak.

## Problem

`s = f() or { … }` leaked the yielded value when the fallible's success value slot is a heap string but the handler default is a literal. The two paths have **heterogeneous ownership** — a malloc-owned success value vs a `.rodata` literal default — which the caller's single `_heap_<lhs>` tracker can't represent, so the `or`-expression was classified non-heap and the success value never freed.

```aether
s = json.stringify(j) or { "" }   // leaked ~40 bytes/call
```

## Fix: uniform-heap boxing, coordinated across every consumption context

| context | fix |
|---|---|
| **boxing** | When the value slot is statically heap, box the handler's value through `aether_uniform_heap_str` with the handler value's **own** heap-ness as the flag — a heap handler value passes through untouched (no re-copy leak), a literal is malloc-copied — so both paths yield a uniformly malloc-owned pointer. The failed call's discarded value slot is freed on the error path. |
| **classification** | `is_heap_string_expr` now classifies an `AST_OR_ELSE` with a heap value slot as heap, so a bound local gets `_heap_<lhs>` and is freed at scope exit. Keyed on the fallible's value-slot type (the `or`-node's own `node_type` isn't reliably stamped in return position). |
| **argument** | `g(f() or { … })` drains the heap temp — added `AST_OR_ELSE` to both the drain-eligibility gate and the substitution point (else the fallible **double-evaluated**). |
| **return** | `return f() or { … }` classifies the function heap (the single-value return walker already routes through `is_heap_string_expr`), so the caller frees it. |

New helper `or_fallible_value_slot_is_heap`, refactored with the existing error-slot helper onto a shared position-keyed classifier. Boxing and classification stay in lock-step (both key on the value-slot type).

## Verification

Leak-clean under valgrind across **six** contexts: bound-local, error-path-taken, heap-handler-value (no re-copy), block-form handler, direct-argument (verified single-eval), and return. All existing `or`-block suites pass. New regression `tests/regression/test_or_result_value_leak.ae` covers each.

CI failures on the branch are the usual unrelated set (stray untracked `test_issue1046_bit_set.ae`, flaky h2/port shell tests).

## Together with #1159

The `or {}` construct is now fully leak-correct: both the discarded error slot (#1159) and the yielded value (this PR) are handled across all consumption contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TUeb6FUn9xeeBwe1Pu8Lr