### PR TITLE
feat(tls13): server certificate validation — reject expired, wrong-host, and self-signed certs (#1298)

### DIFF
--- a/std/cryptography/asn1/module.ae
+++ b/std/cryptography/asn1/module.ae
@@ -51,7 +51,7 @@ exports (
     TAG_UTF8_STRING, TAG_ENUMERATED,
     TAG_CLASS_UNIVERSAL, TAG_CLASS_APPLICATION, TAG_CLASS_CONTEXT_SPECIFIC, TAG_CLASS_PRIVATE,
     TAG_PC_PRIMITIVE, TAG_PC_CONSTRUCTED,
-    reader_new, reader_free, reader_eof, reader_remaining,
+    reader_new, reader_free, reader_eof, reader_remaining, reader_pos,
     read_tlv, last_tag, last_tag_class, last_tag_pc, last_tag_number,
     read_sequence, read_integer, read_oid,
     read_octet_string, read_bit_string, read_null, read_boolean,
@@ -296,6 +296,15 @@ read_tlv(r: ptr) -> (ptr, string) {
 last_tag(r: ptr) -> int {
     rr = r as *Reader
     return rr.last_tag
+}
+
+// Current read offset into the underlying buffer. Bracketing a read_tlv with
+// two reader_pos() calls yields the exact byte span (header+content) of that
+// TLV — needed to recover the precise DER of, e.g., tbsCertificate for
+// signature verification.
+reader_pos(r: ptr) -> int {
+    rr = r as *Reader
+    return rr.pos
 }
 
 // Read a TLV and assert its tag. Returns (content_bytes, "") or (null, err).

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -54,7 +54,9 @@ exports (
     leaf_dns_count, leaf_dns_name,
     leaf_tbs_len, leaf_subject_len, leaf_issuer_len,
     SCHEME_ECDSA_P256_SHA256, SCHEME_ED25519, SCHEME_RSA_PSS_RSAE_SHA256,
-    check_validity, time_to_key, check_hostname
+    check_validity, time_to_key, check_hostname,
+    chain_verify, verify_cert_signature,
+    trust_store_load, free_anchors
 )
 
 // SignatureScheme code points (RFC 8446 §4.2.3).
@@ -756,4 +758,256 @@ check_hostname(c: *LeafCert, host: string) -> string {
         i = i + 1
     }
     return "certificate is not valid for the requested hostname"
+}
+
+// ---- chain building + cert-to-cert signature verification (RFC 5280) ----
+//
+// Nic's third bar: a self-signed leaf (issuer == subject, no trusted anchor)
+// must be REJECTED. chain_verify() rejects any leaf whose issuer DN does not
+// exactly match a trusted anchor's subject DN AND whose tbsCertificate
+// signature does not verify under that anchor's public key.
+//
+// Supported cert signature algorithms (the two that cover the real world):
+//   sha256WithRSAEncryption  1.2.840.113549.1.1.11  -> RSA PKCS#1 v1.5
+//   ecdsa-with-SHA256        1.2.840.10045.4.3.2    -> ECDSA P-256
+// SPKI key algorithms:
+//   rsaEncryption            1.2.840.113549.1.1.1
+//   id-ecPublicKey           1.2.840.10045.2.1
+
+import std.cryptography.rsa
+
+// Compare a bytes-stored OID (ASCII dotted string) against a literal.
+fn oid_is(oid: ptr, want: string) -> int {
+    if oid == null { return 0 }
+    olen = bytes.length(oid)
+    wlen = string.length(want)
+    if olen != wlen { return 0 }
+    i = 0
+    while i < olen {
+        if (bytes.get(oid, i) & 0xFF) != (string_char_at_n(want, wlen, i) & 0xFF) { return 0 }
+        i = i + 1
+    }
+    return 1
+}
+
+// Byte-for-byte DER Name comparison (issuer DN vs subject DN).
+fn dn_equal(a: ptr, alen: int, b: ptr, blen: int) -> int {
+    if a == null { return 0 }
+    if b == null { return 0 }
+    if alen != blen { return 0 }
+    i = 0
+    while i < alen {
+        if (bytes.get(a, i) & 0xFF) != (bytes.get(b, i) & 0xFF) { return 0 }
+        i = i + 1
+    }
+    return 1
+}
+
+// Build the DER DigestInfo for a SHA-256 hash (what PKCS#1 v1.5 verify wants):
+//   SEQUENCE { SEQUENCE { OID 2.16.840.1.101.3.4.2.1, NULL }, OCTET STRING hash }
+// The 19-byte fixed prefix for SHA-256 followed by the 32-byte hash.
+fn sha256_digestinfo(hash32: ptr) -> ptr {
+    // 30 31 30 0d 06 09 60 86 48 01 65 03 04 02 01 05 00 04 20 <hash>
+    prefix = bytes.new(19)
+    bytes.set(prefix, 0, 0x30); bytes.set(prefix, 1, 0x31)
+    bytes.set(prefix, 2, 0x30); bytes.set(prefix, 3, 0x0d)
+    bytes.set(prefix, 4, 0x06); bytes.set(prefix, 5, 0x09)
+    bytes.set(prefix, 6, 0x60); bytes.set(prefix, 7, 0x86)
+    bytes.set(prefix, 8, 0x48); bytes.set(prefix, 9, 0x01)
+    bytes.set(prefix, 10, 0x65); bytes.set(prefix, 11, 0x03)
+    bytes.set(prefix, 12, 0x04); bytes.set(prefix, 13, 0x02)
+    bytes.set(prefix, 14, 0x01); bytes.set(prefix, 15, 0x05)
+    bytes.set(prefix, 16, 0x00); bytes.set(prefix, 17, 0x04)
+    bytes.set(prefix, 18, 0x20)
+    di = bytes.new(51)
+    bytes.set(di, 50, 0)
+    bytes.copy_from_bytes(di, 0, prefix, 0, 19)
+    bytes.copy_from_bytes(di, 19, hash32, 0, 32)
+    bytes.free(prefix)
+    return di
+}
+
+// Parse an RSA SPKI key blob (the SubjectPublicKey content, which for RSA is
+// SEQUENCE { INTEGER n, INTEGER e }) into (n, e) bignums. Returns (n,e,"") or
+// (null,null,err). Caller frees the bignums with bignum.free.
+fn parse_rsa_spki(spki_key: ptr, key_len: int) -> (ptr, ptr, string) {
+    view = bytes.new(key_len)
+    if key_len > 0 { bytes.set(view, key_len - 1, 0) }
+    bytes.copy_from_bytes(view, 0, spki_key, 0, key_len)
+    r = asn1.reader_new(view)
+    sub, body, serr = asn1.read_sequence(r)
+    if string.equals(serr, "") != 1 {
+        asn1.reader_free(r); bytes.free(view)
+        return null, null, serr
+    }
+    n, nerr = asn1.read_integer(sub)
+    if string.equals(nerr, "") != 1 {
+        asn1.reader_free(sub); asn1.reader_free(r); bytes.free(view); bytes.free(body)
+        return null, null, nerr
+    }
+    e, eerr = asn1.read_integer(sub)
+    if string.equals(eerr, "") != 1 {
+        bignum.free(n)
+        asn1.reader_free(sub); asn1.reader_free(r); bytes.free(view); bytes.free(body)
+        return null, null, eerr
+    }
+    asn1.reader_free(sub); asn1.reader_free(r); bytes.free(view); bytes.free(body)
+    return n, e, ""
+}
+
+// Verify `leaf`'s tbsCertificate signature under `issuer`'s public key.
+// Dispatches on leaf.sig_alg_oid. Returns 1 if the signature is valid, else 0.
+verify_cert_signature(leaf: *LeafCert, issuer: *LeafCert) -> int {
+    if leaf.tbs == null { return 0 }
+    if leaf.signature == null { return 0 }
+    if issuer.spki_key == null { return 0 }
+    // Hash the tbsCertificate DER (SHA-256; both supported schemes use it).
+    hash = sha256_of_bytes(leaf.tbs, leaf.tbs_len)
+    if hash == null { return 0 }
+
+    result = 0
+    if oid_is(leaf.sig_alg_oid, "1.2.840.113549.1.1.11") == 1 {
+        // sha256WithRSAEncryption. Issuer key must be rsaEncryption.
+        if oid_is(issuer.spki_algo_oid, "1.2.840.113549.1.1.1") == 1 {
+            n, e, perr = parse_rsa_spki(issuer.spki_key, issuer.spki_key_len)
+            if string.equals(perr, "") == 1 {
+                k = rsa.key_from_components(n, e, null)
+                di = sha256_digestinfo(hash)
+                result = rsa.verify_pkcs1(k, di, leaf.signature)
+                bytes.free(di)
+                rsa.key_free(k)   // frees n, e too
+            }
+        }
+    }
+    if oid_is(leaf.sig_alg_oid, "1.2.840.10045.4.3.2") == 1 {
+        // ecdsa-with-SHA256. Issuer key must be id-ecPublicKey (P-256 point).
+        if oid_is(issuer.spki_algo_oid, "1.2.840.10045.2.1") == 1 {
+            px, py, kerr = ec_point_from_spki(issuer.spki_key, issuer.spki_key_len)
+            if string.equals(kerr, "") == 1 {
+                r32, s32, serr = split_ecdsa_sig(leaf.signature, leaf.signature_len)
+                if string.equals(serr, "") == 1 {
+                    result = p256.ecdsa_verify(px, py, hash, r32, s32)
+                    bytes.free(r32); bytes.free(s32)
+                }
+                bytes.free(px); bytes.free(py)
+            }
+        }
+    }
+    bytes.free(hash)
+    return result
+}
+
+// Split an uncompressed EC point (04 || X32 || Y32) from an SPKI key blob into
+// (X32, Y32, ""). Returns (null,null,err) if it isn't a 65-byte uncompressed
+// point. Caller frees X/Y.
+fn ec_point_from_spki(key: ptr, key_len: int) -> (ptr, ptr, string) {
+    if key_len != 65 { return null, null, "unsupported EC point encoding" }
+    if (bytes.get(key, 0) & 0xFF) != 0x04 { return null, null, "EC point not uncompressed" }
+    x = bytes.new(32); bytes.set(x, 31, 0)
+    y = bytes.new(32); bytes.set(y, 31, 0)
+    bytes.copy_from_bytes(x, 0, key, 1, 32)
+    bytes.copy_from_bytes(y, 0, key, 33, 32)
+    return x, y, ""
+}
+
+// Verify `leaf` chains to one of the trusted `anchors` (a std.list of
+// *LeafCert). Requires an anchor whose subject DN exactly equals leaf.issuer
+// AND under whose key leaf's signature verifies. Returns "" on success, else
+// an error. A self-signed leaf (no matching anchor) is REJECTED here.
+chain_verify(leaf: *LeafCert, anchors: ptr) -> string {
+    if anchors == null { return "no trust anchors" }
+    n = list_size(anchors)
+    if n == 0 { return "no trust anchors" }
+    i = 0
+    while i < n {
+        a = list_get_raw(anchors, i) as *LeafCert
+        if a != null {
+            if dn_equal(leaf.issuer, leaf.issuer_len, a.subject, a.subject_len) == 1 {
+                if verify_cert_signature(leaf, a) == 1 {
+                    return ""
+                }
+            }
+        }
+        i = i + 1
+    }
+    return "certificate does not chain to a trusted anchor"
+}
+
+// ---- system trust store (PEM bundle) ----
+
+import std.fs
+import std.cryptography.pem
+
+// Load a PEM bundle file (e.g. /etc/ssl/certs/ca-certificates.crt) into a
+// std.list of *LeafCert trust anchors. Each PEM CERTIFICATE block is base64-
+// decoded and structurally parsed; blocks that fail to parse are skipped.
+// Returns (list, "") on success or (null, err) if the file can't be read.
+// Caller frees with free_anchors (frees each LeafCert + the list).
+trust_store_load(path: string) -> (ptr, string) {
+    fh = fs.file_open_raw(path, "r")
+    if fh == null { return null, "cannot open trust store" }
+    text = fs.file_read_all_raw(fh)
+    fs.file_close(fh)
+
+    anchors = list_new()
+    end_marker = "-----END CERTIFICATE-----"
+    tlen = string.length(text)
+    mlen = string.length(end_marker)
+    pos = 0
+    while pos < tlen {
+        e = string.index_of_from(text, end_marker, pos)
+        if e < 0 { break }
+        block_end = e + mlen
+        block = string.substring_n(text, tlen, pos, block_end)
+        der, label, perr = pem.parse(block)
+        if string.equals(perr, "") == 1 {
+            if der != null {
+                // sizeof(LeafCert) = 136 on LP64 (9 ptr @8 + 8 int @4, C-packed;
+                // measured via element-stride of a *LeafCert array).
+                leaf = malloc(136) as *LeafCert
+                init_leaf(leaf)
+                dlen = bytes.length(der)
+                cerr = parse_certificate(der, dlen, leaf)
+                if string.equals(cerr, "") == 1 {
+                    list_add_raw(anchors, leaf)
+                } else {
+                    free_leaf(leaf)
+                    free(leaf)
+                }
+            }
+            bytes.free(der)
+        }
+        pos = block_end
+    }
+    return anchors, ""
+}
+
+// Zero every field of a heap-allocated LeafCert.
+fn init_leaf(l: *LeafCert) {
+    l.tbs = null; l.tbs_len = 0
+    l.sig_alg_oid = null
+    l.signature = null; l.signature_len = 0
+    l.spki_algo_oid = null; l.spki_key = null; l.spki_key_len = 0
+    l.issuer = null; l.issuer_len = 0
+    l.subject = null; l.subject_len = 0
+    l.not_before = null; l.not_before_len = 0
+    l.not_after = null; l.not_after_len = 0
+    l.dns_names = null
+}
+
+// Free a trust-anchor list built by trust_store_load: each *LeafCert's buffers,
+// each LeafCert struct, then the list.
+free_anchors(anchors: ptr) {
+    if anchors == null { return }
+    n = list_size(anchors)
+    i = 0
+    while i < n {
+        a = list_get_raw(anchors, i) as *LeafCert
+        if a != null {
+            free_leaf(a)
+            free(a)
+        }
+        i = i + 1
+    }
+    list_free(anchors)
 }

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -37,18 +37,24 @@
 import std.bytes
 import std.string
 import std.bignum
+import std.list
 import std.cryptography.asn1
 import std.cryptography.sha2
 import std.cryptography.p256
 import std.cryptography.ed25519
+import std.os
 
 extern malloc(size: int) -> ptr
 extern free(p: ptr)
 
 exports (
-    cert_verify_content, verify_cert_verify, parse_certificate,
+    cert_verify_content, verify_cert_verify, parse_certificate, free_leaf,
     LeafCert,
-    SCHEME_ECDSA_P256_SHA256, SCHEME_ED25519, SCHEME_RSA_PSS_RSAE_SHA256
+    leaf_not_before, leaf_not_before_len, leaf_not_after, leaf_not_after_len,
+    leaf_dns_count, leaf_dns_name,
+    leaf_tbs_len, leaf_subject_len, leaf_issuer_len,
+    SCHEME_ECDSA_P256_SHA256, SCHEME_ED25519, SCHEME_RSA_PSS_RSAE_SHA256,
+    check_validity, time_to_key, check_hostname
 )
 
 // SignatureScheme code points (RFC 8446 §4.2.3).
@@ -212,69 +218,116 @@ verify_cert_verify(scheme: int, pubx: ptr, puby: ptr, transcript_hash: ptr, th_l
 
 // ---- X.509 structural parse ----
 
-// Views into a parsed leaf Certificate (RFC 5280). All ptr fields are fresh
+// Views into a parsed Certificate (RFC 5280). All ptr fields are fresh
 // std.bytes the caller must free via free_leaf. `tbs` is the exact DER of
-// tbsCertificate (the signed bytes); `spki_algo_oid` is the SPKI algorithm
-// OID (dotted string); `spki_key` is the subjectPublicKey BIT STRING content
-// (for EC: 0x04 || X || Y uncompressed point; for RSA: the RSAPublicKey DER).
+// tbsCertificate INCLUDING its SEQUENCE tag+length (the bytes the certificate
+// signature is computed over); `spki_algo_oid`/`spki_key` are the subject
+// public key (EC: 0x04||X||Y; RSA: RSAPublicKey DER).
+//
+// For chain building and policy: `issuer`/`subject` hold the raw DER of the
+// issuer/subject Name (for issuer==subject DN matching); `not_before`/
+// `not_after` hold the validity times as their raw ASN.1 time strings
+// (UTCTime "YYMMDDHHMMSSZ" or GeneralizedTime "YYYYMMDDHHMMSSZ"); `dns_names`
+// is a std.list of dNSName strings from the SAN extension.
+// NOTE: fields that are STORED and freed later are std.bytes buffers, not
+// strings. Storing an owned AetherString in a struct field and freeing it in a
+// separate cleanup is a refcount minefield in Aether (leaks or double-frees);
+// bytes buffers free deterministically via bytes.free. So OIDs, validity
+// times, and dNSNames are held as bytes; compare via bytes, or stringify a
+// transient copy when needed.
 struct LeafCert {
-    tbs: ptr
+    tbs: ptr             // full tbsCertificate DER (tag+len+content)
     tbs_len: int
-    sig_alg_oid: string
-    signature: ptr
+    sig_alg_oid: ptr     // outer signatureAlgorithm OID (dotted, as bytes) or null
+    signature: ptr       // outer signatureValue (BIT STRING content)
     signature_len: int
-    spki_algo_oid: string
+    spki_algo_oid: ptr   // SPKI algorithm OID (dotted, as bytes) or null
     spki_key: ptr
     spki_key_len: int
+    issuer: ptr          // raw DER of the issuer Name (fresh bytes) or null
+    issuer_len: int
+    subject: ptr         // raw DER of the subject Name (fresh bytes) or null
+    subject_len: int
+    not_before: ptr      // validity notBefore, raw time bytes or null
+    not_before_len: int
+    not_after: ptr       // validity notAfter, raw time bytes or null
+    not_after_len: int
+    dns_names: ptr        // std.list of dNSName BYTES buffers (SAN), or null
 }
 
 // Parse a DER Certificate into `out`. Returns "" on success or an error.
 // Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signatureValue }
+// Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signatureValue }
+// Positionally walks tbsCertificate to extract the full TBS DER, validity,
+// issuer/subject DNs, SAN dNSNames, and the subject public key.
 parse_certificate(der: ptr, len: int, out: *LeafCert) -> string {
     out.tbs = null
     out.tbs_len = 0
-    out.sig_alg_oid = ""
+    out.sig_alg_oid = null
     out.signature = null
     out.signature_len = 0
-    out.spki_algo_oid = ""
+    out.spki_algo_oid = null
     out.spki_key = null
     out.spki_key_len = 0
+    out.issuer = null
+    out.issuer_len = 0
+    out.subject = null
+    out.subject_len = 0
+    out.not_before = null
+    out.not_before_len = 0
+    out.not_after = null
+    out.not_after_len = 0
+    out.dns_names = null
 
     view = bytes.new(len)
     if len > 0 { bytes.set(view, len - 1, 0) }
     bytes.copy_from_bytes(view, 0, der, 0, len)
 
     top = asn1.reader_new(view)
+
+    // Capture the FULL tbsCertificate DER (tag+len+content): bracket the
+    // read with reader_pos so we can slice the exact signed bytes.
+    // Certificate is a SEQUENCE; step into it, then the first element is TBS.
     cert, cert_body, cerr = asn1.read_sequence(top)
     if string.equals(cerr, "") != 1 {
         asn1.reader_free(top); bytes.free(view)
         return cerr
     }
-
-    // tbsCertificate — capture its exact DER bytes (the signed content).
-    tbs, terr = asn1.read_tlv(cert)   // NOTE: content only; we need full TLV
-    // read_tlv returns the CONTENT of the TBS SEQUENCE, not its full DER.
-    // We need the full tbsCertificate DER (tag+len+content) for signature
-    // verification. Re-derive it from cert_body by re-parsing with a length
-    // walk below instead; for THIS brick we expose the TBS content and the
-    // SPKI, which is what the CertificateVerify path consumes (it uses the
-    // leaf's public key, not the chain signature over TBS). Chain-signature
-    // verification lands with the chain-building increment.
+    tbs_start = asn1.reader_pos(cert)
+    tbs_content, terr = asn1.read_tlv(cert)
     if string.equals(terr, "") != 1 {
         asn1.reader_free(cert); asn1.reader_free(top); bytes.free(view); bytes.free(cert_body)
         return terr
     }
-    out.tbs = tbs
-    out.tbs_len = bytes.length(tbs)
+    tbs_end = asn1.reader_pos(cert)
+    // Slice the full TBS DER out of cert_body (cert reads over cert_body).
+    tbs_dlen = tbs_end - tbs_start
+    full_tbs = bytes.new(tbs_dlen)
+    if tbs_dlen > 0 { bytes.set(full_tbs, tbs_dlen - 1, 0) }
+    bytes.copy_from_bytes(full_tbs, 0, cert_body, tbs_start, tbs_dlen)
+    out.tbs = full_tbs
+    out.tbs_len = tbs_dlen
 
-    // Walk tbsCertificate to reach subjectPublicKeyInfo. Fields in order:
-    //   [0] version (optional, explicit), serialNumber INTEGER,
-    //   signature AlgorithmIdentifier, issuer Name, validity, subject Name,
-    //   subjectPublicKeyInfo SEQUENCE { algorithm AlgId, subjectPublicKey BIT }
-    tbsr = asn1.reader_new(tbs)
-    perr = parse_tbs_to_spki(tbsr, out)
+    // outer signatureAlgorithm (SEQUENCE) then signatureValue (BIT STRING).
+    salg_body, salg_full, saerr = asn1.read_sequence(cert)
+    if string.equals(saerr, "") == 1 {
+        soid, soerr = asn1.read_oid(salg_body)
+        if string.equals(soerr, "") == 1 { out.sig_alg_oid = oid_to_bytes(soid); string.release(soid) }
+        asn1.reader_free(salg_body)
+        bytes.free(salg_full)
+    }
+    sigbits, snbits, sberr = asn1.read_bit_string(cert)
+    if string.equals(sberr, "") == 1 {
+        out.signature = sigbits
+        out.signature_len = bytes.length(sigbits)
+    }
+
+    // Positional walk of the TBS content.
+    tbsr = asn1.reader_new(tbs_content)
+    perr = parse_tbs_fields(tbsr, out)
     asn1.reader_free(tbsr)
 
+    bytes.free(tbs_content)
     asn1.reader_free(cert)
     asn1.reader_free(top)
     bytes.free(view)
@@ -282,60 +335,425 @@ parse_certificate(der: ptr, len: int, out: *LeafCert) -> string {
     return perr
 }
 
-// Advance through tbsCertificate to subjectPublicKeyInfo and populate
-// out.spki_algo_oid / out.spki_key. `tbsr` reads the TBS content.
-fn parse_tbs_to_spki(tbsr: ptr, out: *LeafCert) -> string {
-    // Optional [0] version: skip if present (context tag 0xA0).
-    // We peek by reading one TLV and checking last_tag.
-    first, e1 = asn1.read_tlv(tbsr)
-    if string.equals(e1, "") != 1 { return e1 }
-    // If the first element was the explicit [0] version wrapper, the next
-    // element is serialNumber; otherwise `first` WAS serialNumber. Either
-    // way we now skip fields until we've consumed: serialNumber, signature
-    // AlgId, issuer, validity, subject — then the next SEQUENCE is SPKI.
-    bytes.free(first)
-
-    // Skip a fixed number of intervening TLVs then read SPKI. The count
-    // depends on whether [0] version was present. Rather than track that
-    // fragile count, scan for the SPKI: the first SEQUENCE whose first
-    // element is an AlgorithmIdentifier followed by a BIT STRING.
-    return scan_for_spki(tbsr, out)
-}
-
-// Scan remaining TLVs; the SPKI is a SEQUENCE containing an AlgorithmId
-// SEQUENCE then a BIT STRING. We look for a SEQUENCE (tag 0x30) whose body
-// parses as { SEQUENCE(algo), BIT STRING(key) }.
-fn scan_for_spki(tbsr: ptr, out: *LeafCert) -> string {
-    while asn1.reader_eof(tbsr) != 1 {
-        content, e = asn1.read_tlv(tbsr)
-        if string.equals(e, "") != 1 { return e }
-        tag = asn1.last_tag(tbsr)
-        if tag == 0x30 {
-            // Candidate SPKI: try to parse { AlgId SEQUENCE, BIT STRING }.
-            sub = asn1.reader_new(content)
-            algo_body, algo_full, ae = asn1.read_sequence(sub)
-            if string.equals(ae, "") == 1 {
-                // algorithm OID is the first element of the AlgId sequence
-                oid, oerr = asn1.read_oid(algo_body)
-                bitkey, nbits, berr = asn1.read_bit_string(sub)
-                if string.equals(oerr, "") == 1 && string.equals(berr, "") == 1 {
-                    out.spki_algo_oid = oid
-                    out.spki_key = bitkey
-                    out.spki_key_len = bytes.length(bitkey)
-                    asn1.reader_free(algo_body)
-                    asn1.reader_free(sub)
-                    bytes.free(algo_full)
-                    bytes.free(content)
-                    return ""
-                }
-                if string.equals(berr, "") == 1 { bytes.free(bitkey) }
-                asn1.reader_free(algo_body)
-                bytes.free(algo_full)
-            }
-            asn1.reader_free(sub)
-        }
-        bytes.free(content)
+// TBSCertificate ::= SEQUENCE {
+//   [0] version DEFAULT v1, serialNumber, signature AlgId, issuer Name,
+//   validity SEQUENCE { notBefore Time, notAfter Time }, subject Name,
+//   subjectPublicKeyInfo, ... [3] extensions OPTIONAL }
+// `tbsr` reads the TBS *content* (fields in order).
+fn parse_tbs_fields(tbsr: ptr, out: *LeafCert) -> string {
+    // [0] version (context tag 0xA0) — optional; skip if present.
+    v, verr = asn1.read_tlv(tbsr)
+    if string.equals(verr, "") != 1 { return verr }
+    vtag = asn1.last_tag(tbsr)
+    bytes.free(v)
+    if vtag != 0xA0 {
+        // `v` was actually serialNumber; the field after version is
+        // serialNumber, so if there was no version we've now consumed
+        // serialNumber and should NOT read it again. Track this.
+        // (Handled below by not reading serialNumber when vtag != 0xA0.)
     }
-    return "x509: subjectPublicKeyInfo not found"
+
+    // serialNumber INTEGER — only present-to-read if we consumed [0] above.
+    if vtag == 0xA0 {
+        sn, snerr = asn1.read_tlv(tbsr)
+        if string.equals(snerr, "") != 1 { return snerr }
+        bytes.free(sn)
+    }
+
+    // signature AlgorithmIdentifier (SEQUENCE) — skip.
+    sa, saerr = asn1.read_tlv(tbsr)
+    if string.equals(saerr, "") != 1 { return saerr }
+    bytes.free(sa)
+
+    // issuer Name (SEQUENCE) — capture raw DER (tag+len+content).
+    iss, ierr = read_tlv_full(tbsr)
+    if string.equals(ierr, "") != 1 { return ierr }
+    out.issuer = iss
+    out.issuer_len = bytes.length(iss)
+
+    // validity SEQUENCE { notBefore, notAfter }.
+    val_content, valerr = asn1.read_tlv(tbsr)
+    if string.equals(valerr, "") != 1 { return valerr }
+    vr = asn1.reader_new(val_content)
+    nb, nberr = asn1.read_tlv(vr)
+    if string.equals(nberr, "") == 1 { out.not_before = nb; out.not_before_len = bytes.length(nb) }
+    na, naerr = asn1.read_tlv(vr)
+    if string.equals(naerr, "") == 1 { out.not_after = na; out.not_after_len = bytes.length(na) }
+    asn1.reader_free(vr)
+    bytes.free(val_content)
+
+    // subject Name (SEQUENCE) — capture raw DER.
+    subj, suberr = read_tlv_full(tbsr)
+    if string.equals(suberr, "") != 1 { return suberr }
+    out.subject = subj
+    out.subject_len = bytes.length(subj)
+
+    // subjectPublicKeyInfo SEQUENCE { algorithm AlgId, subjectPublicKey BIT }.
+    spki_content, spkierr = asn1.read_tlv(tbsr)
+    if string.equals(spkierr, "") != 1 { return spkierr }
+    sr = asn1.reader_new(spki_content)
+    algo_body, algo_full, ae = asn1.read_sequence(sr)
+    if string.equals(ae, "") == 1 {
+        oid, oerr = asn1.read_oid(algo_body)
+        if string.equals(oerr, "") == 1 { out.spki_algo_oid = oid_to_bytes(oid); string.release(oid) }
+        asn1.reader_free(algo_body)
+        bytes.free(algo_full)
+    }
+    bitkey, nbits, berr = asn1.read_bit_string(sr)
+    if string.equals(berr, "") == 1 {
+        out.spki_key = bitkey
+        out.spki_key_len = bytes.length(bitkey)
+    }
+    asn1.reader_free(sr)
+    bytes.free(spki_content)
+
+    // Remaining: optional [1]/[2] unique IDs and [3] extensions. Scan for the
+    // [3] EXPLICIT extensions wrapper (tag 0xA3) and parse SAN out of it.
+    out.dns_names = list_new()
+    while asn1.reader_eof(tbsr) != 1 {
+        ext_content, eerr = asn1.read_tlv(tbsr)
+        if string.equals(eerr, "") != 1 { break }
+        etag = asn1.last_tag(tbsr)
+        if etag == 0xA3 {
+            parse_extensions_for_san(ext_content, out)
+        }
+        bytes.free(ext_content)
+    }
+
+    return ""
 }
 
+// Read a TLV and return its FULL DER (tag+len+content) as fresh bytes.
+fn read_tlv_full(r: ptr) -> (ptr, string) {
+    start = asn1.reader_pos(r)
+    content, err = asn1.read_tlv(r)
+    if string.equals(err, "") != 1 { return null, err }
+    bytes.free(content)
+    end = asn1.reader_pos(r)
+    // The reader's buffer holds the bytes; re-read the span. We need access to
+    // the buffer — read_tlv already advanced it. Reconstruct by re-reading the
+    // span from a fresh reader over the same buffer is not possible without the
+    // buffer handle, so instead compute from the reader's buffer via a helper.
+    return reader_slice(r, start, end), ""
+}
+
+// Slice [start,end) of the reader's underlying buffer into fresh bytes.
+fn reader_slice(r: ptr, start: int, end: int) -> ptr {
+    rr = r as *ReaderView
+    n = end - start
+    out = bytes.new(n)
+    if n > 0 { bytes.set(out, n - 1, 0) }
+    bytes.copy_from_bytes(out, 0, rr.buf, start, n)
+    return out
+}
+
+// Minimal view of asn1's Reader to reach its buffer for slicing (buf is the
+// first field; this mirrors asn1.Reader's layout).
+struct ReaderView {
+    buf: ptr
+    pos: int
+    len: int
+    last_tag: int
+}
+
+// Parse the [3] extensions content: SEQUENCE OF Extension, each
+// { extnID OID, critical BOOLEAN OPTIONAL, extnValue OCTET STRING }. When the
+// OID is subjectAltName (2.5.29.17), decode its dNSNames into out.dns_names.
+fn parse_extensions_for_san(ext_wrapper: ptr, out: *LeafCert) {
+    wr = asn1.reader_new(ext_wrapper)
+    // [3] wraps a single SEQUENCE OF Extension.
+    seq_content, serr = asn1.read_tlv(wr)
+    asn1.reader_free(wr)
+    if string.equals(serr, "") != 1 { return }
+    er = asn1.reader_new(seq_content)
+    while asn1.reader_eof(er) != 1 {
+        one, oerr = asn1.read_tlv(er)   // one Extension SEQUENCE content
+        if string.equals(oerr, "") != 1 { break }
+        xr = asn1.reader_new(one)
+        oid, oiderr = asn1.read_oid(xr)
+        if string.equals(oiderr, "") == 1 {
+            if string.equals(oid, "2.5.29.17") == 1 {
+                // skip optional critical BOOLEAN, then extnValue OCTET STRING
+                nx, nxerr = asn1.read_tlv(xr)
+                ntag = asn1.last_tag(xr)
+                if string.equals(nxerr, "") == 1 {
+                    if ntag == 0x01 {
+                        // was critical BOOLEAN; read the OCTET STRING next
+                        bytes.free(nx)
+                        os2, os2e = asn1.read_tlv(xr)
+                        if string.equals(os2e, "") == 1 {
+                            decode_san_dnsnames(os2, out)
+                            bytes.free(os2)
+                        }
+                    } else {
+                        // nx WAS the OCTET STRING content
+                        decode_san_dnsnames(nx, out)
+                        bytes.free(nx)
+                    }
+                }
+            }
+            string.release(oid)
+        }
+        asn1.reader_free(xr)
+        bytes.free(one)
+    }
+    asn1.reader_free(er)
+    bytes.free(seq_content)
+}
+
+// The SAN extnValue OCTET STRING wraps GeneralNames ::= SEQUENCE OF GeneralName.
+// dNSName is [2] IMPLICIT IA5String (context tag 0x82). Add each to dns_names,
+// rejecting any with an embedded NUL.
+fn decode_san_dnsnames(octet_content: ptr, out: *LeafCert) {
+    or = asn1.reader_new(octet_content)
+    gn_content, gerr = asn1.read_tlv(or)   // the GeneralNames SEQUENCE content
+    asn1.reader_free(or)
+    if string.equals(gerr, "") != 1 { return }
+    gr = asn1.reader_new(gn_content)
+    while asn1.reader_eof(gr) != 1 {
+        name_content, nerr = asn1.read_tlv(gr)
+        if string.equals(nerr, "") != 1 { break }
+        tag = asn1.last_tag(gr)
+        if tag == 0x82 {
+            // dNSName IA5String content
+            nlen = bytes.length(name_content)
+            has_nul = 0
+            i = 0
+            while i < nlen {
+                if (bytes.get(name_content, i) & 0xFF) == 0 { has_nul = 1 }
+                i = i + 1
+            }
+            if has_nul == 0 {
+                nm = bytes.new(nlen)
+                if nlen > 0 { bytes.set(nm, nlen - 1, 0) }
+                bytes.copy_from_bytes(nm, 0, name_content, 0, nlen)
+                list_add_raw(out.dns_names, nm)
+            }
+        }
+        bytes.free(name_content)
+    }
+    asn1.reader_free(gr)
+    bytes.free(gn_content)
+}
+
+
+// ---- LeafCert accessors + cleanup ----
+
+// Copy a transient OID string into an owned bytes buffer (so it can live in a
+// struct field and be freed deterministically).
+fn oid_to_bytes(oid: string) -> ptr {
+    n = string.length(oid)
+    b = bytes.new(n)
+    if n > 0 { bytes.set(b, n - 1, 0) }
+    i = 0
+    while i < n {
+        bytes.set(b, i, string_char_at_n(oid, n, i) & 0xFF)
+        i = i + 1
+    }
+    return b
+}
+
+leaf_not_before(c: *LeafCert) -> ptr { return c.not_before }
+leaf_not_before_len(c: *LeafCert) -> int { return c.not_before_len }
+leaf_not_after(c: *LeafCert) -> ptr { return c.not_after }
+leaf_not_after_len(c: *LeafCert) -> int { return c.not_after_len }
+leaf_tbs_len(c: *LeafCert) -> int { return c.tbs_len }
+leaf_subject_len(c: *LeafCert) -> int { return c.subject_len }
+leaf_issuer_len(c: *LeafCert) -> int { return c.issuer_len }
+
+leaf_dns_count(c: *LeafCert) -> int {
+    if c.dns_names == null { return 0 }
+    return list_size(c.dns_names)
+}
+
+// The i-th dNSName as a bytes buffer (borrowed; do not free).
+leaf_dns_name(c: *LeafCert, i: int) -> ptr {
+    if c.dns_names == null { return null }
+    if i < 0 { return null }
+    if i >= list_size(c.dns_names) { return null }
+    return list_get_raw(c.dns_names, i) as ptr
+}
+
+// Free every owned buffer/string in a parsed LeafCert.
+free_leaf(c: *LeafCert) {
+    if c.tbs != null { bytes.free(c.tbs) }
+    if c.signature != null { bytes.free(c.signature) }
+    if c.spki_key != null { bytes.free(c.spki_key) }
+    if c.issuer != null { bytes.free(c.issuer) }
+    if c.subject != null { bytes.free(c.subject) }
+    if c.sig_alg_oid != null { bytes.free(c.sig_alg_oid) }
+    if c.spki_algo_oid != null { bytes.free(c.spki_algo_oid) }
+    if c.not_before != null { bytes.free(c.not_before) }
+    if c.not_after != null { bytes.free(c.not_after) }
+    if c.dns_names != null {
+        n = list_size(c.dns_names)
+        i = 0
+        while i < n {
+            e = list_get_raw(c.dns_names, i) as ptr
+            bytes.free(e)
+            i = i + 1
+        }
+        list_free(c.dns_names)
+    }
+}
+
+// ---- validity-period check (RFC 5280 §4.1.2.5) ----
+
+
+// Normalise an ASN.1 time (as bytes: UTCTime "YYMMDDHHMMSSZ" or
+// GeneralizedTime "YYYYMMDDHHMMSSZ") to a 14-char "YYYYMMDDHHMMSS" key string,
+// so times compare chronologically by plain string order. Returns "" on a
+// malformed/unsupported time. UTCTime year: YY>=50 -> 19YY else 20YY (RFC 5280).
+fn time_to_key(t: ptr, tlen: int) -> string {
+    // Collect the leading digits (drop a trailing 'Z').
+    digits = bytes.new(16)
+    dn = 0
+    i = 0
+    while i < tlen {
+        c = bytes.get(t, i) & 0xFF
+        if c >= 48 && c <= 57 {
+            if dn < 14 { bytes.set(digits, dn, c); dn = dn + 1 }
+        }
+        i = i + 1
+    }
+    if dn == 12 {
+        // UTCTime YYMMDDHHMMSS -> expand the 2-digit year
+        yy = ((bytes.get(digits, 0) - 48) * 10) + (bytes.get(digits, 1) - 48)
+        century = 20
+        if yy >= 50 { century = 19 }
+        out = bytes.new(14)
+        bytes.set(out, 0, 48 + (century / 10))
+        bytes.set(out, 1, 48 + (century - ((century / 10) * 10)))
+        k = 0
+        while k < 12 { bytes.set(out, 2 + k, bytes.get(digits, k)); k = k + 1 }
+        r = bytes.to_string(out, 14)
+        bytes.free(out); bytes.free(digits)
+        return r
+    }
+    if dn == 14 {
+        r = bytes.to_string(digits, 14)
+        bytes.free(digits)
+        return r
+    }
+    bytes.free(digits)
+    return ""
+}
+
+// Current UTC time as the same 14-char "YYYYMMDDHHMMSS" key. Derives it from
+// os.now_utc_iso8601() ("YYYY-MM-DDTHH:MM:SSZ") by keeping the digits.
+fn now_key() -> string {
+    iso = os.now_utc_iso8601()
+    n = string.length(iso)
+    out = bytes.new(14)
+    dn = 0
+    i = 0
+    while i < n {
+        c = string_char_at_n(iso, n, i) & 0xFF
+        if c >= 48 && c <= 57 {
+            if dn < 14 { bytes.set(out, dn, c); dn = dn + 1 }
+        }
+        i = i + 1
+    }
+    r = bytes.to_string(out, 14)
+    bytes.free(out)
+    return r
+}
+
+// Check a leaf's validity window against the current time. Returns "" if
+// notBefore <= now <= notAfter, else an error ("certificate expired" /
+// "certificate not yet valid" / "certificate has no/invalid validity").
+check_validity(c: *LeafCert) -> string {
+    if c.not_before == null { return "certificate has no notBefore" }
+    if c.not_after == null { return "certificate has no notAfter" }
+    nb = time_to_key(c.not_before, c.not_before_len)
+    na = time_to_key(c.not_after, c.not_after_len)
+    if string.equals(nb, "") == 1 { return "certificate has invalid notBefore time" }
+    if string.equals(na, "") == 1 { return "certificate has invalid notAfter time" }
+    now = now_key()
+    // string_compare: <0 if a<b. now < nb -> not yet valid; now > na -> expired.
+    if string_compare(now, nb) < 0 { return "certificate not yet valid" }
+    if string_compare(now, na) > 0 { return "certificate expired" }
+    return ""
+}
+
+// ---- hostname / SAN matching (RFC 6125) ----
+
+// ASCII lower-case a single byte (A-Z -> a-z), leaving others untouched.
+fn ascii_lower(c: int) -> int {
+    if c >= 65 && c <= 90 { return c + 32 }
+    return c
+}
+
+// Does the presented dNSName (a bytes buffer, `plen` bytes, no NUL) match the
+// reference hostname `host` (a string) under RFC 6125? Case-insensitive ASCII.
+// A single leftmost "*" wildcard label is allowed and matches exactly one
+// label (no dots): "*.a.com" matches "x.a.com" but not "a.com" or "y.x.a.com".
+// A wildcard anywhere but the leftmost label, or a partial-label wildcard
+// ("f*.a.com"), is not accepted here (we only honour a whole-label leading *).
+fn dnsname_matches(pat: ptr, plen: int, host: string, hlen: int) -> int {
+    if plen <= 0 { return 0 }
+    // Wildcard iff the pattern is "*." + rest  (first byte '*', second '.').
+    is_wild = 0
+    if plen >= 2 {
+        if (bytes.get(pat, 0) & 0xFF) == 42 {         // '*'
+            if (bytes.get(pat, 1) & 0xFF) == 46 {     // '.'
+                is_wild = 1
+            }
+        }
+    }
+    if is_wild == 0 {
+        // Exact case-insensitive match over the whole strings.
+        if plen != hlen { return 0 }
+        i = 0
+        while i < plen {
+            pc = ascii_lower(bytes.get(pat, i) & 0xFF)
+            hc = ascii_lower(string_char_at_n(host, hlen, i) & 0xFF)
+            if pc != hc { return 0 }
+            i = i + 1
+        }
+        return 1
+    }
+    // Wildcard: the host's first label is consumed by '*', the remainder
+    // (pattern from index 1, i.e. ".rest") must match the host from its first
+    // dot onward, case-insensitively. The wildcard label must be non-empty and
+    // must not itself contain a dot (exactly one label).
+    // Find host's first dot.
+    hdot = -1
+    j = 0
+    while j < hlen {
+        if (string_char_at_n(host, hlen, j) & 0xFF) == 46 { hdot = j; break }
+        j = j + 1
+    }
+    if hdot <= 0 { return 0 }        // no dot, or empty first label -> no match
+    // The pattern tail is pat[1..plen) == ".rest"; host tail is host[hdot..hlen).
+    tail_len = plen - 1
+    if tail_len != (hlen - hdot) { return 0 }
+    k = 0
+    while k < tail_len {
+        pc = ascii_lower(bytes.get(pat, 1 + k) & 0xFF)
+        hc = ascii_lower(string_char_at_n(host, hlen, hdot + k) & 0xFF)
+        if pc != hc { return 0 }
+        k = k + 1
+    }
+    return 1
+}
+
+// Verify the leaf certificate identifies `host`. Checks every SAN dNSName
+// (RFC 6125; SAN-only, no CN fallback). Returns "" on a match, else an error.
+check_hostname(c: *LeafCert, host: string) -> string {
+    if c.dns_names == null { return "certificate has no subjectAltName dNSNames" }
+    hlen = string.length(host)
+    if hlen == 0 { return "empty hostname" }
+    n = list_size(c.dns_names)
+    if n == 0 { return "certificate has no subjectAltName dNSNames" }
+    i = 0
+    while i < n {
+        nm = list_get_raw(c.dns_names, i) as ptr
+        if nm != null {
+            plen = bytes.length(nm)
+            if dnsname_matches(nm, plen, host, hlen) == 1 { return "" }
+        }
+        i = i + 1
+    }
+    return "certificate is not valid for the requested hostname"
+}

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -17,14 +17,26 @@
 //     so far; others fail closed)
 //   - no resumption / 0-RTT / mTLS / HelloRetryRequest
 //
-// ⚠️ PARTIAL AUTHENTICATION. connect() DOES verify the server's
-// CertificateVerify signature against the leaf certificate's public key —
-// proving the peer holds that key (RFC 8446 §4.4.3), which stops the basic
-// MITM that a bare key-exchange would allow. It does NOT yet validate the
-// certificate CHAIN against a trust store, nor check the HOSTNAME against the
-// cert's SAN. So a valid-but-untrusted or wrong-host cert is still accepted.
-// Chain + hostname validation is the next increment; until it lands, do not
-// rely on this for authenticating a specific server identity.
+// SERVER AUTHENTICATION. connect() fails closed unless ALL of the following
+// hold, in order (RFC 8446 §4.4.3 + RFC 5280/6125):
+//   1. the server's CertificateVerify signature verifies against the leaf's
+//      public key (the peer proves it holds that key);
+//   2. the leaf is within its validity window (not expired / not-yet-valid);
+//   3. the requested hostname matches a leaf SAN dNSName (exact or a single
+//      leftmost-label wildcard; SAN-only, no CN fallback);
+//   4. the leaf chains to a trusted anchor — its issuer DN equals a trust-
+//      store cert's subject DN and its signature verifies under that CA's key.
+// A self-signed, expired, wrong-host, or untrusted cert is rejected. The trust
+// store is the system CA bundle (SSL_CERT_FILE, else the OS default path); if
+// it cannot be loaded, connect() fails closed rather than proceeding unauthed.
+// Verified end-to-end against openssl s_server: a valid+trusted+matching cert
+// connects; self-signed, wrong-host, and expired certs are each rejected.
+//
+// Remaining subset limits: only ECDSA-P256 CertificateVerify is wired, so an
+// RSA-signed *server* CertificateVerify fails closed (note the cert CHAIN
+// verify handles both RSA-PKCS#1 and ECDSA-P256). Intermediate-CA chains
+// deeper than leaf→root are not yet built (the leaf must chain directly to a
+// trusted anchor); no revocation (CRL/OCSP).
 //
 // This module separates the PURE state machine (transcript, key derivation,
 // flight assembly — offline-testable) from the SOCKET DRIVER (connect + the
@@ -53,6 +65,9 @@ import std.cryptography.tls13_cert
 import std.cryptography.tls13_record
 import std.cryptography
 import std.net
+import std.list
+import std.os
+import std.fs
 
 extern malloc(size: int) -> ptr
 @extern("free") libc_free(p: ptr)
@@ -367,11 +382,10 @@ fn cleanup_hello(pub: ptr, rnd: ptr, sid: ptr, ch: ptr) {
 // The returned ClientConn holds the application-data record contexts for
 // send()/recv().
 //
-// NOTE (subset): the server certificate's CertificateVerify signature is NOT
-// yet checked here (that wiring — extracting the leaf SPKI and running
-// tls13_cert.verify_cert_verify over the transcript — is the next increment);
-// this first cut proves the handshake completes and both sides agree on keys
-// via the Finished MACs. Chain/hostname validation is out of subset.
+// After the flight is read, connect() authenticates the server (see the
+// module header): CertificateVerify signature, validity window, hostname/SAN,
+// and chain to a trusted anchor — failing closed on any of them — before the
+// Finished MACs confirm both sides agree on keys.
 connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     sock = net.tcp_connect_raw(host, port)
     if sock == null { return null, "connect failed" }
@@ -468,8 +482,19 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     result_err = ferr
     if string.equals(ferr, "") == 1 {
         // Authenticate the server: verify its CertificateVerify signature over
-        // the transcript through Certificate (RFC 8446 §4.4.3). Fails closed.
-        auth_err = authenticate_server(fl, fllen, th_through_cert)
+        // the transcript through Certificate (RFC 8446 §4.4.3), then enforce
+        // validity / hostname / chain-to-trusted-anchor. Fails closed. The
+        // trust store is loaded here and freed immediately after.
+        auth_err = ""
+        anchors, tsErr = tls13_cert.trust_store_load(trust_store_path())
+        if anchors == null {
+            // Fail closed: without a trust store we cannot authenticate the
+            // chain, so we must not proceed as if the server were trusted.
+            auth_err = "cannot load system trust store"
+        } else {
+            auth_err = authenticate_server(fl, fllen, th_through_cert, host, anchors)
+            tls13_cert.free_anchors(anchors)
+        }
         if string.equals(auth_err, "") != 1 {
             result_err = auth_err
         } else {
@@ -699,11 +724,12 @@ close_conn(conn: ptr) {
 }
 
 // ============================================================================
-// Server authentication (RFC 8446 §4.4.2 / §4.4.3): extract the leaf cert's
-// public key from the Certificate message and verify the CertificateVerify
-// signature over the transcript hash through Certificate. Proves the peer
-// holds the leaf private key. Chain + hostname validation are a further
-// increment; only ECDSA-P256 is handled in this cut (fails closed otherwise).
+// Server authentication (RFC 8446 §4.4.2 / §4.4.3 + RFC 5280/6125): extract the
+// leaf cert from the Certificate message, verify the CertificateVerify
+// signature over the transcript hash through Certificate (proving the peer
+// holds the leaf private key), then enforce validity, hostname/SAN, and chain-
+// to-a-trusted-anchor. Every step fails closed. Only ECDSA-P256 CertificateVerify
+// is handled (fails closed otherwise); the chain sig-verify handles RSA + ECDSA.
 // ============================================================================
 
 // Extract the leaf certificate DER from a Certificate message body (RFC 8446
@@ -755,7 +781,31 @@ fn split_ec_point(spki_key: ptr, key_len: int) -> (ptr, ptr, string) {
 
 // Authenticate the server: extract the leaf public key from Certificate and
 // verify the CertificateVerify signature over `th_thru_cert`. Fails closed.
-fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr) -> string {
+// Locate the system CA-bundle PEM. Honours SSL_CERT_FILE (the de-facto
+// override that curl/openssl respect), then falls back to the common OS
+// locations. Returns the first path that exists, or the Debian/Ubuntu default
+// (so trust_store_load produces a clear "cannot load" error if nothing is
+// present, rather than us guessing).
+fn trust_store_path() -> string {
+    env = os.os_getenv("SSL_CERT_FILE")
+    if string.equals(env, "") != 1 {
+        return env
+    }
+    debian = "/etc/ssl/certs/ca-certificates.crt"      // Debian/Ubuntu/Alpine
+    if fs.file_exists(debian) == 1 { return debian }
+    fedora = "/etc/pki/tls/certs/ca-bundle.crt"        // Fedora/RHEL/CentOS
+    if fs.file_exists(fedora) == 1 { return fedora }
+    bsd = "/etc/ssl/cert.pem"                          // *BSD / macOS (LibreSSL)
+    if fs.file_exists(bsd) == 1 { return bsd }
+    return debian
+}
+
+fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anchors: ptr) -> string {
+    // The full parsed leaf is kept alive for the whole function so that, after
+    // the CertificateVerify signature check, we can run RFC 5280/6125 policy
+    // (validity window, hostname/SAN, chain to a trusted anchor) over it.
+    leaf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    have_leaf = 0
     leaf_px = null
     leaf_py = null
     cv_scheme = 0
@@ -778,11 +828,11 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr) -> string {
                     if string.equals(derr, "") != 1 {
                         if string.equals(err, "") == 1 { err = derr }
                     } else {
-                        leaf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: "", signature: null, signature_len: 0, spki_algo_oid: "", spki_key: null, spki_key_len: 0 }
                         perr = tls13_cert.parse_certificate(der, dlen, &leaf)
                         if string.equals(perr, "") != 1 {
                             if string.equals(err, "") == 1 { err = perr }
                         } else {
+                            have_leaf = 1
                             px, py, sperr = split_ec_point(leaf.spki_key, leaf.spki_key_len)
                             if string.equals(sperr, "") != 1 {
                                 if string.equals(err, "") == 1 { err = sperr }
@@ -791,9 +841,6 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr) -> string {
                                 leaf_py = py
                             }
                         }
-                        if leaf.tbs != null { bytes.free(leaf.tbs) }
-                        if leaf.spki_key != null { bytes.free(leaf.spki_key) }
-                        if leaf.signature != null { bytes.free(leaf.signature) }
                         bytes.free(der)
                     }
                     bytes.free(cbody)
@@ -830,6 +877,30 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr) -> string {
             }
         }
     }
+    // The peer holds the leaf private key (CertificateVerify passed). Now the
+    // RFC 5280/6125 policy that turns "handshake completed" into "server is who
+    // it claims to be", each failing closed:
+    //   1. validity window (reject expired / not-yet-valid)
+    //   2. hostname / SAN match (reject wrong host)
+    //   3. chain to a trusted anchor (reject self-signed / untrusted)
+    // Skipped only when anchors == null: that is the signature-only entry used
+    // by verify_flight_auth's recorded-transcript tests, which have no trust
+    // store. connect() always passes a loaded store, so it always enforces.
+    if string.equals(err, "") == 1 {
+      if anchors != null {
+        verr = tls13_cert.check_validity(&leaf)
+        if string.equals(verr, "") != 1 { err = verr }
+        else {
+            herr = tls13_cert.check_hostname(&leaf, host)
+            if string.equals(herr, "") != 1 { err = herr }
+            else {
+                cerr = tls13_cert.chain_verify(&leaf, anchors)
+                if string.equals(cerr, "") != 1 { err = cerr }
+            }
+        }
+      }
+    }
+    if have_leaf == 1 { tls13_cert.free_leaf(&leaf) }
     if leaf_px != null { bytes.free(leaf_px) }
     if leaf_py != null { bytes.free(leaf_py) }
     if cv_sig != null { bytes.free(cv_sig) }
@@ -843,5 +914,8 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr) -> string {
 // and the transcript hash through Certificate. Used by the client's connect()
 // internally; exposed so tests can drive it with good and tampered flights.
 verify_flight_auth(fl: ptr, flen: int, th_thru_cert: ptr) -> string {
-    return authenticate_server(fl, flen, th_thru_cert)
+    // Signature-only mode (anchors == null): checks Certificate +
+    // CertificateVerify but not the RFC 5280/6125 policy. connect() enforces
+    // the full policy via a loaded trust store.
+    return authenticate_server(fl, flen, th_thru_cert, "", null)
 }

--- a/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
+++ b/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
@@ -236,6 +236,38 @@ main() {
     } else { println("FAIL exact SAN matched wrong host"); total_ok = 0 }
     tls13_cert.free_leaf(&he)
 
+    // --- chain building + self-signed rejection (Nic's "self-signed must fail") ---
+    // A small ECDSA-P256 PKI generated offline: eca signs eleaf; ess is a
+    // separate self-signed cert (issuer == subject, NOT signed by eca).
+    eca_der = from_hex("308201ac30820153a00302010202147adbec3ab8d2659db358913dcb52b94381dd1235300a06082a8648ce3d040302302c3115301306035504030c0c4543205465737420526f6f7431133011060355040a0c0a41657468657254657374301e170d3236303732383231333633325a170d3336303732353231333633325a302c3115301306035504030c0c4543205465737420526f6f7431133011060355040a0c0a416574686572546573743059301306072a8648ce3d020106082a8648ce3d03010703420004884a91e1b1ff9aade000eb19175b2222364773c348e3b926f6bafdd2aff0000645e7ad368930fd9241fca9c470f0bc2179543c0081e31e8fe099d8c0f43b6e33a3533051301d0603551d0e041604140096d04dcc2db8b08fb4a70f34d2431d03fe10b9301f0603551d230418301680140096d04dcc2db8b08fb4a70f34d2431d03fe10b9300f0603551d130101ff040530030101ff300a06082a8648ce3d0403020347003044022019711a6e00867ff4bd34a8b9f49db4e20a449394a896f33b37222b7f9fdefe0b02203491f3dbdca8b042101f427cdb4a6bdf8304bd1853f46e429b44b05444293f49")
+    elf_der = from_hex("308201af30820155a0030201020214795024acd1f59d13ea26ee4bba4c458593d6f63b300a06082a8648ce3d040302302c3115301306035504030c0c4543205465737420526f6f7431133011060355040a0c0a41657468657254657374301e170d3236303732383231333633325a170d3237303732383231333633325a30293112301006035504030c096c6f63616c686f737431133011060355040a0c0a416574686572546573743059301306072a8648ce3d020106082a8648ce3d030107034200042b3e0fe701f9228fee88ca310d6b4ccde616ad50d7be20f226738027d49f9b691db45e3360408187f8d4e117773919fbc4821ebe52298e8144057d2dda935cc5a358305630140603551d11040d300b82096c6f63616c686f7374301d0603551d0e041604149d72e1349a900b4c8b972c2f2699c448425be1d2301f0603551d230418301680140096d04dcc2db8b08fb4a70f34d2431d03fe10b9300a06082a8648ce3d0403020348003045022100c3ed2bce214ebe239a7f3728b4d527751fb6e727a24ae305777c1ea66fbc7fbe022066eabc2c915a2de69eb7fe673beeb4875bd2c579299178fe8c1cd8b1a40e5d8a")
+    ess_der = from_hex("308201b230820157a00302010202140ecd8a7952500bc62290c557787f5e076f13d8ab300a06082a8648ce3d04030230233112301006035504030c096c6f63616c686f7374310d300b060355040a0c044576696c301e170d3236303732383231343034335a170d3237303732383231343034335a30233112301006035504030c096c6f63616c686f7374310d300b060355040a0c044576696c3059301306072a8648ce3d020106082a8648ce3d03010703420004831376b41fd5c5f61f2309e38372184e7c4e6a574b5ba139f3bbf283a88bb1ef3a42af8b407fe9db34a8883b7690646169a183f7ea2b00808dbaa5e1ed8fbddca3693067301d0603551d0e041604149b9ba9b9b18dcc35984a55192fa4d5a9ed8b6c75301f0603551d230418301680149b9ba9b9b18dcc35984a55192fa4d5a9ed8b6c75300f0603551d130101ff040530030101ff30140603551d11040d300b82096c6f63616c686f7374300a06082a8648ce3d0403020349003046022100eed78b2a101f6712826acb3726f2a10710b146d90b792bcc39a2f4ea1c8e9025022100f0289c5029f09f47b2355fe24d3da04fc6c98362f28984f93869a9aeb3eb2f26")
+    eca = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    elf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    ess = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    tls13_cert.parse_certificate(eca_der, 432, &eca)
+    tls13_cert.parse_certificate(elf_der, 435, &elf)
+    tls13_cert.parse_certificate(ess_der, 438, &ess)
+    trust = list_new()
+    list_add_raw(trust, &eca)
+    // Legit leaf chains to its CA.
+    if string.equals(tls13_cert.chain_verify(&elf, trust), "") == 1 {
+        println("ok   CA-signed leaf chains to anchor")
+    } else { println("FAIL legit leaf rejected by chain_verify"); total_ok = 0 }
+    // Self-signed cert does NOT chain to any anchor -> rejected.
+    if string.equals(tls13_cert.chain_verify(&ess, trust), "") != 1 {
+        println("ok   self-signed cert rejected (no trusted anchor)")
+    } else { println("FAIL self-signed cert accepted"); total_ok = 0 }
+    // Empty trust store rejects even the legit leaf.
+    empty = list_new()
+    if string.equals(tls13_cert.chain_verify(&elf, empty), "") != 1 {
+        println("ok   empty trust store rejects everything")
+    } else { println("FAIL empty trust store accepted a cert"); total_ok = 0 }
+    list_free(empty)
+    list_free(trust)
+    tls13_cert.free_leaf(&eca); tls13_cert.free_leaf(&elf); tls13_cert.free_leaf(&ess)
+    bytes.free(eca_der); bytes.free(elf_der); bytes.free(ess_der)
+
     if total_ok == 0 {
         println("tls13_cert: FAILURES")
         exit(1)

--- a/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
+++ b/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
@@ -14,6 +14,7 @@ import std.cryptography.sha2
 import std.cryptography.asn1
 import std.bytes
 import std.string
+import std.list
 import std.io
 
 extern exit(code: int)
@@ -92,6 +93,31 @@ fn der_ecdsa_sig(r32: ptr, s32: ptr) -> (ptr, int) {
     return tmp, total
 }
 
+// Copy an ASCII string into a fresh bytes buffer of its exact length.
+fn str_to_bytes(s: string) -> ptr {
+    n = string_length(s)
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        bytes.set(b, i, string_char_at_n(s, n, i) & 0xFF)
+        i = i + 1
+    }
+    return b
+}
+
+// A LeafCert carrying only notBefore/notAfter times (for validity tests).
+fn mk_leaf_times(nb: string, na: string) -> tls13_cert.LeafCert {
+    lf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: str_to_bytes(nb), not_before_len: string_length(nb), not_after: str_to_bytes(na), not_after_len: string_length(na), dns_names: null }
+    return lf
+}
+
+// A LeafCert carrying a single SAN dNSName (for hostname tests).
+fn mk_leaf_san(name: string) -> tls13_cert.LeafCert {
+    lf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: list_new() }
+    list_add_raw(lf.dns_names, str_to_bytes(name))
+    return lf
+}
+
 main() {
     total_ok = 1
 
@@ -168,6 +194,47 @@ main() {
     bytes.free(dsig)
     bytes.free(th2)
     bytes.free(th)
+
+    // --- validity-period check (Nic's "expired must fail") ---
+    // notBefore 2020, notAfter 2020 -> expired.
+    exp = mk_leaf_times("200101000000Z", "200102000000Z")
+    if string.equals(tls13_cert.check_validity(&exp), "") != 1 {
+        println("ok   expired cert rejected")
+    } else { println("FAIL expired cert accepted"); total_ok = 0 }
+    tls13_cert.free_leaf(&exp)
+    // notBefore 2030 -> not yet valid.
+    fut = mk_leaf_times("300101000000Z", "310101000000Z")
+    if string.equals(tls13_cert.check_validity(&fut), "") != 1 {
+        println("ok   not-yet-valid cert rejected")
+    } else { println("FAIL not-yet-valid cert accepted"); total_ok = 0 }
+    tls13_cert.free_leaf(&fut)
+    // notBefore 2020, notAfter 2040 -> currently valid.
+    val = mk_leaf_times("200101000000Z", "400101000000Z")
+    if string.equals(tls13_cert.check_validity(&val), "") == 1 {
+        println("ok   currently-valid cert accepted")
+    } else { println("FAIL currently-valid cert rejected"); total_ok = 0 }
+    tls13_cert.free_leaf(&val)
+
+    // --- hostname / SAN matching (Nic's "wrong host must fail") ---
+    hw = mk_leaf_san("*.example.com")
+    if string.equals(tls13_cert.check_hostname(&hw, "foo.example.com"), "") == 1 {
+        println("ok   *.example.com matches foo.example.com")
+    } else { println("FAIL wildcard rejected valid host"); total_ok = 0 }
+    if string.equals(tls13_cert.check_hostname(&hw, "example.com"), "") != 1 {
+        println("ok   *.example.com rejects bare example.com")
+    } else { println("FAIL wildcard matched bare domain"); total_ok = 0 }
+    if string.equals(tls13_cert.check_hostname(&hw, "a.b.example.com"), "") != 1 {
+        println("ok   *.example.com rejects a.b.example.com")
+    } else { println("FAIL wildcard spanned two labels"); total_ok = 0 }
+    tls13_cert.free_leaf(&hw)
+    he = mk_leaf_san("api.example.com")
+    if string.equals(tls13_cert.check_hostname(&he, "API.example.com"), "") == 1 {
+        println("ok   exact match is case-insensitive")
+    } else { println("FAIL exact match not case-insensitive"); total_ok = 0 }
+    if string.equals(tls13_cert.check_hostname(&he, "evil.com"), "") != 1 {
+        println("ok   exact SAN rejects wrong host")
+    } else { println("FAIL exact SAN matched wrong host"); total_ok = 0 }
+    tls13_cert.free_leaf(&he)
 
     if total_ok == 0 {
         println("tls13_cert: FAILURES")

--- a/tests/integration/crypto_tls13_client/README.md
+++ b/tests/integration/crypto_tls13_client/README.md
@@ -32,9 +32,35 @@ A P-256 server cert is required (`-newkey ec -pkeyopt
 ec_paramgen_curve:prime256v1`), because the client verifies the server's
 CertificateVerify signature and only the ECDSA-P256 scheme is wired so far.
 
-**Caveat (partial authentication):** `connect()` verifies the server's
-CertificateVerify signature against the leaf certificate's public key (this
-stops a basic key-exchange MITM), but it does NOT yet validate the certificate
-chain against a trust store, nor check the hostname against the cert SAN. So a
-valid-but-untrusted or wrong-host cert is still accepted. Chain + hostname
-validation is the next increment. See the module header.
+## Server authentication (Nic's bar)
+
+`connect()` now fails closed unless the server cert passes all of: the
+CertificateVerify signature check, the validity window, hostname/SAN match, and
+a chain to a trusted anchor (the system CA bundle via `SSL_CERT_FILE` or the OS
+default). This was verified end-to-end against `openssl s_server`:
+
+| Case | Server cert | Result |
+|------|-------------|--------|
+| valid + trusted + `SAN=localhost` | CA-signed, CA in trust store | **CONNECTED** |
+| untrusted | CA-signed, CA **not** in trust store | rejected — does not chain to a trusted anchor |
+| self-signed | self-signed, `SAN=localhost` | rejected — does not chain to a trusted anchor |
+| wrong host | CA-signed, `SAN=example.com`, connect as `localhost` | rejected — not valid for the requested hostname |
+| expired | CA-signed, `notAfter=2020` | rejected — certificate expired |
+
+Reproduce a rejection, e.g. self-signed:
+
+```sh
+openssl ecparam -name prime256v1 -genkey -noout -out ss.key
+openssl req -x509 -new -key ss.key -out ss.crt -days 2 -sha256 \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost"
+openssl s_server -accept 4433 -tls1_3 \
+  -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -groups X25519 \
+  -cert ss.crt -key ss.key -www -quiet &
+# a client program that calls connect("localhost", 4433, priv) prints the
+# rejection: "certificate does not chain to a trusted anchor"
+```
+
+**Remaining limits:** only ECDSA-P256 CertificateVerify is wired (an RSA server
+CertificateVerify fails closed; the cert *chain* verify handles RSA + ECDSA);
+the leaf must chain directly to a trusted anchor (no intermediate-CA path
+building yet); no revocation (CRL/OCSP). See the module header.


### PR DESCRIPTION
Completes server authentication for the pure-Aether TLS 1.3 client (#1298), meeting the maintainer bar: **"does it reject bad certs, or just finish? Expired, wrong host, and self-signed all have to fail."** They do — proven end-to-end over real TLS 1.3 sockets.

## What connect() now enforces

After the CertificateVerify signature check (which proves the peer holds the leaf key), `connect()` runs the RFC 5280/6125 policy, each **failing closed**:

1. **Validity window** — reject expired / not-yet-valid.
2. **Hostname / SAN** — reject wrong host (RFC 6125: case-insensitive exact + a single leftmost-label wildcard; SAN-only, no CN fallback; embedded-NUL names dropped).
3. **Chain to a trusted anchor** — the leaf's issuer DN must byte-exactly match a trust-store cert's subject DN **and** the leaf signature must verify under that CA's key. A self-signed leaf has no such anchor → rejected.

The trust store is the **system CA bundle** (`SSL_CERT_FILE`, else the OS default path — Debian/Fedora/BSD). If it can't be loaded, `connect()` fails closed rather than proceeding unauthenticated.

## End-to-end verification (openssl s_server)

| Case | Server cert | Result |
|------|-------------|--------|
| valid + trusted + `SAN=localhost` | CA-signed, CA in store | **CONNECTED** |
| untrusted | CA-signed, CA not in store | rejected — does not chain to a trusted anchor |
| **self-signed** | self-signed, `SAN=localhost` | rejected — does not chain to a trusted anchor |
| **wrong host** | CA-signed, `SAN=example.com`, connect as `localhost` | rejected — not valid for the requested hostname |
| **expired** | CA-signed, `notAfter=2020` | rejected — certificate expired |

The trust-store loader was also validated against the real 142-cert system bundle: it parses all of them, rejects a leaf whose CA isn't present, and accepts one whose CA is spliced in.

## New in `std.cryptography.tls13_cert`

- `check_validity`, `check_hostname` — validity + SAN matching.
- `verify_cert_signature` — leaf sig under an issuer key; dispatches on the cert's signatureAlgorithm: **RSA PKCS#1 v1.5 (sha256WithRSA)** and **ECDSA-P256** (both real-world CA sig types).
- `chain_verify` — DN-match + sig-verify against a list of trust anchors.
- `trust_store_load` / `free_anchors` — parse a PEM CA bundle into `*LeafCert` anchors.
- Cert parse extended to capture full tbsCertificate DER, issuer/subject DNs, validity times, and SAN dNSNames (as bytes buffers to sidestep the struct-field string lifecycle quirks); `asn1` gained `reader_pos` for exact TBS slicing.

## Tests

`crypto_tls13_cert` regression extended to 16 offline checks (crafted expired/future/valid certs, wildcard/exact hostname cases, and an embedded ECDSA PKI covering CA-signed-passes / self-signed-rejected / empty-store-rejects). Both RSA and ECDSA chain paths validated against openssl-generated PKIs. The live-server matrix above is documented in the test README (manual, out of CI, as before).

## Remaining subset limits

Only ECDSA-P256 *server CertificateVerify* is wired (RSA server CertificateVerify fails closed; note the cert **chain** verify handles RSA + ECDSA); the leaf must chain directly to a trusted anchor (no intermediate-CA path building yet); no revocation (CRL/OCSP).

## Note on leaks

Leak-clean apart from the known `asn1` tracked-empty runtime bug (#1311): every residual lost block is exactly 1 byte (1 per asn1 read); the new parse/chain/trust-store code adds none of its own. Verified with valgrind over the 143-cert store path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)