### PR TITLE
feat: implement pure-Aether MD2

### DIFF
--- a/std/cryptography/md2/module.ae
+++ b/std/cryptography/md2/module.ae
@@ -1,0 +1,276 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.md2 — MD2 (RFC 1319) in pure Aether, ported from
+// Bouncy Castle's MD2Digest. NO externs to OpenSSL or any C crypto:
+// the nonlinear substitution, padding, and 18-round block processing
+// are all implemented natively here.
+//
+// MD2 is a 128-bit hash developed by Ronald Rivest in 1989.
+//
+// Import with:  import std.cryptography.md2
+//
+// Two shapes are exposed:
+//   one-shot:   md2_hex(data, len) / md2_bytes(data, len)
+//   streaming:  ctx = new(); update(ctx, data, len); final_hex(ctx)
+//   ownership:  final_hex / final_bytes FREE the ctx; call free_ctx
+//               ONLY to abandon a ctx before finalizing (never after).
+
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    md2_hex, md2_bytes
+)
+
+struct Md2Ctx {
+    state: ptr        // std.bytes buffer, 16 bytes
+    checksum: ptr     // std.bytes buffer, 16 bytes
+    buffer: ptr       // std.bytes buffer, 16 bytes
+    count: int        // number of bytes currently in buffer (0..15)
+}
+
+const PI_SUBST: int[256] = [
+    41, 46, 67, 201, 162, 216, 124, 1, 61, 54, 84, 161, 236, 240, 6,
+    19, 98, 167, 5, 243, 192, 199, 115, 140, 152, 147, 43, 217, 188,
+    76, 130, 202, 30, 155, 87, 60, 253, 212, 224, 22, 103, 66, 111, 24,
+    138, 23, 229, 18, 190, 78, 196, 214, 218, 158, 222, 73, 160, 251,
+    245, 142, 187, 47, 238, 122, 169, 104, 121, 145, 21, 178, 7, 63,
+    148, 194, 16, 137, 11, 34, 95, 33, 128, 127, 93, 154, 90, 144, 50,
+    39, 53, 62, 204, 231, 191, 247, 151, 3, 255, 25, 48, 179, 72, 165,
+    181, 209, 215, 94, 146, 42, 172, 86, 170, 198, 79, 184, 56, 210,
+    150, 164, 125, 182, 118, 252, 107, 226, 156, 116, 4, 241, 69, 157,
+    112, 89, 100, 113, 135, 32, 134, 91, 207, 101, 230, 45, 168, 2, 27,
+    96, 37, 173, 174, 176, 185, 246, 28, 70, 97, 105, 52, 64, 126, 15,
+    85, 71, 163, 35, 221, 81, 175, 58, 195, 92, 249, 206, 186, 197,
+    234, 38, 44, 83, 13, 110, 133, 40, 132, 9, 211, 223, 205, 244, 65,
+    129, 77, 82, 106, 220, 55, 200, 108, 193, 171, 250, 36, 225, 123,
+    8, 12, 189, 177, 74, 120, 136, 149, 139, 227, 99, 232, 109, 233,
+    203, 213, 254, 59, 0, 29, 57, 242, 239, 183, 14, 102, 88, 208, 228,
+    166, 119, 114, 248, 235, 117, 75, 10, 49, 68, 80, 180, 143, 237,
+    31, 26, 219, 153, 141, 51, 159, 17, 131, 20
+]
+
+// Transform block. Updates state and checksum based on the given 16-byte block.
+transform(c: *Md2Ctx, block: ptr) {
+    x = bytes.new(48)
+
+    // Form encryption block: x[0..15] = state, x[16..31] = block, x[32..47] = state ^ block
+    bytes.copy_from_bytes(x, 0, c.state, 0, 16)
+    bytes.copy_from_bytes(x, 16, block, 0, 16)
+
+    i = 0
+    while i < 16 {
+        s = bytes.get(c.state, i)
+        b = bytes.get(block, i)
+        bytes.set(x, 32 + i, (s ^ b) & 255)
+        i = i + 1
+    }
+
+    // Encrypt block (18 rounds)
+    t = 0
+    round = 0
+    while round < 18 {
+        k = 0
+        while k < 48 {
+            val = bytes.get(x, k)
+            new_val = (val ^ PI_SUBST[t]) & 255
+            bytes.set(x, k, new_val)
+            t = new_val
+            k = k + 1
+        }
+        t = (t + round) & 255
+        round = round + 1
+    }
+
+    // Save new state
+    bytes.copy_from_bytes(c.state, 0, x, 0, 16)
+    bytes.free(x)
+
+    // Update checksum
+    t_chk = bytes.get(c.checksum, 15)
+    i = 0
+    while i < 16 {
+        chk = bytes.get(c.checksum, i)
+        blk = bytes.get(block, i)
+        new_chk = (chk ^ PI_SUBST[(blk ^ t_chk) & 255]) & 255
+        bytes.set(c.checksum, i, new_chk)
+        t_chk = new_chk
+        i = i + 1
+    }
+}
+
+// Create a new MD2 streaming context. Returns (ctx, "") on success, or
+// (null, error) on allocation failure.
+new() -> {
+    ctx = malloc(64) as *Md2Ctx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.state = bytes.new(16)
+    ctx.checksum = bytes.new(16)
+    ctx.buffer = bytes.new(16)
+    ctx.count = 0
+
+    i = 0
+    while i < 16 {
+        bytes.set(ctx.state, i, 0)
+        bytes.set(ctx.checksum, i, 0)
+        bytes.set(ctx.buffer, i, 0)
+        i = i + 1
+    }
+    return ctx, ""
+}
+
+// Updates context count and block buffer byte-by-byte
+update_byte(c: *Md2Ctx, b: int) {
+    bytes.set(c.buffer, c.count, b & 255)
+    c.count = c.count + 1
+    if c.count == 16 {
+        transform(c, c.buffer)
+        c.count = 0
+    }
+}
+
+// Feed `length` bytes of `data` into the context. Binary-safe.
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *Md2Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        update_byte(c, b)
+        i = i + 1
+    }
+}
+
+// Binary-safe sibling of `update`: feed `length` bytes from a bytes buffer.
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Md2Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        update_byte(c, b)
+        i = i + 1
+    }
+}
+
+// Pad, append the checksum, and emit the 16-byte digest.
+finalize_to_bytes(c: *Md2Ctx) -> ptr {
+    padLen = 16 - c.count
+    i = 0
+    while i < padLen {
+        update_byte(c, padLen)
+        i = i + 1
+    }
+
+    j = 0
+    while j < 16 {
+        chk_byte = bytes.get(c.checksum, j)
+        update_byte(c, chk_byte)
+        j = j + 1
+    }
+
+    out = bytes.new(16)
+    bytes.copy_from_bytes(out, 0, c.state, 0, 16)
+    return out
+}
+
+free_internals(c: *Md2Ctx) {
+    if c.state != null {
+        bytes.free(c.state)
+        c.state = null
+    }
+    if c.checksum != null {
+        bytes.free(c.checksum)
+        c.checksum = null
+    }
+    if c.buffer != null {
+        bytes.free(c.buffer)
+        c.buffer = null
+    }
+}
+
+// Finalize and return the raw digest as a std.bytes buffer. FREES the
+// ctx; do NOT call free_ctx after a successful finalize (double-free).
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *Md2Ctx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 16)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(16)
+    bytes.copy_from_string(res, 0, s, 16)
+    return res
+}
+
+// Finalize and return the digest as lowercase hex. FREES the ctx; do
+// NOT call free_ctx after a successful finalize (double-free).
+final_hex(ctx: ptr) -> string {
+    c = ctx as *Md2Ctx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(32)
+    i = 0
+    while i < 16 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 32)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+// Abandon a context WITHOUT finalizing — the bail-out cleanup path.
+// NULL-safe. final_hex / final_bytes already free the ctx, so free_ctx
+// must be called ONLY when bailing out before a finalize.
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *Md2Ctx
+    free_internals(c)
+    free(ctx)
+}
+
+// ---- One-shot wrappers ----
+md2_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+md2_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/tests/integration/crypto_md2/test_crypto_md2.ae
+++ b/tests/integration/crypto_md2/test_crypto_md2.ae
@@ -1,0 +1,77 @@
+// Validate std.cryptography.md2 against published RFC 1319 test vectors.
+import std.cryptography.md2
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+main() {
+    fails = 0
+
+    // Standard RFC 1319 Test Vectors
+    fails = fails + check("empty",
+        md2.md2_hex("", 0),
+        "8350e5a3e24c153df2275c9f80692773")
+
+    fails = fails + check("a",
+        md2.md2_hex("a", 1),
+        "32ec01ec4a6dac72c0ab96fb34c0b5d1")
+
+    fails = fails + check("abc",
+        md2.md2_hex("abc", 3),
+        "da853b0d3f88d99b30283a69e6ded6bb")
+
+    fails = fails + check("message digest",
+        md2.md2_hex("message digest", 14),
+        "ab4f496bfb2a530b219ff33031fe06b0")
+
+    fails = fails + check("abcdefghijklmnopqrstuvwxyz",
+        md2.md2_hex("abcdefghijklmnopqrstuvwxyz", 26),
+        "4e8ddff3650292ab5a4108c3aa47940b")
+
+    fails = fails + check("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+        md2.md2_hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62),
+        "da33def2a42df13975352846c30338cd")
+
+    fails = fails + check("1234567890...",
+        md2.md2_hex("12345678901234567890123456789012345678901234567890123456789012345678901234567890", 80),
+        "d5976f79d83d3a0dc9806c3c66f3efd8")
+
+    // Streaming API check
+    ctx, err = md2.new()
+    if err != "" {
+        println("FAIL: md2.new failed: ${err}")
+        fails = fails + 1
+    } else {
+        md2.update(ctx, "abc", 3)
+        res = md2.final_hex(ctx)
+        fails = fails + check("streaming abc", res, "da853b0d3f88d99b30283a69e6ded6bb")
+    }
+
+    // Streaming multi-part update check
+    ctx2, err2 = md2.new()
+    if err2 != "" {
+        println("FAIL: md2.new failed: ${err2}")
+        fails = fails + 1
+    } else {
+        md2.update(ctx2, "message ", 8)
+        md2.update(ctx2, "digest", 6)
+        res2 = md2.final_hex(ctx2)
+        fails = fails + check("streaming multi-part", res2, "ab4f496bfb2a530b219ff33031fe06b0")
+    }
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- add std.cryptography.md2 as a pure Aether RFC 1319 MD2 implementation
- expose streaming and one-shot APIs
- add integration coverage using RFC 1319 vectors

## Test
- ./build/ae run tests/integration/crypto_md2/test_crypto_md2.ae