### PR TITLE
feat(ae): cross-compile for FreeBSD via ae build --target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,28 @@ All notable changes to Aether are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Workflow**: New changes go under `## [0.413.0]`. When a PR merges to
+**Workflow**: New changes go under `## [current]`. When a PR merges to
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
-## [0.420.0]
+## [current]
+
+### Added
+
+- **`ae build --target=<triple>` now cross-compiles for FreeBSD** (extends the
+  zig cc backend, #1105). Adds `x86_64-freebsd` / `aarch64-freebsd` (+ `amd64` /
+  `arm64` aliases) as the first Tier B targets: unlike the self-contained Tier A
+  targets (macOS/Linux, whose libc zig bundles), FreeBSD needs a version-matched
+  base sysroot — supplied via `AETHER_SYSROOT` (a `bases/<cpu>-freebsd<ver>/`
+  tree from aether-crossbuild). Without it, the build reports a guided error
+  naming the fetch script. The link is done explicitly against the base's CRT
+  objects and real `libc.so.7` (zig's bundled FreeBSD-14 libc can't satisfy a
+  15 base's `__libc_start1`, and the sysroot's `libc.so` is an absolute-path
+  linker script). Verified end-to-end: a `println` program cross-built on Linux
+  ran on a FreeBSD 15.0 box. Scope matches #1105 — dependency-free / libc-only
+  programs; a program pulling `std.http` / `std.cryptography` additionally needs
+  those third-party libs built into the sysroot (aether-crossbuild's
+  `provision.sh`), untested through this path yet. Requires zig on `PATH`.
 
 ### Added
 
@@ -27,6 +44,30 @@ next version number before tagging the release.
   code is unchanged: the default constructors keep the cap-aware system path.
   See `docs/allocators.md`.
 
+## [0.419.0]
+
+### Added
+
+- **`aetherc` emits a `// aether-link:` header from the resolved import graph**
+  (#1202). The first line of the generated C now names the native libraries the
+  program's imports pull in, so a downstream build linking the `.c` recovers
+  them generically (`AE_LINK="$(sed -n 's|^// aether-link:||p' out.c)"`) instead
+  of rediscovering the list by `undefined reference` per platform. Written by
+  the same resolution that compiled the file (can't disagree with what was
+  compiled) and travels with the artifact. A truthful `{module → libs}` table
+  covers openssl (`std.net`/`std.http.client`/`std.cryptography`), pcre2
+  (`std.regex`), nghttp2 (`std.net` + h2), zlib (`std.zlib` + `http/middleware`),
+  sqlite (`contrib.sqlite`), audio (`std.audio`); matched against the transitive
+  import closure, de-duplicated, stable order. Only import-introduced libs
+  appear — the runtime baseline stays with `ae cflags --libs`. Answers
+  `emit-link-requirements-from-import-graph.md`.
+
+### Fixed
+
+- **Windows: `-DPCRE2_STATIC` when linking static libpcre2-8** (#1200). Without
+  it, MinGW builds of `std.regex`-using programs failed to link against the
+  static PCRE2 import symbols.
+
 ## [0.417.0]
 
 ### Fixed
@@ -40,6 +81,52 @@ next version number before tagging the release.
   low-address discriminator `aether_value_is_list` uses, so a bad pointer
   yields `(null, "")` (out-of-range index behaviour is unchanged). Surfaced
   by an aeb build whose generated code passed such a pointer to `list.get`.
+
+## [0.416.0]
+
+### Fixed
+
+- **Imported `enum` and `sum` types are now emitted** (#1194). The module-merge
+  pass cloned imported `struct` / `bitstruct` / distinct definitions into the
+  consumer's program AST but not `enum` or `sum` ones, so an imported enum used
+  by name failed (`Undefined variable 'Color'`) and an imported sum type failed
+  (`unknown type name 'Shape'` in the generated C). Both are now merged (with
+  dedup), mirroring the struct/bitstruct arms.
+- **A local variable named the same as its own module resolves correctly**
+  (#1194). The member-access typechecker took its namespace-qualified-constant
+  branch whenever the base matched a visible namespace, with no precedence for a
+  same-named in-scope value — so a module named `flags` whose body had a local
+  `flags` mis-resolved `flags.field` as a `flags_field` const lookup
+  (`module 'flags' has no export 'field'`). A local now shadows the namespace.
+  Not bitstruct-specific (reproduced with a plain struct); surfaced by the
+  imported-bitstruct ask's verbatim repro.
+
+## [0.415.0]
+
+### Fixed
+
+- **Imported-module `bitstruct` typedefs are now emitted** (#1192). A
+  `bitstruct` declared in an imported module was referenced by the consumer's
+  generated C (accessor prototypes/return types) but its backing typedef was
+  never emitted — `error: unknown type name 'PropertyFlags'` — because the
+  module-merge pass cloned imported `struct`s but not `bitstruct`s. Reported
+  while porting MicroQuickJS, whose packed property-flags word wanted a
+  layout-exact bitstruct in the module that owns the layout. Answers
+  `asks/imported-module-bitstruct-emission.md`.
+
+## [0.414.0]
+
+### Added
+
+- **Version-stamped SDK: a compile-time header macro + include-tree sidecar**
+  (#1189). An installed SDK tree could not identify itself. Now a generated,
+  dependency-free `runtime/aether_version.h` exposes `AETHER_VERSION` (string)
+  plus `AETHER_VERSION_MAJOR/_MINOR/_PATCH` and `AETHER_VERSION_NUM`
+  (`MAJOR*1000000 + MINOR*1000 + PATCH`) for `#if`-based gating
+  (`#if AETHER_VERSION_NUM < 390000 → #error`), and the install writes an
+  `include/aether/VERSION` sidecar mirroring `lib/aether/VERSION`. All derive
+  from the Makefile's `$(VERSION)` in lockstep with `aetherc --version` — no
+  hand-maintained constant. Answers the version-stamp ask.
 
 ## [0.413.0]
 

--- a/tests/scripts/cross_compile.sh
+++ b/tests/scripts/cross_compile.sh
@@ -98,6 +98,52 @@ else
     bad "unknown target: wrong error"; sed 's/^/        /' "$TMP/err"
 fi
 
+# FreeBSD (Tier B): the triple is RECOGNIZED (not "Unknown target") — this
+# guards the target-list wiring even where zig is absent. A freebsd target
+# needs a base sysroot zig cc doesn't bundle, so without AETHER_SYSROOT it
+# must report the guided sysroot error, NOT "Unknown target".
+env -u AETHER_SYSROOT "$AE" build --target=x86_64-freebsd "$HELLO" -o "$TMP/fb" \
+    >/dev/null 2>"$TMP/err"
+if grep -q "Unknown target" "$TMP/err"; then
+    bad "x86_64-freebsd: reported Unknown target (target-list wiring missing)"
+else
+    ok "x86_64-freebsd recognized as a valid target"
+fi
+# The sysroot-unset guided error lives behind the zig-presence gate (it's
+# raised inside run_cross_build), so only assert it when zig is available —
+# without zig the build errors on zig-not-found first, which is also correct.
+if env -u AETHER_SYSROOT "$AE" build --target=x86_64-freebsd "$HELLO" -o "$TMP/fb" \
+     >/dev/null 2>"$TMP/err"; then
+    bad "x86_64-freebsd without AETHER_SYSROOT: build unexpectedly succeeded"
+elif grep -q "needs a FreeBSD base sysroot" "$TMP/err"; then
+    ok "x86_64-freebsd without AETHER_SYSROOT: guided sysroot error"
+elif grep -q "zig not found" "$TMP/err"; then
+    # Cannot reach the sysroot check without zig — the SKIP guard at the top
+    # means this branch is unreachable here, but keep it explicit for clarity.
+    ok "x86_64-freebsd without AETHER_SYSROOT: zig absent (sysroot check gated behind zig)"
+else
+    bad "x86_64-freebsd without AETHER_SYSROOT: wrong error"; sed 's/^/        /' "$TMP/err"
+fi
+
+# If a real FreeBSD base sysroot is available (AETHER_SYSROOT points at one),
+# build for real and assert a FreeBSD ELF. Skipped in ordinary CI, which has
+# no sysroot; exercised on a box provisioned via aether-crossbuild.
+if [ -n "${AETHER_SYSROOT:-}" ] && [ -f "${AETHER_SYSROOT}/lib/libc.so.7" ]; then
+    if "$AE" build --target=x86_64-freebsd "$HELLO" -o "$TMP/fbsd" \
+         >/dev/null 2>"$TMP/err"; then
+        desc="$(file -b "$TMP/fbsd")"
+        if printf '%s' "$desc" | grep -qi "FreeBSD"; then
+            ok "x86_64-freebsd (real sysroot): $desc"
+        else
+            bad "x86_64-freebsd (real sysroot): expected FreeBSD ELF, got '$desc'"
+        fi
+    else
+        bad "x86_64-freebsd (real sysroot): build failed"; sed 's/^/        /' "$TMP/err"
+    fi
+else
+    echo "  SKIP  x86_64-freebsd real build (no AETHER_SYSROOT base sysroot present)"
+fi
+
 # A program using a library-backed module (std.http) still cross-builds,
 # with a note that those features report unavailable at runtime (matching a
 # native build without OpenSSL/zlib/nghttp2/PCRE2).

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -4945,7 +4945,22 @@ static const char* cross_target_to_zig(const char* t) {
     if (!strcmp(t, "x86_64-macos")  || !strcmp(t, "amd64-macos"))  return "x86_64-macos-none";
     if (!strcmp(t, "aarch64-linux") || !strcmp(t, "arm64-linux"))  return "aarch64-linux-gnu";
     if (!strcmp(t, "x86_64-linux")  || !strcmp(t, "amd64-linux"))  return "x86_64-linux-gnu";
+    /* FreeBSD (Tier B): zig cc does NOT bundle a FreeBSD libc, so these
+     * additionally require a base sysroot (headers + libc) provided via
+     * AETHER_SYSROOT — see cross_target_needs_sysroot() and the
+     * aether-crossbuild repo (scripts/fetch-freebsd-base.sh). The zig target
+     * has no OS-version; the base sysroot carries FreeBSD 14 vs 15. */
+    if (!strcmp(t, "aarch64-freebsd") || !strcmp(t, "arm64-freebsd")) return "aarch64-freebsd";
+    if (!strcmp(t, "x86_64-freebsd")  || !strcmp(t, "amd64-freebsd")) return "x86_64-freebsd";
     return NULL;
+}
+
+/* True if `t` is a cross target whose libc zig cc does NOT bundle, so a base
+ * sysroot must be supplied (via AETHER_SYSROOT). Tier A (macos/linux) is
+ * self-contained; Tier B (freebsd) is not. */
+static bool cross_target_needs_sysroot(const char* t) {
+    if (!t) return false;
+    return strstr(t, "freebsd") != NULL;
 }
 
 /* Locate the authoritative source MANIFEST and the base directory its
@@ -5066,6 +5081,43 @@ static int run_cross_build(const char* c_file, const char* out_file,
     const char* opt = optimize ? "-O2" : "-O0 -g";
     const char* ex = extra ? extra : "";
     const char* feature_defs = "-DAETHER_HAS_SANDBOX";
+    /* Tier-B (FreeBSD) targets need a base sysroot zig cc doesn't bundle;
+     * AETHER_SYSROOT points at it (bases/<cpu>-freebsd[ver]/ from
+     * aether-crossbuild). Applied to BOTH compile and link. Empty for the
+     * self-contained Tier-A targets. NB: for a FreeBSD target, `--sysroot`
+     * ALONE does not make zig cc search the sysroot's usr/include and
+     * usr/lib (unlike its bundled targets) — the -I/-L must be explicit
+     * (verified with zig 0.13). */
+    char sysroot_flag[3200];   /* COMPILE flags: --sysroot + -I/-L */
+    char fbsd_link[4096];      /* LINK tail: CRT objects + the real libc.so.7 */
+    sysroot_flag[0] = '\0';
+    fbsd_link[0] = '\0';
+    if (cross_target_needs_sysroot(ztriple)) {
+        const char* sr = getenv("AETHER_SYSROOT");
+        if (!sr || !*sr) {
+            fprintf(stderr,
+                "Error: target %s needs a FreeBSD base sysroot, but AETHER_SYSROOT is unset.\n"
+                "  zig cc does not bundle a FreeBSD libc. Provision one with aether-crossbuild:\n"
+                "    ./scripts/fetch-freebsd-base.sh <cpu> [major]   # e.g. x86_64 15\n"
+                "  then: AETHER_SYSROOT=<crossbuild>/bases/<cpu>-freebsd[ver] ae build ... --target=%s\n",
+                ztriple, ztriple);
+            return 1;
+        }
+        snprintf(sysroot_flag, sizeof(sysroot_flag),
+                 "--sysroot=%s -I%s/usr/include -L%s/usr/lib -L%s/lib",
+                 sr, sr, sr, sr);
+        /* zig cc can't provide a FreeBSD libc ("error: libc not available"),
+         * and the sysroot's usr/lib/libc.so is a GROUP linker script naming
+         * ABSOLUTE /lib paths that don't exist on this build host. So link
+         * FreeBSD explicitly: -nostdlib + the base's CRT startup objects
+         * (crt1/crti/crtn — crt1 pulls __libc_start1, a FreeBSD-15 symbol) +
+         * the real versioned libc.so.7. Verified end-to-end with zig 0.13
+         * against a FreeBSD-15 base sysroot. */
+        snprintf(fbsd_link, sizeof(fbsd_link),
+                 "-nostdlib \"%s/usr/lib/crt1.o\" \"%s/usr/lib/crti.o\" "
+                 "\"%s/lib/libc.so.7\" \"%s/usr/lib/crtn.o\"",
+                 sr, sr, sr, sr);
+    }
     static char cmd[24576];
     /* Accumulated quoted "<objpath>" list, in compile order, for the ar
      * step. posix_run tokenizes the command itself (no shell), so the
@@ -5089,8 +5141,8 @@ static int run_cross_build(const char* c_file, const char* out_file,
             snprintf(objpath, sizeof(objpath), "%s/%.*so", objdir,
                      (int)(strlen(bn) - 1), bn);
             w = snprintf(cmd, sizeof(cmd),
-                "zig cc -target %s %s %s %s %s -c \"%s\" -o \"%s\"",
-                ztriple, opt, feature_defs, user_cflags, tc.include_flags,
+                "zig cc -target %s %s %s %s %s %s -c \"%s\" -o \"%s\"",
+                ztriple, sysroot_flag, opt, feature_defs, user_cflags, tc.include_flags,
                 srcs[i], objpath);
             if (w < 0 || (size_t)w >= sizeof(cmd)) {
                 fprintf(stderr, "Error: cross-compile command exceeded the %zu-byte buffer.\n",
@@ -5129,18 +5181,44 @@ static int run_cross_build(const char* c_file, const char* out_file,
             break;
         }
 
-        /* 3. Link the program against the archive. */
-        w = snprintf(cmd, sizeof(cmd),
-            "zig cc -target %s %s %s %s \"%s\" %s \"%s/libaether.a\" -o \"%s\" -lm",
-            ztriple, opt, feature_defs, tc.include_flags, c_file, ex, objdir, out_file);
+        /* Clear any stale output so the FreeBSD "output exists == linked"
+         * success signal below can't be fooled by a prior build's binary. */
+        remove(out_file);
+
+        /* 3. Link the program against the archive. FreeBSD (Tier B) needs the
+         *    explicit CRT objects + real libc.so.7 (fbsd_link); zig's bundled
+         *    FreeBSD-14 libc can't satisfy a 15 base's __libc_start1. The CRT
+         *    objects bracket the program/runtime; libm comes from the sysroot
+         *    -L. Tier A keeps the compact -lm form. */
+        if (fbsd_link[0]) {
+            w = snprintf(cmd, sizeof(cmd),
+                "zig cc -target %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" -lm -o \"%s\"",
+                ztriple, sysroot_flag, fbsd_link, opt, feature_defs, tc.include_flags,
+                c_file, ex, objdir, out_file);
+        } else {
+            w = snprintf(cmd, sizeof(cmd),
+                "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" -o \"%s\" -lm",
+                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, out_file);
+        }
         if (w < 0 || (size_t)w >= sizeof(cmd)) {
             fprintf(stderr, "Error: cross-compile link command exceeded the %zu-byte buffer.\n",
                     sizeof(cmd));
             break;
         }
         if (run_cmd_show_warnings(cmd) != 0) {
-            fprintf(stderr, "Error: cross-linking for %s failed.\n", ztriple);
-            break;
+            /* zig cc exits nonzero on a FreeBSD -nostdlib link with a COSMETIC
+             * "error: libc not available" note, even though clang+lld produced
+             * a valid binary (zig reserves that message for targets it can't
+             * supply a libc for — which is exactly why we bring our own). A
+             * GENUINE link failure (undefined symbol) leaves NO output file, so
+             * "the output exists and is non-empty" cleanly separates the two.
+             * Verified with zig 0.13 against a FreeBSD-15 base sysroot. */
+            if (!(fbsd_link[0] && path_exists(out_file))) {
+                fprintf(stderr, "Error: cross-linking for %s failed.\n", ztriple);
+                break;
+            }
+            fprintf(stderr, "note: zig cc reported \"libc not available\" for %s; "
+                            "the FreeBSD binary linked correctly regardless.\n", ztriple);
         }
         rc = 0;
     } while (0);
@@ -5321,7 +5399,8 @@ static int cmd_build(int argc, char** argv) {
     if (target && strcmp(target, "wasm") != 0 && strcmp(target, "native") != 0 && !ztriple) {
         fprintf(stderr, "Error: Unknown target '%s'.\n", target);
         fprintf(stderr, "Valid targets: native, wasm, or a cross triple "
-                        "(aarch64-macos, x86_64-macos, aarch64-linux, x86_64-linux).\n");
+                        "(aarch64-macos, x86_64-macos, aarch64-linux, x86_64-linux, "
+                        "aarch64-freebsd, x86_64-freebsd).\n");
         return 1;
     }
     int is_wasm = target && strcmp(target, "wasm") == 0;
@@ -5360,7 +5439,8 @@ static int cmd_build(int argc, char** argv) {
         fprintf(stderr, "Usage: ae build <file.ae> [-o output] [--extra file.c] [--quick] [--target=<triple>]\n");
         fprintf(stderr, "  --quick    Compile with -O0 -g for faster iteration (default: -O2)\n");
         fprintf(stderr, "  --target   Cross-compile via zig cc: wasm, aarch64-macos, x86_64-macos,\n");
-        fprintf(stderr, "             aarch64-linux, x86_64-linux (dependency-free programs)\n");
+        fprintf(stderr, "             aarch64-linux, x86_64-linux, aarch64-freebsd, x86_64-freebsd\n");
+        fprintf(stderr, "             (freebsd needs AETHER_SYSROOT=<base sysroot>; see aether-crossbuild)\n");
         return 1;
     }
 


### PR DESCRIPTION
Extends the zig cc cross-compile backend (#1105) to **FreeBSD** — the first **Tier B** target (needs a base sysroot; macOS/Linux are Tier A, self-contained via zig's bundled libc).

The `tools/ae.c` change is a sibling's handoff (they wrote and end-to-end-verified the code); this PR adds its **test coverage** and the **CHANGELOG** (which had also drifted).

## What it does (`tools/ae.c`, +90/−10)
- **`cross_target_to_zig`** — adds `x86_64-freebsd` / `aarch64-freebsd` (+ `amd64`/`arm64` aliases) → zig's freebsd targets.
- **`cross_target_needs_sysroot()`** — true for freebsd; gates the sysroot requirement.
- **`run_cross_build`** — reads `AETHER_SYSROOT` (guided error if a freebsd target has it unset); builds the sysroot compile flags (`--sysroot` + **explicit `-I`/`-L`**) and the explicit FreeBSD link tail (`-nostdlib` + the base's `crt1`/`crti`/`crtn` + `libc.so.7`); threads both into compile+link; `remove(out_file)` before linking; treats **"nonzero rc but output exists" as success**.
- Updated the Unknown-target error and `--help` target lists.

### Four zig-vs-FreeBSD facts baked into the comments (each cost a debugging round)
1. `--sysroot` alone does **not** make zig search a freebsd sysroot's include/lib (unlike bundled targets) — explicit `-I`/`-L` required.
2. The sysroot's `usr/lib/libc.so` is a GROUP linker script with absolute `/lib` paths that don't exist on the build host — so link `/lib/libc.so.7` directly with `-nostdlib` + CRT objects, not `-lc`.
3. FreeBSD-15's `crt1.o` references `__libc_start1` (an FBSD_1.7 symbol) that zig's bundled FreeBSD-14 libc lacks — hence a **version-matched base sysroot is mandatory**.
4. zig cc exits nonzero on a freebsd `-nostdlib` link with a **cosmetic** `error: libc not available` note even though lld wrote a valid binary. The code treats "nonzero rc but `out_file` exists" as success; a genuine failure (undefined symbol) leaves no file. The `remove(out_file)` guard prevents a stale binary false-passing.

## Sysroot dependency
FreeBSD targets require `AETHER_SYSROOT` pointing at a `bases/<cpu>-freebsd<ver>/` tree from **aether-crossbuild** (its side is merged: `6d86617`, version-aware `fetch-freebsd-base.sh`). The compiler triple carries no OS version; the sysroot dir carries FreeBSD 14-vs-15.

## Test (`tests/scripts/cross_compile.sh`)
Asserts: `x86_64-freebsd` is a **recognized** target (not "Unknown target" — guards the wiring even where zig is absent); the **sysroot-unset guided error** (behind the zig gate); and — when a real `AETHER_SYSROOT` base is present — an actual **FreeBSD-ELF** build. The two error-path assertions were validated locally with a stubbed zig on PATH.

## Proof (the sibling's, end-to-end)
On a Linux box, `AETHER_SYSROOT=<crossbuild>/bases/x86_64-freebsd15 ae build --target=x86_64-freebsd hello.ae` produced an `ELF … (FreeBSD 15.0)` binary; scp'd to a real FreeBSD 15.0 box, it ran and exited 0. Requires zig on `PATH` (tested with 0.13.0).

## Scope (honest, matching #1105)
**Dependency-free / libc-only FreeBSD programs.** A program pulling `std.http`/`std.cryptography` additionally needs those third-party libs built into the sysroot (aether-crossbuild's `provision.sh`) — untested through this path yet.

## For the reviewer
Fact #4 — the **"nonzero-rc-but-output-exists = success" heuristic** — is the one design decision worth a maintainer's explicit sign-off. It's correct and guarded, but the kind of thing that shouldn't slip in unnoticed.

## Also in this PR: CHANGELOG catch-up
The FreeBSD entry goes under `## [current]`. This also **back-fills drifted history** that shipped without entries — 0.419 (aether-link #1202, pcre2-static #1200), 0.416 (imported enum/sum + shadow #1194), 0.415 (imported bitstruct #1192), 0.414 (SDK version-stamp #1189) — and fixes the stale workflow pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)