### PR TITLE
feat(ae): cross-compile with `ae build --target=<triple>` via a zig cc backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`ae build --target=<triple>` cross-compiles via a `zig cc` backend** (#1105).
+  Builds a foreign-OS/arch binary using zig as a self-contained cross toolchain:
+  zig bundles each target's libc, headers, and linker, so the Aether runtime and
+  standard library compile straight from source for the target with no cross-gcc
+  or sysroot. The platform backend (`epoll` vs `kqueue`, `spawn_sandboxed_linux`
+  vs the BSD/stub path) is chosen by the `__linux__` / `__APPLE__` macros zig
+  predefines, so one source set serves every target. Supported triples:
+  `aarch64-macos`, `x86_64-macos`, `aarch64-linux`, `x86_64-linux`. The runtime
+  and stdlib are compiled from source, archived, and linked on demand (so a user
+  function may share a name with an unreferenced runtime global, exactly as a
+  native `-laether` link allows). Cross binaries are built without OpenSSL / zlib
+  / nghttp2 / PCRE2, so features needing them (HTTPS/TLS, hashing, base64, regex,
+  compression, HTTP/2) report errors at runtime like a native build lacking those
+  libraries; `ae build` prints a note and builds anyway. Executables only for now
+  (`--emit=lib`/`--emit=both` are rejected), POSIX host. Native builds are
+  unchanged. See `docs/build-system.md`.
+
+### Fixed
+
+- **`MANIFEST` now lists the collections and reactor sources.** The authoritative
+  link-suitable source list (`build/MANIFEST`, #329) was generated from
+  `RUNTIME_SRC` + `STD_SRC` only, silently omitting `COLLECTIONS_SRC` and
+  `STD_REACTOR_SRC`, which are part of `libaether.a`. A downstream consumer
+  linking from MANIFEST would fail to resolve `std.collections`
+  (hashmap/vector/set/...) symbols. Both source groups are now emitted.
+
 ## [0.401.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -532,6 +532,13 @@ test-manual-runtime: compiler
 	@echo "Running manual runtime test..."
 	./build/test_runtime_manual$(EXE_EXT)
 
+# Cross-compilation smoke test (#1105): `ae build --target=<triple>` via
+# the zig cc backend. Self-skips when zig is not installed, so it is safe
+# to run anywhere (it is not part of the default `test` gate because CI
+# does not carry the zig toolchain).
+test-cross: ae stdlib
+	@bash tests/scripts/cross_compile.sh
+
 # Test .ae source files - compiles and runs each test file
 ifdef WINDOWS_NATIVE
 test-ae: compiler ae stdlib
@@ -1063,6 +1070,12 @@ build/MANIFEST: Makefile | $(BUILD_DIR)
 	  echo ""; \
 	  echo "# Standard library sources:"; \
 	  for f in $(STD_SRC); do echo "$$f"; done; \
+	  echo ""; \
+	  echo "# Collections sources:"; \
+	  for f in $(COLLECTIONS_SRC); do echo "$$f"; done; \
+	  echo ""; \
+	  echo "# Reactor sources:"; \
+	  for f in $(STD_REACTOR_SRC); do echo "$$f"; done; \
 	) > build/MANIFEST
 	@echo "✓ MANIFEST: $$(grep -c -v -E '^(#|$$)' build/MANIFEST) link-suitable files"
 # Sandbox preload library (libaether_sandbox.so) — the LD_PRELOAD
@@ -1944,7 +1957,7 @@ asan-check: clean
 	  fi
 	@echo "✓ ASan clean — no memory errors detected"
 
-.PHONY: all compiler lsp apkg ae profiler docgen docs-server docs docs-serve test test-build test-valgrind test-asan test-macos-leaks test-memory test-manual-runtime test-install test-release-archive benchmark benchmark-ui examples run compile repl clean help self-test install stats stdlib stdlib-asan stdlib-memory stdlib-dbg ci ci-windows docker-ci docker-ci-windows docker-build-ci valgrind-check asan-check ci-coop ci-wasm ci-embedded ci-portability docker-ci-wasm docker-ci-embedded contrib-host-check contrib install-contrib stdlib-cov ci-coverage ci-coverage-clean ci-coverage-html
+.PHONY: all compiler lsp apkg ae profiler docgen docs-server docs docs-serve test test-build test-valgrind test-asan test-macos-leaks test-memory test-manual-runtime test-cross test-install test-release-archive benchmark benchmark-ui examples run compile repl clean help self-test install stats stdlib stdlib-asan stdlib-memory stdlib-dbg ci ci-windows docker-ci docker-ci-windows docker-build-ci valgrind-check asan-check ci-coop ci-wasm ci-embedded ci-portability docker-ci-wasm docker-ci-embedded contrib-host-check contrib install-contrib stdlib-cov ci-coverage ci-coverage-clean ci-coverage-html
 
 # Cross-language benchmark UI (alias for benchmark)
 benchmark-ui: benchmark

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -258,9 +258,51 @@ qemu-aarch64 ./probe    # load/run the emitted lib under an emulator
 ```
 
 That produces an arm64 `.so` on a cheap x86_64 runner with no arm64 hardware
-and no new codegen. Cross-OS targets (Linux to Windows or macOS) still need
-native runners. A compiler that cannot be found fails fast with
+and no new codegen. A compiler that cannot be found fails fast with
 `C compiler '<name>' (from $CC) not found` rather than a later link error.
+Cross-**OS** targets (for example Linux to macOS) need a matching C toolchain
+plus that OS's headers, which a stock cross-gcc does not carry: for those, use
+the `zig cc` backend below.
+
+### `ae build --target=<triple>` (cross-OS via a `zig cc` backend)
+
+`ae build --target=<triple>` cross-compiles a foreign-OS/arch binary using
+[zig](https://ziglang.org) as a self-contained cross toolchain. zig bundles
+each target's libc, system headers, and linker, so the Aether runtime and
+standard library compile straight from source for the target: no cross-gcc, no
+target sysroot, no per-host file juggling. The platform backend (`epoll` vs
+`kqueue`, `spawn_sandboxed_linux` vs the BSD/stub path) is selected by the
+`__linux__` / `__APPLE__` macros zig predefines for the target, so one source
+set serves every target.
+
+```bash
+ae build --target=x86_64-linux  hello.ae -o hello      # ELF x86-64
+ae build --target=aarch64-macos hello.ae -o hello      # Mach-O arm64
+```
+
+Supported triples: `aarch64-macos`, `x86_64-macos`, `aarch64-linux`,
+`x86_64-linux` (the `arm64-`/`amd64-` spellings are accepted too). `zig` must
+be on `PATH` (`brew install zig`, or <https://ziglang.org/download/>); the
+build fails fast with an install hint otherwise.
+
+**How it links.** The full runtime and standard library are compiled from
+source for the target and archived, then the program links against that
+archive, so the linker pulls only the objects it references, exactly as a
+native `-laether` link against the complete `libaether.a` does. The first build
+recompiles the runtime from source (a few seconds); caching the per-target
+archive is a planned optimization.
+
+**Scope.** Cross binaries are built without OpenSSL / zlib / nghttp2 / PCRE2
+(zig ships none of those), so standard-library features that need them
+(HTTPS/TLS, hashing, base64, regex, compression, HTTP/2) report errors at
+runtime, exactly like a native build on a host that lacks those libraries;
+plain sockets and pure helpers keep working. `ae build` prints a note when a
+program uses such a module (`std.http`, `std.net`, `std.cryptography`,
+`std.regex`, `std.zlib`, `std.encoding`), then builds it anyway. Cross-building
+those libraries is the documented follow-up. Executables only
+(`--emit=lib`/`--emit=both` are rejected for now), and the host must be POSIX
+(Linux/macOS). The generated binary targets another platform, so it is not
+runnable on the build host; copy it to a matching machine (or an emulator).
 
 ## Build Recommendations
 
@@ -273,6 +315,7 @@ native runners. A compiler that cannot be found fails fast with
 | Hardened | `HARDEN=1` | See "Hardening" section below |
 | WASM | `PLATFORM=wasm` | Cooperative scheduler, Emscripten |
 | Embedded | `PLATFORM=embedded` | Cooperative scheduler, no OS |
+| Cross-OS/arch | `ae build --target=<triple>` | `zig cc` backend, POSIX host, executables |
 
 ## Hardening (`HARDEN=1`)
 

--- a/tests/scripts/cross_compile.sh
+++ b/tests/scripts/cross_compile.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Cross-compilation smoke test for `ae build --target=<triple>` (#1105).
+#
+# Verifies the zig cc backend: each supported target produces a binary of
+# the right object format, and the two error paths (unknown target, a
+# program importing an external-lib module) report cleanly. Cross builds
+# for a foreign OS are not runnable on the build host, so this checks the
+# emitted object format via file(1) rather than executing them; the two
+# host-runnable targets are additionally executed.
+#
+# Requires zig on PATH. When zig is absent (e.g. CI without the zig
+# toolchain) the whole script SKIPS with exit 0 so it never breaks a gate.
+#
+# Run with: make test-cross   (or: bash tests/scripts/cross_compile.sh)
+
+set -u
+cd "$(dirname "$0")/../.." || exit 1
+ROOT="$(pwd)"
+AE="$ROOT/build/ae"
+
+pass=0; fail=0
+ok()   { printf '  \033[0;32mOK\033[0m    %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  \033[0;31mFAIL\033[0m  %s\n' "$1"; fail=$((fail+1)); }
+
+if ! command -v zig >/dev/null 2>&1; then
+    echo "SKIP: zig not installed; cross-compilation test requires zig on PATH."
+    exit 0
+fi
+if [ ! -x "$AE" ]; then
+    echo "SKIP: build/ae not found; run 'make ae' first."
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+HELLO="examples/basics/hello.ae"
+ACTOR="examples/actors/counter.ae"
+HTTP="examples/actors/site-poller.ae"
+
+echo "Cross-compilation targets ($(zig version)):"
+
+# target triple | file(1) substring that must appear | runnable-here flag
+check_target() {
+    local triple="$1" want="$2" run="$3" src="$4"
+    local out="$TMP/out_${triple}"
+    if ! "$AE" build --target="$triple" "$src" -o "$out" >/dev/null 2>"$TMP/err"; then
+        bad "$triple: build failed"; sed 's/^/        /' "$TMP/err"; return
+    fi
+    local desc; desc="$(file -b "$out")"
+    if ! printf '%s' "$desc" | grep -q "$want"; then
+        bad "$triple: expected '$want', got '$desc'"; return
+    fi
+    if [ "$run" = "run" ]; then
+        if ! "$out" >/dev/null 2>&1; then bad "$triple: built but did not run"; return; fi
+        ok "$triple (built + ran): $desc"
+    else
+        ok "$triple: $desc"
+    fi
+}
+
+# arch/OS format checks. macos targets run on this host if it is macOS.
+host_os="$(uname -s)"
+mac_run="nofile"; [ "$host_os" = "Darwin" ] && mac_run="run"
+check_target "x86_64-linux"   "ELF 64-bit"          "nofile"   "$HELLO"
+check_target "aarch64-linux"  "ELF 64-bit"          "nofile"   "$HELLO"
+check_target "aarch64-macos"  "Mach-O 64-bit"       "$mac_run" "$ACTOR"
+check_target "x86_64-macos"   "Mach-O 64-bit"       "$mac_run" "$ACTOR"
+
+# Regression: a program defining a top-level function named like an
+# unreferenced runtime global (e.g. `describe` in aether_host.c) must
+# cross-build, exactly as it builds natively. Guards the archive-based
+# link that gives on-demand object pulling. sum-types.ae defines `describe`.
+if [ -f "examples/basics/sum-types.ae" ]; then
+    if "$AE" build --target=x86_64-linux examples/basics/sum-types.ae -o "$TMP/st" \
+         >/dev/null 2>"$TMP/err"; then
+        ok "symbol-collision program (defines 'describe') cross-builds"
+    else
+        bad "symbol-collision program failed to cross-build"; sed 's/^/        /' "$TMP/err"
+    fi
+fi
+
+# Error path: --emit=lib with a cross target is rejected up front.
+if "$AE" build --target=x86_64-linux --emit=lib "$HELLO" -o "$TMP/xl" >/dev/null 2>"$TMP/err"; then
+    bad "--emit=lib cross: build unexpectedly succeeded"
+elif grep -q "executables only" "$TMP/err"; then
+    ok "--emit=lib cross rejected"
+else
+    bad "--emit=lib cross: wrong error"; sed 's/^/        /' "$TMP/err"
+fi
+
+# Error path: unknown target (no zig needed, but exercised here anyway).
+if "$AE" build --target=sparc-solaris "$HELLO" -o "$TMP/x" >/dev/null 2>"$TMP/err"; then
+    bad "unknown target: build unexpectedly succeeded"
+elif grep -q "Unknown target" "$TMP/err"; then
+    ok "unknown target rejected"
+else
+    bad "unknown target: wrong error"; sed 's/^/        /' "$TMP/err"
+fi
+
+# A program using a library-backed module (std.http) still cross-builds,
+# with a note that those features report unavailable at runtime (matching a
+# native build without OpenSSL/zlib/nghttp2/PCRE2).
+if [ -f "$HTTP" ]; then
+    if "$AE" build --target=x86_64-linux "$HTTP" -o "$TMP/xhttp" >/dev/null 2>"$TMP/err" \
+         && [ -f "$TMP/xhttp" ]; then
+        if grep -q "built without OpenSSL" "$TMP/err"; then
+            ok "library-backed program cross-builds with an availability note"
+        else
+            bad "library-backed program built but emitted no note"; sed 's/^/        /' "$TMP/err"
+        fi
+    else
+        bad "library-backed program failed to cross-build"; sed 's/^/        /' "$TMP/err"
+    fi
+fi
+
+echo ""
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -4901,6 +4901,242 @@ int cmd_build_namespace(int argc, char** argv) {
     return rc;
 }
 
+/* ------------------------------------------------------------------ *
+ *  Cross-compilation via a zig cc backend (#1105)
+ *
+ *  `ae build --target=<triple>` builds a foreign-target binary using
+ *  zig as a self-contained cross-compiler: zig bundles each target's
+ *  libc, system headers and linker, so the Aether runtime and stdlib
+ *  compile straight from source for the target. The platform backend
+ *  (epoll vs kqueue, spawn_sandboxed_linux vs bsd) is chosen by the
+ *  compile-time __linux__ / __APPLE__ macros zig predefines for the
+ *  target, so one source set serves every target with no per-host
+ *  file selection.
+ *
+ *  PR 1 scope: dependency-free programs. Stdlib modules whose C code
+ *  needs an external library we cannot yet cross-build (openssl,
+ *  nghttp2, zlib, pcre2) are left out of the compile set, and a
+ *  program importing one is rejected up front with a clear message.
+ *  Networking / crypto / compression / regex cross builds are the
+ *  documented follow-up. Native builds are entirely unaffected.
+ * ------------------------------------------------------------------ */
+
+/* Map an Aether target string to a zig `-target` triple. Returns NULL
+ * for anything that isn't a supported cross triple (native / wasm /
+ * unknown), which the caller treats as "not a cross build". */
+static const char* cross_target_to_zig(const char* t) {
+    if (!t) return NULL;
+    if (!strcmp(t, "aarch64-macos") || !strcmp(t, "arm64-macos"))  return "aarch64-macos-none";
+    if (!strcmp(t, "x86_64-macos")  || !strcmp(t, "amd64-macos"))  return "x86_64-macos-none";
+    if (!strcmp(t, "aarch64-linux") || !strcmp(t, "arm64-linux"))  return "aarch64-linux-gnu";
+    if (!strcmp(t, "x86_64-linux")  || !strcmp(t, "amd64-linux"))  return "x86_64-linux-gnu";
+    return NULL;
+}
+
+/* Locate the authoritative source MANIFEST and the base directory its
+ * entries are relative to. Dev tree: <root>/build/MANIFEST (entries
+ * relative to <root>). Installed: <root>/share/aether/MANIFEST
+ * (entries relative to <root>/share/aether). Returns false if neither
+ * exists. */
+static bool cross_find_manifest(char* manifest, size_t msz,
+                                char* base, size_t bsz) {
+    snprintf(manifest, msz, "%s/build/MANIFEST", tc.root);
+    if (path_exists(manifest)) { snprintf(base, bsz, "%s", tc.root); return true; }
+    snprintf(manifest, msz, "%s/share/aether/MANIFEST", tc.root);
+    if (path_exists(manifest)) { snprintf(base, bsz, "%s/share/aether", tc.root); return true; }
+    return false;
+}
+
+/* Read MANIFEST into `out`, one absolute source path per entry, for
+ * every link-suitable source. Returns the count (capped at `max`), or
+ * -1 on error (unreadable manifest). `zig cc -c` emits only one object
+ * when handed several sources at once, so the caller compiles each path
+ * individually.
+ *
+ * Every runtime/stdlib source compiles for a cross target with no
+ * external library: each openssl / nghttp2 / zlib / pcre2 dependency is
+ * behind an AETHER_HAS_* guard that falls to a graceful "unavailable"
+ * stub when the macro is undefined (which it is here). So we build the
+ * full set, archive it, and let the final link pull only the objects the
+ * program references, exactly as a native `-laether` link against the
+ * complete libaether.a does. Library-backed features (TLS, real crypto,
+ * regex, zlib, HTTP/2) then report unavailable at runtime on the target,
+ * exactly like a native build on a host without those libraries, while
+ * pure helpers such as base64 (std.encoding) keep working. */
+#define CROSS_SRC_PATH_MAX 1024
+static int cross_collect_core_list(char out[][CROSS_SRC_PATH_MAX], int max,
+                                   const char* manifest, const char* base) {
+    FILE* f = fopen(manifest, "r");
+    if (!f) return -1;
+    int count = 0;
+    char line[1024];
+    while (fgets(line, sizeof(line), f) && count < max) {
+        size_t n = strlen(line);
+        while (n && (line[n-1] == '\n' || line[n-1] == '\r' ||
+                     line[n-1] == ' '  || line[n-1] == '\t')) line[--n] = '\0';
+        char* p = line;
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == '\0' || *p == '#') continue;                 /* comment / blank */
+        size_t plen = strlen(p);
+        if (plen < 2 || strcmp(p + plen - 2, ".c") != 0) continue;
+        snprintf(out[count], CROSS_SRC_PATH_MAX, "%s/%s", base, p);
+        count++;
+    }
+    fclose(f);
+    return count;
+}
+
+/* Scan a program's (transitive) imports via `aetherc --emit=inspect`.
+ * If it uses a stdlib module with library-backed features that are not
+ * cross-built (so they report "unavailable" at runtime on the target),
+ * write the module name to `which` and return true. Used to warn, not
+ * to block: the program still builds and the non-library parts still
+ * work. On inspect failure returns false (no warning). */
+static bool cross_uses_unsupported_module(const char* file, char* which, size_t wsz) {
+    static char out[65536];
+    if (aetherc_capture_stdout("--emit=inspect", file, NULL, out, sizeof(out)) != 0)
+        return false;
+    static const char* mods[] = {
+        "std.http", "std.net", "std.cryptography", "std.regex", "std.zlib",
+        "std.encoding", NULL   /* base64 in std.encoding is openssl-backed */
+    };
+    for (int i = 0; mods[i]; i++) {
+        if (strstr(out, mods[i])) { snprintf(which, wsz, "%s", mods[i]); return true; }
+    }
+    return false;
+}
+
+/* Execute a full cross build: compile the dependency-free core to
+ * per-file objects, archive them, then link the program against the
+ * archive. Linking against an archive (rather than force-linking every
+ * runtime object into the image) reproduces a native `-laether` link's
+ * on-demand object pulling: an object is pulled only when the program
+ * references one of its symbols. That is what lets a user program define
+ * a top-level function named like an *unreferenced* runtime global
+ * (e.g. `describe`, `notify`, `event` in aether_host.c) without a
+ * duplicate-symbol clash, exactly as a native build allows. Returns 0
+ * on success, non-zero (with a diagnostic) otherwise. POSIX host only.
+ *
+ * Feature defines mirror the runtime archive's normal Makefile CFLAGS:
+ * AETHER_HAS_SANDBOX is the only one not auto-derived by
+ * aether_optimization_config.h (filesystem / networking / threading
+ * default on when no AETHER_NO_* is passed). The external-library macros
+ * (AETHER_HAS_OPENSSL / _ZLIB / _NGHTTP2 / _PCRE2) are deliberately left
+ * undefined so their stub paths compile, matching the excluded sources. */
+static int run_cross_build(const char* c_file, const char* out_file,
+                           bool optimize, const char* extra,
+                           const char* ztriple) {
+    char manifest[2048], base[1024];
+    if (!cross_find_manifest(manifest, sizeof(manifest), base, sizeof(base))) {
+        fprintf(stderr,
+            "Error: cross-compilation needs the runtime source MANIFEST, which was "
+            "not found (looked under %s/build and %s/share/aether). Run `make stdlib` "
+            "in a source tree, or reinstall the toolchain.\n", tc.root, tc.root);
+        return 1;
+    }
+    static char srcs[256][CROSS_SRC_PATH_MAX];
+    int n = cross_collect_core_list(srcs, 256, manifest, base);
+    if (n <= 0) {
+        fprintf(stderr, "Error: could not assemble the cross-compile source set from %s.\n",
+                manifest);
+        return 1;
+    }
+
+    /* Fresh per-build object directory under the system temp. */
+    char objdir[1024];
+    snprintf(objdir, sizeof(objdir), "%s/ae-cross-%d", get_temp_dir(), (int)getpid());
+    mkdirs(objdir);
+
+    const char* user_cflags = get_cflags();
+    const char* opt = optimize ? "-O2" : "-O0 -g";
+    const char* ex = extra ? extra : "";
+    const char* feature_defs = "-DAETHER_HAS_SANDBOX";
+    static char cmd[24576];
+    /* Accumulated quoted "<objpath>" list, in compile order, for the ar
+     * step. posix_run tokenizes the command itself (no shell), so the
+     * archive must name each object explicitly rather than glob. */
+    static char objlist[24576];
+    size_t obj_pos = 0;
+    objlist[0] = '\0';
+    int rc = 1;
+
+    int w;
+    do {
+        /* 1. Compile each core source to its own object in objdir. zig cc
+         *    -c emits only one object when handed several sources at once,
+         *    so compile one at a time (all core basenames are unique). */
+        bool compile_failed = false;
+        for (int i = 0; i < n; i++) {
+            const char* bn = strrchr(srcs[i], '/');
+            bn = bn ? bn + 1 : srcs[i];
+            char objpath[2048];
+            /* basename with its trailing ".c" replaced by ".o" */
+            snprintf(objpath, sizeof(objpath), "%s/%.*so", objdir,
+                     (int)(strlen(bn) - 1), bn);
+            w = snprintf(cmd, sizeof(cmd),
+                "zig cc -target %s %s %s %s %s -c \"%s\" -o \"%s\"",
+                ztriple, opt, feature_defs, user_cflags, tc.include_flags,
+                srcs[i], objpath);
+            if (w < 0 || (size_t)w >= sizeof(cmd)) {
+                fprintf(stderr, "Error: cross-compile command exceeded the %zu-byte buffer.\n",
+                        sizeof(cmd));
+                compile_failed = true;
+                break;
+            }
+            if (run_cmd_show_warnings(cmd) != 0) {
+                fprintf(stderr, "Error: cross-compiling %s for %s failed.\n", srcs[i], ztriple);
+                compile_failed = true;
+                break;
+            }
+            int ow = snprintf(objlist + obj_pos, sizeof(objlist) - obj_pos,
+                              "%s\"%s\"", obj_pos ? " " : "", objpath);
+            if (ow < 0 || obj_pos + (size_t)ow >= sizeof(objlist)) {
+                fprintf(stderr, "Error: cross-compile object list overflowed its buffer.\n");
+                compile_failed = true;
+                break;
+            }
+            obj_pos += (size_t)ow;
+        }
+        if (compile_failed) break;
+
+        /* 2. Archive the objects (named explicitly, no glob) so the final
+         *    link pulls only what the program references (native
+         *    `-laether` semantics). */
+        w = snprintf(cmd, sizeof(cmd),
+            "zig ar rcs \"%s/libaether.a\" %s", objdir, objlist);
+        if (w < 0 || (size_t)w >= sizeof(cmd)) {
+            fprintf(stderr, "Error: cross-compile archive command exceeded the %zu-byte buffer.\n",
+                    sizeof(cmd));
+            break;
+        }
+        if (run_cmd_show_warnings(cmd) != 0) {
+            fprintf(stderr, "Error: archiving the cross runtime failed.\n");
+            break;
+        }
+
+        /* 3. Link the program against the archive. */
+        w = snprintf(cmd, sizeof(cmd),
+            "zig cc -target %s %s %s %s \"%s\" %s \"%s/libaether.a\" -o \"%s\" -lm",
+            ztriple, opt, feature_defs, tc.include_flags, c_file, ex, objdir, out_file);
+        if (w < 0 || (size_t)w >= sizeof(cmd)) {
+            fprintf(stderr, "Error: cross-compile link command exceeded the %zu-byte buffer.\n",
+                    sizeof(cmd));
+            break;
+        }
+        if (run_cmd_show_warnings(cmd) != 0) {
+            fprintf(stderr, "Error: cross-linking for %s failed.\n", ztriple);
+            break;
+        }
+        rc = 0;
+    } while (0);
+
+    /* Best-effort removal of the temp object tree. */
+    char rmcmd[1100];
+    snprintf(rmcmd, sizeof(rmcmd), "rm -rf \"%s\"", objdir);
+    (void)system(rmcmd);
+    return rc;
+}
+
 static int cmd_build(int argc, char** argv) {
     const char* file = NULL;
     const char* output_name = NULL;
@@ -4925,6 +5161,8 @@ static int cmd_build(int argc, char** argv) {
             quick = true;
         } else if (strcmp(argv[i], "--target") == 0 && i + 1 < argc) {
             target = argv[++i];
+        } else if (strncmp(argv[i], "--target=", 9) == 0) {
+            target = argv[i] + 9;
         } else if (strcmp(argv[i], "--extra") == 0 && i + 1 < argc) {
             if (extra_files[0]) strncat(extra_files, " ", sizeof(extra_files) - strlen(extra_files) - 1);
             strncat(extra_files, argv[++i], sizeof(extra_files) - strlen(extra_files) - 1);
@@ -5062,12 +5300,17 @@ static int cmd_build(int argc, char** argv) {
         }
     }
 
-    // Validate target
-    if (target && strcmp(target, "wasm") != 0 && strcmp(target, "native") != 0) {
-        fprintf(stderr, "Error: Unknown target '%s'. Valid targets: native, wasm\n", target);
+    // Validate target. Beyond native/wasm, a cross triple routes the
+    // build through the zig cc backend (#1105).
+    const char* ztriple = cross_target_to_zig(target);
+    if (target && strcmp(target, "wasm") != 0 && strcmp(target, "native") != 0 && !ztriple) {
+        fprintf(stderr, "Error: Unknown target '%s'.\n", target);
+        fprintf(stderr, "Valid targets: native, wasm, or a cross triple "
+                        "(aarch64-macos, x86_64-macos, aarch64-linux, x86_64-linux).\n");
         return 1;
     }
     int is_wasm = target && strcmp(target, "wasm") == 0;
+    int is_cross = ztriple != NULL;
 
     // Resolve directory argument (e.g. "." or "myproject/") to src/main.ae
     if (file && dir_exists(file)) {
@@ -5099,8 +5342,10 @@ static int cmd_build(int argc, char** argv) {
 
     if (!file) {
         fprintf(stderr, "Error: No input file specified.\n");
-        fprintf(stderr, "Usage: ae build <file.ae> [-o output] [--extra file.c] [--quick]\n");
+        fprintf(stderr, "Usage: ae build <file.ae> [-o output] [--extra file.c] [--quick] [--target=<triple>]\n");
         fprintf(stderr, "  --quick    Compile with -O0 -g for faster iteration (default: -O2)\n");
+        fprintf(stderr, "  --target   Cross-compile via zig cc: wasm, aarch64-macos, x86_64-macos,\n");
+        fprintf(stderr, "             aarch64-linux, x86_64-linux (dependency-free programs)\n");
         return 1;
     }
 
@@ -5206,6 +5451,36 @@ static int cmd_build(int argc, char** argv) {
         return 1;
     }
 
+    // Pre-flight for cross builds: zig provides the backend compiler +
+    // target libc/linker, and the program must be dependency-free (PR 1).
+    if (is_cross) {
+        // Cross builds produce executables only for now; --emit=lib /
+        // --emit=both would emit library-shaped C (no main) that the
+        // executable link rejects. Reject up front, like unknown targets.
+        if (g_emit_lib) {
+            fprintf(stderr,
+                "Error: cross-compilation (--target=%s) supports executables only; "
+                "--emit=lib and --emit=both are not supported yet.\n", target);
+            return 1;
+        }
+        if (run_cmd_quiet("zig version") != 0) {
+            fprintf(stderr, "Error: zig not found on PATH (required to cross-compile for %s).\n",
+                    target);
+            fprintf(stderr, "Install zig 0.11+: https://ziglang.org/download/  (macOS: brew install zig)\n");
+            return 1;
+        }
+        char mod[64];
+        if (cross_uses_unsupported_module(file, mod, sizeof(mod))) {
+            fprintf(stderr,
+                "Note: '%s' uses %s. Cross binaries are built without OpenSSL / zlib /\n"
+                "nghttp2 / PCRE2, so features that need them (HTTPS/TLS, hashing, base64,\n"
+                "regex, compression, HTTP/2) report errors at runtime on %s, exactly like\n"
+                "a native build on a host without those libraries. Plain sockets and pure\n"
+                "helpers still work. Building anyway.\n",
+                file, mod, target);
+        }
+    }
+
     // Merge toml [[bin]] extra_sources into extra_files BEFORE the cache
     // check so an FFI shim edit invalidates the cached exe (extras
     // content is part of the cache key).
@@ -5229,7 +5504,7 @@ static int cmd_build(int argc, char** argv) {
     // (emcc emits .js + .wasm) and --emit=lib produces a different artefact
     // type; both deserve their own cache shape later. --namespace mode
     // produces SDKs in subdirectories, also out of scope.
-    bool cache_eligible = !is_wasm && g_emit_exe && !g_emit_lib;
+    bool cache_eligible = !is_wasm && !is_cross && g_emit_exe && !g_emit_lib;
     char cached_exe[1024] = "";
     unsigned long long cache_key = 0;
     if (cache_eligible) {
@@ -5253,7 +5528,8 @@ static int cmd_build(int argc, char** argv) {
         }
     }
 
-    printf("Building %s%s...\n", file, is_wasm ? " (wasm)" : "");
+    if (is_cross)      printf("Building %s (cross: %s)...\n", file, target);
+    else               printf("Building %s%s...\n", file, is_wasm ? " (wasm)" : "");
 
     // Binary-import prepass: synthesize interface stubs for any
     // `import foo` resolving to a precompiled libfoo.so, link it in.
@@ -5303,27 +5579,38 @@ static int cmd_build(int argc, char** argv) {
     // Step 2: .c to executable (or wasm) with runtime.
     // toml [[bin]] extra_sources were already merged into extra_files
     // above (before the cache check), so no further reading is needed.
-    if (is_wasm) {
-        if (!build_wasm_cmd(cmd, sizeof(cmd), c_file, exe_file)) {
+    // Cross builds run a multi-step compile/archive/link sequence that
+    // surfaces its own errors, so they bypass the shared command run.
+    int build_ret;
+    if (is_cross) {
+        const char* extra = extra_files[0] ? extra_files : NULL;
+        build_ret = run_cross_build(c_file, exe_file, !quick, extra, ztriple);
+        if (build_ret != 0) {
+            fprintf(stderr, "Build failed.\n");
             return 1;
         }
     } else {
-        const char* extra = extra_files[0] ? extra_files : NULL;
-        build_gcc_cmd(cmd, sizeof(cmd), c_file, exe_file, !quick, extra);
-    }
-
-    int build_ret = tc.verbose ? run_cmd(cmd) : run_cmd_quiet(cmd);
-    if (build_ret != 0) {
-        // Retry with visible output for error messages
         if (is_wasm) {
-            build_wasm_cmd(cmd, sizeof(cmd), c_file, exe_file);
+            if (!build_wasm_cmd(cmd, sizeof(cmd), c_file, exe_file)) {
+                return 1;
+            }
         } else {
             const char* extra = extra_files[0] ? extra_files : NULL;
             build_gcc_cmd(cmd, sizeof(cmd), c_file, exe_file, !quick, extra);
         }
-        run_cmd(cmd);
-        fprintf(stderr, "Build failed.\n");
-        return 1;
+        build_ret = tc.verbose ? run_cmd(cmd) : run_cmd_quiet(cmd);
+        if (build_ret != 0) {
+            // Retry with visible output for error messages
+            if (is_wasm) {
+                build_wasm_cmd(cmd, sizeof(cmd), c_file, exe_file);
+            } else {
+                const char* extra = extra_files[0] ? extra_files : NULL;
+                build_gcc_cmd(cmd, sizeof(cmd), c_file, exe_file, !quick, extra);
+            }
+            run_cmd(cmd);
+            fprintf(stderr, "Build failed.\n");
+            return 1;
+        }
     }
 
     // Clean up intermediate C file — ae build produces a binary, not C source
@@ -5371,6 +5658,9 @@ static int cmd_build(int argc, char** argv) {
     }
 
     printf("Built: %s\n", exe_file);
+    if (is_cross) {
+        printf("       target %s: copy to a matching host to run.\n", target);
+    }
     if (is_wasm) {
         // .wasm file is co-located with .js
         char wasm_file[2048];


### PR DESCRIPTION
## Summary

Adds foreign-OS/arch cross-compilation to `ae build` via a `zig cc` backend:

```sh
ae build --target=x86_64-linux  hello.ae -o hello    # ELF x86-64
ae build --target=aarch64-macos hello.ae -o hello    # Mach-O arm64
```

zig is a self-contained cross toolchain (it bundles each target's libc, headers and linker), so the Aether runtime and standard library compile straight from source for the target with no cross-gcc and no sysroot. The platform backend (`epoll` vs `kqueue`, `spawn_sandboxed_linux` vs the BSD/stub path) is chosen by the `__linux__` / `__APPLE__` macros zig predefines for the target, so one source set serves every target. Native builds are entirely unaffected: `--target` is a new, additive path.

Supported triples: `aarch64-macos`, `x86_64-macos`, `aarch64-linux`, `x86_64-linux` (the `arm64-`/`amd64-` spellings are accepted too).

## How it works

- Reads the authoritative `build/MANIFEST` for the runtime + stdlib source list (no second hardcoded list to drift), compiles each file to its own object with `zig cc -target`, archives them, then links the program against that archive. Linking against an archive reproduces a native `-laether` link's on-demand object pulling: an object is pulled only when the program references one of its symbols.
- Cross binaries are built without OpenSSL / zlib / nghttp2 / PCRE2 (zig ships none of those). Every such dependency in the stdlib is behind an `AETHER_HAS_*` guard that falls to a graceful "unavailable" stub, so features needing them (HTTPS/TLS, hashing, base64, regex, compression, HTTP/2) report errors at runtime, exactly like a native build on a host lacking those libraries; plain sockets and pure helpers keep working. `ae build` prints a note when a program uses such a module, then builds it anyway.
- Executables only for now (`--emit=lib` / `--emit=both` are rejected with a clear message); POSIX host.

## Also fixed

`build/MANIFEST` (the "authoritative list of link-suitable sources", #329) was generated from `RUNTIME_SRC` + `STD_SRC` only, silently omitting `COLLECTIONS_SRC` and `STD_REACTOR_SRC` even though both are part of `libaether.a`. A downstream consumer linking from MANIFEST would fail to resolve `std.collections` (hashmap/vector/set/...) symbols. Both source groups are now emitted.

## Verification

Cross-compiled and **ran** a hello program, an actor program (spawn + message passing + scheduler + pthreads) and a sandbox demo (fs + os + sandbox):

| Target | Result |
|---|---|
| aarch64-macos | built + ran natively |
| x86_64-macos | built + ran via Rosetta |
| x86_64-linux | valid ELF + ran the actor binary in a Linux amd64 Docker container |
| aarch64-linux | valid ELF ARM aarch64 |

Output is byte-identical across targets (checked 64-bit arithmetic + recursion). A user function named like an unreferenced runtime global (`describe`, `notify`, ...) now cross-builds, matching native. Programs using `std.http` / `std.encoding` build with a note and run gracefully (lib features report unavailable, no crash).

`234` unit tests, `87` examples and a `-Werror` build all clean. New `make test-cross` (self-skips when zig is absent, so it is safe for a zig-less CI) covers the four targets plus the error and note paths. Docs: `docs/build-system.md` and CHANGELOG updated.

An independent adversarial review found two defects that are fixed here: user functions colliding with runtime globals (fixed by the archive-based on-demand link) and `--emit=lib` cross producing a raw linker error (now rejected up front).

## Follow-ups

Cross-building OpenSSL / zlib / nghttp2 / PCRE2 (so networking/crypto/regex/compression work on the target), and caching the per-target runtime archive so repeat cross builds skip the from-source recompile.

Closes #1105
