### PR TITLE
fix(std.json): read 64-bit integers exactly; get_int clamps (#1204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`std.json` now reads 64-bit integers exactly** (#1204). `json.get_int`
+  returned a 32-bit `int`, so any JSON number above 2^31-1 (a 10-digit ID, a
+  large byte-count) was silently corrupted on read with no diagnostic, even
+  though construction (`json.from_int`) already accepted the full int64 range.
+  The parser now stores integer-valued numbers in a dedicated int64 slot
+  (previously they were parsed into a `double`, lossy past 2^53), a new
+  `json.get_long(value) -> long` reads the exact int64 value, and
+  `json.get_int` now clamps to `+/-2147483647` on overflow instead of
+  truncating. Large integers also round-trip through parse/stringify exactly.
+
 ## [0.421.0]
 
 ### Added
@@ -27,6 +41,8 @@ next version number before tagging the release.
   programs; a program pulling `std.http` / `std.cryptography` additionally needs
   those third-party libs built into the sysroot (aether-crossbuild's
   `provision.sh`), untested through this path yet. Requires zig on `PATH`.
+
+## [0.420.0]
 
 ### Added
 

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -479,8 +479,10 @@ Infallible externs (no tuple):
 - `json.type(value)` → `int` returns one of the `JSON_*` constants.
 - `json.is_null(value)` → `int`.
 - `json.get_bool(value)` → `int` 0 on wrong type.
-- `json.get_number(value)` → `float` 0.0 on wrong type.
-- `json.get_int(value)` → `int` truncates the double.
+- `json.get_number(value)` → `float` 0.0 on wrong type (lossy past 2^53).
+- `json.get_int(value)` → `int`, clamps to `+/-2147483647` on overflow.
+- `json.get_long(value)` → `long`, the full int64 value exactly. Use this for
+  large integer IDs / byte-counts; `get_int` clamps and `get_number` is lossy.
 - `json.object_has(obj, key)` → `int`.
 - `json.array_size(arr)` → `int`.
 - `json.create_null()`, `json.create_bool(v)`, `json.create_number(v)`,

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -982,8 +982,9 @@ The `parse_strict` shape is the std.fs pilot from issue #392 extended to a secon
 - `json.is_null(value)` - Check if null (returns 1/0)
 
 **Value Getters:**
-- `json.get_number(value)` - Get float value
-- `json.get_int(value)` - Get integer value
+- `json.get_number(value)` - Get float value (lossy past 2^53)
+- `json.get_int(value)` - Get 32-bit integer (clamps to +/-2147483647 on overflow)
+- `json.get_long(value)` - Get the full int64 value exactly (IDs, byte-counts)
 - `json.get_bool(value)` - Get boolean (1/0)
 - `json.get_string(value)` → `(string, string)` - Get string value; `(text, err)` tuple, errors with `"not a string"` if `value` is not a `JSON_STRING`
 

--- a/std/json/aether_json.c
+++ b/std/json/aether_json.c
@@ -616,6 +616,11 @@ static JsonValue* jv_new_number(Arena* a, double n) {
     if (v) v->data.number = n;
     return v;
 }
+static JsonValue* jv_new_integer(Arena* a, long long n) {
+    JsonValue* v = jv_new_in(a, JSON_NUMBER);
+    if (v) { v->data.integer = n; v->flags |= JV_FLAG_INTEGER; }
+    return v;
+}
 
 // ---------------------------------------------------------------------------
 // Number parser
@@ -743,19 +748,20 @@ static JsonValue* parse_number(Parser* s) {
         // Signed result. int_acc <= INT64_MAX for non-negative; for negative
         // we allow the full INT64_MIN magnitude (1 more than INT64_MAX abs).
         if (negative) {
-            if (int_acc > (uint64_t)INT64_MAX + 1ULL) {
-                // Exceeds INT64_MIN magnitude — fall through to strtod.
+            if (int_acc == 0 || int_acc > (uint64_t)INT64_MAX + 1ULL) {
+                /* int_acc==0 is "-0": keep the negative zero via the double
+                 * path. A magnitude past INT64_MIN falls through to strtod. */
             } else {
-                double val = -(double)int_acc;
-                if (int_acc == (uint64_t)INT64_MAX + 1ULL) val = (double)INT64_MIN;
-                JsonValue* v = jv_new_number(s->arena, val);
+                long long val = (int_acc == (uint64_t)INT64_MAX + 1ULL)
+                                    ? INT64_MIN
+                                    : -(long long)int_acc;
+                JsonValue* v = jv_new_integer(s->arena, val);
                 if (!v) { err_set(line0, col0, "out of memory"); return NULL; }
                 return v;
             }
         } else {
             if (int_acc <= (uint64_t)INT64_MAX) {
-                double val = (double)(int64_t)int_acc;
-                JsonValue* v = jv_new_number(s->arena, val);
+                JsonValue* v = jv_new_integer(s->arena, (long long)int_acc);
                 if (!v) { err_set(line0, col0, "out of memory"); return NULL; }
                 return v;
             }
@@ -1336,13 +1342,22 @@ double json_get_number(JsonValue* v) {
     return v->data.number;
 }
 
+long long json_get_long(JsonValue* v) {
+    if (!v || v->type != JSON_NUMBER) return 0;
+    if (v->flags & JV_FLAG_INTEGER) return v->data.integer;
+    return (long long)v->data.number;
+}
+
 int json_get_int(JsonValue* v) {
     if (!v || v->type != JSON_NUMBER) return 0;
-    /* Integer-flavoured values read the dedicated slot directly so the
-     * full int64 range survives the round-trip — int->int doesn't lose
-     * precision past 2^53 the way double->int would. */
-    if (v->flags & JV_FLAG_INTEGER) return (int)v->data.integer;
-    return (int)v->data.number;
+    if (v->flags & JV_FLAG_INTEGER) {
+        long long n = v->data.integer;
+        return n > INT32_MAX ? INT32_MAX : (n < INT32_MIN ? INT32_MIN : (int)n);
+    }
+    double d = v->data.number;
+    if (d >= (double)INT32_MAX) return INT32_MAX;
+    if (d <= (double)INT32_MIN) return INT32_MIN;
+    return (int)d;
 }
 
 const char* json_get_string_raw(JsonValue* v) {

--- a/std/json/aether_json.h
+++ b/std/json/aether_json.h
@@ -58,6 +58,7 @@ int json_is_null(JsonValue* value);
 int json_get_bool(JsonValue* value);
 double json_get_number(JsonValue* value);
 int json_get_int(JsonValue* value);
+long long json_get_long(JsonValue* value);
 // Borrowed pointer into the JsonValue's internal string. NULL when
 // `value` is not a JSON_STRING. Valid until json_free(root) is called.
 // The Aether wrapper `json.get_string` copies this into an owned

--- a/std/json/module.ae
+++ b/std/json/module.ae
@@ -16,7 +16,7 @@
 exports (
     json_parse_raw, json_last_error, json_stringify_raw, json_free,
     json_type, json_is_null,
-    json_get_bool, json_get_number, json_get_int, json_get_string_raw,
+    json_get_bool, json_get_number, json_get_int, json_get_long, json_get_string_raw,
     json_object_get_raw, json_object_set_raw, json_object_has,
     json_object_size_raw, json_object_key_at, json_object_value_at,
     json_array_get_raw, json_array_add_raw, json_array_size,
@@ -58,9 +58,13 @@ extern json_type(value: ptr) -> int
 extern json_is_null(value: ptr) -> int
 
 // ---- typed getters (infallible — sentinel 0/0.0 on wrong type) ----
+// get_int is 32-bit and clamps to +/-2147483647 on overflow; use get_long
+// for the full int64 range (IDs, byte-counts). get_number is a float and is
+// lossy past 2^53.
 extern json_get_bool(value: ptr) -> int
 extern json_get_number(value: ptr) -> float
 extern json_get_int(value: ptr) -> int
+extern json_get_long(value: ptr) -> long
 extern json_get_string_raw(value: ptr) -> string
 
 // ---- object operations (raw externs) ----

--- a/tests/regression/test_json_int64.ae
+++ b/tests/regression/test_json_int64.ae
@@ -1,0 +1,41 @@
+// #1204: json.get_long reads the full int64 range exactly; json.get_int
+// clamps instead of silently corrupting; large integers round-trip exactly.
+
+import std.io (println)
+import std.json
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    doc, err = json.parse("{\"id\": 3563282746, \"big\": 9223372036854775807, \"neg\": -9007199254740993}")
+    if err != "" { fail("parse: ${err}") }
+
+    id, e1 = json.object_get(doc, "id")
+    if json.get_long(id) != 3563282746 { fail("get_long id ${json.get_long(id)}") }
+    if json.get_int(id) != 2147483647 { fail("get_int should clamp, got ${json.get_int(id)}") }
+
+    big, e2 = json.object_get(doc, "big")
+    if json.get_long(big) != 9223372036854775807 { fail("get_long INT64_MAX ${json.get_long(big)}") }
+
+    neg, e3 = json.object_get(doc, "neg")
+    if json.get_long(neg) != -9007199254740993 { fail("get_long past-2^53 ${json.get_long(neg)}") }
+
+    s, se = json.stringify(doc)
+    if s != "{\"id\":3563282746,\"big\":9223372036854775807,\"neg\":-9007199254740993}" {
+        fail("roundtrip ${s}")
+    }
+    json_free(doc)
+
+    built = json.obj()
+    json.object_set(built, "count", json.from_int(5000000000))
+    cnode, ce = json.object_get(built, "count")
+    if json.get_long(cnode) != 5000000000 { fail("constructed get_long ${json.get_long(cnode)}") }
+    json_free(built)
+
+    println("PASS")
+}

--- a/tests/regression/test_json_number_precision.ae
+++ b/tests/regression/test_json_number_precision.ae
@@ -55,26 +55,13 @@ main() {
     fails = fails + check("-1", "-1", "neg one")
     fails = fails + check("42", "42", "small pos")
     fails = fails + check("-42", "-42", "small neg")
-    fails = fails + check("1000000", "1e+06", "one million (stringify uses %g)")
+    fails = fails + check("1000000", "1000000", "one million (exact integer, #1204)")
 
-    // int64 edges — 9223372036854775807 and -9223372036854775808.
-    // These are 19 decimal digits, at the int64 boundary. The fast-int
-    // path accepts them; stringify prints in %g form (6-significant-digit
-    // default), so the round-trip is lossy. That's expected: the parser
-    // preserves the VALUE, stringify's precision is a separate concern.
-    // We don't strictly check the output — just that the parse didn't error.
+    // int64 edges round-trip EXACTLY now: integers store in the int64 slot
+    // and stringify emits %lld, not lossy %g (#1204).
     print("\nLarge int boundary:\n")
-    v, perr = json.parse("9223372036854775807")
-    match (perr) {
-        "" -> {
-            println("  PASS int64-max parses without error")
-            json.free(v)
-        }
-        _ -> {
-            println("  FAIL int64-max: ${perr}")
-            fails = fails + 1
-        }
-    }
+    fails = fails + check("9223372036854775807", "9223372036854775807", "int64 max")
+    fails = fails + check("-9223372036854775808", "-9223372036854775808", "int64 min")
 
     // --- fast-double path ---
 


### PR DESCRIPTION
## Summary

`std.json` could construct 64-bit integers (`json.from_int` takes a `long`) but could not read them back: the only integer getter, `json.get_int`, returned a 32-bit `int`, so any JSON number above 2^31-1 was silently corrupted on read with **no diagnostic**. A real 10-digit ID (`3563282746`) read back as a clamped/garbage value, which broke a downstream trading client until they scanned the ID out of the raw JSON text as a string.

## Root cause (deeper than the getter)

The getter was only half of it: the **parser stored integer-valued numbers as a `double`** (the integer fast path called `jv_new_number`), which is itself lossy past 2^53. So even adding a getter that read the double would corrupt large IDs.

## Fix

- **Parser stores pure integers in the dedicated int64 slot** (`JV_FLAG_INTEGER`, `jv_new_integer`), preserving the full int64 range with no precision loss past 2^53. The serializer, `get_number`, and clone already handled that flag.
- **`json.get_long(value) -> long`** reads the exact int64 value.
- **`json.get_int`** now clamps to `+/-2147483647` on overflow (both the int64 and double paths) instead of truncating / relying on UB.
- Large integers now **round-trip through parse/stringify exactly**.

## Verified

```
{"positionID": 3563282746, "big": 9223372036854775807, "neg": -9007199254740993}
  get_long(positionID) -> 3563282746          (was: clamped/garbage)
  get_int(positionID)  -> 2147483647          (clamps, no corruption)
  get_long(neg)        -> -9007199254740993   (exact past 2^53; a double getter is off by 1)
  round-trip           -> identical
```

- 235 unit tests, 87 examples, and the full json suite pass (no serialization regression from the int64-storage change).
- New leak-clean regression test `tests/regression/test_json_int64.ae` (in the macOS leak-gated suite) covers exact reads including past 2^53, clamping, exact round-trip, and constructed values.
- `-Werror` clean.
- Docs updated (`docs/stdlib-reference.md`, `docs/stdlib-api.md`, module comment).

Closes #1204
