### PR TITLE
feat(contrib): cross-compile the python/ruby host bridges

### DIFF
--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5216,6 +5216,17 @@ static int run_cross_build(const char* c_file, const char* out_file,
                  * by the lib that follows. Probed on the VENEER so a program
                  * that doesn't use sqlite links nothing extra. */
                 { "aether_sqlite", "-laether_sqlite -lsqlite3" },
+                /* contrib.host.python: the embedded-Python bridge veneer. NO
+                 * -lpython — the bridge dlopen()s the deploy host's libpython
+                 * at runtime (AETHER_PYTHON_SONAME), so the .a has no
+                 * unresolved CPython symbols and needs no python at link. Just
+                 * the veneer archive. Probed on it so a program not embedding
+                 * python links nothing extra. */
+                { "aether_host_python", "-laether_host_python" },
+                /* contrib.host.ruby: same dlopen model as python (no -lruby;
+                 * the deploy host's libruby is dlopen'd at runtime). Veneer
+                 * only. */
+                { "aether_host_ruby", "-laether_host_ruby" },
             };
             for (size_t i = 0; i < sizeof(t2) / sizeof(t2[0]); i++) {
                 snprintf(probe, sizeof(probe), "%s/lib/lib%s.a", xsr, t2[i].lib);

--- a/tools/docker/scripts/clone-host-headers.sh
+++ b/tools/docker/scripts/clone-host-headers.sh
@@ -18,7 +18,11 @@
 set -eu
 
 HEADERS_REPO="${HEADERS_REPO:-https://github.com/aether-lang-org/hosted-language-headers.git}"
-HEADERS_REF="${HEADERS_REF:-6872b5df70b3098387a2ca44839e67293c14d54a}"
+# Bumped to 80b44be — the commit that adds the per-target configured-header
+# overlays (targets/<triple>/<lang>/). install-python-headers.sh now overlays
+# targets/x86_64-linux-gnu/python/pyconfig.h from this tree, so the pin MUST
+# include it (the prior 6872b5df predates the targets/ restructure).
+HEADERS_REF="${HEADERS_REF:-80b44be5163a7c8279f23fd714dfe4d11993cb6f}"
 HEADERS_DIR="${HEADERS_DIR:-/opt/hosted-language-headers}"
 
 # Skip if already present (e.g. cached layer from a previous build).

--- a/tools/docker/scripts/install-python-headers.sh
+++ b/tools/docker/scripts/install-python-headers.sh
@@ -17,6 +17,14 @@ HEADERS_DIR="${HEADERS_DIR:-/opt/hosted-language-headers}"
 mkdir -p /opt/aether/include
 cp -r "$HEADERS_DIR/python" /opt/aether/include/python
 
+# The configured pyconfig.h is PER-TARGET (captured from a real machine of each
+# platform; removed from the shared tree — see hosted-language-headers/targets/
+# README.md). This docker image is linux-x86_64-glibc, so overlay that target's
+# real config. (Was previously a Debian multiarch dispatcher in the shared tree;
+# the overlay is the actual configured header it used to dispatch to.)
+cp "$HEADERS_DIR/targets/x86_64-linux-gnu/python/pyconfig.h" \
+   /opt/aether/include/python/pyconfig.h
+
 # Verify the contract.
 test -f /opt/aether/include/python/Python.h || {
     echo "install-python-headers: Python.h missing in $HEADERS_DIR/python" >&2


### PR DESCRIPTION
Completes cross-compiling `contrib/host/python` and `contrib/host/ruby` for FreeBSD/Windows/macOS from a Linux box with zero target toolchain (`asks/contrib-host-python-ruby-cross.md`). The bridge work is owned aeo-side; these files live in the branch-protected aether tree, so the aether maintainer lands them.

**Proven end-to-end aeo-side:** real CPython 3.12.8 + Ruby 2.6.10 executed inside Linux-cross-built **macOS** binaries (Hackintosh KVM).

## Changes

**1. `ae.c` — probe the veneers (+11).** Two entries in `run_cross_build`'s per-lib-probed cross-link table `t2[]`, right after the landed `aether_sqlite`:
```c
{ "aether_host_python", "-laether_host_python" }
{ "aether_host_ruby",   "-laether_host_ruby" }
```
Veneer-only — **no `-lpython`/`-lruby`**. The bridges `dlopen()` the **deploy host's** libpython/libruby at runtime (`AETHER_PYTHON_SONAME` / `AETHER_RUBY_SONAME`), so the veneer `.a` has no unresolved language symbols and needs no language SDK at link. That's what makes the binaries ABI-portable: *compile anywhere, run where the language is.* Probed on the veneer, so a program not embedding python/ruby links nothing extra.

**2. `install-python-headers.sh` — overlay the per-target `pyconfig.h` (+8).** hosted-language-headers removed the shared dispatcher `python/pyconfig.h` (a Debian multiarch dispatcher that `#error`s on cross-targets); the configured header is per-target by nature and now comes only from `targets/<triple>/`. This image is linux-x86_64-glibc, so it overlays that target's real config.

**3. `clone-host-headers.sh` — bump `HEADERS_REF` `6872b5df` → `80b44be`.** The commit that adds the `targets/` overlays. **Required by change 2** — the prior pin predates `targets/`, so the overlay `cp` would fail. The ask flagged this pin bump but didn't include it; added here so the docker build is consistent.

## Verification

- `ae` builds; the cross-link probe adds `-laether_host_python`/`-laether_host_ruby` when a `CROSSBUILD_SYSROOT` provides those veneers, and **nothing** when it doesn't (never `-lpython`/`-lruby`).
- `cross_compile.sh` **9/9**.
- Confirmed the pinned `80b44be` contains `targets/x86_64-linux-gnu/python/pyconfig.h` in the headers repo (so the docker overlay resolves).

## Scope (from the ask's proof matrix)

- **macOS**: GREEN — both ran (`PYTHON_RAN: 3.12.8`, `RUBY_RAN: 2.6.10`).
- **FreeBSD**: compiles.
- **Windows**: blocked (the bridges assume POSIX `<sys/select.h>`) — a separate follow-up, not in this batch.
- **linux**: GREEN (native docker path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)