### PR TITLE
feat(crypto): pure-Aether MD5/MD4/SHA-1/ASCON hashes ported from Bouncy Castle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Five pure-Aether hash submodules ported from Bouncy Castle** —
+  `std.cryptography.md5`, `.md4`, `.sha1` (classic digests) plus
+  `.ascon` (ASCON v1.2 Ascon-Hash / Ascon-HashA) and `.ascon256`
+  (Ascon-Hash256, NIST SP 800-232). No externs to OpenSSL or any C
+  crypto — the permutations, IVs, endianness (big-endian for v1.2,
+  little-endian for the SP 800-232 variant), and padding are ported
+  faithfully from BC's `MD5Digest`/`MD4Digest`/`Sha1Digest`/
+  `AsconDigest`/`AsconHash256`. Streaming (`new`/`update`/`update_bytes`/
+  `final_hex`/`final_bytes`) and one-shot helpers are provided.
+  Test coverage matches Bouncy Castle's vectors and extends them to the
+  full RFC 1320/1321 / HAC suites, with multi-part streaming that crosses
+  the 64-byte block boundary and one-shot-vs-split equality checks; the
+  ASCON KATs are pinned to BC's `LWC_HASH_KAT_256` vectors and the
+  Ascon-Hash256 empty-message digest to the published SP 800-232 value
+  (BC's Hash256 KAT resource is absent from the upstream checkout).
+
 ## [0.436.0]
 
 ### Added

--- a/std/cryptography/ascon/module.ae
+++ b/std/cryptography/ascon/module.ae
@@ -1,0 +1,256 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.ascon — ASCON v1.2 Hash (Ascon-Hash and Ascon-HashA)
+// in pure Aether, ported from Bouncy Castle's AsconDigest. NO externs to
+// OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.ascon
+
+import std.bits
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    ascon_hex, ascon_bytes, ascon_a_hex, ascon_a_bytes
+)
+
+struct AsconCtx {
+    v0: long
+    v1: long
+    v2: long
+    v3: long
+    v4: long
+    block: ptr        // std.bytes buffer, 8 bytes
+    block_len: int
+    rounds: int       // 12 (ascon) or 8 (ascon-a)
+    algo: string      // "ascon" or "ascon-a"
+}
+
+round(c: *AsconCtx, rc: long) {
+    sx = c.v2 ^ rc
+    t0 = c.v0 ^ c.v1 ^ sx ^ c.v3 ^ (c.v1 & (c.v0 ^ sx ^ c.v4))
+    t1 = c.v0 ^ sx ^ c.v3 ^ c.v4 ^ ((c.v1 ^ sx) & (c.v1 ^ c.v3))
+    t2 = c.v1 ^ sx ^ c.v4 ^ (c.v3 & c.v4)
+    t3 = c.v0 ^ c.v1 ^ sx ^ ((~c.v0) & (c.v3 ^ c.v4))
+    t4 = c.v1 ^ c.v3 ^ c.v4 ^ ((c.v0 ^ c.v4) & c.v1)
+
+    c.v0 = t0 ^ bits.rotr64(t0, 19) ^ bits.rotr64(t0, 28)
+    c.v1 = t1 ^ bits.rotr64(t1, 39) ^ bits.rotr64(t1, 61)
+    c.v2 = ~(t2 ^ bits.rotr64(t2, 1) ^ bits.rotr64(t2, 6))
+    c.v3 = t3 ^ bits.rotr64(t3, 10) ^ bits.rotr64(t3, 17)
+    c.v4 = t4 ^ bits.rotr64(t4, 7) ^ bits.rotr64(t4, 41)
+}
+
+p_perm(c: *AsconCtx, nr: int) {
+    if nr == 12 {
+        round(c, 0xf0)
+        round(c, 0xe1)
+        round(c, 0xd2)
+        round(c, 0xc3)
+    }
+    round(c, 0xb4)
+    round(c, 0xa5)
+    round(c, 0x96)
+    round(c, 0x87)
+    round(c, 0x78)
+    round(c, 0x69)
+    round(c, 0x5a)
+    round(c, 0x4b)
+}
+
+// Create a streaming ASCON context. `algo` is "ascon" (Ascon-Hash) or
+// "ascon-a" (Ascon-HashA).
+new(algo: string) -> {
+    ctx = malloc(128) as *AsconCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.algo = algo
+    if algo == "ascon" {
+        ctx.v0 = 0xee9398aadb67f03d
+        ctx.v1 = 0x8bb21831c60f1002
+        ctx.v2 = 0xb48a92db98d5da62
+        ctx.v3 = 0x43189921b8f8e3e8
+        ctx.v4 = 0x348fa5c9d525e140
+        ctx.rounds = 12
+    } else if algo == "ascon-a" {
+        ctx.v0 = 0x01470194fc6528a6
+        ctx.v1 = 0x738ec38ac0adffa7
+        ctx.v2 = 0x2ec8e3296c76384c
+        ctx.v3 = 0xd6f6a54d7f52377d
+        ctx.v4 = 0xa13c42a223be8d87
+        ctx.rounds = 8
+    } else {
+        free(ctx)
+        return null, "unknown algorithm"
+    }
+
+    ctx.block_len = 0
+    ctx.block = bytes.new(8)
+    j = 0
+    while j < 8 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *AsconCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_be64(c.block, 0)
+            p_perm(c, c.rounds)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *AsconCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_be64(c.block, 0)
+            p_perm(c, c.rounds)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+finalize_to_bytes(c: *AsconCtx) -> ptr {
+    bytes.set(c.block, c.block_len, 0x80)
+    j = c.block_len + 1
+    while j < 8 {
+        bytes.set(c.block, j, 0)
+        j = j + 1
+    }
+    shift = 56 - (c.block_len << 3)
+    val = bytes.get_be64(c.block, 0)
+    mask = 0xFFFFFFFFFFFFFFFF << shift
+    c.v0 = c.v0 ^ (val & mask)
+    p_perm(c, 12)
+
+    out = bytes.new(32)
+    bytes.set_be64(out, 0, c.v0)
+
+    i = 0
+    while i < 3 {
+        p_perm(c, c.rounds)
+        bytes.set_be64(out, 8 + i * 8, c.v0)
+        i = i + 1
+    }
+    return out
+}
+
+free_internals(c: *AsconCtx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *AsconCtx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 32)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(32)
+    bytes.copy_from_string(res, 0, s, 32)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *AsconCtx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(64)
+    i = 0
+    while i < 32 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 64)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *AsconCtx
+    free_internals(c)
+    free(ctx)
+}
+
+ascon_hex(data: string, len: int) -> string {
+    ctx, err = new("ascon")
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+ascon_bytes(data: string, len: int) -> ptr {
+    ctx, err = new("ascon")
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}
+
+ascon_a_hex(data: string, len: int) -> string {
+    ctx, err = new("ascon-a")
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+ascon_a_bytes(data: string, len: int) -> ptr {
+    ctx, err = new("ascon-a")
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/ascon256/module.ae
+++ b/std/cryptography/ascon256/module.ae
@@ -1,0 +1,216 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.ascon256 — Ascon-Hash256 (NIST SP 800-232) in pure Aether,
+// ported from Bouncy Castle's AsconHash256. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.ascon256
+
+import std.bits
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    ascon256_hex, ascon256_bytes
+)
+
+struct Ascon256Ctx {
+    v0: long
+    v1: long
+    v2: long
+    v3: long
+    v4: long
+    block: ptr        // std.bytes buffer, 8 bytes
+    block_len: int
+}
+
+round(c: *Ascon256Ctx, rc: long) {
+    sx = c.v2 ^ rc
+    t0 = c.v0 ^ c.v1 ^ sx ^ c.v3 ^ (c.v1 & (c.v0 ^ sx ^ c.v4))
+    t1 = c.v0 ^ sx ^ c.v3 ^ c.v4 ^ ((c.v1 ^ sx) & (c.v1 ^ c.v3))
+    t2 = c.v1 ^ sx ^ c.v4 ^ (c.v3 & c.v4)
+    t3 = c.v0 ^ c.v1 ^ sx ^ ((~c.v0) & (c.v3 ^ c.v4))
+    t4 = c.v1 ^ c.v3 ^ c.v4 ^ ((c.v0 ^ c.v4) & c.v1)
+
+    c.v0 = t0 ^ bits.rotr64(t0, 19) ^ bits.rotr64(t0, 28)
+    c.v1 = t1 ^ bits.rotr64(t1, 39) ^ bits.rotr64(t1, 61)
+    c.v2 = ~(t2 ^ bits.rotr64(t2, 1) ^ bits.rotr64(t2, 6))
+    c.v3 = t3 ^ bits.rotr64(t3, 10) ^ bits.rotr64(t3, 17)
+    c.v4 = t4 ^ bits.rotr64(t4, 7) ^ bits.rotr64(t4, 41)
+}
+
+p12(c: *Ascon256Ctx) {
+    round(c, 0xf0)
+    round(c, 0xe1)
+    round(c, 0xd2)
+    round(c, 0xc3)
+    round(c, 0xb4)
+    round(c, 0xa5)
+    round(c, 0x96)
+    round(c, 0x87)
+    round(c, 0x78)
+    round(c, 0x69)
+    round(c, 0x5a)
+    round(c, 0x4b)
+}
+
+// Create a streaming Ascon-Hash256 context.
+new() -> {
+    ctx = malloc(128) as *Ascon256Ctx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.v0 = 0x9b1e5494e934d681
+    ctx.v1 = 0x4bc3a01e333751d2
+    ctx.v2 = 0xae65396c6b34b81a
+    ctx.v3 = 0x3c7fd4a4d56a4db3
+    ctx.v4 = 0x1a5c464906c5976d
+
+    ctx.block_len = 0
+    ctx.block = bytes.new(8)
+    j = 0
+    while j < 8 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *Ascon256Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_le64(c.block, 0)
+            p12(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Ascon256Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_le64(c.block, 0)
+            p12(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+finalize_to_bytes(c: *Ascon256Ctx) -> ptr {
+    bytes.set(c.block, c.block_len, 0x01)
+    j = c.block_len + 1
+    while j < 8 {
+        bytes.set(c.block, j, 0)
+        j = j + 1
+    }
+    val = bytes.get_le64(c.block, 0)
+    c.v0 = c.v0 ^ val
+    p12(c)
+
+    out = bytes.new(32)
+    bytes.set_le64(out, 0, c.v0)
+
+    i = 0
+    while i < 3 {
+        p12(c)
+        bytes.set_le64(out, 8 + i * 8, c.v0)
+        i = i + 1
+    }
+    return out
+}
+
+free_internals(c: *Ascon256Ctx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *Ascon256Ctx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 32)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(32)
+    bytes.copy_from_string(res, 0, s, 32)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *Ascon256Ctx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(64)
+    i = 0
+    while i < 32 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 64)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *Ascon256Ctx
+    free_internals(c)
+    free(ctx)
+}
+
+ascon256_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+ascon256_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/md4/module.ae
+++ b/std/cryptography/md4/module.ae
@@ -1,0 +1,293 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.md4 — MD4 (RFC 1320) in pure Aether, ported from
+// Bouncy Castle's MD4Digest. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.md4
+
+import std.bits
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    md4_hex, md4_bytes
+)
+
+struct Md4Ctx {
+    v0: long
+    v1: long
+    v2: long
+    v3: long
+    block: ptr        // std.bytes buffer, 64 bytes
+    block_len: int
+    count_lo: long
+}
+
+m32(x: long) -> long {
+    return x & 0xFFFFFFFF
+}
+
+rl(x: long, n: int) -> long {
+    return bits.rotl32(x & 0xFFFFFFFF, n) & 0xFFFFFFFF
+}
+
+F(u: long, v: long, w: long) -> long {
+    return ((u & v) | ((~u) & w)) & 0xFFFFFFFF
+}
+
+G(u: long, v: long, w: long) -> long {
+    return ((u & v) | (u & w) | (v & w)) & 0xFFFFFFFF
+}
+
+H(u: long, v: long, w: long) -> long {
+    return (u ^ v ^ w) & 0xFFFFFFFF
+}
+
+process_block(c: *Md4Ctx) {
+    // Load 16 little-endian 32-bit words
+    X0  = bytes.get_le32(c.block, 0) & 0xFFFFFFFF
+    X1  = bytes.get_le32(c.block, 4) & 0xFFFFFFFF
+    X2  = bytes.get_le32(c.block, 8) & 0xFFFFFFFF
+    X3  = bytes.get_le32(c.block, 12) & 0xFFFFFFFF
+    X4  = bytes.get_le32(c.block, 16) & 0xFFFFFFFF
+    X5  = bytes.get_le32(c.block, 20) & 0xFFFFFFFF
+    X6  = bytes.get_le32(c.block, 24) & 0xFFFFFFFF
+    X7  = bytes.get_le32(c.block, 28) & 0xFFFFFFFF
+    X8  = bytes.get_le32(c.block, 32) & 0xFFFFFFFF
+    X9  = bytes.get_le32(c.block, 36) & 0xFFFFFFFF
+    X10 = bytes.get_le32(c.block, 40) & 0xFFFFFFFF
+    X11 = bytes.get_le32(c.block, 44) & 0xFFFFFFFF
+    X12 = bytes.get_le32(c.block, 48) & 0xFFFFFFFF
+    X13 = bytes.get_le32(c.block, 52) & 0xFFFFFFFF
+    X14 = bytes.get_le32(c.block, 56) & 0xFFFFFFFF
+    X15 = bytes.get_le32(c.block, 60) & 0xFFFFFFFF
+
+    a = c.v0
+    b = c.v1
+    cc = c.v2
+    d = c.v3
+
+    // Round 1
+    a = rl(m32(a + F(b, cc, d) + X0), 3)
+    d = rl(m32(d + F(a, b, cc) + X1), 7)
+    cc = rl(m32(cc + F(d, a, b) + X2), 11)
+    b = rl(m32(b + F(cc, d, a) + X3), 19)
+    a = rl(m32(a + F(b, cc, d) + X4), 3)
+    d = rl(m32(d + F(a, b, cc) + X5), 7)
+    cc = rl(m32(cc + F(d, a, b) + X6), 11)
+    b = rl(m32(b + F(cc, d, a) + X7), 19)
+    a = rl(m32(a + F(b, cc, d) + X8), 3)
+    d = rl(m32(d + F(a, b, cc) + X9), 7)
+    cc = rl(m32(cc + F(d, a, b) + X10), 11)
+    b = rl(m32(b + F(cc, d, a) + X11), 19)
+    a = rl(m32(a + F(b, cc, d) + X12), 3)
+    d = rl(m32(d + F(a, b, cc) + X13), 7)
+    cc = rl(m32(cc + F(d, a, b) + X14), 11)
+    b = rl(m32(b + F(cc, d, a) + X15), 19)
+
+    // Round 2
+    a = rl(m32(a + G(b, cc, d) + X0 + 0x5a827999), 3)
+    d = rl(m32(d + G(a, b, cc) + X4 + 0x5a827999), 5)
+    cc = rl(m32(cc + G(d, a, b) + X8 + 0x5a827999), 9)
+    b = rl(m32(b + G(cc, d, a) + X12 + 0x5a827999), 13)
+    a = rl(m32(a + G(b, cc, d) + X1 + 0x5a827999), 3)
+    d = rl(m32(d + G(a, b, cc) + X5 + 0x5a827999), 5)
+    cc = rl(m32(cc + G(d, a, b) + X9 + 0x5a827999), 9)
+    b = rl(m32(b + G(cc, d, a) + X13 + 0x5a827999), 13)
+    a = rl(m32(a + G(b, cc, d) + X2 + 0x5a827999), 3)
+    d = rl(m32(d + G(a, b, cc) + X6 + 0x5a827999), 5)
+    cc = rl(m32(cc + G(d, a, b) + X10 + 0x5a827999), 9)
+    b = rl(m32(b + G(cc, d, a) + X14 + 0x5a827999), 13)
+    a = rl(m32(a + G(b, cc, d) + X3 + 0x5a827999), 3)
+    d = rl(m32(d + G(a, b, cc) + X7 + 0x5a827999), 5)
+    cc = rl(m32(cc + G(d, a, b) + X11 + 0x5a827999), 9)
+    b = rl(m32(b + G(cc, d, a) + X15 + 0x5a827999), 13)
+
+    // Round 3
+    a = rl(m32(a + H(b, cc, d) + X0 + 0x6ed9eba1), 3)
+    d = rl(m32(d + H(a, b, cc) + X8 + 0x6ed9eba1), 9)
+    cc = rl(m32(cc + H(d, a, b) + X4 + 0x6ed9eba1), 11)
+    b = rl(m32(b + H(cc, d, a) + X12 + 0x6ed9eba1), 15)
+    a = rl(m32(a + H(b, cc, d) + X2 + 0x6ed9eba1), 3)
+    d = rl(m32(d + H(a, b, cc) + X10 + 0x6ed9eba1), 9)
+    cc = rl(m32(cc + H(d, a, b) + X6 + 0x6ed9eba1), 11)
+    b = rl(m32(b + H(cc, d, a) + X14 + 0x6ed9eba1), 15)
+    a = rl(m32(a + H(b, cc, d) + X1 + 0x6ed9eba1), 3)
+    d = rl(m32(d + H(a, b, cc) + X9 + 0x6ed9eba1), 9)
+    cc = rl(m32(cc + H(d, a, b) + X5 + 0x6ed9eba1), 11)
+    b = rl(m32(b + H(cc, d, a) + X13 + 0x6ed9eba1), 15)
+    a = rl(m32(a + H(b, cc, d) + X3 + 0x6ed9eba1), 3)
+    d = rl(m32(d + H(a, b, cc) + X11 + 0x6ed9eba1), 9)
+    cc = rl(m32(cc + H(d, a, b) + X7 + 0x6ed9eba1), 11)
+    b = rl(m32(b + H(cc, d, a) + X15 + 0x6ed9eba1), 15)
+
+    c.v0 = m32(c.v0 + a)
+    c.v1 = m32(c.v1 + b)
+    c.v2 = m32(c.v2 + cc)
+    c.v3 = m32(c.v3 + d)
+}
+
+new() -> {
+    ctx = malloc(128) as *Md4Ctx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.v0 = 0x67452301
+    ctx.v1 = 0xefcdab89
+    ctx.v2 = 0x98badcfe
+    ctx.v3 = 0x10325476
+    ctx.block_len = 0
+    ctx.count_lo = 0
+    ctx.block = bytes.new(64)
+    j = 0
+    while j < 64 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *Md4Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            process_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    c.count_lo = c.count_lo + length
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Md4Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            process_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    c.count_lo = c.count_lo + length
+}
+
+push_pad_byte(c: *Md4Ctx, b: int) {
+    bytes.set(c.block, c.block_len, b & 255)
+    c.block_len = c.block_len + 1
+    if c.block_len == 64 {
+        process_block(c)
+        c.block_len = 0
+    }
+}
+
+finalize_to_bytes(c: *Md4Ctx) -> ptr {
+    bit_len = c.count_lo << 3
+
+    push_pad_byte(c, 0x80)
+    while c.block_len != 56 {
+        push_pad_byte(c, 0)
+    }
+    bytes.set_le64(c.block, 56, bit_len)
+    process_block(c)
+    c.block_len = 0
+
+    out = bytes.new(16)
+    bytes.set_le32(out, 0, c.v0)
+    bytes.set_le32(out, 4, c.v1)
+    bytes.set_le32(out, 8, c.v2)
+    bytes.set_le32(out, 12, c.v3)
+    return out
+}
+
+free_internals(c: *Md4Ctx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *Md4Ctx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 16)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(16)
+    bytes.copy_from_string(res, 0, s, 16)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *Md4Ctx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(32)
+    i = 0
+    while i < 16 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 32)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *Md4Ctx
+    free_internals(c)
+    free(ctx)
+}
+
+md4_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+md4_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/md5/module.ae
+++ b/std/cryptography/md5/module.ae
@@ -1,0 +1,315 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.md5 — MD5 (RFC 1321) in pure Aether, ported from
+// Bouncy Castle's MD5Digest. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.md5
+
+import std.bits
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    md5_hex, md5_bytes
+)
+
+struct Md5Ctx {
+    v0: long
+    v1: long
+    v2: long
+    v3: long
+    block: ptr        // std.bytes buffer, 64 bytes
+    block_len: int
+    count_lo: long
+}
+
+m32(x: long) -> long {
+    return x & 0xFFFFFFFF
+}
+
+rl(x: long, n: int) -> long {
+    return bits.rotl32(x & 0xFFFFFFFF, n) & 0xFFFFFFFF
+}
+
+F(u: long, v: long, w: long) -> long {
+    return ((u & v) | ((~u) & w)) & 0xFFFFFFFF
+}
+
+G(u: long, v: long, w: long) -> long {
+    return ((u & w) | (v & (~w))) & 0xFFFFFFFF
+}
+
+H(u: long, v: long, w: long) -> long {
+    return (u ^ v ^ w) & 0xFFFFFFFF
+}
+
+K(u: long, v: long, w: long) -> long {
+    return (v ^ (u | (~w))) & 0xFFFFFFFF
+}
+
+process_block(c: *Md5Ctx) {
+    // Load 16 little-endian 32-bit words
+    X0  = bytes.get_le32(c.block, 0) & 0xFFFFFFFF
+    X1  = bytes.get_le32(c.block, 4) & 0xFFFFFFFF
+    X2  = bytes.get_le32(c.block, 8) & 0xFFFFFFFF
+    X3  = bytes.get_le32(c.block, 12) & 0xFFFFFFFF
+    X4  = bytes.get_le32(c.block, 16) & 0xFFFFFFFF
+    X5  = bytes.get_le32(c.block, 20) & 0xFFFFFFFF
+    X6  = bytes.get_le32(c.block, 24) & 0xFFFFFFFF
+    X7  = bytes.get_le32(c.block, 28) & 0xFFFFFFFF
+    X8  = bytes.get_le32(c.block, 32) & 0xFFFFFFFF
+    X9  = bytes.get_le32(c.block, 36) & 0xFFFFFFFF
+    X10 = bytes.get_le32(c.block, 40) & 0xFFFFFFFF
+    X11 = bytes.get_le32(c.block, 44) & 0xFFFFFFFF
+    X12 = bytes.get_le32(c.block, 48) & 0xFFFFFFFF
+    X13 = bytes.get_le32(c.block, 52) & 0xFFFFFFFF
+    X14 = bytes.get_le32(c.block, 56) & 0xFFFFFFFF
+    X15 = bytes.get_le32(c.block, 60) & 0xFFFFFFFF
+
+    a = c.v0
+    b = c.v1
+    cc = c.v2
+    d = c.v3
+
+    // Round 1
+    a = m32(rl(m32(a + F(b, cc, d) + X0 + 0xd76aa478), 7) + b)
+    d = m32(rl(m32(d + F(a, b, cc) + X1 + 0xe8c7b756), 12) + a)
+    cc = m32(rl(m32(cc + F(d, a, b) + X2 + 0x242070db), 17) + d)
+    b = m32(rl(m32(b + F(cc, d, a) + X3 + 0xc1bdceee), 22) + cc)
+    a = m32(rl(m32(a + F(b, cc, d) + X4 + 0xf57c0faf), 7) + b)
+    d = m32(rl(m32(d + F(a, b, cc) + X5 + 0x4787c62a), 12) + a)
+    cc = m32(rl(m32(cc + F(d, a, b) + X6 + 0xa8304613), 17) + d)
+    b = m32(rl(m32(b + F(cc, d, a) + X7 + 0xfd469501), 22) + cc)
+    a = m32(rl(m32(a + F(b, cc, d) + X8 + 0x698098d8), 7) + b)
+    d = m32(rl(m32(d + F(a, b, cc) + X9 + 0x8b44f7af), 12) + a)
+    cc = m32(rl(m32(cc + F(d, a, b) + X10 + 0xffff5bb1), 17) + d)
+    b = m32(rl(m32(b + F(cc, d, a) + X11 + 0x895cd7be), 22) + cc)
+    a = m32(rl(m32(a + F(b, cc, d) + X12 + 0x6b901122), 7) + b)
+    d = m32(rl(m32(d + F(a, b, cc) + X13 + 0xfd987193), 12) + a)
+    cc = m32(rl(m32(cc + F(d, a, b) + X14 + 0xa679438e), 17) + d)
+    b = m32(rl(m32(b + F(cc, d, a) + X15 + 0x49b40821), 22) + cc)
+
+    // Round 2
+    a = m32(rl(m32(a + G(b, cc, d) + X1 + 0xf61e2562), 5) + b)
+    d = m32(rl(m32(d + G(a, b, cc) + X6 + 0xc040b340), 9) + a)
+    cc = m32(rl(m32(cc + G(d, a, b) + X11 + 0x265e5a51), 14) + d)
+    b = m32(rl(m32(b + G(cc, d, a) + X0 + 0xe9b6c7aa), 20) + cc)
+    a = m32(rl(m32(a + G(b, cc, d) + X5 + 0xd62f105d), 5) + b)
+    d = m32(rl(m32(d + G(a, b, cc) + X10 + 0x02441453), 9) + a)
+    cc = m32(rl(m32(cc + G(d, a, b) + X15 + 0xd8a1e681), 14) + d)
+    b = m32(rl(m32(b + G(cc, d, a) + X4 + 0xe7d3fbc8), 20) + cc)
+    a = m32(rl(m32(a + G(b, cc, d) + X9 + 0x21e1cde6), 5) + b)
+    d = m32(rl(m32(d + G(a, b, cc) + X14 + 0xc33707d6), 9) + a)
+    cc = m32(rl(m32(cc + G(d, a, b) + X3 + 0xf4d50d87), 14) + d)
+    b = m32(rl(m32(b + G(cc, d, a) + X8 + 0x455a14ed), 20) + cc)
+    a = m32(rl(m32(a + G(b, cc, d) + X13 + 0xa9e3e905), 5) + b)
+    d = m32(rl(m32(d + G(a, b, cc) + X2 + 0xfcefa3f8), 9) + a)
+    cc = m32(rl(m32(cc + G(d, a, b) + X7 + 0x676f02d9), 14) + d)
+    b = m32(rl(m32(b + G(cc, d, a) + X12 + 0x8d2a4c8a), 20) + cc)
+
+    // Round 3
+    a = m32(rl(m32(a + H(b, cc, d) + X5 + 0xfffa3942), 4) + b)
+    d = m32(rl(m32(d + H(a, b, cc) + X8 + 0x8771f681), 11) + a)
+    cc = m32(rl(m32(cc + H(d, a, b) + X11 + 0x6d9d6122), 16) + d)
+    b = m32(rl(m32(b + H(cc, d, a) + X14 + 0xfde5380c), 23) + cc)
+    a = m32(rl(m32(a + H(b, cc, d) + X1 + 0xa4beea44), 4) + b)
+    d = m32(rl(m32(d + H(a, b, cc) + X4 + 0x4bdecfa9), 11) + a)
+    cc = m32(rl(m32(cc + H(d, a, b) + X7 + 0xf6bb4b60), 16) + d)
+    b = m32(rl(m32(b + H(cc, d, a) + X10 + 0xbebfbc70), 23) + cc)
+    a = m32(rl(m32(a + H(b, cc, d) + X13 + 0x289b7ec6), 4) + b)
+    d = m32(rl(m32(d + H(a, b, cc) + X0 + 0xeaa127fa), 11) + a)
+    cc = m32(rl(m32(cc + H(d, a, b) + X3 + 0xd4ef3085), 16) + d)
+    b = m32(rl(m32(b + H(cc, d, a) + X6 + 0x04881d05), 23) + cc)
+    a = m32(rl(m32(a + H(b, cc, d) + X9 + 0xd9d4d039), 4) + b)
+    d = m32(rl(m32(d + H(a, b, cc) + X12 + 0xe6db99e5), 11) + a)
+    cc = m32(rl(m32(cc + H(d, a, b) + X15 + 0x1fa27cf8), 16) + d)
+    b = m32(rl(m32(b + H(cc, d, a) + X2 + 0xc4ac5665), 23) + cc)
+
+    // Round 4
+    a = m32(rl(m32(a + K(b, cc, d) + X0 + 0xf4292244), 6) + b)
+    d = m32(rl(m32(d + K(a, b, cc) + X7 + 0x432aff97), 10) + a)
+    cc = m32(rl(m32(cc + K(d, a, b) + X14 + 0xab9423a7), 15) + d)
+    b = m32(rl(m32(b + K(cc, d, a) + X5 + 0xfc93a039), 21) + cc)
+    a = m32(rl(m32(a + K(b, cc, d) + X12 + 0x655b59c3), 6) + b)
+    d = m32(rl(m32(d + K(a, b, cc) + X3 + 0x8f0ccc92), 10) + a)
+    cc = m32(rl(m32(cc + K(d, a, b) + X10 + 0xffeff47d), 15) + d)
+    b = m32(rl(m32(b + K(cc, d, a) + X1 + 0x85845dd1), 21) + cc)
+    a = m32(rl(m32(a + K(b, cc, d) + X8 + 0x6fa87e4f), 6) + b)
+    d = m32(rl(m32(d + K(a, b, cc) + X15 + 0xfe2ce6e0), 10) + a)
+    cc = m32(rl(m32(cc + K(d, a, b) + X6 + 0xa3014314), 15) + d)
+    b = m32(rl(m32(b + K(cc, d, a) + X13 + 0x4e0811a1), 21) + cc)
+    a = m32(rl(m32(a + K(b, cc, d) + X4 + 0xf7537e82), 6) + b)
+    d = m32(rl(m32(d + K(a, b, cc) + X11 + 0xbd3af235), 10) + a)
+    cc = m32(rl(m32(cc + K(d, a, b) + X2 + 0x2ad7d2bb), 15) + d)
+    b = m32(rl(m32(b + K(cc, d, a) + X9 + 0xeb86d391), 21) + cc)
+
+    c.v0 = m32(c.v0 + a)
+    c.v1 = m32(c.v1 + b)
+    c.v2 = m32(c.v2 + cc)
+    c.v3 = m32(c.v3 + d)
+}
+
+new() -> {
+    ctx = malloc(128) as *Md5Ctx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.v0 = 0x67452301
+    ctx.v1 = 0xefcdab89
+    ctx.v2 = 0x98badcfe
+    ctx.v3 = 0x10325476
+    ctx.block_len = 0
+    ctx.count_lo = 0
+    ctx.block = bytes.new(64)
+    j = 0
+    while j < 64 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *Md5Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            process_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    c.count_lo = c.count_lo + length
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Md5Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            process_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    c.count_lo = c.count_lo + length
+}
+
+push_pad_byte(c: *Md5Ctx, b: int) {
+    bytes.set(c.block, c.block_len, b & 255)
+    c.block_len = c.block_len + 1
+    if c.block_len == 64 {
+        process_block(c)
+        c.block_len = 0
+    }
+}
+
+finalize_to_bytes(c: *Md5Ctx) -> ptr {
+    bit_len = c.count_lo << 3
+
+    push_pad_byte(c, 0x80)
+    while c.block_len != 56 {
+        push_pad_byte(c, 0)
+    }
+    bytes.set_le64(c.block, 56, bit_len)
+    process_block(c)
+    c.block_len = 0
+
+    out = bytes.new(16)
+    bytes.set_le32(out, 0, c.v0)
+    bytes.set_le32(out, 4, c.v1)
+    bytes.set_le32(out, 8, c.v2)
+    bytes.set_le32(out, 12, c.v3)
+    return out
+}
+
+free_internals(c: *Md5Ctx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *Md5Ctx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 16)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(16)
+    bytes.copy_from_string(res, 0, s, 16)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *Md5Ctx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(32)
+    i = 0
+    while i < 16 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 32)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *Md5Ctx
+    free_internals(c)
+    free(ctx)
+}
+
+md5_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+md5_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/sha1/module.ae
+++ b/std/cryptography/sha1/module.ae
@@ -1,0 +1,347 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.sha1 — SHA-1 (RFC 3174) in pure Aether, ported from
+// Bouncy Castle's Sha1Digest. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.sha1
+
+import std.bits
+import std.bytes
+import std.intarr
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    sha1_hex, sha1_bytes
+)
+
+struct Sha1Ctx {
+    v0: long
+    v1: long
+    v2: long
+    v3: long
+    v4: long
+    block: ptr        // std.bytes buffer, 64 bytes
+    block_len: int
+    count_lo: long
+    w: ptr            // intarr(80) message schedule
+}
+
+m32(x: long) -> long {
+    return x & 0xFFFFFFFF
+}
+
+rl(x: long, n: int) -> long {
+    return bits.rotl32(x & 0xFFFFFFFF, n) & 0xFFFFFFFF
+}
+
+F(u: long, v: long, w: long) -> long {
+    return ((u & v) | ((~u) & w)) & 0xFFFFFFFF
+}
+
+H(u: long, v: long, w: long) -> long {
+    return (u ^ v ^ w) & 0xFFFFFFFF
+}
+
+G(u: long, v: long, w: long) -> long {
+    return ((u & v) | (u & w) | (v & w)) & 0xFFFFFFFF
+}
+
+process_block(c: *Sha1Ctx) {
+    w = c.w
+    // Load 16 big-endian words
+    i = 0
+    while i < 16 {
+        word = bytes.get_be32(c.block, i * 4) & 0xFFFFFFFF
+        intarr_set_unchecked(w, i, word)
+        i = i + 1
+    }
+    // Expand to 80 words
+    i = 16
+    while i < 80 {
+        w3 = intarr_get_unchecked(w, i - 3) & 0xFFFFFFFF
+        w8 = intarr_get_unchecked(w, i - 8) & 0xFFFFFFFF
+        w14 = intarr_get_unchecked(w, i - 14) & 0xFFFFFFFF
+        w16 = intarr_get_unchecked(w, i - 16) & 0xFFFFFFFF
+        t = w3 ^ w8 ^ w14 ^ w16
+        rot = rl(t, 1)
+        intarr_set_unchecked(w, i, rot)
+        i = i + 1
+    }
+
+    a = c.v0
+    b = c.v1
+    cc = c.v2
+    d = c.v3
+    e = c.v4
+
+    // Round 1
+    idx = 0
+    while idx < 20 {
+        e = m32(e + rl(a, 5) + F(b, cc, d) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x5a827999)
+        b = rl(b, 30)
+        idx = idx + 1
+
+        d = m32(d + rl(e, 5) + F(a, b, cc) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x5a827999)
+        a = rl(a, 30)
+        idx = idx + 1
+
+        cc = m32(cc + rl(d, 5) + F(e, a, b) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x5a827999)
+        e = rl(e, 30)
+        idx = idx + 1
+
+        b = m32(b + rl(cc, 5) + F(d, e, a) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x5a827999)
+        d = rl(d, 30)
+        idx = idx + 1
+
+        a = m32(a + rl(b, 5) + F(cc, d, e) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x5a827999)
+        cc = rl(cc, 30)
+        idx = idx + 1
+    }
+
+    // Round 2
+    while idx < 40 {
+        e = m32(e + rl(a, 5) + H(b, cc, d) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x6ed9eba1)
+        b = rl(b, 30)
+        idx = idx + 1
+
+        d = m32(d + rl(e, 5) + H(a, b, cc) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x6ed9eba1)
+        a = rl(a, 30)
+        idx = idx + 1
+
+        cc = m32(cc + rl(d, 5) + H(e, a, b) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x6ed9eba1)
+        e = rl(e, 30)
+        idx = idx + 1
+
+        b = m32(b + rl(cc, 5) + H(d, e, a) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x6ed9eba1)
+        d = rl(d, 30)
+        idx = idx + 1
+
+        a = m32(a + rl(b, 5) + H(cc, d, e) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x6ed9eba1)
+        cc = rl(cc, 30)
+        idx = idx + 1
+    }
+
+    // Round 3
+    while idx < 60 {
+        e = m32(e + rl(a, 5) + G(b, cc, d) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x8f1bbcdc)
+        b = rl(b, 30)
+        idx = idx + 1
+
+        d = m32(d + rl(e, 5) + G(a, b, cc) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x8f1bbcdc)
+        a = rl(a, 30)
+        idx = idx + 1
+
+        cc = m32(cc + rl(d, 5) + G(e, a, b) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x8f1bbcdc)
+        e = rl(e, 30)
+        idx = idx + 1
+
+        b = m32(b + rl(cc, 5) + G(d, e, a) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x8f1bbcdc)
+        d = rl(d, 30)
+        idx = idx + 1
+
+        a = m32(a + rl(b, 5) + G(cc, d, e) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0x8f1bbcdc)
+        cc = rl(cc, 30)
+        idx = idx + 1
+    }
+
+    // Round 4
+    while idx < 80 {
+        e = m32(e + rl(a, 5) + H(b, cc, d) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0xca62c1d6)
+        b = rl(b, 30)
+        idx = idx + 1
+
+        d = m32(d + rl(e, 5) + H(a, b, cc) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0xca62c1d6)
+        a = rl(a, 30)
+        idx = idx + 1
+
+        cc = m32(cc + rl(d, 5) + H(e, a, b) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0xca62c1d6)
+        e = rl(e, 30)
+        idx = idx + 1
+
+        b = m32(b + rl(cc, 5) + H(d, e, a) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0xca62c1d6)
+        d = rl(d, 30)
+        idx = idx + 1
+
+        a = m32(a + rl(b, 5) + H(cc, d, e) + (intarr_get_unchecked(w, idx) & 0xFFFFFFFF) + 0xca62c1d6)
+        cc = rl(cc, 30)
+        idx = idx + 1
+    }
+
+    c.v0 = m32(c.v0 + a)
+    c.v1 = m32(c.v1 + b)
+    c.v2 = m32(c.v2 + cc)
+    c.v3 = m32(c.v3 + d)
+    c.v4 = m32(c.v4 + e)
+}
+
+new() -> {
+    ctx = malloc(128) as *Sha1Ctx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.v0 = 0x67452301
+    ctx.v1 = 0xefcdab89
+    ctx.v2 = 0x98badcfe
+    ctx.v3 = 0x10325476
+    ctx.v4 = 0xc3d2e1f0
+    ctx.block_len = 0
+    ctx.count_lo = 0
+    ctx.block = bytes.new(64)
+    j = 0
+    while j < 64 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    ctx.w = intarr_new_raw(80)
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *Sha1Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            process_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    c.count_lo = c.count_lo + length
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *Sha1Ctx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 64 {
+            process_block(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+    c.count_lo = c.count_lo + length
+}
+
+push_pad_byte(c: *Sha1Ctx, b: int) {
+    bytes.set(c.block, c.block_len, b & 255)
+    c.block_len = c.block_len + 1
+    if c.block_len == 64 {
+        process_block(c)
+        c.block_len = 0
+    }
+}
+
+finalize_to_bytes(c: *Sha1Ctx) -> ptr {
+    bit_len = c.count_lo << 3
+
+    push_pad_byte(c, 0x80)
+    while c.block_len != 56 {
+        push_pad_byte(c, 0)
+    }
+    bytes.set_be64(c.block, 56, bit_len)
+    process_block(c)
+    c.block_len = 0
+
+    out = bytes.new(20)
+    bytes.set_be32(out, 0, c.v0)
+    bytes.set_be32(out, 4, c.v1)
+    bytes.set_be32(out, 8, c.v2)
+    bytes.set_be32(out, 12, c.v3)
+    bytes.set_be32(out, 16, c.v4)
+    return out
+}
+
+free_internals(c: *Sha1Ctx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+    if c.w != null {
+        intarr_free(c.w)
+        c.w = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *Sha1Ctx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 20)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(20)
+    bytes.copy_from_string(res, 0, s, 20)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *Sha1Ctx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(40)
+    i = 0
+    while i < 20 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 40)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *Sha1Ctx
+    free_internals(c)
+    free(ctx)
+}
+
+sha1_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+sha1_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/tests/integration/crypto_ascon256/test_crypto_ascon256.ae
+++ b/tests/integration/crypto_ascon256/test_crypto_ascon256.ae
@@ -1,0 +1,92 @@
+// Validate std.cryptography.ascon256 (Ascon-Hash256, NIST SP 800-232) —
+// the pure-Aether port of Bouncy Castle's AsconHash256. This is a DISTINCT
+// standard from the deprecated v1.2 Ascon-Hash/HashA (see crypto_bouncy_castle):
+// little-endian absorption, a single 0x01 pad bit, and p12 throughout.
+//
+// Provenance note: bc-csharp's Ascon-Hash256 KAT resource
+// (crypto/ascon/asconhash256/LWC_HASH_KAT_256.txt) is not present in the
+// checkout we ported from, so these digests are pinned to the published
+// SP 800-232 reference value for the empty message and to the port's own
+// deterministic output for the other inputs, cross-checked by the one-shot
+// vs. split-streaming equality below (a mismatch there would expose any
+// absorption/padding drift regardless of the KAT).
+
+import std.cryptography.ascon256
+import std.bytes
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+main() {
+    fails = 0
+
+    // Empty message — the published NIST SP 800-232 Ascon-Hash256 reference.
+    fails = fails + check("empty",
+        ascon256.ascon256_hex("", 0),
+        "0b3be5850f2f6b98caf29f8fdea89b64a1fa70aa249b8f839bd53baa304d92b2")
+
+    // Single 0x00 byte (fed as bytes to avoid NUL string truncation).
+    b0 = bytes.new(1)
+    bytes.set(b0, 0, 0)
+    c0, e0 = ascon256.new()
+    if e0 != "" {
+        println("FAIL: ascon256.new failed: ${e0}")
+        fails = fails + 1
+    } else {
+        ascon256.update_bytes(c0, b0, 1)
+        fails = fails + check("byte 0x00", ascon256.final_hex(c0),
+            "0728621035af3ed2bca03bf6fde900f9456f5330e4b5ee23e7f6a1e70291bc80")
+    }
+    bytes.free(b0)
+
+    // Two bytes 0x00 0x01.
+    b1 = bytes.new(2)
+    bytes.set(b1, 0, 0)
+    bytes.set(b1, 1, 1)
+    c1, e1 = ascon256.new()
+    if e1 != "" {
+        println("FAIL: ascon256.new failed: ${e1}")
+        fails = fails + 1
+    } else {
+        ascon256.update_bytes(c1, b1, 2)
+        fails = fails + check("bytes 0x00 0x01", ascon256.final_hex(c1),
+            "6115e7c9c4081c2797fc8fe1bc57a836afa1c5381e556dd583860ca2dfb48dd2")
+    }
+    bytes.free(b1)
+
+    // A 43-byte ASCII message that crosses the 8-byte absorption rate
+    // several times — one-shot digest.
+    fox = "The quick brown fox jumps over the lazy dog"
+    fails = fails + check("fox one-shot",
+        ascon256.ascon256_hex(fox, 43),
+        "23414503bf4bde7ad0e85aec94c22ae2d7cd807996b537f9564fc2974053f139")
+
+    // Same message split across two updates at a non-block-aligned boundary
+    // must produce the identical digest — proves multi-part absorption.
+    cs, es = ascon256.new()
+    if es != "" {
+        println("FAIL: ascon256.new failed: ${es}")
+        fails = fails + 1
+    } else {
+        ascon256.update(cs, "The quick brown fox ", 20)
+        ascon256.update(cs, "jumps over the lazy dog", 23)
+        fails = fails + check("fox split-streaming", ascon256.final_hex(cs),
+            "23414503bf4bde7ad0e85aec94c22ae2d7cd807996b537f9564fc2974053f139")
+    }
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}

--- a/tests/integration/crypto_bouncy_castle/test_crypto.ae
+++ b/tests/integration/crypto_bouncy_castle/test_crypto.ae
@@ -1,0 +1,233 @@
+// Validate pure Aether submodules ported from Bouncy Castle.
+import std.cryptography.md5
+import std.cryptography.md4
+import std.cryptography.sha1
+import std.cryptography.ascon
+import std.cryptography.ascon256
+import std.bytes
+import std.string
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+hex_to_bytes(hex: string) -> ptr {
+    len = string.length(hex)
+    n = len / 2
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        c_hi = string.char_at(hex, i * 2)
+        c_lo = string.char_at(hex, i * 2 + 1)
+
+        hi = 0
+        if c_hi >= 48 && c_hi <= 57 {
+            hi = c_hi - 48
+        } else if c_hi >= 97 && c_hi <= 102 {
+            hi = c_hi - 87
+        } else if c_hi >= 65 && c_hi <= 70 {
+            hi = c_hi - 55
+        }
+
+        lo = 0
+        if c_lo >= 48 && c_lo <= 57 {
+            lo = c_lo - 48
+        } else if c_lo >= 97 && c_lo <= 102 {
+            lo = c_lo - 87
+        } else if c_lo >= 65 && c_lo <= 70 {
+            lo = c_lo - 55
+        }
+
+        val = (hi << 4) | lo
+        bytes.set(b, i, val)
+        i = i + 1
+    }
+    return b
+}
+
+main() {
+    fails = 0
+
+    // ---- MD5 Tests ----
+    println("=== MD5 Tests ===")
+    fails = fails + check("MD5 empty",
+        md5.md5_hex("", 0),
+        "d41d8cd98f00b204e9800998ecf8427e")
+
+    fails = fails + check("MD5 a",
+        md5.md5_hex("a", 1),
+        "0cc175b9c0f1b6a831c399e269772661")
+
+    fails = fails + check("MD5 abc",
+        md5.md5_hex("abc", 3),
+        "900150983cd24fb0d6963f7d28e17f72")
+
+    fails = fails + check("MD5 alphabet",
+        md5.md5_hex("abcdefghijklmnopqrstuvwxyz", 26),
+        "c3fcd3d76192e4007dfb496cca67e13b")
+
+    // MD5 Streaming
+    ctx_md5, err_md5 = md5.new()
+    if err_md5 != "" {
+        println("FAIL: md5.new failed: ${err_md5}")
+        fails = fails + 1
+    } else {
+        md5.update(ctx_md5, "ab", 2)
+        md5.update(ctx_md5, "c", 1)
+        res_md5 = md5.final_hex(ctx_md5)
+        fails = fails + check("MD5 streaming abc", res_md5, "900150983cd24fb0d6963f7d28e17f72")
+    }
+
+    // ---- MD4 Tests ----
+    println("=== MD4 Tests ===")
+    fails = fails + check("MD4 empty",
+        md4.md4_hex("", 0),
+        "31d6cfe0d16ae931b73c59d7e0c089c0")
+
+    fails = fails + check("MD4 a",
+        md4.md4_hex("a", 1),
+        "bde52cb31de33e46245e05fbdbd6fb24")
+
+    fails = fails + check("MD4 abc",
+        md4.md4_hex("abc", 3),
+        "a448017aaf21d8525fc10ae87aa6729d")
+
+    fails = fails + check("MD4 long",
+        md4.md4_hex("12345678901234567890123456789012345678901234567890123456789012345678901234567890", 80),
+        "e33b4ddc9c38f2199c3e7b164fcc0536")
+
+    // MD4 Streaming
+    ctx_md4, err_md4 = md4.new()
+    if err_md4 != "" {
+        println("FAIL: md4.new failed: ${err_md4}")
+        fails = fails + 1
+    } else {
+        md4.update(ctx_md4, "a", 1)
+        md4.update(ctx_md4, "bc", 2)
+        res_md4 = md4.final_hex(ctx_md4)
+        fails = fails + check("MD4 streaming abc", res_md4, "a448017aaf21d8525fc10ae87aa6729d")
+    }
+
+    // ---- SHA-1 Tests ----
+    println("=== SHA-1 Tests ===")
+    fails = fails + check("SHA-1 empty",
+        sha1.sha1_hex("", 0),
+        "da39a3ee5e6b4b0d3255bfef95601890afd80709")
+
+    fails = fails + check("SHA-1 a",
+        sha1.sha1_hex("a", 1),
+        "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8")
+
+    fails = fails + check("SHA-1 abc",
+        sha1.sha1_hex("abc", 3),
+        "a9993e364706816aba3e25717850c26c9cd0d89d")
+
+    fails = fails + check("SHA-1 alphabet",
+        sha1.sha1_hex("abcdefghijklmnopqrstuvwxyz", 26),
+        "32d10c7b8cf96570ca04ce37f2a19d84240d3a89")
+
+    // SHA-1 Streaming
+    ctx_sha1, err_sha1 = sha1.new()
+    if err_sha1 != "" {
+        println("FAIL: sha1.new failed: ${err_sha1}")
+        fails = fails + 1
+    } else {
+        sha1.update(ctx_sha1, "ab", 2)
+        sha1.update(ctx_sha1, "c", 1)
+        res_sha1 = sha1.final_hex(ctx_sha1)
+        fails = fails + check("SHA-1 streaming abc", res_sha1, "a9993e364706816aba3e25717850c26c9cd0d89d")
+    }
+
+    // ---- Ascon Tests ----
+    println("=== Ascon Tests ===")
+    // Ascon-Hash
+    fails = fails + check("Ascon-Hash empty",
+        ascon.ascon_hex("", 0),
+        "7346bc14f036e87ae03d0997913088f5f68411434b3cf8b54fa796a80d251f91")
+
+    // Use hex_to_bytes to avoid Aether string literal NUL-truncation
+    buf_00 = hex_to_bytes("00")
+    defer bytes.free(buf_00)
+    ctx_ascon_00, _ = ascon.new("ascon")
+    ascon.update_bytes(ctx_ascon_00, buf_00, 1)
+    res_ascon_00 = ascon.final_hex(ctx_ascon_00)
+    fails = fails + check("Ascon-Hash \\x00",
+        res_ascon_00,
+        "8dd446ada58a7740ecf56eb638ef775f7d5c0fd5f0c2bbbdfdec29609d3c43a2")
+
+    buf_0001 = hex_to_bytes("0001")
+    defer bytes.free(buf_0001)
+    ctx_ascon_0001, _ = ascon.new("ascon")
+    ascon.update_bytes(ctx_ascon_0001, buf_0001, 2)
+    res_ascon_0001 = ascon.final_hex(ctx_ascon_0001)
+    fails = fails + check("Ascon-Hash \\x00\\x01",
+        res_ascon_0001,
+        "f77ca13bf89146d3254f1cfb7eddba8fa1bf162284bb29e7f645545cf9e08424")
+
+    // Ascon-HashA
+    fails = fails + check("Ascon-HashA empty",
+        ascon.ascon_a_hex("", 0),
+        "aecd027026d0675f9de7a8ad8ccf512db64b1edcf0b20c388a0c7cc617aaa2c4")
+
+    ctx_ascon_a_00, _ = ascon.new("ascon-a")
+    ascon.update_bytes(ctx_ascon_a_00, buf_00, 1)
+    res_ascon_a_00 = ascon.final_hex(ctx_ascon_a_00)
+    fails = fails + check("Ascon-HashA \\x00",
+        res_ascon_a_00,
+        "5a55f0367763d334a3174f9c17fa476eb9196a22f10daf29505633572e7756e4")
+
+    ctx_ascon_a_0001, _ = ascon.new("ascon-a")
+    ascon.update_bytes(ctx_ascon_a_0001, buf_0001, 2)
+    res_ascon_a_0001 = ascon.final_hex(ctx_ascon_a_0001)
+    fails = fails + check("Ascon-HashA \\x00\\x01",
+        res_ascon_a_0001,
+        "4243fd3b872e1ed4013711382cba032fecb4147d840ddf8436172ac62d129bc4")
+
+    // Ascon-Hash Streaming
+    ctx_ascon_stream, err_ascon = ascon.new("ascon")
+    if err_ascon != "" {
+        println("FAIL: ascon.new failed: ${err_ascon}")
+        fails = fails + 1
+    } else {
+        ascon.update_bytes(ctx_ascon_stream, buf_00, 1)
+        // Wait, buf_0001 contains \x00\x01. To append \x01, we can get byte 1 from buf_0001
+        buf_01 = bytes.new(1)
+        bytes.set(buf_01, 0, 1)
+        defer bytes.free(buf_01)
+        ascon.update_bytes(ctx_ascon_stream, buf_01, 1)
+        res_ascon_stream = ascon.final_hex(ctx_ascon_stream)
+        fails = fails + check("Ascon-Hash streaming \\x00\\x01", res_ascon_stream, "f77ca13bf89146d3254f1cfb7eddba8fa1bf162284bb29e7f645545cf9e08424")
+    }
+
+    // ---- Ascon-Hash256 Tests ----
+    println("=== Ascon-Hash256 Tests ===")
+    fails = fails + check("Ascon-Hash256 empty",
+        ascon256.ascon256_hex("", 0),
+        "0b3be5850f2f6b98caf29f8fdea89b64a1fa70aa249b8f839bd53baa304d92b2")
+
+    // Ascon-Hash256 Streaming
+    ctx_ascon256, err_ascon256 = ascon256.new()
+    if err_ascon256 != "" {
+        println("FAIL: ascon256.new failed: ${err_ascon256}")
+        fails = fails + 1
+    } else {
+        ascon256.update(ctx_ascon256, "", 0)
+        res_ascon256 = ascon256.final_hex(ctx_ascon256)
+        fails = fails + check("Ascon-Hash256 streaming empty", res_ascon256, "0b3be5850f2f6b98caf29f8fdea89b64a1fa70aa249b8f839bd53baa304d92b2")
+    }
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}

--- a/tests/integration/crypto_bouncy_castle/test_crypto.ae
+++ b/tests/integration/crypto_bouncy_castle/test_crypto.ae
@@ -3,7 +3,6 @@ import std.cryptography.md5
 import std.cryptography.md4
 import std.cryptography.sha1
 import std.cryptography.ascon
-import std.cryptography.ascon256
 import std.bytes
 import std.string
 import std.io
@@ -74,7 +73,20 @@ main() {
         md5.md5_hex("abcdefghijklmnopqrstuvwxyz", 26),
         "c3fcd3d76192e4007dfb496cca67e13b")
 
-    // MD5 Streaming
+    // Remaining RFC 1321 / HAC suite vectors (BC tests a subset; full suite here).
+    fails = fails + check("MD5 message digest",
+        md5.md5_hex("message digest", 14),
+        "f96b697d7cb7938d525a2f31aaf161d0")
+
+    fails = fails + check("MD5 mixcase62",
+        md5.md5_hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62),
+        "d174ab98d277d9f5a5611c2c9f419d9f")
+
+    fails = fails + check("MD5 digits80",
+        md5.md5_hex("12345678901234567890123456789012345678901234567890123456789012345678901234567890", 80),
+        "57edf4a22be3c955ac49da2e2107b67a")
+
+    // MD5 Streaming (two-part, at "abc" boundary)
     ctx_md5, err_md5 = md5.new()
     if err_md5 != "" {
         println("FAIL: md5.new failed: ${err_md5}")
@@ -84,6 +96,19 @@ main() {
         md5.update(ctx_md5, "c", 1)
         res_md5 = md5.final_hex(ctx_md5)
         fails = fails + check("MD5 streaming abc", res_md5, "900150983cd24fb0d6963f7d28e17f72")
+    }
+
+    // MD5 multi-part streaming crossing the 64-byte block boundary: the
+    // 80-digit vector split unevenly must equal the one-shot digest.
+    ctx_md5b, err_md5b = md5.new()
+    if err_md5b != "" {
+        println("FAIL: md5.new failed: ${err_md5b}")
+        fails = fails + 1
+    } else {
+        md5.update(ctx_md5b, "1234567890123456789012345678901234567890", 40)
+        md5.update(ctx_md5b, "1234567890123456789012345678901234567890", 40)
+        res_md5b = md5.final_hex(ctx_md5b)
+        fails = fails + check("MD5 streaming digits80 (cross-block)", res_md5b, "57edf4a22be3c955ac49da2e2107b67a")
     }
 
     // ---- MD4 Tests ----
@@ -104,7 +129,20 @@ main() {
         md4.md4_hex("12345678901234567890123456789012345678901234567890123456789012345678901234567890", 80),
         "e33b4ddc9c38f2199c3e7b164fcc0536")
 
-    // MD4 Streaming
+    // Remaining RFC 1320 suite vectors (BC tests a subset; full suite here).
+    fails = fails + check("MD4 message digest",
+        md4.md4_hex("message digest", 14),
+        "d9130a8164549fe818874806e1c7014b")
+
+    fails = fails + check("MD4 alphabet",
+        md4.md4_hex("abcdefghijklmnopqrstuvwxyz", 26),
+        "d79e1c308aa5bbcdeea8ed63df412da9")
+
+    fails = fails + check("MD4 mixcase62",
+        md4.md4_hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62),
+        "043f8582f241db351ce627e153e7f0e4")
+
+    // MD4 Streaming (two-part, at "abc" boundary)
     ctx_md4, err_md4 = md4.new()
     if err_md4 != "" {
         println("FAIL: md4.new failed: ${err_md4}")
@@ -114,6 +152,18 @@ main() {
         md4.update(ctx_md4, "bc", 2)
         res_md4 = md4.final_hex(ctx_md4)
         fails = fails + check("MD4 streaming abc", res_md4, "a448017aaf21d8525fc10ae87aa6729d")
+    }
+
+    // MD4 multi-part streaming crossing the 64-byte block boundary.
+    ctx_md4b, err_md4b = md4.new()
+    if err_md4b != "" {
+        println("FAIL: md4.new failed: ${err_md4b}")
+        fails = fails + 1
+    } else {
+        md4.update(ctx_md4b, "1234567890123456789012345678901234567890", 40)
+        md4.update(ctx_md4b, "1234567890123456789012345678901234567890", 40)
+        res_md4b = md4.final_hex(ctx_md4b)
+        fails = fails + check("MD4 streaming digits80 (cross-block)", res_md4b, "e33b4ddc9c38f2199c3e7b164fcc0536")
     }
 
     // ---- SHA-1 Tests ----
@@ -134,7 +184,20 @@ main() {
         sha1.sha1_hex("abcdefghijklmnopqrstuvwxyz", 26),
         "32d10c7b8cf96570ca04ce37f2a19d84240d3a89")
 
-    // SHA-1 Streaming
+    // Additional standard vectors (HAC / RFC 3174 companion set).
+    fails = fails + check("SHA-1 message digest",
+        sha1.sha1_hex("message digest", 14),
+        "c12252ceda8be8994d5fa0290a47231c1d16aae3")
+
+    fails = fails + check("SHA-1 mixcase62",
+        sha1.sha1_hex("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62),
+        "761c457bf73b14d27e9e9265c46f4b4dda11f940")
+
+    fails = fails + check("SHA-1 digits80",
+        sha1.sha1_hex("12345678901234567890123456789012345678901234567890123456789012345678901234567890", 80),
+        "50abf5706a150990a08b2c5ea40fa0e585554732")
+
+    // SHA-1 Streaming (two-part, at "abc" boundary)
     ctx_sha1, err_sha1 = sha1.new()
     if err_sha1 != "" {
         println("FAIL: sha1.new failed: ${err_sha1}")
@@ -144,6 +207,18 @@ main() {
         sha1.update(ctx_sha1, "c", 1)
         res_sha1 = sha1.final_hex(ctx_sha1)
         fails = fails + check("SHA-1 streaming abc", res_sha1, "a9993e364706816aba3e25717850c26c9cd0d89d")
+    }
+
+    // SHA-1 multi-part streaming crossing the 64-byte block boundary.
+    ctx_sha1b, err_sha1b = sha1.new()
+    if err_sha1b != "" {
+        println("FAIL: sha1.new failed: ${err_sha1b}")
+        fails = fails + 1
+    } else {
+        sha1.update(ctx_sha1b, "1234567890123456789012345678901234567890", 40)
+        sha1.update(ctx_sha1b, "1234567890123456789012345678901234567890", 40)
+        res_sha1b = sha1.final_hex(ctx_sha1b)
+        fails = fails + check("SHA-1 streaming digits80 (cross-block)", res_sha1b, "50abf5706a150990a08b2c5ea40fa0e585554732")
     }
 
     // ---- Ascon Tests ----
@@ -207,22 +282,9 @@ main() {
         fails = fails + check("Ascon-Hash streaming \\x00\\x01", res_ascon_stream, "f77ca13bf89146d3254f1cfb7eddba8fa1bf162284bb29e7f645545cf9e08424")
     }
 
-    // ---- Ascon-Hash256 Tests ----
-    println("=== Ascon-Hash256 Tests ===")
-    fails = fails + check("Ascon-Hash256 empty",
-        ascon256.ascon256_hex("", 0),
-        "0b3be5850f2f6b98caf29f8fdea89b64a1fa70aa249b8f839bd53baa304d92b2")
-
-    // Ascon-Hash256 Streaming
-    ctx_ascon256, err_ascon256 = ascon256.new()
-    if err_ascon256 != "" {
-        println("FAIL: ascon256.new failed: ${err_ascon256}")
-        fails = fails + 1
-    } else {
-        ascon256.update(ctx_ascon256, "", 0)
-        res_ascon256 = ascon256.final_hex(ctx_ascon256)
-        fails = fails + check("Ascon-Hash256 streaming empty", res_ascon256, "0b3be5850f2f6b98caf29f8fdea89b64a1fa70aa249b8f839bd53baa304d92b2")
-    }
+    // Ascon-Hash256 (NIST SP 800-232) has its own dedicated test:
+    // tests/integration/crypto_ascon256/test_crypto_ascon256.ae — it is a
+    // distinct standard from the deprecated v1.2 Ascon-Hash/HashA above.
 
     if fails == 0 {
         println("ALL PASS")


### PR DESCRIPTION
## Summary

Five pure-Aether hash submodules ported from Bouncy Castle, with test coverage brought up to full standard-vector parity. No externs to OpenSSL or any C crypto — permutations, IVs, endianness, and padding are ported faithfully from BC's reference implementations.

| Module | BC source | Standard |
|---|---|---|
| `std.cryptography.md5` | `MD5Digest` | RFC 1321 / HAC |
| `std.cryptography.md4` | `MD4Digest` | RFC 1320 |
| `std.cryptography.sha1` | `Sha1Digest` | RFC 3174 / HAC |
| `std.cryptography.ascon` | `AsconDigest` | ASCON v1.2 (Ascon-Hash, Ascon-HashA) |
| `std.cryptography.ascon256` | `AsconHash256` | NIST SP 800-232 |

The module implementations were authored on the fork (commit `bc99005e`); this PR adds them together with a strengthened test suite (commit `f012542c`).

## Correctness review

Each port was checked against Bouncy Castle ground truth extracted from `bc-csharp`:

- **MD5/MD4/SHA-1** — every digest matches BC's `DigestTest` vectors verbatim; multi-part streaming across the 64-byte block boundary equals the one-shot digest.
- **ASCON v1.2** — IVs, big-endian absorption, round counts (p12 for Hash, p8 for HashA, final pad always p12), and the `0x80` pad byte all match `AsconDigest`; the three `LWC_HASH_KAT_256` KAT vectors for both Ascon-Hash and Ascon-HashA match.
- **Ascon-Hash256** — a genuinely different standard from v1.2: little-endian absorption and a single `0x01` pad bit. The port correctly uses `get_le64`/`set_le64` and the SP 800-232 IVs (`S0=0x9b1e5494e934d681` …), distinct from the v1.2 module's big-endian path. Split into its own test (`tests/integration/crypto_ascon256/`) to keep the two standards from being conflated.

## Test parity work

BC's own `DigestTest` runs only a subset of each RFC's vectors. This PR extends coverage to the full standard suites:

- md5/md4/sha1 gain the `"message digest"`, mixed-case 62-char, and 80-digit vectors (verified against published reference digests).
- Each algorithm gains a cross-block multi-part streaming test.
- ascon256 gains `0x00`, `0x00 0x01`, and a rate-crossing ASCII message with a one-shot-vs-split equality check.

Combined test: 34 passing vectors. Dedicated ascon256 test: 5.

## Provenance note

BC's Ascon-Hash256 KAT resource (`crypto/ascon/asconhash256/LWC_HASH_KAT_256.txt`) is **absent from the upstream bc-csharp checkout**, so its digests can't be cross-checked against BC directly. The empty-message vector is pinned to the published NIST SP 800-232 reference value; the other ascon256 vectors are pinned to the port's deterministic output and guarded by the one-shot-vs-split equality check (which would expose any absorption/padding drift regardless of the KAT). This is documented in the test header.

## Verification

- All three crypto tests pass (`crypto_bouncy_castle`, `crypto_ascon256`, and the pre-existing `crypto_md2`).
- Sibling crypto suites (`crypto_classic_hashes`, `crypto_sha3`, `crypto_blake2`) unaffected.
- ASan build of the ascon256 test runs clean; alloc/free discipline matches the already-shipped MD2 module that passes the leak gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
