### PR TITLE
feat(os): cross-platform non-blocking spawn/wait/wait_any (native parallel scheduler primitive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`os.spawn_proc` / `os.wait` / `os.wait_any` — cross-platform non-blocking
+  spawn + reap, including Windows.** The fan-out/fan-in pair a native parallel
+  build scheduler needs (spawn up to N ready nodes, wait for whichever finishes
+  first, reap it, unblock dependents). Unlike `os.run_pipe` these create no IPC
+  back-channel pipe and set no `AETHER_IPC_FD` — which is exactly why they work
+  on Windows, where the pipe was the only part that needed the
+  `_open_osfhandle`/std-handle-inheritance work that kept `run_pipe` POSIX-only.
+  On Windows, `win_launch` is split into a non-blocking `win_spawn`
+  (`CreateProcessW`, reusing the existing argv escaping) plus the reap half, with
+  spawned handles held in an int-token→HANDLE table (tokens never recycled, so
+  Windows PID reuse can't misattribute a reap); `wait_any` uses
+  `WaitForMultipleObjects` for a true wait-any. The spawn half of
+  `os.run_pipe`/`os.wait_pid` is now wired on Windows too (pipe fd is `-1`
+  there); `run_pipe_drain_and_wait` stays POSIX-only. `spawn` is the wrapper name
+  everywhere except the reserved actor keyword forced `os.spawn_proc`. Verified
+  on Win11/MSYS2: 4×sleep-2 finishing in ~2s (concurrent), completion-order reap,
+  exit-code fidelity with spawn-failure distinguishable, `C:\…\a b\c.txt` argv
+  round-trip, flat handle count across 300 spawns, and clean coexistence with a
+  `run_supervised` Job Object.
+
 ## [0.441.0]
 
 ### Added

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -56,6 +56,21 @@ _tuple_int_string os_wait_pid_raw(int pid) {
     _tuple_int_string out = { -1, "os.wait_pid unavailable" };
     return out;
 }
+_tuple_int_string os_spawn_raw(const char* p, void* a, void* e) {
+    (void)p; (void)a; (void)e;
+    _tuple_int_string out = { -1, "os.spawn unavailable" };
+    return out;
+}
+_tuple_int_string os_wait_raw(int token) {
+    (void)token;
+    _tuple_int_string out = { -1, "os.wait unavailable" };
+    return out;
+}
+_tuple_int_int_string os_wait_any_raw(void* token_list) {
+    (void)token_list;
+    _tuple_int_int_string out = { -1, -1, "os.wait_any unavailable" };
+    return out;
+}
 int os_kill_raw(int pid, int sig) { (void)pid; (void)sig; return -1; }
 _tuple_int_int_string os_wait_pid_timeout_raw(int pid, int secs) {
     (void)pid; (void)secs;
@@ -1323,6 +1338,102 @@ _tuple_int_string os_wait_pid_raw(int pid) {
     return out;
 }
 
+/* ============================================================
+ * Non-blocking spawn + reap, WITHOUT the IPC back-channel pipe.
+ *
+ * These are the fan-out/fan-in pair a parallel build scheduler needs:
+ * start up to N ready children, wait for ANY to finish, reap it, start
+ * more. Unlike os_run_pipe_raw they create no pipe and set no
+ * AETHER_IPC_FD — which is exactly why they are cross-platform (the pipe
+ * is the part that needs coordinated _open_osfhandle on Windows). The
+ * "token" returned by spawn is the reap handle: on POSIX it is the real
+ * pid; on Windows it is an index into a process-handle table.
+ *
+ *   os_spawn_raw()     -> (token, err)       async spawn, no pipe
+ *   os_wait_raw()      -> (exit, err)        reap one token
+ *   os_wait_any_raw()  -> (token, exit, err) reap whichever finishes first
+ *
+ * Each spawned token MUST be reaped exactly once (via wait or wait_any)
+ * or it leaks a zombie (POSIX) / handle (Windows). ============ */
+
+/* Map a waitpid status to (exit, err), shared by wait and wait_any. */
+static _tuple_int_string posix_status_to_tuple(int st) {
+    _tuple_int_string out = { -1, "" };
+    if (WIFEXITED(st)) {
+        out._0 = WEXITSTATUS(st);
+    } else {
+        out._0 = -1;
+        out._1 = "child terminated abnormally";
+    }
+    return out;
+}
+
+_tuple_int_string os_spawn_raw(const char* prog, void* argv_list, void* env_list) {
+    _tuple_int_string out = { -1, "" };
+    if (!prog) { out._1 = "null prog"; return out; }
+    if (!aether_sandbox_check("exec", prog)) { out._1 = "denied by sandbox"; return out; }
+
+    char** av = build_argv_array(prog, argv_list);
+    if (!av) { out._1 = "argv build failed"; return out; }
+    char** envp = build_envp_array(env_list);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        free(av); free(envp);
+        out._1 = "fork failed";
+        return out;
+    }
+    if (pid == 0) {
+        /* Child — no pipe, no fd 3, no AETHER_IPC_FD. Plain exec. */
+        if (envp) {
+            execve(prog, av, envp);
+            /* execve doesn't PATH-resolve; fall back to execvp so a bare
+             * program name still works when an explicit env was supplied. */
+            execvp(prog, av);
+        } else {
+            execvp(prog, av);
+        }
+        _exit(127);
+    }
+    free(av);
+    free(envp);
+    out._0 = (int)pid;   /* token == pid on POSIX */
+    return out;
+}
+
+_tuple_int_string os_wait_raw(int token) {
+    /* On POSIX the token IS the pid, so reap semantics match wait_pid. */
+    _tuple_int_string out = { -1, "" };
+    if (token <= 0) { out._1 = "invalid token"; return out; }
+    int st = 0;
+    if (waitpid((pid_t)token, &st, 0) < 0) { out._1 = "waitpid failed"; return out; }
+    return posix_status_to_tuple(st);
+}
+
+_tuple_int_int_string os_wait_any_raw(void* token_list) {
+    _tuple_int_int_string out = { -1, -1, "" };
+    int n = token_list ? list_size(token_list) : 0;
+    if (n <= 0) { out._2 = "no tokens"; return out; }
+
+    /* On POSIX the token IS the pid, and waitpid(-1) already reports which
+     * child finished — so the returned pid is itself the finished token. We
+     * don't unbox the list here (int-list element boxing is codegen-private
+     * and not part of this file's ABI); the Windows backend, which cannot
+     * wait on "any child" generically, is the one that consumes the list to
+     * build its HANDLE array. A scheduler that spawns only via os_spawn_raw
+     * has no foreign children, so the reaped pid is always one of its
+     * tokens. */
+    int st = 0;
+    pid_t got = waitpid(-1, &st, 0);
+    if (got < 0) { out._2 = "waitpid failed"; return out; }
+
+    _tuple_int_string s = posix_status_to_tuple(st);
+    out._0 = (int)got;      /* which token finished */
+    out._1 = s._0;          /* its exit code */
+    out._2 = s._1;          /* err (abnormal-termination note, if any) */
+    return out;
+}
+
 /* Convenience: spawn + drain pipe + wait. Reads the back-channel
  * to EOF (driven by the child closing fd 3 or exiting) while the
  * child runs, then waits for the child to exit. Returns the
@@ -2165,6 +2276,105 @@ static int win_launch(const char* prog, void* argv_list, void* env_list,
     return 0;
 }
 
+/* ============================================================
+ * Non-blocking spawn + reap on Windows (no IPC pipe).
+ *
+ * win_spawn is win_launch's front half: build the command line (reusing
+ * append_escaped_arg's CreateProcessW quoting), CreateProcessW, return the
+ * live process HANDLE without waiting. The wait/exit-code/close half lives
+ * in os_wait_raw / os_wait_any_raw.
+ *
+ * The Aether "token" ABI is int, but a HANDLE is a pointer — and a raw
+ * dwProcessId can be recycled after exit, so reaping by PID could race onto
+ * a different process. We therefore hand out a small monotonically-growing
+ * int token and keep the live HANDLE in a table keyed by that token. The
+ * token is never recycled within a run, so a stale token cleanly misses. */
+
+typedef struct { int token; HANDLE h; } WinProc;
+static WinProc  g_winprocs[4096];
+static int      g_winproc_count = 0;
+static int      g_winproc_next_token = 1;
+static CRITICAL_SECTION g_winproc_cs;
+static int      g_winproc_cs_init = 0;
+
+static void winproc_lock(void) {
+    /* One-time CS init. Spawns are effectively single-threaded from a build
+     * scheduler, but guard anyway so a threaded caller can't corrupt the
+     * table. The init race is itself benign for the single-threaded case. */
+    if (!g_winproc_cs_init) { InitializeCriticalSection(&g_winproc_cs); g_winproc_cs_init = 1; }
+    EnterCriticalSection(&g_winproc_cs);
+}
+static void winproc_unlock(void) { LeaveCriticalSection(&g_winproc_cs); }
+
+/* Register a live handle, return its token (or -1 if the table is full). */
+static int winproc_register(HANDLE h) {
+    winproc_lock();
+    if (g_winproc_count >= (int)(sizeof(g_winprocs)/sizeof(g_winprocs[0]))) {
+        winproc_unlock();
+        return -1;
+    }
+    int tok = g_winproc_next_token++;
+    g_winprocs[g_winproc_count].token = tok;
+    g_winprocs[g_winproc_count].h = h;
+    g_winproc_count++;
+    winproc_unlock();
+    return tok;
+}
+
+/* Look up a token's handle without removing it. Returns NULL if absent. */
+static HANDLE winproc_find(int token) {
+    HANDLE h = NULL;
+    winproc_lock();
+    for (int i = 0; i < g_winproc_count; i++) {
+        if (g_winprocs[i].token == token) { h = g_winprocs[i].h; break; }
+    }
+    winproc_unlock();
+    return h;
+}
+
+/* Remove a token's slot (after it has been reaped + CloseHandle'd). */
+static void winproc_remove(int token) {
+    winproc_lock();
+    for (int i = 0; i < g_winproc_count; i++) {
+        if (g_winprocs[i].token == token) {
+            g_winprocs[i] = g_winprocs[g_winproc_count - 1];
+            g_winproc_count--;
+            break;
+        }
+    }
+    winproc_unlock();
+}
+
+/* Front half of win_launch: spawn without waiting. Returns the process
+ * HANDLE, or NULL on failure. hThread is closed here (never needed by the
+ * caller); hProcess is the caller's to wait on and close. */
+static HANDLE win_spawn(const char* prog, void* argv_list, void* env_list) {
+    wchar_t* cmdline = build_command_line(prog, argv_list);
+    if (!cmdline) return NULL;
+    wchar_t* wenv = build_environ_block(env_list);
+
+    STARTUPINFOW si;
+    memset(&si, 0, sizeof(si));
+    si.cb = sizeof(si);
+
+    PROCESS_INFORMATION pi;
+    memset(&pi, 0, sizeof(pi));
+
+    /* Same CreateProcessW contract as win_launch: lpApplicationName=NULL so
+     * cmdline[0] is PATH-resolved (issue #706); no handle inheritance (no
+     * pipe), inherit parent env when wenv is NULL. */
+    BOOL ok = CreateProcessW(
+        NULL, cmdline, NULL, NULL, FALSE,
+        CREATE_UNICODE_ENVIRONMENT, wenv, NULL, &si, &pi);
+
+    free(cmdline);
+    free(wenv);
+
+    if (!ok) return NULL;
+    CloseHandle(pi.hThread);   /* thread handle never used */
+    return pi.hProcess;
+}
+
 /* Working-directory accessors — Windows. UTF-8 path in / UTF-8 path out,
  * converted through the wide-char helpers so non-ASCII paths survive. */
 int os_chdir_raw(const char* path) {
@@ -2259,19 +2469,103 @@ _tuple_string_int_string os_run_capture_status_raw(const char* prog, void* argv_
 typedef struct { int _0; int _1; const char* _2; } _tuple_int_int_string;
 typedef struct { int _0; const char* _1; } _tuple_int_string;
 
+/* Reap one token: wait on its handle, read exit code, close, free slot.
+ * Shared by os_wait_raw and (per-handle) os_wait_any_raw. */
+static _tuple_int_string winproc_reap(int token, HANDLE h) {
+    _tuple_int_string out = { -1, "" };
+    WaitForSingleObject(h, INFINITE);
+    DWORD code = 0;
+    GetExitCodeProcess(h, &code);
+    CloseHandle(h);
+    winproc_remove(token);
+    out._0 = (int)code;
+    return out;
+}
+
+/* Non-blocking spawn (no pipe). Returns (token, err). */
+_tuple_int_string os_spawn_raw(const char* prog, void* argv_list, void* env_list) {
+    _tuple_int_string out = { -1, "" };
+    if (!prog) { out._1 = "null prog"; return out; }
+    if (!aether_sandbox_check("exec", prog)) { out._1 = "denied by sandbox"; return out; }
+    HANDLE h = win_spawn(prog, argv_list, env_list);
+    if (!h) { out._1 = "spawn failed"; return out; }
+    int tok = winproc_register(h);
+    if (tok < 0) {
+        /* Table full — don't leak the process: wait+close it and error. */
+        WaitForSingleObject(h, INFINITE);
+        CloseHandle(h);
+        out._1 = "process table full";
+        return out;
+    }
+    out._0 = tok;
+    return out;
+}
+
+/* Reap a single token. Returns (exit, err). */
+_tuple_int_string os_wait_raw(int token) {
+    _tuple_int_string out = { -1, "" };
+    if (token <= 0) { out._1 = "invalid token"; return out; }
+    HANDLE h = winproc_find(token);
+    if (!h) { out._1 = "unknown token"; return out; }
+    return winproc_reap(token, h);
+}
+
+/* Reap whichever token finishes first. Returns (token, exit, err).
+ * WaitForMultipleObjects gives a true wait-any over the live handles. */
+_tuple_int_int_string os_wait_any_raw(void* token_list) {
+    _tuple_int_int_string out = { -1, -1, "" };
+    int n = token_list ? list_size(token_list) : 0;
+    if (n <= 0) { out._2 = "no tokens"; return out; }
+    if (n > MAXIMUM_WAIT_OBJECTS) { out._2 = "too many tokens for one wait_any"; return out; }
+
+    /* Snapshot (token, handle) pairs for the live tokens the caller named.
+     * Tokens are small ints stored INLINE as the list's pointer slot (the
+     * caller boxes them with mem.long_to_ptr(token)); read them back as the
+     * integer value of the pointer, NOT as a pointer-to-int. Only tokens
+     * still in the table (not yet reaped) contribute a handle. */
+    HANDLE handles[MAXIMUM_WAIT_OBJECTS];
+    int    toks[MAXIMUM_WAIT_OBJECTS];
+    int    m = 0;
+    for (int i = 0; i < n; i++) {
+        void* item = list_get_raw(token_list, i);
+        int tok = (int)(intptr_t)item;
+        HANDLE h = winproc_find(tok);
+        if (h) { handles[m] = h; toks[m] = tok; m++; }
+    }
+    if (m == 0) { out._2 = "no live tokens"; return out; }
+
+    DWORD r = WaitForMultipleObjects((DWORD)m, handles, FALSE, INFINITE);
+    if (r >= WAIT_OBJECT_0 && r < WAIT_OBJECT_0 + (DWORD)m) {
+        int idx = (int)(r - WAIT_OBJECT_0);
+        _tuple_int_string s = winproc_reap(toks[idx], handles[idx]);
+        out._0 = toks[idx];
+        out._1 = s._0;
+        out._2 = s._1;
+        return out;
+    }
+    out._2 = "wait_any failed";
+    return out;
+}
+
+/* run_pipe on Windows: the SPAWN works (no back-channel pipe — that half
+ * needs coordinated _open_osfhandle and stays POSIX-only). Returns a -1
+ * pipe fd, the token, and ""; reap the token via os_wait_pid_raw. */
 _tuple_int_int_string os_run_pipe_raw(const char* prog, void* argv_list, void* env_list) {
-    (void)prog; (void)argv_list; (void)env_list;
-    _tuple_int_int_string out = { -1, -1, "unsupported on Windows" };
+    _tuple_int_int_string out = { -1, -1, "" };
+    _tuple_int_string sp = os_spawn_raw(prog, argv_list, env_list);
+    if (sp._1[0]) { out._2 = sp._1; return out; }   /* err */
+    out._0 = -1;        /* no back-channel pipe on Windows */
+    out._1 = sp._0;     /* token doubles as the wait_pid handle */
     return out;
 }
 
 _tuple_int_string os_wait_pid_raw(int pid) {
-    (void)pid;
-    _tuple_int_string out = { -1, "unsupported on Windows" };
-    return out;
+    /* pid here is the token minted by os_run_pipe_raw / os_spawn_raw. */
+    return os_wait_raw(pid);
 }
 
 _tuple_string_int_string os_run_pipe_drain_and_wait_raw(const char* prog, void* argv_list, void* env_list) {
+    /* The back-channel pipe is the POSIX-only part; no Windows equivalent. */
     (void)prog; (void)argv_list; (void)env_list;
     _tuple_string_int_string out = { aether_os_empty_heap(), -1, "unsupported on Windows" };
     return out;

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -2535,7 +2535,10 @@ _tuple_int_int_string os_wait_any_raw(void* token_list) {
     if (m == 0) { out._2 = "no live tokens"; return out; }
 
     DWORD r = WaitForMultipleObjects((DWORD)m, handles, FALSE, INFINITE);
-    if (r >= WAIT_OBJECT_0 && r < WAIT_OBJECT_0 + (DWORD)m) {
+    /* WAIT_OBJECT_0 is 0, so the lower bound (r >= WAIT_OBJECT_0) is always
+     * true for the unsigned DWORD and -Wtype-limits flags it; only the upper
+     * bound distinguishes a signaled index from WAIT_TIMEOUT/WAIT_FAILED. */
+    if (r < WAIT_OBJECT_0 + (DWORD)m) {
         int idx = (int)(r - WAIT_OBJECT_0);
         _tuple_int_string s = winproc_reap(toks[idx], handles[idx]);
         out._0 = toks[idx];

--- a/std/os/module.ae
+++ b/std/os/module.ae
@@ -4,6 +4,7 @@
 exports (
     os_system, os_exec_raw, os_run, os_run_capture_raw, os_run_capture_status_raw,
     os_run_pipe_raw, os_wait_pid_raw, os_run_pipe_drain_and_wait_raw,
+    os_spawn_raw, os_wait_raw, os_wait_any_raw,
     os_getenv, os_which,
     aether_args_count, aether_args_get, aether_argv0, aether_argv_raw,
     aether_args_seal, aether_args_sealed, args_seal, args_sealed,
@@ -23,6 +24,7 @@ exports (
     platform,
     setenv, unsetenv,
     run_pipe, wait_pid, run_pipe_drain_and_wait,
+    spawn_proc, wait, wait_any,
     os_kill_raw, os_wait_pid_timeout_raw, os_run_supervised_raw,
     kill, wait_pid_timeout, run_supervised,
     os_run_full_raw, run_full,
@@ -85,16 +87,18 @@ extern os_run_capture_status_raw(prog: string, argv: ptr, env: ptr) -> (string @
 // (e.g. Aeocha test summaries), this is fine; for larger or
 // streaming payloads, prefer run_pipe_drain_and_wait.
 //
-// On Windows, returns (-1, -1, "unsupported on Windows") — fall
-// back to the file-marker pattern there.
+// On Windows the SPAWN works but there is no back-channel pipe:
+// position 0 (the read fd) is always -1 there, and position 1 is a
+// reap token (not an OS pid). For a pipe-less fan-out scheduler prefer
+// the cross-platform spawn / wait / wait_any trio below.
 extern os_run_pipe_raw(prog: string, argv: ptr, env: ptr) -> (int, int, string)
 
 // Wait for a child to exit and reap it. Companion to
 // os_run_pipe_raw. Returns (exit_code, err). Calling this
 // once per spawn is required to avoid zombies; the
 // run_pipe_drain_and_wait convenience does it internally for
-// callers who don't need the read-fd loop. On Windows, returns
-// (-1, "unsupported on Windows").
+// callers who don't need the read-fd loop. Cross-platform (on
+// Windows it reaps the token os_run_pipe_raw returned).
 extern os_wait_pid_raw(pid: int) -> (int, string)
 
 // Convenience: spawn child with back-channel pipe, drain pipe to
@@ -121,6 +125,38 @@ extern os_wait_pid_raw(pid: int) -> (int, string)
 // payload anywhere in stdlib, tests/, examples/, tools/, or
 // contrib/. See #420 follow-up.
 extern os_run_pipe_drain_and_wait_raw(prog: string, argv: ptr, env: ptr) -> (string @heap, int, string)
+
+// --- Non-blocking spawn + reap (no IPC back-channel) -----------------
+//
+// The fan-out/fan-in pair a parallel scheduler needs: start up to N
+// ready children, wait for whichever finishes first, reap it, start
+// more. Unlike run_pipe these create NO pipe and set NO AETHER_IPC_FD,
+// which is exactly why they work on Windows too. The value returned by
+// spawn is an opaque reap TOKEN (the real pid on POSIX; a handle-table
+// index on Windows) — treat it as an identity to pass to wait/wait_any,
+// not as an OS pid. Each token MUST be reaped exactly once (via wait or
+// wait_any) or it leaks a zombie (POSIX) / process handle (Windows).
+//
+// Need a structured report back from the child? That's the pipe's job —
+// use run_pipe (POSIX-only) instead. These carry no back-channel.
+
+// Spawn a child without blocking. Returns (token, err). err is "" on a
+// successful spawn regardless of the child's eventual exit code.
+extern os_spawn_raw(prog: string, argv: ptr, env: ptr) -> (int, string)
+
+// Reap one token. Blocks until that child exits. Returns (exit_code,
+// err). err is non-empty only for a bad/unknown token or abnormal
+// termination — a non-zero exit_code with err == "" is a normal failed
+// child, distinct from a spawn/reap failure (exit_code -1, err set).
+extern os_wait_raw(token: int) -> (int, string)
+
+// Reap whichever of the given tokens finishes first. `tokens` is a
+// std.list whose elements are the int tokens from spawn, each boxed
+// INLINE via mem.long_to_ptr(token) (small ints stored as the pointer
+// slot itself, not heap-allocated boxes). Returns (token, exit_code,
+// err): which token completed, its exit code, and an error string. Only
+// tokens still live (not already reaped) are waited on. Scheduler fan-in.
+extern os_wait_any_raw(tokens: ptr) -> (int, int, string)
 
 // Get environment variable, returns string or NULL if not set
 extern os_getenv(name: string) -> string
@@ -274,6 +310,27 @@ wait_pid(pid: int) -> {
 // "unsupported on Windows").
 run_pipe_drain_and_wait(prog: string, argv: ptr, env: ptr) -> {
     return os_run_pipe_drain_and_wait_raw(prog, argv, env)
+}
+
+// Spawn a child without blocking, no back-channel pipe. Returns
+// (token, err). Cross-platform. Reap the token exactly once via
+// os.wait or os.wait_any. Named spawn_proc because `spawn` is a
+// reserved keyword (actor spawning). See os_spawn_raw.
+spawn_proc(prog: string, argv: ptr, env: ptr) -> {
+    return os_spawn_raw(prog, argv, env)
+}
+
+// Reap a single spawned token. Blocks until it exits. Returns
+// (exit_code, err). See os_wait_raw.
+wait(token: int) -> {
+    return os_wait_raw(token)
+}
+
+// Reap whichever spawned token finishes first. `tokens` is a list of
+// int tokens. Returns (token, exit_code, err). The fan-in half of a
+// spawn-N-wait-any scheduler loop. See os_wait_any_raw.
+wait_any(tokens: ptr) -> {
+    return os_wait_any_raw(tokens)
 }
 
 // --- Process-supervision primitives -----------------------------------

--- a/tests/integration/os_spawn/test_os_spawn.ae
+++ b/tests/integration/os_spawn/test_os_spawn.ae
@@ -1,0 +1,75 @@
+// Validate the cross-platform non-blocking spawn / wait / wait_any trio
+// (std.os). The key property is CONCURRENCY: multiple children in flight
+// at once, reaped in completion order, with exit codes correctly
+// attributed and spawn failures distinguishable from failed children.
+import std.os
+import std.list
+import std.mem
+import std.io
+
+check(label: string, ok: bool) -> int {
+    if ok {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    return 1
+}
+
+main() {
+    fails = 0
+
+    // ---- spawn + single wait, exit code fidelity ----
+    // `false` exits non-zero; `true` exits zero.
+    at, ae = os.spawn_proc("true", null, null)
+    fails = fails + check("spawn true succeeds", ae == "")
+    ac, aerr = os.wait(at)
+    fails = fails + check("true exits 0", ac == 0 && aerr == "")
+
+    bt, be = os.spawn_proc("false", null, null)
+    fails = fails + check("spawn false succeeds", be == "")
+    bc, berr = os.wait(bt)
+    // A failed child is a non-zero exit with NO error string — distinct
+    // from a spawn/reap failure (which sets err and returns -1).
+    fails = fails + check("false exits non-zero, err empty", bc != 0 && berr == "")
+
+    // ---- spawn failure is distinguishable ----
+    ft, ferr = os.spawn_proc("this_program_does_not_exist_xyz", null, null)
+    // The spawn itself may succeed (fork ok) with the child exec-failing to
+    // 127 on POSIX, OR fail outright on Windows. Either way it must be
+    // distinguishable from a clean exit: reap and confirm non-zero.
+    if ferr == "" {
+        fc, _ = os.wait(ft)
+        fails = fails + check("missing program does not report exit 0", fc != 0)
+    } else {
+        fails = fails + check("missing program reports spawn err", ft == -1)
+    }
+
+    // ---- wait_any returns children in COMPLETION order, not spawn order ----
+    argv_slow = list.new()
+    _ = list.add(argv_slow, "2")
+    argv_fast = list.new()
+    _ = list.add(argv_fast, "1")
+
+    slow, _ = os.spawn_proc("sleep", argv_slow, null)   // spawned first, finishes last
+    fast, _ = os.spawn_proc("sleep", argv_fast, null)   // spawned second, finishes first
+
+    toks = list.new()
+    _ = list.add(toks, mem.long_to_ptr(slow as long))
+    _ = list.add(toks, mem.long_to_ptr(fast as long))
+
+    first_tok, first_code, first_err = os.wait_any(toks)
+    fails = fails + check("wait_any returns the faster child first", first_tok == fast)
+    fails = fails + check("first child exit 0", first_code == 0 && first_err == "")
+
+    second_tok, second_code, _ = os.wait_any(toks)
+    fails = fails + check("wait_any then returns the slower child", second_tok == slow)
+    fails = fails + check("second child exit 0", second_code == 0)
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}


### PR DESCRIPTION
## Summary

Implements `asks/os-run-pipe-on-windows-for-parallel-build-scheduling.md`: a **cross-platform non-blocking spawn + reap** trio so aeb can run a native parallel build scheduler instead of emitting Makefiles and shelling out to `make -jN`. Today there's no way to have two children in flight at once on Windows; this adds it.

New `std.os` surface:

| fn | returns | role |
|---|---|---|
| `os.spawn_proc(prog, argv, env)` | `(token, err)` | non-blocking spawn, no pipe |
| `os.wait(token)` | `(exit, err)` | reap one |
| `os.wait_any(tokens)` | `(token, exit, err)` | reap whichever finishes first — the scheduler's fan-in |

These carry **no IPC back-channel** — which is exactly why they work on Windows. The pipe was the only part of `os.run_pipe` that needed the `_open_osfhandle`/std-handle-inheritance work that kept it POSIX-only; the process-spawning half is separable, and this splits it out.

## Approach (the ask's preferred option 1, plus option 2)

- **Windows**: `win_launch` (`std/os/aether_os.c`) is refactored into a non-blocking `win_spawn` — `CreateProcessW` reusing the existing `append_escaped_arg` argv escaping (the "classic footgun" the ask flags) — plus the wait/reap half. A `HANDLE` is a pointer but the token ABI is `int`, and a raw `dwProcessId` can be recycled after exit, so spawned handles live in a small **int-token→HANDLE table** (tokens never recycled within a run). `wait` → `WaitForSingleObject`; `wait_any` → `WaitForMultipleObjects` (true wait-any).
- **run_pipe/wait_pid spawn half wired on Windows too** (option 2): `run_pipe` returns a `-1` pipe fd + a reap token; `run_pipe_drain_and_wait` stays POSIX-only.
- **POSIX**: `spawn` is fork/execvp with no pipe and no fd 3; `wait` mirrors `wait_pid`; `wait_any` is `waitpid(-1)` (the reaped pid is itself the token). The waitpid→tuple mapping is factored into a shared helper, so existing `wait_pid`/`run_supervised` semantics are unchanged.
- `spawn` is a reserved keyword (actor spawning), so the wrapper is **`os.spawn_proc`**. `wait_any` token lists box each int inline via `mem.long_to_ptr`.

## Verification

**Linux** (`tests/integration/os_spawn/test_os_spawn.ae`, in CI): exit-code fidelity, spawn-failure distinguishable from a failed child, `wait_any` completion-order. sleep 3/1/2 spawned together finish in ~3s wall (not 6s); 208-spawn loop leak-clean under valgrind.

**winbaz (Win11 / MSYS2 / MinGW)** — the ask requires an actual run, not a compile. Every checklist item, verified:

| checklist item | result |
|---|---|
| overlap (4× sleep-2 ≈ 2s not 8s) | **2s wall — concurrent** ✓ |
| reap in completion order not spawn order | tokens `2 3 1` = completion order ✓ |
| exit codes survive | `cmd /c exit 7` → **7** ✓ |
| spawn failure distinguishable | missing prog → **token=-1, err='spawn failed'** ✓ |
| argv spaces + backslashes | `C:\Users\paul\a b\c.txt` round-trips ✓ |
| no handle leak over many spawns | **handle count flat at 72** across 300 spawns ✓ |
| Job Object interaction | spawn child **survives** a `run_supervised` job teardown, reaped cleanly ✓ |

`-Werror` clean on MinGW (one `-Wtype-limits` on the always-true unsigned `WAIT_OBJECT_0` lower bound was fixed).

## Notes

- The winbaz acceptance programs are timing/`cmd`-dependent, so they're **not** added to CI (they'd flake); the deterministic `test_os_spawn.ae` runs cross-platform in CI, and the Windows-specific evidence is the table above.
- Out of scope per the ask: no async/await or thread pool; no IPC back-channel on Windows (`run_pipe`'s pipe stays POSIX-only). This deletes aeb's `make` dependency and its second scheduler; it doesn't restore lost function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
