### PR TITLE
feat(release): cross-build a FreeBSD x86_64 zip via zig cc

### DIFF
--- a/.github/scripts/build_release_body.py
+++ b/.github/scripts/build_release_body.py
@@ -46,17 +46,26 @@ def extract_changelog_section(changelog_path: str, version: str) -> str:
 
 def build_download_table(version: str) -> str:
     targets = [
-        ("Linux",   "x86_64",  f"aether-{version}-linux-x86_64.tar.gz"),
-        ("macOS",   "x86_64",  f"aether-{version}-macos-x86_64.tar.gz"),
-        ("macOS",   "arm64",   f"aether-{version}-macos-arm64.tar.gz"),
-        ("Windows", "x86_64",  f"aether-{version}-windows-x86_64.zip"),
+        ("Linux",   "x86_64",  f"aether-{version}-linux-x86_64.tar.gz", None),
+        ("macOS",   "x86_64",  f"aether-{version}-macos-x86_64.tar.gz", None),
+        ("macOS",   "arm64",   f"aether-{version}-macos-arm64.tar.gz", None),
+        ("Windows", "x86_64",  f"aether-{version}-windows-x86_64.zip", None),
+        # FreeBSD is CROSS-built (no native runner) and best-effort, so it may
+        # be absent from a given release. List it only when the artifact is
+        # actually present in the publish working directory, and flag that it
+        # was not run through the test suite on FreeBSD.
+        ("FreeBSD", "x86_64",  f"aether-{version}-freebsd-x86_64.tar.gz",
+         "cross-built, not tested on FreeBSD"),
     ]
     lines = [
-        "| Platform | Architecture | File |",
-        "|----------|:------------:|------|",
+        "| Platform | Architecture | File | Notes |",
+        "|----------|:------------:|------|-------|",
     ]
-    for platform, arch, filename in targets:
-        lines.append(f"| {platform} | {arch} | `{filename}` |")
+    for platform, arch, filename, note in targets:
+        # Optional (note-bearing) targets are only listed if the file exists.
+        if note is not None and not os.path.exists(filename):
+            continue
+        lines.append(f"| {platform} | {arch} | `{filename}` | {note or ''} |")
     return "\n".join(lines)
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,11 +435,123 @@ jobs:
         retention-days: 7
 
   # ================================================================== #
+  # BUILD-FREEBSD -- cross-compile the FreeBSD zip via zig cc           #
+  #                                                                    #
+  # GitHub Actions has no native FreeBSD runner, so the ae/aetherc     #
+  # toolchain is CROSS-built for FreeBSD on the Linux runner with zig  #
+  # cc (Makefile FREEBSD=1 mode), against a FreeBSD base sysroot        #
+  # provisioned from the aether-crossbuild repo.                        #
+  #                                                                    #
+  # continue-on-error: this leg is BEST-EFFORT — a provisioning hiccup  #
+  # (mirror down, upstream base moved) must never block the release of  #
+  # the four first-class platforms. The artifact is also UNTESTED (no   #
+  # FreeBSD to run `make test` on); it is validated only as a correct   #
+  # FreeBSD ELF. If the leg fails or is skipped, publish simply omits   #
+  # the FreeBSD asset.                                                  #
+  # ================================================================== #
+  build-freebsd:
+    name: Build -- freebsd-x86_64 (cross)
+    needs: tag
+    continue-on-error: true
+    if: |
+      always() && (
+        (needs.tag.result == 'success' && needs.tag.outputs.tag != '') ||
+        startsWith(github.ref, 'refs/tags/')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.tag.outputs.tag || github.ref }}
+        fetch-tags: true
+
+    - name: Setup
+      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+
+    # The cross toolchain (pinned zig) + FreeBSD base sysroot (headers + libc)
+    # live in the sibling aether-crossbuild repo, which encodes the provenance-
+    # clean provisioning (zig from its pinned upstream; FreeBSD base from
+    # FreeBSD's published base.txz — BSD-licensed, freely redistributable).
+    - name: Checkout aether-crossbuild
+      uses: actions/checkout@v4
+      with:
+        repository: aether-lang-org/aether-crossbuild
+        path: crossbuild
+        fetch-depth: 1
+
+    - name: Provision zig + FreeBSD base sysroot
+      id: prov
+      run: |
+        cd crossbuild
+        ./scripts/get-zig.sh
+        ./scripts/fetch-freebsd-base.sh x86_64 15
+        ZIG="$(find "$PWD/toolchain" -maxdepth 2 -name zig -type f | head -1)"
+        SR="$PWD/bases/x86_64-freebsd15"
+        test -x "$ZIG" || { echo "zig not provisioned"; exit 1; }
+        test -f "$SR/lib/libc.so.7" || { echo "FreeBSD base sysroot missing libc.so.7"; exit 1; }
+        echo "zig=$ZIG"       >> "$GITHUB_OUTPUT"
+        echo "sysroot=$SR"    >> "$GITHUB_OUTPUT"
+
+    - name: Cross-build (FREEBSD=1)
+      run: |
+        make compiler ae stdlib \
+          FREEBSD=1 \
+          ZIG="${{ steps.prov.outputs.zig }}" \
+          AETHER_SYSROOT="${{ steps.prov.outputs.sysroot }}"
+        # Confirm the artifacts really are FreeBSD ELFs before packaging — a
+        # cross-build that silently produced Linux binaries would be worse
+        # than no FreeBSD zip.
+        file build/aetherc build/ae
+        file build/ae | grep -q 'FreeBSD' || { echo "ae is not a FreeBSD binary"; exit 1; }
+
+    - name: Strip
+      run: strip build/aetherc build/ae 2>/dev/null || true
+
+    - name: Package
+      run: |
+        VERSION=$(cat VERSION | tr -d '[:space:]')
+        TARGET=freebsd-x86_64
+        mkdir -p release/bin release/lib release/share/aether release/include/aether
+        cp build/aetherc release/bin/
+        cp build/ae      release/bin/
+        chmod 755 release/bin/*
+        if [ -f build/libaether.a ]; then cp build/libaether.a release/lib/; fi
+        for dir in runtime runtime/actors runtime/scheduler runtime/utils \
+                   runtime/memory runtime/config std std/string std/io std/math \
+                   std/net std/collections std/json std/fs std/log std/http \
+                   std/file std/dir std/path std/tcp std/list std/map std/os; do
+          if [ -d "$dir" ]; then
+            mkdir -p "release/include/aether/$dir"
+            cp "$dir"/*.h "release/include/aether/$dir/" 2>/dev/null || true
+          fi
+        done
+        cp -r runtime release/share/aether/
+        cp -r std     release/share/aether/
+        cp LICENSE README.md VERSION release/
+        # Note the cross-build in the archive so downstream users know it was
+        # not run through the test suite on FreeBSD.
+        echo "Cross-built for FreeBSD with zig cc; not run through the test suite on FreeBSD." \
+          > release/FREEBSD-CROSS-BUILD.txt
+        cd release && tar -czf "../aether-${VERSION}-${TARGET}.tar.gz" *
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: aether-freebsd-x86_64
+        path: aether-*-freebsd-x86_64.tar.gz
+        retention-days: 7
+
+  # ================================================================== #
   # PUBLISH -- create or update the GitHub Release                      #
   # ================================================================== #
   publish:
     name: Publish release
-    needs: [tag, build]
+    # build-freebsd is in `needs` only so publish waits for its artifact to be
+    # available — it is NOT in the `if` gate, so a failed/skipped FreeBSD leg
+    # (continue-on-error) never blocks the release; publish just omits the asset.
+    needs: [tag, build, build-freebsd]
     runs-on: ubuntu-latest
     if: |
       always() && needs.build.result == 'success' && (

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,61 @@ else
     endif
 endif
 
+# ---------------------------------------------------------------------------
+# FreeBSD cross-build (FREEBSD=1) — build the ae/aetherc toolchain FOR FreeBSD
+# from a Linux (or any) host, via `zig cc`. GitHub Actions has no native
+# FreeBSD runner, so the release FreeBSD zip is produced this way. This mirrors
+# the link recipe tools/ae_cross.c uses for `ae build --target=x86_64-freebsd`,
+# but applied to the compiler's own C sources through the Makefile's CC/LDFLAGS.
+#
+# Required inputs:
+#   ZIG            path to a zig binary (>= 0.13)         e.g. .../zig
+#   AETHER_SYSROOT FreeBSD base sysroot (headers + libc)  e.g. .../bases/x86_64-freebsd15
+# Provision both with the aether-crossbuild repo (get-zig.sh / fetch-freebsd-base.sh).
+#
+# Notes:
+#   - zig cc does NOT bundle a FreeBSD libc, so we link -nostdlib against the
+#     base's CRT objects + versioned libc.so.7 / libthr.so.3 / libm.so.5 BY
+#     PATH (the .so symlinks point at absolute /lib paths that don't exist on
+#     the build host; -lthr/-lpthread/-lm don't resolve under zig-lld here).
+#   - casper libs are ALWAYS needed: std/casper/aether_casper.c is
+#     unconditionally in the build and references cap_*; the base ships them.
+#   - Optional Tier-2 libs (OpenSSL/zlib/nghttp2/PCRE2/YAML) are forced OFF
+#     for the cross build: pkg-config on the host would find the host's Linux
+#     libs and poison the FreeBSD binary. A cross build ships those std
+#     features as their "unavailable" stubs (same as any build without them);
+#     a future crossbuild-sysroot-staged variant can re-enable them.
+FREEBSD_CPU ?= x86_64
+ifeq ($(FREEBSD),1)
+  ifeq ($(ZIG),)
+    $(error FREEBSD=1 needs ZIG=<path to zig> (>= 0.13))
+  endif
+  ifeq ($(AETHER_SYSROOT),)
+    $(error FREEBSD=1 needs AETHER_SYSROOT=<FreeBSD base sysroot>)
+  endif
+  # Route through the zigcc-freebsd wrapper: on a FreeBSD -nostdlib link zig cc
+  # prints a COSMETIC "libc not available" and exits nonzero even though a valid
+  # binary was produced (see the wrapper + tools/ae_cross.c). The wrapper
+  # forgives that ONLY when the link's -o output actually exists; real compile/
+  # link errors still fail. `$(ZIG)` is passed as the wrapper's first arg.
+  CC := $(CURDIR)/scripts/zigcc-freebsd.sh $(ZIG) -target $(FREEBSD_CPU)-freebsd --sysroot=$(AETHER_SYSROOT) -I$(AETHER_SYSROOT)/usr/include
+  # Host pkg-config is wrong for the target — force the optional libs off.
+  OPENSSL := 0
+  ZLIB := 0
+  NGHTTP2 := 0
+  PCRE2 := 0
+  YAML := 0
+  # Link tail (mirrors tools/ae_cross.c): -nostdlib + CRT + versioned base
+  # libs by path + casper, and the base -L dirs. Overrides the native LDFLAGS
+  # assembly below (guarded by ifneq ($(FREEBSD),1)).
+  FREEBSD_LDFLAGS := -nostdlib \
+    $(AETHER_SYSROOT)/usr/lib/crt1.o $(AETHER_SYSROOT)/usr/lib/crti.o \
+    $(AETHER_SYSROOT)/lib/libc.so.7 $(AETHER_SYSROOT)/lib/libthr.so.3 \
+    $(AETHER_SYSROOT)/lib/libm.so.5 $(AETHER_SYSROOT)/usr/lib/crtn.o \
+    -lcasper -lcap_pwd -lcap_sysctl -lcap_grp -lcap_dns \
+    -L$(AETHER_SYSROOT)/usr/lib -L$(AETHER_SYSROOT)/lib
+endif
+
 # MinGW / MSYS2 (native Windows): bind the printf family to the
 # C99-conformant __mingw_* implementations instead of legacy MSVCRT.
 # MSVCRT mishandles the C99 conversions we emit (%lld / %llu / %zu / %g)
@@ -336,7 +391,13 @@ else ifeq ($(shell uname -s),Darwin)
   AUDIO_LDFLAGS := -framework CoreFoundation -framework CoreAudio -framework AudioToolbox
 endif
 
+ifeq ($(FREEBSD),1)
+# Cross build: the explicit base-libc link tail replaces the native assembly
+# (which would pull the host's -lm / -pthread / globbed host casper libs).
+LDFLAGS = $(FREEBSD_LDFLAGS)
+else
 LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS) $(YAML_LDFLAGS) $(CASPER_LDFLAGS) $(AUDIO_LDFLAGS)
+endif
 
 # Hardening flags (issue #396). Opt-in via `HARDEN=1`. The CI matrix
 # pins a Linux/gcc + HARDEN=1 entry so a hardened-build regression
@@ -366,10 +427,12 @@ LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFL
 ifeq ($(HARDEN),1)
 CFLAGS += -fstack-protector-all -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security
 endif
+ifneq ($(FREEBSD),1)
 ifneq ($(PLATFORM),wasm)
 ifneq ($(PLATFORM),embedded)
 ifeq ($(findstring AETHER_NO_THREADING,$(EXTRA_CFLAGS)),)
 LDFLAGS += -pthread
+endif
 endif
 endif
 endif

--- a/scripts/zigcc-freebsd.sh
+++ b/scripts/zigcc-freebsd.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# zigcc-freebsd.sh — a `cc` shim for cross-building the Aether toolchain FOR
+# FreeBSD with `zig cc` (used by the Makefile's FREEBSD=1 mode).
+#
+# Why this exists: on a FreeBSD `-nostdlib` link, `zig cc` prints a COSMETIC
+# "error: libc not available" and exits nonzero even though clang+lld produced
+# a perfectly good binary — zig reserves that message for targets whose libc it
+# can't supply, which is exactly why we bring our own base sysroot. A genuine
+# link failure (undefined symbol, etc.) leaves NO output file, so "the -o
+# target exists and is non-empty" cleanly separates cosmetic from real. This
+# mirrors tools/ae_cross.c's handling for `ae build --target=x86_64-freebsd`.
+#
+# Usage (from the Makefile):
+#   CC="scripts/zigcc-freebsd.sh <zig> -target x86_64-freebsd --sysroot=..."
+# i.e. $1 is the zig binary, the rest are normal cc args. Compile steps (no
+# produced executable to check, plain -c) pass their exit code through
+# unchanged, so real compile errors still fail the build.
+
+set -eu
+
+ZIG="$1"
+shift
+
+# Find the -o output path (if any), and whether this is a compile-only step.
+# Only LINK steps get the cosmetic-failure forgiveness; a `-c` compile must
+# always propagate its exit code so real compile errors fail the build.
+out=""
+prev=""
+compile_only=0
+for a in "$@"; do
+    if [ "$prev" = "-o" ]; then out="$a"; fi
+    if [ "$a" = "-c" ]; then compile_only=1; fi
+    prev="$a"
+done
+
+# Run the real zig cc. Don't let `set -e` abort — we inspect the code.
+set +e
+"$ZIG" cc "$@"
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ]; then
+    exit 0
+fi
+
+# Nonzero on a LINK step: forgive the cosmetic "libc not available" case, and
+# ONLY when the intended output was actually produced (non-empty). A genuine
+# link failure (undefined symbol) leaves no output, so this cleanly separates
+# cosmetic from real. Compile steps and outputless invocations always fail.
+if [ "$compile_only" -eq 0 ] && [ -n "$out" ] && [ -s "$out" ]; then
+    echo "note: zig cc exited $rc (cosmetic 'libc not available'); '$out' produced, treating the link as success." >&2
+    exit 0
+fi
+
+exit "$rc"


### PR DESCRIPTION
Adds a FreeBSD x86_64 artifact to the release. GitHub Actions has no native FreeBSD runner, so the ae/aetherc toolchain is **cross-built** for FreeBSD on the Linux runner via `zig cc`, packaged into the same zip shape as the other platforms.

## Three pieces

**1. `Makefile` `FREEBSD=1` mode.** Sets `CC` to a zig-cc cross wrapper, forces the optional Tier-2 libs off (host `pkg-config` would resolve the host's *Linux* libs and poison the target), and replaces `LDFLAGS` with the FreeBSD link tail (`-nostdlib` + base CRT + versioned `libc.so.7`/`libthr.so.3`/`libm.so.5` by path + casper libs), mirroring `tools/ae_cross.c`. Needs `ZIG=<zig>` + `AETHER_SYSROOT=<base sysroot>`; native builds are untouched (guarded).

**2. `scripts/zigcc-freebsd.sh`.** The key gotcha this investigation surfaced: on a FreeBSD `-nostdlib` link, `zig cc` prints a **cosmetic** `error: libc not available` and exits nonzero *even though clang+lld produced a valid binary* (zig reserves that message for targets whose libc it can't supply — which is exactly why we bring our own base). The wrapper forgives that **only** on a link step whose `-o` output actually exists; real compile errors and real link failures (undefined symbol → no output) still propagate. Same discrimination `ae_cross.c` already uses for `ae build --target=x86_64-freebsd`.

**3. `build-freebsd` release job** (`continue-on-error`, so it never blocks the four first-class platforms). Clones the sibling `aether-lang-org/aether-crossbuild` repo, provisions the pinned zig + FreeBSD base sysroot (BSD-licensed, freely redistributable), cross-builds `FREEBSD=1`, **verifies the output is actually a FreeBSD ELF** before packaging, strips, uploads. `publish` waits for it non-blocking and picks up the tarball via the existing glob; `build_release_body.py` lists FreeBSD in the download table only when the artifact is present, flagged *"cross-built, not tested on FreeBSD."*

## Verification

Proven locally end-to-end: `make compiler ae stdlib FREEBSD=1` → **exit 0**, producing valid `ELF 64-bit LSB executable, (FreeBSD), for FreeBSD 15.0` binaries for `ae`/`aetherc` plus `libaether.a`. The wrapper was verified to still **fail** on injected compile errors and undefined-symbol link errors (no false forgiveness).

## Caveats (documented in the job + a `FREEBSD-CROSS-BUILD.txt` in the archive)

- The artifact is **untested** — no FreeBSD runner to run `make test`; validated only as a correct FreeBSD ELF.
- Optional std features (TLS/zlib/regex) ship as their "unavailable" stubs on the cross build (host pkg-config can't provide FreeBSD libs). A future crossbuild-sysroot-staged variant could re-enable them.
- The leg depends on `aether-crossbuild` being reachable in CI (same org).

Builds on top of the merged glibc/ubuntu-22.04 pin (#1292); no interaction. First real proof will be the next release producing a loadable FreeBSD zip — worth a smoke-test on a FreeBSD box once it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)