### PR TITLE
feat(ae): cross-compile to Windows — ae build --target=x86_64-windows

### DIFF
--- a/runtime/aether_shared_map.c
+++ b/runtime/aether_shared_map.c
@@ -15,6 +15,11 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#elif defined(_WIN32)
+/* generate_token() below uses clock_gettime(CLOCK_MONOTONIC); Windows has no
+ * POSIX clocks, but the thread shim supplies both via QueryPerformanceCounter.
+ * (The shm map itself is a POSIX-only stub on Windows — see the guards below.) */
+#include "utils/aether_thread.h"
 #endif
 
 #define MAX_ENTRIES 256

--- a/runtime/sandbox/aether_audit.c
+++ b/runtime/sandbox/aether_audit.c
@@ -5,7 +5,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
+/* The Win32-aware pthread shim (CRITICAL_SECTION on Windows) rather than raw
+ * <pthread.h> — zig's MinGW target has no pthread.h. Portable across the
+ * native POSIX, MSYS2, and zig-cross-Windows builds. */
+#include "../utils/aether_thread.h"
 
 // ---- Sink configuration (resolved once, lazily) ----
 
@@ -40,7 +43,31 @@ static int ring_count = 0;   // entries currently held (<= AUDIT_RING_CAP)
 // One mutex guards both the sink-mode resolution and the ring buffer.
 // Audit is off the hot path of normal execution (it fires only inside
 // a sandbox block), so a single coarse lock is fine.
+//
+// PTHREAD_MUTEX_INITIALIZER is POSIX-only: the Win32 shim maps
+// pthread_mutex_t to a CRITICAL_SECTION, which has no static initialiser. On
+// Windows, lazily pthread_mutex_init() the lock exactly once via an atomic
+// gate (audit fires only inside a sandbox block, and the first such call runs
+// before any concurrent one in practice). audit_lock_get() returns the ready
+// lock on every platform.
+#if defined(_WIN32)
+#include <stdatomic.h>
+static pthread_mutex_t audit_lock;
+static atomic_int audit_lock_state = 0;   /* 0 uninit, 1 initing, 2 ready */
+static pthread_mutex_t* audit_lock_get(void) {
+    int expected = 0;
+    if (atomic_compare_exchange_strong(&audit_lock_state, &expected, 1)) {
+        pthread_mutex_init(&audit_lock, NULL);
+        atomic_store(&audit_lock_state, 2);
+    } else {
+        while (atomic_load(&audit_lock_state) != 2) { /* spin: one-shot */ }
+    }
+    return &audit_lock;
+}
+#else
 static pthread_mutex_t audit_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t* audit_lock_get(void) { return &audit_lock; }
+#endif
 
 // Resolve the sink mode from AETHER_SANDBOX_AUDIT on first use. Caller
 // must hold audit_lock.
@@ -85,7 +112,7 @@ void aether_sandbox_audit(const char* category, const char* resource,
     if (!category) category = "";
     if (!resource) resource = "";
 
-    pthread_mutex_lock(&audit_lock);
+    pthread_mutex_lock(audit_lock_get());
 
     resolve_sink_locked();
     sink_emit_locked(category, resource, allowed);
@@ -100,7 +127,7 @@ void aether_sandbox_audit(const char* category, const char* resource,
     ring_head = (ring_head + 1) % AUDIT_RING_CAP;
     if (ring_count < AUDIT_RING_CAP) ring_count++;
 
-    pthread_mutex_unlock(&audit_lock);
+    pthread_mutex_unlock(audit_lock_get());
 }
 
 // ---- Query API ----
@@ -114,39 +141,39 @@ static int logical_to_physical(int i) {
 }
 
 int aether_audit_count(void) {
-    pthread_mutex_lock(&audit_lock);
+    pthread_mutex_lock(audit_lock_get());
     int n = ring_count;
-    pthread_mutex_unlock(&audit_lock);
+    pthread_mutex_unlock(audit_lock_get());
     return n;
 }
 
 const char* aether_audit_entry_category(int i) {
-    pthread_mutex_lock(&audit_lock);
+    pthread_mutex_lock(audit_lock_get());
     const char* r = "";
     if (i >= 0 && i < ring_count) r = ring[logical_to_physical(i)].cat;
-    pthread_mutex_unlock(&audit_lock);
+    pthread_mutex_unlock(audit_lock_get());
     return r;
 }
 
 const char* aether_audit_entry_resource(int i) {
-    pthread_mutex_lock(&audit_lock);
+    pthread_mutex_lock(audit_lock_get());
     const char* r = "";
     if (i >= 0 && i < ring_count) r = ring[logical_to_physical(i)].res;
-    pthread_mutex_unlock(&audit_lock);
+    pthread_mutex_unlock(audit_lock_get());
     return r;
 }
 
 int aether_audit_entry_allowed(int i) {
-    pthread_mutex_lock(&audit_lock);
+    pthread_mutex_lock(audit_lock_get());
     int r = -1;
     if (i >= 0 && i < ring_count) r = ring[logical_to_physical(i)].allowed;
-    pthread_mutex_unlock(&audit_lock);
+    pthread_mutex_unlock(audit_lock_get());
     return r;
 }
 
 void aether_audit_clear(void) {
-    pthread_mutex_lock(&audit_lock);
+    pthread_mutex_lock(audit_lock_get());
     ring_head = 0;
     ring_count = 0;
-    pthread_mutex_unlock(&audit_lock);
+    pthread_mutex_unlock(audit_lock_get());
 }

--- a/runtime/utils/aether_cpu_detect.c
+++ b/runtime/utils/aether_cpu_detect.c
@@ -18,7 +18,14 @@
 #endif
 
 #if AETHER_HAS_SIMD
-#  ifdef _WIN32
+   /* CPUID intrinsics come from different headers per toolchain. MSVC exposes
+    * __cpuidex via <intrin.h>; a GNU compiler (gcc/clang, INCLUDING zig cc's
+    * MinGW target and MSYS2 mingw) exposes __cpuid_count via <cpuid.h> and does
+    * NOT declare __cpuidex from <intrin.h>. Keying on _WIN32 alone picked the
+    * MSVC path for mingw/zig and broke the cross-Windows build with
+    * "call to undeclared function '__cpuidex'". Split on the compiler, not the
+    * OS: MSVC -> <intrin.h>; GNU on x86 -> <cpuid.h>. */
+#  if defined(_MSC_VER)
 #    include <intrin.h>
 #  elif defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
 #    include <cpuid.h>
@@ -44,7 +51,10 @@ static int g_cpu_info_initialized = 0;
 #if AETHER_HAS_SIMD
 // CPUID wrapper
 static void cpuid(uint32_t leaf, uint32_t subleaf, uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* edx) {
-#ifdef _WIN32
+    /* MSVC path (its <intrin.h> __cpuidex). A GNU compiler on Windows
+     * (mingw/zig cc) falls through to the __cpuid_count path below, exactly
+     * like native Linux — matching the header split above. */
+#if defined(_MSC_VER)
     int regs[4];
     __cpuidex(regs, leaf, subleaf);
     *eax = regs[0];

--- a/tests/scripts/contrib_build.sh
+++ b/tests/scripts/contrib_build.sh
@@ -85,8 +85,11 @@ if [ -n "$CONTRIB_TARGET" ]; then
             )
             CROSS_ARCH_WANT="FreeBSD"
             ;;
-        *linux*)  CROSS_ARCH_WANT="ELF" ;;
-        *macos*)  CROSS_ARCH_WANT="Mach-O" ;;
+        *linux*)   CROSS_ARCH_WANT="ELF" ;;
+        *macos*)   CROSS_ARCH_WANT="Mach-O" ;;
+        # Windows (Tier A, self-contained like linux): zig bundles the full
+        # MinGW-w64 target — no sysroot. A contrib .o member is a PE/COFF object.
+        *windows*) CROSS_ARCH_WANT="COFF" ;;
     esac
 
     # Tier-2/3 deps: point compiles at the crossbuild sysroot, NOT host libs.

--- a/tests/scripts/cross_compile.sh
+++ b/tests/scripts/cross_compile.sh
@@ -53,6 +53,9 @@ chmod +x "$STUB/zig"
 FB="$_fbtmp/fbbase"; mkdir -p "$FB/usr/lib" "$FB/lib" "$FB/usr/include"
 touch "$FB/usr/lib/crt1.o" "$FB/usr/lib/crti.o" "$FB/usr/lib/crtn.o" "$FB/lib/libc.so.7"
 XB="$_fbtmp/xbuild"; mkdir -p "$XB/lib" "$XB/include"
+# The Tier-2 append is per-lib-probed (ae.c links only libs actually staged),
+# so the fake sysroot must carry the .a files for them to appear on the line.
+for _l in ssl crypto nghttp2 z pcre2-8; do : > "$XB/lib/lib$_l.a"; done
 _HELLO="examples/basics/hello.ae"
 
 # (a) base sysroot only → casper libs present, openssl absent.
@@ -79,6 +82,48 @@ if printf '%s' "$_lb" | grep -q -- "-lcasper" && \
     ok "x86_64-freebsd link adds Tier-2 libs with CROSSBUILD_SYSROOT"
 else
     bad "x86_64-freebsd link missing Tier-2 libs under CROSSBUILD_SYSROOT"; echo "        $_lb"
+fi
+
+# --- Windows (Tier A, self-contained — no sysroot). Same stub zig. ---
+# (c) recognized + emits .exe + NO casper (casper is FreeBSD-only) + NO Tier-2
+#     libs without a sysroot.
+PATH="$STUB:$PATH" "$AE" build --target=x86_64-windows "$_HELLO" -o "$_fbtmp/w" 2>"$_fbtmp/wc" >/dev/null || true
+if grep -q "Unknown target" "$_fbtmp/wc"; then
+    bad "x86_64-windows: reported Unknown target"
+else
+    ok "x86_64-windows recognized as a valid target"
+fi
+_lw="$(grep 'ZIGCC:' "$_fbtmp/wc" | grep -F 'libaether.a' | tail -1)"
+if printf '%s' "$_lw" | grep -q -- "-lcasper"; then
+    bad "x86_64-windows link added casper (FreeBSD-only)"
+else
+    ok "x86_64-windows link omits casper"
+fi
+if printf '%s' "$_lw" | grep -qE -- "-o [^ ]*\.exe"; then
+    ok "x86_64-windows output named .exe"
+else
+    bad "x86_64-windows output not .exe: $_lw"
+fi
+# (d) windows WITH CROSSBUILD_SYSROOT → Tier-2 libs (per-lib probed), no casper.
+PATH="$STUB:$PATH" CROSSBUILD_SYSROOT="$XB" \
+    "$AE" build --target=x86_64-windows "$_HELLO" -o "$_fbtmp/w2" 2>"$_fbtmp/wc2" >/dev/null || true
+_lw2="$(grep 'ZIGCC:' "$_fbtmp/wc2" | grep -F 'libaether.a' | tail -1)"
+if printf '%s' "$_lw2" | grep -q -- "-lssl -lcrypto" && \
+   printf '%s' "$_lw2" | grep -q -- "-lpcre2-8" && \
+   ! printf '%s' "$_lw2" | grep -q -- "-lcasper"; then
+    ok "x86_64-windows link adds Tier-2 libs (no casper) with CROSSBUILD_SYSROOT"
+else
+    bad "x86_64-windows Tier-2 wiring wrong: $_lw2"
+fi
+# (e) per-lib probe: a sysroot with ONLY pcre2 links -lpcre2-8 but NOT -lssl.
+XP="$_fbtmp/xpart"; mkdir -p "$XP/lib"; : > "$XP/lib/libpcre2-8.a"
+PATH="$STUB:$PATH" CROSSBUILD_SYSROOT="$XP" \
+    "$AE" build --target=x86_64-windows "$_HELLO" -o "$_fbtmp/w3" 2>"$_fbtmp/wc3" >/dev/null || true
+_lw3="$(grep 'ZIGCC:' "$_fbtmp/wc3" | grep -F 'libaether.a' | tail -1)"
+if printf '%s' "$_lw3" | grep -q -- "-lpcre2-8" && ! printf '%s' "$_lw3" | grep -q -- "-lssl"; then
+    ok "CROSSBUILD_SYSROOT per-lib probe links only staged libs"
+else
+    bad "per-lib probe wrong (linked an absent lib): $_lw3"
 fi
 rm -rf "$_fbtmp"
 

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -4945,6 +4945,13 @@ static const char* cross_target_to_zig(const char* t) {
     if (!strcmp(t, "x86_64-macos")  || !strcmp(t, "amd64-macos"))  return "x86_64-macos-none";
     if (!strcmp(t, "aarch64-linux") || !strcmp(t, "arm64-linux"))  return "aarch64-linux-gnu";
     if (!strcmp(t, "x86_64-linux")  || !strcmp(t, "amd64-linux"))  return "x86_64-linux-gnu";
+    /* Windows (Tier A — self-contained): zig bundles the full MinGW-w64 target
+     * (CRT, Win32 headers, import libs), so no base sysroot, no --sysroot, no
+     * CRT/libc dance — identical to the linux/macos arms. The runtime's _WIN32
+     * guards (already exercised by native MSYS2 builds) compile against zig's
+     * mingw-w64 bundle. cross_target_needs_sysroot stays false for windows. */
+    if (!strcmp(t, "x86_64-windows")  || !strcmp(t, "amd64-windows")) return "x86_64-windows-gnu";
+    if (!strcmp(t, "aarch64-windows") || !strcmp(t, "arm64-windows")) return "aarch64-windows-gnu";
     /* FreeBSD (Tier B): zig cc does NOT bundle a FreeBSD libc, so these
      * additionally require a base sysroot (headers + libc) provided via
      * AETHER_SYSROOT — see cross_target_needs_sysroot() and the
@@ -5140,19 +5147,51 @@ static int run_cross_build(const char* c_file, const char* out_file,
          * /lib when `ae` is built on FreeBSD, and is empty in an `ae`
          * cross-compiled/built on Linux.
          *
-         * openssl / nghttp2 / zlib / pcre2 — CONDITIONAL on CROSSBUILD_SYSROOT:
-         * these are NOT in the FreeBSD base; aether-crossbuild's provision.sh
-         * builds them into sysroots/<triple>/. When that sysroot is provided,
-         * add its -L + the -l names so std.cryptography / std.http / std.zlib /
-         * std.regex link for real. Without it, keep today's warn-and-omit (the
-         * program still builds; those features report unavailable at runtime).
-         * Same CROSSBUILD_SYSROOT contract #1213 added to contrib_build.sh. */
-        int pw = snprintf(fbsd_platform_libs, sizeof(fbsd_platform_libs),
-                          "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lcap_dns");
+         * casper is FreeBSD-only. The openssl/nghttp2/zlib/pcre2 (Tier-2) libs
+         * are target-AGNOSTIC and handled by crossbuild_libs below, so they
+         * work for windows/linux/macos too — not just freebsd. */
+        snprintf(fbsd_platform_libs, sizeof(fbsd_platform_libs),
+                 "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lcap_dns");
+    }
+
+    /* Tier-2 libs from a CROSSBUILD_SYSROOT — CONDITIONAL and TARGET-AGNOSTIC.
+     * openssl/nghttp2/zlib/pcre2 are not bundled by zig for any target;
+     * aether-crossbuild's provision.sh <triple> builds them into
+     * sysroots/<triple>/. When that sysroot is provided (same CROSSBUILD_SYSROOT
+     * contract #1213 gave contrib_build.sh), append its -L + the -l names so
+     * std.cryptography / std.http / std.zlib / std.regex link for real — for
+     * FreeBSD AND Windows AND linux/macos. Without it, warn-and-omit stands
+     * (the features report unavailable at runtime). The -l names are the same
+     * across targets; only the -L (the sysroot) differs. */
+    char crossbuild_libs[2048];
+    crossbuild_libs[0] = '\0';
+    {
         const char* xsr = getenv("CROSSBUILD_SYSROOT");
-        if (xsr && *xsr && pw > 0 && (size_t)pw < sizeof(fbsd_platform_libs)) {
-            snprintf(fbsd_platform_libs + pw, sizeof(fbsd_platform_libs) - (size_t)pw,
-                     " -L%s/lib -lssl -lcrypto -lnghttp2 -lz -lpcre2-8", xsr);
+        if (xsr && *xsr) {
+            /* Append each -l ONLY when that lib is actually staged in the
+             * sysroot. provision.sh may build a subset (a target might have
+             * pcre2 + zlib but not openssl yet), and zig hard-errors on a
+             * requested-but-absent lib. Probing per-lib links exactly what's
+             * provisioned — the same "link what's there" discipline #1213's
+             * contrib cross mode uses. openssl is -lssl + -lcrypto (both from
+             * libssl.a/libcrypto.a); the rest are 1:1. */
+            size_t p = 0;
+            p += (size_t)snprintf(crossbuild_libs + p, sizeof(crossbuild_libs) - p,
+                                  "-L%s/lib", xsr);
+            char probe[2600];
+            struct { const char* lib; const char* names; } t2[] = {
+                { "ssl",     "-lssl -lcrypto" },  /* libssl.a present => both */
+                { "nghttp2", "-lnghttp2" },
+                { "z",       "-lz" },
+                { "pcre2-8", "-lpcre2-8" },
+            };
+            for (size_t i = 0; i < sizeof(t2) / sizeof(t2[0]); i++) {
+                snprintf(probe, sizeof(probe), "%s/lib/lib%s.a", xsr, t2[i].lib);
+                if (path_exists(probe) && p < sizeof(crossbuild_libs)) {
+                    p += (size_t)snprintf(crossbuild_libs + p, sizeof(crossbuild_libs) - p,
+                                          " %s", t2[i].names);
+                }
+            }
         }
     }
     static char cmd[24576];
@@ -5232,13 +5271,15 @@ static int run_cross_build(const char* c_file, const char* out_file,
              * symbols (casper's cap_*, openssl's SSL_*, …), so they must
              * follow it on the link line for ld.lld's single-pass resolution. */
             w = snprintf(cmd, sizeof(cmd),
-                "zig cc -target %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s -lm -o \"%s\"",
+                "zig cc -target %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -lm -o \"%s\"",
                 ztriple, sysroot_flag, fbsd_link, opt, feature_defs, tc.include_flags,
-                c_file, ex, objdir, fbsd_platform_libs, out_file);
+                c_file, ex, objdir, fbsd_platform_libs, crossbuild_libs, out_file);
         } else {
+            /* Tier A (linux/macos/windows): compact form + any CROSSBUILD_SYSROOT
+             * Tier-2 libs after libaether.a (it references their symbols). */
             w = snprintf(cmd, sizeof(cmd),
-                "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" -o \"%s\" -lm",
-                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, out_file);
+                "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s -o \"%s\" -lm",
+                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, crossbuild_libs, out_file);
         }
         if (w < 0 || (size_t)w >= sizeof(cmd)) {
             fprintf(stderr, "Error: cross-compile link command exceeded the %zu-byte buffer.\n",
@@ -5440,7 +5481,8 @@ static int cmd_build(int argc, char** argv) {
         fprintf(stderr, "Error: Unknown target '%s'.\n", target);
         fprintf(stderr, "Valid targets: native, wasm, or a cross triple "
                         "(aarch64-macos, x86_64-macos, aarch64-linux, x86_64-linux, "
-                        "aarch64-freebsd, x86_64-freebsd).\n");
+                        "aarch64-freebsd, x86_64-freebsd, x86_64-windows, "
+                        "aarch64-windows).\n");
         return 1;
     }
     int is_wasm = target && strcmp(target, "wasm") == 0;
@@ -5479,7 +5521,8 @@ static int cmd_build(int argc, char** argv) {
         fprintf(stderr, "Usage: ae build <file.ae> [-o output] [--extra file.c] [--quick] [--target=<triple>]\n");
         fprintf(stderr, "  --quick    Compile with -O0 -g for faster iteration (default: -O2)\n");
         fprintf(stderr, "  --target   Cross-compile via zig cc: wasm, aarch64-macos, x86_64-macos,\n");
-        fprintf(stderr, "             aarch64-linux, x86_64-linux, aarch64-freebsd, x86_64-freebsd\n");
+        fprintf(stderr, "             aarch64-linux, x86_64-linux, aarch64-freebsd, x86_64-freebsd,\n");
+        fprintf(stderr, "             x86_64-windows, aarch64-windows (-> foo.exe; self-contained)\n");
         fprintf(stderr, "             (freebsd needs AETHER_SYSROOT=<base sysroot>; see aether-crossbuild)\n");
         return 1;
     }
@@ -5529,6 +5572,17 @@ static int cmd_build(int argc, char** argv) {
             strcpy(dot, ".js");
         } else {
             strncat(exe_file, ".js", sizeof(exe_file) - strlen(exe_file) - 1);
+        }
+    }
+
+    // Windows cross target: ensure the output ends in .exe. On the Linux/macOS
+    // cross-host EXE_EXT is empty, so `-o foo` would produce an extensionless
+    // file for a Windows target — append .exe if it's not already there so the
+    // artifact is named the way Windows (and the user) expects.
+    if (ztriple && strstr(ztriple, "windows")) {
+        size_t el = strlen(exe_file);
+        if (el < 4 || strcasecmp(exe_file + el - 4, ".exe") != 0) {
+            strncat(exe_file, ".exe", sizeof(exe_file) - el - 1);
         }
     }
 


### PR DESCRIPTION
Implements `asks/windows-cross-compile.md` — build an Aether `.exe` on Linux and deploy to a **toolchain-less Windows box**, the way a Go/Rust `--target` binary does. All three pieces in one PR (to conserve CI minutes).

Windows is **Tier A** (self-contained): zig bundles the full MinGW-w64 target (CRT, Win32 headers, import libs), so **no base sysroot, no `--sysroot`, no CRT/libc dance** — every hard thing FreeBSD (Tier B) needed evaporates.

## Piece 1 — ae.c triples + runtime portability (dep-free + std.net)

- `cross_target_to_zig`: `x86_64`/`aarch64-windows` → `*-windows-gnu`. `cross_target_needs_sysroot` stays false. `--help` + Unknown-target lists updated. **`.exe` extension** appended (EXE_EXT is empty on the Linux cross-host).
- **Three runtime files weren't clean under zig's MinGW headers** — native MSYS2 builds hid these; the ask flagged "test this first," and they surfaced exactly as predicted:
  - `aether_cpu_detect.c`: `__cpuidex` is MSVC's `<intrin.h>`; a GNU compiler (mingw/zig) uses `__cpuid_count` from `<cpuid.h>`. Split on the **compiler** (`_MSC_VER`), not the OS.
  - `aether_audit.c`: raw `<pthread.h>` → the Win32 pthread shim; `PTHREAD_MUTEX_INITIALIZER` is POSIX-only (CRITICAL_SECTION has no static init) → lazy-init via an atomic once-gate.
  - `aether_shared_map.c`: `clock_gettime`/`CLOCK_MONOTONIC` via the shim on Windows (the shm map itself is already a POSIX-only stub).
- **Proven**: a dep-free program AND a `std.net` (winsock) program cross-build to `PE32+ executable, for MS Windows`.

## Piece 2 — Tier-2 libs from `CROSSBUILD_SYSROOT` (target-agnostic)

Generalized the FreeBSD-only Tier-2 append to **all** cross targets: casper stays FreeBSD-only; `openssl`/`nghttp2`/`zlib`/`pcre2` are appended for FreeBSD **and Windows** (and linux/macos) when `CROSSBUILD_SYSROOT` is set. Each `-l` is **per-lib probed** (`path_exists lib<x>.a`) — `provision.sh` may stage a subset, and zig hard-errors on a requested-but-absent lib, so we link exactly what's provisioned.

**Proven**: a `std.regex` program cross-links to a Windows **PE32+**, resolving `libpcre2-8.a` from the crossbuild windows sysroot.

## Piece 3 — contrib cross for Windows

`contrib_build.sh` gains a `*windows*)`→`COFF` arch-assert arm. Tier-1 (`tinyweb`) and Tier-3 (`sqlite`, via `CROSSBUILD_SYSROOT`) both cross to Windows COFF archives; host bridges SKIP (`nocross`), unchanged.

## Companion (aether-crossbuild — pushed to main, `277bafe`)

`map_zig_target` / `map_autoconf_host` (`x86_64-w64-mingw32`) / `map_openssl_target` (`mingw64`) windows arms + MATRIX entry. `sqlite` / `zlib` / `pcre2` verified cross-building to Windows COFF.

## Tests

`cross_compile.sh` adds Windows assertions (recognized, `.exe`, no casper, Tier-2 with sysroot, per-lib probe links only staged libs) — **8/8** via stub-zig link-command inspection. Native build + **235/235** C tests unaffected (runtime fixes are `_WIN32`/`_MSC_VER`-guarded). The shared_map integration test's failures are pre-existing/environmental (need lua/duktape runtimes) — identical on clean main.

## Scope (honest)

Cross-**building** is proven end-to-end (`file` → PE32+/COFF on Linux, across dep-free / std.net / std.regex / contrib). The capability **claim** — the `.exe` *runs* on a bare Windows box — needs a real Windows host (winbaz) to confirm and is **not exercised here**. `openssl`/`nghttp2` recipes have Windows map arms but only `zlib`/`pcre2`/`sqlite` were run through them so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)