### PR TITLE
fix(std.longarr): get() truncated 64-bit values to 32 bits

### DIFF
--- a/std/longarr/module.ae
+++ b/std/longarr/module.ae
@@ -85,7 +85,7 @@ new_filled(size: int, init: long) -> {
 // for null array or OOB index. Use the raw `longarr_get_raw` directly
 // (imported above) when you don't need to tell absent apart from
 // stored-zero — it's one fewer function call and one fewer branch.
-get(arr: ptr, i: int) -> {
+get(arr: ptr, i: int) -> (long, string) {
     if arr == null {
         return 0, "null array"
     }

--- a/tests/regression/test_longarr_64bit.ae
+++ b/tests/regression/test_longarr_64bit.ae
@@ -1,0 +1,61 @@
+// Regression: std.longarr.get truncated 64-bit values to 32 bits.
+//
+// `get(arr, i) -> {` used an INFERRED tuple return type. Its error paths
+// return `0, "..."` — an INT literal in slot 0 — which pinned the tuple's
+// value slot to 32-bit int (the tuple-slot-inference gotcha). The happy
+// path `return longarr_get_raw(arr, i), ""` then narrowed the `long` to
+// that int slot, so any stored value above 2^31 came back truncated
+// (`9000000000` -> `410065408`). Fixed by giving get an explicit
+// `-> (long, string)` return type so slot 0 is `long`.
+//
+// The value is stored correctly (set/new_filled were always fine); only the
+// READ wrapper truncated, so a raw-read saw the right bits while the wrapper
+// did not — this test drives the wrapper on both ends.
+
+import std.longarr
+
+extern exit(code: int)
+
+fn ck(cond: bool, msg: string) -> int {
+    if !cond { println("FAIL: ${msg}"); return 1 }
+    return 0
+}
+
+main() {
+    fails = 0
+
+    a, _ = longarr.new_filled(4, 0)
+
+    // Values that exceed the 32-bit range must survive set -> get.
+    longarr.set(a, 0, 9000000000)          // ~2^33
+    longarr.set(a, 1, 30000000000)         // ~2^34
+    longarr.set(a, 2, 1099511627776)       // 2^40
+    longarr.set(a, 3, -9000000000)         // negative, |v| > 2^31
+
+    v0, e0 = longarr.get(a, 0)
+    fails = fails + ck(e0 == "" && v0 == 9000000000, "9e9 round-trips (was 410065408)")
+    v1, _ = longarr.get(a, 1)
+    fails = fails + ck(v1 == 30000000000, "3e10 round-trips")
+    v2, _ = longarr.get(a, 2)
+    fails = fails + ck(v2 == 1099511627776, "2^40 round-trips")
+    v3, _ = longarr.get(a, 3)
+    fails = fails + ck(v3 == -9000000000, "negative large round-trips")
+
+    // new_filled with a large init decodes correctly through get too.
+    b, _ = longarr.new_filled(2, 5000000000)
+    bv, _ = longarr.get(b, 1)
+    fails = fails + ck(bv == 5000000000, "new_filled large init")
+
+    // error path still reports errors (and the value slot is a benign 0).
+    _, oe = longarr.get(a, 99)
+    fails = fails + ck(oe != "", "out-of-range errors")
+
+    longarr.free(a)
+    longarr.free(b)
+
+    if fails != 0 {
+        println("longarr-64bit: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_longarr_64bit")
+}


### PR DESCRIPTION
Fixing the bugs I flagged during the C3 stdlib batch. Investigation found **one real bug, not two** — and it was different from how I first described it.

## The real bug: `longarr.get` truncates 64-bit values

`longarr.get(arr, i) -> {` used an **inferred** tuple return type. Its error paths `return 0, "..."` put an **int literal** in slot 0, which pinned the tuple's value slot to 32-bit int (the tuple-slot-inference gotcha). The happy path `return longarr_get_raw(arr, i), ""` then narrowed the `long` to that int slot:

```aether
longarr.set(a, 0, 9000000000)   // stored fine (64-bit end to end)
v, _ = longarr.get(a, 0)        // v == 410065408  (truncated!)  ← bug
```

The value was **stored** correctly all along — `set`/`new_filled`/the raw externs are 64-bit end to end; only the **read wrapper** truncated (a raw read saw the right bits, the wrapper did not). My original flag ("`longarr.set` big-literal truncation") was wrong on both counts — it's `get`, and it's the inference gotcha, not literals.

**Fix:** give `get` an explicit `-> (long, string)` return type so slot 0 is `long` and the int-literal error returns coerce up instead of pinning the slot down. Verified across 2^33 / 2^34 / 2^40 and a large negative; regression `tests/regression/test_longarr_64bit.ae`.

Only `longarr.get` was affected — `intarr.get` returns int (correct), and `floatarr.get`'s error paths return `0.0` (float literal → slot already float, no truncation).

## The second "bug" was not a bug

I'd flagged a `floatarr` `float`/`double` extern mismatch. On investigation, `floatarr.get`/`.set` work with full double precision — verified (`3.14159`/`2.71828` round-trip exactly). The float-sort scramble I'd attributed to it was **entirely my own shell-sort gap-chain bug**, already fixed in the merged batch (#1169). Aether `float` lowers to C `double`, so the `float` extern declaration is correct. Nothing to fix.

CI green apart from pre-existing unrelated failures (stray `test_issue1046_bit_set.ae`, flaky h2/proxy/port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)