### PR TITLE
ci: fill the miniaudio cache only from merges to main, on miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,14 +74,32 @@ jobs:
     # audio-cache-restore double-checks a content stamp before reusing it and
     # falls back to a fresh compile on any mismatch. Never shared across
     # platforms (matrix.os/matrix.cc are in the key).
-    - name: Cache miniaudio object
-      uses: actions/cache@v4
+    #
+    # Split restore/save: every run RESTORES, but only a trusted push to main
+    # SAVES, and only on a cache MISS. So PR builds (throwaway) read the cache
+    # but never fill it; the cache is populated once from the merge and shared
+    # to every subsequent PR (GitHub lets PR runs read the default branch's
+    # cache). The key embeds the source hash, so an unchanged miniaudio source
+    # is a key hit → nothing new to save. A miss simply recompiles miniaudio;
+    # correctness never depends on a cache hit.
+    - name: Restore miniaudio object cache
+      id: audio_cache
+      uses: actions/cache/restore@v4
       with:
         path: .ci-cache
         key: audio-obj-${{ matrix.os }}-${{ matrix.cc }}-h${{ matrix.harden }}-${{ hashFiles('std/audio/miniaudio.h', 'std/audio/aether_audio.c', 'std/audio/aether_audio.h') }}
 
     - name: Run full CI suite
       run: HARDEN=${{ matrix.harden }} CC=${{ matrix.cc }} make ci
+
+    - name: Save miniaudio object cache (merge to main, on miss only)
+      if: >-
+        github.event_name == 'push' && github.ref == 'refs/heads/main'
+        && steps.audio_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: .ci-cache
+        key: audio-obj-${{ matrix.os }}-${{ matrix.cc }}-h${{ matrix.harden }}-${{ hashFiles('std/audio/miniaudio.h', 'std/audio/aether_audio.c', 'std/audio/aether_audio.h') }}
 
     # macOS leaks(1) gate (#468). Runs only on the ARM64 macOS job —
     # one macOS arch is enough leak coverage, and MallocStackLogging

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,10 @@
 name: Windows Build
 
 on:
+  # push to main also runs so the merge build can FILL the miniaudio object
+  # cache (PR runs only read it; see the Restore/Save split below).
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
@@ -45,9 +49,12 @@ jobs:
     # Cache the compiled miniaudio object — same rationale as ci.yml. The
     # MinGW toolchain identity is folded into the Makefile stamp, and the key
     # is Windows/MinGW-specific, so it never collides with the Linux/macOS
-    # caches.
-    - name: Cache miniaudio object
-      uses: actions/cache@v4
+    # caches. Split restore/save: PR runs only RESTORE; only a push to main
+    # SAVES, and only on a cache miss (an unchanged source is a key hit, so
+    # there is nothing new to write — the key already embeds the source hash).
+    - name: Restore miniaudio object cache
+      id: audio_cache
+      uses: actions/cache/restore@v4
       with:
         path: .ci-cache
         key: audio-obj-windows-mingw64-${{ hashFiles('std/audio/miniaudio.h', 'std/audio/aether_audio.c', 'std/audio/aether_audio.h') }}
@@ -61,6 +68,15 @@ jobs:
         echo "SSL_CERT_FILE=$SSL_CERT_FILE"
         ls -la "$(cygpath -u "$SSL_CERT_FILE")"
         make ci
+
+    - name: Save miniaudio object cache (merge to main, on miss only)
+      if: >-
+        github.event_name == 'push' && github.ref == 'refs/heads/main'
+        && steps.audio_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: .ci-cache
+        key: audio-obj-windows-mingw64-${{ hashFiles('std/audio/miniaudio.h', 'std/audio/aether_audio.c', 'std/audio/aether_audio.h') }}
 
     - name: Upload Windows binaries
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The miniaudio object cache used `actions/cache@v4`, which **auto-saves on every run** — so every throwaway PR build was populating the shared cache. It should be filled **only from trusted post-merge builds, and only when the source actually changed**.

## Change

Split restore/save in both `ci.yml` and `windows.yml`:

- **Restore** (`actions/cache/restore@v4`) — every run reads the cache.
- **Save** (`actions/cache/save@v4`) — gated on:
  ```yaml
  github.event_name == 'push' && github.ref == 'refs/heads/main'
    && steps.audio_cache.outputs.cache-hit != 'true'
  ```

So:
- **PR builds only READ** — they never fill the shared cache.
- **A merge to `main` SAVES**, and only on a **cache miss** — an unchanged miniaudio source is a key hit (the key embeds `hashFiles(miniaudio.h, aether_audio.c/.h)`), so there's nothing new to write. This satisfies "only if the source changed."
- The merge-filled cache is shared to every subsequent PR (GitHub lets PR runs read the default branch's cache).
- A miss just recompiles miniaudio; **correctness never depends on a cache hit** (the Makefile's content-stamp already guards reuse).

## windows.yml trigger

`windows.yml` was `pull_request`-only, so it had no push run to fill from. Added a `push: [main]` trigger so the merge build populates its (Windows-specific, non-colliding-key) cache — the full Windows build now also runs on merge to main, which is the cost of keeping the Windows audio-compile speedup.

## Note

The Makefile's `audio-cache-save` still writes the local `.ci-cache/` on every `make ci` (it serves local users and is a cheap file copy). Only the **GitHub-level upload** is now gated — which is exactly what stops PR runs filling the shared cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)