### PR TITLE
fix(ae): FreeBSD cross-link casper set was one lib short — add -lcap_dns

### DIFF
--- a/tests/scripts/cross_compile.sh
+++ b/tests/scripts/cross_compile.sh
@@ -59,7 +59,7 @@ _HELLO="examples/basics/hello.ae"
 PATH="$STUB:$PATH" AETHER_SYSROOT="$FB" \
     "$AE" build --target=x86_64-freebsd "$_HELLO" -o "$_fbtmp/lk" 2>"$_fbtmp/zc" >/dev/null || true
 _la="$(grep 'ZIGCC:' "$_fbtmp/zc" | grep -F 'libaether.a' | tail -1)"
-if printf '%s' "$_la" | grep -q -- "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp"; then
+if printf '%s' "$_la" | grep -q -- "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lcap_dns"; then
     ok "x86_64-freebsd link appends casper libs (always)"
 else
     bad "x86_64-freebsd link missing casper libs"; echo "        $_la"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5125,13 +5125,20 @@ static int run_cross_build(const char* c_file, const char* out_file,
          * resolves these; only the -l names were missing on the cross path.
          *
          * casper — ALWAYS: std/casper/aether_casper.c is unconditionally in
-         * libaether.a and calls cap_getpwnam / cap_sysctlbyname / ..., so a
-         * FreeBSD cross-link fails with `undefined symbol: cap_getpwnam`
-         * regardless of what the app imports. The base ships all of them
-         * (libcasper, libcap_pwd, libcap_sysctl, libcap_grp). We emit the
-         * names literally rather than via AETHER_CASPER_LIBS — that macro is
-         * populated by globbing the HOST's /lib when `ae` is built on FreeBSD,
-         * and is empty in an `ae` cross-compiled/built on Linux.
+         * libaether.a and calls cap_getpwnam / cap_sysctlbyname / cap_getaddrinfo
+         * / ..., so a FreeBSD cross-link fails with `undefined symbol: cap_*`
+         * regardless of what the app imports. The base ships all of them. The
+         * complete set, per the cap_* symbols aether_casper.c references:
+         *   cap_init/cap_close/cap_service_open -> libcasper (core)
+         *   cap_getpwnam                        -> libcap_pwd
+         *   cap_sysctl(byname)                  -> libcap_sysctl
+         *   (grp)                               -> libcap_grp
+         *   cap_getaddrinfo (aether_casper_resolve, DNS) -> libcap_dns
+         * cap_dns was the one #1216 missed (its DNS path only surfaces after
+         * pwd/sysctl resolve). We emit the names literally rather than via
+         * AETHER_CASPER_LIBS — that macro is populated by globbing the HOST's
+         * /lib when `ae` is built on FreeBSD, and is empty in an `ae`
+         * cross-compiled/built on Linux.
          *
          * openssl / nghttp2 / zlib / pcre2 — CONDITIONAL on CROSSBUILD_SYSROOT:
          * these are NOT in the FreeBSD base; aether-crossbuild's provision.sh
@@ -5141,7 +5148,7 @@ static int run_cross_build(const char* c_file, const char* out_file,
          * program still builds; those features report unavailable at runtime).
          * Same CROSSBUILD_SYSROOT contract #1213 added to contrib_build.sh. */
         int pw = snprintf(fbsd_platform_libs, sizeof(fbsd_platform_libs),
-                          "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp");
+                          "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lcap_dns");
         const char* xsr = getenv("CROSSBUILD_SYSROOT");
         if (xsr && *xsr && pw > 0 && (size_t)pw < sizeof(fbsd_platform_libs)) {
             snprintf(fbsd_platform_libs + pw, sizeof(fbsd_platform_libs) - (size_t)pw,


### PR DESCRIPTION
Follow-up to #1216 (`asks/freebsd-cross-link-platform-libs.md` UPDATE 2026-07-21).

#1216 shipped the casper set `-lcasper -lcap_pwd -lcap_sysctl -lcap_grp`, which resolved `cap_getpwnam` / `cap_sysctlbyname`. But re-testing real aeo on the fixed `ae` surfaced a **fourth** casper symbol (its DNS path only shows up once pwd/sysctl resolve):

```
ld.lld: error: undefined symbol: cap_getaddrinfo
  >>> referenced by aether_casper.c:82 ... aether_casper_resolve
```

`cap_getaddrinfo` lives in **`libcap_dns`**, which the shipped set omitted.

## The complete set

Enumerated every `cap_*` symbol `std/casper/aether_casper.c` references and its base lib:

| symbol | lib | in #1216? |
|---|---|---|
| `cap_init` / `cap_close` / `cap_service_open` | libcasper | ✅ |
| `cap_getpwnam` | libcap_pwd | ✅ |
| `cap_sysctl(byname)` | libcap_sysctl | ✅ |
| (grp) | libcap_grp | ✅ |
| **`cap_getaddrinfo`** | **libcap_dns** | ❌ → now added |

So the correct always-on set is:

```
-lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lcap_dns
```

**Proven complete** in the ask: hand-linking the emitted C against that set resolves all six symbols, producing a clean `ELF … (FreeBSD 15.0)` binary with zero undefined symbols.

## Verified

- Emitted link line now: `libaether.a -lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lcap_dns -lm`.
- `tests/scripts/cross_compile.sh` assertion updated to expect `-lcap_dns`; 3/3 pass (stub-zig link-command inspection, no real toolchain needed).
- The conditional Tier-2 half (openssl/nghttp2/zlib/pcre2 under `CROSSBUILD_SYSROOT`) is unchanged.

One line of substance. This is the "missed the tail" class of bug — the DNS symbol was latent behind the pwd/sysctl ones #1216 fixed; I've now exhaustively enumerated the `cap_*` references so the set is provably complete, not just one-more-deep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)