### PR TITLE
fix(ae): FreeBSD cross-link libthr.so.3 by path (pthread_create undefined)

### DIFF
--- a/tests/scripts/cross_compile.sh
+++ b/tests/scripts/cross_compile.sh
@@ -67,6 +67,14 @@ if printf '%s' "$_la" | grep -q -- "-lcasper -lcap_pwd -lcap_sysctl -lcap_grp -l
 else
     bad "x86_64-freebsd link missing casper libs"; echo "        $_la"
 fi
+# libthr.so.3 (POSIX threads) must be linked BY PATH, next to libc.so.7 — the
+# runtime/scheduler + std.http server call pthread_create, and -lthr/-lpthread
+# does NOT resolve under zig-lld + -nostdlib against the split base sysroot.
+if printf '%s' "$_la" | grep -q -- "/lib/libthr.so.3"; then
+    ok "x86_64-freebsd link includes libthr.so.3 by path"
+else
+    bad "x86_64-freebsd link missing libthr.so.3 (pthread_create would be undefined)"; echo "        $_la"
+fi
 if printf '%s' "$_la" | grep -q -- "-lssl"; then
     bad "x86_64-freebsd link added openssl WITHOUT CROSSBUILD_SYSROOT"
 else

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5147,10 +5147,20 @@ static int run_cross_build(const char* c_file, const char* out_file,
          * (crt1/crti/crtn — crt1 pulls __libc_start1, a FreeBSD-15 symbol) +
          * the real versioned libc.so.7. Verified end-to-end with zig 0.13
          * against a FreeBSD-15 base sysroot. */
+        /* libthr.so.3 (POSIX threads) BY EXPLICIT PATH, next to libc.so.7. The
+         * Aether runtime (scheduler, actor threads) and std.http's server call
+         * pthread_create/mutex/cond, so a FreeBSD cross-link fails `undefined
+         * symbol: pthread_create` regardless of what the app imports (the native
+         * FreeBSD build gets this via -pthread, ae.c ~2367). It MUST be a path,
+         * not `-lpthread`: base/usr/lib/libpthread.so is a symlink onto libthr,
+         * and -lthr/-lpthread does NOT resolve under zig-lld + -nostdlib against
+         * this split base (verified: the -l form leaves pthread_create undefined,
+         * the explicit libthr.so.3 path links clean). Versioned .so.3 like
+         * libc.so.7 above. */
         snprintf(fbsd_link, sizeof(fbsd_link),
                  "-nostdlib \"%s/usr/lib/crt1.o\" \"%s/usr/lib/crti.o\" "
-                 "\"%s/lib/libc.so.7\" \"%s/usr/lib/crtn.o\"",
-                 sr, sr, sr, sr);
+                 "\"%s/lib/libc.so.7\" \"%s/lib/libthr.so.3\" \"%s/usr/lib/crtn.o\"",
+                 sr, sr, sr, sr, sr);
 
         /* Platform libs the FreeBSD link needs, mirroring the NATIVE FreeBSD
          * build (ae.c ~2368). The base sysroot's -L (from sysroot_flag) already


### PR DESCRIPTION
Implements `asks/freebsd-cross-link-pthread.md`. A one-line-of-substance fix (plus a guard test) for `ae build --target=x86_64-freebsd` failing to link any program that uses threads.

## Symptom

Any FreeBSD cross-build whose program or runtime touches POSIX threads failed at link:
```
ld.lld: error: undefined symbol: pthread_create
  >>> referenced by aether_http_server.c:3708 ... in archive libaether.a
```
The Aether runtime (scheduler, actor threads) and `std.http`'s server call `pthread_create`/mutex/cond, so this bit **essentially every non-trivial FreeBSD cross-build**. The native FreeBSD build links threads via `-pthread` (ae.c ~2367); the cross path omitted them.

## Fix — and why the obvious version is wrong

Add `libthr.so.3` to the `fbsd_link` string **by explicit path**, next to `libc.so.7`.

It **must** be a path, **not `-lpthread`/`-lthr`**: `base/usr/lib/libpthread.so` is a symlink onto `libthr.so` onto `../../lib/libthr.so.3`, and under `zig-lld + -nostdlib` against this split base sysroot the `-l` search chain leaves `pthread_create` undefined. The sibling proved this via `strace` of the actual link — the `-l` form lands on the command line but doesn't resolve; the explicit `libthr.so.3` path links clean. This mirrors `libc.so.7`, already linked by path for the same split-base reason.

```
libc.so.7 <sr>/lib/libthr.so.3 <sr>/usr/lib/crtn.o
```

## Proven end-to-end (sibling, aeo-side)

`ae build bin/aeo-agent.ae --target=x86_64-freebsd` (freebsd15 base + `CROSSBUILD_SYSROOT`) builds a valid FreeBSD ELF; scp'd to a real FreeBSD 15 box (.204) it **runs and serves `/health`=ok** over its pthread-backed `std.http` server.

## Verified here

- `ae` builds; the emitted freebsd link line carries `/lib/libthr.so.3` positioned between `libc.so.7` and `crtn.o` (by path). snprintf arg count matched (5 `%s` / 5 `sr`).
- Linux/macos cross targets **unaffected** (freebsd-only).
- `cross_compile.sh` asserts the freebsd link includes `/lib/libthr.so.3` by path — **10/10** (stub-zig inspection).

## Relationship / downstream

Separate from `freebsd-cross-link-platform-libs` (casper): casper `-l` names go **after** `libaether.a`; libthr goes in `fbsd_link` **by path** alongside the CRT/libc. Both are "the cross path was missing what the native `-pthread`/`-lcasper` build has."

The aeo repo's `release-aeo-agent.yml` gained an x86_64-freebsd agent asset that self-gates on `ae >= 0.428.0` — whichever aether release carries this should be ≥ that (or the gate constant wants bumping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)