### PR TITLE
docs(LLM): uint64-vs-long for logical shifts / masks

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -355,6 +355,20 @@ workaround, they cover cases a porter often hand-rolls.
   (exclusive); overlaps need `@overlap`; it's strictly nominal (cross to the raw
   word with `as`). Byte order is NOT part of it — compose with `std.mem`'s
   `get_u16_be` / `set_u32_le` etc., so the swap stays visible.
+- **Unsigned data → `uint64`, not `long`, so `>>` and masks behave.** Aether's
+  `long` is signed, so `>>` on it is an *arithmetic* shift: `long ones =
+  0xFFFFFFFFFFFFFFFF; ones >> 8` is `-1` (sign-extends), not `0x00FF…FF`. Declare
+  a variable `uint64` and `>>` is logical (`uint64 ones = 0xFFFF…FF; ones >> 8`
+  == `0x00FF…FF`), matching what crypto/codec code means by a bit pattern. This
+  bit the v1.2 Ascon-AEAD decrypt mask (#1285): the KAT *encrypt* passed but the
+  round-trip *open* failed only on partial blocks, because the tag-reconstruction
+  mask never cleared its top bits — the KAT's encrypt-only assertions couldn't
+  see it. The escape hatch when a value must stay `long` is `bits.lsr64(x, n)`
+  (logical shift). Right-shifts that are immediately `& 0xFF`-masked (byte
+  extraction like `(v >> 4) & 15`) or shift a known-non-negative counter are
+  fine either way; the hazard is specifically a high-bit-set word right-shifted
+  *for its bits* (an all-ones mask, a 64-bit state word). Prefer `uint64` for
+  sponge/state words up front rather than sprinkling `lsr64`.
 - **Function contracts `requires` / `ensures` (issue #348).** Eiffel-style
   pre/postconditions between the return arrow and the body: `add(a: int, b: int)
   -> int requires a >= 0 ensures result >= a { … }`. Each is a boolean


### PR DESCRIPTION
Documents the `long` (signed → arithmetic `>>`) vs `uint64` (logical `>>`) distinction in LLM.md, prompted by the "envious look at Coda" comparison (Coda is unsigned-explicit-by-intent).

## Why

Aether's `long` is signed, so `long ones = 0xFFFFFFFFFFFFFFFF; ones >> 8` is `-1` (sign-extends), not `0x00FF…FF`. `uint64` right-shifts are logical. This exact trap bit the v1.2 Ascon-AEAD decrypt partial-block mask (#1285) — and the failure mode is sneaky: the KAT **encrypt** assertions passed while the round-trip **open** failed only on partial blocks, because the tag-reconstruction mask never cleared its top bits. Encrypt-only KAT vectors can't see it.

## Scope — preventive, not a fix

I audited every `std/cryptography` module for the hazardous pattern (a high-bit-set word right-shifted *for its bits*). **Found none live:**
- Most `>>` sites are byte extraction immediately masked (`(v >> 4) & 15`, `(r >> 8) & 255`) — sign-extension is irrelevant.
- The rest shift known-non-negative counters/indices (`i >> 1`, `state_words >> 1`).
- Modules that needed logical shifts (mlkem, sha2, tiger, dstu7564, …) already use `bits.lsr64`/`lsr32`.
- `ascon_aead`'s `low_mask` already uses `bits.lsr64` (the #1285 fix).

So a `long`→`uint64` sweep would be pure churn on sensitive, KAT-tested crypto with zero behavioral gain and real regression risk — not worth it. The valuable, low-risk deliverable is the documented rule so the next author reaches for `uint64` (or `bits.lsr64`) by default.

Doc-only; `[skip actions]` on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)