### PR TITLE
docs: error-unification §141 — string? == is content-compared (stale note)

### DIFF
--- a/docs/error-unification.md
+++ b/docs/error-unification.md
@@ -138,9 +138,13 @@ its own PR), scoping §4 found live defects in the foundations:
    `tests/regression/test_or_block_value.ae` (verified failing on the
    unfixed compiler) and `tests/integration/or_block_reject/`.
 2. **Noted, lower priority:** `T??` parses but is unguarded and fragile;
-   optional-vs-optional `==` on `string?` compares pointers, not content;
    optionals in tuples / struct-literal fields / actor messages are
    unexercised. None block §6; recorded so they're not rediscovered.
+
+   (The former note here — that `==` on `string?` compares pointers, not
+   content — is resolved: §366 and `language-reference.md` §Optionals both
+   specify content comparison, and it is verified: two distinct allocations of
+   the same text, typed `string?`, compare equal.)
 
 ## 3. What C3's design maps to here — and what doesn't
 


### PR DESCRIPTION
## What

`docs/error-unification.md` §141 (the "Noted, lower priority" list) claims:

> optional-vs-optional `==` on `string?` compares pointers, not content

That note is **stale** — the behaviour it describes as a bug is fixed and documented as such elsewhere.

## Why it's wrong

Two other authorities say the opposite, and the compiler agrees:

- **Same doc, §366:** *"same-text dynamic `string?` — No: content-equal strings compare equal"*
- **`language-reference.md` §Optionals:** *"`a == b` … for `string?` compares the **contents** … not the underlying pointers"*
- **Verified on the current compiler:** two DISTINCT heap allocations of the same text, typed `string?`, compare **EQUAL**:

  ```aether
  main() {
      x = "bar"; y = "ar"
      let a: string? = "foo${x}"    // distinct allocation
      let b: string? = "foob${y}"   // distinct allocation, same content
      if a == b { println("EQUAL") } else { println("NOT EQUAL") }
  }
  // prints: EQUAL   (content comparison — pointer-compare would print NOT EQUAL)
  ```

## The fix

Remove the stale clause and replace it with a resolved-note that cross-references both specs, so it isn't "rediscovered" as an open item. The other lower-priority entries (`T??` fragility, optionals in tuples/struct-fields/messages) are left intact.

Docs-only, no code change. `[skip actions]` on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)