### PR TITLE
fix(cross): working HMAC on cross builds (fail-open fix) + real Tier-2 paths with sysroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Cross-built binaries now compute a working `std.cryptography` HMAC (was a
+  silent stub → fail-open).** The string-API `cryptography.hmac_sha256_hex` /
+  `_bytes` were OpenSSL-backed, and on the zig cross path OpenSSL is never
+  compiled in, so they stubbed to an empty digest — which made a wrong (and an
+  empty) auth token compare equal to a correct one on cross-built agents.
+  These now delegate to the **pure-Aether** `std.cryptography.hmac`
+  implementation, which needs no libcrypto and produces a byte-identical
+  digest, so HMAC works on every target with no sysroot required. Verified on
+  a real aarch64 (Raspberry Pi 5) cross build: correct RFC-vector output,
+  no OpenSSL linked.
+- **`CROSSBUILD_SYSROOT` now enables the *real* OpenSSL/zlib/nghttp2/PCRE2 code
+  paths on cross builds, not just links them.** The Tier-2 probe appended
+  `-lssl -lcrypto` etc. when a sysroot staged the libs, but never defined the
+  matching `-DAETHER_HAS_*` macros or added the sysroot's include dir — so the
+  sources still compiled their "unavailable" stub and the `-l` referenced
+  nothing. The probe now also adds `-DAETHER_HAS_OPENSSL/_ZLIB/_NGHTTP2/_PCRE2`
+  (per lib actually staged) and `-I<sysroot>/include`, so e.g. `sha256_hex`
+  returns a real digest on a cross target with a sysroot. Verified on aarch64.
+- **The cross "built without OpenSSL" note is now precise.** It distinguishes
+  the sysroot-present case (features that the sysroot stages link for real)
+  from the no-sysroot case, and no longer implies HMAC is unavailable (it
+  isn't — HMAC is pure-Aether).
+
 ## [0.442.0]
 
 ### Added

--- a/std/cryptography/module.ae
+++ b/std/cryptography/module.ae
@@ -18,6 +18,7 @@
 import std.string
 import std.bytes
 import std.encoding
+import std.cryptography.hmac
 
 exports (
     cryptography_sha1_hex_raw, cryptography_sha256_hex_raw,
@@ -165,10 +166,31 @@ md5_hex(data: string, length: int) -> {
 // key derivation (each round's output keys the next), use the raw
 // bytes form `hmac_sha256_bytes` so intermediate steps don't
 // round-trip through hex.
+// Copy a length-prefixed string payload (binary-safe, embedded NULs OK)
+// into a fresh AetherBytes buffer for the pure-Aether HMAC.
+hmac_str_to_bytes(s: string, n: int) -> ptr {
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        bytes.set(b, i, string_char_at_n(s, n, i))
+        i = i + 1
+    }
+    return b
+}
+
 hmac_sha256_hex(key: string, key_len: int, msg: string, msg_len: int) -> {
-    out = cryptography_hmac_sha256_hex_raw(key, key_len, msg, msg_len)
-    if out == 0 {
-        return "", "openssl unavailable"
+    // Delegate to the PURE-AETHER HMAC (std.cryptography.hmac): it needs no
+    // libcrypto and produces a byte-identical digest, so HMAC works on every
+    // target — including cross builds without an OpenSSL sysroot. This closes
+    // the fail-open where the openssl-backed path stubbed to "" on cross,
+    // making a wrong/empty MAC compare equal in auth checks.
+    kb = hmac_str_to_bytes(key, key_len)
+    mb = hmac_str_to_bytes(msg, msg_len)
+    out = hmac.hmac_sha256_hex(kb, key_len, mb, msg_len)
+    bytes.free(kb)
+    bytes.free(mb)
+    if out == "" {
+        return "", "hmac failed"
     }
     return out, ""
 }
@@ -179,14 +201,21 @@ hmac_sha256_hex(key: string, key_len: int, msg: string, msg_len: int) -> {
 // derivation (SigV4, HKDF-shaped flows) where each round's output
 // keys the next.
 hmac_sha256_bytes(key: string, key_len: int, msg: string, msg_len: int) -> {
-    ok = cryptography_hmac_sha256_bytes_raw(key, key_len, msg, msg_len)
-    if ok == 0 {
-        return "", 0, "openssl unavailable"
+    // Pure-Aether HMAC (see hmac_sha256_hex) — works on every target, no
+    // libcrypto. Returns the raw 32-byte digest as a length-preserving
+    // AetherString so embedded NULs survive (SigV4/HKDF chaining).
+    kb = hmac_str_to_bytes(key, key_len)
+    mb = hmac_str_to_bytes(msg, msg_len)
+    digest = hmac.hmac_sha256(kb, key_len, mb, msg_len)
+    bytes.free(kb)
+    bytes.free(mb)
+    if digest == null {
+        return "", 0, "hmac failed"
     }
-    raw = cryptography_get_binary_digest()
-    n   = cryptography_get_binary_digest_length()
-    owned = string_new_with_length(raw, n)
-    cryptography_release_binary_digest()
+    n = bytes.length(digest)
+    // bytes.finish hands the buffer off to a length-preserving AetherString
+    // (binary-safe, embedded NULs intact) and consumes the buffer.
+    owned = bytes.finish(digest, n)
     return owned, n, ""
 }
 

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5015,13 +5015,31 @@ static int cmd_build(int argc, char** argv) {
         }
         char mod[64];
         if (cross_uses_unsupported_module(file, mod, sizeof(mod))) {
-            fprintf(stderr,
-                "Note: '%s' uses %s. Cross binaries are built without OpenSSL / zlib /\n"
-                "nghttp2 / PCRE2, so features that need them (HTTPS/TLS, hashing, base64,\n"
-                "regex, compression, HTTP/2) report errors at runtime on %s, exactly like\n"
-                "a native build on a host without those libraries. Plain sockets and pure\n"
-                "helpers still work. Building anyway.\n",
-                file, mod, target);
+            const char* xsr = getenv("CROSSBUILD_SYSROOT");
+            if (xsr && *xsr) {
+                /* A sysroot is staged: the ae_cross probe links + compiles the
+                 * real path for whichever Tier-2 libs it actually contains, so
+                 * we can't promise all features work (the sysroot may be a
+                 * subset) but we must NOT claim they're all unavailable. */
+                fprintf(stderr,
+                    "Note: '%s' uses %s. CROSSBUILD_SYSROOT is set, so each of OpenSSL /\n"
+                    "zlib / nghttp2 / PCRE2 that the sysroot actually stages is compiled\n"
+                    "and linked for real on %s; any it does not stage reports unavailable\n"
+                    "at runtime. Building.\n",
+                    file, mod, target);
+            } else {
+                /* No sysroot: openssl/zlib/nghttp2/pcre2-backed features stub
+                 * out. HMAC is the exception — std.cryptography's HMAC is
+                 * pure-Aether and works regardless — so it is NOT listed here. */
+                fprintf(stderr,
+                    "Note: '%s' uses %s. Without a CROSSBUILD_SYSROOT, cross binaries link\n"
+                    "no OpenSSL / zlib / nghttp2 / PCRE2, so features needing them (HTTPS/TLS,\n"
+                    "SHA/MD hashing, base64, regex, compression, HTTP/2) report errors at\n"
+                    "runtime on %s. HMAC (pure-Aether) and plain sockets still work. Stage a\n"
+                    "sysroot (aether-crossbuild) and set CROSSBUILD_SYSROOT to link them for\n"
+                    "real. Building anyway.\n",
+                    file, mod, target);
+            }
         }
     }
 

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -207,7 +207,11 @@ int run_cross_build(const char* c_file, const char* out_file,
      * warn-and-degrade as openssl/nghttp2 on a Tier-B target). Without this, a
      * macos cross-build of ANY program fails compiling aether_audio.c, even one
      * that never touches std.audio (the runtime always compiles it). */
-    char feature_defs[128] = "-DAETHER_HAS_SANDBOX";
+    /* feature_defs grows below when the CROSSBUILD_SYSROOT probe finds a
+     * Tier-2 lib staged: each such lib both LINKS (crossbuild_libs) and
+     * COMPILES REAL (its -DAETHER_HAS_* here). Sized for the base defs plus
+     * every Tier-2 macro. */
+    char feature_defs[2048] = "-DAETHER_HAS_SANDBOX";
     if (strstr(ztriple, "macos")) {
         strncat(feature_defs, " -DMA_NO_COREAUDIO",
                 sizeof(feature_defs) - strlen(feature_defs) - 1);
@@ -324,36 +328,70 @@ int run_cross_build(const char* c_file, const char* out_file,
             size_t p = 0;
             p += (size_t)snprintf(crossbuild_libs + p, sizeof(crossbuild_libs) - p,
                                   "-L%s/lib", xsr);
+            /* The sysroot's headers (openssl/*, zlib.h, pcre2.h, ...) must be on
+             * the COMPILE include path too, else enabling a real path below
+             * (-DAETHER_HAS_OPENSSL etc.) hits `openssl/ssl.h file not found`.
+             * Added once, unconditionally when a CROSSBUILD_SYSROOT is set —
+             * harmless when a probed lib is absent (nothing includes its
+             * header) and required when present. */
+            strncat(feature_defs, " -I",
+                    sizeof(feature_defs) - strlen(feature_defs) - 1);
+            strncat(feature_defs, xsr,
+                    sizeof(feature_defs) - strlen(feature_defs) - 1);
+            strncat(feature_defs, "/include",
+                    sizeof(feature_defs) - strlen(feature_defs) - 1);
             char probe[2600];
-            struct { const char* lib; const char* names; } t2[] = {
-                { "ssl",     "-lssl -lcrypto" },  /* libssl.a present => both */
-                { "nghttp2", "-lnghttp2" },
-                { "z",       "-lz" },
-                { "pcre2-8", "-lpcre2-8" },
+            /* `defines` is the -D that makes the corresponding stdlib source
+             * compile its REAL path instead of the "unavailable" stub. It MUST
+             * accompany the -l: linking libcrypto.a without -DAETHER_HAS_OPENSSL
+             * leaves the stub compiled in (the -l references nothing) — which
+             * is exactly the bug where a cross-built agent's hmac_sha256_hex
+             * returned "" despite a staged sysroot. Empty for libs with no
+             * compile-time guard (contrib veneers link but have no AETHER_HAS_*
+             * macro of their own). */
+            struct { const char* lib; const char* names; const char* defines; } t2[] = {
+                /* libssl.a present => both -l names AND the openssl compile
+                 * macro. HMAC/SHA (std.cryptography) need only libcrypto, but
+                 * the source guard is a single AETHER_HAS_OPENSSL, so staging
+                 * libssl.a (which the sysroot pairs with libcrypto.a) enables
+                 * the real crypto path; TLS (std.http) additionally needs the
+                 * libssl symbols, which the same -lssl provides. */
+                { "ssl",     "-lssl -lcrypto", "-DAETHER_HAS_OPENSSL" },
+                { "nghttp2", "-lnghttp2",      "-DAETHER_HAS_NGHTTP2" },
+                { "z",       "-lz",            "-DAETHER_HAS_ZLIB" },
+                { "pcre2-8", "-lpcre2-8",      "-DAETHER_HAS_PCRE2" },
                 /* contrib.sqlite: the Aether veneer archive
                  * (libaether_sqlite.a, from contrib_build.sh CONTRIB_TARGET
                  * mode) BEFORE the underlying C lib (libsqlite3.a) — ld.lld's
                  * single pass needs the veneer's sqlite3_* references resolved
                  * by the lib that follows. Probed on the VENEER so a program
                  * that doesn't use sqlite links nothing extra. */
-                { "aether_sqlite", "-laether_sqlite -lsqlite3" },
+                { "aether_sqlite", "-laether_sqlite -lsqlite3", "" },
                 /* contrib.host.python: the embedded-Python bridge veneer. NO
                  * -lpython — the bridge dlopen()s the deploy host's libpython
                  * at runtime (AETHER_PYTHON_SONAME), so the .a has no
                  * unresolved CPython symbols and needs no python at link. Just
                  * the veneer archive. Probed on it so a program not embedding
                  * python links nothing extra. */
-                { "aether_host_python", "-laether_host_python" },
+                { "aether_host_python", "-laether_host_python", "" },
                 /* contrib.host.ruby: same dlopen model as python (no -lruby;
                  * the deploy host's libruby is dlopen'd at runtime). Veneer
                  * only. */
-                { "aether_host_ruby", "-laether_host_ruby" },
+                { "aether_host_ruby", "-laether_host_ruby", "" },
             };
             for (size_t i = 0; i < sizeof(t2) / sizeof(t2[0]); i++) {
                 snprintf(probe, sizeof(probe), "%s/lib/lib%s.a", xsr, t2[i].lib);
                 if (path_exists(probe) && p < sizeof(crossbuild_libs)) {
                     p += (size_t)snprintf(crossbuild_libs + p, sizeof(crossbuild_libs) - p,
                                           " %s", t2[i].names);
+                    /* Also compile the matching stdlib source's REAL path, not
+                     * its stub — the fix for the "linked but stubbed" bug. */
+                    if (t2[i].defines[0]) {
+                        strncat(feature_defs, " ",
+                                sizeof(feature_defs) - strlen(feature_defs) - 1);
+                        strncat(feature_defs, t2[i].defines,
+                                sizeof(feature_defs) - strlen(feature_defs) - 1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Resolves `asks/cross-build-crypto-unavailable-despite-sysroot.md`: cross-built binaries shipped a non-functional `std.cryptography` HMAC that returned an empty digest, which downstream turned into a **fail-open auth bug** (two empty MACs compare equal → every token authenticates). Fixed at the source, plus the underlying "sysroot present but crypto still stubbed" wiring gap. **Both fixes verified on a real aarch64 Raspberry Pi 5** — the exact hardware the ask came from.

## Root cause (found via Pi 5 testing, and it reframes the ask)

There are two `hmac_sha256_hex`:

- **`std.cryptography.hmac.hmac_sha256_hex`** — pure-Aether, takes byte buffers. **Already works on cross** (needs no OpenSSL).
- **`std.cryptography.hmac_sha256_hex`** — OpenSSL-backed via `cryptography_hmac_sha256_hex_raw`, takes strings. On the zig cross path OpenSSL is **never compiled in** (`AETHER_HAS_OPENSSL` undefined), so it hit the `#else` stub → `return NULL` → empty hex. **This** is the ask's culprit.

Critically: the OpenSSL "unavailable → stub" is a **compile-time** decision. Staging `libcrypto.a` in `CROSSBUILD_SYSROOT` added `-lcrypto` to the link, but nothing defined `AETHER_HAS_OPENSSL`, so the real code was never compiled and the `-l` referenced nothing. That's why setting the sysroot changed nothing.

## Fixes

1. **HMAC fail-open (the security fix).** The string-API HMAC now **delegates to the pure-Aether `std.cryptography.hmac`** — verified byte-identical to the OpenSSL output — so it works on every target with **no sysroot at all**. No libcrypto, no stub, no fail-open.

2. **`CROSSBUILD_SYSROOT` now compiles the real path, not just links it.** The Tier-2 probe in `ae_cross.c` now adds the matching `-DAETHER_HAS_OPENSSL/_ZLIB/_NGHTTP2/_PCRE2` per lib actually staged, plus `-I<sysroot>/include`, so OpenSSL-only primitives (`sha256_hex`, MD4/5, EVP base64) compile and link for real when a sysroot is present.

3. **Precise cross note (ask #3).** The "built without OpenSSL" message now distinguishes sysroot-present from no-sysroot, and no longer implies HMAC is unavailable — it never was.

A companion fix in **aether-crossbuild** (`recipes/nghttp2.sh`) stages the nghttp2 header at `include/nghttp2/` instead of flattened; without it, enabling `AETHER_HAS_NGHTTP2` failed to find the header.

## Verification (real aarch64 Pi 5, Debian 13)

| test | result |
|---|---|
| pure-Aether HMAC, **no sysroot**, cross aarch64 | `f7bc83f4…3cd8` — correct RFC vector ✓ |
| **string-API** HMAC (the agent's path), **no sysroot** | correct digest, `err=''`, exit 0 ✓ |
| `sha256_hex` (OpenSSL EVP), **with** sysroot | `ba7816bf…15ad` — real digest ✓ |
| pure-Aether vs OpenSSL HMAC, native | byte-**identical** ✓ |
| full crypto regression suite (15 tests) + HMAC-DRBG | all pass ✓ |

## Notes

- Separately discovered: an OpenSSL-linked FreeBSD cross binary SIGBUSes at startup (and the pre-fix stub crashed identically) — a **pre-existing** FreeBSD-cross issue unrelated to this change, worth its own investigation. This PR's HMAC fix makes FreeBSD agents work anyway, since HMAC no longer links OpenSSL.
- The ask notes aeo already made its verifier fail-closed; this restores cross-built agents to *usable* (working HMAC) rather than inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
