### PR TITLE
feat(crypto): 5 pure-Aether LWC hashes from Bouncy Castle (+ fix Sparkle rate-boundary bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,31 @@ next version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **Five more pure-Aether hash/XOF submodules ported from Bouncy Castle** —
+  `std.cryptography.ascon_xof128` (Ascon-XOF128, NIST SP 800-232),
+  `std.cryptography.dstu7564` (Ukrainian DSTU 7564 / Kupyna, 256/384/512),
+  `std.cryptography.isap` (ISAP-Hash), `std.cryptography.photon_beetle`
+  (PHOTON-Beetle Hash), and `std.cryptography.sparkle` (Esch-256 / Esch-384).
+  No externs to OpenSSL or any C crypto. Verified against Bouncy Castle's
+  `LWC_HASH_KAT` vectors (present for ISAP/PHOTON/Sparkle) and BC's DSTU 7564
+  digest vectors across all three widths; Ascon-XOF128 is pinned to the
+  SP 800-232 reference output (BC's own XOF128 KAT is absent from the upstream
+  checkout) and anchored by its verified IV plus a variable-length XOF-prefix
+  check. Tests cover rate-boundary inputs and multi-part streaming for each.
+
 ### Fixed
+
+- **`std.cryptography.sparkle` (Esch) hashed one block short at every rate
+  multiple.** A message that filled the 16-byte rate exactly was absorbed
+  eagerly with slim steps in `update`, so `final` then ran on an empty padded
+  block with the wrong domain constant — e.g. a 16-byte input produced
+  `889f75ad…` instead of the correct `acff841e…`. `update` now holds a
+  rate-filling block until more data arrives (matching Bouncy Castle), so the
+  last data block gets the big-step + domain-separation treatment. Inputs
+  shorter than the rate were unaffected; the bug only appeared at 16, 32, …
+  byte lengths. Regression vectors at the rate boundary added.
 
 - **Cross-built binaries now compute a working `std.cryptography` HMAC (was a
   silent stub → fail-open).** The string-API `cryptography.hmac_sha256_hex` /

--- a/std/cryptography/ascon_xof128/module.ae
+++ b/std/cryptography/ascon_xof128/module.ae
@@ -1,0 +1,262 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.ascon_xof128 — Ascon-XOF128 (NIST SP 800-232) in pure Aether,
+// ported from Bouncy Castle's AsconXof128.cs. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.ascon_xof128
+
+import std.bits
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    ascon_xof128_hex, ascon_xof128_bytes
+)
+
+struct AsconXofCtx {
+    v0: long
+    v1: long
+    v2: long
+    v3: long
+    v4: long
+    block: ptr        // std.bytes buffer, 8 bytes
+    block_len: int
+    squeezing: int
+}
+
+round(c: *AsconXofCtx, rc: long) {
+    sx = c.v2 ^ rc
+    t0 = c.v0 ^ c.v1 ^ sx ^ c.v3 ^ (c.v1 & (c.v0 ^ sx ^ c.v4))
+    t1 = c.v0 ^ sx ^ c.v3 ^ c.v4 ^ ((c.v1 ^ sx) & (c.v1 ^ c.v3))
+    t2 = c.v1 ^ sx ^ c.v4 ^ (c.v3 & c.v4)
+    t3 = c.v0 ^ c.v1 ^ sx ^ ((~c.v0) & (c.v3 ^ c.v4))
+    t4 = c.v1 ^ c.v3 ^ c.v4 ^ ((c.v0 ^ c.v4) & c.v1)
+
+    c.v0 = t0 ^ bits.rotr64(t0, 19) ^ bits.rotr64(t0, 28)
+    c.v1 = t1 ^ bits.rotr64(t1, 39) ^ bits.rotr64(t1, 61)
+    c.v2 = ~(t2 ^ bits.rotr64(t2, 1) ^ bits.rotr64(t2, 6))
+    c.v3 = t3 ^ bits.rotr64(t3, 10) ^ bits.rotr64(t3, 17)
+    c.v4 = t4 ^ bits.rotr64(t4, 7) ^ bits.rotr64(t4, 41)
+}
+
+p12(c: *AsconXofCtx) {
+    round(c, 0xf0)
+    round(c, 0xe1)
+    round(c, 0xd2)
+    round(c, 0xc3)
+    round(c, 0xb4)
+    round(c, 0xa5)
+    round(c, 0x96)
+    round(c, 0x87)
+    round(c, 0x78)
+    round(c, 0x69)
+    round(c, 0x5a)
+    round(c, 0x4b)
+}
+
+new() -> {
+    ctx = malloc(64) as *AsconXofCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.v0 = 0xda82ce768d9447eb
+    ctx.v1 = 0xcc7ce6c75f1ef969
+    ctx.v2 = 0xe7508fd780085631
+    ctx.v3 = 0x0ee0ea53416b58cc
+    ctx.v4 = 0xe0547524db6f0bde
+    ctx.block_len = 0
+    ctx.squeezing = 0
+    ctx.block = bytes.new(8)
+    j = 0
+    while j < 8 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *AsconXofCtx
+    if c.squeezing == 1 {
+        return
+    }
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_le64(c.block, 0)
+            c.block_len = 0
+            p12(c)
+        }
+        i = i + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *AsconXofCtx
+    if c.squeezing == 1 {
+        return
+    }
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_le64(c.block, 0)
+            c.block_len = 0
+            p12(c)
+        }
+        i = i + 1
+    }
+}
+
+pad_and_absorb(c: *AsconXofCtx) {
+    finalBits = c.block_len << 3
+    j = c.block_len
+    while j < 8 {
+        bytes.set(c.block, j, 0)
+        j = j + 1
+    }
+    val = bytes.get_le64(c.block, 0)
+    long mask = 0
+    if finalBits > 0 {
+        mask = 0x00FFFFFFFFFFFFFF >> (56 - finalBits)
+    }
+    c.v0 = c.v0 ^ (val & mask)
+    c.v0 = c.v0 ^ (1 << finalBits)
+}
+
+squeeze_bytes(c: *AsconXofCtx, out_len: int) -> ptr {
+    if c.squeezing == 0 {
+        pad_and_absorb(c)
+        c.squeezing = 1
+        c.block_len = 8
+    }
+
+    out = bytes.new(out_len)
+    produced = 0
+
+    if c.block_len < 8 {
+        avail = 8 - c.block_len
+        to_copy = out_len - produced
+        if to_copy > avail {
+            to_copy = avail
+        }
+        bytes.copy_from_bytes(out, produced, c.block, c.block_len, to_copy)
+        c.block_len = c.block_len + to_copy
+        produced = produced + to_copy
+    }
+
+    while (out_len - produced) >= 8 {
+        p12(c)
+        bytes.set_le64(out, produced, c.v0)
+        produced = produced + 8
+    }
+
+    if produced < out_len {
+        p12(c)
+        bytes.set_le64(c.block, 0, c.v0)
+        to_copy = out_len - produced
+        bytes.copy_from_bytes(out, produced, c.block, 0, to_copy)
+        c.block_len = to_copy
+        produced = produced + to_copy
+    }
+
+    return out
+}
+
+free_internals(c: *AsconXofCtx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+}
+
+final_bytes(ctx: ptr, out_len: int) -> ptr {
+    c = ctx as *AsconXofCtx
+    n = out_len
+    if n <= 0 {
+        n = 32
+    }
+    out = squeeze_bytes(c, n)
+    s = bytes.finish(out, n)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(n)
+    bytes.copy_from_string(res, 0, s, n)
+    return res
+}
+
+final_hex(ctx: ptr, out_len: int) -> string {
+    c = ctx as *AsconXofCtx
+    n = out_len
+    if n <= 0 {
+        n = 32
+    }
+    out = squeeze_bytes(c, n)
+    hexbuf = bytes.new(n * 2)
+    i = 0
+    while i < n {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, n * 2)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *AsconXofCtx
+    free_internals(c)
+    free(ctx)
+}
+
+ascon_xof128_hex(data: string, len: int, out_len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx, out_len)
+}
+
+ascon_xof128_bytes(data: string, len: int, out_len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx, out_len)
+}

--- a/std/cryptography/dstu7564/module.ae
+++ b/std/cryptography/dstu7564/module.ae
@@ -1,0 +1,675 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.dstu7564 — Ukrainian DSTU 7564 (Kupyna) in pure Aether,
+// ported from Bouncy Castle's Dstu7564Digest.cs. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.dstu7564
+
+import std.bits
+import std.bytes
+import std.longarr
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    dstu7564_hex, dstu7564_bytes
+)
+
+const S0_KUPYNA: int[256] = [
+    0xa8, 0x43, 0x5f, 0x06, 0x6b, 0x75, 0x6c, 0x59, 0x71, 0xdf, 0x87, 0x95, 0x17, 0xf0, 0xd8, 0x09,
+    0x6d, 0xf3, 0x1d, 0xcb, 0xc9, 0x4d, 0x2c, 0xaf, 0x79, 0xe0, 0x97, 0xfd, 0x6f, 0x4b, 0x45, 0x39,
+    0x3e, 0xdd, 0xa3, 0x4f, 0xb4, 0xb6, 0x9a, 0x0e, 0x1f, 0xbf, 0x15, 0xe1, 0x49, 0xd2, 0x93, 0xc6,
+    0x92, 0x72, 0x9e, 0x61, 0xd1, 0x63, 0xfa, 0xee, 0xf4, 0x19, 0xd5, 0xad, 0x58, 0xa4, 0xbb, 0xa1,
+    0xdc, 0xf2, 0x83, 0x37, 0x42, 0xe4, 0x7a, 0x32, 0x9c, 0xcc, 0xab, 0x4a, 0x8f, 0x6e, 0x04, 0x27,
+    0x2e, 0xe7, 0xe2, 0x5a, 0x96, 0x16, 0x23, 0x2b, 0xc2, 0x65, 0x66, 0x0f, 0xbc, 0xa9, 0x47, 0x41,
+    0x34, 0x48, 0xfc, 0xb7, 0x6a, 0x88, 0xa5, 0x53, 0x86, 0xf9, 0x5b, 0xdb, 0x38, 0x7b, 0xc3, 0x1e,
+    0x22, 0x33, 0x24, 0x28, 0x36, 0xc7, 0xb2, 0x3b, 0x8e, 0x77, 0xba, 0xf5, 0x14, 0x9f, 0x08, 0x55,
+    0x9b, 0x4c, 0xfe, 0x60, 0x5c, 0xda, 0x18, 0x46, 0xcd, 0x7d, 0x21, 0xb0, 0x3f, 0x1b, 0x89, 0xff,
+    0xeb, 0x84, 0x69, 0x3a, 0x9d, 0xd7, 0xd3, 0x70, 0x67, 0x40, 0xb5, 0xde, 0x5d, 0x30, 0x91, 0xb1,
+    0x78, 0x11, 0x01, 0xe5, 0x00, 0x68, 0x98, 0xa0, 0xc5, 0x02, 0xa6, 0x74, 0x2d, 0x0b, 0xa2, 0x76,
+    0xb3, 0xbe, 0xce, 0xbd, 0xae, 0xe9, 0x8a, 0x31, 0x1c, 0xec, 0xf1, 0x99, 0x94, 0xaa, 0xf6, 0x26,
+    0x2f, 0xef, 0xe8, 0x8c, 0x35, 0x03, 0xd4, 0x7f, 0xfb, 0x05, 0xc1, 0x5e, 0x90, 0x20, 0x3d, 0x82,
+    0xf7, 0xea, 0x0a, 0x0d, 0x7e, 0xf8, 0x50, 0x1a, 0xc4, 0x07, 0x57, 0xb8, 0x3c, 0x62, 0xe3, 0xc8,
+    0xac, 0x52, 0x64, 0x10, 0xd0, 0xd9, 0x13, 0x0c, 0x12, 0x29, 0x51, 0xb9, 0xcf, 0xd6, 0x73, 0x8d,
+    0x81, 0x54, 0xc0, 0xed, 0x4e, 0x44, 0xa7, 0x2a, 0x85, 0x25, 0xe6, 0xca, 0x7c, 0x8b, 0x56, 0x80
+]
+
+const S1_KUPYNA: int[256] = [
+    0xce, 0xbb, 0xeb, 0x92, 0xea, 0xcb, 0x13, 0xc1, 0xe9, 0x3a, 0xd6, 0xb2, 0xd2, 0x90, 0x17, 0xf8,
+    0x42, 0x15, 0x56, 0xb4, 0x65, 0x1c, 0x88, 0x43, 0xc5, 0x5c, 0x36, 0xba, 0xf5, 0x57, 0x67, 0x8d,
+    0x31, 0xf6, 0x64, 0x58, 0x9e, 0xf4, 0x22, 0xaa, 0x75, 0x0f, 0x02, 0xb1, 0xdf, 0x6d, 0x73, 0x4d,
+    0x7c, 0x26, 0x2e, 0xf7, 0x08, 0x5d, 0x44, 0x3e, 0x9f, 0x14, 0xc8, 0xae, 0x54, 0x10, 0xd8, 0xbc,
+    0x1a, 0x6b, 0x69, 0xf3, 0xbd, 0x33, 0xab, 0xfa, 0xd1, 0x9b, 0x68, 0x4e, 0x16, 0x95, 0x91, 0xee,
+    0x4c, 0x63, 0x8e, 0x5b, 0xcc, 0x3c, 0x19, 0xa1, 0x81, 0x49, 0x7b, 0xd9, 0x6f, 0x37, 0x60, 0xca,
+    0xe7, 0x2b, 0x48, 0xfd, 0x96, 0x45, 0xfc, 0x41, 0x12, 0x0d, 0x79, 0xe5, 0x89, 0x8c, 0xe3, 0x20,
+    0x30, 0xdc, 0xb7, 0x6c, 0x4a, 0xb5, 0x3f, 0x97, 0xd4, 0x62, 0x2d, 0x06, 0xa4, 0xa5, 0x83, 0x5f,
+    0x2a, 0xda, 0xc9, 0x00, 0x7e, 0xa2, 0x55, 0xbf, 0x11, 0xd5, 0x9c, 0xcf, 0x0e, 0x0a, 0x3d, 0x51,
+    0x7d, 0x93, 0x1b, 0xfe, 0xc4, 0x47, 0x09, 0x86, 0x0b, 0x8f, 0x9d, 0x6a, 0x07, 0xb9, 0xb0, 0x98,
+    0x18, 0x32, 0x71, 0x4b, 0xef, 0x3b, 0x70, 0xa0, 0xe4, 0x40, 0xff, 0xc3, 0xa9, 0xe6, 0x78, 0xf9,
+    0x8b, 0x46, 0x80, 0x1e, 0x38, 0xe1, 0xb8, 0xa8, 0xe0, 0x0c, 0x23, 0x76, 0x1d, 0x25, 0x24, 0x05,
+    0xf1, 0x6e, 0x94, 0x28, 0x9a, 0x84, 0xe8, 0xa3, 0x4f, 0x77, 0xd3, 0x85, 0xe2, 0x52, 0xf2, 0x82,
+    0x50, 0x7a, 0x2f, 0x74, 0x53, 0xb3, 0x61, 0xaf, 0x39, 0x35, 0xde, 0xcd, 0x1f, 0x99, 0xac, 0xad,
+    0x72, 0x2c, 0xdd, 0xd0, 0x87, 0xbe, 0x5e, 0xa6, 0xec, 0x04, 0xc6, 0x03, 0x34, 0xfb, 0xdb, 0x59,
+    0xb6, 0xc2, 0x01, 0xf0, 0x5a, 0xed, 0xa7, 0x66, 0x21, 0x7f, 0x8a, 0x27, 0xc7, 0xc0, 0x29, 0xd7
+]
+
+const S2_KUPYNA: int[256] = [
+    0x93, 0xd9, 0x9a, 0xb5, 0x98, 0x22, 0x45, 0xfc, 0xba, 0x6a, 0xdf, 0x02, 0x9f, 0xdc, 0x51, 0x59,
+    0x4a, 0x17, 0x2b, 0xc2, 0x94, 0xf4, 0xbb, 0xa3, 0x62, 0xe4, 0x71, 0xd4, 0xcd, 0x70, 0x16, 0xe1,
+    0x49, 0x3c, 0xc0, 0xd8, 0x5c, 0x9b, 0xad, 0x85, 0x53, 0xa1, 0x7a, 0xc8, 0x2d, 0xe0, 0xd1, 0x72,
+    0xa6, 0x2c, 0xc4, 0xe3, 0x76, 0x78, 0xb7, 0xb4, 0x09, 0x3b, 0x0e, 0x41, 0x4c, 0xde, 0xb2, 0x90,
+    0x25, 0xa5, 0xd7, 0x03, 0x11, 0x00, 0xc3, 0x2e, 0x92, 0xef, 0x4e, 0x12, 0x9d, 0x7d, 0xcb, 0x35,
+    0x10, 0xd5, 0x4f, 0x9e, 0x4d, 0xa9, 0x55, 0xc6, 0xd0, 0x7b, 0x18, 0x97, 0xd3, 0x36, 0xe6, 0x48,
+    0x56, 0x81, 0x8f, 0x77, 0xcc, 0x9c, 0xb9, 0xe2, 0xac, 0xb8, 0x2f, 0x15, 0xa4, 0x7c, 0xda, 0x38,
+    0x1e, 0x0b, 0x05, 0xd6, 0x14, 0x6e, 0x6c, 0x7e, 0x66, 0xfd, 0xb1, 0xe5, 0x60, 0xaf, 0x5e, 0x33,
+    0x87, 0xc9, 0xf0, 0x5d, 0x6d, 0x3f, 0x88, 0x8d, 0xc7, 0xf7, 0x1d, 0xe9, 0xec, 0xed, 0x80, 0x29,
+    0x27, 0xcf, 0x99, 0xa8, 0x50, 0x0f, 0x37, 0x24, 0x28, 0x30, 0x95, 0xd2, 0x3e, 0x5b, 0x40, 0x83,
+    0xb3, 0x69, 0x57, 0x1f, 0x07, 0x1c, 0x8a, 0xbc, 0x20, 0xeb, 0xce, 0x8e, 0xab, 0xee, 0x31, 0xa2,
+    0x73, 0xf9, 0xca, 0x3a, 0x1a, 0xfb, 0x0d, 0xc1, 0xfe, 0xfa, 0xf2, 0x6f, 0xbd, 0x96, 0xdd, 0x43,
+    0x52, 0xb6, 0x08, 0xf3, 0xae, 0xbe, 0x19, 0x89, 0x32, 0x26, 0xb0, 0xea, 0x4b, 0x64, 0x84, 0x82,
+    0x6b, 0xf5, 0x79, 0xbf, 0x01, 0x5f, 0x75, 0x63, 0x1b, 0x23, 0x3d, 0x68, 0x2a, 0x65, 0xe8, 0x91,
+    0xf6, 0xff, 0x13, 0x58, 0xf1, 0x47, 0x0a, 0x7f, 0xc5, 0xa7, 0xe7, 0x61, 0x5a, 0x06, 0x46, 0x44,
+    0x42, 0x04, 0xa0, 0xdb, 0x39, 0x86, 0x54, 0xaa, 0x8c, 0x34, 0x21, 0x8b, 0xf8, 0x0c, 0x74, 0x67
+]
+
+const S3_KUPYNA: int[256] = [
+    0x68, 0x8d, 0xca, 0x4d, 0x73, 0x4b, 0x4e, 0x2a, 0xd4, 0x52, 0x26, 0xb3, 0x54, 0x1e, 0x19, 0x1f,
+    0x22, 0x03, 0x46, 0x3d, 0x2d, 0x4a, 0x53, 0x83, 0x13, 0x8a, 0xb7, 0xd5, 0x25, 0x79, 0xf5, 0xbd,
+    0x58, 0x2f, 0x0d, 0x02, 0xed, 0x51, 0x9e, 0x11, 0xf2, 0x3e, 0x55, 0x5e, 0xd1, 0x16, 0x3c, 0x66,
+    0x70, 0x5d, 0xf3, 0x45, 0x40, 0xcc, 0xe8, 0x94, 0x56, 0x08, 0xce, 0x1a, 0x3a, 0xd2, 0xe1, 0xdf,
+    0xb5, 0x38, 0x6e, 0x0e, 0xe5, 0xf4, 0xf9, 0x86, 0xe9, 0x4f, 0xd6, 0x85, 0x23, 0xcf, 0x32, 0x99,
+    0x31, 0x14, 0xae, 0xee, 0xc8, 0x48, 0xd3, 0x30, 0xa1, 0x92, 0x41, 0xb1, 0x18, 0xc4, 0x2c, 0x71,
+    0x72, 0x44, 0x15, 0xfd, 0x37, 0xbe, 0x5f, 0xaa, 0x9b, 0x88, 0xd8, 0xab, 0x89, 0x9c, 0xfa, 0x60,
+    0xea, 0xbc, 0x62, 0x0c, 0x24, 0xa6, 0xa8, 0xec, 0x67, 0x20, 0xdb, 0x7c, 0x28, 0xdd, 0xac, 0x5b,
+    0x34, 0x7e, 0x10, 0xf1, 0x7b, 0x8f, 0x63, 0xa0, 0x05, 0x9a, 0x43, 0x77, 0x21, 0xbf, 0x27, 0x09,
+    0xc3, 0x9f, 0xb6, 0xd7, 0x29, 0xc2, 0xeb, 0xc0, 0xa4, 0x8b, 0x8c, 0x1d, 0xfb, 0xff, 0xc1, 0xb2,
+    0x97, 0x2e, 0xf8, 0x65, 0xf6, 0x75, 0x07, 0x04, 0x49, 0x33, 0xe4, 0xd9, 0xb9, 0xd0, 0x42, 0xc7, 0x6c, 0x90, 0x00, 0x8e, 0x6f, 0x50, 0x01, 0xc5, 0xda, 0x47, 0x3f, 0xcd, 0x69, 0xa2, 0xe2, 0x7a,
+    0xa7, 0xc6, 0x93, 0x0f, 0x0a, 0x06, 0xe6, 0x2b, 0x96, 0xa3, 0x1c, 0xaf, 0x6a, 0x12, 0x84, 0x39,
+    0xe7, 0xb0, 0x82, 0xf7, 0xfe, 0x9d, 0x87, 0x5c, 0x81, 0x35, 0xde, 0xb4, 0xa5, 0xfc, 0x80, 0xef,
+    0xcb, 0xbb, 0x6b, 0x76, 0xba, 0x5a, 0x7d, 0x78, 0x0b, 0x95, 0xe3, 0xad, 0x74, 0x98, 0x3b, 0x36,
+    0x64, 0x6d, 0xdc, 0xf0, 0x59, 0xa9, 0x4c, 0x17, 0x7f, 0x91, 0xb8, 0xc9, 0x57, 0x1b, 0xe0, 0x61
+]
+
+struct DstuCtx {
+    hash_size: int
+    block_size: int
+    columns: int
+    rounds: int
+    state: ptr         // longarr(16)
+    temp_state1: ptr   // longarr(16)
+    temp_state2: ptr   // longarr(16)
+    input_blocks: long
+    buf_off: int
+    buf: ptr           // std.bytes (128 bytes)
+    algo: string       // "dstu7564-256", "dstu7564-384", "dstu7564-512"
+}
+
+rotate(n: int, x: long) -> long {
+    return (bits.lsr64(x, n) | (x << (64 - n)))
+}
+
+mix_column(c: long) -> long {
+    x1 = ((c & 0x7F7F7F7F7F7F7F7F) << 1) ^ (((bits.lsr64(c, 7) & 0x0101010101010101) * 0x1D))
+    u = rotate(8, c) ^ c
+    u = u ^ rotate(16, u)
+    u = u ^ rotate(48, c)
+
+    v = u ^ c ^ x1
+
+    term1 = (bits.lsr64(v, 6) & 0x0202020202020202) * 0x1D
+    term2 = (bits.lsr64(v, 6) & 0x0101010101010101) * 0x1D
+    v = ((v & 0x3F3F3F3F3F3F3F3F) << 2) ^ term1 ^ term2
+
+    return u ^ rotate(32, v) ^ rotate(40, x1) ^ rotate(48, x1)
+}
+
+mix_columns(c: *DstuCtx, s: ptr) {
+    col = 0
+    while col < c.columns {
+        val = longarr_get_unchecked(s, col)
+        longarr_set_unchecked(s, col, mix_column(val))
+        col = col + 1
+    }
+}
+
+sub_bytes(c_ctx: *DstuCtx, s: ptr) {
+    col = 0
+    while col < c_ctx.columns {
+        u = longarr_get_unchecked(s, col)
+        lo = u & 0xFFFFFFFF
+        hi = bits.lsr64(u, 32) & 0xFFFFFFFF
+
+        t0 = S0_KUPYNA[lo & 255]
+        t1 = S1_KUPYNA[(lo >> 8) & 255]
+        t2 = S2_KUPYNA[(lo >> 16) & 255]
+        t3 = S3_KUPYNA[(lo >> 24) & 255]
+        long new_lo = (t0 as long) | ((t1 as long) << 8) | ((t2 as long) << 16) | ((t3 as long) << 24)
+
+        t4 = S0_KUPYNA[hi & 255]
+        t5 = S1_KUPYNA[(hi >> 8) & 255]
+        t6 = S2_KUPYNA[(hi >> 16) & 255]
+        t7 = S3_KUPYNA[(hi >> 24) & 255]
+        long new_hi = (t4 as long) | ((t5 as long) << 8) | ((t6 as long) << 16) | ((t7 as long) << 24)
+
+        longarr_set_unchecked(s, col, (new_lo & 0xFFFFFFFF) | ((new_hi & 0xFFFFFFFF) << 32))
+        col = col + 1
+    }
+}
+
+shift_rows(c_ctx: *DstuCtx, s: ptr) {
+    if c_ctx.columns == 8 {
+        c0 = longarr_get_unchecked(s, 0)
+        c1 = longarr_get_unchecked(s, 1)
+        c2 = longarr_get_unchecked(s, 2)
+        c3 = longarr_get_unchecked(s, 3)
+        c4 = longarr_get_unchecked(s, 4)
+        c5 = longarr_get_unchecked(s, 5)
+        c6 = longarr_get_unchecked(s, 6)
+        c7 = longarr_get_unchecked(s, 7)
+
+        d = (c0 ^ c4) & 0xFFFFFFFF00000000
+        c0 = c0 ^ d
+        c4 = c4 ^ d
+
+        d = (c1 ^ c5) & 0x00FFFFFFFF000000
+        c1 = c1 ^ d
+        c5 = c5 ^ d
+
+        d = (c2 ^ c6) & 0x0000FFFFFFFF0000
+        c2 = c2 ^ d
+        c6 = c6 ^ d
+
+        d = (c3 ^ c7) & 0x000000FFFFFFFF00
+        c3 = c3 ^ d
+        c7 = c7 ^ d
+
+        d = (c0 ^ c2) & 0xFFFF0000FFFF0000
+        c0 = c0 ^ d
+        c2 = c2 ^ d
+
+        d = (c1 ^ c3) & 0x00FFFF0000FFFF00
+        c1 = c1 ^ d
+        c3 = c3 ^ d
+
+        d = (c4 ^ c6) & 0xFFFF0000FFFF0000
+        c4 = c4 ^ d
+        c6 = c6 ^ d
+
+        d = (c5 ^ c7) & 0x00FFFF0000FFFF00
+        c5 = c5 ^ d
+        c7 = c7 ^ d
+
+        d = (c0 ^ c1) & 0xFF00FF00FF00FF00
+        c0 = c0 ^ d
+        c1 = c1 ^ d
+
+        d = (c2 ^ c3) & 0xFF00FF00FF00FF00
+        c2 = c2 ^ d
+        c3 = c3 ^ d
+
+        d = (c4 ^ c5) & 0xFF00FF00FF00FF00
+        c4 = c4 ^ d
+        c5 = c5 ^ d
+
+        d = (c6 ^ c7) & 0xFF00FF00FF00FF00
+        c6 = c6 ^ d
+        c7 = c7 ^ d
+
+        longarr_set_unchecked(s, 0, c0)
+        longarr_set_unchecked(s, 1, c1)
+        longarr_set_unchecked(s, 2, c2)
+        longarr_set_unchecked(s, 3, c3)
+        longarr_set_unchecked(s, 4, c4)
+        longarr_set_unchecked(s, 5, c5)
+        longarr_set_unchecked(s, 6, c6)
+        longarr_set_unchecked(s, 7, c7)
+    } else {
+        c00 = longarr_get_unchecked(s, 0)
+        c01 = longarr_get_unchecked(s, 1)
+        c02 = longarr_get_unchecked(s, 2)
+        c03 = longarr_get_unchecked(s, 3)
+        c04 = longarr_get_unchecked(s, 4)
+        c05 = longarr_get_unchecked(s, 5)
+        c06 = longarr_get_unchecked(s, 6)
+        c07 = longarr_get_unchecked(s, 7)
+        c08 = longarr_get_unchecked(s, 8)
+        c09 = longarr_get_unchecked(s, 9)
+        c10 = longarr_get_unchecked(s, 10)
+        c11 = longarr_get_unchecked(s, 11)
+        c12 = longarr_get_unchecked(s, 12)
+        c13 = longarr_get_unchecked(s, 13)
+        c14 = longarr_get_unchecked(s, 14)
+        c15 = longarr_get_unchecked(s, 15)
+
+        d = (c00 ^ c08) & 0xFF00000000000000
+        c00 = c00 ^ d
+        c08 = c08 ^ d
+
+        d = (c01 ^ c09) & 0xFF00000000000000
+        c01 = c01 ^ d
+        c09 = c09 ^ d
+
+        d = (c02 ^ c10) & 0xFFFF000000000000
+        c02 = c02 ^ d
+        c10 = c10 ^ d
+
+        d = (c03 ^ c11) & 0xFFFFFF0000000000
+        c03 = c03 ^ d
+        c11 = c11 ^ d
+
+        d = (c04 ^ c12) & 0xFFFFFFFF00000000
+        c04 = c04 ^ d
+        c12 = c12 ^ d
+
+        d = (c05 ^ c13) & 0x00FFFFFFFF000000
+        c05 = c05 ^ d
+        c13 = c13 ^ d
+
+        d = (c06 ^ c14) & 0x00FFFFFFFFFF0000
+        c06 = c06 ^ d
+        c14 = c14 ^ d
+
+        d = (c07 ^ c15) & 0x00FFFFFFFFFFFF00
+        c07 = c07 ^ d
+        c15 = c15 ^ d
+
+        d = (c00 ^ c04) & 0x00FFFFFF00000000
+        c00 = c00 ^ d
+        c04 = c04 ^ d
+
+        d = (c01 ^ c05) & 0xFFFFFFFFFF000000
+        c01 = c01 ^ d
+        c05 = c05 ^ d
+
+        d = (c02 ^ c06) & 0xFF00FFFFFFFF0000
+        c02 = c02 ^ d
+        c06 = c06 ^ d
+
+        d = (c03 ^ c07) & 0xFF0000FFFFFFFF00
+        c03 = c03 ^ d
+        c07 = c07 ^ d
+
+        d = (c08 ^ c12) & 0x00FFFFFF00000000
+        c08 = c08 ^ d
+        c12 = c12 ^ d
+
+        d = (c09 ^ c13) & 0xFFFFFFFFFF000000
+        c09 = c09 ^ d
+        c13 = c13 ^ d
+
+        d = (c10 ^ c14) & 0xFF00FFFFFFFF0000
+        c10 = c10 ^ d
+        c14 = c14 ^ d
+
+        d = (c11 ^ c15) & 0xFF0000FFFFFFFF00
+        c11 = c11 ^ d
+        c15 = c15 ^ d
+
+        d = (c00 ^ c02) & 0xFFFF0000FFFF0000
+        c00 = c00 ^ d
+        c02 = c02 ^ d
+
+        d = (c01 ^ c03) & 0x00FFFF0000FFFF00
+        c01 = c01 ^ d
+        c03 = c03 ^ d
+
+        d = (c04 ^ c06) & 0xFFFF0000FFFF0000
+        c04 = c04 ^ d
+        c06 = c06 ^ d
+
+        d = (c05 ^ c07) & 0x00FFFF0000FFFF00
+        c05 = c05 ^ d
+        c07 = c07 ^ d
+
+        d = (c08 ^ c10) & 0xFFFF0000FFFF0000
+        c08 = c08 ^ d
+        c10 = c10 ^ d
+
+        d = (c09 ^ c11) & 0x00FFFF0000FFFF00
+        c09 = c09 ^ d
+        c11 = c11 ^ d
+
+        d = (c12 ^ c14) & 0xFFFF0000FFFF0000
+        c12 = c12 ^ d
+        c14 = c14 ^ d
+
+        d = (c13 ^ c15) & 0x00FFFF0000FFFF00
+        c13 = c13 ^ d
+        c15 = c15 ^ d
+
+        d = (c00 ^ c01) & 0xFF00FF00FF00FF00
+        c00 = c00 ^ d
+        c01 = c01 ^ d
+
+        d = (c02 ^ c03) & 0xFF00FF00FF00FF00
+        c02 = c02 ^ d
+        c03 = c03 ^ d
+
+        d = (c04 ^ c05) & 0xFF00FF00FF00FF00
+        c04 = c04 ^ d
+        c05 = c05 ^ d
+
+        d = (c06 ^ c07) & 0xFF00FF00FF00FF00
+        c06 = c06 ^ d
+        c07 = c07 ^ d
+
+        d = (c08 ^ c09) & 0xFF00FF00FF00FF00
+        c08 = c08 ^ d
+        c09 = c09 ^ d
+
+        d = (c10 ^ c11) & 0xFF00FF00FF00FF00
+        c10 = c10 ^ d
+        c11 = c11 ^ d
+
+        d = (c12 ^ c13) & 0xFF00FF00FF00FF00
+        c12 = c12 ^ d
+        c13 = c13 ^ d
+
+        d = (c14 ^ c15) & 0xFF00FF00FF00FF00
+        c14 = c14 ^ d
+        c15 = c15 ^ d
+
+        longarr_set_unchecked(s, 0, c00)
+        longarr_set_unchecked(s, 1, c01)
+        longarr_set_unchecked(s, 2, c02)
+        longarr_set_unchecked(s, 3, c03)
+        longarr_set_unchecked(s, 4, c04)
+        longarr_set_unchecked(s, 5, c05)
+        longarr_set_unchecked(s, 6, c06)
+        longarr_set_unchecked(s, 7, c07)
+        longarr_set_unchecked(s, 8, c08)
+        longarr_set_unchecked(s, 9, c09)
+        longarr_set_unchecked(s, 10, c10)
+        longarr_set_unchecked(s, 11, c11)
+        longarr_set_unchecked(s, 12, c12)
+        longarr_set_unchecked(s, 13, c13)
+        longarr_set_unchecked(s, 14, c14)
+        longarr_set_unchecked(s, 15, c15)
+    }
+}
+
+P_perm(c_ctx: *DstuCtx, s: ptr) {
+    round = 0
+    while round < c_ctx.rounds {
+        long rc = round
+
+        col = 0
+        while col < c_ctx.columns {
+            val = longarr_get_unchecked(s, col)
+            longarr_set_unchecked(s, col, val ^ rc)
+            rc = rc + 0x10
+            col = col + 1
+        }
+
+        shift_rows(c_ctx, s)
+        sub_bytes(c_ctx, s)
+        mix_columns(c_ctx, s)
+
+        round = round + 1
+    }
+}
+
+Q_perm(c_ctx: *DstuCtx, s: ptr) {
+    round = 0
+    while round < c_ctx.rounds {
+        long rc = (((c_ctx.columns - 1) << 4) ^ round) << 56
+        rc = rc | 0x00F0F0F0F0F0F0F3
+
+        col = 0
+        while col < c_ctx.columns {
+            val = longarr_get_unchecked(s, col)
+            longarr_set_unchecked(s, col, val + rc)
+            rc = rc - 0x1000000000000000
+            col = col + 1
+        }
+
+        shift_rows(c_ctx, s)
+        sub_bytes(c_ctx, s)
+        mix_columns(c_ctx, s)
+
+        round = round + 1
+    }
+}
+
+process_block(c: *DstuCtx, input: ptr, inOff: int) {
+    pos = inOff
+    col = 0
+    while col < c.columns {
+        word = bytes.get_le64(input, pos)
+        pos = pos + 8
+
+        longarr_set_unchecked(c.temp_state1, col, longarr_get_unchecked(c.state, col) ^ word)
+        longarr_set_unchecked(c.temp_state2, col, word)
+        col = col + 1
+    }
+
+    P_perm(c, c.temp_state1)
+    Q_perm(c, c.temp_state2)
+
+    col = 0
+    while col < c.columns {
+        val = longarr_get_unchecked(c.state, col) ^ longarr_get_unchecked(c.temp_state1, col) ^ longarr_get_unchecked(c.temp_state2, col)
+        longarr_set_unchecked(c.state, col, val)
+        col = col + 1
+    }
+}
+
+new(algo: string) -> {
+    ctx = malloc(96) as *DstuCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.algo = algo
+    if algo == "dstu7564-256" {
+        ctx.hash_size = 32
+        ctx.columns = 8
+        ctx.rounds = 10
+    } else if algo == "dstu7564-384" {
+        ctx.hash_size = 48
+        ctx.columns = 16
+        ctx.rounds = 14
+    } else if algo == "dstu7564-512" {
+        ctx.hash_size = 64
+        ctx.columns = 16
+        ctx.rounds = 14
+    } else {
+        free(ctx)
+        return null, "unknown algorithm"
+    }
+
+    ctx.block_size = ctx.columns << 3
+    ctx.state = longarr_new_raw(16)
+    ctx.temp_state1 = longarr_new_raw(16)
+    ctx.temp_state2 = longarr_new_raw(16)
+    ctx.buf = bytes.new(128)
+
+    i = 0
+    while i < 16 {
+        longarr_set_unchecked(ctx.state, i, 0)
+        longarr_set_unchecked(ctx.temp_state1, i, 0)
+        longarr_set_unchecked(ctx.temp_state2, i, 0)
+        i = i + 1
+    }
+
+    longarr_set_unchecked(ctx.state, 0, ctx.block_size)
+    ctx.input_blocks = 0
+    ctx.buf_off = 0
+
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c_ctx = ctx as *DstuCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c_ctx.buf, c_ctx.buf_off, b & 255)
+        c_ctx.buf_off = c_ctx.buf_off + 1
+        if c_ctx.buf_off == c_ctx.block_size {
+            process_block(c_ctx, c_ctx.buf, 0)
+            c_ctx.buf_off = 0
+            c_ctx.input_blocks = c_ctx.input_blocks + 1
+        }
+        i = i + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c_ctx = ctx as *DstuCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c_ctx.buf, c_ctx.buf_off, b & 255)
+        c_ctx.buf_off = c_ctx.buf_off + 1
+        if c_ctx.buf_off == c_ctx.block_size {
+            process_block(c_ctx, c_ctx.buf, 0)
+            c_ctx.buf_off = 0
+            c_ctx.input_blocks = c_ctx.input_blocks + 1
+        }
+        i = i + 1
+    }
+}
+
+finalize_to_bytes(c_ctx: *DstuCtx) -> ptr {
+    input_bytes = c_ctx.buf_off
+    bytes.set(c_ctx.buf, c_ctx.buf_off, 0x80)
+    c_ctx.buf_off = c_ctx.buf_off + 1
+
+    len_pos = c_ctx.block_size - 12
+    if c_ctx.buf_off > len_pos {
+        while c_ctx.buf_off < c_ctx.block_size {
+            bytes.set(c_ctx.buf, c_ctx.buf_off, 0)
+            c_ctx.buf_off = c_ctx.buf_off + 1
+        }
+        c_ctx.buf_off = 0
+        process_block(c_ctx, c_ctx.buf, 0)
+    }
+
+    while c_ctx.buf_off < len_pos {
+        bytes.set(c_ctx.buf, c_ctx.buf_off, 0)
+        c_ctx.buf_off = c_ctx.buf_off + 1
+    }
+
+    c = ((c_ctx.input_blocks & 0xFFFFFFFF) * c_ctx.block_size + input_bytes) << 3
+    bytes.set_le32(c_ctx.buf, c_ctx.buf_off, c & 0xFFFFFFFF)
+    c_ctx.buf_off = c_ctx.buf_off + 4
+    c = bits.lsr64(c, 32)
+    c = c + (((bits.lsr64(c_ctx.input_blocks, 32)) * c_ctx.block_size) << 3)
+    bytes.set_le64(c_ctx.buf, c_ctx.buf_off, c)
+
+    process_block(c_ctx, c_ctx.buf, 0)
+
+    // Apply transformation
+    i = 0
+    while i < c_ctx.columns {
+        longarr_set_unchecked(c_ctx.temp_state1, i, longarr_get_unchecked(c_ctx.state, i))
+        i = i + 1
+    }
+
+    P_perm(c_ctx, c_ctx.temp_state1)
+
+    i = 0
+    while i < c_ctx.columns {
+        val = longarr_get_unchecked(c_ctx.state, i) ^ longarr_get_unchecked(c_ctx.temp_state1, i)
+        longarr_set_unchecked(c_ctx.state, i, val)
+        i = i + 1
+    }
+
+    out = bytes.new(c_ctx.hash_size)
+    needed_columns = c_ctx.hash_size / 8
+    col = c_ctx.columns - needed_columns
+    out_pos = 0
+    while col < c_ctx.columns {
+        bytes.set_le64(out, out_pos, longarr_get_unchecked(c_ctx.state, col))
+        out_pos = out_pos + 8
+        col = col + 1
+    }
+
+    return out
+}
+
+free_internals(c: *DstuCtx) {
+    if c.state != null { longarr_free(c.state); c.state = null }
+    if c.temp_state1 != null { longarr_free(c.temp_state1); c.temp_state1 = null }
+    if c.temp_state2 != null { longarr_free(c.temp_state2); c.temp_state2 = null }
+    if c.buf != null { bytes.free(c.buf); c.buf = null }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *DstuCtx
+    n = c.hash_size
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, n)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(n)
+    bytes.copy_from_string(res, 0, s, n)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *DstuCtx
+    n = c.hash_size
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(n * 2)
+    i = 0
+    while i < n {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, n * 2)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *DstuCtx
+    free_internals(c)
+    free(ctx)
+}
+
+dstu7564_hex(algo: string, data: string, len: int) -> string {
+    ctx, err = new(algo)
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+dstu7564_bytes(algo: string, data: string, len: int) -> ptr {
+    ctx, err = new(algo)
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/isap/module.ae
+++ b/std/cryptography/isap/module.ae
@@ -1,0 +1,217 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.isap — ISAP Hash in pure Aether, ported from
+// Bouncy Castle's IsapDigest.cs. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.isap
+
+import std.bits
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    isap_hex, isap_bytes
+)
+
+struct IsapCtx {
+    v0: long
+    v1: long
+    v2: long
+    v3: long
+    v4: long
+    block: ptr        // std.bytes buffer, 8 bytes
+    block_len: int
+}
+
+round(c: *IsapCtx, rc: long) {
+    sx = c.v2 ^ rc
+    t0 = c.v0 ^ c.v1 ^ sx ^ c.v3 ^ (c.v1 & (c.v0 ^ sx ^ c.v4))
+    t1 = c.v0 ^ sx ^ c.v3 ^ c.v4 ^ ((c.v1 ^ sx) & (c.v1 ^ c.v3))
+    t2 = c.v1 ^ sx ^ c.v4 ^ (c.v3 & c.v4)
+    t3 = c.v0 ^ c.v1 ^ sx ^ ((~c.v0) & (c.v3 ^ c.v4))
+    t4 = c.v1 ^ c.v3 ^ c.v4 ^ ((c.v0 ^ c.v4) & c.v1)
+
+    c.v0 = t0 ^ bits.rotr64(t0, 19) ^ bits.rotr64(t0, 28)
+    c.v1 = t1 ^ bits.rotr64(t1, 39) ^ bits.rotr64(t1, 61)
+    c.v2 = ~(t2 ^ bits.rotr64(t2, 1) ^ bits.rotr64(t2, 6))
+    c.v3 = t3 ^ bits.rotr64(t3, 10) ^ bits.rotr64(t3, 17)
+    c.v4 = t4 ^ bits.rotr64(t4, 7) ^ bits.rotr64(t4, 41)
+}
+
+p12(c: *IsapCtx) {
+    round(c, 0xf0)
+    round(c, 0xe1)
+    round(c, 0xd2)
+    round(c, 0xc3)
+    round(c, 0xb4)
+    round(c, 0xa5)
+    round(c, 0x96)
+    round(c, 0x87)
+    round(c, 0x78)
+    round(c, 0x69)
+    round(c, 0x5a)
+    round(c, 0x4b)
+}
+
+new() -> {
+    ctx = malloc(64) as *IsapCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.v0 = 0xee9398aadb67f03d
+    ctx.v1 = 0x8bb21831c60f1002
+    ctx.v2 = 0xb48a92db98d5da62
+    ctx.v3 = 0x43189921b8f8e3e8
+    ctx.v4 = 0x348fa5c9d525e140
+    ctx.block_len = 0
+    ctx.block = bytes.new(8)
+    j = 0
+    while j < 8 {
+        bytes.set(ctx.block, j, 0)
+        j = j + 1
+    }
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *IsapCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_be64(c.block, 0)
+            p12(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *IsapCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 8 {
+            c.v0 = c.v0 ^ bytes.get_be64(c.block, 0)
+            p12(c)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+finish_absorbing(c: *IsapCtx) {
+    bytes.set(c.block, c.block_len, 0x80)
+    j = c.block_len + 1
+    while j < 8 {
+        bytes.set(c.block, j, 0)
+        j = j + 1
+    }
+    val = bytes.get_be64(c.block, 0)
+    shift = 56 - (c.block_len << 3)
+    mask = 0xFFFFFFFFFFFFFFFF << shift
+    c.v0 = c.v0 ^ (val & mask)
+}
+
+finalize_to_bytes(c: *IsapCtx) -> ptr {
+    finish_absorbing(c)
+
+    out = bytes.new(32)
+    i = 0
+    while i < 4 {
+        p12(c)
+        bytes.set_be64(out, i * 8, c.v0)
+        i = i + 1
+    }
+    return out
+}
+
+free_internals(c: *IsapCtx) {
+    if c.block != null {
+        bytes.free(c.block)
+        c.block = null
+    }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *IsapCtx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 32)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(32)
+    bytes.copy_from_string(res, 0, s, 32)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *IsapCtx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(64)
+    i = 0
+    while i < 32 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 64)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *IsapCtx
+    free_internals(c)
+    free(ctx)
+}
+
+isap_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+isap_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/photon_beetle/module.ae
+++ b/std/cryptography/photon_beetle/module.ae
@@ -1,0 +1,382 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.photon_beetle — Photon-Beetle Hash in pure Aether,
+// ported from Bouncy Castle's PhotonBeetleDigest.cs. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.photon_beetle
+
+import std.bytes
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    photon_beetle_hex, photon_beetle_bytes
+)
+
+const RC_PB: int[96] = [
+     1,  0,  2,  6, 14, 15, 13,  9,
+     3,  2,  0,  4, 12, 13, 15, 11,
+     7,  6,  4,  0,  8,  9, 11, 15,
+    14, 15, 13,  9,  1,  0,  2,  6,
+    13, 12, 14, 10,  2,  3,  1,  5,
+    11, 10,  8, 12,  4,  5,  7,  3,
+     6,  7,  5,  1,  9,  8, 10, 14,
+    12, 13, 15, 11,  3,  2,  0,  4,
+     9,  8, 10, 14,  6,  7,  5,  1,
+     2,  3,  1,  5, 13, 12, 14, 10,
+     5,  4,  6,  2, 10, 11,  9, 13,
+    10, 11,  9, 13,  5,  4,  6,  2
+]
+
+const MixColMatrix: int[64] = [
+     2,  4,  2, 11,  2,  8,  5,  6,
+    12,  9,  8, 13,  7,  7,  5,  2,
+     4,  4, 13, 13,  9,  4, 13,  9,
+     1,  6,  5,  1, 12, 13, 15, 14,
+    15, 12,  9, 13, 14,  5, 14, 13,
+     9, 14,  5, 15,  4, 12,  9,  6,
+    12,  2,  2, 10,  3,  1,  1, 14,
+    15,  1, 13, 10,  5, 10,  2,  3
+]
+
+const SBOX_PB: int[16] = [ 12, 5, 6, 11, 9, 0, 10, 13, 3, 14, 15, 8, 4, 7, 1, 2 ]
+
+struct PhotonBeetleCtx {
+    state: ptr        // std.bytes, 32 bytes
+    state_2d: ptr     // std.bytes, 64 bytes (8x8)
+    block: ptr        // std.bytes, 16 bytes
+    block_len: int
+    phase: int
+    temp_row: ptr     // std.bytes, 8 bytes
+    temp_mix: ptr     // std.bytes, 8 bytes
+}
+
+new() -> {
+    ctx = malloc(64) as *PhotonBeetleCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.state = bytes.new(32)
+    ctx.state_2d = bytes.new(64)
+    ctx.block = bytes.new(16)
+    ctx.temp_row = bytes.new(8)
+    ctx.temp_mix = bytes.new(8)
+
+    i = 0
+    while i < 32 {
+        bytes.set(ctx.state, i, 0)
+        i = i + 1
+    }
+    i = 0
+    while i < 64 {
+        bytes.set(ctx.state_2d, i, 0)
+        i = i + 1
+    }
+    i = 0
+    while i < 16 {
+        bytes.set(ctx.block, i, 0)
+        i = i + 1
+    }
+    i = 0
+    while i < 8 {
+        bytes.set(ctx.temp_row, i, 0)
+        bytes.set(ctx.temp_mix, i, 0)
+        i = i + 1
+    }
+
+    ctx.block_len = 0
+    ctx.phase = 0
+    return ctx, ""
+}
+
+xor_to(len: int, src: ptr, src_off: int, dest: ptr, dest_off: int) {
+    i = 0
+    while i < len {
+        s_val = bytes.get(src, src_off + i)
+        d_val = bytes.get(dest, dest_off + i)
+        bytes.set(dest, dest_off + i, (d_val ^ s_val) & 255)
+        i = i + 1
+    }
+}
+
+photon_permutation(c: *PhotonBeetleCtx) {
+    D = 8
+    DSquare = 64
+    ROUND = 12
+
+    // Load state into state_2d
+    i = 0
+    while i < DSquare {
+        byte_idx = i >> 1
+        shift = (i & 1) * 4
+        nibble = (bytes.get(c.state, byte_idx) >> shift) & 15
+        bytes.set(c.state_2d, i, nibble)
+        i = i + 1
+    }
+
+    round_idx = 0
+    while round_idx < ROUND {
+        // AddConstant
+        rcOff = round_idx * D
+        i = 0
+        while i < D {
+            val = bytes.get(c.state_2d, i * D)
+            bytes.set(c.state_2d, i * D, (val ^ RC_PB[rcOff + i]) & 15)
+            i = i + 1
+        }
+
+        // SubCells
+        i = 0
+        while i < D {
+            j = 0
+            while j < D {
+                idx = i * D + j
+                val = bytes.get(c.state_2d, idx)
+                bytes.set(c.state_2d, idx, SBOX_PB[val])
+                j = j + 1
+            }
+            i = i + 1
+        }
+
+        // ShiftRows
+        row = 1
+        while row < D {
+            j = 0
+            while j < D {
+                bytes.set(c.temp_row, j, bytes.get(c.state_2d, row * D + j))
+                j = j + 1
+            }
+            j = 0
+            while j < D {
+                target_idx = (j - row + D) % D
+                bytes.set(c.state_2d, row * D + target_idx, bytes.get(c.temp_row, j))
+                j = j + 1
+            }
+            row = row + 1
+        }
+
+        // MixColumnSerial
+        j = 0
+        while j < D {
+            i = 0
+            while i < D {
+                sum = 0
+                k = 0
+                while k < D {
+                    x = MixColMatrix[i * D + k]
+                    b = bytes.get(c.state_2d, k * D + j)
+
+                    sum = sum ^ (x * (b & 1))
+                    sum = sum ^ (x * (b & 2))
+                    sum = sum ^ (x * (b & 4))
+                    sum = sum ^ (x * (b & 8))
+                    k = k + 1
+                }
+
+                t0 = sum >> 4
+                sum = (sum & 15) ^ t0 ^ (t0 << 1)
+
+                t1 = sum >> 4
+                sum = (sum & 15) ^ t1 ^ (t1 << 1)
+
+                bytes.set(c.temp_mix, i, sum & 15)
+                i = i + 1
+            }
+            i = 0
+            while i < D {
+                bytes.set(c.state_2d, i * D + j, bytes.get(c.temp_mix, i))
+                i = i + 1
+            }
+            j = j + 1
+        }
+
+        round_idx = round_idx + 1
+    }
+
+    // Save state_2d back to state
+    i = 0
+    while i < DSquare {
+        byte_idx = i >> 1
+        val_0 = bytes.get(c.state_2d, i) & 15
+        val_1 = bytes.get(c.state_2d, i + 1) & 15
+        bytes.set(c.state, byte_idx, val_0 | (val_1 << 4))
+        i = i + 2
+    }
+}
+
+process_buffer(c: *PhotonBeetleCtx, buf: ptr, pos: int) {
+    if c.phase == 0 {
+        bytes.copy_from_bytes(c.state, 0, buf, pos, 16)
+        c.phase = 1
+    } else {
+        photon_permutation(c)
+        xor_to(4, buf, pos + 0, c.state, 0)
+        photon_permutation(c)
+        xor_to(4, buf, pos + 4, c.state, 0)
+        photon_permutation(c)
+        xor_to(4, buf, pos + 8, c.state, 0)
+        photon_permutation(c)
+        xor_to(4, buf, pos + 12, c.state, 0)
+        c.phase = 2
+    }
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *PhotonBeetleCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 16 {
+            process_buffer(c, c.block, 0)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *PhotonBeetleCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 16 {
+            process_buffer(c, c.block, 0)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+finish_absorbing(c: *PhotonBeetleCtx) {
+    if c.phase == 0 {
+        if c.block_len != 0 {
+            bytes.copy_from_bytes(c.state, 0, c.block, 0, c.block_len)
+            val = bytes.get(c.state, c.block_len)
+            bytes.set(c.state, c.block_len, (val ^ 1) & 255)
+        }
+        val = bytes.get(c.state, 31)
+        bytes.set(c.state, 31, (val ^ (1 << 5)) & 255)
+    } else if c.phase == 1 && c.block_len == 0 {
+        val = bytes.get(c.state, 31)
+        bytes.set(c.state, 31, (val ^ (2 << 5)) & 255)
+    } else {
+        pos = 0
+        limit = c.block_len - 4
+        while pos <= limit {
+            photon_permutation(c)
+            xor_to(4, c.block, pos, c.state, 0)
+            pos = pos + 4
+        }
+        remaining = c.block_len - pos
+        if remaining != 0 {
+            photon_permutation(c)
+            xor_to(remaining, c.block, pos, c.state, 0)
+            val = bytes.get(c.state, remaining)
+            bytes.set(c.state, remaining, (val ^ 1) & 255)
+            val = bytes.get(c.state, 31)
+            bytes.set(c.state, 31, (val ^ (2 << 5)) & 255)
+        } else {
+            val = bytes.get(c.state, 31)
+            bytes.set(c.state, 31, (val ^ (1 << 5)) & 255)
+        }
+    }
+}
+
+finalize_to_bytes(c: *PhotonBeetleCtx) -> ptr {
+    finish_absorbing(c)
+    photon_permutation(c)
+    out = bytes.new(32)
+    bytes.copy_from_bytes(out, 0, c.state, 0, 16)
+    photon_permutation(c)
+    bytes.copy_from_bytes(out, 16, c.state, 0, 16)
+    return out
+}
+
+free_internals(c: *PhotonBeetleCtx) {
+    if c.state != null { bytes.free(c.state); c.state = null }
+    if c.state_2d != null { bytes.free(c.state_2d); c.state_2d = null }
+    if c.block != null { bytes.free(c.block); c.block = null }
+    if c.temp_row != null { bytes.free(c.temp_row); c.temp_row = null }
+    if c.temp_mix != null { bytes.free(c.temp_mix); c.temp_mix = null }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *PhotonBeetleCtx
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, 32)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(32)
+    bytes.copy_from_string(res, 0, s, 32)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *PhotonBeetleCtx
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(64)
+    i = 0
+    while i < 32 {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, 64)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *PhotonBeetleCtx
+    free_internals(c)
+    free(ctx)
+}
+
+photon_beetle_hex(data: string, len: int) -> string {
+    ctx, err = new()
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+photon_beetle_bytes(data: string, len: int) -> ptr {
+    ctx, err = new()
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/std/cryptography/sparkle/module.ae
+++ b/std/cryptography/sparkle/module.ae
@@ -292,12 +292,18 @@ update(ctx: ptr, data: string, length: int) {
     i = 0
     while i < length {
         b = string_char_at_n(data, length, i)
-        bytes.set(c.block, c.block_len, b & 255)
-        c.block_len = c.block_len + 1
+        // Process a FULL buffer only when another byte follows, so the block
+        // that fills the rate exactly is held for finalize (Esch runs its last
+        // data block with big steps + domain separation — see finalize). BC
+        // does the same: Update() processes the buffer BEFORE storing the new
+        // byte. Processing eagerly at block_len==16 hashed one byte short at
+        // every rate multiple.
         if c.block_len == 16 {
             process_block(c, c.block, 0, c.sparkle_steps_slim)
             c.block_len = 0
         }
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
         i = i + 1
     }
 }
@@ -310,12 +316,14 @@ update_bytes(ctx: ptr, data: ptr, length: int) {
     i = 0
     while i < length {
         b = bytes.get(data, i)
-        bytes.set(c.block, c.block_len, b & 255)
-        c.block_len = c.block_len + 1
+        // See update() — process the full buffer only when another byte
+        // follows, holding the rate-filling block for finalize.
         if c.block_len == 16 {
             process_block(c, c.block, 0, c.sparkle_steps_slim)
             c.block_len = 0
         }
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
         i = i + 1
     }
 }

--- a/std/cryptography/sparkle/module.ae
+++ b/std/cryptography/sparkle/module.ae
@@ -1,0 +1,442 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.sparkle — ESCH-256 and ESCH-384 Hash in pure Aether,
+// ported from Bouncy Castle's SparkleDigest.cs / SparkleEngine.cs. NO externs to OpenSSL or any C crypto.
+//
+// Import with:  import std.cryptography.sparkle
+
+import std.bits
+import std.bytes
+import std.longarr
+
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+exports (
+    new, update, update_bytes, final_hex, final_bytes, free_ctx,
+    sparkle_hex, sparkle_bytes
+)
+
+const RCON: long[8] = [
+    0xB7E15162, 0xBF715880, 0x38B4DA56, 0x324E7738,
+    0xBB1185EB, 0x4F7C7B57, 0xCFBFA1C8, 0xC2B3293D
+]
+
+struct SparkleCtx {
+    state: ptr        // longarr(16)
+    block: ptr        // std.bytes, 16 bytes
+    block_len: int
+    digest_bytes: int
+    sparkle_steps_slim: int
+    sparkle_steps_big: int
+    state_words: int
+    algo: string      // "esch-256" or "esch-384"
+}
+
+ell(x: long) -> long {
+    return (bits.rotr32(x & 0xFFFFFFFF, 16) ^ (x & 0xFFFF)) & 0xFFFFFFFF
+}
+
+arx_box(rc: long, s00: long, s01: long) -> (long, long) {
+    s00 = (s00 + bits.rotr32(s01, 31)) & 0xFFFFFFFF
+    s01 = s01 ^ bits.rotr32(s00, 24)
+    s00 = s00 ^ rc
+    s00 = (s00 + bits.rotr32(s01, 17)) & 0xFFFFFFFF
+    s01 = s01 ^ bits.rotr32(s00, 17)
+    s00 = s00 ^ rc
+    s00 = (s00 + s01) & 0xFFFFFFFF
+    s01 = s01 ^ bits.rotr32(s00, 31)
+    s00 = s00 ^ rc
+    s00 = (s00 + bits.rotr32(s01, 24)) & 0xFFFFFFFF
+    s01 = s01 ^ bits.rotr32(s00, 16)
+    s00 = s00 ^ rc
+    return s00, s01
+}
+
+sparkle_opt12(state: ptr, steps: int) {
+    s00 = longarr_get_unchecked(state, 0)
+    s01 = longarr_get_unchecked(state, 1)
+    s02 = longarr_get_unchecked(state, 2)
+    s03 = longarr_get_unchecked(state, 3)
+    s04 = longarr_get_unchecked(state, 4)
+    s05 = longarr_get_unchecked(state, 5)
+    s06 = longarr_get_unchecked(state, 6)
+    s07 = longarr_get_unchecked(state, 7)
+    s08 = longarr_get_unchecked(state, 8)
+    s09 = longarr_get_unchecked(state, 9)
+    s10 = longarr_get_unchecked(state, 10)
+    s11 = longarr_get_unchecked(state, 11)
+
+    step = 0
+    while step < steps {
+        s01 = s01 ^ RCON[step & 7]
+        s03 = s03 ^ step
+
+        s00, s01 = arx_box(RCON[0], s00, s01)
+        s02, s03 = arx_box(RCON[1], s02, s03)
+        s04, s05 = arx_box(RCON[2], s04, s05)
+        s06, s07 = arx_box(RCON[3], s06, s07)
+        s08, s09 = arx_box(RCON[4], s08, s09)
+        s10, s11 = arx_box(RCON[5], s10, s11)
+
+        t024 = ell(s00 ^ s02 ^ s04)
+        t135 = ell(s01 ^ s03 ^ s05)
+
+        u00 = s00 ^ s06
+        u01 = s01 ^ s07
+        u02 = s02 ^ s08
+        u03 = s03 ^ s09
+        u04 = s04 ^ s10
+        u05 = s05 ^ s11
+
+        s06 = s00
+        s07 = s01
+        s08 = s02
+        s09 = s03
+        s10 = s04
+        s11 = s05
+
+        s00 = u02 ^ t135
+        s01 = u03 ^ t024
+        s02 = u04 ^ t135
+        s03 = u05 ^ t024
+        s04 = u00 ^ t135
+        s05 = u01 ^ t024
+
+        step = step + 1
+    }
+
+    longarr_set_unchecked(state, 0, s00)
+    longarr_set_unchecked(state, 1, s01)
+    longarr_set_unchecked(state, 2, s02)
+    longarr_set_unchecked(state, 3, s03)
+    longarr_set_unchecked(state, 4, s04)
+    longarr_set_unchecked(state, 5, s05)
+    longarr_set_unchecked(state, 6, s06)
+    longarr_set_unchecked(state, 7, s07)
+    longarr_set_unchecked(state, 8, s08)
+    longarr_set_unchecked(state, 9, s09)
+    longarr_set_unchecked(state, 10, s10)
+    longarr_set_unchecked(state, 11, s11)
+}
+
+sparkle_opt16(state: ptr, steps: int) {
+    s00 = longarr_get_unchecked(state, 0)
+    s01 = longarr_get_unchecked(state, 1)
+    s02 = longarr_get_unchecked(state, 2)
+    s03 = longarr_get_unchecked(state, 3)
+    s04 = longarr_get_unchecked(state, 4)
+    s05 = longarr_get_unchecked(state, 5)
+    s06 = longarr_get_unchecked(state, 6)
+    s07 = longarr_get_unchecked(state, 7)
+    s08 = longarr_get_unchecked(state, 8)
+    s09 = longarr_get_unchecked(state, 9)
+    s10 = longarr_get_unchecked(state, 10)
+    s11 = longarr_get_unchecked(state, 11)
+    s12 = longarr_get_unchecked(state, 12)
+    s13 = longarr_get_unchecked(state, 13)
+    s14 = longarr_get_unchecked(state, 14)
+    s15 = longarr_get_unchecked(state, 15)
+
+    step = 0
+    while step < steps {
+        // STEP 1
+        s01 = s01 ^ RCON[step & 7]
+        s03 = s03 ^ step
+        step = step + 1
+
+        s00, s01 = arx_box(RCON[0], s00, s01)
+        s02, s03 = arx_box(RCON[1], s02, s03)
+        s04, s05 = arx_box(RCON[2], s04, s05)
+        s06, s07 = arx_box(RCON[3], s06, s07)
+        s08, s09 = arx_box(RCON[4], s08, s09)
+        s10, s11 = arx_box(RCON[5], s10, s11)
+        s12, s13 = arx_box(RCON[6], s12, s13)
+        s14, s15 = arx_box(RCON[7], s14, s15)
+
+        t0246 = ell(s00 ^ s02 ^ s04 ^ s06)
+        t1357 = ell(s01 ^ s03 ^ s05 ^ s07)
+
+        u08 = s08
+        u09 = s09
+
+        s08 = s02 ^ s10 ^ t1357
+        s09 = s03 ^ s11 ^ t0246
+        s10 = s04 ^ s12 ^ t1357
+        s11 = s05 ^ s13 ^ t0246
+        s12 = s06 ^ s14 ^ t1357
+        s13 = s07 ^ s15 ^ t0246
+        s14 = s00 ^ u08 ^ t1357
+        s15 = s01 ^ u09 ^ t0246
+
+        // STEP 2
+        s09 = s09 ^ RCON[step & 7]
+        s11 = s11 ^ step
+        step = step + 1
+
+        s08, s09 = arx_box(RCON[0], s08, s09)
+        s10, s11 = arx_box(RCON[1], s10, s11)
+        s12, s13 = arx_box(RCON[2], s12, s13)
+        s14, s15 = arx_box(RCON[3], s14, s15)
+        s00, s01 = arx_box(RCON[4], s00, s01)
+        s02, s03 = arx_box(RCON[5], s02, s03)
+        s04, s05 = arx_box(RCON[6], s04, s05)
+        s06, s07 = arx_box(RCON[7], s06, s07)
+
+        t8ACE = ell(s08 ^ s10 ^ s12 ^ s14)
+        t9BDF = ell(s09 ^ s11 ^ s13 ^ s15)
+
+        u00 = s00
+        u01 = s01
+
+        s00 = s02 ^ s10 ^ t9BDF
+        s01 = s03 ^ s11 ^ t8ACE
+        s02 = s04 ^ s12 ^ t9BDF
+        s03 = s05 ^ s13 ^ t8ACE
+        s04 = s06 ^ s14 ^ t9BDF
+        s05 = s07 ^ s15 ^ t8ACE
+        s06 = u00 ^ s08 ^ t9BDF
+        s07 = u01 ^ s09 ^ t8ACE
+    }
+
+    longarr_set_unchecked(state, 0, s00)
+    longarr_set_unchecked(state, 1, s01)
+    longarr_set_unchecked(state, 2, s02)
+    longarr_set_unchecked(state, 3, s03)
+    longarr_set_unchecked(state, 4, s04)
+    longarr_set_unchecked(state, 5, s05)
+    longarr_set_unchecked(state, 6, s06)
+    longarr_set_unchecked(state, 7, s07)
+    longarr_set_unchecked(state, 8, s08)
+    longarr_set_unchecked(state, 9, s09)
+    longarr_set_unchecked(state, 10, s10)
+    longarr_set_unchecked(state, 11, s11)
+    longarr_set_unchecked(state, 12, s12)
+    longarr_set_unchecked(state, 13, s13)
+    longarr_set_unchecked(state, 14, s14)
+    longarr_set_unchecked(state, 15, s15)
+}
+
+process_block(c: *SparkleCtx, buf: ptr, off: int, steps: int) {
+    t0 = bytes.get_le32(buf, off)
+    t1 = bytes.get_le32(buf, off + 4)
+    t2 = bytes.get_le32(buf, off + 8)
+    t3 = bytes.get_le32(buf, off + 12)
+
+    tx = ell(t0 ^ t2)
+    ty = ell(t1 ^ t3)
+
+    longarr_set_unchecked(c.state, 0, longarr_get_unchecked(c.state, 0) ^ t0 ^ ty)
+    longarr_set_unchecked(c.state, 1, longarr_get_unchecked(c.state, 1) ^ t1 ^ tx)
+    longarr_set_unchecked(c.state, 2, longarr_get_unchecked(c.state, 2) ^ t2 ^ ty)
+    longarr_set_unchecked(c.state, 3, longarr_get_unchecked(c.state, 3) ^ t3 ^ tx)
+    longarr_set_unchecked(c.state, 4, longarr_get_unchecked(c.state, 4) ^ ty)
+    longarr_set_unchecked(c.state, 5, longarr_get_unchecked(c.state, 5) ^ tx)
+
+    if c.state_words == 16 {
+        longarr_set_unchecked(c.state, 6, longarr_get_unchecked(c.state, 6) ^ ty)
+        longarr_set_unchecked(c.state, 7, longarr_get_unchecked(c.state, 7) ^ tx)
+        sparkle_opt16(c.state, steps)
+    } else {
+        sparkle_opt12(c.state, steps)
+    }
+}
+
+new(algo: string) -> {
+    ctx = malloc(64) as *SparkleCtx
+    if ctx == null {
+        return null, "allocation failed"
+    }
+    ctx.algo = algo
+    if algo == "esch-256" {
+        ctx.digest_bytes = 32
+        ctx.sparkle_steps_slim = 7
+        ctx.sparkle_steps_big = 11
+        ctx.state_words = 12
+    } else if algo == "esch-384" {
+        ctx.digest_bytes = 48
+        ctx.sparkle_steps_slim = 8
+        ctx.sparkle_steps_big = 12
+        ctx.state_words = 16
+    } else {
+        free(ctx)
+        return null, "unknown algorithm"
+    }
+
+    ctx.state = longarr_new_raw(16)
+    ctx.block = bytes.new(16)
+    ctx.block_len = 0
+
+    i = 0
+    while i < 16 {
+        longarr_set_unchecked(ctx.state, i, 0)
+        i = i + 1
+    }
+    i = 0
+    while i < 16 {
+        bytes.set(ctx.block, i, 0)
+        i = i + 1
+    }
+
+    return ctx, ""
+}
+
+update(ctx: ptr, data: string, length: int) {
+    c = ctx as *SparkleCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = string_char_at_n(data, length, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 16 {
+            process_block(c, c.block, 0, c.sparkle_steps_slim)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+update_bytes(ctx: ptr, data: ptr, length: int) {
+    c = ctx as *SparkleCtx
+    if length <= 0 {
+        return
+    }
+    i = 0
+    while i < length {
+        b = bytes.get(data, i)
+        bytes.set(c.block, c.block_len, b & 255)
+        c.block_len = c.block_len + 1
+        if c.block_len == 16 {
+            process_block(c, c.block, 0, c.sparkle_steps_slim)
+            c.block_len = 0
+        }
+        i = i + 1
+    }
+}
+
+finalize_to_bytes(c: *SparkleCtx) -> ptr {
+    idx = (c.state_words >> 1) - 1
+    if c.block_len < 16 {
+        longarr_set_unchecked(c.state, idx, longarr_get_unchecked(c.state, idx) ^ (1 << 24))
+        bytes.set(c.block, c.block_len, 0x80)
+        c.block_len = c.block_len + 1
+        while c.block_len < 16 {
+            bytes.set(c.block, c.block_len, 0x00)
+            c.block_len = c.block_len + 1
+        }
+    } else {
+        longarr_set_unchecked(c.state, idx, longarr_get_unchecked(c.state, idx) ^ (1 << 25))
+    }
+
+    process_block(c, c.block, 0, c.sparkle_steps_big)
+
+    out = bytes.new(c.digest_bytes)
+    i = 0
+    while i < 4 {
+        bytes.set_le32(out, i * 4, longarr_get_unchecked(c.state, i) & 0xFFFFFFFF)
+        i = i + 1
+    }
+
+    if c.state_words == 16 {
+        sparkle_opt16(c.state, c.sparkle_steps_slim)
+        i = 0
+        while i < 4 {
+            bytes.set_le32(out, 16 + i * 4, longarr_get_unchecked(c.state, i) & 0xFFFFFFFF)
+            i = i + 1
+        }
+        sparkle_opt16(c.state, c.sparkle_steps_slim)
+        i = 0
+        while i < 4 {
+            bytes.set_le32(out, 32 + i * 4, longarr_get_unchecked(c.state, i) & 0xFFFFFFFF)
+            i = i + 1
+        }
+    } else {
+        sparkle_opt12(c.state, c.sparkle_steps_slim)
+        i = 0
+        while i < 4 {
+            bytes.set_le32(out, 16 + i * 4, longarr_get_unchecked(c.state, i) & 0xFFFFFFFF)
+            i = i + 1
+        }
+    }
+
+    return out
+}
+
+free_internals(c: *SparkleCtx) {
+    if c.state != null { longarr_free(c.state); c.state = null }
+    if c.block != null { bytes.free(c.block); c.block = null }
+}
+
+final_bytes(ctx: ptr) -> ptr {
+    c = ctx as *SparkleCtx
+    n = c.digest_bytes
+    out = finalize_to_bytes(c)
+    s = bytes.finish(out, n)
+    free_internals(c)
+    free(ctx)
+    res = bytes.new(n)
+    bytes.copy_from_string(res, 0, s, n)
+    return res
+}
+
+final_hex(ctx: ptr) -> string {
+    c = ctx as *SparkleCtx
+    n = c.digest_bytes
+    out = finalize_to_bytes(c)
+    hexbuf = bytes.new(n * 2)
+    i = 0
+    while i < n {
+        b = bytes.get(out, i)
+        hi = (b >> 4) & 15
+        lo = b & 15
+        c_hi = 48 + hi
+        if hi >= 10 {
+            c_hi = 87 + hi
+        }
+        c_lo = 48 + lo
+        if lo >= 10 {
+            c_lo = 87 + lo
+        }
+        bytes.set(hexbuf, i * 2, c_hi)
+        bytes.set(hexbuf, i * 2 + 1, c_lo)
+        i = i + 1
+    }
+    bytes.free(out)
+    s = bytes.finish(hexbuf, n * 2)
+    free_internals(c)
+    free(ctx)
+    return s
+}
+
+free_ctx(ctx: ptr) {
+    if ctx == null {
+        return
+    }
+    c = ctx as *SparkleCtx
+    free_internals(c)
+    free(ctx)
+}
+
+sparkle_hex(algo: string, data: string, len: int) -> string {
+    ctx, err = new(algo)
+    if err != "" {
+        return ""
+    }
+    update(ctx, data, len)
+    return final_hex(ctx)
+}
+
+sparkle_bytes(algo: string, data: string, len: int) -> ptr {
+    ctx, err = new(algo)
+    if err != "" {
+        return null
+    }
+    update(ctx, data, len)
+    return final_bytes(ctx)
+}

--- a/tests/integration/crypto_ascon_xof128/test_crypto_ascon_xof128.ae
+++ b/tests/integration/crypto_ascon_xof128/test_crypto_ascon_xof128.ae
@@ -1,0 +1,97 @@
+import std.cryptography.ascon_xof128
+import std.bytes
+import std.string
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+hex_to_bytes(hex: string) -> ptr {
+    len = string.length(hex)
+    n = len / 2
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        c_hi = string.char_at(hex, i * 2)
+        c_lo = string.char_at(hex, i * 2 + 1)
+
+        hi = 0
+        if c_hi >= 48 && c_hi <= 57 {
+            hi = c_hi - 48
+        } else if c_hi >= 97 && c_hi <= 102 {
+            hi = c_hi - 87
+        } else if c_hi >= 65 && c_hi <= 70 {
+            hi = c_hi - 55
+        }
+
+        lo = 0
+        if c_lo >= 48 && c_lo <= 57 {
+            lo = c_lo - 48
+        } else if c_lo >= 97 && c_lo <= 102 {
+            lo = c_lo - 87
+        } else if c_lo >= 65 && c_lo <= 70 {
+            lo = c_lo - 55
+        }
+
+        val = (hi << 4) | lo
+        bytes.set(b, i, val)
+        i = i + 1
+    }
+    return b
+}
+
+main() {
+    fails = 0
+
+    // Ascon-XOF128 test vectors from LWC_XOF_KAT_128_512.txt (64 bytes / 512 bits)
+    fails = fails + check("empty",
+        ascon_xof128.ascon_xof128_hex("", 0, 64),
+        "473d5e6164f58b39dfd84aacdb8ae42ec2d91fed33388ee0d960d9b3993295c6ad77855a5d3b13fe6ad9e6098988373af7d0956d05a8f1665d2c67d1a3ad10ff")
+
+    // Msg = 00
+    b_00 = hex_to_bytes("00")
+    defer bytes.free(b_00)
+    ctx, _ = ascon_xof128.new()
+    ascon_xof128.update_bytes(ctx, b_00, 1)
+    res_00 = ascon_xof128.final_hex(ctx, 64)
+    fails = fails + check("00", res_00, "51430e0438ecdf642b393630d977625f5f337656ba58ab1e960784ac32a16e0d446405551f5469384f8ea283cf12e64fa72c426bfebaea3aa1529e2c4ab23a2f")
+
+    // Msg = 0001
+    b_0001 = hex_to_bytes("0001")
+    defer bytes.free(b_0001)
+    ctx2, _ = ascon_xof128.new()
+    ascon_xof128.update_bytes(ctx2, b_0001, 2)
+    res_0001 = ascon_xof128.final_hex(ctx2, 64)
+    fails = fails + check("0001", res_0001, "a05383077af971d3830bd37e7b981497a773d441db077c6494cc73125953846eb6427fba4cd308ff90a11385d51101341bf5379249217bfdace9cca1148cc966")
+
+    // Msg = 000102
+    b_000102 = hex_to_bytes("000102")
+    defer bytes.free(b_000102)
+    ctx3, _ = ascon_xof128.new()
+    ascon_xof128.update_bytes(ctx3, b_000102, 3)
+    res_000102 = ascon_xof128.final_hex(ctx3, 64)
+    fails = fails + check("000102", res_000102, "9c96f31c3e7bdfdc5ef6ba836f760a0d6548d94dd0a512033022c9242e8ba916c30c3961d37d7dd7282e2191494d60dc5058588b276c60c90be2aaa7e7013d96")
+
+    // Msg = 00010203
+    b_00010203 = hex_to_bytes("00010203")
+    defer bytes.free(b_00010203)
+    ctx4, _ = ascon_xof128.new()
+    ascon_xof128.update_bytes(ctx4, b_00010203, 4)
+    res_00010203 = ascon_xof128.final_hex(ctx4, 64)
+    fails = fails + check("00010203", res_00010203, "21f7fd74588e244af45f9016b8db19b857ec5e6208978cfc1b4611ed91fb38f87e8f82a6409fb2b77acfbba8862aa22a7b0c98c1c01d5a4fdf64827b450fa1eb")
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}

--- a/tests/integration/crypto_ascon_xof128/test_crypto_ascon_xof128.ae
+++ b/tests/integration/crypto_ascon_xof128/test_crypto_ascon_xof128.ae
@@ -51,7 +51,13 @@ hex_to_bytes(hex: string) -> ptr {
 main() {
     fails = 0
 
-    // Ascon-XOF128 test vectors from LWC_XOF_KAT_128_512.txt (64 bytes / 512 bits)
+    // Ascon-XOF128 (NIST SP 800-232). Provenance note: Bouncy Castle's own
+    // XOF128 KAT (crypto/ascon/asconxof128/LWC_XOF_KAT_128_512.txt) is ABSENT
+    // from the upstream checkout, so these 64-byte/512-bit vectors are pinned
+    // to the SP 800-232 / ascon-c reference output. The port's IV matches BC's
+    // AsconXof128 post-P12 state exactly (0xda82ce768d9447eb...), and the
+    // variable-length + streaming-split checks below guard the squeeze/absorb
+    // paths independently of the pinned constants.
     fails = fails + check("empty",
         ascon_xof128.ascon_xof128_hex("", 0, 64),
         "473d5e6164f58b39dfd84aacdb8ae42ec2d91fed33388ee0d960d9b3993295c6ad77855a5d3b13fe6ad9e6098988373af7d0956d05a8f1665d2c67d1a3ad10ff")
@@ -87,6 +93,25 @@ main() {
     ascon_xof128.update_bytes(ctx4, b_00010203, 4)
     res_00010203 = ascon_xof128.final_hex(ctx4, 64)
     fails = fails + check("00010203", res_00010203, "21f7fd74588e244af45f9016b8db19b857ec5e6208978cfc1b4611ed91fb38f87e8f82a6409fb2b77acfbba8862aa22a7b0c98c1c01d5a4fdf64827b450fa1eb")
+
+    // Variable-length XOF property: a 32-byte squeeze must be the exact prefix
+    // of a 64-byte squeeze of the same input. This validates the squeeze path
+    // for a non-32 length independently of any pinned KAT.
+    x32 = ascon_xof128.ascon_xof128_hex("", 0, 32)
+    x64prefix = string.substring(
+        ascon_xof128.ascon_xof128_hex("", 0, 64), 0, 64)
+    fails = fails + check("XOF 32B is prefix of 64B", x32, x64prefix)
+
+    // Multi-part streaming: input 00010203 fed as {00} then {01,02,03} must
+    // equal the one-shot digest — proves multi-block absorption.
+    tail3 = hex_to_bytes("010203")
+    defer bytes.free(tail3)
+    ctx_sp, _ = ascon_xof128.new()
+    ascon_xof128.update_bytes(ctx_sp, b_00, 1)
+    ascon_xof128.update_bytes(ctx_sp, tail3, 3)
+    fails = fails + check("00010203 split 1+3",
+        ascon_xof128.final_hex(ctx_sp, 64),
+        "21f7fd74588e244af45f9016b8db19b857ec5e6208978cfc1b4611ed91fb38f87e8f82a6409fb2b77acfbba8862aa22a7b0c98c1c01d5a4fdf64827b450fa1eb")
 
     if fails == 0 {
         println("ALL PASS")

--- a/tests/integration/crypto_dstu7564/test_crypto_dstu7564.ae
+++ b/tests/integration/crypto_dstu7564/test_crypto_dstu7564.ae
@@ -1,0 +1,82 @@
+import std.cryptography.dstu7564
+import std.bytes
+import std.string
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+hex_to_bytes(hex: string) -> ptr {
+    len = string.length(hex)
+    n = len / 2
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        c_hi = string.char_at(hex, i * 2)
+        c_lo = string.char_at(hex, i * 2 + 1)
+
+        hi = 0
+        if c_hi >= 48 && c_hi <= 57 {
+            hi = c_hi - 48
+        } else if c_hi >= 97 && c_hi <= 102 {
+            hi = c_hi - 87
+        } else if c_hi >= 65 && c_hi <= 70 {
+            hi = c_hi - 55
+        }
+
+        lo = 0
+        if c_lo >= 48 && c_lo <= 57 {
+            lo = c_lo - 48
+        } else if c_lo >= 97 && c_lo <= 102 {
+            lo = c_lo - 87
+        } else if c_lo >= 65 && c_lo <= 70 {
+            lo = c_lo - 55
+        }
+
+        val = (hi << 4) | lo
+        bytes.set(b, i, val)
+        i = i + 1
+    }
+    return b
+}
+
+main() {
+    fails = 0
+
+    // ---- dstu7564-256 ----
+    fails = fails + check("dstu7564-256 empty",
+        dstu7564.dstu7564_hex("dstu7564-256", "", 0),
+        "cd5101d1ccdf0d1d1f4ada56e888cd724ca1a0838a3521e7131d4fb78d0f5eb6")
+
+    b_ff = hex_to_bytes("ff")
+    defer bytes.free(b_ff)
+    ctx, _ = dstu7564.new("dstu7564-256")
+    dstu7564.update_bytes(ctx, b_ff, 1)
+    res_ff = dstu7564.final_hex(ctx)
+    fails = fails + check("dstu7564-256 ff", res_ff, "ea7677ca4526555680441c117982ea14059ea6d0d7124d6ecdb3deec49e890f4")
+
+    // ---- dstu7564-512 ----
+    fails = fails + check("dstu7564-512 empty",
+        dstu7564.dstu7564_hex("dstu7564-512", "", 0),
+        "656b2f4cd71462388b64a37043ea55dbe445d452aecd46c3298343314ef04019bcfa3f04265a9857f91be91fce197096187ceda78c9c1c021c294a0689198538")
+
+    ctx2, _ = dstu7564.new("dstu7564-512")
+    dstu7564.update_bytes(ctx2, b_ff, 1)
+    res2_ff = dstu7564.final_hex(ctx2)
+    fails = fails + check("dstu7564-512 ff", res2_ff, "871b18cf754b72740307a97b449abeb32b64444cc0d5a4d65830ae5456837a72d8458f12c8f06c98c616abe11897f86263b5cb77c420fb375374bec52b6d0292")
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}

--- a/tests/integration/crypto_dstu7564/test_crypto_dstu7564.ae
+++ b/tests/integration/crypto_dstu7564/test_crypto_dstu7564.ae
@@ -48,30 +48,96 @@ hex_to_bytes(hex: string) -> ptr {
     return b
 }
 
+// A buffer of `n` incrementing bytes 0x00,0x01,... (mod 256) — BC's
+// hash256/384/512 vectors use these fixed-length sequences.
+incrementing(n: int) -> ptr {
+    b = bytes.new(n)
+    i = 0
+    while i < n { bytes.set(b, i, i & 255); i = i + 1 }
+    return b
+}
+
+// One-shot digest of a byte buffer (the *_hex string wrapper only takes a
+// string, so drive the streaming API for binary inputs).
+digest_bytes(algo: string, b: ptr, n: int) -> string {
+    ctx, _ = dstu7564.new(algo)
+    dstu7564.update_bytes(ctx, b, n)
+    return dstu7564.final_hex(ctx)
+}
+
 main() {
     fails = 0
 
-    // ---- dstu7564-256 ----
+    b_ff = hex_to_bytes("ff")
+    defer bytes.free(b_ff)
+
+    // ---- dstu7564-256 (DSTU 7564:2014 / BC Dstu7564Test vectors) ----
     fails = fails + check("dstu7564-256 empty",
         dstu7564.dstu7564_hex("dstu7564-256", "", 0),
         "cd5101d1ccdf0d1d1f4ada56e888cd724ca1a0838a3521e7131d4fb78d0f5eb6")
 
-    b_ff = hex_to_bytes("ff")
-    defer bytes.free(b_ff)
-    ctx, _ = dstu7564.new("dstu7564-256")
-    dstu7564.update_bytes(ctx, b_ff, 1)
-    res_ff = dstu7564.final_hex(ctx)
-    fails = fails + check("dstu7564-256 ff", res_ff, "ea7677ca4526555680441c117982ea14059ea6d0d7124d6ecdb3deec49e890f4")
+    fails = fails + check("dstu7564-256 ff",
+        digest_bytes("dstu7564-256", b_ff, 1),
+        "ea7677ca4526555680441c117982ea14059ea6d0d7124d6ecdb3deec49e890f4")
+
+    b64 = incrementing(64)
+    fails = fails + check("dstu7564-256 64B(0x00..0x3F)",
+        digest_bytes("dstu7564-256", b64, 64),
+        "08f4ee6f1be6903b324c4e27990cb24ef69dd58dbe84813ee0a52f6631239875")
+
+    b128 = incrementing(128)
+    fails = fails + check("dstu7564-256 128B(0x00..0x7F)",
+        digest_bytes("dstu7564-256", b128, 128),
+        "0a9474e645a7d25e255e9e89fff42ec7eb31349007059284f0b182e452bda882")
+
+    b256 = incrementing(256)
+    fails = fails + check("dstu7564-256 256B(0x00..0xFF)",
+        digest_bytes("dstu7564-256", b256, 256),
+        "d305a32b963d149dc765f68594505d4077024f836c1bf03806e1624ce176c08f")
+
+    // ---- dstu7564-384 (was previously untested; BC's 95-byte vector) ----
+    b95 = incrementing(95)
+    fails = fails + check("dstu7564-384 95B(0x00..0x5E)",
+        digest_bytes("dstu7564-384", b95, 95),
+        "d9021692d84e5175735654846ba751e6d0ed0fac36dfbc0841287dcb0b5584c75016c3decc2a6e47c50b2f3811e351b8")
+    bytes.free(b95)
 
     // ---- dstu7564-512 ----
     fails = fails + check("dstu7564-512 empty",
         dstu7564.dstu7564_hex("dstu7564-512", "", 0),
         "656b2f4cd71462388b64a37043ea55dbe445d452aecd46c3298343314ef04019bcfa3f04265a9857f91be91fce197096187ceda78c9c1c021c294a0689198538")
 
-    ctx2, _ = dstu7564.new("dstu7564-512")
-    dstu7564.update_bytes(ctx2, b_ff, 1)
-    res2_ff = dstu7564.final_hex(ctx2)
-    fails = fails + check("dstu7564-512 ff", res2_ff, "871b18cf754b72740307a97b449abeb32b64444cc0d5a4d65830ae5456837a72d8458f12c8f06c98c616abe11897f86263b5cb77c420fb375374bec52b6d0292")
+    fails = fails + check("dstu7564-512 ff",
+        digest_bytes("dstu7564-512", b_ff, 1),
+        "871b18cf754b72740307a97b449abeb32b64444cc0d5a4d65830ae5456837a72d8458f12c8f06c98c616abe11897f86263b5cb77c420fb375374bec52b6d0292")
+
+    fails = fails + check("dstu7564-512 64B(0x00..0x3F)",
+        digest_bytes("dstu7564-512", b64, 64),
+        "3813e2109118cdfb5a6d5e72f7208dccc80a2dfb3afdfb02f46992b5edbe536b3560dd1d7e29c6f53978af58b444e37ba685c0dd910533ba5d78efffc13de62a")
+
+    fails = fails + check("dstu7564-512 256B(0x00..0xFF)",
+        digest_bytes("dstu7564-512", b256, 256),
+        "0dd03d7350c409cb3c29c25893a0724f6b133fa8b9eb90a64d1a8fa93b56556611eb187d715a956b107e3bfc76482298133a9ce8cbc0bd5e1436a5b197284f7e")
+
+    // Multi-part streaming across the 64-byte (256) / 128-byte (512) block
+    // boundary must equal the one-shot digest.
+    ctx_s, _ = dstu7564.new("dstu7564-256")
+    dstu7564.update_bytes(ctx_s, b128, 40)
+    b128_tail = incrementing(128)
+    k = 40
+    while k < 128 {
+        bytes.set(b128_tail, k - 40, k & 255)
+        k = k + 1
+    }
+    dstu7564.update_bytes(ctx_s, b128_tail, 88)
+    fails = fails + check("dstu7564-256 128B split-streaming",
+        dstu7564.final_hex(ctx_s),
+        "0a9474e645a7d25e255e9e89fff42ec7eb31349007059284f0b182e452bda882")
+    bytes.free(b128_tail)
+
+    bytes.free(b64)
+    bytes.free(b128)
+    bytes.free(b256)
 
     if fails == 0 {
         println("ALL PASS")

--- a/tests/integration/crypto_isap/test_crypto_isap.ae
+++ b/tests/integration/crypto_isap/test_crypto_isap.ae
@@ -88,6 +88,37 @@ main() {
     res_00010203 = isap.final_hex(ctx4)
     fails = fails + check("00010203", res_00010203, "8013eaaa1951580a7bef7d29bac323377e64f279ea73e6881b8aed69855ef764")
 
+    // Rate-boundary vectors (ISAP absorbs an 8-byte / 64-bit rate). 8 bytes is
+    // exactly one rate block; 16 bytes is two. BC LWC_HASH_KAT counts 9 and 17.
+    inc8 = bytes.new(8)
+    j = 0
+    while j < 8 { bytes.set(inc8, j, j); j = j + 1 }
+    defer bytes.free(inc8)
+    ctx8, _ = isap.new()
+    isap.update_bytes(ctx8, inc8, 8)
+    fails = fails + check("8B(exact rate)", isap.final_hex(ctx8),
+        "f4c6a44b29915d3d57cf928a18ec6226bb8dd6c1136acd24965f7e7780cd69cf")
+
+    inc16 = bytes.new(16)
+    j = 0
+    while j < 16 { bytes.set(inc16, j, j); j = j + 1 }
+    defer bytes.free(inc16)
+    ctx16, _ = isap.new()
+    isap.update_bytes(ctx16, inc16, 16)
+    fails = fails + check("16B(2x rate)", isap.final_hex(ctx16),
+        "d4e56c4841e2a0069d4f07e61b2dca94fd6d3f9c0df78393e6e8292921bc841d")
+
+    // Multi-part streaming across the rate: 8 bytes fed 3+5.
+    ctx_sp, _ = isap.new()
+    isap.update_bytes(ctx_sp, inc8, 3)
+    tail5 = bytes.new(5)
+    k = 3
+    while k < 8 { bytes.set(tail5, k - 3, k); k = k + 1 }
+    defer bytes.free(tail5)
+    isap.update_bytes(ctx_sp, tail5, 5)
+    fails = fails + check("8B split 3+5", isap.final_hex(ctx_sp),
+        "f4c6a44b29915d3d57cf928a18ec6226bb8dd6c1136acd24965f7e7780cd69cf")
+
     if fails == 0 {
         println("ALL PASS")
         return

--- a/tests/integration/crypto_isap/test_crypto_isap.ae
+++ b/tests/integration/crypto_isap/test_crypto_isap.ae
@@ -1,0 +1,97 @@
+import std.cryptography.isap
+import std.bytes
+import std.string
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+hex_to_bytes(hex: string) -> ptr {
+    len = string.length(hex)
+    n = len / 2
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        c_hi = string.char_at(hex, i * 2)
+        c_lo = string.char_at(hex, i * 2 + 1)
+
+        hi = 0
+        if c_hi >= 48 && c_hi <= 57 {
+            hi = c_hi - 48
+        } else if c_hi >= 97 && c_hi <= 102 {
+            hi = c_hi - 87
+        } else if c_hi >= 65 && c_hi <= 70 {
+            hi = c_hi - 55
+        }
+
+        lo = 0
+        if c_lo >= 48 && c_lo <= 57 {
+            lo = c_lo - 48
+        } else if c_lo >= 97 && c_lo <= 102 {
+            lo = c_lo - 87
+        } else if c_lo >= 65 && c_lo <= 70 {
+            lo = c_lo - 55
+        }
+
+        val = (hi << 4) | lo
+        bytes.set(b, i, val)
+        i = i + 1
+    }
+    return b
+}
+
+main() {
+    fails = 0
+
+    // ISAP Hash test vectors from LWC_HASH_KAT_256.txt
+    fails = fails + check("empty",
+        isap.isap_hex("", 0),
+        "7346bc14f036e87ae03d0997913088f5f68411434b3cf8b54fa796a80d251f91")
+
+    // Msg = 00
+    b_00 = hex_to_bytes("00")
+    defer bytes.free(b_00)
+    ctx, _ = isap.new()
+    isap.update_bytes(ctx, b_00, 1)
+    res_00 = isap.final_hex(ctx)
+    fails = fails + check("00", res_00, "8dd446ada58a7740ecf56eb638ef775f7d5c0fd5f0c2bbbdfdec29609d3c43a2")
+
+    // Msg = 0001
+    b_0001 = hex_to_bytes("0001")
+    defer bytes.free(b_0001)
+    ctx2, _ = isap.new()
+    isap.update_bytes(ctx2, b_0001, 2)
+    res_0001 = isap.final_hex(ctx2)
+    fails = fails + check("0001", res_0001, "f77ca13bf89146d3254f1cfb7eddba8fa1bf162284bb29e7f645545cf9e08424")
+
+    // Msg = 000102
+    b_000102 = hex_to_bytes("000102")
+    defer bytes.free(b_000102)
+    ctx3, _ = isap.new()
+    isap.update_bytes(ctx3, b_000102, 3)
+    res_000102 = isap.final_hex(ctx3)
+    fails = fails + check("000102", res_000102, "15ccf3b00f73ef96faa08c9b440660bea52d6f6aa53c8e2da3f8200a990a122f")
+
+    // Msg = 00010203
+    b_00010203 = hex_to_bytes("00010203")
+    defer bytes.free(b_00010203)
+    ctx4, _ = isap.new()
+    isap.update_bytes(ctx4, b_00010203, 4)
+    res_00010203 = isap.final_hex(ctx4)
+    fails = fails + check("00010203", res_00010203, "8013eaaa1951580a7bef7d29bac323377e64f279ea73e6881b8aed69855ef764")
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}

--- a/tests/integration/crypto_photon_beetle/test_crypto_photon_beetle.ae
+++ b/tests/integration/crypto_photon_beetle/test_crypto_photon_beetle.ae
@@ -1,0 +1,97 @@
+import std.cryptography.photon_beetle
+import std.bytes
+import std.string
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+hex_to_bytes(hex: string) -> ptr {
+    len = string.length(hex)
+    n = len / 2
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        c_hi = string.char_at(hex, i * 2)
+        c_lo = string.char_at(hex, i * 2 + 1)
+
+        hi = 0
+        if c_hi >= 48 && c_hi <= 57 {
+            hi = c_hi - 48
+        } else if c_hi >= 97 && c_hi <= 102 {
+            hi = c_hi - 87
+        } else if c_hi >= 65 && c_hi <= 70 {
+            hi = c_hi - 55
+        }
+
+        lo = 0
+        if c_lo >= 48 && c_lo <= 57 {
+            lo = c_lo - 48
+        } else if c_lo >= 97 && c_lo <= 102 {
+            lo = c_lo - 87
+        } else if c_lo >= 65 && c_lo <= 70 {
+            lo = c_lo - 55
+        }
+
+        val = (hi << 4) | lo
+        bytes.set(b, i, val)
+        i = i + 1
+    }
+    return b
+}
+
+main() {
+    fails = 0
+
+    // Photon-Beetle Hash test vectors from LWC_HASH_KAT_256.txt
+    fails = fails + check("empty",
+        photon_beetle.photon_beetle_hex("", 0),
+        "44a99882fea033566856a27e7f0c94dc84fac7e411b08b890a4a574e3db75d4a")
+
+    // Msg = 00
+    b_00 = hex_to_bytes("00")
+    defer bytes.free(b_00)
+    ctx, _ = photon_beetle.new()
+    photon_beetle.update_bytes(ctx, b_00, 1)
+    res_00 = photon_beetle.final_hex(ctx)
+    fails = fails + check("00", res_00, "f165ccd18640b9703e96f1bd9a4a4ee32dd4031e4680a1b9890891dcc63468a7")
+
+    // Msg = 0001
+    b_0001 = hex_to_bytes("0001")
+    defer bytes.free(b_0001)
+    ctx2, _ = photon_beetle.new()
+    photon_beetle.update_bytes(ctx2, b_0001, 2)
+    res_0001 = photon_beetle.final_hex(ctx2)
+    fails = fails + check("0001", res_0001, "2ef2d38f71e77928df37fba337872b639f7748556c1a081821b9b8460ac68fac")
+
+    // Msg = 000102
+    b_000102 = hex_to_bytes("000102")
+    defer bytes.free(b_000102)
+    ctx3, _ = photon_beetle.new()
+    photon_beetle.update_bytes(ctx3, b_000102, 3)
+    res_000102 = photon_beetle.final_hex(ctx3)
+    fails = fails + check("000102", res_000102, "f9a8c467209e7b5f32db28bde50d5210a81a9c6aa9c1686a05c3619cbf44061d")
+
+    // Msg = 00010203
+    b_00010203 = hex_to_bytes("00010203")
+    defer bytes.free(b_00010203)
+    ctx4, _ = photon_beetle.new()
+    photon_beetle.update_bytes(ctx4, b_00010203, 4)
+    res_00010203 = photon_beetle.final_hex(ctx4)
+    fails = fails + check("00010203", res_00010203, "efab98a1ffeb6f9e832db6fa7fc6bff670895f8a2abe987cd962e93b0127ec3c")
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}

--- a/tests/integration/crypto_photon_beetle/test_crypto_photon_beetle.ae
+++ b/tests/integration/crypto_photon_beetle/test_crypto_photon_beetle.ae
@@ -88,6 +88,37 @@ main() {
     res_00010203 = photon_beetle.final_hex(ctx4)
     fails = fails + check("00010203", res_00010203, "efab98a1ffeb6f9e832db6fa7fc6bff670895f8a2abe987cd962e93b0127ec3c")
 
+    // Rate-boundary vectors (PHOTON-Beetle absorbs a 16-byte rate). BC
+    // LWC_HASH_KAT counts 9 (8 bytes) and 17 (16 bytes, exact rate).
+    inc8 = bytes.new(8)
+    j = 0
+    while j < 8 { bytes.set(inc8, j, j); j = j + 1 }
+    defer bytes.free(inc8)
+    ctx8, _ = photon_beetle.new()
+    photon_beetle.update_bytes(ctx8, inc8, 8)
+    fails = fails + check("8B", photon_beetle.final_hex(ctx8),
+        "87947eed1020ec45eec25cc05a135e08e5928fb6dc1f9214e6a69421a3bc30da")
+
+    inc16 = bytes.new(16)
+    j = 0
+    while j < 16 { bytes.set(inc16, j, j); j = j + 1 }
+    defer bytes.free(inc16)
+    ctx16, _ = photon_beetle.new()
+    photon_beetle.update_bytes(ctx16, inc16, 16)
+    fails = fails + check("16B(exact rate)", photon_beetle.final_hex(ctx16),
+        "ab0d1eb0315df8af7f7ae0ac42eaf2f52fb0fdf0904e182dcc796b6cb8d7981a")
+
+    // Multi-part streaming across the rate: 16 bytes fed 5+11.
+    ctx_sp, _ = photon_beetle.new()
+    photon_beetle.update_bytes(ctx_sp, inc16, 5)
+    tail11 = bytes.new(11)
+    k = 5
+    while k < 16 { bytes.set(tail11, k - 5, k); k = k + 1 }
+    defer bytes.free(tail11)
+    photon_beetle.update_bytes(ctx_sp, tail11, 11)
+    fails = fails + check("16B split 5+11", photon_beetle.final_hex(ctx_sp),
+        "ab0d1eb0315df8af7f7ae0ac42eaf2f52fb0fdf0904e182dcc796b6cb8d7981a")
+
     if fails == 0 {
         println("ALL PASS")
         return

--- a/tests/integration/crypto_sparkle/test_crypto_sparkle.ae
+++ b/tests/integration/crypto_sparkle/test_crypto_sparkle.ae
@@ -48,6 +48,19 @@ hex_to_bytes(hex: string) -> ptr {
     return b
 }
 
+incrementing(n: int) -> ptr {
+    b = bytes.new(n)
+    i = 0
+    while i < n { bytes.set(b, i, i & 255); i = i + 1 }
+    return b
+}
+
+esch_digest(algo: string, b: ptr, n: int) -> string {
+    ctx, _ = sparkle.new(algo)
+    sparkle.update_bytes(ctx, b, n)
+    return sparkle.final_hex(ctx)
+}
+
 main() {
     fails = 0
 
@@ -84,6 +97,48 @@ main() {
     sparkle.update_bytes(ctx4, b_0001, 2)
     res4_0001 = sparkle.final_hex(ctx4)
     fails = fails + check("esch-384 0001", res4_0001, "76a4f5b45a6062de68f974824fcc7de8ce4bd9ce64ce9a8958a3409151b2481d13b5d9c1bdca1a658d31110088c54922")
+
+    // ---- Rate-boundary vectors (BC LWC_HASH_KAT). These guard the bug where
+    // a rate-filling block (16 bytes) was absorbed eagerly with slim steps and
+    // finalize then ran on an empty padded block, hashing one block short.
+    // An input of EXACTLY the 16-byte rate is the critical case. ----
+    inc16 = incrementing(16)   // 0x00..0x0F
+    fails = fails + check("esch-256 16B(0x00..0x0F, exact rate)",
+        esch_digest("esch-256", inc16, 16),
+        "acff841e2a526d83d6e94ab5564d6d64c98f5e8016bb1c2950386ed156c6c174")
+    fails = fails + check("esch-384 16B(0x00..0x0F, exact rate)",
+        esch_digest("esch-384", inc16, 16),
+        "0008f97d6bbb701d5e33fcc178efe3e3d5e77915d4a4daf6e1ae34cd28edb895a053e19d930b50f72837e1a8f5b1f450")
+    bytes.free(inc16)
+
+    // Just under and one over the rate (15 and 17 bytes) — BC vectors.
+    inc15 = incrementing(15)
+    fails = fails + check("esch-256 15B(one under rate)",
+        esch_digest("esch-256", inc15, 15),
+        "5753e34e3fc970881e1752b59c573e89448d08a93eae46da2a5d8ab04790a60c")
+    bytes.free(inc15)
+
+    // 8-byte input (BC count 9) for esch-384.
+    inc8 = incrementing(8)
+    fails = fails + check("esch-384 8B",
+        esch_digest("esch-384", inc8, 8),
+        "571560322d28dc5f8039794b4a3290a17ccdd60fa6c36ee78dcf9c05ce592d64021ef324af69fcac6829fd84aa69f35b")
+
+    // Multi-part streaming across the rate: 16 bytes fed 7+9 must equal the
+    // one-shot 16-byte digest.
+    ctx_sp, _ = sparkle.new("esch-256")
+    inc16b = incrementing(16)
+    sparkle.update_bytes(ctx_sp, inc16b, 7)
+    tail9 = bytes.new(9)
+    k = 7
+    while k < 16 { bytes.set(tail9, k - 7, k); k = k + 1 }
+    sparkle.update_bytes(ctx_sp, tail9, 9)
+    fails = fails + check("esch-256 16B split 7+9",
+        sparkle.final_hex(ctx_sp),
+        "acff841e2a526d83d6e94ab5564d6d64c98f5e8016bb1c2950386ed156c6c174")
+    bytes.free(inc16b)
+    bytes.free(tail9)
+    bytes.free(inc8)
 
     if fails == 0 {
         println("ALL PASS")

--- a/tests/integration/crypto_sparkle/test_crypto_sparkle.ae
+++ b/tests/integration/crypto_sparkle/test_crypto_sparkle.ae
@@ -1,0 +1,94 @@
+import std.cryptography.sparkle
+import std.bytes
+import std.string
+import std.io
+
+check(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("ok   ${label}")
+        return 0
+    }
+    println("FAIL ${label}")
+    println("  got:  ${got}")
+    println("  want: ${want}")
+    return 1
+}
+
+hex_to_bytes(hex: string) -> ptr {
+    len = string.length(hex)
+    n = len / 2
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        c_hi = string.char_at(hex, i * 2)
+        c_lo = string.char_at(hex, i * 2 + 1)
+
+        hi = 0
+        if c_hi >= 48 && c_hi <= 57 {
+            hi = c_hi - 48
+        } else if c_hi >= 97 && c_hi <= 102 {
+            hi = c_hi - 87
+        } else if c_hi >= 65 && c_hi <= 70 {
+            hi = c_hi - 55
+        }
+
+        lo = 0
+        if c_lo >= 48 && c_lo <= 57 {
+            lo = c_lo - 48
+        } else if c_lo >= 97 && c_lo <= 102 {
+            lo = c_lo - 87
+        } else if c_lo >= 65 && c_lo <= 70 {
+            lo = c_lo - 55
+        }
+
+        val = (hi << 4) | lo
+        bytes.set(b, i, val)
+        i = i + 1
+    }
+    return b
+}
+
+main() {
+    fails = 0
+
+    // ---- ESCH-256 ----
+    fails = fails + check("esch-256 empty",
+        sparkle.sparkle_hex("esch-256", "", 0),
+        "c0e815d78b875dc768c6c8b3afa51987cd69e5c087d387368628a511cfad5730")
+
+    b_00 = hex_to_bytes("00")
+    defer bytes.free(b_00)
+    ctx, _ = sparkle.new("esch-256")
+    sparkle.update_bytes(ctx, b_00, 1)
+    res_00 = sparkle.final_hex(ctx)
+    fails = fails + check("esch-256 00", res_00, "d515fd9c2852d9d6f00c9cf01d858af467eedf21ff68cc14c005b3eff7a6ecd3")
+
+    b_0001 = hex_to_bytes("0001")
+    defer bytes.free(b_0001)
+    ctx2, _ = sparkle.new("esch-256")
+    sparkle.update_bytes(ctx2, b_0001, 2)
+    res_0001 = sparkle.final_hex(ctx2)
+    fails = fails + check("esch-256 0001", res_0001, "fbcad7ab77fd4cc844534d2716d08c092b40b86e00647ecaa429afdfe3b3fc43")
+
+    // ---- ESCH-384 ----
+    fails = fails + check("esch-384 empty",
+        sparkle.sparkle_hex("esch-384", "", 0),
+        "2981715e2263ebd0cb6e5c2c99d0776d5e691ee737fde05247895e75d02e7447fd6ab707e2ec8385a539777965e472ee")
+
+    ctx3, _ = sparkle.new("esch-384")
+    sparkle.update_bytes(ctx3, b_00, 1)
+    res3_00 = sparkle.final_hex(ctx3)
+    fails = fails + check("esch-384 00", res3_00, "ca78366c86e82726c19ebd1dbbb1375cef93c570f856ce2ff5da0ca87140dacd65f3e1c5af5f84b3f6390b9ac1a2fa4d")
+
+    ctx4, _ = sparkle.new("esch-384")
+    sparkle.update_bytes(ctx4, b_0001, 2)
+    res4_0001 = sparkle.final_hex(ctx4)
+    fails = fails + check("esch-384 0001", res4_0001, "76a4f5b45a6062de68f974824fcc7de8ce4bd9ce64ce9a8958a3409151b2481d13b5d9c1bdca1a658d31110088c54922")
+
+    if fails == 0 {
+        println("ALL PASS")
+        return
+    }
+    println("FAILURES: ${fails}")
+    exit(1)
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -74,6 +74,16 @@ extern char** environ;
 #endif
 #define AE_VERSION AETHER_VERSION
 
+/* Buffer size for assembled gcc/aetherc command lines. Must hold the full
+ * link command: cc + one -I per std/ subdirectory (100+ and growing as std
+ * modules are added) + the -L/-l tail + I/O paths. On macOS CI the toolchain
+ * lives under a long temp path (/var/folders/.../T/tmp.XXXX/inst/current/...),
+ * so every -I carries that prefix; the old 16 KiB buffer truncated the link
+ * command there (dropping -L lib) once enough std dirs existed. 64 KiB leaves
+ * generous headroom. The command runners (posix_run/win_run) use the same
+ * size so a large command isn't re-truncated when handed off. */
+#define AE_CMD_BUF 65536
+
 // --------------------------------------------------------------------------
 // Cross-platform temp directory
 // --------------------------------------------------------------------------
@@ -339,7 +349,7 @@ void build_aetherc_cmd(char* cmd, size_t cmd_size, const char* input, const char
 // quiet=0: show all output, quiet=1: hide stdout+stderr, quiet=2: hide stdout only (keep stderr for warnings)
 static int posix_run(const char* cmd_str, int quiet) {
     if (tc.verbose) fprintf(stderr, "[cmd] %s\n", cmd_str);
-    char buf[16384];
+    char buf[AE_CMD_BUF];
     strncpy(buf, cmd_str, sizeof(buf) - 1);
     buf[sizeof(buf) - 1] = '\0';
 
@@ -407,7 +417,7 @@ static int posix_run(const char* cmd_str, int quiet) {
 #endif
 static int win_run(const char* cmd_str, int quiet) {
     if (tc.verbose) fprintf(stderr, "[cmd] %s\n", cmd_str);
-    char buf[16384];
+    char buf[AE_CMD_BUF];
     strncpy(buf, cmd_str, sizeof(buf) - 1);
     buf[sizeof(buf) - 1] = '\0';
 
@@ -2781,7 +2791,7 @@ static int cmd_run(int argc, char** argv) {
         return 1;
     }
 
-    char c_file[2048], exe_file[2048], cmd[16384];
+    char c_file[2048], exe_file[2048], cmd[AE_CMD_BUF];
 
     // Merge toml [[bin]] extra_sources into extra_files BEFORE the cache
     // check. Otherwise editing an FFI shim listed in aether.toml wouldn't
@@ -4900,7 +4910,7 @@ static int cmd_build(int argc, char** argv) {
     }
 
     const char* base = get_basename(file);
-    char c_file[2048], exe_file[2048], cmd[16384];
+    char c_file[2048], exe_file[2048], cmd[AE_CMD_BUF];
 
     if (output_name) {
         // Explicit -o: use the path as-is
@@ -5411,7 +5421,7 @@ static int cmd_test(int argc, char** argv) {
         printf("  %-45s ", test);
         fflush(stdout);
 
-        char c_file[2048], exe_file[2048], cmd[16384];
+        char c_file[2048], exe_file[2048], cmd[AE_CMD_BUF];
 
         if (tc.dev_mode) {
             snprintf(c_file, sizeof(c_file), "%s/build/_test_%d.c", tc.root, i);
@@ -5697,7 +5707,7 @@ static int cmd_examples(int argc, char** argv) {
         printf("  %-30s ", base);
         fflush(stdout);
 
-        char c_file[2048], exe_file[2048], cmd[16384];
+        char c_file[2048], exe_file[2048], cmd[AE_CMD_BUF];
         snprintf(c_file, sizeof(c_file), "build/examples/%s.c", base);
         snprintf(exe_file, sizeof(exe_file), "build/examples/%s" EXE_EXT, base);
 


### PR DESCRIPTION
## Summary

Five more pure-Aether hash/XOF submodules ported from Bouncy Castle, scrutinized against BC ground truth. **Four were correct; one (Sparkle/Esch) had a real block-boundary bug this pass caught and fixed.** No externs to OpenSSL or any C crypto.

| Module | BC source | Standard |
|---|---|---|
| `std.cryptography.ascon_xof128` | `AsconXof128` | Ascon-XOF128, NIST SP 800-232 |
| `std.cryptography.dstu7564` | `DSTU7564Digest` | DSTU 7564 (Kupyna), 256/384/512 |
| `std.cryptography.isap` | `ISAPDigest` | ISAP-Hash (Ascon-p) |
| `std.cryptography.photon_beetle` | `PhotonBeetleDigest` | PHOTON-Beetle Hash |
| `std.cryptography.sparkle` | `SparkleDigest` | Esch-256 / Esch-384 |

Two commits: the ports (`google-labs-jules[bot]`, co-authored by @paul-hammant) and a scrutiny/fix/hardening pass.

## The bug (Sparkle/Esch)

The original tests only used ≤2-byte inputs, which never fill a block — so a rate-boundary bug slipped through. `update()` absorbed a block that filled the 16-byte rate **exactly** with slim steps immediately; `final()` then ran on an empty padded block with the wrong domain constant. A 16-byte input produced `889f75ad…` instead of BC's `acff841e…`.

Root cause vs BC: BC's `SparkleDigest.Update` processes the buffer **before** storing a new byte, and its `BlockUpdate` uses a strict `remaining > RATE_BYTES` — so a rate-filling block is **held** until more data arrives, letting the last data block get the big-step + domain-separation treatment in `DoFinal`. The port processed eagerly at `block_len == 16`. Fixed to defer, matching BC.

Notably **ISAP and PHOTON-Beetle use the same eager pattern but are correct** — they treat every absorbed block identically (no slim-vs-big final-block distinction), so only Esch was affected. Verified this by testing all three at their rate boundaries against BC KATs.

## Correctness (all verified against Bouncy Castle)

- **ISAP / PHOTON-Beetle / Sparkle** — every vector matches BC's `LWC_HASH_KAT` files verbatim, now including rate-boundary (8/16-byte) entries.
- **DSTU 7564** — 256/384/512 all match BC's digest vectors (incrementing-byte 64/128/256, the 95-byte 384 vector, `ff`).
- **Ascon-XOF128** — IV matches BC's `AsconXof128` post-P12 state exactly (`0xda82ce768d9447eb…`). BC's own XOF128 KAT is **absent** from the checkout, so the vectors are pinned to the SP 800-232 reference output; a variable-length XOF-prefix check (32B output == prefix of 64B) guards the squeeze path independently.

## Test hardening (to BC parity)

- **dstu7564**: added the previously-**untested 384 variant** + BC incrementing-byte vectors + cross-block streaming (4 → 11 vectors).
- **ascon_xof128**: variable-length XOF-prefix + streaming-split; provenance documented.
- **isap / photon_beetle / sparkle**: BC rate-boundary vectors + multi-part streaming; the sparkle 16-byte vector is the regression guard for the bug.

## Verification

- All five tests pass; sibling crypto suites (classic/sha3/blake2/ascon256/bouncy_castle) unaffected.
- All five leak-clean under valgrind with proper string release (0 lost, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
