### PR TITLE
fix(ae): FreeBSD cross-link appends platform libs (casper always; TLS conditional)

### DIFF
--- a/tests/scripts/cross_compile.sh
+++ b/tests/scripts/cross_compile.sh
@@ -23,13 +23,71 @@ pass=0; fail=0
 ok()   { printf '  \033[0;32mOK\033[0m    %s\n' "$1"; pass=$((pass+1)); }
 bad()  { printf '  \033[0;31mFAIL\033[0m  %s\n' "$1"; fail=$((fail+1)); }
 
-if ! command -v zig >/dev/null 2>&1; then
-    echo "SKIP: zig not installed; cross-compilation test requires zig on PATH."
-    exit 0
-fi
 if [ ! -x "$AE" ]; then
     echo "SKIP: build/ae not found; run 'make ae' first."
     exit 0
+fi
+
+# --- FreeBSD cross-LINK platform libs (asks/freebsd-cross-link-platform-libs.md)
+# These run WITHOUT a real zig (they provide a stub `zig` that echoes its argv)
+# so they execute even on hosts lacking the toolchain — hence before the zig
+# SKIP guard below. They assert the emitted LINK COMMAND, not a produced binary:
+#   casper libs ALWAYS (aether_casper.o is unconditionally in libaether.a and
+#   calls cap_getpwnam/cap_sysctlbyname/…), openssl/nghttp2/zlib/pcre2 ONLY when
+#   CROSSBUILD_SYSROOT is provided. A minimal fake base sysroot satisfies the
+#   path checks.
+_fbtmp="$(mktemp -d)"
+STUB="$_fbtmp/stubzig"; mkdir -p "$STUB"
+cat > "$STUB/zig" <<'STUBEOF'
+#!/bin/sh
+case "$1" in
+  version) echo "0.13.0" ;;
+  cc)  echo "ZIGCC: $*" >&2
+       out=""; prev=""; for a in "$@"; do [ "$prev" = "-o" ] && out="$a"; prev="$a"; done
+       [ -n "$out" ] && : > "$out"; exit 0 ;;
+  ar)  shift; exec ar "$@" ;;
+  *) exit 0 ;;
+esac
+STUBEOF
+chmod +x "$STUB/zig"
+FB="$_fbtmp/fbbase"; mkdir -p "$FB/usr/lib" "$FB/lib" "$FB/usr/include"
+touch "$FB/usr/lib/crt1.o" "$FB/usr/lib/crti.o" "$FB/usr/lib/crtn.o" "$FB/lib/libc.so.7"
+XB="$_fbtmp/xbuild"; mkdir -p "$XB/lib" "$XB/include"
+_HELLO="examples/basics/hello.ae"
+
+# (a) base sysroot only → casper libs present, openssl absent.
+PATH="$STUB:$PATH" AETHER_SYSROOT="$FB" \
+    "$AE" build --target=x86_64-freebsd "$_HELLO" -o "$_fbtmp/lk" 2>"$_fbtmp/zc" >/dev/null || true
+_la="$(grep 'ZIGCC:' "$_fbtmp/zc" | grep -F 'libaether.a' | tail -1)"
+if printf '%s' "$_la" | grep -q -- "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp"; then
+    ok "x86_64-freebsd link appends casper libs (always)"
+else
+    bad "x86_64-freebsd link missing casper libs"; echo "        $_la"
+fi
+if printf '%s' "$_la" | grep -q -- "-lssl"; then
+    bad "x86_64-freebsd link added openssl WITHOUT CROSSBUILD_SYSROOT"
+else
+    ok "x86_64-freebsd link omits openssl without CROSSBUILD_SYSROOT"
+fi
+
+# (b) with CROSSBUILD_SYSROOT → casper + openssl/nghttp2/zlib/pcre2.
+PATH="$STUB:$PATH" AETHER_SYSROOT="$FB" CROSSBUILD_SYSROOT="$XB" \
+    "$AE" build --target=x86_64-freebsd "$_HELLO" -o "$_fbtmp/lk2" 2>"$_fbtmp/zc2" >/dev/null || true
+_lb="$(grep 'ZIGCC:' "$_fbtmp/zc2" | grep -F 'libaether.a' | tail -1)"
+if printf '%s' "$_lb" | grep -q -- "-lcasper" && \
+   printf '%s' "$_lb" | grep -q -- "-lssl -lcrypto -lnghttp2 -lz -lpcre2-8"; then
+    ok "x86_64-freebsd link adds Tier-2 libs with CROSSBUILD_SYSROOT"
+else
+    bad "x86_64-freebsd link missing Tier-2 libs under CROSSBUILD_SYSROOT"; echo "        $_lb"
+fi
+rm -rf "$_fbtmp"
+
+if ! command -v zig >/dev/null 2>&1; then
+    echo "SKIP: rest of cross-compilation test requires a real zig on PATH."
+    echo ""
+    echo "  $pass passed, $fail failed"
+    [ "$fail" -eq 0 ]
+    exit $?
 fi
 
 TMP="$(mktemp -d)"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5090,8 +5090,10 @@ static int run_cross_build(const char* c_file, const char* out_file,
      * (verified with zig 0.13). */
     char sysroot_flag[3200];   /* COMPILE flags: --sysroot + -I/-L */
     char fbsd_link[4096];      /* LINK tail: CRT objects + the real libc.so.7 */
+    char fbsd_platform_libs[2048]; /* LINK tail: FreeBSD platform -l names */
     sysroot_flag[0] = '\0';
     fbsd_link[0] = '\0';
+    fbsd_platform_libs[0] = '\0';
     if (cross_target_needs_sysroot(ztriple)) {
         const char* sr = getenv("AETHER_SYSROOT");
         if (!sr || !*sr) {
@@ -5117,6 +5119,34 @@ static int run_cross_build(const char* c_file, const char* out_file,
                  "-nostdlib \"%s/usr/lib/crt1.o\" \"%s/usr/lib/crti.o\" "
                  "\"%s/lib/libc.so.7\" \"%s/usr/lib/crtn.o\"",
                  sr, sr, sr, sr);
+
+        /* Platform libs the FreeBSD link needs, mirroring the NATIVE FreeBSD
+         * build (ae.c ~2368). The base sysroot's -L (from sysroot_flag) already
+         * resolves these; only the -l names were missing on the cross path.
+         *
+         * casper — ALWAYS: std/casper/aether_casper.c is unconditionally in
+         * libaether.a and calls cap_getpwnam / cap_sysctlbyname / ..., so a
+         * FreeBSD cross-link fails with `undefined symbol: cap_getpwnam`
+         * regardless of what the app imports. The base ships all of them
+         * (libcasper, libcap_pwd, libcap_sysctl, libcap_grp). We emit the
+         * names literally rather than via AETHER_CASPER_LIBS — that macro is
+         * populated by globbing the HOST's /lib when `ae` is built on FreeBSD,
+         * and is empty in an `ae` cross-compiled/built on Linux.
+         *
+         * openssl / nghttp2 / zlib / pcre2 — CONDITIONAL on CROSSBUILD_SYSROOT:
+         * these are NOT in the FreeBSD base; aether-crossbuild's provision.sh
+         * builds them into sysroots/<triple>/. When that sysroot is provided,
+         * add its -L + the -l names so std.cryptography / std.http / std.zlib /
+         * std.regex link for real. Without it, keep today's warn-and-omit (the
+         * program still builds; those features report unavailable at runtime).
+         * Same CROSSBUILD_SYSROOT contract #1213 added to contrib_build.sh. */
+        int pw = snprintf(fbsd_platform_libs, sizeof(fbsd_platform_libs),
+                          "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp");
+        const char* xsr = getenv("CROSSBUILD_SYSROOT");
+        if (xsr && *xsr && pw > 0 && (size_t)pw < sizeof(fbsd_platform_libs)) {
+            snprintf(fbsd_platform_libs + pw, sizeof(fbsd_platform_libs) - (size_t)pw,
+                     " -L%s/lib -lssl -lcrypto -lnghttp2 -lz -lpcre2-8", xsr);
+        }
     }
     static char cmd[24576];
     /* Accumulated quoted "<objpath>" list, in compile order, for the ar
@@ -5191,10 +5221,13 @@ static int run_cross_build(const char* c_file, const char* out_file,
          *    objects bracket the program/runtime; libm comes from the sysroot
          *    -L. Tier A keeps the compact -lm form. */
         if (fbsd_link[0]) {
+            /* Platform -l names go AFTER libaether.a — it references their
+             * symbols (casper's cap_*, openssl's SSL_*, …), so they must
+             * follow it on the link line for ld.lld's single-pass resolution. */
             w = snprintf(cmd, sizeof(cmd),
-                "zig cc -target %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" -lm -o \"%s\"",
+                "zig cc -target %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s -lm -o \"%s\"",
                 ztriple, sysroot_flag, fbsd_link, opt, feature_defs, tc.include_flags,
-                c_file, ex, objdir, out_file);
+                c_file, ex, objdir, fbsd_platform_libs, out_file);
         } else {
             w = snprintf(cmd, sizeof(cmd),
                 "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" -o \"%s\" -lm",


### PR DESCRIPTION
Implements `asks/freebsd-cross-link-platform-libs.md` — the next FreeBSD cross-compile gap after #1213 closed the compile-side one.

## The gap

`run_cross_build`'s FreeBSD link ended `... "libaether.a" -lm` — appending **none** of the platform libs the native FreeBSD link (`ae.c ~2368/2382`) adds. Since `std/casper/aether_casper.c` is **unconditionally** in `libaether.a` and calls `cap_getpwnam` / `cap_sysctlbyname` / …, **every non-trivial FreeBSD cross-build failed to link**:

```
ld.lld: error: undefined symbol: cap_getpwnam
  >>> referenced by aether_casper.c ... aether_casper_pwd_uid
```

Not a missing-dep wall — `libcasper` / `libcap_*` are in the FreeBSD base sysroot; the `-L` is already on the line (from #1208). Only the `-l` names were missing.

## Fix (in `run_cross_build`'s FreeBSD branch)

- **casper — ALWAYS**: `-lcasper -lcap_pwd -lcap_sysctl -lcap_grp`, after `libaether.a` (link order — it references `cap_*`). Emitted **literally**, not via `AETHER_CASPER_LIBS`: that macro is populated by globbing the *host's* `/lib` when `ae` is built on FreeBSD, and is empty in an `ae` built on the Linux cross host. This is the blocker — it's what stops real aeo linking today.
- **openssl / nghttp2 / zlib / pcre2 — CONDITIONAL on `CROSSBUILD_SYSROOT`**: when set, add `-L$CROSSBUILD_SYSROOT/lib -lssl -lcrypto -lnghttp2 -lz -lpcre2-8`, so `std.cryptography` / `std.http` / `std.zlib` / `std.regex` link for real. Without it, today's warn-and-omit stands. Reuses the exact `CROSSBUILD_SYSROOT` contract #1213 added to `contrib_build.sh`, so core and contrib agree.
- Non-FreeBSD cross targets (linux/macos) are **unaffected**.

## Verified — link command inspection (no real toolchain needed)

`tests/scripts/cross_compile.sh` gains assertions using a **stub `zig`** that echoes its argv + a fake base sysroot, so they run even where zig is absent (moved before the zig SKIP guard). All pass (3/3 here):

| Case | Link tail |
|---|---|
| base sysroot only | `libaether.a -lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lm` |
| + `CROSSBUILD_SYSROOT` | `… -lcasper … -L<xsr>/lib -lssl -lcrypto -lnghttp2 -lz -lpcre2-8 -lm` |
| linux cross | `libaether.a -o out` (unchanged) |

`ae` builds clean; native build unaffected (only `run_cross_build` touched).

## Scope / honesty

Part 1 (casper) unblocks the FreeBSD cross-**link** — the jail/rctl/zfs drivers (pure shell-out, no extra libs) then work. Part 2 (openssl et al.) is code-ready but only lights up once `aether-crossbuild`'s `provision.sh <freebsd-triple>` has actually built those libs into the sysroot (its recipes exist — openssl/zlib/nghttp2/pcre2 — but no FreeBSD sysroot is provisioned yet). Verified here by **command inspection**, not an end-to-end FreeBSD binary run (this box has no FreeBSD toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)