### PR TITLE
ci: cache the compiled miniaudio object across matrix runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,19 @@ jobs:
       if: matrix.install != ''
       run: ${{ matrix.install }}
 
+    # Cache the compiled miniaudio object (std.audio's ~96k-line vendored
+    # header costs ~1 min to compile, and `make ci` starts with a clean).
+    # Keyed per-OS + per-compiler + per-build-variant + the header/source
+    # content, so a hit is only ever a byte-identical object; the Makefile's
+    # audio-cache-restore double-checks a content stamp before reusing it and
+    # falls back to a fresh compile on any mismatch. Never shared across
+    # platforms (matrix.os/matrix.cc are in the key).
+    - name: Cache miniaudio object
+      uses: actions/cache@v4
+      with:
+        path: .ci-cache
+        key: audio-obj-${{ matrix.os }}-${{ matrix.cc }}-h${{ matrix.harden }}-${{ hashFiles('std/audio/miniaudio.h', 'std/audio/aether_audio.c', 'std/audio/aether_audio.h') }}
+
     - name: Run full CI suite
       run: HARDEN=${{ matrix.harden }} CC=${{ matrix.cc }} make ci
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,6 +42,16 @@ jobs:
           make
           bc
 
+    # Cache the compiled miniaudio object — same rationale as ci.yml. The
+    # MinGW toolchain identity is folded into the Makefile stamp, and the key
+    # is Windows/MinGW-specific, so it never collides with the Linux/macOS
+    # caches.
+    - name: Cache miniaudio object
+      uses: actions/cache@v4
+      with:
+        path: .ci-cache
+        key: audio-obj-windows-mingw64-${{ hashFiles('std/audio/miniaudio.h', 'std/audio/aether_audio.c', 'std/audio/aether_audio.h') }}
+
     - name: Run full CI suite
       # See ci.yml::ci-windows for why SSL_CERT_FILE is exported here.
       # Hardcoded probe paths in aether_http.c don't match the GitHub

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ editor/vscode/*.vsix
 .DS_Store
 Thumbs.db
 desktop.ini
+.ci-cache/

--- a/Makefile
+++ b/Makefile
@@ -406,6 +406,55 @@ AUDIO_CFLAGS_RELAX = -Wno-unused-function -Wno-unused-variable \
                      $(AUDIO_GCC_ONLY_RELAX)
 $(OBJ_DIR)/std/audio/aether_audio.o: CFLAGS += $(AUDIO_CFLAGS_RELAX)
 
+# ---- miniaudio object cache (CI) ---------------------------------------
+# Compiling MINIAUDIO_IMPLEMENTATION (the ~96k-line vendored header) costs ~1
+# minute per build, paid on every matrix leg because `make ci` starts with
+# `clean` (rm -rf build). miniaudio.h changes ~never, so we cache the compiled
+# object OUTSIDE build/ (so clean can't wipe it) and restore it after clean.
+#
+# Safety: a cached object is used ONLY when it would be byte-identical to a
+# fresh compile. AUDIO_CACHE_STAMP is a content hash of the source, the header,
+# and the compiler identity + audio flags; the restore refuses a stamp mismatch
+# and falls back to a normal compile. In CI the actions/cache KEY already pins
+# hash(miniaudio.h)+OS+compiler, so a restored object is guaranteed to match;
+# the stamp guards local/edge use. A miss always rebuilds — never stale.
+AUDIO_CACHE_DIR    := .ci-cache
+AUDIO_CACHE_OBJ    := $(AUDIO_CACHE_DIR)/aether_audio.o
+AUDIO_CACHE_STAMP  := $(AUDIO_CACHE_DIR)/aether_audio.stamp
+AUDIO_OBJ          := $(OBJ_DIR)/std/audio/aether_audio.o
+# Portable content hasher (sha256sum on Linux, shasum on macOS, cksum fallback).
+CKSUM_CMD := $(shell command -v sha256sum >/dev/null 2>&1 && echo sha256sum || (command -v shasum >/dev/null 2>&1 && echo 'shasum -a 256' || echo cksum))
+# Content key: source + vendored header + compiler identity + every build knob
+# that can change the emitted object — compiler version, the audio relax flags,
+# and the build-variant flags (HARDEN, EXTRA_CFLAGS: coop/wasm/embedded set
+# -DAETHER_NO_THREADING etc). If any of these differ the stamp differs, so a
+# hardened / coop / cross object never gets restored over a plain one.
+AUDIO_CACHE_KEY := $(shell cat std/audio/aether_audio.c std/audio/miniaudio.h std/audio/aether_audio.h 2>/dev/null | $(CKSUM_CMD) 2>/dev/null | cut -d' ' -f1)-$(shell $(CC) --version 2>/dev/null | head -1 | tr -dc 'a-zA-Z0-9.')-h$(HARDEN)-$(shell printf '%s %s' "$(AUDIO_GCC_ONLY_RELAX)" "$(EXTRA_CFLAGS)" | $(CKSUM_CMD) 2>/dev/null | cut -d' ' -f1)
+
+# Restore the cached object into build/ if the stamp matches, then touch it
+# newer than its source so make treats it as up-to-date and skips the compile.
+# No-op (silent) when there is no valid cache — the normal rule then builds it.
+.PHONY: audio-cache-restore
+audio-cache-restore:
+	@if [ -f "$(AUDIO_CACHE_OBJ)" ] && [ -f "$(AUDIO_CACHE_STAMP)" ] && \
+	    [ "$$(cat $(AUDIO_CACHE_STAMP))" = "$(AUDIO_CACHE_KEY)" ]; then \
+	  mkdir -p "$(dir $(AUDIO_OBJ))"; \
+	  cp "$(AUDIO_CACHE_OBJ)" "$(AUDIO_OBJ)"; \
+	  touch "$(AUDIO_OBJ)"; \
+	  echo "audio-cache: restored miniaudio object (stamp hit) — skipping ~96k-line compile"; \
+	else \
+	  echo "audio-cache: no valid cached object — will compile miniaudio from source"; \
+	fi
+
+# Save the freshly-built object + its stamp to the cache dir (idempotent).
+# actions/cache then persists $(AUDIO_CACHE_DIR) between runs.
+.PHONY: audio-cache-save
+audio-cache-save: $(AUDIO_OBJ)
+	@mkdir -p "$(AUDIO_CACHE_DIR)"
+	@cp "$(AUDIO_OBJ)" "$(AUDIO_CACHE_OBJ)"
+	@printf '%s' "$(AUDIO_CACHE_KEY)" > "$(AUDIO_CACHE_STAMP)"
+	@echo "audio-cache: saved miniaudio object to $(AUDIO_CACHE_OBJ)"
+
 # Compiler target (incremental build with object files)
 compiler: $(COMPILER_OBJS) $(STD_OBJS) $(COLLECTIONS_OBJS) $(OBJ_DIR)/runtime/aether_sandbox.o $(OBJ_DIR)/runtime/aether_resource_caps.o $(IO_POLLER_OBJS)
 	@echo "Linking compiler..."
@@ -1851,8 +1900,12 @@ ci: clean
 	@echo "  Parallel: $(NPROC) jobs (build) / $(NPROC) (.ae tests) / $${SH_NPROC:-1} (shell tests)"
 	@echo "==================================="
 	@echo ""
+	@echo "[0/9] Restoring miniaudio object cache (if valid)..."
+	@$(MAKE) audio-cache-restore
+	@echo ""
 	@echo "[1/9] Building compiler (-Werror)..."
 	@$(MAKE) -j$(NPROC) compiler EXTRA_CFLAGS=-Werror
+	@$(MAKE) audio-cache-save
 	@echo ""
 	@echo "[2/9] Building ae CLI..."
 	@$(MAKE) -j$(NPROC) ae


### PR DESCRIPTION
`std.audio`'s vendored `miniaudio.h` (~96k-line single header) costs **~1 min** to compile via `MINIAUDIO_IMPLEMENTATION`, and `make ci` starts with `clean` — so **every matrix leg paid it on every push** (~9 legs in ci.yml + Windows).

The object is safe to reuse because it depends only on things that don't change per-Aether-commit: the frozen upstream header and the per-runner-fixed compiler. `aether_audio.c` is a thin, stable FFI wrapper with zero Aether coupling.

### Mechanism (surgical — one hot object, not a whole-build cache)

**Makefile:**
- `audio-cache-restore` copies a cached object into `build/` after clean and `touch`es it up-to-date so `make` skips the compile.
- `audio-cache-save` writes it back for `actions/cache` to persist.
- Wired into `ci`: `[0/9]` restore, save after `[1/9]`.
- A content **stamp** (source + `miniaudio.h` + `aether_audio.h` + `$(CC) --version` + `HARDEN` + audio/`EXTRA_CFLAGS` hash) gates reuse. **Mismatch → clean recompile**, so a stale object can never be linked.

**Workflows:** `actions/cache` persists `.ci-cache/` keyed per `matrix.os` + `matrix.cc` + `harden` + `hashFiles(miniaudio.h, aether_audio.c/.h)`. Each OS/compiler permutation (Linux gcc/clang/hardened, macOS ARM64/x86_64, Windows MinGW) gets **its own entry** — objects are never shared across platforms.

### Safety

Two independent layers keep it correct:
1. The `actions/cache` **key** includes OS + compiler → a macOS object is never even downloaded onto a Linux runner.
2. The Makefile **stamp** re-checks compiler identity + build flags before reusing → even a wrong object is rejected → clean recompile.

A key miss (miniaudio bump, or GitHub updating a runner's compiler) rebuilds once, then recaches. **Self-healing, never stale.**

Left `memory-check.yml` alone: it builds with its own `-O0`/ASan `CFLAGS` via `make compiler` (a different object), which would need separate keys for little gain.

### Verified locally
- Restore hit → `make compiler` links with **no** `Compiling std/audio/aether_audio.c` line (compile skipped).
- Corrupted stamp → correctly forces a from-source rebuild (no stale link).

This PR intentionally runs the full matrix (no `[skip actions]`) so the cache populates and a hit can be confirmed on the next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)