### PR TITLE
feat(std): port five foundational modules from the C3 stdlib

### DIFF
--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -3679,7 +3679,28 @@ static void emit_return_value(CodeGenerator* gen, ASTNode* stmt) {
         if (!(v->node_type && v->node_type->kind == TYPE_TUPLE)) {
             fprintf(gen->output, "(%s){ ._0 = ",
                     get_c_type(gen->current_func_return_type));
-            generate_expression(gen, v);
+            /* When position 0 of this `T!` is classified heap (some other
+             * return yields a heap value there), EVERY value-slot return —
+             * including this single-value auto-wrap of a literal `""` — must
+             * be uniform-heap-wrapped, exactly as the multi-value
+             * `emit_tuple_return_position` does. Otherwise a bare `return
+             * ""` hands the caller a `.rodata` literal that its `_heap_`
+             * tracker (set because the position is heap) frees at scope
+             * exit → invalid free. Gate on the same classifier the caller's
+             * destructure uses, and only for a string value slot. */
+            Type* v0 = gen->current_func_return_type->tuple_types
+                       ? gen->current_func_return_type->tuple_types[0] : NULL;
+            int wrap_v0 = v0 && v0->kind == TYPE_STRING &&
+                          gen->current_function &&
+                          function_def_returns_heap_at(gen, gen->current_function, 0);
+            if (wrap_v0) {
+                fprintf(gen->output, "aether_uniform_heap_str((const char*)(");
+                generate_expression(gen, v);
+                fprintf(gen->output, "), %d)",
+                        is_heap_string_expr(gen, v) ? 1 : 0);
+            } else {
+                generate_expression(gen, v);
+            }
             fprintf(gen->output, ", ._1 = \"\" }");
             return;
         }

--- a/contrib/templating/liquid/module.ae
+++ b/contrib/templating/liquid/module.ae
@@ -32,6 +32,7 @@ import std.strbuilder
 import std.map
 import std.collections
 import std.cryptography
+import std.encoding
 import std.fs
 import std.path
 import std.mem
@@ -1336,13 +1337,11 @@ apply_filter(val: string, name: string, args: string) -> (string, string) {
         if argc != 0 { return "", "base64_encode takes no args" }
         // Use the PADDED form to match Shopify's `base64_encode` filter
         // (RFC 4648 standard alphabet with `=` padding to a multiple of 4).
-        out, b64err = cryptography.base64_encode_padded(val, string_length(val))
-        if b64err != "" { return "", b64err }
-        return out, ""
+        return encoding.base64_encode_padded(val, string_length(val)), ""
     }
     if string.equals(name, "base64_decode") == 1 {
         if argc != 0 { return "", "base64_decode takes no args" }
-        out, _, derr = cryptography.base64_decode(val)
+        out, derr = encoding.base64_decode(val)
         if derr != "" { return "", derr }
         return out, ""
     }

--- a/std/cryptography/module.ae
+++ b/std/cryptography/module.ae
@@ -17,15 +17,11 @@
 
 import std.string
 import std.bytes
+import std.encoding
 
 exports (
     cryptography_sha1_hex_raw, cryptography_sha256_hex_raw,
     cryptography_hash_hex_raw, cryptography_hash_supported,
-    cryptography_base64_encode_raw, cryptography_base64_encode_padded_raw,
-    cryptography_base64_decode_raw,
-    cryptography_get_base64_decode,
-    cryptography_get_base64_decode_length,
-    cryptography_release_base64_decode,
     cryptography_md4_hex_raw, cryptography_md5_hex_raw,
     cryptography_hmac_sha256_hex_raw, cryptography_hmac_sha256_bytes_raw,
     cryptography_md4_bytes_raw, cryptography_md5_bytes_raw,
@@ -40,7 +36,6 @@ exports (
     cryptography_digest_final_hex_raw, cryptography_digest_final_bytes_raw,
     cryptography_digest_free_raw,
     sha1_hex, sha256_hex, hash_hex, hash_supported,
-    base64_encode, base64_encode_padded, base64_decode,
     md4_hex, md5_hex, hmac_sha256_hex, hmac_sha256_bytes,
     md4_bytes, md5_bytes, sha1_bytes, sha256_bytes, hash_bytes,
     random_bytes, random_hex, random_base64,
@@ -52,12 +47,6 @@ extern cryptography_sha1_hex_raw(data: string, length: int) -> string
 extern cryptography_sha256_hex_raw(data: string, length: int) -> string
 extern cryptography_hash_hex_raw(algo: string, data: string, length: int) -> string
 extern cryptography_hash_supported(algo: string) -> int
-extern cryptography_base64_encode_raw(data: string, length: int) -> string
-extern cryptography_base64_encode_padded_raw(data: string, length: int) -> string
-extern cryptography_base64_decode_raw(b64: string) -> int
-extern cryptography_get_base64_decode() -> string
-extern cryptography_get_base64_decode_length() -> int
-extern cryptography_release_base64_decode()
 extern cryptography_md4_hex_raw(data: string, length: int) -> string
 extern cryptography_md5_hex_raw(data: string, length: int) -> string
 extern cryptography_hmac_sha256_hex_raw(key: string, key_len: int,
@@ -140,59 +129,10 @@ hash_supported(algo: string) -> int {
     return cryptography_hash_supported(algo)
 }
 
-// Encode `length` bytes of `data` as Base64 (RFC 4648 §4 standard
-// alphabet, unpadded for compactness). Callers that need `=`
-// padding to make the output length a multiple of 4 can append it
-// themselves; the unpadded length is `((n + 2) / 3) * 4` for an
-// n-byte input.
-//
-// Returns (b64_string, "") on success, ("", error) on failure.
-base64_encode(data: string, length: int) -> {
-    out = cryptography_base64_encode_raw(data, length)
-    if out == 0 {
-        return "", "openssl unavailable"
-    }
-    return out, ""
-}
-
-// Padded sibling of base64_encode — RFC 4648 §4 standard alphabet
-// WITH `=` padding to a multiple of 4 bytes. Reach for this when
-// the wire format on the other end expects padded base64 — most
-// non-strict decoders accept either, but some auth headers and
-// JSON-encoded blob formats explicitly require padding.
-//
-// Returns (b64_string, "") on success, ("", error) on failure.
-base64_encode_padded(data: string, length: int) -> {
-    out = cryptography_base64_encode_padded_raw(data, length)
-    if out == 0 {
-        return "", "openssl unavailable"
-    }
-    return out, ""
-}
-
-// Decode a Base64 string back into raw bytes. Accepts both padded
-// and unpadded RFC 4648 §4 input. Returns (bytes, length, "")
-// on success — `bytes` is an AetherString preserving any embedded
-// NULs in the decoded payload.
-//
-// Returns ("", 0, error) on:
-//   - malformed Base64 input
-//   - OpenSSL unavailable
-//   - allocation failure
-//
-// Same shape as fs.read_binary so callers can chain through the
-// same destructure pattern.
-base64_decode(b64: string) -> {
-    ok = cryptography_base64_decode_raw(b64)
-    if ok == 0 {
-        return "", 0, "base64 decode failed"
-    }
-    raw = cryptography_get_base64_decode()
-    n = cryptography_get_base64_decode_length()
-    owned = string_new_with_length(raw, n)
-    cryptography_release_base64_decode()
-    return owned, n, ""
-}
+// Base64 now lives in std.encoding (its correct home — it is an encoding,
+// not cryptography). Use `encoding.base64_encode` / `_padded` / `_decode`.
+// `random_base64` below still offers a crypto-random-bytes-to-base64
+// convenience, now built on encoding.base64_encode.
 
 // MD4 hex digest. Legacy — included for interop with formats that
 // bake it into the wire shape (zsync's per-block strong checksum,
@@ -399,7 +339,7 @@ random_base64(n: int) -> {
     if n == 0 {
         return "", ""
     }
-    return base64_encode(raw, raw_n)
+    return encoding.base64_encode(raw, raw_n), ""
 }
 
 // ---- Incremental (streaming) digest context ----

--- a/std/deque/module.ae
+++ b/std/deque/module.ae
@@ -1,0 +1,137 @@
+// std.deque — a fixed-capacity double-ended queue / ring buffer of `long`
+// values (a `long` holds any int, and a pointer via mem.ptr_to_long, so this
+// backs work queues, sliding windows, and FIFO/LIFO buffers uniformly).
+//
+// Circular-buffer backed: push/pop at either end are O(1) with no element
+// shuffling. `push_back` on a full buffer OVERWRITES the oldest element
+// (front), matching C3's `std::collections::ringbuffer` semantics — the
+// classic sliding-window behaviour. Use the fallible `pop_*` return to
+// distinguish empty. Values are `long`; store an int directly or a pointer
+// via std.mem.
+//
+// Modelled on C3's ringbuffer + deque (MIT, Copyright (c) 2022-2026
+// Christoffer Lernö and contributors), re-expressed for a concrete `long`
+// element type (no generics).
+
+import std.longarr
+
+exports (
+    Deque,
+    new, free,
+    len, cap, is_empty, is_full,
+    push_back, push_front,
+    pop_front, pop_back,
+    peek_front, peek_back,
+    clear
+)
+
+// A ring buffer. `head` is the index of the current front element; `count`
+// is how many are live. The backing store holds `capacity` slots.
+struct Deque {
+    store: ptr      // longarr of `capacity` slots
+    capacity: int
+    head: int       // index of the front element
+    count: int      // number of live elements
+}
+
+// Create a deque holding up to `capacity` elements (capacity >= 1).
+new(capacity: int) -> Deque {
+    n = capacity
+    if n < 1 { n = 1 }
+    s, _ = longarr.new_filled(n, 0)
+    d = Deque { store: s, capacity: n, head: 0, count: 0 }
+    return d
+}
+
+// Release the backing store. The Deque value is invalid afterwards.
+free(d: Deque) {
+    longarr.free(d.store)
+}
+
+len(d: Deque) -> int { return d.count }
+cap(d: Deque) -> int { return d.capacity }
+is_empty(d: Deque) -> bool { return d.count == 0 }
+is_full(d: Deque) -> bool { return d.count == d.capacity }
+
+// Index of the slot `offset` positions after `head`, wrapping.
+fn wrap(d: Deque, offset: int) -> int {
+    i = d.head + offset
+    while i >= d.capacity { i = i - d.capacity }
+    while i < 0 { i = i + d.capacity }
+    return i
+}
+
+// Append at the back. On a full buffer this OVERWRITES the oldest (front)
+// element and advances the front — the ring-buffer/sliding-window
+// behaviour. Returns the updated Deque (value semantics: reassign it,
+// `d = deque.push_back(d, x)`).
+push_back(d: Deque, value: long) -> Deque {
+    r = d
+    if r.count == r.capacity {
+        // full: drop the front, write over its slot at the back
+        slot = wrap(r, r.count)          // == head (the front slot)
+        longarr.set(r.store, slot, value)
+        r.head = wrap(r, 1)
+        return r
+    }
+    slot = wrap(r, r.count)
+    longarr.set(r.store, slot, value)
+    r.count = r.count + 1
+    return r
+}
+
+// Prepend at the front. On a full buffer this OVERWRITES the newest (back)
+// element. Returns the updated Deque.
+push_front(d: Deque, value: long) -> Deque {
+    r = d
+    r.head = wrap(r, -1)
+    longarr.set(r.store, r.head, value)
+    if r.count < r.capacity {
+        r.count = r.count + 1
+    }
+    return r
+}
+
+// Remove and return the front element as (value, deque, ""), or
+// (0, deque, error) when empty. Reassign the returned deque.
+pop_front(d: Deque) -> (long, Deque, string) {
+    r = d
+    if r.count == 0 { return 0, r, "deque: empty" }
+    v, _ = longarr.get(r.store, r.head)
+    r.head = wrap(r, 1)
+    r.count = r.count - 1
+    return v, r, ""
+}
+
+// Remove and return the back element as (value, deque, ""), or
+// (0, deque, error) when empty.
+pop_back(d: Deque) -> (long, Deque, string) {
+    r = d
+    if r.count == 0 { return 0, r, "deque: empty" }
+    slot = wrap(r, r.count - 1)
+    v, _ = longarr.get(r.store, slot)
+    r.count = r.count - 1
+    return v, r, ""
+}
+
+// Read the front element without removing it: (value, "") or (0, error).
+peek_front(d: Deque) -> (long, string) {
+    if d.count == 0 { return 0, "deque: empty" }
+    v, _ = longarr.get(d.store, d.head)
+    return v, ""
+}
+
+// Read the back element without removing it.
+peek_back(d: Deque) -> (long, string) {
+    if d.count == 0 { return 0, "deque: empty" }
+    v, _ = longarr.get(d.store, wrap(d, d.count - 1))
+    return v, ""
+}
+
+// Empty the deque (keeps capacity). Returns the updated Deque.
+clear(d: Deque) -> Deque {
+    r = d
+    r.head = 0
+    r.count = 0
+    return r
+}

--- a/std/encoding/module.ae
+++ b/std/encoding/module.ae
@@ -8,19 +8,24 @@
 // fallible decode returns `string!` — the value on success, a non-empty
 // error on malformed input.
 //
-// hex is RFC 4648 §8; base64 is RFC 4648 §4. The hex codec is a direct
-// port of C3's `std::encoding::hex` (RFC 4648, https://rfc-editor.org/
-// rfc/rfc4648) — Copyright (c) 2022-2026 Christoffer Lernö and
-// contributors, MIT (the c3c stdlib), re-expressed in Aether. base64
-// re-surfaces Aether's existing, tested implementation
-// (std/cryptography/aether_cryptography.c).
+// hex is RFC 4648 §8; base64 is §4; base32 is §6. The hex and base32
+// codecs are direct ports of C3's `std::encoding::{hex,base32}` (RFC 4648,
+// https://rfc-editor.org/rfc/rfc4648) — Copyright (c) 2022-2026 Christoffer
+// Lernö and contributors, MIT (the c3c stdlib), re-expressed in Aether.
+// base64 wraps Aether's existing implementation in
+// std/cryptography/aether_cryptography.c — it moved here from
+// std.cryptography (its correct home: base64 is an encoding, not
+// cryptography). `cryptography.random_base64` still offers the
+// crypto-random-bytes-to-base64 convenience, now built on this module.
 
 import std.string
 import std.bytes
 
 exports (
     hex_encode, hex_decode,
-    base64_encode, base64_encode_url, base64_decode
+    base64_encode, base64_encode_padded, base64_decode,
+    base32_encode, base32_decode,
+    csv_split, csv_count, csv_field, csv_free
 )
 
 // ---------------------------------------------------------------------------
@@ -101,9 +106,10 @@ base64_encode(data: string, length: int) -> string {
     return cryptography_base64_encode_raw(data, length)
 }
 
-// Standard-alphabet base64 WITH `=` padding — the form most non-strict
-// decoders on the wire expect.
-base64_encode_url(data: string, length: int) -> string {
+// Standard-alphabet base64 WITH `=` padding to a multiple of 4 — the form
+// some auth headers and JSON blob formats require. (Standard `+/`
+// alphabet; NOT the url-safe `-_` alphabet.)
+base64_encode_padded(data: string, length: int) -> string {
     if length <= 0 { return "" }
     return cryptography_base64_encode_padded_raw(data, length)
 }
@@ -122,4 +128,166 @@ base64_decode(b64: string) -> string! {
     owned = string_new_with_length(raw, n)
     cryptography_release_base64_decode()
     return owned
+}
+
+// ---------------------------------------------------------------------------
+// base32 (RFC 4648 §6) — standard alphabet, `=` padded. Ported from C3's
+// `std::encoding::base32` (MIT, Copyright (c) 2022-2026 Christoffer Lernö and
+// contributors): 5 input bytes -> 8 output chars, five bits per char.
+// ---------------------------------------------------------------------------
+
+// Standard base32 alphabet index (0..31) -> ASCII. A..Z map to 0..25,
+// 2..7 map to 26..31. (RFC 4648 §6.)
+fn b32_digit(v: int) -> int {
+    if v < 26 { return 65 + v }        // 'A' + v
+    return 24 + v                       // '2' + (v - 26) == 50 + v - 26
+}
+
+// ASCII base32 char -> value 0..31, or -1 if not in the alphabet.
+// Case-insensitive on the A..Z portion.
+fn b32_value(c: int) -> int {
+    if c >= 65 && c <= 90 { return c - 65 }   // 'A'..'Z'
+    if c >= 97 && c <= 122 { return c - 97 }  // 'a'..'z' (accepted)
+    if c >= 50 && c <= 55 { return c - 24 }   // '2'..'7' -> 26..31
+    return -1
+}
+
+// Encode `length` bytes of `data` as standard, `=`-padded base32.
+base32_encode(data: string, length: int) -> string {
+    if length <= 0 { return "" }
+    // Output is ceil(length/5)*8 characters (padded).
+    groups = (length + 4) / 5
+    out_len = groups * 8
+    buf = bytes.new(out_len)
+    i = 0
+    o = 0
+    while i < length {
+        // Load up to 5 bytes into a 40-bit value (missing bytes = 0).
+        n = length - i
+        if n > 5 { n = 5 }
+        b0 = string.char_at_n(data, length, i) & 255
+        b1 = 0
+        b2 = 0
+        b3 = 0
+        b4 = 0
+        if n > 1 { b1 = string.char_at_n(data, length, i + 1) & 255 }
+        if n > 2 { b2 = string.char_at_n(data, length, i + 2) & 255 }
+        if n > 3 { b3 = string.char_at_n(data, length, i + 3) & 255 }
+        if n > 4 { b4 = string.char_at_n(data, length, i + 4) & 255 }
+        // 40-bit accumulator across two ints (msb: top 32 bits, lsb adds b4).
+        // Extract eight 5-bit chunks, most-significant first.
+        c0 = (b0 >> 3) & 31
+        c1 = ((b0 << 2) | (b1 >> 6)) & 31
+        c2 = (b1 >> 1) & 31
+        c3 = ((b1 << 4) | (b2 >> 4)) & 31
+        c4 = ((b2 << 1) | (b3 >> 7)) & 31
+        c5 = (b3 >> 2) & 31
+        c6 = ((b3 << 3) | (b4 >> 5)) & 31
+        c7 = b4 & 31
+        // Number of output chars produced by `n` input bytes (RFC 4648):
+        // 1->2, 2->4, 3->5, 4->7, 5->8; the rest are '='.
+        produced = 8
+        if n == 1 { produced = 2 }
+        if n == 2 { produced = 4 }
+        if n == 3 { produced = 5 }
+        if n == 4 { produced = 7 }
+        bytes.set(buf, o, b32_digit(c0))
+        bytes.set(buf, o + 1, b32_digit(c1))
+        if produced > 2 { bytes.set(buf, o + 2, b32_digit(c2)) } else { bytes.set(buf, o + 2, 61) }
+        if produced > 3 { bytes.set(buf, o + 3, b32_digit(c3)) } else { bytes.set(buf, o + 3, 61) }
+        if produced > 4 { bytes.set(buf, o + 4, b32_digit(c4)) } else { bytes.set(buf, o + 4, 61) }
+        if produced > 5 { bytes.set(buf, o + 5, b32_digit(c5)) } else { bytes.set(buf, o + 5, 61) }
+        if produced > 6 { bytes.set(buf, o + 6, b32_digit(c6)) } else { bytes.set(buf, o + 6, 61) }
+        if produced > 7 { bytes.set(buf, o + 7, b32_digit(c7)) } else { bytes.set(buf, o + 7, 61) }
+        o = o + 8
+        i = i + 5
+    }
+    return bytes.finish(buf, out_len)
+}
+
+// Decode a standard-alphabet base32 string (with or without `=` padding)
+// to its bytes. Returns the decoded bytes, or a non-empty error on a
+// character outside the alphabet.
+base32_decode(s: string) -> string! {
+    n = string.length(s)
+    if n == 0 { return "" }
+    // Strip trailing '=' padding for the bit math; each 8-char group of
+    // chars carries 40 bits -> 5 bytes, fewer for a short final group.
+    real = n
+    while real > 0 && (string.char_at_n(s, n, real - 1) & 255) == 61 {
+        real = real - 1
+    }
+    // Output length: real chars * 5 bits / 8.
+    out_len = (real * 5) / 8
+    buf = bytes.new(out_len)
+    // Accumulate 5 bits per char into a running bit buffer; emit a byte
+    // every time we have >= 8 bits.
+    acc = 0
+    nbits = 0
+    o = 0
+    i = 0
+    while i < real {
+        v = b32_value(string.char_at_n(s, n, i) & 255)
+        if v < 0 {
+            bytes.free(buf)
+            return "", "base32: invalid character"
+        }
+        acc = (acc << 5) | v
+        nbits = nbits + 5
+        if nbits >= 8 {
+            nbits = nbits - 8
+            bytes.set(buf, o, (acc >> nbits) & 255)
+            o = o + 1
+        }
+        i = i + 1
+    }
+    return bytes.finish(buf, out_len)
+}
+
+// ---------------------------------------------------------------------------
+// csv (RFC 4180-lite) — field splitting on a caller-chosen separator, the
+// same simple model as C3's `std::encoding::csv` (MIT, Copyright (c)
+// 2022-2026 Christoffer Lernö and contributors): split a record on the
+// separator, no embedded-quote handling. Multi-row input is handled by the
+// caller splitting on "\n" first; csv_split trims a trailing "\r" so
+// "\r\n"-terminated lines parse cleanly.
+//
+// Usage:
+//   h = encoding.csv_split("a,b,c", ",")
+//   n = encoding.csv_count(h)          // 3
+//   f = encoding.csv_field(h, 0)       // "a"
+//   encoding.csv_free(h)               // release the field array
+// ---------------------------------------------------------------------------
+
+// Split one CSV record into fields on `sep`. Returns an owned handle;
+// read it with csv_count / csv_field, then release with csv_free. A
+// trailing "\r" (from a "\r\n" line ending) is trimmed before splitting.
+csv_split(record: string, sep: string) -> ptr {
+    n = string.length(record)
+    rec = record
+    if n > 0 && (string.char_at_n(record, n, n - 1) & 255) == 13 {
+        // strip trailing '\r'
+        rec = string.substring(record, 0, n - 1)
+    }
+    return string.split(rec, sep)
+}
+
+// Number of fields in a handle returned by csv_split.
+csv_count(handle: ptr) -> int {
+    return string.array_size(handle)
+}
+
+// Field `i` (0-based) as a string. Out-of-range yields "". The returned
+// string is BORROWED from the handle — valid until csv_free(handle); copy
+// it (string.concat(f, "")) if you need to hold it past the free.
+csv_field(handle: ptr, i: int) -> string {
+    if i < 0 || i >= string.array_size(handle) { return "" }
+    p = string.array_get(handle, i)
+    if p == null { return "" }
+    return p as string
+}
+
+// Release a handle returned by csv_split.
+csv_free(handle: ptr) {
+    string.array_free(handle)
 }

--- a/std/hash/module.ae
+++ b/std/hash/module.ae
@@ -1,0 +1,115 @@
+// std.hash — fast NON-cryptographic hashes for checksums and hashmap
+// seeding. NOT for security (use std.cryptography for that).
+//
+//   fnv32 / fnv64  — FNV-1a (Fowler–Noll–Vo), simple and fast for short keys
+//   murmur3_32     — MurmurHash3 x86 32-bit, good distribution for hashmaps
+//
+// Input is a byte string (embedded NULs honoured via the supplied length).
+// Results are the exact 32-/64-bit unsigned values the reference algorithms
+// produce, carried in Aether's signed `int`/`long` (mask with 0xFFFFFFFF /
+// interpret bit-for-bit as unsigned). Ported from C3's `std::hash::*` (MIT,
+// Copyright (c) 2022-2026 Christoffer Lernö and contributors).
+
+import std.string
+import std.bits
+
+exports (
+    fnv32, fnv64, murmur3_32
+)
+
+// FNV-1a 32-bit. offset basis 0x811c9dc5, prime 0x01000193. Returned as a
+// non-negative 32-bit value in a `long` (masked each step so the multiply
+// wraps like unsigned uint32 regardless of Aether's signed int width).
+fnv32(data: string, length: int) -> long {
+    let mask: long = 0xFFFFFFFF
+    let h: long = 0x811c9dc5
+    i = 0
+    while i < length {
+        b = (string.char_at_n(data, length, i) & 255) as long
+        h = (h ^ b) & mask
+        h = (h * 0x01000193) & mask
+        i = i + 1
+    }
+    return h
+}
+
+// FNV-1a 64-bit. offset basis 0xcbf29ce484222325, prime 0x100000001b3.
+// Uses wrapping 64-bit multiply so the product wraps like unsigned uint64.
+fnv64(data: string, length: int) -> long {
+    h = 0xcbf29ce484222325
+    prime = 0x100000001b3
+    i = 0
+    while i < length {
+        b = (string.char_at_n(data, length, i) & 255) as long
+        h = h ^ b
+        h = bits.wrapping_mul64(h, prime)
+        i = i + 1
+    }
+    return h
+}
+
+// MurmurHash3 x86 32-bit. `seed` lets callers salt the hash (0 for a plain
+// digest). Processes 4-byte little-endian blocks then the 1..3-byte tail,
+// with the standard fmix32 finalizer.
+// Implemented in 64-bit `long` throughout with an explicit 32-bit mask after
+// every step, so the arithmetic matches unsigned uint32 exactly regardless
+// of Aether's signed-int width, and the final value is a non-negative 32-bit
+// number. Rotates use the 32-bit rotate on the masked value.
+murmur3_32(data: string, length: int, seed: int) -> long {
+    let c1: long = 0xcc9e2d51
+    let c2: long = 0x1b873593
+    let mask: long = 0xFFFFFFFF
+    let h1: long = (seed as long) & mask
+    nblocks = length / 4
+    i = 0
+    while i < nblocks {
+        base = i * 4
+        b0 = (string.char_at_n(data, length, base) & 255) as long
+        b1 = (string.char_at_n(data, length, base + 1) & 255) as long
+        b2 = (string.char_at_n(data, length, base + 2) & 255) as long
+        b3 = (string.char_at_n(data, length, base + 3) & 255) as long
+        let k1: long = (b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)) & mask
+        k1 = (k1 * c1) & mask
+        k1 = rotl32m(k1, 15)
+        k1 = (k1 * c2) & mask
+        h1 = (h1 ^ k1) & mask
+        h1 = rotl32m(h1, 13)
+        h1 = ((h1 * 5) + 0xe6546b64) & mask
+        i = i + 1
+    }
+    // tail: remaining 1..3 bytes
+    tail = nblocks * 4
+    rem = length - tail
+    let k1t: long = 0
+    if rem == 3 { k1t = k1t ^ (((string.char_at_n(data, length, tail + 2) & 255) as long) << 16) }
+    if rem >= 2 { k1t = k1t ^ (((string.char_at_n(data, length, tail + 1) & 255) as long) << 8) }
+    if rem >= 1 {
+        k1t = k1t ^ ((string.char_at_n(data, length, tail) & 255) as long)
+        k1t = (k1t * c1) & mask
+        k1t = rotl32m(k1t, 15)
+        k1t = (k1t * c2) & mask
+        h1 = (h1 ^ k1t) & mask
+    }
+    // finalization
+    h1 = (h1 ^ (length as long)) & mask
+    h1 = fmix32(h1)
+    return h1
+}
+
+// 32-bit left rotate of a value already masked to 32 bits, in `long`.
+fn rotl32m(x: long, r: int) -> long {
+    let mask: long = 0xFFFFFFFF
+    return ((x << r) | (x >> (32 - r))) & mask
+}
+
+// MurmurHash3 32-bit finalizer (in `long`, masked).
+fn fmix32(h0: long) -> long {
+    let mask: long = 0xFFFFFFFF
+    h = h0 & mask
+    h = (h ^ (h >> 16)) & mask
+    h = (h * 0x85ebca6b) & mask
+    h = (h ^ (h >> 13)) & mask
+    h = (h * 0xc2b2ae35) & mask
+    h = (h ^ (h >> 16)) & mask
+    return h
+}

--- a/std/sort/module.ae
+++ b/std/sort/module.ae
@@ -1,0 +1,179 @@
+// std.sort — in-place ascending sort + binary search over the concrete
+// numeric array types (std.intarr / std.longarr / std.floatarr).
+//
+// Scoped to concrete types by design (see docs/cross-references/
+// c3-stdlib-gaps.md §2.3): C3's `std::sort` is generics-first, which
+// Aether lowers differently; here each element type gets a direct sort so
+// there is no generic machinery to reason about. The default order is
+// ascending. Sorts are IN PLACE and stable is not guaranteed (shell sort).
+//
+// The algorithm choice (shell sort with the Ciura gap sequence) and the
+// binary-search contract follow C3's `std::sort` at the capability level
+// (MIT, Copyright (c) 2022-2026 Christoffer Lernö and contributors),
+// re-expressed for Aether's concrete array types.
+
+exports (
+    ints, longs, floats,
+    int_search, long_search, float_search
+)
+
+// ---- array externs (bound to the same C the array modules use) -----------
+extern intarr_size(arr: ptr) -> int
+extern intarr_get_unchecked(arr: ptr, i: int) -> int
+extern intarr_set_unchecked(arr: ptr, i: int, value: int)
+
+extern longarr_size(arr: ptr) -> int
+extern longarr_get_unchecked(arr: ptr, i: int) -> long
+extern longarr_set_unchecked(arr: ptr, i: int, value: long)
+
+extern floatarr_size(arr: ptr) -> int
+extern floatarr_get_unchecked(arr: ptr, i: int) -> double
+extern floatarr_set_unchecked(arr: ptr, i: int, value: double)
+
+// Ciura's gap sequence, extended by *2.25 for larger n. A module-level
+// const array of the fixed prefix; larger gaps are computed on the fly.
+const CIURA[] = [1, 4, 10, 23, 57, 132, 301, 701]
+
+// ---- intarr ---------------------------------------------------------------
+
+// Sort an intarr ascending, in place.
+ints(arr: ptr) {
+    n = intarr_size(arr)
+    if n < 2 { return }
+    // Build the largest starting gap <= n/2 (Ciura, then *2.25 growth).
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4   // ~*2.25
+    }
+    // Shell sort with the descending gap chain.
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = intarr_get_unchecked(arr, i)
+            j = i
+            while j >= gap && intarr_get_unchecked(arr, j - gap) > tmp {
+                intarr_set_unchecked(arr, j, intarr_get_unchecked(arr, j - gap))
+                j = j - gap
+            }
+            intarr_set_unchecked(arr, j, tmp)
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
+}
+
+// Binary search a SORTED intarr for `x`. Returns the index of `x` if
+// present, otherwise the insertion point (the index where `x` would be
+// inserted to keep the array sorted) — matching C3's binarysearch contract.
+int_search(arr: ptr, x: int) -> int {
+    lo = 0
+    hi = intarr_size(arr)
+    while lo < hi {
+        mid = lo + (hi - lo) / 2
+        v = intarr_get_unchecked(arr, mid)
+        if v < x { lo = mid + 1 } else { hi = mid }
+    }
+    return lo
+}
+
+// ---- longarr --------------------------------------------------------------
+
+longs(arr: ptr) {
+    n = longarr_size(arr)
+    if n < 2 { return }
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4
+    }
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = longarr_get_unchecked(arr, i)
+            j = i
+            while j >= gap && longarr_get_unchecked(arr, j - gap) > tmp {
+                longarr_set_unchecked(arr, j, longarr_get_unchecked(arr, j - gap))
+                j = j - gap
+            }
+            longarr_set_unchecked(arr, j, tmp)
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
+}
+
+long_search(arr: ptr, x: long) -> int {
+    lo = 0
+    hi = longarr_size(arr)
+    while lo < hi {
+        mid = lo + (hi - lo) / 2
+        v = longarr_get_unchecked(arr, mid)
+        if v < x { lo = mid + 1 } else { hi = mid }
+    }
+    return lo
+}
+
+// ---- floatarr -------------------------------------------------------------
+
+floats(arr: ptr) {
+    n = floatarr_size(arr)
+    if n < 2 { return }
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4
+    }
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = floatarr_get_unchecked(arr, i)
+            j = i
+            while j >= gap && floatarr_get_unchecked(arr, j - gap) > tmp {
+                floatarr_set_unchecked(arr, j, floatarr_get_unchecked(arr, j - gap))
+                j = j - gap
+            }
+            floatarr_set_unchecked(arr, j, tmp)
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
+}
+
+float_search(arr: ptr, x: double) -> int {
+    lo = 0
+    hi = floatarr_size(arr)
+    while lo < hi {
+        mid = lo + (hi - lo) / 2
+        v = floatarr_get_unchecked(arr, mid)
+        if v < x { lo = mid + 1 } else { hi = mid }
+    }
+    return lo
+}

--- a/std/time/module.ae
+++ b/std/time/module.ae
@@ -1,0 +1,272 @@
+// std.time — civil date/time over Unix epoch seconds (UTC).
+//
+// The canonical value is Unix epoch SECONDS (a `long`); civil fields
+// (year/month/day/hour/min/sec + weekday/year-day) are derived from it and
+// vice versa with an exact, dependency-free proleptic-Gregorian algorithm
+// (Howard Hinnant's `days_from_civil` / `civil_from_days`, public domain —
+// http://howardhinnant.github.io/date_algorithms.html), so results are
+// deterministic and testable without libc timezone state. All times are UTC.
+//
+// The calendar algorithm and the ISO-8601 shape mirror C3's `std::time`
+// (MIT, Copyright (c) 2022-2026 Christoffer Lernö and contributors) at the
+// capability level, re-expressed in Aether's idiom (free functions +
+// tuples/struct rather than methods/operators). Duration is measured in
+// whole seconds here; sub-second precision is a later extension.
+
+import std.string
+import std.os
+
+exports (
+    DateTime,
+    now, now_ms,
+    from_civil,
+    from_unix, to_unix,
+    weekday, day_of_year, is_leap_year, days_in_month,
+    add_seconds, add_minutes, add_hours, add_days,
+    diff_seconds, is_before, is_after,
+    to_iso8601, parse_iso8601
+)
+
+// A civil UTC date/time. `epoch` (epoch seconds) is canonical; the civil
+// fields are a decoded view of it. Build with from_civil / from_unix / now;
+// read fields directly.
+struct DateTime {
+    epoch: long      // canonical: seconds since 1970-01-01T00:00:00Z
+    year: int
+    month: int      // 1..12
+    day: int        // 1..31
+    hour: int       // 0..23
+    minute: int     // 0..59
+    second: int     // 0..59
+    wday: int       // 0=Sunday .. 6=Saturday
+    yday: int       // 1..366
+}
+
+// ---- calendar core (Hinnant's algorithms) --------------------------------
+
+is_leap_year(y: int) -> bool {
+    if y % 4 != 0 { return false }
+    if y % 100 != 0 { return true }
+    return y % 400 == 0
+}
+
+days_in_month(y: int, m: int) -> int {
+    if m == 2 {
+        if is_leap_year(y) { return 29 }
+        return 28
+    }
+    // Apr, Jun, Sep, Nov -> 30; the rest 31.
+    if m == 4 || m == 6 || m == 9 || m == 11 { return 30 }
+    return 31
+}
+
+// Days since 1970-01-01 for a civil y/m/d (proleptic Gregorian). Exact for
+// all years; `m` in 1..12, `d` in 1..31.
+fn days_from_civil(y: int, m: int, d: int) -> long {
+    yy = y
+    if m <= 2 { yy = yy - 1 }
+    era = yy
+    if era < 0 { era = era - 399 }
+    era = era / 400
+    yoe = yy - era * 400                       // [0, 399]
+    mp = m + 9
+    if m > 2 { mp = m - 3 }                     // [0, 11]
+    doy = (153 * mp + 2) / 5 + d - 1            // [0, 365]
+    doe = yoe * 365 + yoe / 4 - yoe / 100 + doy // [0, 146096]
+    return (era as long) * 146097 + (doe as long) - 719468
+}
+
+// Inverse: civil y/m/d from days-since-epoch. Returns (year, month, day).
+fn civil_from_days(z: long) -> (int, int, int) {
+    zz = z + 719468
+    era = zz
+    if era < 0 { era = era - 146096 }
+    era = era / 146097
+    doe = zz - era * 146097                     // [0, 146096]
+    yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365  // [0, 399]
+    y = (yoe as int) + (era as int) * 400
+    doy = doe - (365 * yoe + yoe / 4 - yoe / 100)               // [0, 365]
+    mp = (5 * (doy as int) + 2) / 153                            // [0, 11]
+    d = (doy as int) - (153 * mp + 2) / 5 + 1                    // [1, 31]
+    m = mp + 3
+    if mp >= 10 { m = mp - 9 }                                   // [1, 12]
+    yr = y
+    if m <= 2 { yr = y + 1 }
+    return yr, m, d
+}
+
+// ---- construction --------------------------------------------------------
+
+const SECS_PER_DAY = 86400
+const SECS_PER_HOUR = 3600
+const SECS_PER_MIN = 60
+
+// Build a DateTime from an epoch-seconds value, decoding civil fields.
+from_unix(epoch: long) -> DateTime {
+    // Floor-divide into days + intraday seconds (handles negatives).
+    days = epoch / SECS_PER_DAY
+    rem = epoch - days * SECS_PER_DAY
+    if rem < 0 {
+        rem = rem + SECS_PER_DAY
+        days = days - 1
+    }
+    y, mo, d = civil_from_days(days)
+    secs = rem as int
+    hh = secs / SECS_PER_HOUR
+    mm = (secs - hh * SECS_PER_HOUR) / SECS_PER_MIN
+    ss = secs - hh * SECS_PER_HOUR - mm * SECS_PER_MIN
+    // Weekday: 1970-01-01 was a Thursday (=4). days can be negative.
+    w = ((days + 4) % 7) as int
+    if w < 0 { w = w + 7 }
+    // Day of year (1-based).
+    yd = (days - days_from_civil(y, 1, 1)) as int + 1
+    dt = DateTime {
+        epoch: epoch, year: y, month: mo, day: d,
+        hour: hh, minute: mm, second: ss, wday: w, yday: yd
+    }
+    return dt
+}
+
+// Build a DateTime from civil UTC fields (normalising via epoch seconds).
+from_civil(year: int, month: int, day: int, hour: int, minute: int, second: int) -> DateTime {
+    days = days_from_civil(year, month, day)
+    intraday = (hour as long) * SECS_PER_HOUR + (minute as long) * SECS_PER_MIN + (second as long)
+    epoch = days * SECS_PER_DAY + intraday
+    return from_unix(epoch)
+}
+
+// Current UTC time (whole seconds).
+now() -> DateTime {
+    return from_unix(now_ms() / 1000)
+}
+
+// Current Unix time in milliseconds (raw, no civil decode).
+now_ms() -> long {
+    return os.now_unix_ms()
+}
+
+// The canonical epoch-seconds value of a DateTime.
+to_unix(dt: DateTime) -> long {
+    return dt.epoch
+}
+
+// ---- field accessors (also available directly on the struct) -------------
+
+weekday(dt: DateTime) -> int { return dt.wday }
+day_of_year(dt: DateTime) -> int { return dt.yday }
+
+// ---- arithmetic (returns a fresh normalised DateTime) --------------------
+
+add_seconds(dt: DateTime, s: long) -> DateTime { return from_unix(dt.epoch + s) }
+add_minutes(dt: DateTime, m: long) -> DateTime { return from_unix(dt.epoch + m * SECS_PER_MIN) }
+add_hours(dt: DateTime, h: long) -> DateTime { return from_unix(dt.epoch + h * SECS_PER_HOUR) }
+add_days(dt: DateTime, d: long) -> DateTime { return from_unix(dt.epoch + d * SECS_PER_DAY) }
+
+// Signed difference a - b in whole seconds.
+diff_seconds(a: DateTime, b: DateTime) -> long { return a.epoch - b.epoch }
+
+is_before(a: DateTime, b: DateTime) -> bool { return a.epoch < b.epoch }
+is_after(a: DateTime, b: DateTime) -> bool { return a.epoch > b.epoch }
+
+// ---- ISO-8601 / RFC-3339 (UTC, "Z") --------------------------------------
+
+fn pad2(buf: ptr, off: int, v: int) -> int {
+    // write v (0..99) as two ASCII digits at off
+    bytes_set2(buf, off, 48 + (v / 10) % 10, 48 + v % 10)
+    return off + 2
+}
+
+// Format as "YYYY-MM-DDTHH:MM:SSZ" (RFC-3339 UTC). Years are zero-padded to
+// at least 4 digits.
+to_iso8601(dt: DateTime) -> string {
+    // YYYY (4) - (1) MM (2) - (1) DD (2) T (1) HH (2) : MM : SS Z  = 20 chars
+    buf = bytes_new(20)
+    y = dt.year
+    if y < 0 { y = 0 }
+    bytes_set(buf, 0, 48 + (y / 1000) % 10)
+    bytes_set(buf, 1, 48 + (y / 100) % 10)
+    bytes_set(buf, 2, 48 + (y / 10) % 10)
+    bytes_set(buf, 3, 48 + y % 10)
+    bytes_set(buf, 4, 45)   // '-'
+    pad2(buf, 5, dt.month)
+    bytes_set(buf, 7, 45)   // '-'
+    pad2(buf, 8, dt.day)
+    bytes_set(buf, 10, 84)  // 'T'
+    pad2(buf, 11, dt.hour)
+    bytes_set(buf, 13, 58)  // ':'
+    pad2(buf, 14, dt.minute)
+    bytes_set(buf, 16, 58)  // ':'
+    pad2(buf, 17, dt.second)
+    bytes_set(buf, 19, 90)  // 'Z'
+    return bytes_finish(buf, 20)
+}
+
+// Parse "YYYY-MM-DDTHH:MM:SS" with an optional trailing 'Z' (UTC). A space
+// may replace the 'T'. Returns the DateTime, or a non-empty error on a
+// malformed shape / out-of-range field.
+parse_iso8601(s: string) -> (DateTime, string) {
+    n = string.length(s)
+    if n < 19 { return zero_dt(), "time: string too short for ISO-8601" }
+    y = digits4(s, n, 0)
+    mo = digits2(s, n, 5)
+    d = digits2(s, n, 8)
+    hh = digits2(s, n, 11)
+    mm = digits2(s, n, 14)
+    ss = digits2(s, n, 17)
+    if y < 0 || mo < 1 || mo > 12 || d < 1 || d > 31 ||
+       hh < 0 || hh > 23 || mm < 0 || mm > 59 || ss < 0 || ss > 59 {
+        return zero_dt(), "time: invalid ISO-8601 field"
+    }
+    // Separators must be '-','-','T'|' ',':',':'.
+    if (string.char_at_n(s, n, 4) & 255) != 45 { return zero_dt(), "time: bad date separator" }
+    if (string.char_at_n(s, n, 7) & 255) != 45 { return zero_dt(), "time: bad date separator" }
+    sep = string.char_at_n(s, n, 10) & 255
+    if sep != 84 && sep != 32 { return zero_dt(), "time: bad date/time separator" }
+    if (string.char_at_n(s, n, 13) & 255) != 58 { return zero_dt(), "time: bad time separator" }
+    if (string.char_at_n(s, n, 16) & 255) != 58 { return zero_dt(), "time: bad time separator" }
+    if d > days_in_month(y, mo) { return zero_dt(), "time: day out of range for month" }
+    return from_civil(y, mo, d, hh, mm, ss), ""
+}
+
+// ---- helpers -------------------------------------------------------------
+
+fn zero_dt() -> DateTime {
+    return from_unix(0)
+}
+
+// Parse a run of ASCII digits; returns the value or -1 if any char in the
+// window is not a digit.
+fn digits2(s: string, n: int, off: int) -> int {
+    if off + 2 > n { return -1 }
+    a = (string.char_at_n(s, n, off) & 255) - 48
+    b = (string.char_at_n(s, n, off + 1) & 255) - 48
+    if a < 0 || a > 9 || b < 0 || b > 9 { return -1 }
+    return a * 10 + b
+}
+
+fn digits4(s: string, n: int, off: int) -> int {
+    if off + 4 > n { return -1 }
+    v = 0
+    i = 0
+    while i < 4 {
+        c = (string.char_at_n(s, n, off + i) & 255) - 48
+        if c < 0 || c > 9 { return -1 }
+        v = v * 10 + c
+        i = i + 1
+    }
+    return v
+}
+
+// bytes wrappers (direct externs so the heap-string classifier recognises
+// bytes_finish by name for a leak-clean owned return).
+extern aether_bytes_new(initial_capacity: int) -> ptr
+extern aether_bytes_set(b: ptr, index: int, value: int) -> int
+extern aether_bytes_finish(b: ptr, length: int) -> string @heap
+
+fn bytes_new(cap: int) -> ptr { return aether_bytes_new(cap) }
+fn bytes_set(b: ptr, i: int, v: int) -> int { return aether_bytes_set(b, i, v) }
+fn bytes_set2(b: ptr, i: int, v0: int, v1: int) -> int {
+    aether_bytes_set(b, i, v0)
+    return aether_bytes_set(b, i + 1, v1)
+}
+fn bytes_finish(b: ptr, len: int) -> string { return aether_bytes_finish(b, len) }

--- a/tests/integration/aether_string_to_c_extern/probe.ae
+++ b/tests/integration/aether_string_to_c_extern/probe.ae
@@ -16,6 +16,7 @@
 import std.string
 import std.bytes
 import std.cryptography
+import std.encoding
 
 extern read_first4_as_int(content: string) -> int
 extern memcpy_into(dst: string, src: string, n: int) -> int
@@ -43,9 +44,9 @@ main() {
     // Case 2: cryptography.base64_decode returns an AetherString*
     // with embedded NULs. The C side memcpys 4 bytes; the buffer
     // we receive should contain those 4 bytes verbatim.
-    raw, raw_len, _ = cryptography.base64_decode("AABCAA==")  // 0x00 0x00 0x42 0x00
-    if raw_len != 4 {
-        println("FAIL: base64 raw_len=${raw_len}, want 4")
+    raw, _ = encoding.base64_decode("AABCAA==")  // 0x00 0x00 0x42 0x00
+    if string.length(raw) != 4 {
+        println("FAIL: base64 raw_len=${string.length(raw)}, want 4")
         exit(1)
     }
     b = bytes.new(8)

--- a/tests/integration/cryptography_v2/probe.ae
+++ b/tests/integration/cryptography_v2/probe.ae
@@ -13,6 +13,7 @@
 // Same SKIP-when-no-OpenSSL pattern as cryptography_sha test.
 
 import std.cryptography
+import std.encoding
 import std.string
 import std.io
 
@@ -37,8 +38,7 @@ main() {
 
     // ---- Test 1: base64_encode("Man", 3) == "TWFu" ----
     print("Test 1: base64_encode(\"Man\", 3) == \"TWFu\"\n")
-    e1, eerr1 = cryptography.base64_encode("Man", 3)
-    if eerr1 != "" { println("  FAIL: ${eerr1}"); exit(1) }
+    e1 = encoding.base64_encode("Man", 3)
     if string.equals(e1, "TWFu") != 1 {
         println("  FAIL: got '${e1}', want 'TWFu'")
         exit(1)
@@ -47,8 +47,7 @@ main() {
 
     // ---- Test 2: base64_encode("hello world", 11) == "aGVsbG8gd29ybGQ" ----
     print("\nTest 2: base64_encode(\"hello world\", 11)\n")
-    e2, eerr2 = cryptography.base64_encode("hello world", 11)
-    if eerr2 != "" { println("  FAIL: ${eerr2}"); exit(1) }
+    e2 = encoding.base64_encode("hello world", 11)
     if string.equals(e2, "aGVsbG8gd29ybGQ") != 1 {
         println("  FAIL: got '${e2}', want 'aGVsbG8gd29ybGQ'")
         exit(1)
@@ -58,11 +57,11 @@ main() {
     // ---- Test 3: ASCII round-trip ----
     print("\nTest 3: ASCII round-trip\n")
     payload3 = "the quick brown fox"
-    enc3, _ = cryptography.base64_encode(payload3, 19)
-    dec3, dlen3, derr3 = cryptography.base64_decode(enc3)
+    enc3 = encoding.base64_encode(payload3, 19)
+    dec3, derr3 = encoding.base64_decode(enc3)
     if derr3 != "" { println("  FAIL decode: ${derr3}"); exit(1) }
-    if dlen3 != 19 {
-        println("  FAIL: expected 19 bytes, got ${dlen3}")
+    if string.length(dec3) != 19 {
+        println("  FAIL: expected 19 bytes, got ${string.length(dec3)}")
         exit(1)
     }
     if string.equals(dec3, payload3) != 1 {
@@ -78,19 +77,18 @@ main() {
     print("\nTest 4: binary payload with NUL round-trips\n")
     bin = cryptography_v2_probe_make_binary()
     bin_len = 10
-    enc4, eerr4 = cryptography.base64_encode(bin, bin_len)
-    if eerr4 != "" { println("  FAIL encode: ${eerr4}"); exit(1) }
-    dec4, dlen4, derr4 = cryptography.base64_decode(enc4)
+    enc4 = encoding.base64_encode(bin, bin_len)
+    dec4, derr4 = encoding.base64_decode(enc4)
     if derr4 != "" { println("  FAIL decode: ${derr4}"); exit(1) }
-    if dlen4 != 10 {
-        println("  FAIL: expected 10 bytes, got ${dlen4}")
+    if string.length(dec4) != 10 {
+        println("  FAIL: expected 10 bytes, got ${string.length(dec4)}")
         exit(1)
     }
     // Verify byte-identical via sha256: the digest of the round-tripped
     // bytes must match the digest of the original. We can't string.equals
     // because of the embedded NUL.
     h_orig, _ = cryptography.sha256_hex(bin, bin_len)
-    h_rt, _   = cryptography.sha256_hex(dec4, dlen4)
+    h_rt, _   = cryptography.sha256_hex(dec4, string.length(dec4))
     if string.equals(h_orig, h_rt) != 1 {
         println("  FAIL: round-tripped digest differs")
         println("    orig=${h_orig}")
@@ -101,16 +99,15 @@ main() {
 
     // ---- Test 5: empty input ----
     print("\nTest 5: empty input encodes to \"\", decodes to 0 bytes\n")
-    e5, eerr5 = cryptography.base64_encode("", 0)
-    if eerr5 != "" { println("  FAIL encode: ${eerr5}"); exit(1) }
+    e5 = encoding.base64_encode("", 0)
     if string.length(e5) != 0 {
         println("  FAIL: empty encode should be 0 chars, got '${e5}'")
         exit(1)
     }
-    _, dlen5, derr5 = cryptography.base64_decode("")
+    d5, derr5 = encoding.base64_decode("")
     if derr5 != "" { println("  FAIL decode: ${derr5}"); exit(1) }
-    if dlen5 != 0 {
-        println("  FAIL: empty decode should be 0 bytes, got ${dlen5}")
+    if string.length(d5) != 0 {
+        println("  FAIL: empty decode should be 0 bytes, got ${string.length(d5)}")
         exit(1)
     }
     print("  PASS\n")

--- a/tests/regression/test_deque.ae
+++ b/tests/regression/test_deque.ae
@@ -1,0 +1,89 @@
+// std.deque regression — fixed-capacity ring buffer / double-ended queue.
+// Vectors adapted from C3's stdlib unit test (test/unit/stdlib/collections/
+// ringbuffer.c3) — Copyright (c) 2022-2026 Christoffer Lernö and
+// contributors, MIT — re-expressed for Aether's value-semantics API
+// (push/pop return the updated Deque).
+
+import std.deque
+import std.string
+
+extern exit(code: int)
+
+fn ck(cond: bool, msg: string) -> int {
+    if !cond { println("FAIL: ${msg}"); return 1 }
+    return 0
+}
+
+main() {
+    fails = 0
+
+    // ---- empty invariants ----
+    d = deque.new(8)
+    fails = fails + ck(deque.is_empty(d), "new is empty")
+    fails = fails + ck(!deque.is_full(d), "new not full")
+    fails = fails + ck(deque.len(d) == 0, "new len 0")
+    fails = fails + ck(deque.cap(d) == 8, "cap 8")
+    // pop on empty errors
+    _, d, pe = deque.pop_front(d)
+    fails = fails + ck(pe != "", "pop empty errors")
+
+    // ---- push half, check len (C3 push_pop) ----
+    i = 1
+    while i <= 4 { d = deque.push_back(d, i); i = i + 1 }
+    fails = fails + ck(deque.len(d) == 4 && !deque.is_full(d), "half filled")
+
+    // ---- fill to capacity ----
+    while i <= 8 { d = deque.push_back(d, i); i = i + 1 }
+    fails = fails + ck(deque.is_full(d) && deque.len(d) == 8, "full")
+
+    // ---- FIFO pop order: 1,2,3,...,8 ----
+    j = 1
+    ok = true
+    while j <= 8 {
+        v, d2, e = deque.pop_front(d)
+        d = d2
+        if e != "" || v != j { ok = false }
+        j = j + 1
+    }
+    fails = fails + ck(ok, "FIFO pop order 1..8")
+    fails = fails + ck(deque.is_empty(d), "empty after draining")
+
+    // ---- overwrite-on-full (ring/sliding window) ----
+    r = deque.new(3)
+    r = deque.push_back(r, 10)
+    r = deque.push_back(r, 20)
+    r = deque.push_back(r, 30)   // full: [10,20,30]
+    r = deque.push_back(r, 40)   // overwrite 10: [20,30,40]
+    fails = fails + ck(deque.len(r) == 3, "ring stays at cap")
+    pf, _ = deque.peek_front(r)
+    pb, _ = deque.peek_back(r)
+    fails = fails + ck(pf == 20 && pb == 40, "ring overwrote oldest")
+
+    // ---- double-ended: push_front / pop_back ----
+    q = deque.new(4)
+    q = deque.push_back(q, 2)
+    q = deque.push_back(q, 3)
+    q = deque.push_front(q, 1)   // [1,2,3]
+    fq, _ = deque.peek_front(q)
+    bq, _ = deque.peek_back(q)
+    fails = fails + ck(fq == 1 && bq == 3, "push_front/back ends")
+    vb, q, _ = deque.pop_back(q)  // pops 3
+    fails = fails + ck(vb == 3, "pop_back")
+    vf, q, _ = deque.pop_front(q) // pops 1
+    fails = fails + ck(vf == 1, "pop_front after pop_back")
+    fails = fails + ck(deque.len(q) == 1, "one left")
+
+    // ---- clear ----
+    q = deque.clear(q)
+    fails = fails + ck(deque.is_empty(q), "cleared")
+
+    deque.free(d)
+    deque.free(r)
+    deque.free(q)
+
+    if fails != 0 {
+        println("deque: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_deque")
+}

--- a/tests/regression/test_encoding.ae
+++ b/tests/regression/test_encoding.ae
@@ -46,8 +46,24 @@ main() {
     fails = fails + check(encoding.base64_encode("foobar", 6) == "Zm9vYmFy", "b64 encode foobar")
 
     // ---- base64 encode (padded, from c3 encode) ----
-    fails = fails + check(encoding.base64_encode_url("f", 1) == "Zg==", "b64 padded f")
-    fails = fails + check(encoding.base64_encode_url("foobar", 6) == "Zm9vYmFy", "b64 padded foobar")
+    fails = fails + check(encoding.base64_encode_padded("f", 1) == "Zg==", "b64 padded f")
+    fails = fails + check(encoding.base64_encode_padded("foobar", 6) == "Zm9vYmFy", "b64 padded foobar")
+
+    // ---- base32 (RFC 4648 §6 vectors, from c3 base32.c3) ----
+    fails = fails + check(encoding.base32_encode("", 0) == "", "b32 empty")
+    fails = fails + check(encoding.base32_encode("f", 1) == "MY======", "b32 f")
+    fails = fails + check(encoding.base32_encode("fo", 2) == "MZXQ====", "b32 fo")
+    fails = fails + check(encoding.base32_encode("foo", 3) == "MZXW6===", "b32 foo")
+    fails = fails + check(encoding.base32_encode("foob", 4) == "MZXW6YQ=", "b32 foob")
+    fails = fails + check(encoding.base32_encode("fooba", 5) == "MZXW6YTB", "b32 fooba")
+    fails = fails + check(encoding.base32_encode("foobar", 6) == "MZXW6YTBOI======", "b32 foobar")
+    b32d, b32e = encoding.base32_decode("MZXW6YTBOI======")
+    fails = fails + check(b32e == "" && b32d == "foobar", "b32 decode foobar")
+    b32d2, b32e2 = encoding.base32_decode("MZXW6===")
+    fails = fails + check(b32e2 == "" && b32d2 == "foo", "b32 decode foo")
+    // base32 round-trip
+    b32r, _ = encoding.base32_decode(encoding.base32_encode("hello world", 11))
+    fails = fails + check(b32r == "hello world", "b32 round-trip")
 
     // ---- base64 decode (padded and unpadded, from c3 decode) ----
     bd1, be1 = encoding.base64_decode("Zm9vYmFy")
@@ -64,6 +80,31 @@ main() {
     fails = fails + check(hround == msg, "hex round-trip")
     bround, _ = encoding.base64_decode(encoding.base64_encode(msg, mlen))
     fails = fails + check(bround == msg, "base64 round-trip")
+
+    // ---- csv (vectors from c3 encoding/csv test) ----
+    // comma-separated
+    h1 = encoding.csv_split("aaa,bbb,ccc", ",")
+    fails = fails + check(encoding.csv_count(h1) == 3, "csv comma count")
+    fails = fails + check(encoding.csv_field(h1, 0) == "aaa", "csv f0")
+    fails = fails + check(encoding.csv_field(h1, 2) == "ccc", "csv f2")
+    encoding.csv_free(h1)
+    // semicolon separator (c3 vector {"aaa;bbb;ccc",";"})
+    h2 = encoding.csv_split("aaa;bbb;ccc", ";")
+    fails = fails + check(encoding.csv_count(h2) == 3, "csv semicolon count")
+    fails = fails + check(encoding.csv_field(h2, 1) == "bbb", "csv semicolon f1")
+    encoding.csv_free(h2)
+    // whitespace preserved inside fields (c3 vector: "aaa , bbb" -> "aaa ", " bbb")
+    h3 = encoding.csv_split("aaa , bbb ,ccc", ",")
+    fails = fails + check(encoding.csv_field(h3, 0) == "aaa " && encoding.csv_field(h3, 1) == " bbb ", "csv preserves spaces")
+    encoding.csv_free(h3)
+    // \r\n line ending: trailing \r trimmed (caller split on \n)
+    h4 = encoding.csv_split("111,222,333\r", ",")
+    fails = fails + check(encoding.csv_count(h4) == 3 && encoding.csv_field(h4, 2) == "333", "csv strips trailing CR")
+    encoding.csv_free(h4)
+    // out-of-range field yields ""
+    h5 = encoding.csv_split("a,b", ",")
+    fails = fails + check(encoding.csv_field(h5, 9) == "", "csv oob empty")
+    encoding.csv_free(h5)
 
     if fails != 0 {
         println("encoding: ${fails} failure(s)")

--- a/tests/regression/test_hash.ae
+++ b/tests/regression/test_hash.ae
@@ -1,0 +1,57 @@
+// std.hash regression — non-cryptographic hashes against published
+// reference vectors (FNV-1a, MurmurHash3 x86 32-bit). Algorithms ported
+// from C3's std::hash (MIT, Copyright (c) 2022-2026 Christoffer Lernö and
+// contributors); the expected values are the canonical reference outputs
+// for these hashes, independent of any implementation.
+
+import std.hash
+import std.string
+
+extern exit(code: int)
+
+fn ck(cond: bool, msg: string) -> int {
+    if !cond { println("FAIL: ${msg}"); return 1 }
+    return 0
+}
+
+main() {
+    fails = 0
+
+    // ---- FNV-1a 32-bit (canonical vectors) ----
+    fails = fails + ck(hash.fnv32("", 0) == 2166136261, "fnv32 empty (0x811c9dc5)")
+    fails = fails + ck(hash.fnv32("a", 1) == 3826002220, "fnv32 'a' (0xe40c292c)")
+    fails = fails + ck(hash.fnv32("hello", 5) == 1335831723, "fnv32 'hello' (0x4f9f2cab)")
+    fails = fails + ck(hash.fnv32("foobar", 6) == 3214735720, "fnv32 'foobar' (0xbf9cf968)")
+
+    // ---- FNV-1a 64-bit (canonical vectors; signed view of the u64) ----
+    // 0xcbf29ce484222325 / 0xa430d84680aabd0b
+    fails = fails + ck(hash.fnv64("", 0) == -3750763034362895579, "fnv64 empty")
+    fails = fails + ck(hash.fnv64("hello", 5) == -6615550055289275125, "fnv64 'hello'")
+
+    // ---- MurmurHash3 x86 32-bit (seed 0 reference vectors) ----
+    fails = fails + ck(hash.murmur3_32("", 0, 0) == 0, "murmur empty seed0")
+    fails = fails + ck(hash.murmur3_32("hello", 5, 0) == 613153351, "murmur 'hello' (0x248bfa47)")
+    // seed changes the digest
+    fails = fails + ck(hash.murmur3_32("hello", 5, 42) != hash.murmur3_32("hello", 5, 0), "murmur seed matters")
+
+    // ---- determinism + distribution sanity ----
+    fails = fails + ck(hash.fnv32("abc", 3) == hash.fnv32("abc", 3), "fnv32 deterministic")
+    fails = fails + ck(hash.fnv32("abc", 3) != hash.fnv32("abd", 3), "fnv32 distinguishes 1 bit")
+    fails = fails + ck(hash.murmur3_32("abc", 3, 0) != hash.murmur3_32("abd", 3, 0), "murmur distinguishes 1 bit")
+
+    // ---- tail-length coverage for murmur (1,2,3,4,5-byte inputs) ----
+    // exercises the 4-byte-block + 1..3-byte-tail paths; just assert they run
+    // and are non-zero & distinct for distinct inputs.
+    m1 = hash.murmur3_32("A", 1, 0)
+    m2 = hash.murmur3_32("AB", 2, 0)
+    m3 = hash.murmur3_32("ABC", 3, 0)
+    m4 = hash.murmur3_32("ABCD", 4, 0)
+    m5 = hash.murmur3_32("ABCDE", 5, 0)
+    fails = fails + ck(m1 != m2 && m2 != m3 && m3 != m4 && m4 != m5, "murmur tail lengths distinct")
+
+    if fails != 0 {
+        println("hash: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_hash")
+}

--- a/tests/regression/test_sort.ae
+++ b/tests/regression/test_sort.ae
@@ -1,0 +1,135 @@
+// std.sort regression — in-place ascending sort + binary search over the
+// concrete numeric array types. Vectors ported from C3's stdlib unit tests
+// (test/unit/stdlib/sort/{quicksort,binarysearch}.c3) — Copyright (c)
+// 2022-2026 Christoffer Lernö and contributors, MIT — re-expressed for
+// Aether's concrete intarr/longarr/floatarr.
+
+import std.intarr
+import std.longarr
+import std.floatarr
+import std.sort
+import std.string
+
+extern exit(code: int)
+
+fn ck(cond: bool, msg: string) -> int {
+    if !cond { println("FAIL: ${msg}"); return 1 }
+    return 0
+}
+
+// Is the intarr sorted ascending over [0, n)?
+fn is_sorted_int(a: ptr, n: int) -> bool {
+    i = 1
+    while i < n {
+        p, _ = intarr.get(a, i - 1)
+        c, _ = intarr.get(a, i)
+        if p > c { return false }
+        i = i + 1
+    }
+    return true
+}
+
+main() {
+    fails = 0
+
+    // ---- intarr: C3 quicksort vectors -> verify sorted ----
+    // {4, 8, 100, 1, 2} -> {1, 2, 4, 8, 100}
+    a, _ = intarr.new_filled(5, 0)
+    intarr.set(a, 0, 4)
+    intarr.set(a, 1, 8)
+    intarr.set(a, 2, 100)
+    intarr.set(a, 3, 1)
+    intarr.set(a, 4, 2)
+    sort.ints(a)
+    v0, _ = intarr.get(a, 0)
+    v1, _ = intarr.get(a, 1)
+    v2, _ = intarr.get(a, 2)
+    v3, _ = intarr.get(a, 3)
+    v4, _ = intarr.get(a, 4)
+    fails = fails + ck(v0 == 1 && v1 == 2 && v2 == 4 && v3 == 8 && v4 == 100, "int exact sort")
+
+    // {3, 2, 1} and {2, 1, 3} -> sorted
+    b, _ = intarr.new_filled(3, 0)
+    intarr.set(b, 0, 3); intarr.set(b, 1, 2); intarr.set(b, 2, 1)
+    sort.ints(b)
+    fails = fails + ck(is_sorted_int(b, 3), "int {3,2,1} sorted")
+    c, _ = intarr.new_filled(3, 0)
+    intarr.set(c, 0, 2); intarr.set(c, 1, 1); intarr.set(c, 2, 3)
+    sort.ints(c)
+    fails = fails + ck(is_sorted_int(c, 3), "int {2,1,3} sorted")
+
+    // empty + single are no-ops (must not crash)
+    e0, _ = intarr.new_filled(0, 0)
+    sort.ints(e0)
+    e1, _ = intarr.new_filled(1, 0)
+    intarr.set(e1, 0, 42)
+    sort.ints(e1)
+    s1, _ = intarr.get(e1, 0)
+    fails = fails + ck(s1 == 42, "int single unchanged")
+
+    // a larger randomish array crosses the shell-sort gap chain
+    big, _ = intarr.new_filled(50, 0)
+    i = 0
+    while i < 50 { intarr.set(big, i, (i * 37) % 50); i = i + 1 }
+    sort.ints(big)
+    fails = fails + ck(is_sorted_int(big, 50), "int 50-element sorted")
+
+    // ---- binary search (C3 binarysearch vectors) ----
+    // {1,2,3}: search 1->0, 2->1, 3->2, 4->3 (insertion point)
+    srt, _ = intarr.new_filled(3, 0)
+    intarr.set(srt, 0, 1); intarr.set(srt, 1, 2); intarr.set(srt, 2, 3)
+    fails = fails + ck(sort.int_search(srt, 1) == 0, "search 1 -> 0")
+    fails = fails + ck(sort.int_search(srt, 2) == 1, "search 2 -> 1")
+    fails = fails + ck(sort.int_search(srt, 3) == 2, "search 3 -> 2")
+    fails = fails + ck(sort.int_search(srt, 4) == 3, "search 4 -> 3 (insert)")
+    // {10,20,30}: 14 -> 1, 26 -> 2 (insertion points)
+    srt2, _ = intarr.new_filled(3, 0)
+    intarr.set(srt2, 0, 10); intarr.set(srt2, 1, 20); intarr.set(srt2, 2, 30)
+    fails = fails + ck(sort.int_search(srt2, 14) == 1, "search 14 -> 1")
+    fails = fails + ck(sort.int_search(srt2, 26) == 2, "search 26 -> 2")
+
+    // ---- longarr ----
+    la, _ = longarr.new_filled(5, 0)
+    longarr.set(la, 0, 500)
+    longarr.set(la, 1, 3)
+    longarr.set(la, 2, 501)
+    longarr.set(la, 3, 1)
+    longarr.set(la, 4, 250)
+    sort.longs(la)
+    l0, _ = longarr.get(la, 0)
+    l4, _ = longarr.get(la, 4)
+    l2, _ = longarr.get(la, 2)
+    fails = fails + ck(l0 == 1 && l2 == 250 && l4 == 501, "long sort order")
+    fails = fails + ck(sort.long_search(la, 500) == 3, "long search")
+
+    // ---- floatarr ----
+    fa, _ = floatarr.new_filled(4, 0.0)
+    floatarr.set(fa, 0, 3.5)
+    floatarr.set(fa, 1, 1.25)
+    floatarr.set(fa, 2, 2.75)
+    floatarr.set(fa, 3, 0.5)
+    sort.floats(fa)
+    f0, _ = floatarr.get(fa, 0)
+    f3, _ = floatarr.get(fa, 3)
+    fails = fails + ck(f0 < 0.6 && f3 > 3.4, "float sort endpoints")
+    fails = fails + ck(sort.float_search(fa, 2.75) == 2, "float search")
+
+    // Reclaim the arrays (std.sort itself allocates nothing — it sorts in
+    // place — so the only heap here is the test's own arrays).
+    intarr.free(a)
+    intarr.free(b)
+    intarr.free(c)
+    intarr.free(e0)
+    intarr.free(e1)
+    intarr.free(big)
+    intarr.free(srt)
+    intarr.free(srt2)
+    longarr.free(la)
+    floatarr.free(fa)
+
+    if fails != 0 {
+        println("sort: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_sort")
+}

--- a/tests/regression/test_stdlib_binary_safety_batch.ae
+++ b/tests/regression/test_stdlib_binary_safety_batch.ae
@@ -9,7 +9,7 @@
 
 import std.string
 import std.os
-import std.cryptography
+import std.encoding
 
 extern exit(code: int)
 
@@ -33,11 +33,7 @@ main() {
 
     // --- cryptography.base64_encode_padded ---
     // 2 input bytes "AB" → "QUI" unpadded, "QUI=" padded.
-    pad, perr = cryptography.base64_encode_padded("AB", 2)
-    if string.length(perr) > 0 {
-        println("FAIL 3: padded err='${perr}'")
-        exit(1)
-    }
+    pad = encoding.base64_encode_padded("AB", 2)
     if string.equals(pad, "QUI=") == 0 {
         println("FAIL 3: padded='${pad}', want 'QUI='")
         exit(1)
@@ -45,7 +41,7 @@ main() {
     println("  PASS 3: base64_encode_padded(2 bytes) == 'QUI='")
 
     // 3 input bytes — already a multiple of 3, no padding either way.
-    pad3, _ = cryptography.base64_encode_padded("ABC", 3)
+    pad3 = encoding.base64_encode_padded("ABC", 3)
     if string.equals(pad3, "QUJD") == 0 {
         println("FAIL 4: padded='${pad3}', want 'QUJD'")
         exit(1)
@@ -53,7 +49,7 @@ main() {
     println("  PASS 4: base64_encode_padded(3 bytes) == 'QUJD' (no padding needed)")
 
     // 1 input byte → "QQ==" padded ("QQ" unpadded).
-    pad1, _ = cryptography.base64_encode_padded("A", 1)
+    pad1 = encoding.base64_encode_padded("A", 1)
     if string.equals(pad1, "QQ==") == 0 {
         println("FAIL 5: padded='${pad1}', want 'QQ=='")
         exit(1)
@@ -62,7 +58,7 @@ main() {
 
     // The unpadded sibling is unchanged — verify both forms produce
     // the right shapes side-by-side.
-    unp, _ = cryptography.base64_encode("AB", 2)
+    unp = encoding.base64_encode("AB", 2)
     if string.equals(unp, "QUI") == 0 {
         println("FAIL 6: unpadded='${unp}', want 'QUI'")
         exit(1)

--- a/tests/regression/test_string_concat_wrapped.ae
+++ b/tests/regression/test_string_concat_wrapped.ae
@@ -18,14 +18,15 @@
 
 import std.string
 import std.cryptography
+import std.encoding
 
 extern exit(code: int)
 
 main() {
     // Case 1: wrapped concat with binary content — embedded NULs survive.
-    raw, raw_len, _ = cryptography.base64_decode("AABCAA==")  // 4 bytes: 0x00 0x00 0x42 0x00
-    if raw_len != 4 {
-        println("FAIL: base64_decode raw_len=${raw_len}, expected 4")
+    raw, _ = encoding.base64_decode("AABCAA==")  // 4 bytes: 0x00 0x00 0x42 0x00
+    if string.length(raw) != 4 {
+        println("FAIL: base64_decode raw_len=${string.length(raw)}, expected 4")
         exit(1)
     }
     joined = string_concat_wrapped("[", raw)

--- a/tests/regression/test_time.ae
+++ b/tests/regression/test_time.ae
@@ -1,0 +1,98 @@
+// std.time regression — civil date/time over Unix epoch (UTC).
+//
+// Vectors adapted from C3's stdlib unit tests (test/unit/stdlib/time/
+// datetime.c3) — Copyright (c) 2022-2026 Christoffer Lernö and
+// contributors, MIT — plus known Unix-epoch fixtures. Aether's API is
+// free-function + struct-field rather than C3's methods/operators, so the
+// vectors are re-expressed (e.g. `d.add_weeks(1)` -> `time.add_days(d, 7)`).
+
+import std.time
+import std.string
+
+extern exit(code: int)
+
+fn ck(cond: bool, msg: string) -> int {
+    if !cond { println("FAIL: ${msg}"); return 1 }
+    return 0
+}
+
+main() {
+    fails = 0
+
+    // ---- known epoch fixtures ----
+    e0 = time.from_unix(0)
+    fails = fails + ck(e0.year == 1970 && e0.month == 1 && e0.day == 1, "epoch date")
+    fails = fails + ck(e0.hour == 0 && e0.minute == 0 && e0.second == 0, "epoch time")
+    fails = fails + ck(e0.wday == 4, "epoch is Thursday (wday 4)")
+
+    // 1234567890 = 2009-02-13T23:31:30Z (a Friday)
+    t = time.from_unix(1234567890)
+    fails = fails + ck(t.year == 2009 && t.month == 2 && t.day == 13, "1234567890 date")
+    fails = fails + ck(t.hour == 23 && t.minute == 31 && t.second == 30, "1234567890 time")
+    fails = fails + ck(t.wday == 5, "1234567890 is Friday")
+
+    // ---- civil round-trip ----
+    c = time.from_civil(2009, 2, 13, 23, 31, 30)
+    fails = fails + ck(c.epoch == 1234567890, "civil -> epoch round-trip")
+
+    // ---- C3 datetime vector: 1973-04-27, add 1 week -> 1973-05-04 ----
+    d = time.from_civil(1973, 4, 27, 0, 0, 0)
+    fails = fails + ck(d.year == 1973 && d.month == 4 && d.day == 27, "c3 base date")
+    d1 = time.add_days(d, 7)
+    fails = fails + ck(d1.year == 1973 && d1.month == 5 && d1.day == 4, "c3 add 1 week")
+    // + 1 day / - 1 day
+    dp = time.add_days(d1, 1)
+    fails = fails + ck(dp.day == 5, "c3 add 1 day")
+    dm = time.add_days(dp, -1)
+    fails = fails + ck(dm.day == 4, "c3 sub 1 day")
+
+    // ---- leap-year handling: 2000 is leap, 1900 is not, 2001 is not ----
+    fails = fails + ck(time.is_leap_year(2000), "2000 leap")
+    fails = fails + ck(!time.is_leap_year(1900), "1900 not leap")
+    fails = fails + ck(!time.is_leap_year(2001), "2001 not leap")
+    fails = fails + ck(time.is_leap_year(2024), "2024 leap")
+    fails = fails + ck(time.days_in_month(2024, 2) == 29, "feb 2024 = 29")
+    fails = fails + ck(time.days_in_month(2023, 2) == 28, "feb 2023 = 28")
+
+    // crossing a leap day: 2024-02-28 + 1 day = 2024-02-29
+    ld = time.add_days(time.from_civil(2024, 2, 28, 0, 0, 0), 1)
+    fails = fails + ck(ld.month == 2 && ld.day == 29, "leap-day crossing")
+
+    // ---- ISO-8601 format + parse round-trip ----
+    fails = fails + ck(time.to_iso8601(t) == "2009-02-13T23:31:30Z", "iso format")
+    p, pe = time.parse_iso8601("2009-02-13T23:31:30Z")
+    fails = fails + ck(pe == "" && p.epoch == 1234567890, "iso parse")
+    // space separator accepted
+    p2, pe2 = time.parse_iso8601("2009-02-13 23:31:30")
+    fails = fails + ck(pe2 == "" && p2.epoch == 1234567890, "iso parse (space sep)")
+    // malformed rejected
+    _, be = time.parse_iso8601("not-a-date")
+    fails = fails + ck(be != "", "malformed rejected")
+    _, be2 = time.parse_iso8601("2009-13-13T00:00:00Z")   // month 13
+    fails = fails + ck(be2 != "", "bad month rejected")
+    _, be3 = time.parse_iso8601("2023-02-29T00:00:00Z")   // not a leap year
+    fails = fails + ck(be3 != "", "feb 29 non-leap rejected")
+
+    // ---- diff + ordering ----
+    a = time.from_unix(1000)
+    b = time.from_unix(1060)
+    fails = fails + ck(time.diff_seconds(b, a) == 60, "diff 60s")
+    fails = fails + ck(time.is_before(a, b), "a before b")
+    fails = fails + ck(time.is_after(b, a), "b after a")
+
+    // ---- add_hours / add_minutes ----
+    h = time.add_hours(e0, 25)   // 1970-01-02T01:00:00Z
+    fails = fails + ck(h.day == 2 && h.hour == 1, "add 25 hours")
+
+    // ---- a far-future + negative (pre-epoch) date, exact civil math ----
+    // 1969-12-31T23:59:59Z = epoch -1
+    neg = time.from_unix(-1)
+    fails = fails + ck(neg.year == 1969 && neg.month == 12 && neg.day == 31, "pre-epoch date")
+    fails = fails + ck(neg.hour == 23 && neg.minute == 59 && neg.second == 59, "pre-epoch time")
+
+    if fails != 0 {
+        println("time: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_time")
+}


### PR DESCRIPTION
Implements the high-value gaps from [`docs/cross-references/c3-stdlib-gaps.md`](../blob/main/docs/cross-references/c3-stdlib-gaps.md) — porting from C3 **source** (not transplanting its generated C, the survey's rejected approach), staying pure Aether, with **test vectors ported from C3's own unit tests** where they exist. Everything is re-expressed in Aether's idiom (free functions + structs/tuples, not C3's generics/methods/operators).

## Modules

**`std.encoding`** (§2.1, §4)
- `hex` (RFC 4648 §8), `base32` (§6), `csv` field-splitting — direct ports of C3's `std::encoding::{hex,base32,csv}`.
- **`base64` moved here out of `std.cryptography`** (its correct home — an encoding, not cryptography); `base64_encode_url` renamed to the accurate `base64_encode_padded`. All callers (liquid + 4 tests) migrated to the new API/tuple shapes; `cryptography.random_base64` rebuilt on `encoding.base64`.

**`std.time`** (§2.2) — `DateTime` over Unix epoch seconds (UTC) with exact, dependency-free civil↔epoch math (Hinnant's algorithms, no libc timezone state): `now()`, `from_civil`/`from_unix`, ISO-8601 format/parse, `add_*`/`diff`/ordering, leap-year + day-of-week. Vectors from C3's datetime test.

**`std.sort`** (§2.3) — in-place ascending sort (shell sort, Ciura gaps) + binary search over the concrete numeric array types (`intarr`/`longarr`/`floatarr`). Concrete-types-first by design, not C3's generics. Vectors from C3's quicksort/binarysearch tests.

**`std.deque`** (§3.1) — fixed-capacity ring buffer / double-ended queue of `long`: O(1) push/pop at both ends, overwrite-oldest-on-full (sliding window), value semantics. Vectors from C3's ringbuffer test.

**`std.hash`** (§3.3) — non-crypto FNV-1a 32/64 and MurmurHash3 x86 32-bit, verified against canonical reference vectors. Ported from C3's `std::hash`.

## Compiler fix surfaced by the ports

`std.encoding`'s `hex_decode`/`base32_decode` return `bytes.finish(...)` from a `T!` function, which exposed a heap-classifier gap (`codegen_stmt.c`):

- A single-child `return <heap-expr>` in a `T!` function is the result **auto-wrap** `(<expr>, "")`, not a whole-tuple passthrough — but the heap-position walker **vetoed** it, so an imported `T!` returning a bare heap value was misclassified → **leak**.
- The auto-wrap **emit** path didn't uniform-heap-wrap the value slot, so a bare `return ""` in a heap-position `T!` handed the caller a `.rodata` literal it then freed → **invalid-free crash**.

Both closed: the value slot is now classified and emitted consistently with the multi-value tuple path. Verified leak-clean; full suite green with zero blast radius (the shared change doesn't perturb the json/fs/result-migration tests or the leak gates).

## Verification

Five new regression tests (`test_encoding`, `test_time`, `test_sort`, `test_deque`, `test_hash`), all with ported C3 vectors, all leak-checked under valgrind. `make ci` green apart from pre-existing unrelated failures (stray untracked `test_issue1046_bit_set.ae`, flaky h2/proxy/port shell tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)