### PR TITLE
fix(ae): three cross-compile completions (windows syslibs, macos audio, sqlite veneer)

### DIFF
--- a/tests/scripts/cross_compile.sh
+++ b/tests/scripts/cross_compile.sh
@@ -104,6 +104,16 @@ if printf '%s' "$_lw" | grep -qE -- "-o [^ ]*\.exe"; then
 else
     bad "x86_64-windows output not .exe: $_lw"
 fi
+# Windows system libs — ALWAYS: zig bundles the mingw CRT but not these -l
+# names. The runtime + static openssl reference them (BCryptGenRandom needs
+# bcrypt; winsock needs ws2_32; etc.), so the cross link must append them or a
+# real socket/RNG program fails to link. Same always-on shape as freebsd casper.
+if printf '%s' "$_lw" | grep -q -- "-lws2_32" && \
+   printf '%s' "$_lw" | grep -q -- "-lbcrypt"; then
+    ok "x86_64-windows link appends Windows system libs (ws2_32/bcrypt/...)"
+else
+    bad "x86_64-windows link missing Windows system libs: $_lw"
+fi
 # (d) windows WITH CROSSBUILD_SYSROOT → Tier-2 libs (per-lib probed), no casper.
 PATH="$STUB:$PATH" CROSSBUILD_SYSROOT="$XB" \
     "$AE" build --target=x86_64-windows "$_HELLO" -o "$_fbtmp/w2" 2>"$_fbtmp/wc2" >/dev/null || true

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5087,7 +5087,20 @@ static int run_cross_build(const char* c_file, const char* out_file,
     const char* user_cflags = get_cflags();
     const char* opt = optimize ? "-O2" : "-O0 -g";
     const char* ex = extra ? extra : "";
-    const char* feature_defs = "-DAETHER_HAS_SANDBOX";
+    /* std.audio's vendored miniaudio auto-selects a backend by platform macro:
+     * on a macos target it #includes <CoreAudio/CoreAudio.h>, an APPLE FRAMEWORK
+     * header that zig's bundled macOS SDK stubs deliberately do NOT ship (the
+     * Apple-licensed part). A cross-built binary can't use CoreAudio without a
+     * real Mac SDK anyway, so disable it: -DMA_NO_COREAUDIO makes miniaudio fall
+     * back to its null backend (std.audio reports unavailable at runtime — same
+     * warn-and-degrade as openssl/nghttp2 on a Tier-B target). Without this, a
+     * macos cross-build of ANY program fails compiling aether_audio.c, even one
+     * that never touches std.audio (the runtime always compiles it). */
+    char feature_defs[128] = "-DAETHER_HAS_SANDBOX";
+    if (strstr(ztriple, "macos")) {
+        strncat(feature_defs, " -DMA_NO_COREAUDIO",
+                sizeof(feature_defs) - strlen(feature_defs) - 1);
+    }
     /* Tier-B (FreeBSD) targets need a base sysroot zig cc doesn't bundle;
      * AETHER_SYSROOT points at it (bases/<cpu>-freebsd[ver]/ from
      * aether-crossbuild). Applied to BOTH compile and link. Empty for the
@@ -5098,9 +5111,21 @@ static int run_cross_build(const char* c_file, const char* out_file,
     char sysroot_flag[3200];   /* COMPILE flags: --sysroot + -I/-L */
     char fbsd_link[4096];      /* LINK tail: CRT objects + the real libc.so.7 */
     char fbsd_platform_libs[2048]; /* LINK tail: FreeBSD platform -l names */
+    char win_platform_libs[512];   /* LINK tail: Windows system -l names */
     sysroot_flag[0] = '\0';
     fbsd_link[0] = '\0';
     fbsd_platform_libs[0] = '\0';
+    win_platform_libs[0] = '\0';
+    /* Windows system libs. std.cryptography's OS RNG uses BCryptGenRandom
+     * (bcrypt.dll); winsock, crypt32, advapi32 etc. are pulled by the runtime
+     * and static openssl. Same shape as fbsd_platform_libs (casper) — a
+     * target-specific always-on set the cross link must append (zig bundles the
+     * mingw CRT but NOT these -l names). Matches the native Windows
+     * win_link_libs. Detected off the zig triple (…-windows-gnu). */
+    if (strstr(ztriple, "windows")) {
+        snprintf(win_platform_libs, sizeof(win_platform_libs),
+                 "-lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp");
+    }
     if (cross_target_needs_sysroot(ztriple)) {
         const char* sr = getenv("AETHER_SYSROOT");
         if (!sr || !*sr) {
@@ -5184,6 +5209,13 @@ static int run_cross_build(const char* c_file, const char* out_file,
                 { "nghttp2", "-lnghttp2" },
                 { "z",       "-lz" },
                 { "pcre2-8", "-lpcre2-8" },
+                /* contrib.sqlite: the Aether veneer archive
+                 * (libaether_sqlite.a, from contrib_build.sh CONTRIB_TARGET
+                 * mode) BEFORE the underlying C lib (libsqlite3.a) — ld.lld's
+                 * single pass needs the veneer's sqlite3_* references resolved
+                 * by the lib that follows. Probed on the VENEER so a program
+                 * that doesn't use sqlite links nothing extra. */
+                { "aether_sqlite", "-laether_sqlite -lsqlite3" },
             };
             for (size_t i = 0; i < sizeof(t2) / sizeof(t2[0]); i++) {
                 snprintf(probe, sizeof(probe), "%s/lib/lib%s.a", xsr, t2[i].lib);
@@ -5276,10 +5308,11 @@ static int run_cross_build(const char* c_file, const char* out_file,
                 c_file, ex, objdir, fbsd_platform_libs, crossbuild_libs, out_file);
         } else {
             /* Tier A (linux/macos/windows): compact form + any CROSSBUILD_SYSROOT
-             * Tier-2 libs after libaether.a (it references their symbols). */
+             * Tier-2 libs AND the Windows system libs after libaether.a (it
+             * references their symbols — BCryptGenRandom etc.). */
             w = snprintf(cmd, sizeof(cmd),
-                "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s -o \"%s\" -lm",
-                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, crossbuild_libs, out_file);
+                "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
+                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, crossbuild_libs, win_platform_libs, out_file);
         }
         if (w < 0 || (size_t)w >= sizeof(cmd)) {
             fprintf(stderr, "Error: cross-compile link command exceeded the %zu-byte buffer.\n",


### PR DESCRIPTION
Three follow-ups to the cross-compile work (#1220 Windows, #1213 contrib), all in `run_cross_build`. The `tools/ae.c` changes originated from a sibling session; this PR commits, **verifies, and tests** them.

## 1. Windows system libs — ALWAYS on the Windows cross link

#1220 proved programs cross-**build** to PE32+, but the Tier-A link appended only `-lm` — a **hollow link-time proof**. zig bundles the mingw CRT but **not** the Windows system `-l` names the runtime + static openssl reference, so a real program fails to **link**:
- `bcrypt` — `std.cryptography`'s OS RNG (`BCryptGenRandom`)
- `ws2_32` — winsock (`std.net` sockets)
- `crypt32`/`advapi32`/`gdi32`/`user32`/`dbghelp` — runtime + static openssl

Appends `-lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp` after `libaether.a`. Same always-on shape as the FreeBSD casper set; matches the **native** Windows link's `win_link_libs`. This is the *exact* "the link tail was incomplete" gap the casper set hit twice (#1216/#1218) — #1220's `std.net` test never linked an actual socket, so the missing winsock lib didn't surface.

## 2. macOS: `-DMA_NO_COREAUDIO` on the macos cross compile

`std.audio`'s vendored miniaudio `#include`s `<CoreAudio/CoreAudio.h>` on a macos target — an Apple **framework** header zig's macOS SDK stubs deliberately don't ship. So **any** macos cross-build failed compiling `aether_audio.c` (the runtime always compiles it), even a program that never touches `std.audio`. Disabling it falls back to miniaudio's null backend (warn-and-degrade, same as openssl on a Tier-B target). `feature_defs` is now a buffer so the flag appends per-target.

## 3. `contrib.sqlite` Tier-2 wiring

Adds `aether_sqlite` → `-laether_sqlite -lsqlite3` to the per-lib-probed `crossbuild_libs` table (the Aether veneer archive **before** the underlying C lib, for ld.lld's single pass; probed on the veneer so a non-sqlite program links nothing extra).

## Safety / verification

- FreeBSD/linux paths **unaffected** — each addition is gated on the target triple. Verified the linux link is clean and the freebsd link still carries only casper + Tier-2.
- `cross_compile.sh` asserts the Windows link carries `ws2_32` + `bcrypt` — **9/9** (stub-zig link-command inspection).
- macos `-DMA_NO_COREAUDIO` and sqlite-veneer wiring are inspection-verified (present on their target, absent elsewhere).

## Honest scope

Same as #1220: cross-**building/linking** is proven by command inspection on Linux; the capability *claim* (the `.exe` runs on a bare Windows box, the macos binary runs on a Mac) needs real target hosts to confirm and isn't exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)