### PR TITLE
feat(std): std.encoding — hex + base64 (RFC 4648)

### DIFF
--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1555,6 +1555,25 @@ static void walk_returns_for_heap_at(CodeGenerator* gen, ASTNode* node,
                         gen->program, fn);
                 }
             }
+            /* `T!` auto-wrap, NOT a tuple passthrough: a single-child
+             * `return <expr>` whose expr is a plain (non-tuple) value is
+             * the result auto-wrap `(<expr>, "")` — position 0 is exactly
+             * <expr>, and emit_tuple_return_position DOES wrap it. So if
+             * <expr> is a heap-string producer, position 0 is heap; no veto.
+             * This is the shape a fallible `-> T!` uses when it returns a
+             * bare heap value (`return bytes.finish(...)` /
+             * `return string.concat(...)`), as opposed to the genuine
+             * whole-tuple passthrough (`return g(...)` where g is
+             * tuple-typed) the veto below guards. Distinguish by the
+             * child's own type: a non-tuple child is an auto-wrap. */
+            int child_is_tuple =
+                child && child->node_type &&
+                child->node_type->kind == TYPE_TUPLE;
+            if (position == 0 && !child_is_tuple &&
+                is_heap_string_expr(gen, child)) {
+                *any_heap = 1;
+                return;
+            }
             if (callee && function_def_returns_heap_at(gen, callee, position)) {
                 *any_heap = 1;
             } else if (ext_callee && ext_callee->node_type &&
@@ -1564,6 +1583,12 @@ static void walk_returns_for_heap_at(CodeGenerator* gen, ASTNode* node,
                        ext_callee->node_type->tuple_heap_flags &&
                        ext_callee->node_type->tuple_heap_flags[position]) {
                 *any_heap = 1;
+            } else if (position == 0 && !child_is_tuple) {
+                /* Auto-wrap of a non-heap value at position 0 (e.g.
+                 * `return ""` / `return borrowed`): not heap, but NOT a
+                 * veto either — it is a legitimate non-heap success value,
+                 * not an unfreeable passthrough. Leave found set, any_heap
+                 * unchanged, no veto. */
             } else {
                 *vetoed = 1;
             }

--- a/std/encoding/module.ae
+++ b/std/encoding/module.ae
@@ -1,0 +1,125 @@
+// std.encoding — general-purpose binary/text encodings.
+//
+// A discoverable home for the codecs that were previously either missing
+// or buried in other modules (base64 lived under `std.cryptography`, which
+// is the wrong namespace — it is encoding, not cryptography). Binary data
+// is carried in a length-aware Aether string (embedded NULs survive), the
+// same representation `std.bytes` / `std.cryptography` already use. A
+// fallible decode returns `string!` — the value on success, a non-empty
+// error on malformed input.
+//
+// hex is RFC 4648 §8; base64 is RFC 4648 §4. The hex codec is a direct
+// port of C3's `std::encoding::hex` (RFC 4648, https://rfc-editor.org/
+// rfc/rfc4648) — Copyright (c) 2022-2026 Christoffer Lernö and
+// contributors, MIT (the c3c stdlib), re-expressed in Aether. base64
+// re-surfaces Aether's existing, tested implementation
+// (std/cryptography/aether_cryptography.c).
+
+import std.string
+import std.bytes
+
+exports (
+    hex_encode, hex_decode,
+    base64_encode, base64_encode_url, base64_decode
+)
+
+// ---------------------------------------------------------------------------
+// hex (RFC 4648 §8) — lowercase on encode, case-insensitive on decode.
+// ---------------------------------------------------------------------------
+
+// Lowercase nibble -> ASCII hex digit. 0..9 -> '0'..'9', 10..15 -> 'a'..'f'.
+fn hex_digit(nibble: int) -> int {
+    if nibble < 10 { return 48 + nibble }   // '0'
+    return 87 + nibble                       // 'a' + (nibble - 10)
+}
+
+// ASCII hex digit -> nibble value, or -1 if not a hex digit. Accepts both
+// upper- and lower-case (RFC 4648 §8 permits either on decode).
+fn hex_value(c: int) -> int {
+    if c >= 48 && c <= 57 { return c - 48 }   // '0'..'9'
+    if c >= 65 && c <= 70 { return c - 55 }   // 'A'..'F'
+    if c >= 97 && c <= 102 { return c - 87 }  // 'a'..'f'
+    return -1
+}
+
+// Encode `length` bytes of `data` as lowercase hex. Output is 2*length
+// characters; empty input yields "".
+hex_encode(data: string, length: int) -> string {
+    if length <= 0 { return "" }
+    buf = bytes.new(length * 2)
+    i = 0
+    while i < length {
+        c = string.char_at_n(data, length, i) & 255
+        bytes.set(buf, i * 2, hex_digit((c >> 4) & 15))
+        bytes.set(buf, i * 2 + 1, hex_digit(c & 15))
+        i = i + 1
+    }
+    return bytes.finish(buf, length * 2)
+}
+
+// Decode a hex string to its bytes. The input must have even length and
+// contain only hex digits. Returns the decoded bytes on success, a
+// non-empty error otherwise.
+hex_decode(s: string) -> string! {
+    n = string.length(s)
+    if n == 0 { return "" }
+    if n % 2 != 0 { return "", "hex: input is not of even length" }
+    buf = bytes.new(n / 2)
+    j = 0
+    while j < n {
+        a = hex_value(string.char_at_n(s, n, j) & 255)
+        b = hex_value(string.char_at_n(s, n, j + 1) & 255)
+        if a < 0 || b < 0 {
+            bytes.free(buf)
+            return "", "hex: invalid character"
+        }
+        bytes.set(buf, j / 2, (a << 4) | b)
+        j = j + 2
+    }
+    return bytes.finish(buf, n / 2)
+}
+
+// ---------------------------------------------------------------------------
+// base64 (RFC 4648 §4) — re-surfaced from the existing cryptography codec.
+// The C symbols below live in std/cryptography/aether_cryptography.c and are
+// already compiled into libaether; re-declaring the externs here binds the
+// same implementation under the correct `std.encoding` namespace.
+// ---------------------------------------------------------------------------
+
+extern cryptography_base64_encode_raw(data: string, length: int) -> string
+extern cryptography_base64_encode_padded_raw(data: string, length: int) -> string
+extern cryptography_base64_decode_raw(b64: string) -> int
+extern cryptography_get_base64_decode() -> string
+extern cryptography_get_base64_decode_length() -> int
+extern cryptography_release_base64_decode()
+extern string_new_with_length(data: string, length: int) -> ptr
+
+// Standard-alphabet base64 WITHOUT padding (RFC 4648 §4, the `+/` alphabet;
+// no trailing `=`). Encodes `length` bytes of `data`.
+base64_encode(data: string, length: int) -> string {
+    if length <= 0 { return "" }
+    return cryptography_base64_encode_raw(data, length)
+}
+
+// Standard-alphabet base64 WITH `=` padding — the form most non-strict
+// decoders on the wire expect.
+base64_encode_url(data: string, length: int) -> string {
+    if length <= 0 { return "" }
+    return cryptography_base64_encode_padded_raw(data, length)
+}
+
+// Decode a base64 string (accepts padded and unpadded standard-alphabet
+// input) to its bytes. Returns the decoded bytes on success, a non-empty
+// error on malformed input.
+base64_decode(b64: string) -> string! {
+    if string.length(b64) == 0 { return "" }
+    ok = cryptography_base64_decode_raw(b64)
+    if ok == 0 {
+        return "", "base64: invalid input"
+    }
+    raw = cryptography_get_base64_decode()
+    n = cryptography_get_base64_decode_length()
+    owned = string_new_with_length(raw, n)
+    cryptography_release_base64_decode()
+    return owned
+}

--- a/tests/regression/test_encoding.ae
+++ b/tests/regression/test_encoding.ae
@@ -1,0 +1,73 @@
+// std.encoding regression test — hex and base64 codecs (RFC 4648).
+//
+// Test vectors are ported from the c3c standard-library unit tests
+// (test/unit/stdlib/encoding/{hex,base64}.c3) — Copyright (c) 2022-2026
+// Christoffer Lernö and contributors, MIT. The classic RFC 4648 §10
+// "" / "f" / "fo" / "foo" / "foobar" progression plus hex byte patterns.
+
+import std.encoding
+import std.string
+
+extern exit(code: int)
+
+fn check(cond: bool, msg: string) -> int {
+    if !cond { println("FAIL: ${msg}"); return 1 }
+    return 0
+}
+
+main() {
+    fails = 0
+
+    // ---- hex encode (lowercase; from c3 hex.c3 test cases) ----
+    fails = fails + check(encoding.hex_encode("", 0) == "", "hex encode empty")
+    fails = fails + check(encoding.hex_encode("g", 1) == "67", "hex encode 'g'")
+    fails = fails + check(encoding.hex_encode("hello", 5) == "68656c6c6f", "hex encode hello")
+
+    // ---- hex decode (case-insensitive; even length) ----
+    d1, e1 = encoding.hex_decode("68656c6c6f")
+    fails = fails + check(e1 == "" && d1 == "hello", "hex decode lower")
+    d2, e2 = encoding.hex_decode("E3A1")   // upper-case accepted
+    fails = fails + check(e2 == "" && string.length(d2) == 2, "hex decode upper len")
+    // round-trip: upper and lower decode to the same bytes
+    dl, _ = encoding.hex_decode("e3a1")
+    fails = fails + check(dl == d2, "hex decode case-insensitive")
+
+    // ---- hex decode errors ----
+    _, oe = encoding.hex_decode("abc")     // odd length
+    fails = fails + check(oe != "", "hex odd-length rejected")
+    _, ce = encoding.hex_decode("zz")      // non-hex chars
+    fails = fails + check(ce != "", "hex invalid-char rejected")
+
+    // ---- base64 encode (unpadded, from c3 base64.c3 encode_nopadding) ----
+    fails = fails + check(encoding.base64_encode("", 0) == "", "b64 encode empty")
+    fails = fails + check(encoding.base64_encode("f", 1) == "Zg", "b64 encode f")
+    fails = fails + check(encoding.base64_encode("fo", 2) == "Zm8", "b64 encode fo")
+    fails = fails + check(encoding.base64_encode("foo", 3) == "Zm9v", "b64 encode foo")
+    fails = fails + check(encoding.base64_encode("foobar", 6) == "Zm9vYmFy", "b64 encode foobar")
+
+    // ---- base64 encode (padded, from c3 encode) ----
+    fails = fails + check(encoding.base64_encode_url("f", 1) == "Zg==", "b64 padded f")
+    fails = fails + check(encoding.base64_encode_url("foobar", 6) == "Zm9vYmFy", "b64 padded foobar")
+
+    // ---- base64 decode (padded and unpadded, from c3 decode) ----
+    bd1, be1 = encoding.base64_decode("Zm9vYmFy")
+    fails = fails + check(be1 == "" && bd1 == "foobar", "b64 decode foobar")
+    bd2, be2 = encoding.base64_decode("Zg==")
+    fails = fails + check(be2 == "" && bd2 == "f", "b64 decode padded f")
+    bd3, be3 = encoding.base64_decode("Zm8")
+    fails = fails + check(be3 == "" && bd3 == "fo", "b64 decode unpadded fo")
+
+    // ---- round-trip a longer string through both ----
+    let msg = "The quick brown fox"
+    let mlen = string.length(msg)
+    hround, _ = encoding.hex_decode(encoding.hex_encode(msg, mlen))
+    fails = fails + check(hround == msg, "hex round-trip")
+    bround, _ = encoding.base64_decode(encoding.base64_encode(msg, mlen))
+    fails = fails + check(bround == msg, "base64 round-trip")
+
+    if fails != 0 {
+        println("encoding: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_encoding")
+}


### PR DESCRIPTION
First module from the [C3 stdlib gap analysis](../blob/main/docs/cross-references/c3-stdlib-gaps.md) §2.1.

## What

A discoverable `std.encoding` home for codecs that were missing or misplaced — base64 lived under `std.cryptography` (wrong namespace; it's encoding, not crypto), and general-purpose hex didn't exist.

```aether
import std.encoding
h = encoding.hex_encode("hello", 5)        // "68656c6c6f"
d, e = encoding.hex_decode(h)              // "hello", ""  (string!)
b = encoding.base64_encode("hello", 5)     // "aGVsbG8"
bd, be = encoding.base64_decode(b)         // "hello", ""
```

- **hex** — RFC 4648 §8; a direct port of C3's `std::encoding::hex` (MIT, © 2022-2026 Christoffer Lernö and contributors), re-expressed in Aether.
- **base64** — RFC 4648 §4; re-surfaces Aether's existing, tested implementation under the correct namespace.
- Fallible decodes return `string!`.

**Tests** are ported from C3's stdlib unit tests — the RFC 4648 §10 `""`/`"f"`/`"foo"`/`"foobar"` progression + hex byte patterns — credited in the test source. (Per the plan: copy their tests for confidence, credit C3 even under the same MIT license.)

## Compiler fix surfaced by the port

The module exposed a real heap-classifier bug (`walk_returns_for_heap_at`): a single-child `return <heap-expr>` in a `T!` function is the result **auto-wrap** `(<expr>, "")`, but the walker treated *every* single-child tuple-function return as a whole-tuple **passthrough** and vetoed it. So any imported `T!` function returning a bare heap value (`return bytes.finish(...)`) was classified non-heap and **leaked** at the destructure site.

Fix: a non-tuple child at position 0 is recognized as an auto-wrap — heap if the expr is a heap producer, a legitimate non-heap value otherwise, **never a veto**. The genuine tuple-passthrough veto (`return g()` where `g` is tuple-typed) is unchanged. This benefits every `T!` function returning a bare heap value, not just encoding.

## Verification

`test_encoding` passes and is **leak-clean under valgrind** (the fix was needed to get there). Full CI green apart from pre-existing unrelated failures (stray `test_issue1046_bit_set.ae`, flaky h2/proxy). The shared walker change has **zero blast radius** across the ~864-test suite, including all leak gates and the json/fs/result-migration tests that exercise the same classifier.

## Follow-ups from the gap doc

base32 (§2.1), then `std.time` (§2.2) and `std.sort` (§2.3) — each its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TUeb6FUn9xeeBwe1Pu8Lr