### PR TITLE
build: define PCRE2_STATIC on Windows when linking static libpcre2-8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,13 @@ else
 endif
 ifneq ($(PCRE2_LDFLAGS),)
   PCRE2_CFLAGS += -DAETHER_HAS_PCRE2
+  # On Windows/MinGW we link the STATIC libpcre2-8.a; without PCRE2_STATIC the
+  # pcre2.h prototypes default to __declspec(dllimport), so the linker looks for
+  # __imp_pcre2_* import stubs that the static lib doesn't provide. Define it so
+  # the header declares plain symbols matching the static archive.
+  ifneq ($(IS_WINDOWS),)
+    PCRE2_CFLAGS += -DPCRE2_STATIC
+  endif
 endif
 
 # #959: homebrew's pkg-config .pc files emit versioned


### PR DESCRIPTION
Without it, pcre2.h declares __declspec(dllimport) symbols and every std.regex user fails at link with undefined __imp_pcre2_* on MinGW static builds. Found bringing aether-ui's vg effects suite up on real Windows (winbaz); with this fix + `pacman -S mingw-w64-x86_64-pcre2`, test_effects went 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5pckLB6QCPfjVQAYcE9LZ