### PR TITLE
std.cryptography: Ascon AEAD (SP 800-232 + v1.2) in pure Aether

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Ascon AEAD (authenticated encryption) in `std.cryptography`, pure Aether** —
+  the first pure-Aether AEAD in `std`, completing the Ascon port so a
+  cross-built binary with no OpenSSL (where AES-GCM stubs out) has a real
+  encrypt+authenticate channel. Two modules, both ported from Bouncy Castle
+  (same provenance as the shipped Ascon hashes), no externs to OpenSSL or any
+  C crypto:
+  - `std.cryptography.ascon_aead128` — **Ascon-AEAD128 (NIST SP 800-232**, the
+    finalized standard; little-endian, rate 16). `aead_seal` / `aead_open`.
+  - `std.cryptography.ascon_aead` — **Ascon v1.2 AEAD (Ascon-128 + Ascon-128a**,
+    the NIST LWC winner; big-endian, rate 8/16) for interop with v1.2
+    deployments. `aead_seal(algo, …)` / `aead_open(algo, …)` plus `a128_*` /
+    `a128a_*` variant-pinned wrappers.
+  The seal/open API mirrors `contrib.cryptography.chacha20poly1305`. Both are
+  verified against official Known-Answer Test vectors — SP 800-232 KATs from
+  the `ascon/ascon-c` reference, and the NIST LWC KATs shipped in bc-csharp —
+  spanning every block boundary (empty, partial, full, multi-block AAD), with
+  round-trip and tamper-rejection checks, and are leak-clean.
+
 ## [0.443.0]
 
 ### Added

--- a/std/cryptography/ascon_aead/module.ae
+++ b/std/cryptography/ascon_aead/module.ae
@@ -1,0 +1,363 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.ascon_aead — Ascon v1.2 AEAD (Ascon-128 and Ascon-128a) in
+// pure Aether, ported from Bouncy Castle's AsconEngine. Authenticated
+// encryption with associated data. NO externs to OpenSSL or any C crypto.
+//
+// This is the NIST LWC 2023 winner's v1.2 AEAD: big-endian, 128-bit key /
+// nonce / tag. Two variants:
+//   - "ascon-128"  : rate  8, p6 for AAD/data, IV 0x80400c0600000000
+//   - "ascon-128a" : rate 16, p8 for AAD/data, IV 0x80800c0800000000
+// Both use p12 for init/finalize. This is DISTINCT from the finalized NIST
+// SP 800-232 Ascon-AEAD128 (see std.cryptography.ascon_aead128), which is
+// little-endian with a different IV. Prefer ascon_aead128 for new designs;
+// this module exists for interop with v1.2 deployments and its LWC KATs.
+//
+// Import with:  import std.cryptography.ascon_aead
+//
+// API (mirrors contrib.cryptography.chacha20poly1305):
+//   aead_seal(algo, key16, nonce16, aad, aad_len, pt, pt_len) -> ptr ct-with-tag
+//   aead_open(algo, key16, nonce16, aad, aad_len, ct_with_tag, ct_len) -> (pt, "")
+// `algo` is "ascon-128" or "ascon-128a". Convenience wrappers a128_* / a128a_*
+// pin the variant. key/nonce/aad/pt are std.bytes; returns are std.bytes.
+
+import std.bits
+import std.bytes
+
+exports (
+    aead_seal, aead_open,
+    a128_seal, a128_open, a128a_seal, a128a_open,
+    KEY_BYTES, NONCE_BYTES, TAG_BYTES
+)
+
+const KEY_BYTES   = 16
+const NONCE_BYTES = 16
+const TAG_BYTES   = 16
+
+struct Aead12St {
+    s0: long
+    s1: long
+    s2: long
+    s3: long
+    s4: long
+    rate: int      // 8 (ascon-128) or 16 (ascon-128a)
+    nr: int        // 6 (ascon-128) or 8 (ascon-128a) for AAD/data rounds
+    iv: long
+}
+
+fn round(st: *Aead12St, rc: long) {
+    sx = st.s2 ^ rc
+    t0 = st.s0 ^ st.s1 ^ sx ^ st.s3 ^ (st.s1 & (st.s0 ^ sx ^ st.s4))
+    t1 = st.s0 ^ sx ^ st.s3 ^ st.s4 ^ ((st.s1 ^ sx) & (st.s1 ^ st.s3))
+    t2 = st.s1 ^ sx ^ st.s4 ^ (st.s3 & st.s4)
+    t3 = st.s0 ^ st.s1 ^ sx ^ ((~st.s0) & (st.s3 ^ st.s4))
+    t4 = st.s1 ^ st.s3 ^ st.s4 ^ ((st.s0 ^ st.s4) & st.s1)
+    st.s0 = t0 ^ bits.rotr64(t0, 19) ^ bits.rotr64(t0, 28)
+    st.s1 = t1 ^ bits.rotr64(t1, 39) ^ bits.rotr64(t1, 61)
+    st.s2 = ~(t2 ^ bits.rotr64(t2, 1) ^ bits.rotr64(t2, 6))
+    st.s3 = t3 ^ bits.rotr64(t3, 10) ^ bits.rotr64(t3, 17)
+    st.s4 = t4 ^ bits.rotr64(t4, 7) ^ bits.rotr64(t4, 41)
+}
+
+// p(nr): the last `nr` of the 12 round constants (p12 = all 12, p8 = last 8,
+// p6 = last 6). The round-constant schedule is 0xf0,0xe1,...,0x4b.
+fn perm(st: *Aead12St, nr: int) {
+    if nr == 12 {
+        round(st, 0xf0)
+        round(st, 0xe1)
+        round(st, 0xd2)
+        round(st, 0xc3)
+        round(st, 0xb4)
+        round(st, 0xa5)
+    } else if nr == 8 {
+        round(st, 0xb4)
+        round(st, 0xa5)
+    } else {
+        // nr == 6
+    }
+    round(st, 0x96)
+    round(st, 0x87)
+    round(st, 0x78)
+    round(st, 0x69)
+    round(st, 0x5a)
+    round(st, 0x4b)
+}
+
+// Big-endian 8-byte load.
+fn ld64(b: ptr, off: int) -> long {
+    return bytes.get_be64(b, off)
+}
+
+// Big-endian load of the high `n` (0..7) bytes at `off`, i.e. byte [off] is
+// the MOST-significant of the returned word; bytes below (8-n) read as zero.
+// This matches Pack.BE_To_UInt64 over a right-zero-padded buffer.
+fn ld_high(b: ptr, off: int, n: int) -> long {
+    long v = 0
+    i = 0
+    while i < n {
+        long byte_v = bytes.get(b, off + i) & 255
+        v = v | (byte_v << ((7 - i) << 3))
+        i = i + 1
+    }
+    return v
+}
+
+// Store the high `n` (0..8) bytes of `v` big-endian into `b` at `off` (byte
+// [off] is the most-significant).
+fn st_high(b: ptr, off: int, v: long, n: int) {
+    i = 0
+    while i < n {
+        bytes.set(b, off + i, ((v >> ((7 - i) << 3)) & 255) as int)
+        i = i + 1
+    }
+}
+
+// v1.2 pad: a single 0x80 byte at big-endian position `i` (i bytes already
+// filled), i.e. 0x80 << (56 - i*8) as a 64-bit big-endian word.
+fn pad(i: int) -> long {
+    long p = 0x80
+    return p << (56 - (i << 3))
+}
+
+// Mask keeping the LOW (8-i)*8 bits (clearing the top `i` bytes just
+// overwritten by ciphertext during decryption): 0xFFFF... >> (i*8). Matches
+// BC's `ulong.MaxValue >> (inLen << 3)`. Must be a LOGICAL right shift —
+// Aether's `>>` is arithmetic, so `0xFFFF...FF >> 8` would sign-extend to -1
+// and clear nothing; bits.lsr64 does the unsigned shift.
+fn low_mask(i: int) -> long {
+    long ones = 0xFFFFFFFFFFFFFFFF
+    return bits.lsr64(ones, i << 3)
+}
+
+fn init_state(st: *Aead12St, key: ptr, nonce: ptr, k1: long, k2: long) {
+    st.s0 = st.iv
+    st.s1 = k1
+    st.s2 = k2
+    st.s3 = ld64(nonce, 0)
+    st.s4 = ld64(nonce, 8)
+    perm(st, 12)
+    st.s3 = st.s3 ^ k1
+    st.s4 = st.s4 ^ k2
+}
+
+fn absorb_aad(st: *Aead12St, aad: ptr, aad_len: int) {
+    off = 0
+    remaining = aad_len
+    while remaining >= st.rate {
+        st.s0 = st.s0 ^ ld64(aad, off)
+        if st.rate == 16 {
+            st.s1 = st.s1 ^ ld64(aad, off + 8)
+        }
+        perm(st, st.nr)
+        off = off + st.rate
+        remaining = remaining - st.rate
+    }
+    if aad_len > 0 {
+        // Partial final block: set 0x80 pad byte at position `remaining`.
+        if remaining >= 8 {
+            st.s0 = st.s0 ^ ld64(aad, off)
+            r2 = remaining - 8
+            st.s1 = st.s1 ^ (ld_high(aad, off + 8, r2) ^ pad(r2))
+        } else {
+            st.s0 = st.s0 ^ (ld_high(aad, off, remaining) ^ pad(remaining))
+        }
+        perm(st, st.nr)
+    }
+    // domain separation
+    st.s4 = st.s4 ^ 0x0000000000000001
+}
+
+fn finish_data(st: *Aead12St, key: ptr) {
+    if st.rate == 16 {
+        // ascon-128a mixes the key into s2/s3.
+        st.s2 = st.s2 ^ ld64(key, 0)
+        st.s3 = st.s3 ^ ld64(key, 8)
+    } else {
+        // ascon-128 mixes the key into s1/s2.
+        st.s1 = st.s1 ^ ld64(key, 0)
+        st.s2 = st.s2 ^ ld64(key, 8)
+    }
+    perm(st, 12)
+    st.s3 = st.s3 ^ ld64(key, 0)
+    st.s4 = st.s4 ^ ld64(key, 8)
+}
+
+fn encrypt_body(st: *Aead12St, pt: ptr, pt_len: int, ct: ptr, key: ptr) {
+    off = 0
+    remaining = pt_len
+    while remaining >= st.rate {
+        st.s0 = st.s0 ^ ld64(pt, off)
+        st_high(ct, off, st.s0, 8)
+        if st.rate == 16 {
+            st.s1 = st.s1 ^ ld64(pt, off + 8)
+            st_high(ct, off + 8, st.s1, 8)
+        }
+        perm(st, st.nr)
+        off = off + st.rate
+        remaining = remaining - st.rate
+    }
+    // Final partial (or empty) block.
+    if st.rate == 16 && remaining >= 8 {
+        st.s0 = st.s0 ^ ld64(pt, off)
+        st_high(ct, off, st.s0, 8)
+        r2 = remaining - 8
+        if r2 > 0 {
+            st.s1 = st.s1 ^ ld_high(pt, off + 8, r2)
+            st_high(ct, off + 8, st.s1, r2)
+        }
+        st.s1 = st.s1 ^ pad(r2)
+    } else {
+        if remaining > 0 {
+            st.s0 = st.s0 ^ ld_high(pt, off, remaining)
+            st_high(ct, off, st.s0, remaining)
+        }
+        st.s0 = st.s0 ^ pad(remaining)
+    }
+    finish_data(st, key)
+}
+
+fn decrypt_body(st: *Aead12St, ct: ptr, ct_len: int, pt: ptr, key: ptr) {
+    off = 0
+    remaining = ct_len
+    while remaining >= st.rate {
+        c0 = ld64(ct, off)
+        st_high(pt, off, st.s0 ^ c0, 8)
+        st.s0 = c0
+        if st.rate == 16 {
+            c1 = ld64(ct, off + 8)
+            st_high(pt, off + 8, st.s1 ^ c1, 8)
+            st.s1 = c1
+        }
+        perm(st, st.nr)
+        off = off + st.rate
+        remaining = remaining - st.rate
+    }
+    // Partial final block. Mirrors BC AsconEngine.ProcessFinalDecrypt: the
+    // pad is XORed into the rate word BEFORE the ciphertext bytes are folded
+    // back, and the state word keeps its LOW bits (the un-decrypted rate/cap
+    // boundary) via low_mask.
+    if st.rate == 16 && remaining >= 8 {
+        c0 = ld64(ct, off)
+        st.s0 = st.s0 ^ c0
+        st_high(pt, off, st.s0, 8)
+        st.s0 = c0
+        r2 = remaining - 8
+        st.s1 = st.s1 ^ pad(r2)
+        if r2 > 0 {
+            c1 = ld_high(ct, off + 8, r2)
+            st.s1 = st.s1 ^ c1
+            st_high(pt, off + 8, st.s1, r2)
+            st.s1 = (st.s1 & low_mask(r2)) ^ c1
+        }
+    } else {
+        st.s0 = st.s0 ^ pad(remaining)
+        if remaining > 0 {
+            c0 = ld_high(ct, off, remaining)
+            st.s0 = st.s0 ^ c0
+            st_high(pt, off, st.s0, remaining)
+            st.s0 = (st.s0 & low_mask(remaining)) ^ c0
+        }
+    }
+    finish_data(st, key)
+}
+
+// Configure an already-allocated state for `algo`. Returns 1 on success, 0 on
+// an unknown algo. (We fill a caller-owned struct rather than return a pointer
+// to a local, which would dangle after return.)
+fn config_state(st: *Aead12St, algo: string) -> int {
+    st.s0 = 0
+    st.s1 = 0
+    st.s2 = 0
+    st.s3 = 0
+    st.s4 = 0
+    if algo == "ascon-128" {
+        st.rate = 8
+        st.nr = 6
+        st.iv = 0x80400c0600000000
+        return 1
+    }
+    if algo == "ascon-128a" {
+        st.rate = 16
+        st.nr = 8
+        st.iv = 0x80800c0800000000
+        return 1
+    }
+    return 0
+}
+
+// Seal with the named variant. Returns ct-with-tag (pt_len + 16), or null on a
+// bad algo/key/nonce.
+aead_seal(algo: string, key: ptr, nonce: ptr, aad: ptr, aad_len: int, pt: ptr, pt_len: int) -> ptr {
+    if key == null || nonce == null { return null }
+    if bytes.length(key) < KEY_BYTES || bytes.length(nonce) < NONCE_BYTES { return null }
+    st = Aead12St { s0: 0, s1: 0, s2: 0, s3: 0, s4: 0, rate: 0, nr: 0, iv: 0 }
+    if config_state(&st, algo) == 0 { return null }
+
+    k1 = ld64(key, 0)
+    k2 = ld64(key, 8)
+    init_state(&st, key, nonce, k1, k2)
+    absorb_aad(&st, aad, aad_len)
+
+    out_len = pt_len + TAG_BYTES
+    out = bytes.new(out_len)
+    j = 0
+    while j < out_len {
+        bytes.set(out, j, 0)
+        j = j + 1
+    }
+    encrypt_body(&st, pt, pt_len, out, key)
+    // Tag is (s3, s4) big-endian.
+    st_high(out, pt_len, st.s3, 8)
+    st_high(out, pt_len + 8, st.s4, 8)
+    return out
+}
+
+// Open with the named variant. Returns (pt, "") on a valid tag, else
+// (null, error).
+aead_open(algo: string, key: ptr, nonce: ptr, aad: ptr, aad_len: int, ct_with_tag: ptr, ct_len: int) -> ptr! {
+    ok = ""
+    if key == null || nonce == null || ct_with_tag == null { return null, "null argument" }
+    if bytes.length(key) < KEY_BYTES || bytes.length(nonce) < NONCE_BYTES { return null, "bad key/nonce length" }
+    if ct_len < TAG_BYTES { return null, "ciphertext too short" }
+    st = Aead12St { s0: 0, s1: 0, s2: 0, s3: 0, s4: 0, rate: 0, nr: 0, iv: 0 }
+    if config_state(&st, algo) == 0 { return null, "unknown algorithm" }
+
+    k1 = ld64(key, 0)
+    k2 = ld64(key, 8)
+    init_state(&st, key, nonce, k1, k2)
+    absorb_aad(&st, aad, aad_len)
+
+    pt_len = ct_len - TAG_BYTES
+    pt = bytes.new(pt_len)
+    j = 0
+    while j < pt_len {
+        bytes.set(pt, j, 0)
+        j = j + 1
+    }
+    decrypt_body(&st, ct_with_tag, pt_len, pt, key)
+
+    r3 = st.s3 ^ ld64(ct_with_tag, pt_len)
+    r4 = st.s4 ^ ld64(ct_with_tag, pt_len + 8)
+    if (r3 | r4) != 0 {
+        bytes.free(pt)
+        return null, "tag verification failed"
+    }
+    return pt, ok
+}
+
+// ---- Variant-pinned convenience wrappers ----
+
+a128_seal(key: ptr, nonce: ptr, aad: ptr, aad_len: int, pt: ptr, pt_len: int) -> ptr {
+    return aead_seal("ascon-128", key, nonce, aad, aad_len, pt, pt_len)
+}
+a128_open(key: ptr, nonce: ptr, aad: ptr, aad_len: int, ct_with_tag: ptr, ct_len: int) -> ptr! {
+    return aead_open("ascon-128", key, nonce, aad, aad_len, ct_with_tag, ct_len)
+}
+a128a_seal(key: ptr, nonce: ptr, aad: ptr, aad_len: int, pt: ptr, pt_len: int) -> ptr {
+    return aead_seal("ascon-128a", key, nonce, aad, aad_len, pt, pt_len)
+}
+a128a_open(key: ptr, nonce: ptr, aad: ptr, aad_len: int, ct_with_tag: ptr, ct_len: int) -> ptr! {
+    return aead_open("ascon-128a", key, nonce, aad, aad_len, ct_with_tag, ct_len)
+}

--- a/std/cryptography/ascon_aead128/module.ae
+++ b/std/cryptography/ascon_aead128/module.ae
@@ -1,0 +1,318 @@
+// MIT License (https://opensource.org/licenses/MIT)
+// Portions copyright (c) 2000-2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+// Portions copyright (c) 2026 Aether Developers.
+//
+// std.cryptography.ascon_aead128 — Ascon-AEAD128 (NIST SP 800-232) in pure
+// Aether, ported from Bouncy Castle's AsconAead128. Authenticated encryption
+// with associated data (AEAD). NO externs to OpenSSL or any C crypto — the
+// same pure-Aether footing as the shipped Ascon hashes, so it works on the
+// cross-built targets where OpenSSL/AES-GCM stub out.
+//
+// Ascon-AEAD128 is the finalized NIST lightweight-crypto standard (SP 800-232,
+// Aug 2025): little-endian, 128-bit key, 128-bit nonce, 128-bit tag, rate 16,
+// p12 init/finalize and p8 for AAD/data. This is DISTINCT from the earlier v1.2
+// Ascon-128/128a (see std.cryptography.ascon_aead), which is big-endian with a
+// different IV and rate.
+//
+// Import with:  import std.cryptography.ascon_aead128
+//
+// API (mirrors contrib.cryptography.chacha20poly1305):
+//   aead_seal(key16, nonce16, aad, aad_len, pt, pt_len)
+//       -> ptr ciphertext-with-tag (pt_len + 16 bytes; 16-byte tag appended)
+//   aead_open(key16, nonce16, aad, aad_len, ct_with_tag, ct_len)
+//       -> (plaintext_ptr, "") on a valid tag, or (null, error) on failure.
+// key/nonce/aad/pt are std.bytes buffers; returned buffers are std.bytes too.
+
+import std.bits
+import std.bytes
+
+exports (
+    aead_seal, aead_open,
+    KEY_BYTES, NONCE_BYTES, TAG_BYTES
+)
+
+const KEY_BYTES   = 16
+const NONCE_BYTES = 16
+const TAG_BYTES   = 16
+const RATE        = 16
+
+// The 320-bit sponge state, carried explicitly through the one-shot flow.
+struct Aead128St {
+    s0: long
+    s1: long
+    s2: long
+    s3: long
+    s4: long
+}
+
+// One Ascon round (identical S-box + linear layer to the Ascon hashes).
+fn round(st: *Aead128St, rc: long) {
+    sx = st.s2 ^ rc
+    t0 = st.s0 ^ st.s1 ^ sx ^ st.s3 ^ (st.s1 & (st.s0 ^ sx ^ st.s4))
+    t1 = st.s0 ^ sx ^ st.s3 ^ st.s4 ^ ((st.s1 ^ sx) & (st.s1 ^ st.s3))
+    t2 = st.s1 ^ sx ^ st.s4 ^ (st.s3 & st.s4)
+    t3 = st.s0 ^ st.s1 ^ sx ^ ((~st.s0) & (st.s3 ^ st.s4))
+    t4 = st.s1 ^ st.s3 ^ st.s4 ^ ((st.s0 ^ st.s4) & st.s1)
+    st.s0 = t0 ^ bits.rotr64(t0, 19) ^ bits.rotr64(t0, 28)
+    st.s1 = t1 ^ bits.rotr64(t1, 39) ^ bits.rotr64(t1, 61)
+    st.s2 = ~(t2 ^ bits.rotr64(t2, 1) ^ bits.rotr64(t2, 6))
+    st.s3 = t3 ^ bits.rotr64(t3, 10) ^ bits.rotr64(t3, 17)
+    st.s4 = t4 ^ bits.rotr64(t4, 7) ^ bits.rotr64(t4, 41)
+}
+
+fn p12(st: *Aead128St) {
+    round(st, 0xf0)
+    round(st, 0xe1)
+    round(st, 0xd2)
+    round(st, 0xc3)
+    round(st, 0xb4)
+    round(st, 0xa5)
+    round(st, 0x96)
+    round(st, 0x87)
+    round(st, 0x78)
+    round(st, 0x69)
+    round(st, 0x5a)
+    round(st, 0x4b)
+}
+
+fn p8(st: *Aead128St) {
+    round(st, 0xb4)
+    round(st, 0xa5)
+    round(st, 0x96)
+    round(st, 0x87)
+    round(st, 0x78)
+    round(st, 0x69)
+    round(st, 0x5a)
+    round(st, 0x4b)
+}
+
+// Load 8 little-endian bytes from `b` at `off` into a long (zero-extended;
+// callers requesting past-end never do so — bounds are precomputed).
+fn ld64(b: ptr, off: int) -> long {
+    return bytes.get_le64(b, off)
+}
+
+// Load the low `n` (0..7) bytes at `off` as a little-endian long, i.e. byte
+// [off] is the least-significant. Bytes above `n` read as zero.
+fn ld_low(b: ptr, off: int, n: int) -> long {
+    long v = 0
+    i = 0
+    while i < n {
+        long byte_v = bytes.get(b, off + i) & 255
+        v = v | (byte_v << (i << 3))
+        i = i + 1
+    }
+    return v
+}
+
+// Store the low `n` (0..8) bytes of `v` little-endian into `b` at `off`.
+fn st_low(b: ptr, off: int, v: long, n: int) {
+    i = 0
+    while i < n {
+        bytes.set(b, off + i, ((v >> (i << 3)) & 255) as int)
+        i = i + 1
+    }
+}
+
+// Pad(i) = 0x01 << (i*8): the single 1-bit that terminates a partial block.
+fn pad(i: int) -> long {
+    long one = 1
+    return one << (i << 3)
+}
+
+// Initialize the state from key/nonce (SP 800-232 §Init).
+fn init_state(st: *Aead128St, key: ptr, nonce: ptr, k0: long, k1: long) {
+    st.s0 = 0x00001000808c0001
+    st.s1 = k0
+    st.s2 = k1
+    st.s3 = ld64(nonce, 0)
+    st.s4 = ld64(nonce, 8)
+    p12(st)
+    st.s3 = st.s3 ^ k0
+    st.s4 = st.s4 ^ k1
+}
+
+// Absorb all associated data, then apply domain separation. Mirrors BC's
+// ProcessBufferAad (full 16-byte blocks) + FinishAad (partial block padded
+// with 0x01, then S4 ^= 0x8000000000000000).
+fn absorb_aad(st: *Aead128St, aad: ptr, aad_len: int) {
+    off = 0
+    remaining = aad_len
+    // Full rate blocks.
+    while remaining >= RATE {
+        st.s0 = st.s0 ^ ld64(aad, off)
+        st.s1 = st.s1 ^ ld64(aad, off + 8)
+        p8(st)
+        off = off + RATE
+        remaining = remaining - RATE
+    }
+    // Final (possibly empty) partial block — only when AAD is non-empty.
+    if aad_len > 0 {
+        if remaining >= 8 {
+            st.s0 = st.s0 ^ ld64(aad, off)
+            r2 = remaining - 8
+            st.s1 = st.s1 ^ (ld_low(aad, off + 8, r2) ^ pad(r2))
+        } else {
+            st.s0 = st.s0 ^ (ld_low(aad, off, remaining) ^ pad(remaining))
+        }
+        p8(st)
+    }
+    // Domain separation between AAD and message processing.
+    st.s4 = st.s4 ^ 0x8000000000000000
+}
+
+// Mix the key in at the end of message processing (SP 800-232 §Finalize),
+// leaving the 128-bit tag in (S3, S4).
+fn finish_data(st: *Aead128St, k0: long, k1: long) {
+    st.s2 = st.s2 ^ k0
+    st.s3 = st.s3 ^ k1
+    p12(st)
+    st.s3 = st.s3 ^ k0
+    st.s4 = st.s4 ^ k1
+}
+
+// Encrypt `pt_len` bytes of plaintext into `ct` (same length), updating the
+// rate words as it goes. Leaves the tag material in (S3, S4) after
+// finish_data. `ct` must have room for pt_len bytes.
+fn encrypt_body(st: *Aead128St, pt: ptr, pt_len: int, ct: ptr, k0: long, k1: long) {
+    off = 0
+    remaining = pt_len
+    while remaining >= RATE {
+        st.s0 = st.s0 ^ ld64(pt, off)
+        bytes.set_le64(ct, off, st.s0)
+        st.s1 = st.s1 ^ ld64(pt, off + 8)
+        bytes.set_le64(ct, off + 8, st.s1)
+        p8(st)
+        off = off + RATE
+        remaining = remaining - RATE
+    }
+    // Final partial (or empty) block.
+    if remaining >= 8 {
+        st.s0 = st.s0 ^ ld64(pt, off)
+        bytes.set_le64(ct, off, st.s0)
+        r2 = remaining - 8
+        if r2 > 0 {
+            st.s1 = st.s1 ^ ld_low(pt, off + 8, r2)
+            st_low(ct, off + 8, st.s1, r2)
+        }
+        st.s1 = st.s1 ^ pad(r2)
+    } else {
+        if remaining > 0 {
+            st.s0 = st.s0 ^ ld_low(pt, off, remaining)
+            st_low(ct, off, st.s0, remaining)
+        }
+        st.s0 = st.s0 ^ pad(remaining)
+    }
+    finish_data(st, k0, k1)
+}
+
+// Decrypt `ct_len` bytes of ciphertext into `pt` (same length), updating the
+// rate words with the recovered plaintext. Leaves tag material in (S3, S4).
+fn decrypt_body(st: *Aead128St, ct: ptr, ct_len: int, pt: ptr, k0: long, k1: long) {
+    off = 0
+    remaining = ct_len
+    while remaining >= RATE {
+        c0 = ld64(ct, off)
+        bytes.set_le64(pt, off, st.s0 ^ c0)
+        st.s0 = c0
+        c1 = ld64(ct, off + 8)
+        bytes.set_le64(pt, off + 8, st.s1 ^ c1)
+        st.s1 = c1
+        p8(st)
+        off = off + RATE
+        remaining = remaining - RATE
+    }
+    if remaining >= 8 {
+        c0 = ld64(ct, off)
+        bytes.set_le64(pt, off, st.s0 ^ c0)
+        st.s0 = c0
+        r2 = remaining - 8
+        if r2 > 0 {
+            t = ld_low(ct, off + 8, r2)
+            st_low(pt, off + 8, st.s1 ^ t, r2)
+            ones = 0xFFFFFFFFFFFFFFFF
+            st.s1 = st.s1 & (ones << (r2 << 3))
+            st.s1 = st.s1 ^ t
+        }
+        st.s1 = st.s1 ^ pad(r2)
+    } else {
+        if remaining > 0 {
+            t = ld_low(ct, off, remaining)
+            st_low(pt, off, st.s0 ^ t, remaining)
+            ones = 0xFFFFFFFFFFFFFFFF
+            st.s0 = st.s0 & (ones << (remaining << 3))
+            st.s0 = st.s0 ^ t
+        }
+        st.s0 = st.s0 ^ pad(remaining)
+    }
+    finish_data(st, k0, k1)
+}
+
+// Seal: authenticated-encrypt `pt` under `key`/`nonce` with associated data
+// `aad`. Returns a fresh std.bytes buffer of pt_len + 16 bytes: the ciphertext
+// followed by the 16-byte tag. Returns null on a bad key/nonce length.
+aead_seal(key: ptr, nonce: ptr, aad: ptr, aad_len: int, pt: ptr, pt_len: int) -> ptr {
+    if key == null || nonce == null { return null }
+    if bytes.length(key) < KEY_BYTES || bytes.length(nonce) < NONCE_BYTES { return null }
+
+    k0 = ld64(key, 0)
+    k1 = ld64(key, 8)
+
+    st = Aead128St { s0: 0, s1: 0, s2: 0, s3: 0, s4: 0 }
+    init_state(&st, key, nonce, k0, k1)
+    absorb_aad(&st, aad, aad_len)
+
+    out_len = pt_len + TAG_BYTES
+    out = bytes.new(out_len)
+    // zero-fill so any unwritten tail is defined
+    j = 0
+    while j < out_len {
+        bytes.set(out, j, 0)
+        j = j + 1
+    }
+
+    encrypt_body(&st, pt, pt_len, out, k0, k1)
+
+    // Append the tag (S3, S4) little-endian.
+    bytes.set_le64(out, pt_len, st.s3)
+    bytes.set_le64(out, pt_len + 8, st.s4)
+    return out
+}
+
+// Open: verify + decrypt `ct_with_tag` (ciphertext followed by its 16-byte
+// tag). Returns (plaintext_ptr, "") on success, or (null, error) if the tag is
+// invalid or inputs are malformed. The plaintext buffer is ct_len-16 bytes.
+aead_open(key: ptr, nonce: ptr, aad: ptr, aad_len: int, ct_with_tag: ptr, ct_len: int) -> ptr! {
+    ok = ""
+    if key == null || nonce == null || ct_with_tag == null { return null, "null argument" }
+    if bytes.length(key) < KEY_BYTES || bytes.length(nonce) < NONCE_BYTES { return null, "bad key/nonce length" }
+    if ct_len < TAG_BYTES { return null, "ciphertext too short" }
+
+    k0 = ld64(key, 0)
+    k1 = ld64(key, 8)
+
+    st = Aead128St { s0: 0, s1: 0, s2: 0, s3: 0, s4: 0 }
+    init_state(&st, key, nonce, k0, k1)
+    absorb_aad(&st, aad, aad_len)
+
+    pt_len = ct_len - TAG_BYTES
+    pt = bytes.new(pt_len)
+    j = 0
+    while j < pt_len {
+        bytes.set(pt, j, 0)
+        j = j + 1
+    }
+
+    decrypt_body(&st, ct_with_tag, pt_len, pt, k0, k1)
+
+    // Constant-time-ish tag check: XOR the computed tag with the received one
+    // and OR the differences — zero iff they match. (The Ascon standard's own
+    // check compares the recomputed (S3,S4) against the received tag words.)
+    r3 = st.s3 ^ ld64(ct_with_tag, pt_len)
+    r4 = st.s4 ^ ld64(ct_with_tag, pt_len + 8)
+    if (r3 | r4) != 0 {
+        bytes.free(pt)
+        return null, "tag verification failed"
+    }
+    return pt, ok
+}

--- a/tests/integration/crypto_ascon_aead/test_crypto_ascon_aead.ae
+++ b/tests/integration/crypto_ascon_aead/test_crypto_ascon_aead.ae
@@ -1,0 +1,147 @@
+// Validate std.cryptography.ascon_aead — Ascon v1.2 AEAD (Ascon-128 and
+// Ascon-128a) — the pure-Aether port of Bouncy Castle's AsconEngine. Vectors
+// are the NIST LWC Known-Answer Tests shipped in bc-csharp
+// (crypto/test/data/crypto/ascon/LWC_AEAD_KAT_128_128.txt and _a.txt), the
+// same provenance as the shipped Ascon hashes. Coverage spans the block
+// boundaries for both rates (8 for ascon-128, 16 for ascon-128a): AAD-only
+// 0/1/8/9/16/17, plaintext 1/8/16/32, and a combined PT+AAD case with multi-
+// block AAD. Each seal must reproduce the KAT ciphertext-with-tag; each is
+// round-tripped through open; a tampered tag must be rejected.
+
+import std.cryptography.ascon_aead
+import std.bytes
+import std.string
+import std.io
+
+extern exit(code: int)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+extern string_length(s: string) -> int
+
+fn hexval(h: int) -> int {
+    if h >= 48 && h <= 57 { return h - 48 }
+    if h >= 97 && h <= 102 { return h - 87 }
+    if h >= 65 && h <= 70 { return h - 55 }
+    return 0
+}
+
+fn from_hex(s: string) -> ptr {
+    slen = string_length(s)
+    n = slen / 2
+    b = bytes.new(n)
+    if n == 0 { return b }
+    i = 0
+    while i < n {
+        hi = hexval(string_char_at_n(s, slen, i * 2))
+        lo = hexval(string_char_at_n(s, slen, i * 2 + 1))
+        bytes.set(b, i, (hi << 4) | lo)
+        i = i + 1
+    }
+    return b
+}
+
+fn to_hex(b: ptr, n: int) -> string {
+    hx = bytes.new(n * 2)
+    i = 0
+    while i < n {
+        v = bytes.get(b, i)
+        hi = (v >> 4) & 15
+        lo = v & 15
+        chi = 48 + hi
+        if hi >= 10 { chi = 87 + hi }
+        clo = 48 + lo
+        if lo >= 10 { clo = 87 + lo }
+        bytes.set(hx, i * 2, chi)
+        bytes.set(hx, i * 2 + 1, clo)
+        i = i + 1
+    }
+    return bytes.finish(hx, n * 2)
+}
+
+fn kat(algo: string, label: string, key: ptr, nonce: ptr, ad_hex: string, pt_hex: string, want_hex: string) -> int {
+    fails = 0
+    ad = from_hex(ad_hex)
+    pt = from_hex(pt_hex)
+    ad_len = string_length(ad_hex) / 2
+    pt_len = string_length(pt_hex) / 2
+
+    ct = ascon_aead.aead_seal(algo, key, nonce, ad, ad_len, pt, pt_len)
+    got = to_hex(ct, bytes.length(ct))
+    if got == want_hex {
+        println("ok   seal ${algo} ${label}")
+    } else {
+        println("FAIL seal ${algo} ${label}")
+        println("  got:  ${got}")
+        println("  want: ${want_hex}")
+        fails = fails + 1
+    }
+
+    op, oerr = ascon_aead.aead_open(algo, key, nonce, ad, ad_len, ct, bytes.length(ct))
+    if oerr == "" && to_hex(op, pt_len) == pt_hex {
+        println("ok   open ${algo} ${label}")
+    } else {
+        println("FAIL open ${algo} ${label}: err='${oerr}' got=${to_hex(op, pt_len)}")
+        fails = fails + 1
+    }
+
+    tlen = bytes.length(ct)
+    bytes.set(ct, tlen - 1, bytes.get(ct, tlen - 1) ^ 1)
+    tp, terr = ascon_aead.aead_open(algo, key, nonce, ad, ad_len, ct, tlen)
+    if terr != "" {
+        println("ok   tamper-reject ${algo} ${label}")
+    } else {
+        println("FAIL tamper NOT rejected ${algo} ${label}")
+        fails = fails + 1
+    }
+
+    if op != null { bytes.free(op) }
+    if tp != null { bytes.free(tp) }
+    bytes.free(ct)
+    bytes.free(ad)
+    bytes.free(pt)
+    string.release(oerr)
+    string.release(terr)
+    return fails
+}
+
+main() {
+    println("=== test_crypto_ascon_aead (Ascon v1.2 AEAD) ===")
+    fails = 0
+    // v1.2 KATs use key == nonce == 000102...0F.
+    key = from_hex("000102030405060708090a0b0c0d0e0f")
+    nonce = from_hex("000102030405060708090a0b0c0d0e0f")
+
+    // ---- Ascon-128 (rate 8) ----
+    fails = fails + kat("ascon-128", "c1 empty",   key, nonce, "", "", "e355159f292911f794cb1432a0103a8a")
+    fails = fails + kat("ascon-128", "c2 aad1",    key, nonce, "00", "", "944df887cd4901614c5dedbc42fc0da0")
+    fails = fails + kat("ascon-128", "c9 aad8",    key, nonce, "0001020304050607", "", "e3dcf95f869752f61cd7a2db895f918e")
+    fails = fails + kat("ascon-128", "c10 aad9",   key, nonce, "000102030405060708", "", "abcdb317eccfe67a62cf70ae974c3dbe")
+    fails = fails + kat("ascon-128", "c17 aad16",  key, nonce, "000102030405060708090a0b0c0d0e0f", "", "ef5763e75fe32f96d7863410ff0b4786")
+    fails = fails + kat("ascon-128", "c18 aad17",  key, nonce, "000102030405060708090a0b0c0d0e0f10", "", "79ac0fa2bf3859d6962d0c0af45b1d3e")
+    fails = fails + kat("ascon-128", "c34 pt1",    key, nonce, "", "00", "bc18c3f4e39eca7222490d967c79bffc92")
+    fails = fails + kat("ascon-128", "c265 pt8",   key, nonce, "", "0001020304050607", "bc820dbdf7a4631c01a8807a44254b42ac6bb490da1e000a")
+    fails = fails + kat("ascon-128", "c529 pt16",  key, nonce, "", "000102030405060708090a0b0c0d0e0f", "bc820dbdf7a4631c5b29884ad69175c3f58e28436dd71556d58dfa56ac890beb")
+    fails = fails + kat("ascon-128", "c1057 pt32", key, nonce, "", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "bc820dbdf7a4631c5b29884ad69175c3389655ca8135c9e6e8fe7467276f89770d975efab2ebaa41c0f3abeee425e784")
+    fails = fails + kat("ascon-128", "c297 pt8+ad32", key, nonce, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "0001020304050607", "b96c78651b6246b0f4ddfdf86ced08389f0d3a1b58a4882a")
+
+    // ---- Ascon-128a (rate 16) ----
+    fails = fails + kat("ascon-128a", "c1 empty",   key, nonce, "", "", "7a834e6f09210957067b10fd831f0078")
+    fails = fails + kat("ascon-128a", "c2 aad1",    key, nonce, "00", "", "af3031b07b129ec84153373ddcaba528")
+    fails = fails + kat("ascon-128a", "c9 aad8",    key, nonce, "0001020304050607", "", "d60e199ffd3f9b694713dabc6d89f46f")
+    fails = fails + kat("ascon-128a", "c10 aad9",   key, nonce, "000102030405060708", "", "8273ddd267b984a4d0ecfd98c548f63a")
+    fails = fails + kat("ascon-128a", "c17 aad16",  key, nonce, "000102030405060708090a0b0c0d0e0f", "", "56c15eb024de91ca0165362a49b31ebd")
+    fails = fails + kat("ascon-128a", "c18 aad17",  key, nonce, "000102030405060708090a0b0c0d0e0f10", "", "917d530f34157158cf8ca49d01af44f0")
+    fails = fails + kat("ascon-128a", "c34 pt1",    key, nonce, "", "00", "6e652b55bfdc8cad2ec43815b1666b1a3a")
+    fails = fails + kat("ascon-128a", "c265 pt8",   key, nonce, "", "0001020304050607", "6e490cfed5b35467b89c7e12863ce5f76afc808fff786b9e")
+    fails = fails + kat("ascon-128a", "c529 pt16",  key, nonce, "", "000102030405060708090a0b0c0d0e0f", "6e490cfed5b3546767350cd83c4acfbdb10f611b7d79278bd8067fc1bcdf39be")
+    fails = fails + kat("ascon-128a", "c1057 pt32", key, nonce, "", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "6e490cfed5b3546767350cd83c4acfbd4cfb4bd07abf5bc24d4b104645717c1e513abfd1335acfd296c49a35e0d54b73")
+    fails = fails + kat("ascon-128a", "c297 pt8+ad32", key, nonce, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "0001020304050607", "a55236ac020dbda78e59e325520306254892d585f50a3ef7")
+
+    bytes.free(key)
+    bytes.free(nonce)
+
+    if fails != 0 {
+        println("test_crypto_ascon_aead: ${fails} failure(s)")
+        exit(1)
+    }
+    println("=== test_crypto_ascon_aead passed ===")
+}

--- a/tests/integration/crypto_ascon_aead128/test_crypto_ascon_aead128.ae
+++ b/tests/integration/crypto_ascon_aead128/test_crypto_ascon_aead128.ae
@@ -1,0 +1,142 @@
+// Validate std.cryptography.ascon_aead128 — Ascon-AEAD128 (NIST SP 800-232)
+// — the pure-Aether port of Bouncy Castle's AsconAead128. Vectors are the
+// official SP 800-232 Known-Answer Tests from the ascon/ascon-c reference
+// (crypto_aead/asconaead128/LWC_AEAD_KAT_128_128.txt), chosen to span every
+// block boundary: empty, AAD-only across the 16-byte rate (0/1/8/9/16/17),
+// plaintext across the rate (1/8/9/16/32), and a combined PT+AD case. Each
+// vector's seal must reproduce the KAT ciphertext-with-tag exactly; each is
+// then round-tripped through open, and a tampered tag must be rejected.
+
+import std.cryptography.ascon_aead128
+import std.bytes
+import std.string
+import std.io
+
+extern exit(code: int)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+
+fn hexval(h: int) -> int {
+    if h >= 48 && h <= 57 { return h - 48 }
+    if h >= 97 && h <= 102 { return h - 87 }
+    if h >= 65 && h <= 70 { return h - 55 }
+    return 0
+}
+
+fn from_hex(s: string) -> ptr {
+    slen = string_length(s)
+    n = slen / 2
+    b = bytes.new(n)
+    if n == 0 { return b }
+    i = 0
+    while i < n {
+        hi = hexval(string_char_at_n(s, slen, i * 2))
+        lo = hexval(string_char_at_n(s, slen, i * 2 + 1))
+        bytes.set(b, i, (hi << 4) | lo)
+        i = i + 1
+    }
+    return b
+}
+
+fn to_hex(b: ptr, n: int) -> string {
+    hx = bytes.new(n * 2)
+    i = 0
+    while i < n {
+        v = bytes.get(b, i)
+        hi = (v >> 4) & 15
+        lo = v & 15
+        chi = 48 + hi
+        if hi >= 10 { chi = 87 + hi }
+        clo = 48 + lo
+        if lo >= 10 { clo = 87 + lo }
+        bytes.set(hx, i * 2, chi)
+        bytes.set(hx, i * 2 + 1, clo)
+        i = i + 1
+    }
+    return bytes.finish(hx, n * 2)
+}
+
+extern string_length(s: string) -> int
+
+// A KAT case: pt/ad given as hex, expected ct-with-tag as hex.
+fn kat(label: string, key: ptr, nonce: ptr, ad_hex: string, pt_hex: string, want_hex: string) -> int {
+    fails = 0
+    ad = from_hex(ad_hex)
+    pt = from_hex(pt_hex)
+    ad_len = string_length(ad_hex) / 2
+    pt_len = string_length(pt_hex) / 2
+
+    ct = ascon_aead128.aead_seal(key, nonce, ad, ad_len, pt, pt_len)
+    got = to_hex(ct, bytes.length(ct))
+    if got == want_hex {
+        println("ok   seal ${label}")
+    } else {
+        println("FAIL seal ${label}")
+        println("  got:  ${got}")
+        println("  want: ${want_hex}")
+        fails = fails + 1
+    }
+
+    // Round-trip: open must recover the plaintext with no error.
+    op, oerr = ascon_aead128.aead_open(key, nonce, ad, ad_len, ct, bytes.length(ct))
+    if oerr == "" && to_hex(op, pt_len) == pt_hex {
+        println("ok   open ${label}")
+    } else {
+        println("FAIL open ${label}: err='${oerr}' got=${to_hex(op, pt_len)}")
+        fails = fails + 1
+    }
+
+    // Tamper: flip a tag byte, open must reject.
+    tlen = bytes.length(ct)
+    bytes.set(ct, tlen - 1, bytes.get(ct, tlen - 1) ^ 1)
+    tp, terr = ascon_aead128.aead_open(key, nonce, ad, ad_len, ct, tlen)
+    if terr != "" {
+        println("ok   tamper-reject ${label}")
+    } else {
+        println("FAIL tamper NOT rejected ${label}")
+        fails = fails + 1
+    }
+
+    // Free everything this case allocated (open returns a caller-owned buffer
+    // on success; on the tamper path it returns null).
+    if op != null { bytes.free(op) }
+    if tp != null { bytes.free(tp) }
+    bytes.free(ct)
+    bytes.free(ad)
+    bytes.free(pt)
+    string.release(oerr)
+    string.release(terr)
+    return fails
+}
+
+main() {
+    println("=== test_crypto_ascon_aead128 (NIST SP 800-232) ===")
+    fails = 0
+    key = from_hex("000102030405060708090a0b0c0d0e0f")
+    nonce = from_hex("101112131415161718191a1b1c1d1e1f")
+
+    // AAD boundary sweep (empty PT).
+    fails = fails + kat("c1 empty",    key, nonce, "", "", "4f9c278211bec9316bf68f46ee8b2ec6")
+    fails = fails + kat("c2 aad1",     key, nonce, "30", "", "cccb674fe18a09a285d6ab11b35675c0")
+    fails = fails + kat("c9 aad8",     key, nonce, "3031323334353637", "", "865c594093a9edee2c1d6384ccb4939e")
+    fails = fails + kat("c10 aad9",    key, nonce, "303132333435363738", "", "24f13284a0f90f906b18c7e4061c0896")
+    fails = fails + kat("c17 aad16",   key, nonce, "303132333435363738393a3b3c3d3e3f", "", "e4230cdb8330ee9dc0cfd7c7b346e6dc")
+    fails = fails + kat("c18 aad17",   key, nonce, "303132333435363738393a3b3c3d3e3f40", "", "bd8851cd3af9847844839a791dd70e8c")
+
+    // Plaintext boundary sweep (empty AAD).
+    fails = fails + kat("c34 pt1",     key, nonce, "", "20", "e8dd576aba1cd3e6fc704de02aedb79588")
+    fails = fails + kat("c265 pt8",    key, nonce, "", "2021222324252627", "e8c3deee246cc5eae455ef6b33b782a3dd91ed6695373c27")
+    fails = fails + kat("c529 pt16",   key, nonce, "", "202122232425262728292a2b2c2d2e2f", "e8c3deee246cc5eae3e872313897a2bb9eaa915c9dd3245d77048f24d46d27a7")
+    fails = fails + kat("c1057 pt32",  key, nonce, "", "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f", "e8c3deee246cc5eae3e872313897a2bb6089aa3e15e80307970f2d1f006654c2aaa5fa172cb9f07d07463cefc7440bc1")
+
+    // Combined PT (9 bytes) + AAD (2 bytes).
+    fails = fails + kat("c300 pt9+ad2", key, nonce, "3031", "202122232425262728", "30fcefad28275df1a3cfaeedc161bed25c45cfae2ba5ede064")
+
+    bytes.free(key)
+    bytes.free(nonce)
+
+    if fails != 0 {
+        println("test_crypto_ascon_aead128: ${fails} failure(s)")
+        exit(1)
+    }
+    println("=== test_crypto_ascon_aead128 passed ===")
+}


### PR DESCRIPTION
Adds the first pure-Aether **authenticated encryption** to `std.cryptography`, completing the Ascon port. Answers `asks/ascon-aead-in-std-cryptography.md`: `std` could authenticate (hashes / HMAC / KDF) but had **nothing pure-Aether to encrypt** — the only AEAD was OpenSSL-backed AES-GCM, which stubs to "unavailable" on every zig cross-build (e.g. the RAM-tight arm64 aeo-agent with no OpenSSL). Both new modules are pure Aether, **no externs to OpenSSL or any C crypto**, ported from Bouncy Castle (same provenance as the shipped Ascon hashes).

Per the ask's "implement both" decision:

- **`std.cryptography.ascon_aead128`** — Ascon-AEAD128, the **finalized NIST standard** (SP 800-232, Aug 2025): little-endian, rate 16, 128-bit key/nonce/tag. `aead_seal` / `aead_open`.
- **`std.cryptography.ascon_aead`** — **Ascon v1.2 AEAD** (Ascon-128 + Ascon-128a, the NIST LWC 2023 winner): big-endian, rate 8/16, for interop with v1.2 deployments. `aead_seal(algo, …)` / `aead_open(algo, …)` plus `a128_*` / `a128a_*` variant-pinned wrappers.

Both reuse the exact Ascon permutation already shipped for the hashes (byte-identical S-box + rotation constants) and expose the seal/open shape of `contrib.cryptography.chacha20poly1305`, so aeo can key an AEAD off a KDF of its pre-shared key and get confidentiality + integrity on the open LAN without TLS/OpenSSL.

## Verification

Validated against **official Known-Answer Test vectors** spanning every block boundary (empty, partial, full, multi-block AAD), each with round-trip + tamper-rejection:

- **SP 800-232**: KATs from the `ascon/ascon-c` reference — 33 checks across 11 vectors (AAD 0/1/8/9/16/17, PT 1/8/16/32, combined PT+AAD).
- **v1.2**: the NIST LWC KATs shipped in bc-csharp (`LWC_AEAD_KAT_128_128.txt` / `_a.txt`) — 66 checks across 22 vectors, both variants.

Both modules and their integration tests are **leak-clean under valgrind**. Full `.ae` suite: **908 passed**; the 6 failures are all pre-existing and unrelated (HTTP network flakes, an untracked `bit_set` file, open #1252).

Two Aether-specific gotchas surfaced (noted in the commit for future crypto ports): `seal` is a reserved keyword (hence `aead_seal`), and `>>` is an arithmetic shift — a `0xFFFF…FF` mask right-shifted sign-extends to all-ones, so the decrypt partial-block mask uses `bits.lsr64` (logical shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)