### PR TITLE
feat(typechecker): `??` accepts a fallible T! left side (error-unification P1.3)

### DIFF
--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -1271,11 +1271,17 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
             return create_optional_type(create_type(TYPE_UNKNOWN));
 
         case AST_NULL_COALESCE: {
-            // `opt ?? d` -> the optional's inner T (or T if LHS already non-opt).
+            // `x ?? d` yields the value type:
+            //   - optional `T?`     -> inner T
+            //   - result `T!` / (value, err) tuple -> the value slot (#e-u P1.3:
+            //     `??` on a fallible is the same value-or-default as `f() or {d}`)
+            //   - already non-opt   -> T
             if (expr->child_count < 2) return create_type(TYPE_UNKNOWN);
             Type* o = infer_type(expr->children[0], table);
             Type* r;
             if (o && o->kind == TYPE_OPTIONAL && o->element_type) r = clone_type(o->element_type);
+            else if (o && o->kind == TYPE_TUPLE && o->tuple_count >= 2 && o->tuple_types[0])
+                r = clone_type(o->tuple_types[0]);
             else if (o) r = clone_type(o);
             else r = infer_type(expr->children[1], table);
             if (o) free_type(o);
@@ -5857,28 +5863,49 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             typecheck_expression(expr->children[0], table);
             typecheck_expression(expr->children[1], table);
             Type* o = infer_type(expr->children[0], table);
-            if (!o || o->kind != TYPE_OPTIONAL) {
-                type_error("`??` requires an optional `T?` on its left",
+            /* `??` accepts EITHER an optional `T?` (value-or-default over
+             * presence) OR a fallible `T!` / `(value, err)` tuple (value-or-
+             * default over failure — #error-unification P1.3, the same
+             * value-yielding lowering as `f() or { default }`). The value
+             * type is the optional's element or the tuple's first slot. */
+            int is_opt = o && o->kind == TYPE_OPTIONAL;
+            int is_result = o && o->kind == TYPE_TUPLE && o->tuple_count >= 2 &&
+                            o->tuple_types[0];
+            if (!is_opt && !is_result) {
+                type_error("`??` requires an optional `T?` or a fallible `T!` "
+                           "on its left",
                            expr->line, expr->column);
                 if (o) free_type(o);
                 if (expr->node_type) free_type(expr->node_type);
                 expr->node_type = create_type(TYPE_UNKNOWN);
                 return 0;
             }
-            Type* inner = o->element_type ? clone_type(o->element_type)
-                                          : create_type(TYPE_UNKNOWN);
+            Type* value_t = is_opt
+                ? (o->element_type ? clone_type(o->element_type)
+                                   : create_type(TYPE_UNKNOWN))
+                : clone_type(o->tuple_types[0]);
             Type* d = infer_type(expr->children[1], table);
-            if (d && inner->kind != TYPE_UNKNOWN && d->kind != TYPE_UNKNOWN &&
-                !is_assignable(d, inner)) {
+            if (d && value_t->kind != TYPE_UNKNOWN && d->kind != TYPE_UNKNOWN &&
+                !is_assignable(d, value_t)) {
                 char msg[200];
                 snprintf(msg, sizeof(msg),
                     "`??` default type %s is not assignable to the value type %s",
-                    type_name(d), type_name(inner));
+                    type_name(d), type_name(value_t));
                 type_error(msg, expr->line, expr->column);
             }
             if (d) free_type(d);
             if (expr->node_type) free_type(expr->node_type);
-            expr->node_type = inner;   // transfer ownership
+            expr->node_type = value_t;   // transfer ownership
+            /* #error-unification P1.3: `result ?? default` IS `result or
+             * { default }` — same value-or-default-over-failure lowering.
+             * Rewrite the node to AST_OR_ELSE (a bare-expression handler) so
+             * codegen reuses the single, ownership-correct `or` lowering
+             * (error-slot free, uniform-heap boxing, heap classification, arg
+             * drain) with no duplicated logic. The optional `??` keeps its own
+             * codegen (AST_NULL_COALESCE). Left unchanged for is_opt. */
+            if (is_result) {
+                expr->type = AST_OR_ELSE;
+            }
             free_type(o);
             return 1;
         }

--- a/tests/regression/test_coalesce_result.ae
+++ b/tests/regression/test_coalesce_result.ae
@@ -1,0 +1,46 @@
+// Phase 1 #3 of error-unification: `??` accepts a fallible `T!` left side,
+// not just an optional `T?`. `result ?? default` is the same value-or-
+// default-over-failure as `result or { default }` — one default operator
+// across both the "absent" (`T?`) and "failed" (`T!`) axes. The result form
+// is rewritten to `or` at typecheck time, so it reuses the single
+// ownership-correct `or` lowering (error-slot free, uniform-heap boxing).
+//
+// The heap-string result case (`json.stringify(j) ?? ""`) is exercised for
+// leak-cleanliness under the CI leak gates; this test pins the observable
+// value-or-default behaviour.
+
+import std.string
+
+extern exit(code: int)
+
+fallible(x: int) -> int! {
+    if x < 0 { return 0, "neg" }
+    return x
+}
+
+main() {
+    fails = 0
+
+    // T! success yields the value; failure yields the default.
+    if (fallible(5) ?? -1) != 5 { println("FAIL: result ?? success"); fails = fails + 1 }
+    if (fallible(-1) ?? -1) != -1 { println("FAIL: result ?? failure"); fails = fails + 1 }
+
+    // stdlib T! (string.to_long : long!)
+    if (string.to_long("42") ?? -9) != 42 { println("FAIL: to_long ?? success"); fails = fails + 1 }
+    if (string.to_long("nope") ?? -9) != -9 { println("FAIL: to_long ?? failure"); fails = fails + 1 }
+
+    // Optional `??` is unchanged (both axes share the operator).
+    let present: int? = 5
+    let absent: int? = none
+    if (present ?? 99) != 5 { println("FAIL: opt ?? present"); fails = fails + 1 }
+    if (absent ?? 99) != 99 { println("FAIL: opt ?? absent"); fails = fails + 1 }
+
+    // `??` in argument position (heap temp drained correctly).
+    if string.length("${fallible(3) ?? 0}") != 1 { println("FAIL: ?? in arg"); fails = fails + 1 }
+
+    if fails != 0 {
+        println("coalesce-result: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_coalesce_result")
+}


### PR DESCRIPTION
The final item from [`docs/error-unification.md`](../blob/main/docs/error-unification.md) §6 — `??` now works over the **"failed"** axis, not just the "absent" axis.

```aether
n = string.to_long(s) ?? 0        // was: `?? requires an optional`
data = json.parse(s) ?? fallback  // value-or-default over failure
```

`result ?? default` yields the value on success and `default` on failure — the same value-or-default lowering as `result or { default }`. **One default operator across both worlds**; `or` remains for block handlers.

## How

`??` now accepts EITHER an optional `T?` (over presence) OR a fallible `T!` / `(value, err)` tuple (over failure). The value type is the optional's element or the tuple's first slot, and the default must be assignable to it.

For the result case, the `AST_NULL_COALESCE` node is **rewritten to `AST_OR_ELSE` at typecheck time**, so codegen reuses the single, ownership-correct `or` lowering — error-slot free (#1159), uniform-heap boxing of the result (#1160), heap classification, argument drain — with **zero duplicated codegen**. That's why a heap-string result (`json.stringify(j) ?? ""`) is leak-clean immediately: it rides the machinery those PRs already hardened.

Optional `??` is untouched (keeps its own `AST_NULL_COALESCE` codegen).

## Verification

`tests/regression/test_coalesce_result` — T! success/failure, stdlib `long!`, optional `??` unchanged, and `??` in argument position. Heap-string result verified leak-clean under valgrind. Full CI green apart from pre-existing unrelated failures (stray `test_issue1046_bit_set.ae`, flaky h2/proxy/port). ~45 lines in the typechecker, matching the doc's estimate.

## error-unification: done

This closes the last item. The arc: P0 (`or {}` fix) → P1 (migrate to `T!`) → P1.5 (single-payload boundary) → P2 (consumption enforcement) → P3 (declared faults) → **P1.3 (`??` over `T!`)**, plus the two `or {}` leak fixes. `T!` is the fallible spine, unconsumed results are compile errors, faults give cheap identity, and one `??`/`or` vocabulary spans both the absent and failed axes — C3's benefits without its payload loss or ABI rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TUeb6FUn9xeeBwe1Pu8Lr