### PR TITLE
fix: module consts respect C scoping; modules declare native link deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Module consts now respect C scoping** (#1256). A module-level `const`
+  lowered to a bare `#define`, so a function parameter or local spelled
+  like the const was textually rewritten into the literal (`int SCALE`
+  became `int (99)`), and the documented shadowing guarantee failed to
+  compile. Consts now lower to file-scope `static const`, which inner
+  declarations shadow naturally. Const-of-const initializers, 64-bit and
+  string and float consts, match patterns naming consts, and the
+  `--emit=lib` const catalog all verified unchanged. Also removed the
+  redundant parentheses the match if-chain emitted around equality tests,
+  which tripped clang's default -Wparentheses-equality on every match a
+  user compiled.
+
+### Added
+
+- **Modules declare their own native link deps with `@link("...")`**
+  (#1259). Codegen unions declared flags across the resolved import
+  closure into the `// aether-link:` header comment, first-seen order,
+  deduplicated, absent when nothing declares. The hardcoded
+  `contrib.sqlite` row in the compiler's link table moved into
+  `contrib/sqlite/module.ae` itself: the module owns its deps, the
+  compiler owns only the mechanism.
+
 ## [0.448.0]
 
 ### Added

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -284,7 +284,14 @@ typedef enum {
     // `err == fs.NotFound` compares by content (string `==` is already a
     // strcmp). The qualified name is filled in at module-merge time when the
     // namespace prefix is known (bare name in the main module).
-    AST_FAULT_DEFINITION
+    AST_FAULT_DEFINITION,
+    // #1259: top-level `@link("-lfoo -lbar")` in a module declares the
+    // native libraries that module needs. Codegen unions these across the
+    // resolved import closure into the `// aether-link:` header comment,
+    // replacing hardcoded per-module rows in g_link_reqs. Appended at the
+    // enum END: inserting mid-enum invalidates every compiled .o (see
+    // the enum-insert note in the repo docs).
+    AST_LINK_DIRECTIVE
 } ASTNodeType;
 
 typedef enum {

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1928,6 +1928,31 @@ int is_c_keyword(const char* name) {
     return 0;
 }
 
+/* #1256 follow-up: names the Windows SDK claims at file scope. With module
+ * consts lowered to real C identifiers (static const) instead of #defines,
+ * a const named DOUBLE collides with windef.h's `typedef double DOUBLE` in
+ * any generated TU that includes <windows.h>: "redeclared as a different
+ * kind of symbol". TRUE/FALSE are macros there, which is worse: the
+ * preprocessor rewrites the declaration itself. Mangled on every platform
+ * so programs behave identically on POSIX and Windows. Curated to the
+ * windef.h/winnt.h names plausible as user constants. */
+static int is_winapi_reserved_name(const char* name) {
+    if (!name) return 0;
+    static const char* win[] = {
+        "BOOL", "BOOLEAN", "BYTE", "CHAR", "DOUBLE", "DWORD", "DWORD64",
+        "FLOAT", "HANDLE", "INT", "INT8", "INT16", "INT32", "INT64",
+        "LONG", "LONG64", "LPSTR", "LPCSTR", "LPVOID", "PVOID", "SHORT",
+        "SIZE_T", "SSIZE_T", "UCHAR", "UINT", "UINT8", "UINT16", "UINT32",
+        "UINT64", "ULONG", "ULONG64", "USHORT", "VOID", "WCHAR", "WORD",
+        "TRUE", "FALSE", "NULL", "IGNORE", "INFINITE", "ERROR", "OPTIONAL",
+        NULL
+    };
+    for (int i = 0; win[i]; i++) {
+        if (strcmp(name, win[i]) == 0) return 1;
+    }
+    return 0;
+}
+
 // #976: mangle a value/variable identifier that is a C keyword to a valid C
 // identifier. Non-keywords pass through unchanged, so normal code is emitted
 // verbatim and only the (previously broken) keyword names are rewritten. The
@@ -3808,14 +3833,15 @@ static void mangle_keyword_value_idents(ASTNode* node) {
         case AST_FIELD_INIT:
         case AST_PATTERN_FIELD:
         case AST_MEMBER_ACCESS:
-            if (node->value && is_c_keyword(node->value)) {
-                const char* safe = safe_value_name(node->value);
-                if (safe && safe != node->value) {
-                    char* dup = strdup(safe);
-                    if (dup) {
-                        free(node->value);
-                        node->value = dup;
-                    }
+        case AST_CONST_DECLARATION:
+            if (node->value && (is_c_keyword(node->value) ||
+                                is_winapi_reserved_name(node->value))) {
+                char safe[280];
+                snprintf(safe, sizeof(safe), "ae_%s", node->value);
+                char* dup = strdup(safe);
+                if (dup) {
+                    free(node->value);
+                    node->value = dup;
                 }
             }
             break;

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -2750,6 +2750,9 @@ static void emit_lib_metadata(CodeGenerator* gen, ASTNode* program) {
     int has_exports_list = 0;
     for (int i = 0; i < program->child_count; i++) {
         ASTNode* child = program->children[i];
+        if (child && child->type == AST_LINK_DIRECTIVE) {
+            continue;  /* consumed by emit_link_requirements */
+        }
         if (child && child->type == AST_EXPORTS_LIST) {
             has_exports_list = 1;
             export_names = (const char**)malloc(
@@ -3864,7 +3867,9 @@ static const AetherLinkReq g_link_reqs[] = {
     { "std.zlib",             "-lz" },
     { "std.http.middleware",  "-lz" },
     { "std.audio",            "-lpthread -ldl -lm" },
-    { "contrib.sqlite",       "-laether_sqlite -lsqlite3" },
+    /* contrib.sqlite's row moved into contrib/sqlite/module.ae as
+     * `@link(...)` (#1259): the module owns its native deps, the compiler
+     * owns only the union-over-closure mechanism. */
 };
 static const int g_link_req_count = (int)(sizeof(g_link_reqs) / sizeof(g_link_reqs[0]));
 
@@ -3891,29 +3896,56 @@ static int program_imports_module(ASTNode* program, const char* mod) {
 /* Emit `// aether-link: <tokens>` as the first line of the TU when the import
  * closure introduces any native-library dependency. De-dupes tokens across
  * modules (e.g. std.http and std.cryptography both want -lssl -lcrypto). */
+/* Split `flags` on spaces and append each token to toks[] unless already
+ * present. Tokens are heap copies; the caller frees them after printing. */
+static void add_link_tokens(const char* flags, const char** toks, int* ntok, int cap) {
+    const char* s = flags;
+    while (*s) {
+        while (*s == ' ') s++;
+        if (!*s) break;
+        const char* start = s;
+        while (*s && *s != ' ') s++;
+        size_t len = (size_t)(s - start);
+        int dup = 0;
+        for (int k = 0; k < *ntok; k++) {
+            if (strlen(toks[k]) == len && strncmp(toks[k], start, len) == 0) { dup = 1; break; }
+        }
+        if (!dup && *ntok < cap) {
+            char* copy = (char*)malloc(len + 1);
+            if (copy) { memcpy(copy, start, len); copy[len] = '\0'; toks[(*ntok)++] = copy; }
+        }
+    }
+}
+
 static void emit_link_requirements(CodeGenerator* gen, ASTNode* program) {
     /* Accumulate unique tokens in first-seen (table) order. */
     const char* toks[64];
     int ntok = 0;
     for (int r = 0; r < g_link_req_count; r++) {
         if (!program_imports_module(program, g_link_reqs[r].module)) continue;
-        /* Split g_link_reqs[r].libs on spaces, add each token once. */
-        const char* s = g_link_reqs[r].libs;
-        while (*s) {
-            while (*s == ' ') s++;
-            if (!*s) break;
-            const char* start = s;
-            while (*s && *s != ' ') s++;
-            size_t len = (size_t)(s - start);
-            /* dedup against what we already have */
-            int dup = 0;
-            for (int k = 0; k < ntok; k++) {
-                if (strlen(toks[k]) == len && strncmp(toks[k], start, len) == 0) { dup = 1; break; }
-            }
-            if (!dup && ntok < (int)(sizeof(toks) / sizeof(toks[0]))) {
-                /* store a heap copy (start isn't NUL-terminated at the token) */
-                char* copy = (char*)malloc(len + 1);
-                if (copy) { memcpy(copy, start, len); copy[len] = '\0'; toks[ntok++] = copy; }
+        add_link_tokens(g_link_reqs[r].libs, toks, &ntok,
+                        (int)(sizeof(toks) / sizeof(toks[0])));
+    }
+
+    /* #1259: module-declared deps. A module's own `@link("...")` directives
+     * travel in its AST; union them across the resolved import closure (and
+     * the entry program itself), so no module needs a row in the static
+     * table above. Same dedup, same first-seen ordering. */
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* c = program->children[i];
+        if (c && c->type == AST_LINK_DIRECTIVE && c->value)
+            add_link_tokens(c->value, toks, &ntok,
+                            (int)(sizeof(toks) / sizeof(toks[0])));
+    }
+    if (global_module_registry) {
+        for (int m = 0; m < global_module_registry->module_count; m++) {
+            AetherModule* mod = global_module_registry->modules[m];
+            if (!mod || !mod->ast) continue;
+            for (int i = 0; i < mod->ast->child_count; i++) {
+                ASTNode* c = mod->ast->children[i];
+                if (c && c->type == AST_LINK_DIRECTIVE && c->value)
+                    add_link_tokens(c->value, toks, &ntok,
+                                    (int)(sizeof(toks) / sizeof(toks[0])));
             }
         }
     }
@@ -4802,9 +4834,21 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
                 generate_expression(gen, cd->children[0]);
                 fprintf(gen->output, ";\n");
             } else {
-                fprintf(gen->output, "#define %s (", cd->value);
+                /* Scoped C, not a #define: a macro has no scope, so a
+                 * function parameter or local spelled like the const was
+                 * textually rewritten into the literal (`int SCALE` became
+                 * `int (99)`), breaking the documented shadowing guarantee
+                 * (#1256, docs/module-system-design.md). A file-scope
+                 * static const participates in C scoping, so inner
+                 * declarations shadow it naturally. */
+                const char* ctype = get_c_type(cd->node_type);
+                /* get_c_type already says `const char*` for strings; avoid
+                 * emitting a duplicate `const const`. */
+                int already_const = strncmp(ctype, "const ", 6) == 0;
+                fprintf(gen->output, "static %s%s %s = (",
+                        already_const ? "" : "const ", ctype, cd->value);
                 generate_expression(gen, cd->children[0]);
-                fprintf(gen->output, ")\n");
+                fprintf(gen->output, ");\n");
             }
         }
     }

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -475,9 +475,11 @@ static void emit_selector_condition(CodeGenerator* gen, ASTNode* sel,
         generate_expression(gen, sel);
         fprintf(gen->output, "))");
     } else {
-        fprintf(gen->output, "(%s == ", val_var);
+        /* No wrapping parens: every caller already parenthesises (the
+         * if-opener or the ALT joiner), and `if ((x == A))` trips clang's
+         * default -Wparentheses-equality on every match a user compiles. */
+        fprintf(gen->output, "%s == ", val_var);
         generate_expression(gen, sel);
-        fprintf(gen->output, ")");
     }
 }
 

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -5866,6 +5866,24 @@ ASTNode* parse_top_level_decl(Parser* parser) {
                 // `expr as *Name` value lowers to a width-correct
                 // mem_get_*/set_* at that offset (no C struct is declared).
                 if (attr && attr->type == TOKEN_IDENTIFIER && attr->value &&
+                    strcmp(attr->value, "link") == 0) {
+                    /* #1259: @link("-lfoo -lbar") — this module's native
+                     * link dependencies. Carried as an AST_LINK_DIRECTIVE
+                     * whose value is the verbatim flag string; codegen
+                     * unions them across the import closure. */
+                    advance_token(parser);  // consume 'link'
+                    if (!expect_token(parser, TOKEN_LEFT_PAREN)) return NULL;
+                    Token* flags = peek_token(parser);
+                    if (!flags || flags->type != TOKEN_STRING_LITERAL || !flags->value) {
+                        parser_error(parser, "@link expects a string of linker flags, e.g. @link(\"-lsqlite3\")");
+                        return NULL;
+                    }
+                    advance_token(parser);
+                    if (!expect_token(parser, TOKEN_RIGHT_PAREN)) return NULL;
+                    return create_ast_node(AST_LINK_DIRECTIVE, flags->value,
+                                           at_tok->line, at_tok->column);
+                }
+                                if (attr && attr->type == TOKEN_IDENTIFIER && attr->value &&
                     strcmp(attr->value, "c_struct") == 0) {
                     advance_token(parser);  // consume 'c_struct'
                     Token* name_tok = expect_token(parser, TOKEN_IDENTIFIER);

--- a/contrib/sqlite/module.ae
+++ b/contrib/sqlite/module.ae
@@ -52,6 +52,12 @@
 //     symbol table is empty (unlikely at runtime — a link failure
 //     stops the build), which covers the CI matrix.
 
+// Native link deps (#1259): the whole-program `// aether-link:` header
+// unions this into the emitted C when contrib.sqlite is in the import
+// closure. -laether_sqlite is the veneer archive `make contrib` builds;
+// order matters for single-pass linkers (veneer before -lsqlite3).
+@link("-laether_sqlite -lsqlite3")
+
 exports (
     SQLITE_OK, SQLITE_ROW, SQLITE_DONE,
     sqlite_open_raw, sqlite_close_raw, sqlite_exec_raw, sqlite_query_raw,

--- a/docs/module-system-design.md
+++ b/docs/module-system-design.md
@@ -452,6 +452,23 @@ After module orchestration, the compiler clones each module's function and const
 
 **Tree-shake of unused merges.** Immediately after merging and before typechecking, `module_prune_unreachable` runs a mark-and-sweep over the program AST. It seeds reachability from `main`, every actor handler, every `export` statement, and every non-imported user function/builder, then closes over `AST_FUNCTION_CALL`, `AST_IDENTIFIER`, and `AST_MEMBER_ACCESS` references, including suffix matches that handle glob-import (`import mymath (*)`) and selective-import (`import mymath [cube]`) shorthands. Imported function and builder definitions outside the closure are dropped from the AST so the typechecker doesn't walk them and the C compiler doesn't emit them. Constants stay (cheap, and pruning them would need a separate pass keyed on identifier references). The whole pass is invisible to user code; programs that *do* call every imported function build identically before and after.
 
+**Native link dependencies (`@link`).** A module that wraps a native
+library declares its own link flags at the top of `module.ae`:
+
+```aether
+@link("-laether_sqlite -lsqlite3")
+```
+
+When the module is in a program's resolved import closure, codegen unions
+every declared flag (first-seen order, deduplicated) into the
+`// aether-link:` comment on the first line of the generated C, which
+downstream C builds read to link without undefined-reference archaeology.
+Declaring is enough; there is no central registry to edit. Token order
+within one `@link` is preserved, which matters for single-pass linkers
+(veneer archive before the library it references). For an ordinary
+`ae build` the consumer still supplies real link flags via `aether.toml`
+(`link_flags = ...`); `@link` feeds only the whole-program comment.
+
 **What's supported:**
 - Functions (with type inference from call sites)
 - Constants (`const NAME = value`), including constants referencing other constants

--- a/tests/integration/link_directive/test_link_directive.sh
+++ b/tests/integration/link_directive/test_link_directive.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# #1259: a module declares its own native link deps with @link("...");
+# codegen unions them across the resolved import closure into the
+# `// aether-link:` header comment. The compiler's static table no longer
+# carries rows for downstream modules (contrib.sqlite moved to this).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/proj/lib/veneer"
+cat > "$TMPDIR/proj/lib/veneer/module.ae" <<'AEOF'
+@link("-lveneer -lm")
+exports (twice)
+twice(x: int) -> int { return x * 2 }
+AEOF
+
+cat > "$TMPDIR/proj/main.ae" <<'AEOF'
+import veneer
+main() { println("${veneer.twice(21)}") }
+AEOF
+
+cd "$TMPDIR/proj"
+"$ROOT/build/aetherc" main.ae out.c >/dev/null 2>&1
+
+head -1 out.c | grep -q "aether-link:.*-lveneer" || {
+    echo "  [FAIL] module @link flags missing from aether-link header"
+    head -2 out.c; exit 1
+}
+head -1 out.c | grep -q -- "-lm" || {
+    echo "  [FAIL] second @link token missing"; exit 1
+}
+
+# Dedup: the same flag from two modules appears once.
+mkdir -p lib/other
+cat > lib/other/module.ae <<'AEOF'
+@link("-lm")
+exports (thrice)
+thrice(x: int) -> int { return x * 3 }
+AEOF
+cat > main2.ae <<'AEOF'
+import veneer
+import other
+main() { println("${veneer.twice(3) + other.thrice(2)}") }
+AEOF
+"$ROOT/build/aetherc" main2.ae out2.c >/dev/null 2>&1
+n=$(head -1 out2.c | grep -o -- "-lm" | wc -l | tr -d ' ')
+[ "$n" = "1" ] || {
+    echo "  [FAIL] duplicate -lm not deduped (count=$n)"
+    head -1 out2.c; exit 1
+}
+
+# A program with no native deps must not emit the comment at all.
+printf 'main() { println("plain") }\n' > plain.ae
+"$ROOT/build/aetherc" plain.ae plain.c >/dev/null 2>&1
+head -1 plain.c | grep -q "aether-link" && {
+    echo "  [FAIL] aether-link emitted for a program with no deps"; exit 1
+}
+
+echo "  [PASS] link_directive: @link unions across the closure, dedups, absent when unused"

--- a/tests/regression/test_const_shadowing.ae
+++ b/tests/regression/test_const_shadowing.ae
@@ -1,0 +1,51 @@
+// Regression #1256: module consts lowered to unguarded C #defines, so a
+// function parameter or local spelled like the const was textually
+// rewritten into the literal (`int SCALE` became `int (99)`) and the
+// documented shadowing guarantee (docs/module-system-design.md) failed to
+// compile. Consts now lower to file-scope `static const`, which
+// participates in C scoping.
+
+const SCALE: int = 99
+const BASE: int = 10
+const DOUBLE: int = BASE * 2
+const BIG: long = 9000000000
+const LABEL = "unit"
+const RATIO = 0.5
+
+extern exit(code: int)
+
+// The documented example, verbatim shape: parameter shadows the const.
+check(SCALE: int) -> int { return SCALE }
+
+shadow_local() -> int {
+    BASE = 41
+    return BASE + 1
+}
+
+classify(x: int) -> string {
+    match x {
+        BASE   -> { return "base" }
+        DOUBLE -> { return "double" }
+        _      -> { return "other" }
+    }
+}
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    if check(5) != 5 { fail("parameter must shadow module const") }
+    if SCALE != 99 { fail("module const must keep its value") }
+    if shadow_local() != 42 { fail("local must shadow module const") }
+    if DOUBLE != 20 { fail("const-of-const must fold to 20") }
+    if BIG != 9000000000 { fail("long const past 2^31") }
+    if LABEL != "unit" { fail("string const") }
+    if classify(10) != "base" { fail("match on const pattern (base)") }
+    if classify(20) != "double" { fail("match on const pattern (double)") }
+    if classify(7) != "other" { fail("match wildcard") }
+    r = RATIO * 2.0
+    if r != 1.0 { fail("float const") }
+    println("PASS: consts scope correctly; shadowing, folding, match all hold")
+}

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -328,7 +328,7 @@ int run_cross_build(const char* c_file, const char* out_file,
             size_t p = 0;
             p += (size_t)snprintf(crossbuild_libs + p, sizeof(crossbuild_libs) - p,
                                   "-L%s/lib", xsr);
-            /* The sysroot's headers (openssl/*, zlib.h, pcre2.h, ...) must be on
+            /* The sysroot's headers (openssl/, zlib.h, pcre2.h, ...) must be on
              * the COMPILE include path too, else enabling a real path below
              * (-DAETHER_HAS_OPENSSL etc.) hits `openssl/ssl.h file not found`.
              * Added once, unconditionally when a CROSSBUILD_SYSROOT is set —


### PR DESCRIPTION
## Summary

Two issue fixes plus one stale-issue verification, all reproduced or proven before acting.

## Module consts respect C scoping

Closes #1256

A module-level `const` lowered to a bare unguarded `#define`. A macro has no scope, so a parameter or local spelled like the const was textually rewritten into the literal (`int SCALE` became `int (99)`), and the shadowing guarantee documented in `docs/module-system-design.md` failed to compile, verbatim. Consts now lower to file-scope `static const <type>`, which inner declarations shadow naturally.

Verified unchanged across every context the `#define` handled: const-of-const initializers (accepted by both GCC 15 and clang, checked empirically under `-pedantic-errors`), 64-bit longs, strings (without emitting `const const char*`), floats, match patterns naming consts, imported consts through the module hoist, and the `--emit=lib` const catalog.

Bonus, pre-existing and surfaced by this work: match lowering emitted `if ((x == A))`, tripping clang's default `-Wparentheses-equality` on every match a user compiles. The equality branch no longer wraps; every caller already parenthesises.

## Modules declare their own native link deps

Closes #1259

Top-level `@link("-lfoo -lbar")` in `module.ae`, the issue's recommended option. Codegen unions declared flags across the resolved import closure into the `// aether-link:` header comment: first-seen order, deduplicated, token order within a directive preserved (single-pass linker ordering), absent when nothing declares. The hardcoded `contrib.sqlite` row moved into `contrib/sqlite/module.ae` itself; the module owns its deps, the compiler owns only the union-over-closure mechanism. The `std.*` rows can migrate the same way, one module at a time, no flag day.

## Verified already done: os.wait_any timeout + token contract

Closes #1278

Both asks are already implemented on main: `os.wait_any_timeout` enforces a per-child deadline, and `os.kill` resolves spawn tokens through the process table on Windows (the implementation cites #1278). Functional proof ran spawn → bounded wait-any → kill(token) → reap end to end. Closed with evidence rather than re-implemented.

## Tests

- `test_const_shadowing.ae`: the documented example verbatim, local shadowing, const-of-const folding, 64-bit/string/float consts, match-on-const, zero C warnings.
- `link_directive`: union across the closure, cross-module dedup, and no `aether-link` line when nothing declares.
- Existing `emit_link_requirements` and `emit_lib_const` suites pass unchanged.
