### PR TITLE
feat(contrib): Windows support for the python/ruby host bridges

### DIFF
--- a/contrib/host/aep_dl.h
+++ b/contrib/host/aep_dl.h
@@ -1,0 +1,62 @@
+// aep_dl.h — tiny portable dlopen shim for the contrib.host.* bridges.
+//
+// The bridges load the deploy host's libpython/libruby at RUNTIME (not at
+// link) via dlopen+dlsym, so a binary is ABI-portable: compile anywhere, run
+// where the language is. POSIX spells that dlopen/dlsym/dlclose (<dlfcn.h>);
+// Windows spells it LoadLibrary/GetProcAddress/FreeLibrary (no <dlfcn.h>).
+// This header maps the POSIX names the bridges already use onto Win32 so the
+// bridge source stays single-source across FreeBSD/macOS/Linux/Windows.
+#ifndef AEP_DL_H
+#define AEP_DL_H
+
+#if defined(_WIN32)
+
+#include <windows.h>
+#include <stdio.h>   // snprintf, used by the dlerror() fallback below
+
+// RTLD_* flags have no Win32 meaning; accept and ignore them so call sites
+// (dlopen(name, RTLD_NOW | RTLD_GLOBAL)) compile unchanged.
+#ifndef RTLD_NOW
+#define RTLD_NOW    0
+#endif
+#ifndef RTLD_GLOBAL
+#define RTLD_GLOBAL 0
+#endif
+
+static inline void* dlopen(const char* name, int flags) {
+    (void)flags;
+    return (void*)LoadLibraryA(name);
+}
+static inline void* dlsym(void* handle, const char* sym) {
+    return (void*)GetProcAddress((HMODULE)handle, sym);
+}
+static inline int dlclose(void* handle) {
+    // POSIX dlclose returns 0 on success; FreeLibrary returns nonzero on success.
+    return FreeLibrary((HMODULE)handle) ? 0 : -1;
+}
+// POSIX dlerror(): NULL when no error, else a human string. Map to the last
+// Win32 error; returns NULL when the last error is 0 (clean), matching the
+// bridge's `dlerror() ? dlerror() : "(none)"` usage. Not thread-safe (nor is
+// POSIX dlerror strictly); fine for the bridge's one-shot load-failure path.
+static inline char* dlerror(void) {
+    DWORD e = GetLastError();
+    if (e == 0) return (char*)0;
+    static char buf[256];
+    DWORD n = FormatMessageA(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        (void*)0, e, 0, buf, (DWORD)sizeof(buf), (va_list*)0);
+    if (n == 0) {
+        // No message text; report the numeric code so it isn't silently "(none)".
+        snprintf(buf, sizeof(buf), "Win32 error %lu", (unsigned long)e);
+    }
+    SetLastError(0);  // POSIX dlerror clears the error after reporting it.
+    return buf;
+}
+
+#else  // POSIX
+
+#include <dlfcn.h>
+
+#endif
+
+#endif // AEP_DL_H

--- a/contrib/host/python/aether_host_python.c
+++ b/contrib/host/python/aether_host_python.c
@@ -28,7 +28,7 @@
 
 #ifdef AETHER_HAS_PYTHON
 #include <Python.h>
-#include <dlfcn.h>
+#include "../aep_dl.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/contrib/host/ruby/aether_host_ruby.c
+++ b/contrib/host/ruby/aether_host_ruby.c
@@ -42,7 +42,7 @@
 // C strings (no Ruby format extensions), so we want libc snprintf
 // — undef the substitution.
 #undef snprintf
-#include <dlfcn.h>
+#include "../aep_dl.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -59,6 +59,10 @@ static struct {
     void (*ruby_init)(void);
     void (*ruby_init_loadpath)(void);
     void (*ruby_init_stack)(volatile VALUE* addr);
+    // Windows-only: ruby_sysinit(&argc,&argv) MUST run before ruby_init on
+    // Windows (sets up the ucrt/argv layer ruby_init assumes). Absent/unneeded
+    // on POSIX. Soft-resolved; only called under _WIN32.
+    void (*ruby_sysinit)(int* argc, char*** argv);
     void (*ruby_finalize)(void);
     // Eval + error introspection.
     VALUE (*rb_eval_string_protect)(const char*, int*);
@@ -92,6 +96,8 @@ static int resolve_ruby_symbols(void* h) {
     RESOLVE(ruby_init,              "ruby_init");
     RESOLVE(ruby_init_loadpath,     "ruby_init_loadpath");
     RESOLVE(ruby_init_stack,        "ruby_init_stack");
+    // soft-resolve (not RESOLVE): POSIX libruby need not export it.
+    *(void**)(&g_rb.ruby_sysinit) = dlsym(h, "ruby_sysinit");
     RESOLVE(ruby_finalize,          "ruby_finalize");
     RESOLVE(rb_eval_string_protect, "rb_eval_string_protect");
     RESOLVE(rb_errinfo,             "rb_errinfo");
@@ -202,6 +208,16 @@ int ruby_init_host(void) {
     // stack bottom for GC. Must happen on the calling thread, before
     // ruby_init().
     volatile VALUE stack_bottom = 0;
+#if defined(_WIN32)
+    // Windows requires ruby_sysinit() before any other ruby_* call.
+    if (g_rb.ruby_sysinit) {
+        static char* aep_argv0 = "aether";
+        char* aep_argv_storage[2] = { aep_argv0, (char*)0 };
+        char** aep_argv = aep_argv_storage;
+        int aep_argc = 1;
+        g_rb.ruby_sysinit(&aep_argc, &aep_argv);
+    }
+#endif
     g_rb.ruby_init_stack(&stack_bottom);
 
     g_rb.ruby_init();


### PR DESCRIPTION
Follow-up to the python/ruby bridge cross-compile (`asks/contrib-host-python-ruby-windows.md`). macOS/FreeBSD/Linux landed earlier (#1227); Windows was listed "blocked: `<sys/select.h>`".

**That block was not in our source.** It came from CPython's `pyport.h`, gated on `HAVE_SYS_SELECT_H` — which the **per-target `pyconfig.h` overlay** (hosted-language-headers `targets/x86_64-windows`) simply omits. So Windows was a missing header **capture** (done in hosted-language-headers `e7f4807`) plus these three aether-tree code changes.

**Proven end-to-end on winbaz** (Windows 11 VM): `PYTHON_RAN: 3.12.8 on win32`, `RUBY_RAN: 3.1.4 on x64-mingw-ucrt` — both inside Linux-cross-built `.exe`s.

## Changes (all `_WIN32`-guarded or passthrough — POSIX unregressed)

**1. NEW `contrib/host/aep_dl.h` — portable dlopen shim.** The bridges `dlopen` the deploy host's libpython/libruby at **runtime** (ABI-portable: compile anywhere, run where the language is). POSIX spells that `<dlfcn.h>`; Windows has no dlfcn — this maps `dlopen`/`dlsym`/`dlclose`/`dlerror` + `RTLD_*` onto `LoadLibrary`/`GetProcAddress`/`FreeLibrary`/`FormatMessage` under `#if _WIN32`, else passes through to `<dlfcn.h>`. Self-contained.

**2. include-swap** — `<dlfcn.h>` → `"../aep_dl.h"` in both bridges (one line each).

**3. `ruby_sysinit` — a real Windows runtime fix.** Windows ruby SEGVs (`0xC0000005`) in `ruby_init` unless `ruby_sysinit(&argc,&argv)` runs first (it sets up the ucrt/argv layer POSIX ruby doesn't need). Added a **soft-resolved** fn ptr (`dlsym`, not the abort-on-miss `RESOLVE` macro — POSIX libruby need not export it) + a `_WIN32`-guarded call before `ruby_init_stack`. Locals are `aep_`-prefixed to dodge ruby's `rb_*` macro namespace (bare `rb_argv` collides with `rb_get_argv`).

None of this touches `ae.c` or the cross-link probe — the dlopen model was already Windows-agnostic.

## Verification

- Both bridges **compile natively** (POSIX path unchanged).
- `aep_dl.h` compiles clean **for x86_64-windows via zig** (Win32 path → PE32+) **and on POSIX** (`<dlfcn.h>` passthrough) — tested a real `dlopen("kernel32.dll") → dlsym → dlclose` round-trip both ways.
- Full both-bridges-**run** proof is the aeo-side winbaz result above.

## Deploy notes (doc/runtime, not code)

- dlopen target is the versioned DLL: `AETHER_PYTHON_SONAME` → `python312.dll`; `AETHER_RUBY_SONAME` → `x64-ucrt-ruby310.dll`.
- RubyInstaller keeps ruby's dependency DLLs in `bin\ruby_builtin_dlls\` — that dir must be on the DLL search path or `LoadLibrary` fails with `ERROR_MOD_NOT_FOUND` (126). Worth a line in the ruby bridge's deploy docs.

## Remaining (not this PR)

- FreeBSD run-proof for both bridges (they compile; runtime proof on .204 is the last matrix gap). Not Windows-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)