### PR TITLE
fix(collections): list_get_raw rejects invalid pointers instead of se…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`list.get` / `list_get_raw` no longer segfaults on an invalid list
+  pointer.** The accessor read `list->size` / `list->items[index]` without
+  validating the pointer, so a dangling, type-confused, or freed list — a
+  struct with the wrong `_kind_magic`, a reused struct, or a small int
+  intptr-cast to `ptr` — crashed deep inside the accessor instead of
+  returning a safe NULL. It now applies the same `_kind_magic` +
+  low-address discriminator `aether_value_is_list` uses, so a bad pointer
+  yields `(null, "")` (out-of-range index behaviour is unchanged). Surfaced
+  by an aeb build whose generated code passed such a pointer to `list.get`.
+
 ## [0.413.0]
 
 ### Added

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -177,7 +177,19 @@ int list_add_closure_owned(ArrayList* list, void* box) {
 }
 
 void* list_get_raw(ArrayList* list, int index) {
-    if (!list || index < 0 || index >= list->size) return NULL;
+    /* Validity guard before touching any field. `list` may be NULL, a
+     * low-address scalar (a small int intptr-cast to `ptr`), a freed list
+     * (list_free zeroes `_kind_magic`), a struct whose memory has been
+     * reused, or another kind (e.g. a HashMap) mistaken for a list. Any of
+     * those would otherwise fault on `list->size` / `list->items[index]`.
+     * Applying the same `_kind_magic` + low-address discriminator that
+     * aether_value_is_list uses turns a type-confusion / use-after-free
+     * into a safe NULL instead of a SIGSEGV deep inside the accessor. */
+    if (!list || (uintptr_t)list < AETHER_KIND_MIN_VALID_ADDR
+              || list->_kind_magic != AETHER_KIND_LIST_MAGIC) {
+        return NULL;
+    }
+    if (index < 0 || index >= list->size) return NULL;
     return list->items[index];
 }
 

--- a/tests/runtime/test_runtime_collections.c
+++ b/tests/runtime/test_runtime_collections.c
@@ -24,6 +24,34 @@ TEST_CATEGORY(list_add_and_get, TEST_CATEGORY_COLLECTIONS) {
     list_free(list);
 }
 
+/* Regression: list_get_raw must reject a non-list pointer with a safe NULL
+ * rather than faulting on list->size / list->items[index]. A dangling /
+ * type-confused pointer (wrong _kind_magic) reaching the accessor used to
+ * SIGSEGV deep inside it; the kind + low-address guard now catches it. */
+TEST_CATEGORY(list_get_raw_rejects_invalid_pointers, TEST_CATEGORY_COLLECTIONS) {
+    /* NULL list. */
+    ASSERT_NULL(list_get_raw(NULL, 0));
+
+    /* Low-address scalar: a small int intptr-cast to `ptr`. Below the
+     * mmap-min guard, so it must never be dereferenced. */
+    ASSERT_NULL(list_get_raw((ArrayList*)(uintptr_t)42, 0));
+
+    /* Another kind mistaken for a list: a HashMap has a valid struct at a
+     * valid address but carries AETHER_KIND_MAP_MAGIC, not the list magic —
+     * exactly the shape that crashed (valid pointer, wrong magic). */
+    HashMap* map = map_new();
+    ASSERT_NOT_NULL(map);
+    ASSERT_NULL(list_get_raw((ArrayList*)map, 0));
+    map_free(map);
+
+    /* The guard must not regress valid lists. */
+    ArrayList* list = list_new();
+    int v = 7;
+    list_add_raw(list, &v);
+    ASSERT_EQ(&v, list_get_raw(list, 0));
+    list_free(list);
+}
+
 TEST_CATEGORY(list_set_and_remove, TEST_CATEGORY_COLLECTIONS) {
     ArrayList* list = list_new();
 


### PR DESCRIPTION
…gfaulting

list_get_raw dereferenced list->size / list->items[index] after only a NULL and bounds check, so a pointer that isn't a valid ArrayList — a dangling or type-confused pointer, a freed list (list_free zeroes _kind_magic), a reused struct, or a small int intptr-cast to `ptr` — faulted deep inside the accessor. Discovered via an aeb build whose generated code passed such a pointer to list.get: SIGSEGV in list_get_raw reading list->size on a struct whose _kind_magic was garbage (0x555dfe90, not 0xAE57E715).

Apply the same _kind_magic + low-address discriminator that aether_value_is_list already uses, before touching any field, so a bad pointer yields a safe NULL (list.get -> (null, "")). Valid lists and the existing out-of-range behaviour are unchanged.

Regression test: list_get_raw_rejects_invalid_pointers (NULL, low-address scalar, and a HashMap mistaken for a list — the valid-pointer/wrong-magic shape that crashed), plus a valid-list sanity assert.