### PR TITLE
std.cbor: CBOR library (leak-clean)

### DIFF
--- a/std/cbor/module.ae
+++ b/std/cbor/module.ae
@@ -1,0 +1,1109 @@
+// MIT License (https://opensource.org/licenses/MIT)
+//
+// Portions copyright (c) 2019-present Faye Amacker (https://github.com/fxamacker/cbor)
+//
+// Portions copyright (c) 2026 Aether Developers.
+
+import std.list
+import std.string
+import std.bytes
+import std.heap
+import std.mem
+import std.encoding
+
+exports (
+    CBOR_INT, CBOR_BYTES, CBOR_TEXT, CBOR_ARRAY, CBOR_MAP, CBOR_TAG, CBOR_SIMPLE, CBOR_FLOAT,
+    parse, encode, stringify, type, is_null, is_undefined,
+    get_bool, get_int, get_long, get_float, get_string, get_bytes, get_tag_val, get_tag_child,
+    object_get, map_get, object_set, array_add, map_set, object_size, array_size, object_entry,
+    obj, arr, str, bytes, num, from_int, boolean, null_value, undefined_value, tag,
+    set, push, map_push, free, diagnose
+)
+
+const CBOR_INT    = 0
+const CBOR_BYTES  = 1
+const CBOR_TEXT   = 2
+const CBOR_ARRAY  = 3
+const CBOR_MAP    = 4
+const CBOR_TAG    = 5
+const CBOR_SIMPLE = 6
+const CBOR_FLOAT  = 7
+
+struct CborValue {
+    type: int
+    int_val: long
+    float_val: float
+    str_val: string
+    tag_val: long
+    tag_child: ptr     // *CborValue
+    list_val: ptr      // list pointer (std.list)
+    map_keys: ptr      // list pointer (std.list)
+    map_values: ptr    // list pointer (std.list)
+}
+
+struct Reader {
+    data: string
+    len: int
+    offset: int
+}
+
+struct Writer {
+    buf: ptr // std.bytes
+    offset: int
+}
+
+// ---- FLOAT HELPERS (using std.mem) ----
+
+is_nan(val: float) -> bool {
+    bits = mem.bits_of_float(val)
+    exp = (bits >> 52) & 2047
+    frac = bits & 4503599627370495 as long
+    return exp == 2047 && frac != 0
+}
+
+is_pos_inf(val: float) -> bool {
+    bits = mem.bits_of_float(val)
+    return bits == 9218868437227405312 as long
+}
+
+is_neg_inf(val: float) -> bool {
+    bits = mem.bits_of_float(val)
+    return bits == -4503599627370496 as long
+}
+
+float32_from_bits(val: long) -> float {
+    sign = (val >> 31) & 1
+    exp = (val >> 23) & 255
+    frac = val & 8388607
+
+    if exp == 0 {
+        if frac == 0 {
+            if sign == 1 { return -0.0 }
+            return 0.0
+        }
+        // subnormal to normal double
+        while (frac & 8388608) == 0 {
+            frac = frac << 1
+            exp = exp - 1
+        }
+        exp = exp + 1
+        frac = frac & 8388607
+        real_exp = exp - 127 + 1023
+        dbits = ((sign as long) << 63) | ((real_exp as long) << 52) | ((frac as long) << 29)
+        return mem.float_from_bits(dbits)
+    }
+    if exp == 255 {
+        if frac == 0 {
+            if sign == 1 { return mem.float_from_bits(-4503599627370496 as long) }
+            return mem.float_from_bits(9218868437227405312 as long)
+        }
+        return mem.float_from_bits(9221120237041090560 as long)
+    }
+    real_exp = exp - 127 + 1023
+    dbits = ((sign as long) << 63) | ((real_exp as long) << 52) | ((frac as long) << 29)
+    return mem.float_from_bits(dbits)
+}
+
+float16_to_float32(val: int) -> float {
+    sign = (val >> 15) & 1
+    exp = (val >> 10) & 31
+    frac = val & 1023
+
+    if exp == 0 {
+        if frac == 0 {
+            if sign == 1 { return -0.0 }
+            return 0.0
+        }
+        while (frac & 1024) == 0 {
+            frac = frac << 1
+            exp = exp - 1
+        }
+        exp = exp + 1
+        frac = frac & 1023
+        real_exp = exp - 15 + 127
+        bits = ((sign as long) << 31) | ((real_exp as long) << 23) | ((frac as long) << 13)
+        return float32_from_bits(bits)
+    }
+    if exp == 31 {
+        if frac == 0 {
+            if sign == 1 { return mem.float_from_bits(-4503599627370496 as long) }
+            return mem.float_from_bits(9218868437227405312 as long)
+        }
+        return mem.float_from_bits(9221120237041090560 as long)
+    }
+    real_exp = exp - 15 + 127
+    bits = ((sign as long) << 31) | ((real_exp as long) << 23) | ((frac as long) << 13)
+    return float32_from_bits(bits)
+}
+
+// ---- DECODER IMPLEMENTATION ----
+
+read_value(r: ptr, ai: int) -> (long, string) {
+    reader = r as *Reader
+    if ai < 24 {
+        return ai as long, ""
+    }
+    if ai == 24 {
+        if reader.offset >= reader.len { return 0, "cbor: unexpected EOF" }
+        v = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+        reader.offset = reader.offset + 1
+        return v as long, ""
+    }
+    if ai == 25 {
+        if reader.offset + 2 > reader.len { return 0, "cbor: unexpected EOF" }
+        b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+        b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+        reader.offset = reader.offset + 2
+        v = (b0 << 8) | b1
+        return v as long, ""
+    }
+    if ai == 26 {
+        if reader.offset + 4 > reader.len { return 0, "cbor: unexpected EOF" }
+        b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+        b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+        b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
+        b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
+        reader.offset = reader.offset + 4
+        v = ((b0 as long) << 24) | ((b1 as long) << 16) | ((b2 as long) << 8) | (b3 as long)
+        return v, ""
+    }
+    if ai == 27 {
+        if reader.offset + 8 > reader.len { return 0, "cbor: unexpected EOF" }
+        b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+        b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+        b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
+        b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
+        b4 = string.char_at_n(reader.data, reader.len, reader.offset + 4) & 255
+        b5 = string.char_at_n(reader.data, reader.len, reader.offset + 5) & 255
+        b6 = string.char_at_n(reader.data, reader.len, reader.offset + 6) & 255
+        b7 = string.char_at_n(reader.data, reader.len, reader.offset + 7) & 255
+        reader.offset = reader.offset + 8
+        v = ((b0 as long) << 56) | ((b1 as long) << 48) | ((b2 as long) << 40) | ((b3 as long) << 32) |
+            ((b4 as long) << 24) | ((b5 as long) << 16) | ((b6 as long) << 8) | (b7 as long)
+        return v, ""
+    }
+    return 0, "cbor: invalid additional information"
+}
+
+parse_item(r: ptr) -> (ptr, string) {
+    reader = r as *Reader
+    if reader.offset >= reader.len {
+        return null, "cbor: unexpected EOF"
+    }
+    ib = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+    reader.offset = reader.offset + 1
+
+    mt = (ib >> 5) & 7
+    ai = ib & 31
+
+    if mt == 0 {
+        val, err = read_value(r, ai)
+        if err != "" { return null, err }
+        cv = heap.new(CborValue)
+        cv.type = CBOR_INT
+        cv.int_val = val
+        return cv as ptr, ""
+    }
+    if mt == 1 {
+        val, err = read_value(r, ai)
+        if err != "" { return null, err }
+        cv = heap.new(CborValue)
+        cv.type = CBOR_INT
+        cv.int_val = -1 - val
+        return cv as ptr, ""
+    }
+    if mt == 2 {
+        if ai == 31 {
+            // Indefinite length byte string. Parse indefinite chunks.
+            // We concatenate all chunk strings.
+            sb = bytes.new(32)
+            sb_len = 0
+            while true {
+                if reader.offset >= reader.len {
+                    bytes.free(sb)
+                    return null, "cbor: unexpected EOF in indefinite byte string"
+                }
+                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                if next_byte == 255 { // break code
+                    reader.offset = reader.offset + 1
+                    break
+                }
+                child, err = parse_item(r)
+                if err != "" {
+                    bytes.free(sb)
+                    return null, err
+                }
+                child_cv = child as *CborValue
+                if child_cv.type != CBOR_BYTES {
+                    bytes.free(sb)
+                    free_value(child)
+                    return null, "cbor: indefinite byte string contains non-byte-string"
+                }
+                chunk_len = string.length(child_cv.str_val)
+                _ = bytes.copy_from_string(sb, sb_len, child_cv.str_val, chunk_len)
+                sb_len = sb_len + chunk_len
+                free_value(child)
+            }
+            cv = heap.new(CborValue)
+            cv.type = CBOR_BYTES
+            cv.str_val = bytes.finish(sb, sb_len)
+            return cv as ptr, ""
+        }
+        len_val, err = read_value(r, ai)
+        if err != "" { return null, err }
+        if reader.offset + (len_val as int) > reader.len { return null, "cbor: unexpected EOF" }
+        sub = string.substring(reader.data, reader.offset, reader.offset + (len_val as int))
+        reader.offset = reader.offset + (len_val as int)
+        cv = heap.new(CborValue)
+        cv.type = CBOR_BYTES
+        cv.str_val = sub
+        return cv as ptr, ""
+    }
+    if mt == 3 {
+        if ai == 31 {
+            // Indefinite length text string
+            sb = bytes.new(32)
+            sb_len = 0
+            while true {
+                if reader.offset >= reader.len {
+                    bytes.free(sb)
+                    return null, "cbor: unexpected EOF in indefinite text string"
+                }
+                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                if next_byte == 255 {
+                    reader.offset = reader.offset + 1
+                    break
+                }
+                child, err = parse_item(r)
+                if err != "" {
+                    bytes.free(sb)
+                    return null, err
+                }
+                child_cv = child as *CborValue
+                if child_cv.type != CBOR_TEXT {
+                    bytes.free(sb)
+                    free_value(child)
+                    return null, "cbor: indefinite text string contains non-text-string"
+                }
+                chunk_len = string.length(child_cv.str_val)
+                _ = bytes.copy_from_string(sb, sb_len, child_cv.str_val, chunk_len)
+                sb_len = sb_len + chunk_len
+                free_value(child)
+            }
+            cv = heap.new(CborValue)
+            cv.type = CBOR_TEXT
+            cv.str_val = bytes.finish(sb, sb_len)
+            return cv as ptr, ""
+        }
+        len_val, err = read_value(r, ai)
+        if err != "" { return null, err }
+        if reader.offset + (len_val as int) > reader.len { return null, "cbor: unexpected EOF" }
+        sub = string.substring(reader.data, reader.offset, reader.offset + (len_val as int))
+        reader.offset = reader.offset + (len_val as int)
+        cv = heap.new(CborValue)
+        cv.type = CBOR_TEXT
+        cv.str_val = sub
+        return cv as ptr, ""
+    }
+    if mt == 4 {
+        if ai == 31 {
+            lst = list.new()
+            while true {
+                if reader.offset >= reader.len { return null, "cbor: unexpected EOF in indefinite array" }
+                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                if next_byte == 255 {
+                    reader.offset = reader.offset + 1
+                    break
+                }
+                child, err = parse_item(r)
+                if err != "" { return null, err }
+                _ = list.add(lst, child)
+            }
+            cv = heap.new(CborValue)
+            cv.type = CBOR_ARRAY
+            cv.list_val = lst
+            return cv as ptr, ""
+        }
+        len_val, err = read_value(r, ai)
+        if err != "" { return null, err }
+        lst = list.new()
+        i = 0
+        while i < (len_val as int) {
+            child, err = parse_item(r)
+            if err != "" { return null, err }
+            _ = list.add(lst, child)
+            i = i + 1
+        }
+        cv = heap.new(CborValue)
+        cv.type = CBOR_ARRAY
+        cv.list_val = lst
+        return cv as ptr, ""
+    }
+    if mt == 5 {
+        if ai == 31 {
+            keys_lst = list.new()
+            vals_lst = list.new()
+            while true {
+                if reader.offset >= reader.len { return null, "cbor: unexpected EOF in indefinite map" }
+                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                if next_byte == 255 {
+                    reader.offset = reader.offset + 1
+                    break
+                }
+                key_cv, err = parse_item(r)
+                if err != "" { return null, err }
+                val_cv, err2 = parse_item(r)
+                if err2 != "" {
+                    free_value(key_cv)
+                    return null, err2
+                }
+                _ = list.add(keys_lst, key_cv)
+                _ = list.add(vals_lst, val_cv)
+            }
+            cv = heap.new(CborValue)
+            cv.type = CBOR_MAP
+            cv.map_keys = keys_lst
+            cv.map_values = vals_lst
+            return cv as ptr, ""
+        }
+        len_val, err = read_value(r, ai)
+        if err != "" { return null, err }
+        keys_lst = list.new()
+        vals_lst = list.new()
+        i = 0
+        while i < (len_val as int) {
+            key_cv, err = parse_item(r)
+            if err != "" { return null, err }
+            val_cv, err2 = parse_item(r)
+            if err2 != "" {
+                free_value(key_cv)
+                return null, err2
+            }
+            _ = list.add(keys_lst, key_cv)
+            _ = list.add(vals_lst, val_cv)
+            i = i + 1
+        }
+        cv = heap.new(CborValue)
+        cv.type = CBOR_MAP
+        cv.map_keys = keys_lst
+        cv.map_values = vals_lst
+        return cv as ptr, ""
+    }
+    if mt == 6 {
+        tag_val, err = read_value(r, ai)
+        if err != "" { return null, err }
+        child_cv, err2 = parse_item(r)
+        if err2 != "" { return null, err2 }
+        cv = heap.new(CborValue)
+        cv.type = CBOR_TAG
+        cv.tag_val = tag_val
+        cv.tag_child = child_cv
+        return cv as ptr, ""
+    }
+    if mt == 7 {
+        if ai == 20 {
+            cv = heap.new(CborValue)
+            cv.type = CBOR_SIMPLE
+            cv.int_val = 20
+            return cv as ptr, ""
+        }
+        if ai == 21 {
+            cv = heap.new(CborValue)
+            cv.type = CBOR_SIMPLE
+            cv.int_val = 21
+            return cv as ptr, ""
+        }
+        if ai == 22 {
+            cv = heap.new(CborValue)
+            cv.type = CBOR_SIMPLE
+            cv.int_val = 22
+            return cv as ptr, ""
+        }
+        if ai == 23 {
+            cv = heap.new(CborValue)
+            cv.type = CBOR_SIMPLE
+            cv.int_val = 23
+            return cv as ptr, ""
+        }
+        if ai == 24 {
+            if reader.offset >= reader.len { return null, "cbor: unexpected EOF" }
+            v = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+            reader.offset = reader.offset + 1
+            cv = heap.new(CborValue)
+            cv.type = CBOR_SIMPLE
+            cv.int_val = v as long
+            return cv as ptr, ""
+        }
+        if ai == 25 {
+            if reader.offset + 2 > reader.len { return null, "cbor: unexpected EOF" }
+            b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+            b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+            reader.offset = reader.offset + 2
+            bits = (b0 << 8) | b1
+            f = float16_to_float32(bits)
+            cv = heap.new(CborValue)
+            cv.type = CBOR_FLOAT
+            cv.float_val = f
+            return cv as ptr, ""
+        }
+        if ai == 26 {
+            if reader.offset + 4 > reader.len { return null, "cbor: unexpected EOF" }
+            b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+            b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+            b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
+            b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
+            reader.offset = reader.offset + 4
+            bits = ((b0 as long) << 24) | ((b1 as long) << 16) | ((b2 as long) << 8) | (b3 as long)
+            f = float32_from_bits(bits)
+            cv = heap.new(CborValue)
+            cv.type = CBOR_FLOAT
+            cv.float_val = f
+            return cv as ptr, ""
+        }
+        if ai == 27 {
+            if reader.offset + 8 > reader.len { return null, "cbor: unexpected EOF" }
+            b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+            b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+            b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
+            b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
+            b4 = string.char_at_n(reader.data, reader.len, reader.offset + 4) & 255
+            b5 = string.char_at_n(reader.data, reader.len, reader.offset + 5) & 255
+            b6 = string.char_at_n(reader.data, reader.len, reader.offset + 6) & 255
+            b7 = string.char_at_n(reader.data, reader.len, reader.offset + 7) & 255
+            reader.offset = reader.offset + 8
+            bits = ((b0 as long) << 56) | ((b1 as long) << 48) | ((b2 as long) << 40) | ((b3 as long) << 32) |
+                   ((b4 as long) << 24) | ((b5 as long) << 16) | ((b6 as long) << 8) | (b7 as long)
+            f = mem.float_from_bits(bits)
+            cv = heap.new(CborValue)
+            cv.type = CBOR_FLOAT
+            cv.float_val = f
+            return cv as ptr, ""
+        }
+    }
+    return null, "cbor: unsupported major type"
+}
+
+// Parse a CBOR binary string. Returns (value_ptr, "") on success, (null, error) on failure.
+// Caller owns the returned value and must free with cbor.free.
+parse(cbor_data: string) -> ptr! {
+    r = heap.new(Reader)
+    r.data = cbor_data
+    r.len = string.length(cbor_data)
+    r.offset = 0
+    res, err = parse_item(r as ptr)
+    heap.free(r)
+    if err != "" {
+        return null, err
+    }
+    return res, ""
+}
+
+// ---- ENCODER IMPLEMENTATION ----
+
+write_byte(w: ptr, b: int) {
+    writer = w as *Writer
+    _ = bytes.set(writer.buf, writer.offset, b)
+    writer.offset = writer.offset + 1
+}
+
+write_be16(w: ptr, val: int) {
+    writer = w as *Writer
+    _ = bytes.set_be16(writer.buf, writer.offset, val)
+    writer.offset = writer.offset + 2
+}
+
+write_be32(w: ptr, val: int) {
+    writer = w as *Writer
+    _ = bytes.set_be32(writer.buf, writer.offset, val)
+    writer.offset = writer.offset + 4
+}
+
+write_be64(w: ptr, val: long) {
+    writer = w as *Writer
+    _ = bytes.set_be64(writer.buf, writer.offset, val)
+    writer.offset = writer.offset + 8
+}
+
+write_string(w: ptr, s: string, len: int) {
+    writer = w as *Writer
+    _ = bytes.copy_from_string(writer.buf, writer.offset, s, len)
+    writer.offset = writer.offset + len
+}
+
+encode_header(w: ptr, major: int, val: long) {
+    writer = w as *Writer
+    base = major << 5
+    if val < 24 {
+        write_byte(w, base | (val as int))
+    } else if val <= 255 {
+        write_byte(w, base | 24)
+        write_byte(w, val as int)
+    } else if val <= 65535 {
+        write_byte(w, base | 25)
+        write_be16(w, val as int)
+    } else if val <= 4294967295 {
+        write_byte(w, base | 26)
+        write_be32(w, val as int)
+    } else {
+        write_byte(w, base | 27)
+        write_be64(w, val)
+    }
+}
+
+encode_item(w: ptr, cv: ptr) -> string {
+    if cv == null {
+        // Encode null as default
+        write_byte(w, 246)
+        return ""
+    }
+
+    cv_val = cv as *CborValue
+    if cv_val.type == CBOR_INT {
+        v = cv_val.int_val
+        if v >= 0 {
+            encode_header(w, 0, v)
+        } else {
+            encode_header(w, 1, -1 - v)
+        }
+        return ""
+    }
+    if cv_val.type == CBOR_BYTES {
+        len = string.length(cv_val.str_val)
+        encode_header(w, 2, len as long)
+        write_string(w, cv_val.str_val, len)
+        return ""
+    }
+    if cv_val.type == CBOR_TEXT {
+        len = string.length(cv_val.str_val)
+        encode_header(w, 3, len as long)
+        write_string(w, cv_val.str_val, len)
+        return ""
+    }
+    if cv_val.type == CBOR_ARRAY {
+        n = list.size(cv_val.list_val)
+        encode_header(w, 4, n as long)
+        i = 0
+        while i < n {
+            item, _ = list.get(cv_val.list_val, i)
+            err = encode_item(w, item)
+            if err != "" { return err }
+            i = i + 1
+        }
+        return ""
+    }
+    if cv_val.type == CBOR_MAP {
+        n = list.size(cv_val.map_keys)
+        encode_header(w, 5, n as long)
+        i = 0
+        while i < n {
+            k, _ = list.get(cv_val.map_keys, i)
+            v, _ = list.get(cv_val.map_values, i)
+            err = encode_item(w, k)
+            if err != "" { return err }
+            err2 = encode_item(w, v)
+            if err2 != "" { return err2 }
+            i = i + 1
+        }
+        return ""
+    }
+    if cv_val.type == CBOR_TAG {
+        encode_header(w, 6, cv_val.tag_val)
+        err = encode_item(w, cv_val.tag_child)
+        return err
+    }
+    if cv_val.type == CBOR_SIMPLE {
+        v = cv_val.int_val
+        if v < 24 {
+            write_byte(w, 224 | (v as int))
+        } else {
+            write_byte(w, 224 | 24)
+            write_byte(w, v as int)
+        }
+        return ""
+    }
+    if cv_val.type == CBOR_FLOAT {
+        write_byte(w, 224 | 27) // double-precision float
+        bits = mem.bits_of_float(cv_val.float_val)
+        write_be64(w, bits)
+        return ""
+    }
+    return "cbor: unsupported CBOR value type for encoding"
+}
+
+// Serialize a CBOR value tree to a binary string.
+// Returns (encoded_bytes, "") on success, ("", error) on failure.
+encode(value: ptr) -> string! {
+    w = heap.new(Writer)
+    w.buf = bytes.new(32)
+    w.offset = 0
+    err = encode_item(w as ptr, value)
+    if err != "" {
+        bytes.free(w.buf)
+        heap.free(w)
+        return "", err
+    }
+    res = bytes.finish(w.buf, w.offset)
+    heap.free(w)
+    return res, ""
+}
+
+// Alias of encode for JSON symmetry.
+stringify(value: ptr) -> string! {
+    return encode(value)
+}
+
+// ---- ERGONOMIC GETTERS ----
+
+type(value: ptr) -> int {
+    if value == null { return -1 }
+    cv = value as *CborValue
+    return cv.type
+}
+
+is_null(value: ptr) -> int {
+    if value == null { return 0 }
+    cv = value as *CborValue
+    if cv.type == CBOR_SIMPLE && cv.int_val == 22 { return 1 }
+    return 0
+}
+
+is_undefined(value: ptr) -> int {
+    if value == null { return 0 }
+    cv = value as *CborValue
+    if cv.type == CBOR_SIMPLE && cv.int_val == 23 { return 1 }
+    return 0
+}
+
+get_bool(value: ptr) -> int {
+    if value == null { return 0 }
+    cv = value as *CborValue
+    if cv.type == CBOR_SIMPLE {
+        if cv.int_val == 21 { return 1 }
+    }
+    return 0
+}
+
+get_int(value: ptr) -> int {
+    if value == null { return 0 }
+    cv = value as *CborValue
+    if cv.type == CBOR_INT {
+        return cv.int_val as int
+    }
+    return 0
+}
+
+get_long(value: ptr) -> long {
+    if value == null { return 0 }
+    cv = value as *CborValue
+    if cv.type == CBOR_INT {
+        return cv.int_val
+    }
+    return 0
+}
+
+get_float(value: ptr) -> float {
+    if value == null { return 0.0 }
+    cv = value as *CborValue
+    if cv.type == CBOR_FLOAT {
+        return cv.float_val
+    }
+    if cv.type == CBOR_INT {
+        return cv.int_val as float
+    }
+    return 0.0
+}
+
+get_string(value: ptr) -> string! {
+    if value == null { return "", "not a string" }
+    cv = value as *CborValue
+    if cv.type != CBOR_TEXT {
+        return "", "not a string"
+    }
+    return string.concat(cv.str_val, ""), ""
+}
+
+get_bytes(value: ptr) -> string! {
+    if value == null { return "", "not a byte string" }
+    cv = value as *CborValue
+    if cv.type != CBOR_BYTES {
+        return "", "not a byte string"
+    }
+    return string.concat(cv.str_val, ""), ""
+}
+
+get_tag_val(value: ptr) -> long {
+    if value == null { return 0 }
+    cv = value as *CborValue
+    if cv.type == CBOR_TAG {
+        return cv.tag_val
+    }
+    return 0
+}
+
+get_tag_child(value: ptr) -> ptr {
+    if value == null { return null }
+    cv = value as *CborValue
+    if cv.type == CBOR_TAG {
+        return cv.tag_child
+    }
+    return null
+}
+
+object_get(obj_ptr: ptr, key: string) -> ptr! {
+    if obj_ptr == null { return null, "null map" }
+    cv = obj_ptr as *CborValue
+    if cv.type != CBOR_MAP { return null, "not a map" }
+    n = list.size(cv.map_keys)
+    i = 0
+    while i < n {
+        k_ptr, _ = list.get(cv.map_keys, i)
+        k = k_ptr as *CborValue
+        if k.type == CBOR_TEXT && k.str_val == key {
+            val_ptr, _ = list.get(cv.map_values, i)
+            return val_ptr, ""
+        }
+        i = i + 1
+    }
+    return null, ""
+}
+
+fn equal_val(a: ptr, b: ptr) -> bool {
+    if a == b { return true }
+    if a == null || b == null { return false }
+    acv = a as *CborValue
+    bcv = b as *CborValue
+    if acv.type != bcv.type { return false }
+    if acv.type == CBOR_INT { return acv.int_val == bcv.int_val }
+    if acv.type == CBOR_FLOAT { return acv.float_val == bcv.float_val }
+    if acv.type == CBOR_TEXT || acv.type == CBOR_BYTES { return acv.str_val == bcv.str_val }
+    if acv.type == CBOR_SIMPLE { return acv.int_val == bcv.int_val }
+    if acv.type == CBOR_TAG {
+        return acv.tag_val == bcv.tag_val && equal_val(acv.tag_child, bcv.tag_child)
+    }
+    return false
+}
+
+map_get(obj_ptr: ptr, key_ptr: ptr) -> ptr! {
+    if obj_ptr == null { return null, "null map" }
+    cv = obj_ptr as *CborValue
+    if cv.type != CBOR_MAP { return null, "not a map" }
+    n = list.size(cv.map_keys)
+    i = 0
+    while i < n {
+        k_ptr, _ = list.get(cv.map_keys, i)
+        if equal_val(k_ptr, key_ptr) {
+            val_ptr, _ = list.get(cv.map_values, i)
+            return val_ptr, ""
+        }
+        i = i + 1
+    }
+    return null, ""
+}
+
+object_set(obj_ptr: ptr, key: string, value: ptr) -> string {
+    if obj_ptr == null { return "null map" }
+    cv = obj_ptr as *CborValue
+    if cv.type != CBOR_MAP {
+        free_value(value as *CborValue)
+        return "not a map"
+    }
+    key_cv = str(key)
+    _ = list.add(cv.map_keys, key_cv)
+    _ = list.add(cv.map_values, value)
+    return ""
+}
+
+// Terse helper alias for object_set (similar to json.set)
+set(obj_ptr: ptr, key: string, value: ptr) -> string {
+    return object_set(obj_ptr, key, value)
+}
+
+array_add(arr_ptr: ptr, value: ptr) -> string {
+    if arr_ptr == null { return "null array" }
+    cv = arr_ptr as *CborValue
+    if cv.type != CBOR_ARRAY {
+        free_value(value as *CborValue)
+        return "not an array"
+    }
+    _ = list.add(cv.list_val, value)
+    return ""
+}
+
+// Terse helper alias for array_add (similar to json.push)
+push(arr_ptr: ptr, value: ptr) -> string {
+    return array_add(arr_ptr, value)
+}
+
+map_set(obj_ptr: ptr, key_ptr: ptr, value_ptr: ptr) -> string {
+    if obj_ptr == null { return "null map" }
+    cv = obj_ptr as *CborValue
+    if cv.type != CBOR_MAP {
+        free_value(key_ptr as *CborValue)
+        free_value(value_ptr as *CborValue)
+        return "not a map"
+    }
+    _ = list.add(cv.map_keys, key_ptr)
+    _ = list.add(cv.map_values, value_ptr)
+    return ""
+}
+
+// Terse helper alias for map_set
+map_push(obj_ptr: ptr, key_ptr: ptr, value_ptr: ptr) -> string {
+    return map_set(obj_ptr, key_ptr, value_ptr)
+}
+
+object_size(obj_ptr: ptr) -> int {
+    if obj_ptr == null { return -1 }
+    cv = obj_ptr as *CborValue
+    if cv.type != CBOR_MAP { return -1 }
+    return list.size(cv.map_keys)
+}
+
+array_size(arr_ptr: ptr) -> int {
+    if arr_ptr == null { return -1 }
+    cv = arr_ptr as *CborValue
+    if cv.type != CBOR_ARRAY { return -1 }
+    return list.size(cv.list_val)
+}
+
+object_entry(obj_ptr: ptr, i: int) -> (ptr, ptr, string) {
+    if obj_ptr == null { return null, null, "null map" }
+    cv = obj_ptr as *CborValue
+    if cv.type != CBOR_MAP { return null, null, "not a map" }
+    n = list.size(cv.map_keys)
+    if i < 0 || i >= n { return null, null, "index out of range" }
+    k, _ = list.get(cv.map_keys, i)
+    v, _ = list.get(cv.map_values, i)
+    return k, v, ""
+}
+
+// ---- TERSE VALUE BUILDERS ----
+
+obj() -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_MAP
+    cv.map_keys = list.new()
+    cv.map_values = list.new()
+    return cv as ptr
+}
+
+arr() -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_ARRAY
+    cv.list_val = list.new()
+    return cv as ptr
+}
+
+str(value: string) -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_TEXT
+    cv.str_val = value
+    return cv as ptr
+}
+
+bytes(value: string) -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_BYTES
+    cv.str_val = value
+    return cv as ptr
+}
+
+num(value: float) -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_FLOAT
+    cv.float_val = value
+    return cv as ptr
+}
+
+from_int(value: long) -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_INT
+    cv.int_val = value
+    return cv as ptr
+}
+
+boolean(value: int) -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_SIMPLE
+    if value != 0 {
+        cv.int_val = 21
+    } else {
+        cv.int_val = 20
+    }
+    return cv as ptr
+}
+
+null_value() -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_SIMPLE
+    cv.int_val = 22
+    return cv as ptr
+}
+
+undefined_value() -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_SIMPLE
+    cv.int_val = 23
+    return cv as ptr
+}
+
+tag(tag_num: long, child: ptr) -> ptr {
+    cv = heap.new(CborValue)
+    cv.type = CBOR_TAG
+    cv.tag_val = tag_num
+    cv.tag_child = child
+    return cv as ptr
+}
+
+// ---- RECURSIVE CLEANUP ----
+
+free_value(cv: ptr) {
+    if cv == null { return }
+    cv_val = cv as *CborValue
+    if cv_val.type == CBOR_ARRAY {
+        n = list.size(cv_val.list_val)
+        i = 0
+        while i < n {
+            item, _ = list.get(cv_val.list_val, i)
+            free_value(item)
+            i = i + 1
+        }
+        list.free(cv_val.list_val)
+    } else if cv_val.type == CBOR_MAP {
+        n = list.size(cv_val.map_keys)
+        i = 0
+        while i < n {
+            k, _ = list.get(cv_val.map_keys, i)
+            free_value(k)
+            v, _ = list.get(cv_val.map_values, i)
+            free_value(v)
+            i = i + 1
+        }
+        list.free(cv_val.map_keys)
+        list.free(cv_val.map_values)
+    } else if cv_val.type == CBOR_TAG {
+        free_value(cv_val.tag_child)
+    }
+    heap.free(cv_val)
+}
+
+free(value: ptr) {
+    free_value(value)
+}
+
+// ---- DIAGNOSTIC NOTATION (EDN) ----
+
+escape_string(s: string) -> string {
+    len = string.length(s)
+    buf = bytes.new(len * 2 + 2)
+    bytes.set(buf, 0, 34)
+    out = 1
+    i = 0
+    while i < len {
+        c = string.char_at_n(s, len, i) & 255
+        if c == 34 {
+            bytes.set(buf, out, 92)
+            bytes.set(buf, out + 1, 34)
+            out = out + 2
+        } else if c == 92 {
+            bytes.set(buf, out, 92)
+            bytes.set(buf, out + 1, 92)
+            out = out + 2
+        } else {
+            bytes.set(buf, out, c)
+            out = out + 1
+        }
+        i = i + 1
+    }
+    bytes.set(buf, out, 34)
+    out = out + 1
+    return bytes.finish(buf, out)
+}
+
+format_bytes_diag(s: string) -> string {
+    len = string.length(s)
+    hex_str = encoding.hex_encode(s, len)
+    return string.concat("h'", string.concat(hex_str, "'"))
+}
+
+format_float_diag(val: float) -> string {
+    if is_nan(val) { return "NaN" }
+    if is_pos_inf(val) { return "Infinity" }
+    if is_neg_inf(val) { return "-Infinity" }
+    s = string.from_float(val)
+    if string.contains(s, ".") == 0 && string.contains(s, "e") == 0 && string.contains(s, "E") == 0 {
+        return string.concat(s, ".0")
+    }
+    return s
+}
+
+to_diagnose_string(cv: ptr) -> string {
+    if cv == null { return "null" }
+    cv_val = cv as *CborValue
+    if cv_val.type == CBOR_INT {
+        return string.from_long(cv_val.int_val)
+    }
+    if cv_val.type == CBOR_FLOAT {
+        return format_float_diag(cv_val.float_val)
+    }
+    if cv_val.type == CBOR_TEXT {
+        return escape_string(cv_val.str_val)
+    }
+    if cv_val.type == CBOR_BYTES {
+        return format_bytes_diag(cv_val.str_val)
+    }
+    if cv_val.type == CBOR_SIMPLE {
+        if cv_val.int_val == 20 { return "false" }
+        if cv_val.int_val == 21 { return "true" }
+        if cv_val.int_val == 22 { return "null" }
+        if cv_val.int_val == 23 { return "undefined" }
+        return string.concat("simple(", string.concat(string.from_long(cv_val.int_val), ")"))
+    }
+    if cv_val.type == CBOR_TAG {
+        child_str = to_diagnose_string(cv_val.tag_child)
+        return string.concat(string.from_long(cv_val.tag_val), string.concat("(", string.concat(child_str, ")")))
+    }
+    if cv_val.type == CBOR_ARRAY {
+        n = list.size(cv_val.list_val)
+        if n == 0 { return "[]" }
+        s = "["
+        i = 0
+        while i < n {
+            item, _ = list.get(cv_val.list_val, i)
+            item_str = to_diagnose_string(item)
+            if i > 0 {
+                s = string.concat(s, ", ")
+            }
+            s = string.concat(s, item_str)
+            i = i + 1
+        }
+        return string.concat(s, "]")
+    }
+    if cv_val.type == CBOR_MAP {
+        n = list.size(cv_val.map_keys)
+        if n == 0 { return "{}" }
+        s = "{"
+        i = 0
+        while i < n {
+            k_ptr, _ = list.get(cv_val.map_keys, i)
+            v_ptr, _ = list.get(cv_val.map_values, i)
+            k_str = to_diagnose_string(k_ptr)
+            v_str = to_diagnose_string(v_ptr)
+            if i > 0 {
+                s = string.concat(s, ", ")
+            }
+            s = string.concat(s, string.concat(k_str, string.concat(": ", v_str)))
+            i = i + 1
+        }
+        return string.concat(s, "}")
+    }
+    return ""
+}
+
+// Convert a parsed CBOR value or input bytes to Extended Diagnostic Notation (EDN).
+diagnose(value: ptr) -> string! {
+    if value == null {
+        return "null", ""
+    }
+    return to_diagnose_string(value), ""
+}

--- a/std/cbor/module.ae
+++ b/std/cbor/module.ae
@@ -29,11 +29,21 @@ const CBOR_TAG    = 5
 const CBOR_SIMPLE = 6
 const CBOR_FLOAT  = 7
 
+// Memory model: a CborValue tree owns its text/byte-string payloads as an
+// AetherBytes buffer (str_bytes + str_len), NOT a refcounted `string` field.
+// A `string` stored in a heap.new struct field leaks — heap.free reclaims
+// only the struct, and the escape walker won't follow a string into a struct
+// field so it can't be released manually without a double-free. std.bytes is
+// malloc-backed with an explicit bytes.free (leak-clean); free_value reclaims
+// the buffer alongside the struct. get_string/get_bytes mint a fresh
+// caller-owned string on demand via the non-consuming bytes.to_string. This
+// is the same treatment std.msgpack uses for the identical problem.
 struct CborValue {
     type: int
     int_val: long
     float_val: float
-    str_val: string
+    str_bytes: ptr     // owned AetherBytes for text/byte-string payload (null if empty); freed in free_value
+    str_len: int       // payload byte length
     tag_val: long
     tag_child: ptr     // *CborValue
     list_val: ptr      // list pointer (std.list)
@@ -41,10 +51,97 @@ struct CborValue {
     map_values: ptr    // list pointer (std.list)
 }
 
+// ---- str payload helpers (see Memory model above) ----
+
+// Store `len` bytes of `src` (an AetherString) as cv's owned payload.
+// Empty payload records str_bytes = null / str_len = 0 (no allocation).
+fn set_str_payload(cv: *CborValue, src: string, len: int) {
+    if len <= 0 {
+        cv.str_bytes = null
+        cv.str_len = 0
+        return
+    }
+    b = bytes.new(len)
+    _ = bytes.copy_from_string(b, 0, src, len)
+    cv.str_bytes = b
+    cv.str_len = len
+}
+
+// Adopt an already-owned AetherBytes buffer (e.g. an assembled indefinite-
+// string buffer) as cv's payload, transferring ownership. `len` is the
+// logical byte length.
+fn adopt_str_payload(cv: *CborValue, b: ptr, len: int) {
+    if len <= 0 {
+        cv.str_bytes = null
+        cv.str_len = 0
+        bytes.free(b)
+        return
+    }
+    cv.str_bytes = b
+    cv.str_len = len
+}
+
+// Fresh caller-owned string copy of cv's payload; non-consuming.
+fn str_payload_string(cv: *CborValue) -> string {
+    if cv.str_bytes == null || cv.str_len <= 0 {
+        return ""
+    }
+    return bytes.to_string(cv.str_bytes, cv.str_len)
+}
+
+// Byte-for-byte compare of two payloads without minting strings.
+fn str_payload_equal(a: *CborValue, b: *CborValue) -> bool {
+    if a.str_len != b.str_len { return false }
+    if a.str_len == 0 { return true }
+    sa = str_payload_string(a)
+    sb = str_payload_string(b)
+    eq = sa == sb
+    string.release(sa)
+    string.release(sb)
+    return eq
+}
+
+// Compare a payload against a plain string key without escaping a string.
+fn str_payload_equals_key(cv: *CborValue, key: string) -> bool {
+    if cv.str_len != string.length(key) { return false }
+    if cv.str_len == 0 { return true }
+    s = str_payload_string(cv)
+    eq = s == key
+    string.release(s)
+    return eq
+}
+
+// The reader holds an owned std.bytes copy of the input, NOT the caller's
+// string. Borrowing the caller's string into this struct field trips the
+// escape walker, which then suppresses the caller's release of that string
+// (it leaks). Copying into a bytes buffer we own and free ourselves keeps
+// the caller's input fully the caller's to release — the same approach
+// std.msgpack's unpack uses.
 struct Reader {
-    data: string
+    buf: ptr    // owned std.bytes copy of the input
     len: int
     offset: int
+}
+
+// Read the byte at `off` (0..255). Bounds are checked by callers.
+fn rd(reader: *Reader, off: int) -> int {
+    return bytes.get(reader.buf, off) & 255
+}
+
+// Copy `len` bytes from the reader's buffer at its current offset into a
+// fresh owned payload buffer on `cv`, then advance the offset. No
+// intermediate string is minted. Bounds are checked by the caller.
+fn read_str_payload(cv: *CborValue, reader: *Reader, len: int) {
+    if len <= 0 {
+        cv.str_bytes = null
+        cv.str_len = 0
+        return
+    }
+    b = bytes.new(len)
+    _ = bytes.copy_from_bytes(b, 0, reader.buf, reader.offset, len)
+    reader.offset = reader.offset + len
+    cv.str_bytes = b
+    cv.str_len = len
 }
 
 struct Writer {
@@ -139,48 +236,51 @@ float16_to_float32(val: int) -> float {
 // ---- DECODER IMPLEMENTATION ----
 
 read_value(r: ptr, ai: int) -> (long, string) {
+    // Single tracked empty-error binding; a bare "" per success return mints
+    // a fresh 1-byte heap string the caller discards (one leak per call).
+    ok = ""
     reader = r as *Reader
     if ai < 24 {
-        return ai as long, ""
+        return ai as long, ok
     }
     if ai == 24 {
         if reader.offset >= reader.len { return 0, "cbor: unexpected EOF" }
-        v = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+        v = rd(reader, reader.offset)
         reader.offset = reader.offset + 1
-        return v as long, ""
+        return v as long, ok
     }
     if ai == 25 {
         if reader.offset + 2 > reader.len { return 0, "cbor: unexpected EOF" }
-        b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
-        b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+        b0 = rd(reader, reader.offset)
+        b1 = rd(reader, reader.offset + 1)
         reader.offset = reader.offset + 2
         v = (b0 << 8) | b1
-        return v as long, ""
+        return v as long, ok
     }
     if ai == 26 {
         if reader.offset + 4 > reader.len { return 0, "cbor: unexpected EOF" }
-        b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
-        b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
-        b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
-        b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
+        b0 = rd(reader, reader.offset)
+        b1 = rd(reader, reader.offset + 1)
+        b2 = rd(reader, reader.offset + 2)
+        b3 = rd(reader, reader.offset + 3)
         reader.offset = reader.offset + 4
         v = ((b0 as long) << 24) | ((b1 as long) << 16) | ((b2 as long) << 8) | (b3 as long)
-        return v, ""
+        return v, ok
     }
     if ai == 27 {
         if reader.offset + 8 > reader.len { return 0, "cbor: unexpected EOF" }
-        b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
-        b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
-        b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
-        b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
-        b4 = string.char_at_n(reader.data, reader.len, reader.offset + 4) & 255
-        b5 = string.char_at_n(reader.data, reader.len, reader.offset + 5) & 255
-        b6 = string.char_at_n(reader.data, reader.len, reader.offset + 6) & 255
-        b7 = string.char_at_n(reader.data, reader.len, reader.offset + 7) & 255
+        b0 = rd(reader, reader.offset)
+        b1 = rd(reader, reader.offset + 1)
+        b2 = rd(reader, reader.offset + 2)
+        b3 = rd(reader, reader.offset + 3)
+        b4 = rd(reader, reader.offset + 4)
+        b5 = rd(reader, reader.offset + 5)
+        b6 = rd(reader, reader.offset + 6)
+        b7 = rd(reader, reader.offset + 7)
         reader.offset = reader.offset + 8
         v = ((b0 as long) << 56) | ((b1 as long) << 48) | ((b2 as long) << 40) | ((b3 as long) << 32) |
             ((b4 as long) << 24) | ((b5 as long) << 16) | ((b6 as long) << 8) | (b7 as long)
-        return v, ""
+        return v, ok
     }
     return 0, "cbor: invalid additional information"
 }
@@ -190,7 +290,7 @@ parse_item(r: ptr) -> (ptr, string) {
     if reader.offset >= reader.len {
         return null, "cbor: unexpected EOF"
     }
-    ib = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+    ib = rd(reader, reader.offset)
     reader.offset = reader.offset + 1
 
     mt = (ib >> 5) & 7
@@ -199,6 +299,7 @@ parse_item(r: ptr) -> (ptr, string) {
     if mt == 0 {
         val, err = read_value(r, ai)
         if err != "" { return null, err }
+        string.release(err)
         cv = heap.new(CborValue)
         cv.type = CBOR_INT
         cv.int_val = val
@@ -207,6 +308,7 @@ parse_item(r: ptr) -> (ptr, string) {
     if mt == 1 {
         val, err = read_value(r, ai)
         if err != "" { return null, err }
+        string.release(err)
         cv = heap.new(CborValue)
         cv.type = CBOR_INT
         cv.int_val = -1 - val
@@ -223,7 +325,7 @@ parse_item(r: ptr) -> (ptr, string) {
                     bytes.free(sb)
                     return null, "cbor: unexpected EOF in indefinite byte string"
                 }
-                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                next_byte = rd(reader, reader.offset)
                 if next_byte == 255 { // break code
                     reader.offset = reader.offset + 1
                     break
@@ -233,30 +335,32 @@ parse_item(r: ptr) -> (ptr, string) {
                     bytes.free(sb)
                     return null, err
                 }
+                string.release(err)
                 child_cv = child as *CborValue
                 if child_cv.type != CBOR_BYTES {
                     bytes.free(sb)
                     free_value(child)
                     return null, "cbor: indefinite byte string contains non-byte-string"
                 }
-                chunk_len = string.length(child_cv.str_val)
-                _ = bytes.copy_from_string(sb, sb_len, child_cv.str_val, chunk_len)
+                chunk_len = child_cv.str_len
+                if chunk_len > 0 {
+                    _ = bytes.copy_from_bytes(sb, sb_len, child_cv.str_bytes, 0, chunk_len)
+                }
                 sb_len = sb_len + chunk_len
                 free_value(child)
             }
             cv = heap.new(CborValue)
             cv.type = CBOR_BYTES
-            cv.str_val = bytes.finish(sb, sb_len)
+            adopt_str_payload(cv as *CborValue, sb, sb_len)
             return cv as ptr, ""
         }
         len_val, err = read_value(r, ai)
         if err != "" { return null, err }
+        string.release(err)
         if reader.offset + (len_val as int) > reader.len { return null, "cbor: unexpected EOF" }
-        sub = string.substring(reader.data, reader.offset, reader.offset + (len_val as int))
-        reader.offset = reader.offset + (len_val as int)
         cv = heap.new(CborValue)
         cv.type = CBOR_BYTES
-        cv.str_val = sub
+        read_str_payload(cv as *CborValue, reader, len_val as int)
         return cv as ptr, ""
     }
     if mt == 3 {
@@ -269,7 +373,7 @@ parse_item(r: ptr) -> (ptr, string) {
                     bytes.free(sb)
                     return null, "cbor: unexpected EOF in indefinite text string"
                 }
-                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                next_byte = rd(reader, reader.offset)
                 if next_byte == 255 {
                     reader.offset = reader.offset + 1
                     break
@@ -279,121 +383,150 @@ parse_item(r: ptr) -> (ptr, string) {
                     bytes.free(sb)
                     return null, err
                 }
+                string.release(err)
                 child_cv = child as *CborValue
                 if child_cv.type != CBOR_TEXT {
                     bytes.free(sb)
                     free_value(child)
                     return null, "cbor: indefinite text string contains non-text-string"
                 }
-                chunk_len = string.length(child_cv.str_val)
-                _ = bytes.copy_from_string(sb, sb_len, child_cv.str_val, chunk_len)
+                chunk_len = child_cv.str_len
+                if chunk_len > 0 {
+                    _ = bytes.copy_from_bytes(sb, sb_len, child_cv.str_bytes, 0, chunk_len)
+                }
                 sb_len = sb_len + chunk_len
                 free_value(child)
             }
             cv = heap.new(CborValue)
             cv.type = CBOR_TEXT
-            cv.str_val = bytes.finish(sb, sb_len)
+            adopt_str_payload(cv as *CborValue, sb, sb_len)
             return cv as ptr, ""
         }
         len_val, err = read_value(r, ai)
         if err != "" { return null, err }
+        string.release(err)
         if reader.offset + (len_val as int) > reader.len { return null, "cbor: unexpected EOF" }
-        sub = string.substring(reader.data, reader.offset, reader.offset + (len_val as int))
-        reader.offset = reader.offset + (len_val as int)
         cv = heap.new(CborValue)
         cv.type = CBOR_TEXT
-        cv.str_val = sub
+        read_str_payload(cv as *CborValue, reader, len_val as int)
         return cv as ptr, ""
     }
     if mt == 4 {
+        // Build the container up front so any error path can free_value(cv)
+        // to reclaim the list and every child already parsed into it.
+        cv = heap.new(CborValue)
+        cv.type = CBOR_ARRAY
+        cv.list_val = list.new()
         if ai == 31 {
-            lst = list.new()
             while true {
-                if reader.offset >= reader.len { return null, "cbor: unexpected EOF in indefinite array" }
-                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                if reader.offset >= reader.len {
+                    free_value(cv)
+                    return null, "cbor: unexpected EOF in indefinite array"
+                }
+                next_byte = rd(reader, reader.offset)
                 if next_byte == 255 {
                     reader.offset = reader.offset + 1
                     break
                 }
                 child, err = parse_item(r)
-                if err != "" { return null, err }
-                _ = list.add(lst, child)
+                if err != "" {
+                    free_value(cv)
+                    return null, err
+                }
+                string.release(err)
+                _ = list.add(cv.list_val, child)
             }
-            cv = heap.new(CborValue)
-            cv.type = CBOR_ARRAY
-            cv.list_val = lst
             return cv as ptr, ""
         }
         len_val, err = read_value(r, ai)
-        if err != "" { return null, err }
-        lst = list.new()
+        if err != "" {
+            free_value(cv)
+            return null, err
+        }
+        string.release(err)
         i = 0
         while i < (len_val as int) {
             child, err = parse_item(r)
-            if err != "" { return null, err }
-            _ = list.add(lst, child)
+            if err != "" {
+                free_value(cv)
+                return null, err
+            }
+            string.release(err)
+            _ = list.add(cv.list_val, child)
             i = i + 1
         }
-        cv = heap.new(CborValue)
-        cv.type = CBOR_ARRAY
-        cv.list_val = lst
         return cv as ptr, ""
     }
     if mt == 5 {
+        // Build the container up front so any error path can free_value(cv)
+        // to reclaim both lists and every key/value already parsed.
+        cv = heap.new(CborValue)
+        cv.type = CBOR_MAP
+        cv.map_keys = list.new()
+        cv.map_values = list.new()
         if ai == 31 {
-            keys_lst = list.new()
-            vals_lst = list.new()
             while true {
-                if reader.offset >= reader.len { return null, "cbor: unexpected EOF in indefinite map" }
-                next_byte = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+                if reader.offset >= reader.len {
+                    free_value(cv)
+                    return null, "cbor: unexpected EOF in indefinite map"
+                }
+                next_byte = rd(reader, reader.offset)
                 if next_byte == 255 {
                     reader.offset = reader.offset + 1
                     break
                 }
                 key_cv, err = parse_item(r)
-                if err != "" { return null, err }
+                if err != "" {
+                    free_value(cv)
+                    return null, err
+                }
+                string.release(err)
                 val_cv, err2 = parse_item(r)
                 if err2 != "" {
                     free_value(key_cv)
+                    free_value(cv)
                     return null, err2
                 }
-                _ = list.add(keys_lst, key_cv)
-                _ = list.add(vals_lst, val_cv)
+                string.release(err2)
+                _ = list.add(cv.map_keys, key_cv)
+                _ = list.add(cv.map_values, val_cv)
             }
-            cv = heap.new(CborValue)
-            cv.type = CBOR_MAP
-            cv.map_keys = keys_lst
-            cv.map_values = vals_lst
             return cv as ptr, ""
         }
         len_val, err = read_value(r, ai)
-        if err != "" { return null, err }
-        keys_lst = list.new()
-        vals_lst = list.new()
+        if err != "" {
+            free_value(cv)
+            return null, err
+        }
+        string.release(err)
         i = 0
         while i < (len_val as int) {
             key_cv, err = parse_item(r)
-            if err != "" { return null, err }
+            if err != "" {
+                free_value(cv)
+                return null, err
+            }
+            string.release(err)
             val_cv, err2 = parse_item(r)
             if err2 != "" {
                 free_value(key_cv)
+                free_value(cv)
                 return null, err2
             }
-            _ = list.add(keys_lst, key_cv)
-            _ = list.add(vals_lst, val_cv)
+            string.release(err2)
+            _ = list.add(cv.map_keys, key_cv)
+            _ = list.add(cv.map_values, val_cv)
             i = i + 1
         }
-        cv = heap.new(CborValue)
-        cv.type = CBOR_MAP
-        cv.map_keys = keys_lst
-        cv.map_values = vals_lst
         return cv as ptr, ""
     }
     if mt == 6 {
         tag_val, err = read_value(r, ai)
         if err != "" { return null, err }
+        string.release(err)
         child_cv, err2 = parse_item(r)
         if err2 != "" { return null, err2 }
+        string.release(err2)
         cv = heap.new(CborValue)
         cv.type = CBOR_TAG
         cv.tag_val = tag_val
@@ -427,7 +560,7 @@ parse_item(r: ptr) -> (ptr, string) {
         }
         if ai == 24 {
             if reader.offset >= reader.len { return null, "cbor: unexpected EOF" }
-            v = string.char_at_n(reader.data, reader.len, reader.offset) & 255
+            v = rd(reader, reader.offset)
             reader.offset = reader.offset + 1
             cv = heap.new(CborValue)
             cv.type = CBOR_SIMPLE
@@ -436,8 +569,8 @@ parse_item(r: ptr) -> (ptr, string) {
         }
         if ai == 25 {
             if reader.offset + 2 > reader.len { return null, "cbor: unexpected EOF" }
-            b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
-            b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
+            b0 = rd(reader, reader.offset)
+            b1 = rd(reader, reader.offset + 1)
             reader.offset = reader.offset + 2
             bits = (b0 << 8) | b1
             f = float16_to_float32(bits)
@@ -448,10 +581,10 @@ parse_item(r: ptr) -> (ptr, string) {
         }
         if ai == 26 {
             if reader.offset + 4 > reader.len { return null, "cbor: unexpected EOF" }
-            b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
-            b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
-            b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
-            b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
+            b0 = rd(reader, reader.offset)
+            b1 = rd(reader, reader.offset + 1)
+            b2 = rd(reader, reader.offset + 2)
+            b3 = rd(reader, reader.offset + 3)
             reader.offset = reader.offset + 4
             bits = ((b0 as long) << 24) | ((b1 as long) << 16) | ((b2 as long) << 8) | (b3 as long)
             f = float32_from_bits(bits)
@@ -462,14 +595,14 @@ parse_item(r: ptr) -> (ptr, string) {
         }
         if ai == 27 {
             if reader.offset + 8 > reader.len { return null, "cbor: unexpected EOF" }
-            b0 = string.char_at_n(reader.data, reader.len, reader.offset) & 255
-            b1 = string.char_at_n(reader.data, reader.len, reader.offset + 1) & 255
-            b2 = string.char_at_n(reader.data, reader.len, reader.offset + 2) & 255
-            b3 = string.char_at_n(reader.data, reader.len, reader.offset + 3) & 255
-            b4 = string.char_at_n(reader.data, reader.len, reader.offset + 4) & 255
-            b5 = string.char_at_n(reader.data, reader.len, reader.offset + 5) & 255
-            b6 = string.char_at_n(reader.data, reader.len, reader.offset + 6) & 255
-            b7 = string.char_at_n(reader.data, reader.len, reader.offset + 7) & 255
+            b0 = rd(reader, reader.offset)
+            b1 = rd(reader, reader.offset + 1)
+            b2 = rd(reader, reader.offset + 2)
+            b3 = rd(reader, reader.offset + 3)
+            b4 = rd(reader, reader.offset + 4)
+            b5 = rd(reader, reader.offset + 5)
+            b6 = rd(reader, reader.offset + 6)
+            b7 = rd(reader, reader.offset + 7)
             reader.offset = reader.offset + 8
             bits = ((b0 as long) << 56) | ((b1 as long) << 48) | ((b2 as long) << 40) | ((b3 as long) << 32) |
                    ((b4 as long) << 24) | ((b5 as long) << 16) | ((b6 as long) << 8) | (b7 as long)
@@ -486,16 +619,29 @@ parse_item(r: ptr) -> (ptr, string) {
 // Parse a CBOR binary string. Returns (value_ptr, "") on success, (null, error) on failure.
 // Caller owns the returned value and must free with cbor.free.
 parse(cbor_data: string) -> ptr! {
+    ok = ""
+    dlen = string.length(cbor_data)
+    // Copy the input into an owned bytes buffer. We must NOT store the
+    // caller's string in the Reader struct: doing so escapes it and the
+    // caller's release of `cbor_data` is suppressed (it leaks).
+    buf = bytes.new(dlen)
+    if dlen > 0 {
+        _ = bytes.copy_from_string(buf, 0, cbor_data, dlen)
+    }
     r = heap.new(Reader)
-    r.data = cbor_data
-    r.len = string.length(cbor_data)
+    r.buf = buf
+    r.len = dlen
     r.offset = 0
     res, err = parse_item(r as ptr)
+    bytes.free(r.buf)
     heap.free(r)
     if err != "" {
         return null, err
     }
-    return res, ""
+    // parse_item's success path returns a fresh heap "" in the error slot;
+    // discard it here (we return our own ok) or it leaks one byte per parse.
+    string.release(err)
+    return res, ok
 }
 
 // ---- ENCODER IMPLEMENTATION ----
@@ -568,15 +714,23 @@ encode_item(w: ptr, cv: ptr) -> string {
         return ""
     }
     if cv_val.type == CBOR_BYTES {
-        len = string.length(cv_val.str_val)
+        len = cv_val.str_len
         encode_header(w, 2, len as long)
-        write_string(w, cv_val.str_val, len)
+        if len > 0 {
+            s = str_payload_string(cv_val)
+            write_string(w, s, len)
+            string.release(s)
+        }
         return ""
     }
     if cv_val.type == CBOR_TEXT {
-        len = string.length(cv_val.str_val)
+        len = cv_val.str_len
         encode_header(w, 3, len as long)
-        write_string(w, cv_val.str_val, len)
+        if len > 0 {
+            s = str_payload_string(cv_val)
+            write_string(w, s, len)
+            string.release(s)
+        }
         return ""
     }
     if cv_val.type == CBOR_ARRAY {
@@ -719,7 +873,7 @@ get_string(value: ptr) -> string! {
     if cv.type != CBOR_TEXT {
         return "", "not a string"
     }
-    return string.concat(cv.str_val, ""), ""
+    return str_payload_string(cv), ""
 }
 
 get_bytes(value: ptr) -> string! {
@@ -728,7 +882,7 @@ get_bytes(value: ptr) -> string! {
     if cv.type != CBOR_BYTES {
         return "", "not a byte string"
     }
-    return string.concat(cv.str_val, ""), ""
+    return str_payload_string(cv), ""
 }
 
 get_tag_val(value: ptr) -> long {
@@ -758,7 +912,7 @@ object_get(obj_ptr: ptr, key: string) -> ptr! {
     while i < n {
         k_ptr, _ = list.get(cv.map_keys, i)
         k = k_ptr as *CborValue
-        if k.type == CBOR_TEXT && k.str_val == key {
+        if k.type == CBOR_TEXT && str_payload_equals_key(k, key) {
             val_ptr, _ = list.get(cv.map_values, i)
             return val_ptr, ""
         }
@@ -775,7 +929,7 @@ fn equal_val(a: ptr, b: ptr) -> bool {
     if acv.type != bcv.type { return false }
     if acv.type == CBOR_INT { return acv.int_val == bcv.int_val }
     if acv.type == CBOR_FLOAT { return acv.float_val == bcv.float_val }
-    if acv.type == CBOR_TEXT || acv.type == CBOR_BYTES { return acv.str_val == bcv.str_val }
+    if acv.type == CBOR_TEXT || acv.type == CBOR_BYTES { return str_payload_equal(acv, bcv) }
     if acv.type == CBOR_SIMPLE { return acv.int_val == bcv.int_val }
     if acv.type == CBOR_TAG {
         return acv.tag_val == bcv.tag_val && equal_val(acv.tag_child, bcv.tag_child)
@@ -897,14 +1051,14 @@ arr() -> ptr {
 str(value: string) -> ptr {
     cv = heap.new(CborValue)
     cv.type = CBOR_TEXT
-    cv.str_val = value
+    set_str_payload(cv as *CborValue, value, string.length(value))
     return cv as ptr
 }
 
 bytes(value: string) -> ptr {
     cv = heap.new(CborValue)
     cv.type = CBOR_BYTES
-    cv.str_val = value
+    set_str_payload(cv as *CborValue, value, string.length(value))
     return cv as ptr
 }
 
@@ -984,6 +1138,10 @@ free_value(cv: ptr) {
     } else if cv_val.type == CBOR_TAG {
         free_value(cv_val.tag_child)
     }
+    if cv_val.str_bytes != null {
+        bytes.free(cv_val.str_bytes)
+        cv_val.str_bytes = null
+    }
     heap.free(cv_val)
 }
 
@@ -1047,10 +1205,16 @@ to_diagnose_string(cv: ptr) -> string {
         return format_float_diag(cv_val.float_val)
     }
     if cv_val.type == CBOR_TEXT {
-        return escape_string(cv_val.str_val)
+        s = str_payload_string(cv_val)
+        out = escape_string(s)
+        string.release(s)
+        return out
     }
     if cv_val.type == CBOR_BYTES {
-        return format_bytes_diag(cv_val.str_val)
+        s = str_payload_string(cv_val)
+        out = format_bytes_diag(s)
+        string.release(s)
+        return out
     }
     if cv_val.type == CBOR_SIMPLE {
         if cv_val.int_val == 20 { return "false" }

--- a/tests/regression/test_cbor.ae
+++ b/tests/regression/test_cbor.ae
@@ -1,0 +1,184 @@
+// Regression test for std.cbor
+// Asserts correct encoding and decoding of integers, floats, strings, arrays, maps, and tags.
+
+import std.cbor
+import std.encoding
+import std.string
+
+extern exit(code: int)
+
+fn run_test(hex_data: string, expected_diag: string) -> int {
+    binary_data, err = encoding.hex_decode(hex_data)
+    if err != "" {
+        println("  FAIL: hex decode failed for ${hex_data}: ${err}")
+        return 1
+    }
+
+    cv_ptr, err2 = cbor.parse(binary_data)
+    if err2 != "" {
+        println("  FAIL: cbor parse failed for ${hex_data}: ${err2}")
+        return 1
+    }
+
+    diag, err3 = cbor.diagnose(cv_ptr)
+    if err3 != "" {
+        println("  FAIL: cbor diagnose failed for ${hex_data}: ${err3}")
+        cbor.free(cv_ptr)
+        return 1
+    }
+
+    if diag != expected_diag {
+        println("  FAIL: diag mismatch for ${hex_data}")
+        println("    got:      '${diag}'")
+        println("    expected: '${expected_diag}'")
+        cbor.free(cv_ptr)
+        return 1
+    }
+
+    // Roundtrip encode
+    encoded, err4 = cbor.encode(cv_ptr)
+    if err4 != "" {
+        println("  FAIL: cbor encode failed for ${hex_data}: ${err4}")
+        cbor.free(cv_ptr)
+        return 1
+    }
+
+    // Convert encoded back to hex to compare
+    encoded_len = string.length(encoded)
+    encoded_hex = encoding.hex_encode(encoded, encoded_len)
+
+    // We only assert exact hex match for non-floats and non-indefinite values
+    is_float = string.starts_with(hex_data, "f9") == 1 || string.starts_with(hex_data, "fa") == 1 || string.starts_with(hex_data, "fb") == 1
+    is_indefinite = string.starts_with(hex_data, "9f") == 1 || string.starts_with(hex_data, "bf") == 1 || string.starts_with(hex_data, "5f") == 1 || string.starts_with(hex_data, "7f") == 1
+    if !is_float && !is_indefinite {
+        if encoded_hex != string.to_lower(hex_data) {
+            println("  FAIL: encode hex mismatch for ${hex_data}")
+            println("    got:      '${encoded_hex}'")
+            println("    expected: '${string.to_lower(hex_data)}'")
+            cbor.free(cv_ptr)
+            return 1
+        }
+    }
+
+    cbor.free(cv_ptr)
+    return 0
+}
+
+fn test_builders() -> int {
+    root = cbor.obj()
+    _ = cbor.set(root, "name", cbor.str("aether"))
+    _ = cbor.set(root, "ok", cbor.boolean(1))
+    _ = cbor.set(root, "nil", cbor.null_value())
+    _ = cbor.set(root, "undef", cbor.undefined_value())
+    _ = cbor.set(root, "n", cbor.from_int(12345))
+    _ = cbor.set(root, "f", cbor.num(123.45))
+
+    tags = cbor.arr()
+    _ = cbor.push(tags, cbor.str("lang"))
+    _ = cbor.push(tags, cbor.str("actor"))
+    _ = cbor.set(root, "tags", tags)
+
+    diag, _ = cbor.diagnose(root)
+    expected = "{\"name\": \"aether\", \"ok\": true, \"nil\": null, \"undef\": undefined, \"n\": 12345, \"f\": 123.45, \"tags\": [\"lang\", \"actor\"]}"
+    if diag != expected {
+        println("  FAIL builder: diag mismatch")
+        println("    got:      '${diag}'")
+        println("    expected: '${expected}'")
+        cbor.free(root)
+        return 1
+    }
+
+    encoded, _ = cbor.encode(root)
+    root2, err = cbor.parse(encoded)
+    if err != "" {
+        println("  FAIL builder: parse back failed: ${err}")
+        cbor.free(root)
+        return 1
+    }
+
+    diag2, _ = cbor.diagnose(root2)
+    if diag2 != expected {
+        println("  FAIL builder: roundtrip diag mismatch")
+        println("    got:      '${diag2}'")
+        println("    expected: '${expected}'")
+        cbor.free(root)
+        cbor.free(root2)
+        return 1
+    }
+
+    cbor.free(root)
+    cbor.free(root2)
+    return 0
+}
+
+main() {
+    println("=== test_cbor ===")
+    fails = 0
+
+    // ---- Integers (Major 0 & 1) ----
+    fails = fails + run_test("00", "0")
+    fails = fails + run_test("01", "1")
+    fails = fails + run_test("0a", "10")
+    fails = fails + run_test("17", "23")
+    fails = fails + run_test("1818", "24")
+    fails = fails + run_test("1819", "25")
+    fails = fails + run_test("1864", "100")
+    fails = fails + run_test("1903e8", "1000")
+    fails = fails + run_test("1a000f4240", "1000000")
+    fails = fails + run_test("1b000000e8d4a51000", "1000000000000")
+    fails = fails + run_test("20", "-1")
+    fails = fails + run_test("29", "-10")
+    fails = fails + run_test("3863", "-100")
+    fails = fails + run_test("3903e7", "-1000")
+
+    // ---- Simple Values ----
+    fails = fails + run_test("f4", "false")
+    fails = fails + run_test("f5", "true")
+    fails = fails + run_test("f6", "null")
+    fails = fails + run_test("f7", "undefined")
+
+    // ---- Floats ----
+    fails = fails + run_test("f93c00", "1.0")
+    fails = fails + run_test("f93e00", "1.5")
+    fails = fails + run_test("f9c400", "-4.0")
+    fails = fails + run_test("fa47c35000", "100000.0")
+    fails = fails + run_test("fb3ff199999999999a", "1.1")
+    fails = fails + run_test("f97c00", "Infinity")
+    fails = fails + run_test("f9fc00", "-Infinity")
+    fails = fails + run_test("f97e00", "NaN")
+
+    // ---- Strings & Bytes ----
+    fails = fails + run_test("40", "h''")
+    fails = fails + run_test("4401020304", "h'01020304'")
+    fails = fails + run_test("60", "\"\"")
+    fails = fails + run_test("6161", "\"a\"")
+    fails = fails + run_test("6449455446", "\"IETF\"")
+    fails = fails + run_test("62225c", "\"\\\"\\\\\"")
+
+    // ---- Arrays & Maps (Definite) ----
+    fails = fails + run_test("80", "[]")
+    fails = fails + run_test("83010203", "[1, 2, 3]")
+    fails = fails + run_test("a0", "{}")
+    fails = fails + run_test("a26161016162820203", "{\"a\": 1, \"b\": [2, 3]}")
+
+    // ---- Indefinite Collections ----
+    fails = fails + run_test("9f0102ff", "[1, 2]")
+    fails = fails + run_test("bf616101ff", "{\"a\": 1}")
+    fails = fails + run_test("5f41014102ff", "h'0102'")
+    fails = fails + run_test("7f61616162ff", "\"ab\"")
+
+    // ---- Tags ----
+    fails = fails + run_test("c074323031332d30332d32315432303a30343a30355a", "0(\"2013-03-21T20:04:05Z\")")
+    fails = fails + run_test("c11a514b67b0", "1(1363896240)")
+    fails = fails + run_test("c249010000000000000000", "2(h'010000000000000000')")
+
+    // ---- Builders ----
+    fails = fails + test_builders()
+
+    if fails != 0 {
+        println("CBOR: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_cbor")
+    println("=== test_cbor passed ===")
+}

--- a/tests/regression/test_cbor_roundtrip_no_leak.ae
+++ b/tests/regression/test_cbor_roundtrip_no_leak.ae
@@ -1,0 +1,97 @@
+// Regression: std.cbor must be leak-clean across build → encode → parse →
+// read → diagnose → free, including nested containers, tags, byte strings,
+// and truncated-input error paths. The original test_cbor barely stresses
+// string payloads or error cleanup; this one loops enough to make any
+// per-item leak obvious under the macOS leaks(1) gate / ASan.
+//
+// The value model owns text/byte payloads as std.bytes buffers (not string
+// struct fields) and copies parse input into an owned buffer, so nothing the
+// caller passes in or reads out is leaked. See std/cbor/module.ae's memory
+// model note.
+
+import std.cbor
+import std.string
+
+extern exit(code: int)
+
+check(cond: int, msg: string) -> int {
+    if cond != 0 {
+        return 0
+    }
+    println("  FAIL: ${msg}")
+    return 1
+}
+
+main() {
+    println("=== test_cbor_roundtrip_no_leak ===")
+    fails = 0
+
+    n = 0
+    while n < 100 {
+        // Build a map with text keys and mixed values incl. nested array,
+        // byte string (with embedded NUL), int, and a tagged value.
+        m = cbor.obj()
+        _ = cbor.set(m, "name", cbor.str("a reasonably long text string value"))
+        _ = cbor.set(m, "count", cbor.from_int(12345))
+        _ = cbor.set(m, "blob", cbor.bytes("some-binary-bytes"))
+        a = cbor.arr()
+        _ = cbor.push(a, cbor.str("alpha"))
+        _ = cbor.push(a, cbor.str("beta"))
+        _ = cbor.set(m, "list", a)
+        _ = cbor.set(m, "when", cbor.tag(0, cbor.str("2026-07-26")))
+
+        enc, eerr = cbor.encode(m)
+        fails = fails + check(string.equals(eerr, ""), "encode err")
+        string.release(eerr)
+        cbor.free(m)
+
+        v, perr = cbor.parse(enc)
+        fails = fails + check(string.equals(perr, ""), "parse err")
+        string.release(perr)
+        string.release(enc)
+
+        // Read a text value back out (fresh caller-owned string).
+        nm, _ = cbor.object_get(v, "name")
+        s, gerr = cbor.get_string(nm)
+        string.release(gerr)
+        fails = fails + check(string.equals(s, "a reasonably long text string value"), "roundtrip name")
+        string.release(s)
+
+        // Read the byte string with the embedded NUL back.
+        bl, _ = cbor.object_get(v, "blob")
+        bs, berr = cbor.get_bytes(bl)
+        string.release(berr)
+        fails = fails + check(string.equals(bs, "some-binary-bytes"), "roundtrip blob")
+        string.release(bs)
+
+        // Diagnose (exercises escape_string + format_bytes_diag payload reads).
+        d, derr = cbor.diagnose(v)
+        string.release(derr)
+        string.release(d)
+
+        cbor.free(v)
+        n = n + 1
+    }
+
+    // Truncated inputs must error cleanly and leak nothing (partial trees
+    // are reclaimed on the error path).
+    n = 0
+    while n < 100 {
+        a1, e1 = cbor.parse("\x63")          // text len 3, no data
+        string.release(e1)
+        if a1 != null { cbor.free(a1) }
+        a2, e2 = cbor.parse("\x82\x01")      // array of 2, only 1 item
+        string.release(e2)
+        if a2 != null { cbor.free(a2) }
+        a3, e3 = cbor.parse("\xa1\x61\x61")  // map, key but no value
+        string.release(e3)
+        if a3 != null { cbor.free(a3) }
+        n = n + 1
+    }
+
+    if fails != 0 {
+        println("test_cbor_roundtrip_no_leak: ${fails} failure(s)")
+        exit(1)
+    }
+    println("=== test_cbor_roundtrip_no_leak passed ===")
+}


### PR DESCRIPTION
Adds `std.cbor`, a CBOR (RFC 8949) parse/encode/diagnostic library, ported from [fxamacker/cbor](https://github.com/fxamacker/cbor) (MIT). Covers all 8 major types — unsigned/negative ints, byte strings, text strings (definite + indefinite), arrays, maps, tags, simple values, and half/single/double floats — plus EDN diagnostic notation.

The base implementation is Jules-authored (`becc63f6`). The follow-up commit (`b2cd9470`) makes it leak-clean — this is the sibling we held back from the MessagePack PR (#1280) because it shared the same string-ownership design flaw, now fixed with the same treatment.

## What the follow-up fixes

**Struct-field string-ownership leak** (same as msgpack): each value stored its text/byte payload in a `string` field of a `heap.new(CborValue)` struct, which leaks — `heap.free` reclaims only the struct, and a string can't be released out of a struct field without a double-free. Payloads now live as an owned **AetherBytes buffer** (`str_bytes` + `str_len`), reclaimed by `free_value`; `get_string`/`get_bytes` mint a fresh caller-owned string on demand via `bytes.to_string`.

**Borrowed-input escape leak:** the `Reader` stored the caller's input string in a struct field, which escapes it and suppresses the caller's release of the parsed string (a whole-tree-sized leak per `parse`). The input is now copied into an owned bytes buffer the module frees itself and read through directly — this also drops the per-item `string.substring` allocations.

**Error-slot leak:** `parse_item`'s success path returned a fresh heap `""` in the error slot, one byte per decoded value. The discarded child error is now released at every recursive call site and at `parse()`.

**Error-path partial-tree leak:** truncated-input error paths (EOF mid-array/map, child parse error) returned without freeing the partial container and the children already parsed into it (~264 bytes per truncated-input iteration). Containers are now built up front so any error path can `free_value(cv)` to reclaim everything.

## Verification

- **Leak-clean under valgrind (0 bytes, 0 invalid frees)** across: a 200-iteration build/encode/parse/read/diagnose stress with nested containers/tags/byte strings, the `object_get`/`map_get`/`object_entry`/`diagnose` API paths, and truncated-input error paths.
- The existing `test_cbor` drops from **1,467 leaked bytes to 0**.
- New `test_cbor_roundtrip_no_leak` stresses the round-trip and error paths.
- Full `.ae` suite: **905 passed**. The 6 failures are all pre-existing and unrelated (HTTP network flakes, an untracked `bit_set` file, open #1252).

🤖 Generated with [Claude Code](https://claude.com/claude-code)