### PR TITLE
feat(tls13): real-HTTPS milestone — AES-GCM, RSA-PSS, intermediate chains, P-384 (#1298)

### DIFF
--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -41,6 +41,7 @@ import std.list
 import std.cryptography.asn1
 import std.cryptography.sha2
 import std.cryptography.p256
+import std.cryptography.p384
 import std.cryptography.ed25519
 import std.os
 
@@ -112,7 +113,7 @@ cert_verify_content(transcript_hash: ptr, th_len: int) -> (ptr, int) {
 // Split a DER ECDSA-Sig-Value  SEQUENCE { r INTEGER, s INTEGER }  into two
 // fixed 32-byte big-endian scalars (left-padded / high-byte-trimmed as
 // needed). Returns (r32, s32, "") or (null, null, err).
-fn split_ecdsa_sig(sig: ptr, sig_len: int) -> (ptr, ptr, string) {
+fn split_ecdsa_sig(sig: ptr, sig_len: int, coord: int) -> (ptr, ptr, string) {
     view = bytes.new(sig_len)
     if sig_len > 0 { bytes.set(view, sig_len - 1, 0) }
     bytes.copy_from_bytes(view, 0, sig, 0, sig_len)
@@ -135,37 +136,37 @@ fn split_ecdsa_sig(sig: ptr, sig_len: int) -> (ptr, ptr, string) {
         asn1.reader_free(sub); asn1.reader_free(rdr); bytes.free(view); bytes.free(body)
         return null, null, serr2
     }
-    r32 = bn_to_fixed32(rint)
-    s32 = bn_to_fixed32(sint)
+    r = bn_to_fixed(rint, coord)
+    s = bn_to_fixed(sint, coord)
     bignum.free(rint)
     bignum.free(sint)
     asn1.reader_free(sub)
     asn1.reader_free(rdr)
     bytes.free(view)
     bytes.free(body)
-    return r32, s32, ""
+    return r, s, ""
 }
 
 // Render a std.bignum into exactly 32 big-endian bytes (left-padded with
 // zeros; high bytes dropped if the value somehow exceeds 32 bytes — it never
 // should for a P-256 scalar).
-fn bn_to_fixed32(v: ptr) -> ptr {
+fn bn_to_fixed(v: ptr, width: int) -> ptr {
     be = bignum.to_bytes_unsigned(v)   // variable-length big-endian magnitude
     n = bytes.length(be)
-    out = bytes.new(32)
+    out = bytes.new(width)
     i = 0
-    while i < 32 {
+    while i < width {
         bytes.set(out, i, 0)
         i = i + 1
     }
-    // Right-align: copy the low min(n,32) bytes into the tail of `out`.
+    // Right-align: copy the low min(n,width) bytes into the tail of `out`.
     copy_n = n
     src_start = 0
-    if n > 32 {
-        copy_n = 32
-        src_start = n - 32
+    if n > width {
+        copy_n = width
+        src_start = n - width
     }
-    dst = 32 - copy_n
+    dst = width - copy_n
     k = 0
     while k < copy_n {
         bytes.set(out, dst + k, bytes.get(be, src_start + k) & 0xFF)
@@ -201,7 +202,7 @@ verify_cert_verify(scheme: int, pubx: ptr, puby: ptr, transcript_hash: ptr, th_l
         // NOTE: sha2.sha256_bytes takes a STRING; content is a std.bytes
         // buffer, so we must hash it through the streaming update_bytes path.
         digest = sha256_of_bytes(content, clen)
-        r32, s32, serr = split_ecdsa_sig(sig, sig_len)
+        r32, s32, serr = split_ecdsa_sig(sig, sig_len, 32)
         if string.equals(serr, "") == 1 {
             result = p256.ecdsa_verify(pubx, puby, digest, r32, s32)
             bytes.free(r32)
@@ -788,6 +789,7 @@ check_hostname(c: *LeafCert, host: string) -> string {
 // Supported cert signature algorithms (the two that cover the real world):
 //   sha256WithRSAEncryption  1.2.840.113549.1.1.11  -> RSA PKCS#1 v1.5
 //   ecdsa-with-SHA256        1.2.840.10045.4.3.2    -> ECDSA P-256
+//   ecdsa-with-SHA384        1.2.840.10045.4.3.3    -> ECDSA P-384
 // SPKI key algorithms:
 //   rsaEncryption            1.2.840.113549.1.1.1
 //   id-ecPublicKey           1.2.840.10045.2.1
@@ -879,14 +881,12 @@ verify_cert_signature(leaf: *LeafCert, issuer: *LeafCert) -> int {
     if leaf.tbs == null { return 0 }
     if leaf.signature == null { return 0 }
     if issuer.spki_key == null { return 0 }
-    // Hash the tbsCertificate DER (SHA-256; both supported schemes use it).
-    hash = sha256_of_bytes(leaf.tbs, leaf.tbs_len)
-    if hash == null { return 0 }
 
     result = 0
     if oid_is(leaf.sig_alg_oid, "1.2.840.113549.1.1.11") == 1 {
         // sha256WithRSAEncryption. Issuer key must be rsaEncryption.
         if oid_is(issuer.spki_algo_oid, "1.2.840.113549.1.1.1") == 1 {
+            hash = sha256_of_bytes(leaf.tbs, leaf.tbs_len)
             n, e, perr = parse_rsa_spki(issuer.spki_key, issuer.spki_key_len)
             if string.equals(perr, "") == 1 {
                 k = rsa.key_from_components(n, e, null)
@@ -895,36 +895,68 @@ verify_cert_signature(leaf: *LeafCert, issuer: *LeafCert) -> int {
                 bytes.free(di)
                 rsa.key_free(k)   // frees n, e too
             }
+            bytes.free(hash)
         }
     }
     if oid_is(leaf.sig_alg_oid, "1.2.840.10045.4.3.2") == 1 {
-        // ecdsa-with-SHA256. Issuer key must be id-ecPublicKey (P-256 point).
+        // ecdsa-with-SHA256 on a P-256 issuer key (65-byte uncompressed point).
         if oid_is(issuer.spki_algo_oid, "1.2.840.10045.2.1") == 1 {
-            px, py, kerr = ec_point_from_spki(issuer.spki_key, issuer.spki_key_len)
-            if string.equals(kerr, "") == 1 {
-                r32, s32, serr = split_ecdsa_sig(leaf.signature, leaf.signature_len)
-                if string.equals(serr, "") == 1 {
-                    result = p256.ecdsa_verify(px, py, hash, r32, s32)
-                    bytes.free(r32); bytes.free(s32)
+            if issuer.spki_key_len == 65 {
+                hash = sha256_of_bytes(leaf.tbs, leaf.tbs_len)
+                px, py, kerr = ec_point_from_spki(issuer.spki_key, issuer.spki_key_len, 32)
+                if string.equals(kerr, "") == 1 {
+                    r32, s32, serr = split_ecdsa_sig(leaf.signature, leaf.signature_len, 32)
+                    if string.equals(serr, "") == 1 {
+                        result = p256.ecdsa_verify(px, py, hash, r32, s32)
+                        bytes.free(r32); bytes.free(s32)
+                    }
+                    bytes.free(px); bytes.free(py)
                 }
-                bytes.free(px); bytes.free(py)
+                bytes.free(hash)
             }
         }
     }
-    bytes.free(hash)
+    if oid_is(leaf.sig_alg_oid, "1.2.840.10045.4.3.3") == 1 {
+        // ecdsa-with-SHA384 on a P-384 issuer key (97-byte uncompressed point).
+        // Common on modern roots/intermediates (e.g. Google Trust Services).
+        if oid_is(issuer.spki_algo_oid, "1.2.840.10045.2.1") == 1 {
+            if issuer.spki_key_len == 97 {
+                hash = sha384_of_bytes(leaf.tbs, leaf.tbs_len)
+                px, py, kerr = ec_point_from_spki(issuer.spki_key, issuer.spki_key_len, 48)
+                if string.equals(kerr, "") == 1 {
+                    r48, s48, serr = split_ecdsa_sig(leaf.signature, leaf.signature_len, 48)
+                    if string.equals(serr, "") == 1 {
+                        result = p384.ecdsa_verify(px, py, hash, r48, s48)
+                        bytes.free(r48); bytes.free(s48)
+                    }
+                    bytes.free(px); bytes.free(py)
+                }
+                bytes.free(hash)
+            }
+        }
+    }
     return result
 }
 
-// Split an uncompressed EC point (04 || X32 || Y32) from an SPKI key blob into
-// (X32, Y32, ""). Returns (null,null,err) if it isn't a 65-byte uncompressed
-// point. Caller frees X/Y.
-fn ec_point_from_spki(key: ptr, key_len: int) -> (ptr, ptr, string) {
-    if key_len != 65 { return null, null, "unsupported EC point encoding" }
+// SHA-384 of a std.bytes buffer (streaming path).
+fn sha384_of_bytes(data: ptr, len: int) -> ptr {
+    ctx, err = sha2.new("sha384")
+    if err != "" { return null }
+    sha2.update_bytes(ctx, data, len)
+    return sha2.final_bytes(ctx)
+}
+
+// Split an uncompressed EC point (04 || X || Y, each `coord` bytes) from an SPKI
+// key blob into (X, Y, ""). Returns (null,null,err) if it isn't a
+// (1 + 2*coord)-byte uncompressed point. Caller frees X/Y. coord = 32 for
+// P-256, 48 for P-384.
+fn ec_point_from_spki(key: ptr, key_len: int, coord: int) -> (ptr, ptr, string) {
+    if key_len != 1 + 2 * coord { return null, null, "unsupported EC point encoding" }
     if (bytes.get(key, 0) & 0xFF) != 0x04 { return null, null, "EC point not uncompressed" }
-    x = bytes.new(32); bytes.set(x, 31, 0)
-    y = bytes.new(32); bytes.set(y, 31, 0)
-    bytes.copy_from_bytes(x, 0, key, 1, 32)
-    bytes.copy_from_bytes(y, 0, key, 33, 32)
+    x = bytes.new(coord); bytes.set(x, coord - 1, 0)
+    y = bytes.new(coord); bytes.set(y, coord - 1, 0)
+    bytes.copy_from_bytes(x, 0, key, 1, coord)
+    bytes.copy_from_bytes(y, 0, key, 1 + coord, coord)
     return x, y, ""
 }
 

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -55,7 +55,7 @@ exports (
     leaf_tbs_len, leaf_subject_len, leaf_issuer_len,
     SCHEME_ECDSA_P256_SHA256, SCHEME_ED25519, SCHEME_RSA_PSS_RSAE_SHA256,
     check_validity, time_to_key, check_hostname,
-    chain_verify, verify_cert_signature,
+    chain_verify, chain_verify_path, verify_cert_signature,
     trust_store_load, free_anchors
 )
 
@@ -949,6 +949,106 @@ chain_verify(leaf: *LeafCert, anchors: ptr) -> string {
         i = i + 1
     }
     return "certificate does not chain to a trusted anchor"
+}
+
+// Does `cert` chain DIRECTLY to any trusted anchor (issuer DN == anchor subject
+// DN and cert signature verifies under that anchor)? Returns 1 if so.
+fn chains_to_anchor(cert: *LeafCert, anchors: ptr) -> int {
+    n = list_size(anchors)
+    i = 0
+    while i < n {
+        a = list_get_raw(anchors, i) as *LeafCert
+        if a != null {
+            if dn_equal(cert.issuer, cert.issuer_len, a.subject, a.subject_len) == 1 {
+                if verify_cert_signature(cert, a) == 1 {
+                    return 1
+                }
+            }
+        }
+        i = i + 1
+    }
+    return 0
+}
+
+// Verify a certificate PATH: `leaf` may chain through server-sent
+// `intermediates` (a std.list of *LeafCert, possibly empty/null) up to a
+// trusted anchor in `anchors`. At each hop the child's signature must verify
+// under the parent's key and the DNs must match; the path terminates when a
+// cert chains directly to a trusted anchor. A self-signed / untrusted leaf with
+// no such path is REJECTED. Bounded to MAX_CHAIN_DEPTH hops to stop cycles.
+// Returns "" on a valid path, else an error.
+chain_verify_path(leaf: *LeafCert, intermediates: ptr, anchors: ptr) -> string {
+    if anchors == null { return "no trust anchors" }
+    if list_size(anchors) == 0 { return "no trust anchors" }
+
+    current = leaf
+    // Track which intermediates we've consumed so a malicious server can't loop
+    // us with a cycle of mutually-signed intermediates.
+    used = list_new()
+    depth = 0
+    result = "certificate does not chain to a trusted anchor"
+    walking = 1
+    while walking == 1 {
+        if chains_to_anchor(current, anchors) == 1 {
+            result = ""
+            walking = 0
+        } else {
+            if depth >= MAX_CHAIN_DEPTH {
+                result = "certificate chain too long"
+                walking = 0
+            } else {
+                if intermediates == null {
+                    walking = 0
+                } else {
+                    idx = find_issuer_unused(current, intermediates, used)
+                    if idx < 0 {
+                        walking = 0
+                    } else {
+                        list_add_raw(used, list_get_raw(intermediates, idx))
+                        current = list_get_raw(intermediates, idx) as *LeafCert
+                        depth = depth + 1
+                    }
+                }
+            }
+        }
+    }
+    list_free(used)
+    return result
+}
+
+const MAX_CHAIN_DEPTH = 8
+
+// Like find_issuer but skips any intermediate already in `used` (pointer
+// identity), preventing a signed-intermediate cycle from looping forever.
+fn find_issuer_unused(cert: *LeafCert, intermediates: ptr, used: ptr) -> int {
+    n = list_size(intermediates)
+    i = 0
+    while i < n {
+        m = list_get_raw(intermediates, i) as *LeafCert
+        if m != null {
+            if is_in_list(intermediates, i, used) == 0 {
+                if dn_equal(cert.issuer, cert.issuer_len, m.subject, m.subject_len) == 1 {
+                    if verify_cert_signature(cert, m) == 1 {
+                        return i
+                    }
+                }
+            }
+        }
+        i = i + 1
+    }
+    return -1
+}
+
+// Is the intermediate at index `idx` (by stored pointer) already in `used`?
+fn is_in_list(intermediates: ptr, idx: int, used: ptr) -> int {
+    target = list_get_raw(intermediates, idx)
+    un = list_size(used)
+    j = 0
+    while j < un {
+        if list_get_raw(used, j) == target { return 1 }
+        j = j + 1
+    }
+    return 0
 }
 
 // ---- system trust store (PEM bundle) ----

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -48,7 +48,7 @@ extern malloc(size: int) -> ptr
 extern free(p: ptr)
 
 exports (
-    cert_verify_content, verify_cert_verify, parse_certificate, free_leaf,
+    cert_verify_content, verify_cert_verify, verify_cert_verify_rsa_pss, parse_certificate, free_leaf,
     LeafCert,
     leaf_not_before, leaf_not_before_len, leaf_not_after, leaf_not_after_len,
     leaf_dns_count, leaf_dns_name,
@@ -215,6 +215,24 @@ verify_cert_verify(scheme: int, pubx: ptr, puby: ptr, transcript_hash: ptr, th_l
     }
 
     bytes.free(content)
+    return result
+}
+
+// Verify an RSASSA-PSS (rsae, SHA-256) CertificateVerify — SCHEME_RSA_PSS_
+// RSAE_SHA256 (0x0804), the mainstream RSA server signature. The RSA public key
+// comes from the leaf SPKI (RSAPublicKey SEQUENCE { n, e }). PSS parameters for
+// this scheme are fixed: SHA-256 for both the message hash and MGF1, salt
+// length = hash length = 32. Returns 1 if valid, 0 otherwise.
+verify_cert_verify_rsa_pss(spki_key: ptr, spki_len: int, transcript_hash: ptr, th_len: int, sig: ptr, sig_len: int) -> int {
+    n, e, perr = parse_rsa_spki(spki_key, spki_len)
+    if string.equals(perr, "") != 1 { return 0 }
+    content, clen = cert_verify_content(transcript_hash, th_len)
+    digest = sha256_of_bytes(content, clen)
+    k = rsa.key_from_components(n, e, null)
+    result = rsa.verify_pss(k, digest, sig, 32)
+    rsa.key_free(k)   // frees n, e
+    bytes.free(content)
+    bytes.free(digest)
     return result
 }
 

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -8,13 +8,12 @@
 //   tls13_cert (CertificateVerify), tls13_record (record protection),
 //   and sha2 (transcript hash).
 //
-// Subset (first cut, matches #1298):
-//   - TLS 1.3 only, X25519 key exchange, TLS_CHACHA20_POLY1305_SHA256
-//   - client-side; the handshake completes, the server's CertificateVerify
-//     signature is checked, and both sides prove key agreement via the
-//     Finished MACs
-//   - server cert must be ECDSA-P256 (the only CertificateVerify scheme wired
-//     so far; others fail closed)
+// Subset (matches #1298):
+//   - TLS 1.3 only, X25519 key exchange
+//   - cipher suites: TLS_CHACHA20_POLY1305_SHA256 and TLS_AES_128_GCM_SHA256
+//     (negotiated from the ServerHello)
+//   - server CertificateVerify: ECDSA-P256 or RSA-PSS-rsae-SHA256
+//   - full chain validation (see SERVER AUTHENTICATION below)
 //   - no resumption / 0-RTT / mTLS / HelloRetryRequest
 //
 // SERVER AUTHENTICATION. connect() fails closed unless ALL of the following
@@ -24,19 +23,21 @@
 //   2. the leaf is within its validity window (not expired / not-yet-valid);
 //   3. the requested hostname matches a leaf SAN dNSName (exact or a single
 //      leftmost-label wildcard; SAN-only, no CN fallback);
-//   4. the leaf chains to a trusted anchor — its issuer DN equals a trust-
-//      store cert's subject DN and its signature verifies under that CA's key.
+//   4. the leaf chains to a trusted anchor — walking any server-sent
+//      intermediate CAs (leaf→intermediate→…→root), each hop verified by
+//      issuer/subject DN match + signature, terminating at a trust-store root.
 // A self-signed, expired, wrong-host, or untrusted cert is rejected. The trust
 // store is the system CA bundle (SSL_CERT_FILE, else the OS default path); if
 // it cannot be loaded, connect() fails closed rather than proceeding unauthed.
 // Verified end-to-end against openssl s_server: a valid+trusted+matching cert
-// connects; self-signed, wrong-host, and expired certs are each rejected.
+// (including a leaf→intermediate→root chain) connects; self-signed, wrong-host,
+// and expired certs are each rejected.
 //
-// Remaining subset limits: only ECDSA-P256 CertificateVerify is wired, so an
-// RSA-signed *server* CertificateVerify fails closed (note the cert CHAIN
-// verify handles both RSA-PKCS#1 and ECDSA-P256). Intermediate-CA chains
-// deeper than leaf→root are not yet built (the leaf must chain directly to a
-// trusted anchor); no revocation (CRL/OCSP).
+// The CertificateVerify accepts ECDSA-P256 and RSA-PSS-rsae-SHA256 (the two
+// mainstream server signatures); the record layer negotiates ChaCha20-Poly1305
+// or AES-128-GCM from the ServerHello. Remaining limits: X25519-only key
+// exchange, no HelloRetryRequest, no resumption/0-RTT/mTLS, no revocation
+// (CRL/OCSP).
 //
 // This module separates the PURE state machine (transcript, key derivation,
 // flight assembly — offline-testable) from the SOCKET DRIVER (connect + the
@@ -830,6 +831,9 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anch
     // (validity window, hostname/SAN, chain to a trusted anchor) over it.
     leaf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
     have_leaf = 0
+    // Server-sent intermediate CAs (everything in the Certificate list after
+    // the leaf). Heap-allocated *LeafCert entries; freed at function end.
+    intermediates = list_new()
     leaf_px = null
     leaf_py = null
     cv_scheme = 0
@@ -848,6 +852,7 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anch
                     cbody = bytes.new(ml)
                     if ml > 0 { bytes.set(cbody, ml-1, 0) }
                     bytes.copy_from_bytes(cbody, 0, fl, p+4, ml)
+                    // First entry is the leaf; the rest are intermediates.
                     der, dlen, derr = extract_leaf_der(cbody, ml)
                     if string.equals(derr, "") != 1 {
                         if string.equals(err, "") == 1 { err = derr }
@@ -867,6 +872,8 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anch
                             }
                         }
                         bytes.free(der)
+                        // Parse the remaining certs into `intermediates`.
+                        parse_intermediates(cbody, ml, intermediates)
                     }
                     bytes.free(cbody)
                 }
@@ -931,17 +938,95 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anch
             herr = tls13_cert.check_hostname(&leaf, host)
             if string.equals(herr, "") != 1 { err = herr }
             else {
-                cerr = tls13_cert.chain_verify(&leaf, anchors)
+                cerr = tls13_cert.chain_verify_path(&leaf, intermediates, anchors)
                 if string.equals(cerr, "") != 1 { err = cerr }
             }
         }
       }
     }
     if have_leaf == 1 { tls13_cert.free_leaf(&leaf) }
+    free_intermediates(intermediates)
     if leaf_px != null { bytes.free(leaf_px) }
     if leaf_py != null { bytes.free(leaf_py) }
     if cv_sig != null { bytes.free(cv_sig) }
     return err
+}
+
+// Parse every certificate AFTER the leaf in a Certificate message body into
+// `out` (a std.list of heap-allocated *LeafCert). The body is
+// context<1> || certificate_list<3>, each entry cert_data<3> || extensions<2>.
+// Malformed / unparseable entries are skipped (the chain check will just fail
+// to find a path). Never errors — best-effort intermediate collection.
+fn parse_intermediates(body: ptr, body_len: int, out: ptr) {
+    if body_len < 1 { return }
+    ctx_len = bytes.get(body, 0) & 0xFF
+    p = 1 + ctx_len
+    if p + 3 > body_len { return }
+    list_len = ((bytes.get(body, p)&0xFF)<<16)|((bytes.get(body, p+1)&0xFF)<<8)|(bytes.get(body, p+2)&0xFF)
+    p = p + 3
+    list_end = p + list_len
+    if list_end > body_len { list_end = body_len }
+    idx = 0
+    while p + 3 <= list_end {
+        cert_len = ((bytes.get(body, p)&0xFF)<<16)|((bytes.get(body, p+1)&0xFF)<<8)|(bytes.get(body, p+2)&0xFF)
+        p = p + 3
+        if p + cert_len > list_end { p = list_end } else {
+            if idx > 0 {
+                // idx 0 is the leaf (already parsed); parse the rest.
+                der = bytes.new(cert_len)
+                if cert_len > 0 { bytes.set(der, cert_len - 1, 0) }
+                bytes.copy_from_bytes(der, 0, body, p, cert_len)
+                mc = malloc(136) as *LeafCert
+                init_intermediate(mc)
+                cerr = tls13_cert.parse_certificate(der, cert_len, mc)
+                if string.equals(cerr, "") == 1 {
+                    list_add_raw(out, mc)
+                } else {
+                    tls13_cert.free_leaf(mc)
+                    libc_free(mc)
+                }
+                bytes.free(der)
+            }
+            p = p + cert_len
+            // Skip the entry's extensions<2>.
+            if p + 2 <= list_end {
+                ext_len = ((bytes.get(body, p)&0xFF)<<8)|(bytes.get(body, p+1)&0xFF)
+                p = p + 2 + ext_len
+            } else {
+                p = list_end
+            }
+        }
+        idx = idx + 1
+    }
+}
+
+// Zero a heap LeafCert (matches tls13_cert's internal init).
+fn init_intermediate(l: *LeafCert) {
+    l.tbs = null; l.tbs_len = 0
+    l.sig_alg_oid = null
+    l.signature = null; l.signature_len = 0
+    l.spki_algo_oid = null; l.spki_key = null; l.spki_key_len = 0
+    l.issuer = null; l.issuer_len = 0
+    l.subject = null; l.subject_len = 0
+    l.not_before = null; l.not_before_len = 0
+    l.not_after = null; l.not_after_len = 0
+    l.dns_names = null
+}
+
+// Free a list of heap-allocated *LeafCert intermediates and the list itself.
+fn free_intermediates(lst: ptr) {
+    if lst == null { return }
+    n = list_size(lst)
+    i = 0
+    while i < n {
+        m = list_get_raw(lst, i) as *LeafCert
+        if m != null {
+            tls13_cert.free_leaf(m)
+            libc_free(m)
+        }
+        i = i + 1
+    }
+    list_free(lst)
 }
 
 // verify_flight_auth(flight, flight_len, th_thru_cert) -> "" | error.

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -33,11 +33,16 @@
 // (including a leaf→intermediate→root chain) connects; self-signed, wrong-host,
 // and expired certs are each rejected.
 //
-// The CertificateVerify accepts ECDSA-P256 and RSA-PSS-rsae-SHA256 (the two
-// mainstream server signatures); the record layer negotiates ChaCha20-Poly1305
-// or AES-128-GCM from the ServerHello. Remaining limits: X25519-only key
-// exchange, no HelloRetryRequest, no resumption/0-RTT/mTLS, no revocation
-// (CRL/OCSP).
+// The CertificateVerify accepts ECDSA-P256 and RSA-PSS-rsae-SHA256; the chain
+// signature verify additionally handles RSA-PKCS#1-SHA256 and ECDSA-P384-SHA384
+// (common on modern intermediates/roots). The record layer negotiates
+// ChaCha20-Poly1305 or AES-128-GCM, and the ClientHello sends SNI. Verified
+// end-to-end against a real public HTTPS server (github.com): X25519 handshake,
+// full chain authentication (leaf→intermediate→root, mixed P-256/P-384),
+// hostname + validity, and a decrypted HTTP/1.1 200 response.
+//
+// Remaining limits: X25519-only key exchange, no HelloRetryRequest, no
+// resumption/0-RTT/mTLS, no revocation (CRL/OCSP).
 //
 // This module separates the PURE state machine (transcript, key derivation,
 // flight assembly — offline-testable) from the SOCKET DRIVER (connect + the
@@ -306,13 +311,42 @@ fn recio_free(r: *RecordIO) {
 // Pull more bytes from the socket into the buffer. Returns bytes read, or <= 0
 // on close/error.
 fn recio_fill(r: *RecordIO) -> int {
-    chunk, n, err = net.tcp_receive_n_raw(r.sock, 4096)
-    if string.equals(err, "") != 1 { return -1 }
-    if n <= 0 { return n }
-    bytes.copy_from_string(r.buf, r.len, chunk, n)
-    r.len = r.len + n
-    return n
+    // Retry on a would-block "timeout" (peer idle, not closed); only an orderly
+    // FIN or hard error is a real close. Without this, a server that pauses even
+    // briefly after the handshake (network latency to a real host) is mistaken
+    // for a dropped connection. -1 = closed/error, >0 = bytes buffered.
+    tries = 0
+    filling = 1
+    result = -1
+    while filling == 1 {
+        chunk, n, err = net.tcp_receive_n_raw(r.sock, 4096)
+        if string.equals(err, "") == 1 {
+            if n <= 0 { result = n; filling = 0 } else {
+                bytes.copy_from_string(r.buf, r.len, chunk, n)
+                r.len = r.len + n
+                result = n
+                filling = 0
+            }
+        } else {
+            if string.equals(err, "timeout") == 1 {
+                // Idle read; retry a bounded number of times before giving up.
+                tries = tries + 1
+                if tries >= RECIO_MAX_TIMEOUT_RETRIES {
+                    result = -1
+                    filling = 0
+                }
+            } else {
+                result = -1
+                filling = 0
+            }
+        }
+    }
+    return result
 }
+
+// Bound on consecutive would-block retries in recio_fill. Each underlying recv
+// carries the OS socket timeout, so this caps the total post-handshake wait.
+const RECIO_MAX_TIMEOUT_RETRIES = 50
 
 // Read exactly one complete TLS record. Returns (record_bytes, total_len, "")
 // where record_bytes is a fresh buffer of the whole record (header + payload),
@@ -408,7 +442,7 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     pub = x25519.base_point(x25519_priv)
     rnd = rand_into(32)
     sid = rand_into(32)
-    ch = tls13_hs.client_hello(rnd, sid, 32, pub)
+    ch = tls13_hs.client_hello_sni(rnd, sid, 32, pub, host)
     ch_len = bytes.length(ch)
     tr = transcript_new()
     transcript_add(tr, ch, ch_len)

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -91,8 +91,23 @@ const HS_CERTIFICATE          = 11
 const HS_CERTIFICATE_VERIFY   = 15
 const HS_FINISHED             = 20
 
-// Record-cipher parameters for the subset's TLS_CHACHA20_POLY1305_SHA256.
-const CHACHA_KEY_LEN = 32
+// Record-cipher key lengths for the two negotiable suites.
+const CHACHA_KEY_LEN  = 32
+const AES_128_KEY_LEN = 16
+
+// Map a negotiated cipher_suite to its record AEAD id (for tls13_record) and
+// AEAD key length. Both suites use SHA-256, a 12-byte nonce, and a 16-byte tag,
+// so only the cipher + key length differ. Returns (aead_id, key_len, "") or
+// (0, 0, err) for an unsupported suite.
+fn suite_params(cipher_suite: int) -> (int, int, string) {
+    if cipher_suite == tls13_hs.TLS_CHACHA20_POLY1305_SHA256 {
+        return tls13_record.AEAD_CHACHA20_POLY1305, CHACHA_KEY_LEN, ""
+    }
+    if cipher_suite == tls13_hs.TLS_AES_128_GCM_SHA256 {
+        return tls13_record.AEAD_AES_128_GCM, AES_128_KEY_LEN, ""
+    }
+    return 0, 0, "server chose an unsupported cipher suite"
+}
 
 // ---- transcript hash accumulator ----
 //
@@ -162,16 +177,16 @@ struct HsKeys {
 // derive_handshake_keys(ecdhe32, transcript_hash_ch_sh) -> HsKeys.
 // `ecdhe` is the 32-byte X25519 shared secret; `th` is Transcript-Hash(CH..SH).
 // All output buffers are fresh (freed via free_hs_keys).
-derive_handshake_keys(ecdhe: ptr, ec_len: int, th: ptr, th_len: int) -> ptr {
+derive_handshake_keys(ecdhe: ptr, ec_len: int, th: ptr, th_len: int, key_len: int) -> ptr {
     early = tls13_ks.early_secret("sha256")
     hs = tls13_ks.handshake_secret("sha256", early, ecdhe, ec_len)
 
     c_hs = tls13_ks.traffic_secret("sha256", hs, "c hs traffic", th, th_len)
     s_hs = tls13_ks.traffic_secret("sha256", hs, "s hs traffic", th, th_len)
 
-    ck = tls13_ks.write_key("sha256", c_hs, CHACHA_KEY_LEN)
+    ck = tls13_ks.write_key("sha256", c_hs, key_len)
     civ = tls13_ks.write_iv("sha256", c_hs)
-    sk = tls13_ks.write_key("sha256", s_hs, CHACHA_KEY_LEN)
+    sk = tls13_ks.write_key("sha256", s_hs, key_len)
     siv = tls13_ks.write_iv("sha256", s_hs)
 
     k = malloc(56) as *HsKeys
@@ -429,9 +444,18 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
         cleanup_hello(pub, rnd, sid, ch); transcript_free(tr); recio_free(rio); net.tcp_close(sock)
         return null, agerr
     }
+    // Negotiate the record AEAD from the server's chosen cipher suite.
+    rec_aead, rec_key_len, suite_err = suite_params(parsed.cipher_suite)
+    if string.equals(suite_err, "") != 1 {
+        if parsed.key_share != null { bytes.free(parsed.key_share) }
+        bytes.free(shared); bytes.free(sh); bytes.free(shrec)
+        cleanup_hello(pub, rnd, sid, ch); transcript_free(tr); recio_free(rio); net.tcp_close(sock)
+        return null, suite_err
+    }
+
     th_chsh = transcript_hash(tr)
-    keys = derive_handshake_keys(shared, 32, th_chsh, 32)
-    srv_ctx = tls13_record.new(hs_server_key(keys), CHACHA_KEY_LEN, hs_server_iv(keys))
+    keys = derive_handshake_keys(shared, 32, th_chsh, 32, rec_key_len)
+    srv_ctx = tls13_record.new_aead(rec_aead, hs_server_key(keys), rec_key_len, hs_server_iv(keys))
 
     // Read + decrypt the server flight, adding each handshake message to the
     // transcript. Snapshot the transcript hash BEFORE the server Finished (for
@@ -513,22 +537,22 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
             // Client Finished over th_sf, encrypted with the CLIENT handshake keys.
             cvd = finished_verify_data(hs_client_secret(keys), th_sf, 32)
             cfin = build_finished_msg(cvd)
-            cli_hs_ctx = tls13_record.new(hs_client_key(keys), CHACHA_KEY_LEN, hs_client_iv(keys))
+            cli_hs_ctx = tls13_record.new_aead(rec_aead, hs_client_key(keys), rec_key_len, hs_client_iv(keys))
             cfin_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, cfin, bytes.length(cfin))
             cfs = bytes.to_string(cfin_rec, bytes.length(cfin_rec))
             net.tcp_send_n_raw(sock, cfs, bytes.length(cfin_rec))
 
             // Application record contexts (fresh sequence numbers per key).
-            ck = tls13_ks.write_key("sha256", c_ap, CHACHA_KEY_LEN)
+            ck = tls13_ks.write_key("sha256", c_ap, rec_key_len)
             civ = tls13_ks.write_iv("sha256", c_ap)
-            sk = tls13_ks.write_key("sha256", s_ap, CHACHA_KEY_LEN)
+            sk = tls13_ks.write_key("sha256", s_ap, rec_key_len)
             siv = tls13_ks.write_iv("sha256", s_ap)
 
             conn = malloc(32) as *ClientConn
             conn.sock = sock
             conn.rio = rio as ptr
-            conn.app_send = tls13_record.new(ck, CHACHA_KEY_LEN, civ) as ptr
-            conn.app_recv = tls13_record.new(sk, CHACHA_KEY_LEN, siv) as ptr
+            conn.app_send = tls13_record.new_aead(rec_aead, ck, rec_key_len, civ) as ptr
+            conn.app_recv = tls13_record.new_aead(rec_aead, sk, rec_key_len, siv) as ptr
             result = conn as ptr
 
             bytes.free(ck); bytes.free(civ); bytes.free(sk); bytes.free(siv)

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -857,10 +857,11 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anch
                             if string.equals(err, "") == 1 { err = perr }
                         } else {
                             have_leaf = 1
+                            // Extract the EC point only if the SPKI is one; a
+                            // non-EC (RSA) leaf leaves leaf_px null, which the
+                            // RSA-PSS dispatch handles. Not an error here.
                             px, py, sperr = split_ec_point(leaf.spki_key, leaf.spki_key_len)
-                            if string.equals(sperr, "") != 1 {
-                                if string.equals(err, "") == 1 { err = sperr }
-                            } else {
+                            if string.equals(sperr, "") == 1 {
                                 leaf_px = px
                                 leaf_py = py
                             }
@@ -888,15 +889,27 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anch
         }
     }
     if string.equals(err, "") == 1 {
-        if leaf_px == null { err = "server did not send a usable Certificate" }
+        if have_leaf == 0 { err = "server did not send a usable Certificate" }
         else {
             if cv_sig == null { err = "server did not send CertificateVerify" }
             else {
-                if cv_scheme != tls13_cert.SCHEME_ECDSA_P256_SHA256 {
-                    err = "unsupported CertificateVerify scheme (only ECDSA-P256 handled)"
+                // Dispatch the CertificateVerify by SignatureScheme:
+                //   ECDSA-P256 (0x0403) -> EC point from the leaf SPKI
+                //   RSA-PSS rsae SHA-256 (0x0804) -> RSA key from the leaf SPKI
+                if cv_scheme == tls13_cert.SCHEME_ECDSA_P256_SHA256 {
+                    if leaf_px == null {
+                        err = "ECDSA CertificateVerify but leaf is not an EC cert"
+                    } else {
+                        ok = tls13_cert.verify_cert_verify(cv_scheme, leaf_px, leaf_py, th_thru_cert, 32, cv_sig, cv_sig_len)
+                        if ok != 1 { err = "CertificateVerify signature invalid" }
+                    }
                 } else {
-                    ok = tls13_cert.verify_cert_verify(cv_scheme, leaf_px, leaf_py, th_thru_cert, 32, cv_sig, cv_sig_len)
-                    if ok != 1 { err = "CertificateVerify signature invalid" }
+                    if cv_scheme == tls13_cert.SCHEME_RSA_PSS_RSAE_SHA256 {
+                        ok = tls13_cert.verify_cert_verify_rsa_pss(leaf.spki_key, leaf.spki_key_len, th_thru_cert, 32, cv_sig, cv_sig_len)
+                        if ok != 1 { err = "CertificateVerify signature invalid" }
+                    } else {
+                        err = "unsupported CertificateVerify scheme (only ECDSA-P256 and RSA-PSS-SHA256 handled)"
+                    }
                 }
             }
         }

--- a/std/cryptography/tls13_hs/module.ae
+++ b/std/cryptography/tls13_hs/module.ae
@@ -32,9 +32,11 @@ import std.bytes
 
 extern malloc(size: int) -> ptr
 extern free(p: ptr)
+extern string_length(s: string) -> int
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
 
 exports (
-    client_hello, parse_server_hello,
+    client_hello, client_hello_sni, parse_server_hello,
     ShParsed,
     TLS_CHACHA20_POLY1305_SHA256, TLS_AES_128_GCM_SHA256,
     GROUP_X25519
@@ -116,7 +118,14 @@ fn get24(b: ptr, off: int) -> int {
 // bytes; session_id 0..32 bytes (TLS 1.3 middlebox-compat: usually a 32-byte
 // echo value); x25519_pub is our 32-byte ephemeral public key.
 client_hello(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr) -> ptr {
-    // Generous fixed buffer; this CH is ~200 bytes.
+    return client_hello_sni(random, session_id, sid_len, x25519_pub, "")
+}
+
+// Like client_hello but includes a server_name (SNI) extension for `host`
+// (RFC 6066 §3). CDNs require SNI to select the right certificate. An empty
+// host omits the extension (identical to the bare client_hello).
+client_hello_sni(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, host: string) -> ptr {
+    // Generous fixed buffer; this CH is ~200 bytes + the hostname.
     buf = bytes.new(1024)
     bytes.set(buf, 1023, 0)   // force full zero-fill
 
@@ -144,6 +153,22 @@ client_hello(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr) -> ptr
     ext_len_pos = off
     off = off + 2
     ext_start = off
+
+    // server_name (0): a single host_name entry (RFC 6066). Omitted if empty.
+    host_len = string_length(host)
+    if host_len > 0 {
+        off = put16(buf, off, 0)              // extension_type = server_name
+        off = put16(buf, off, host_len + 5)   // ext body = list(2) + type(1) + namelen(2) + name
+        off = put16(buf, off, host_len + 3)   // ServerNameList length
+        off = put8(buf, off, 0)               // name_type = host_name(0)
+        off = put16(buf, off, host_len)       // HostName length
+        hi = 0
+        while hi < host_len {
+            bytes.set(buf, off + hi, string_char_at_n(host, host_len, hi) & 0xFF)
+            hi = hi + 1
+        }
+        off = off + host_len
+    }
 
     // supported_versions (43): client form = list; { 0x0304 }
     off = put16(buf, off, 43)

--- a/std/cryptography/tls13_record/module.ae
+++ b/std/cryptography/tls13_record/module.ae
@@ -38,16 +38,25 @@ import std.bytes
 import std.string
 import std.bits
 import std.cryptography.chacha20poly1305
+import std.cryptography.aes
 
 extern malloc(size: int) -> ptr
 @extern("free") libc_free(p: ptr)
 
 exports (
-    new, free_ctx, seal_record, open_record, nonce_for,
+    new, new_aead, free_ctx, seal_record, open_record, nonce_for,
     RecordCtx, OpenedRecord,
     CONTENT_HANDSHAKE, CONTENT_APPLICATION_DATA, CONTENT_ALERT,
-    TAG_LEN, RECORD_HEADER_LEN
+    TAG_LEN, RECORD_HEADER_LEN,
+    AEAD_CHACHA20_POLY1305, AEAD_AES_128_GCM
 )
+
+// Which AEAD a record context uses. TLS 1.3's two mainstream suites:
+//   TLS_CHACHA20_POLY1305_SHA256 -> ChaCha20-Poly1305 (32-byte key)
+//   TLS_AES_128_GCM_SHA256       -> AES-128-GCM        (16-byte key)
+// Both use a 12-byte nonce and a 16-byte tag, so only the cipher differs.
+const AEAD_CHACHA20_POLY1305 = 0
+const AEAD_AES_128_GCM       = 1
 
 const CONTENT_ALERT            = 21
 const CONTENT_HANDSHAKE        = 22
@@ -65,12 +74,21 @@ struct RecordCtx {
     key_len: int
     iv: ptr        // 12-byte base write_iv
     seq: long      // record sequence number (starts at 0)
+    aead: int      // AEAD_CHACHA20_POLY1305 | AEAD_AES_128_GCM
+    aes_ctx: ptr   // pre-built AES encryptor (AES-GCM only), else null
 }
 
-// Create a record context from an AEAD key and a 12-byte base iv. Both are
-// copied (the ctx owns its copies). key_len is 32 for ChaCha20-Poly1305.
+// Create a ChaCha20-Poly1305 record context (the default AEAD). key_len is 32.
+// Kept as the back-compat entry; new_aead selects the cipher explicitly.
 new(key: ptr, key_len: int, iv12: ptr) -> ptr {
-    ctx = malloc(32) as *RecordCtx
+    return new_aead(AEAD_CHACHA20_POLY1305, key, key_len, iv12)
+}
+
+// Create a record context for a specific AEAD. Both key and iv are copied (the
+// ctx owns its copies). For AES-128-GCM the key_len is 16 and an AES encryptor
+// is built once here (GCM only runs the cipher forward, for seal AND open).
+new_aead(aead_id: int, key: ptr, key_len: int, iv12: ptr) -> ptr {
+    ctx = malloc(48) as *RecordCtx
     k = bytes.new(key_len)
     if key_len > 0 { bytes.set(k, key_len - 1, 0) }
     bytes.copy_from_bytes(k, 0, key, 0, key_len)
@@ -81,6 +99,11 @@ new(key: ptr, key_len: int, iv12: ptr) -> ptr {
     ctx.key_len = key_len
     ctx.iv = iv
     ctx.seq = 0
+    ctx.aead = aead_id
+    ctx.aes_ctx = null
+    if aead_id == AEAD_AES_128_GCM {
+        ctx.aes_ctx = aes.new_encryptor(k, key_len)
+    }
     return ctx as ptr
 }
 
@@ -88,6 +111,7 @@ free_ctx(ctx: ptr) {
     c = ctx as *RecordCtx
     bytes.free(c.key)
     bytes.free(c.iv)
+    if c.aes_ctx != null { aes.free(c.aes_ctx) }
     libc_free(ctx)
 }
 
@@ -146,7 +170,12 @@ seal_record(ctx: ptr, content_type: int, plaintext: ptr, pt_len: int) -> ptr {
     aad = build_aad(ct_len)
     nonce = nonce_for(c.iv, c.seq)
 
-    enc = chacha20poly1305.aead_seal(c.key, nonce, aad, RECORD_HEADER_LEN, inner, inner_len)
+    enc = null
+    if c.aead == AEAD_AES_128_GCM {
+        enc = aes.gcm_seal(c.aes_ctx, nonce, aad, RECORD_HEADER_LEN, inner, inner_len)
+    } else {
+        enc = chacha20poly1305.aead_seal(c.key, nonce, aad, RECORD_HEADER_LEN, inner, inner_len)
+    }
     // enc is inner_len + 16 bytes (ciphertext-with-tag) == ct_len
 
     // Full record: header (0x17 0x0303 len16) || enc
@@ -172,6 +201,15 @@ struct OpenedRecord {
     content_type: int
     plaintext: ptr    // fresh bytes (caller frees) — the inner content
     plaintext_len: int
+}
+
+// Dispatch AEAD-Open to the negotiated cipher. Returns (inner_plaintext, "")
+// or (null, err) exactly like the underlying aead_open primitives.
+fn aead_open_dispatch(c: *RecordCtx, nonce: ptr, aad: ptr, ctbuf: ptr, ct_len: int) -> (ptr, string) {
+    if c.aead == AEAD_AES_128_GCM {
+        return aes.gcm_open(c.aes_ctx, nonce, aad, RECORD_HEADER_LEN, ctbuf, ct_len)
+    }
+    return chacha20poly1305.aead_open(c.key, nonce, aad, RECORD_HEADER_LEN, ctbuf, ct_len)
 }
 
 // Open a TLSCiphertext record (5-byte header + encrypted_record) into `out`.
@@ -206,7 +244,7 @@ open_record(ctx: ptr, record: ptr, rec_len: int, out: *OpenedRecord) -> string {
     bytes.copy_from_bytes(ctbuf, 0, record, RECORD_HEADER_LEN, ct_len)
 
     nonce = nonce_for(c.iv, c.seq)
-    inner, err = chacha20poly1305.aead_open(c.key, nonce, aad, RECORD_HEADER_LEN, ctbuf, ct_len)
+    inner, err = aead_open_dispatch(c, nonce, aad, ctbuf, ct_len)
 
     bytes.free(aad)
     bytes.free(ctbuf)

--- a/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
+++ b/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
@@ -284,6 +284,34 @@ main() {
     } else { println("FAIL RSA-PSS accepted tampered sig"); total_ok = 0 }
     bytes.free(rsa_spki); bytes.free(rsa_sig); bytes.free(rsa_th)
 
+    // --- intermediate-CA chain building (chain_verify_path) ---
+    // 3-level ECDSA PKI: leaf <- intermediate <- root. Only root is trusted;
+    // the intermediate is a server-sent CA the path must traverse.
+    cp_root = from_hex("3082017e30820123a00302010202145c702d3cc21d8183652f2cfa02e9b7f6844b8da5300a06082a8648ce3d04030230143112301006035504030c095465737420526f6f74301e170d3236303732383232353133325a170d3236303733313232353133325a30143112301006035504030c095465737420526f6f743059301306072a8648ce3d020106082a8648ce3d030107034200041740254dfbb1c90c7ef083091d0f4c1622a202de87b55cedd2bb0f786b4f244c6bbde1bf3abb3ddb0e1644e8234a1aa3f867de35303edb156664c450800f2801a3533051301d0603551d0e04160414b27999d5d4667a7a87cc5357cb0a866c2236e699301f0603551d23041830168014b27999d5d4667a7a87cc5357cb0a866c2236e699300f0603551d130101ff040530030101ff300a06082a8648ce3d0403020349003046022100ac69c0f3a06e882a53f23af02c53f176ec0f3bafe20e89ec59343a733ccddcc4022100be41ede785a8c707b48917082ffaa0cf3ccc4f99744eb3f83d0bbcd1c4de84a2")
+    cp_int  = from_hex("3082018e30820135a00302010202144dabe3cd6d7512d3897ae34ff552226c0d16125a300a06082a8648ce3d04030230143112301006035504030c095465737420526f6f74301e170d3236303732383232353133335a170d3236303733313232353133335a301c311a301806035504030c115465737420496e7465726d6564696174653059301306072a8648ce3d020106082a8648ce3d030107034200041c75b3de45ad714bcbd377f4fc50a2f94b24e53632fa9478fe0ed1bd1fa4dbb403458519822dca095933ced4a4ec876661a6efa5682b55b8ecba92e15d045755a35d305b300c0603551d13040530030101ff300b0603551d0f040403020204301d0603551d0e041604140a74b333ea0cd034f90333f79cd1127feca903ab301f0603551d23041830168014b27999d5d4667a7a87cc5357cb0a866c2236e699300a06082a8648ce3d040302034700304402206fe0684b0bb4e4d3e85dae7d88267a3768a218c115e262f60ddd477e5535d08902204f1dd369a0e932cef441f6fdd923c4a430315aca27937f2cde1f8031e58be210")
+    cp_leaf = from_hex("3082018b30820130a003020102021402b286e4bdc746e47304f6935a264a8f9606f2d9300a06082a8648ce3d040302301c311a301806035504030c115465737420496e7465726d656469617465301e170d3236303732383232353133335a170d3236303733303232353133335a30143112301006035504030c096c6f63616c686f73743059301306072a8648ce3d020106082a8648ce3d0301070342000410f1edfe0c66ec3ebe94f1689629f901d215e9592104da1e3f1dcfa8af65a8b882c14adb2d0379069c87545c81544b86a37ec3c8bbdd28d5bb799fdcb185ad66a358305630140603551d11040d300b82096c6f63616c686f7374301d0603551d0e04160414ef5c392fa331d2e00730805fc54a1083a45b1531301f0603551d230418301680140a74b333ea0cd034f90333f79cd1127feca903ab300a06082a8648ce3d0403020349003046022100f523de6be6de2fe0849888b1f5275e6ac437f64cbada051ba2c9529c0d66a301022100c86009498ab965939e733219e10175889c9ba1d501ba0febcaef880e96f430d9")
+    croot = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    cint  = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    cleaf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    tls13_cert.parse_certificate(cp_root, bytes.length(cp_root), &croot)
+    tls13_cert.parse_certificate(cp_int,  bytes.length(cp_int),  &cint)
+    tls13_cert.parse_certificate(cp_leaf, bytes.length(cp_leaf), &cleaf)
+    canchors = list_new(); list_add_raw(canchors, &croot)
+    cinters  = list_new(); list_add_raw(cinters, &cint)
+    cempty   = list_new()
+    if string.equals(tls13_cert.chain_verify_path(&cleaf, cinters, canchors), "") == 1 {
+        println("ok   leaf->intermediate->root path verified")
+    } else { println("FAIL intermediate chain rejected"); total_ok = 0 }
+    if string.equals(tls13_cert.chain_verify_path(&cleaf, cempty, canchors), "") != 1 {
+        println("ok   leaf without intermediate rejected")
+    } else { println("FAIL leaf-alone accepted"); total_ok = 0 }
+    if string.equals(tls13_cert.chain_verify_path(&cint, cempty, canchors), "") == 1 {
+        println("ok   intermediate chains directly to root")
+    } else { println("FAIL intermediate->root rejected"); total_ok = 0 }
+    list_free(canchors); list_free(cinters); list_free(cempty)
+    tls13_cert.free_leaf(&croot); tls13_cert.free_leaf(&cint); tls13_cert.free_leaf(&cleaf)
+    bytes.free(cp_root); bytes.free(cp_int); bytes.free(cp_leaf)
+
     if total_ok == 0 {
         println("tls13_cert: FAILURES")
         exit(1)

--- a/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
+++ b/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
@@ -312,6 +312,27 @@ main() {
     tls13_cert.free_leaf(&croot); tls13_cert.free_leaf(&cint); tls13_cert.free_leaf(&cleaf)
     bytes.free(cp_root); bytes.free(cp_int); bytes.free(cp_leaf)
 
+    // --- P-384 / SHA-384 chain hop (mirrors real CDN chains, e.g. Cloudflare) ---
+    // P-256 leaf (ecdsa-with-SHA384) <- P-384 intermediate <- P-384 root; the
+    // intermediate->root hop exercises ecdsa-with-SHA384 on a P-384 key.
+    p3_root = from_hex("308201bb30820140a00302010202143b4dd64f182548ee3b4db75b13a8056dcab225b0300a06082a8648ce3d04030330143112301006035504030c095033383420526f6f74301e170d3236303732383233323034375a170d3236303733313233323034375a30143112301006035504030c095033383420526f6f743076301006072a8648ce3d020106052b8104002203620004e8cec1ccdf3617fe9d5ed125213cbc44c59d042296aabd3e8f3ee254720218387186645288ce368b0f85a6de2fb6eb66a3bbc6cd8a7f6d9c69fa146cf2474d106c21371bb12d18140c8f56a9de6a27a175b5ac676f1fac3de0b8df425f123f2ba3533051301d0603551d0e041604143199a441395addd70ef98c40f0f9bb5deb258041301f0603551d230418301680143199a441395addd70ef98c40f0f9bb5deb258041300f0603551d130101ff040530030101ff300a06082a8648ce3d0403030369003066023100d92a730144a13a69cafe4fdb6aac0f11a73720c8c139398ed8b517b86a1745cbf843d7e6cafba79b0a69a35d8532d11a023100f760d19516a65ff3cffca412c3b7eb065dcbba060d5f6fa15d3877d19b5ad3aac4654f8939d8d38dc4ed2e3c0d650250")
+    p3_int  = from_hex("308201bf30820145a00302010202147da90084287b98be35e8d0f8b0560f14551202ef300a06082a8648ce3d04030330143112301006035504030c095033383420526f6f74301e170d3236303732383233323034375a170d3236303733313233323034375a301c311a301806035504030c115033383420496e7465726d6564696174653076301006072a8648ce3d020106052b8104002203620004507484ddb93c1e5669110a6a4553908b10024d6f9815a14163766f345da99794408e172a6f41797d7ffa9932c8ea55045c2214780e4ca693c37cbec98cee36cab06035e40bfb8c7df4367ea24f730cbdeaffef55247d59ebf8b8b85a4065731ea350304e300c0603551d13040530030101ff301d0603551d0e04160414f454ad54fef131117122913fa2a9405e39590bd6301f0603551d230418301680143199a441395addd70ef98c40f0f9bb5deb258041300a06082a8648ce3d04030303680030650231009062c469e647bc1ed74dba16ad9dae64874e2553761f60e9b5ec9ba3d524235832c1e602dc338919ec8eb8e81d8f370b023021eb3efd29f65703132409340757ad5fcf261ea0ffac9f309b5bfc8ca3752a1b04b40d6242d592e070ac585e67af954e")
+    p3_leaf = from_hex("308201ab30820130a0030201020214630cdd4abcb25aefaa8c8ed4fd78f20890c307e0300a06082a8648ce3d040303301c311a301806035504030c115033383420496e7465726d656469617465301e170d3236303732383233323330365a170d3236303733303233323330365a30143112301006035504030c096c6f63616c686f73743059301306072a8648ce3d020106082a8648ce3d030107034200042bd74544c6d2914d7014fdced7ee45c8eae202d5cf49683f507035853d293a7a91c7fbf62c6f775ed813995839e86438fa103a9e64c686b72580dccbc58c525ca358305630140603551d11040d300b82096c6f63616c686f7374301d0603551d0e04160414b794ef309a904f1e3ac5f8d0411edc36eaa2c0fb301f0603551d23041830168014f454ad54fef131117122913fa2a9405e39590bd6300a06082a8648ce3d04030303690030660231009c75af244bd359d8c9ee1ecb8dd109f88e624da9b4946d5895d23f284f7253bb8b8eda49bbd0165de5ee8079a01c456f023100a07599984a4a581989aa81222a33d1a7b7ba3bf8325320d16b087f0df2540229f7e8dc0c4c0d11daef1529d41740f52f")
+    p3r = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    p3i = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    p3l = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+    tls13_cert.parse_certificate(p3_root, bytes.length(p3_root), &p3r)
+    tls13_cert.parse_certificate(p3_int,  bytes.length(p3_int),  &p3i)
+    tls13_cert.parse_certificate(p3_leaf, bytes.length(p3_leaf), &p3l)
+    p3anchors = list_new(); list_add_raw(p3anchors, &p3r)
+    p3inters  = list_new(); list_add_raw(p3inters, &p3i)
+    if string.equals(tls13_cert.chain_verify_path(&p3l, p3inters, p3anchors), "") == 1 {
+        println("ok   P-256 leaf <- P-384/SHA-384 intermediate <- P-384 root verified")
+    } else { println("FAIL P-384 chain hop rejected"); total_ok = 0 }
+    list_free(p3anchors); list_free(p3inters)
+    tls13_cert.free_leaf(&p3r); tls13_cert.free_leaf(&p3i); tls13_cert.free_leaf(&p3l)
+    bytes.free(p3_root); bytes.free(p3_int); bytes.free(p3_leaf)
+
     if total_ok == 0 {
         println("tls13_cert: FAILURES")
         exit(1)

--- a/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
+++ b/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
@@ -268,6 +268,22 @@ main() {
     tls13_cert.free_leaf(&eca); tls13_cert.free_leaf(&elf); tls13_cert.free_leaf(&ess)
     bytes.free(eca_der); bytes.free(elf_der); bytes.free(ess_der)
 
+    // --- RSA-PSS server CertificateVerify (SCHEME_RSA_PSS_RSAE_SHA256) ---
+    // A real RSA-2048 PSS(SHA-256, salt=32) signature over the RFC 8446
+    // §4.4.3 content for a fixed 32-byte transcript hash (0x00..0x1f),
+    // with the leaf RSAPublicKey SEQUENCE{n,e} as the SPKI key blob.
+    rsa_spki = from_hex("3082010a0282010100b2ea251f97391dec908f54e44ddd36bcb95d320a46bc6a39d9f54d14b263ebfd3bad694b68673072c55f717485ef79f7981e336560d3c79adbad07ca3e71969c749f8f9e7a360bc59acf6d502806203b71f6b34d86a6a6c82c86b6bf269e64a1ec1c5e1643ee17250c89ee4c58fc8445b34a1ed1b570ac8f0099001571ceb65122b4b5da8e92a10974a6cc7435a8a29d8abfab1289005aa8bf644fd378b5fb190b4185eb5c6c3fb828f80a06da4adab0f6a4a5e137b1c0093fb985f837a4160c8fc956ed4f46f58400e865d68e0277d925de3f3537e279fcde7d4ee39e13ddef81591f41b7acd9814406af93827b8a169143696dbe975a4129dd04718d8d038b0203010001")
+    rsa_sig  = from_hex("59f2417a31649c0040504c1d58e5629c97ed5e6f790b538584390efb7ff870137e0363d5f5cea5b1aadf0a3935fbcbe56f20838bbb2a5342e46d3f9a4e16b9b53dcf1df588cb9213200a445b46273c1ef03da6ba9401db49bf81c18a7584907744ac625a429d4edfbe5adcf41fc3edfc3e78004d2d39ed52894716571657dee2cbbd3cc9d6ce4e3d8644db5147438f7bdca55cb841716d6294d9e8a76e34788dc39b849af51b6484ed46d350d05127e3611c2f0a1c47137a5d0ea68192ff8079885f5b13a99cce2aa830effbea500deb047bd04a2e250d8a3d5af76b14b59540173080258a57aa2d8f43b034bf0930ee1f3c7b732a5e89f2a8b970dc0da295fe")
+    rsa_th   = from_hex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+    if tls13_cert.verify_cert_verify_rsa_pss(rsa_spki, bytes.length(rsa_spki), rsa_th, 32, rsa_sig, bytes.length(rsa_sig)) == 1 {
+        println("ok   RSA-PSS CertificateVerify accepts valid sig")
+    } else { println("FAIL RSA-PSS rejected valid sig"); total_ok = 0 }
+    bytes.set(rsa_sig, 0, (bytes.get(rsa_sig, 0) ^ 0x01) & 0xFF)
+    if tls13_cert.verify_cert_verify_rsa_pss(rsa_spki, bytes.length(rsa_spki), rsa_th, 32, rsa_sig, bytes.length(rsa_sig)) == 0 {
+        println("ok   RSA-PSS CertificateVerify rejects tampered sig")
+    } else { println("FAIL RSA-PSS accepted tampered sig"); total_ok = 0 }
+    bytes.free(rsa_spki); bytes.free(rsa_sig); bytes.free(rsa_th)
+
     if total_ok == 0 {
         println("tls13_cert: FAILURES")
         exit(1)

--- a/tests/integration/crypto_tls13_client/test_tls13_client.ae
+++ b/tests/integration/crypto_tls13_client/test_tls13_client.ae
@@ -77,7 +77,8 @@ main() {
     // --- handshake key derivation (RFC 8448 §3) ---
     ecdhe = from_hex("8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d")
     thash = from_hex("860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8")
-    k = tls13_client.derive_handshake_keys(ecdhe, 32, thash, 32)
+    // key_len=32 -> the ChaCha20 record key for RFC 8448 §3's s hs traffic secret.
+    k = tls13_client.derive_handshake_keys(ecdhe, 32, thash, 32, 32)
 
     // server_iv matches RFC 8448 §3 exactly (iv is cipher-length-independent)
     siv = tls13_client.hs_server_iv(k)
@@ -96,6 +97,18 @@ main() {
         println("FAIL server_key = ${to_hex(sk, 32)}"); total_ok = 0
     }
     tls13_client.free_hs_keys(k)
+
+    // key_len=16 -> the AES-128 record key. RFC 8448 §3 s hs traffic secret's
+    // AES-128 key is 3fce516009c21727d0f2e4e86ee403bc (the HKDF length label
+    // binds 16, so this is the canonical AES-128-GCM key for the same secret).
+    k16 = tls13_client.derive_handshake_keys(ecdhe, 32, thash, 32, 16)
+    sk16 = tls13_client.hs_server_key(k16)
+    if to_hex(sk16, 16) == "3fce516009c21727d0f2e4e86ee403bc" {
+        println("ok   server_key == AES-128 16B key for RFC 8448 s hs traffic")
+    } else {
+        println("FAIL AES-128 server_key = ${to_hex(sk16, 16)}"); total_ok = 0
+    }
+    tls13_client.free_hs_keys(k16)
     bytes.free(ecdhe); bytes.free(thash)
 
     // --- Finished key (RFC 8446 §4.4.4; RFC 8448 §3 server value) ---

--- a/tests/integration/crypto_tls13_record/test_tls13_record.ae
+++ b/tests/integration/crypto_tls13_record/test_tls13_record.ae
@@ -154,6 +154,40 @@ main() {
     if o1.plaintext != null { bytes.free(o1.plaintext) }
     if o2.plaintext != null { bytes.free(o2.plaintext) }
 
+    // --- AES-128-GCM AEAD selection round-trips (16-byte key) ---
+    akey = bytes.new(16)
+    ai = 0
+    while ai < 16 { bytes.set(akey, ai, (ai * 13 + 5) & 0xFF); ai = ai + 1 }
+    aiv = bytes.new(12)
+    ai2 = 0
+    while ai2 < 12 { bytes.set(aiv, ai2, (ai2 * 3 + 1) & 0xFF); ai2 = ai2 + 1 }
+    asend = tls13_record.new_aead(tls13_record.AEAD_AES_128_GCM, akey, 16, aiv)
+    arecv = tls13_record.new_aead(tls13_record.AEAD_AES_128_GCM, akey, 16, aiv)
+    amsg = bytes.new(20)
+    am = 0
+    while am < 20 { bytes.set(amsg, am, 97 + (am % 26)); am = am + 1 }
+    arec = tls13_record.seal_record(asend, tls13_record.CONTENT_APPLICATION_DATA, amsg, 20)
+    ao = tls13_record.OpenedRecord { content_type: 0, plaintext: null, plaintext_len: 0 }
+    aerr = tls13_record.open_record(arecv, arec, bytes.length(arec), &ao)
+    aok = 1
+    if string.equals(aerr, "") != 1 { aok = 0 }
+    else {
+        if ao.content_type != tls13_record.CONTENT_APPLICATION_DATA { aok = 0 }
+        if ao.plaintext_len != 20 { aok = 0 }
+        if aok == 1 {
+            if to_hex(ao.plaintext, 20) != to_hex(amsg, 20) { aok = 0 }
+        }
+    }
+    if aok == 1 {
+        println("ok   AES-128-GCM record round-trips (16-byte key)")
+    } else {
+        println("FAIL AES-128-GCM record round-trip"); total_ok = 0
+    }
+    if ao.plaintext != null { bytes.free(ao.plaintext) }
+    tls13_record.free_ctx(asend)
+    tls13_record.free_ctx(arecv)
+    bytes.free(akey); bytes.free(aiv); bytes.free(amsg); bytes.free(arec)
+
     tls13_record.free_ctx(sender)
     tls13_record.free_ctx(receiver)
     tls13_record.free_ctx(receiver2)


### PR DESCRIPTION
The pure-Aether TLS 1.3 client now connects to the **real internet**. Verified end-to-end against **github.com**: X25519 handshake, full certificate-chain authentication (leaf → intermediate → trusted root, mixed P-256/P-384), hostname + validity checks, and a decrypted **HTTP/1.1 200 OK** over ChaCha20-Poly1305 — no OpenSSL anywhere.

```
HANDSHAKE OK — authenticated github.com
GOT 1370 bytes of decrypted response:
HTTP/1.1 200 OK
...
```

This PR is four bricks that together close the gap from "works against a hand-configured `s_server`" to "works against actual HTTPS servers."

## 1. AES-128-GCM record support
The client offered `TLS_AES_128_GCM_SHA256` but the record layer only did ChaCha20-Poly1305, so an AES-picking server broke. `tls13_record` now carries an AEAD id and dispatches seal/open to `aes.gcm_seal`/`gcm_open` or ChaCha; `tls13_client.suite_params` negotiates the cipher + key length from the ServerHello and threads it through key derivation. Cross-validated against RFC 8448 §3 (the AES-128 server write_key `3fce…403bc` matches).

## 2. RSA-PSS server CertificateVerify
Most real servers sign CertificateVerify with RSA-PSS, not ECDSA. `verify_cert_verify_rsa_pss` parses the leaf RSAPublicKey, builds the §4.4.3 content, and runs `rsa.verify_pss` (SHA-256, salt 32). `authenticate_server` dispatches ECDSA-P256 vs RSA-PSS by SignatureScheme. Validated against a real openssl RSA-2048 PSS signature.

## 3. Intermediate-CA chain building
Real chains are leaf → intermediate(s) → root, with only the root trusted. `chain_verify_path` walks the path — each hop verified by issuer/subject DN match + signature — terminating at a trust-store anchor (cycle-guarded). `authenticate_server` parses **all** certs from the Certificate message, not just the leaf. Verified against `s_server -cert leaf -cert_chain int`: a 3-level chain connects; self-signed still rejected.

## 4. Real-HTTPS enablers
- **SNI**: `client_hello_sni` adds the server_name extension (RFC 6066) — CDNs need it to select the cert.
- **P-384 / ecdsa-with-SHA384**: ubiquitous on modern intermediates/roots (it's the intermediate→root hop in Cloudflare's and GitHub's chains). `verify_cert_signature` now handles it via the existing `p384` + `sha384` primitives; the EC helpers were generalised to a coordinate width and pick the curve by SPKI point size (65=P-256, 97=P-384).
- **Idle-read retry**: `recio_fill` retries on the would-block `"timeout"` sentinel instead of treating a brief post-handshake pause (real-network latency) as a dropped connection.

## Cipher/algorithm coverage now

| Layer | Supported |
|-------|-----------|
| Key exchange | X25519 |
| Record AEAD | ChaCha20-Poly1305, AES-128-GCM |
| Server CertificateVerify | ECDSA-P256, RSA-PSS-rsae-SHA256 |
| Chain signatures | RSA-PKCS#1-SHA256, ECDSA-P256-SHA256, ECDSA-P384-SHA384 |

## Tests
`tls13_record` gains an AES-128-GCM round-trip; `tls13_cert` gains RSA-PSS accept/reject, a 3-level intermediate-chain path, and a P-256-leaf ← P-384/SHA-384-intermediate ← P-384-root path. The live github.com run is the end-to-end proof (manual, as documented).

## Leaks
Leak-clean modulo the known asn1 tracked-empty (#1311): valgrind over the chain path shows every residual lost block is exactly 1 byte; the new code adds none.

## Remaining limits
X25519-only key exchange; no HelloRetryRequest; no resumption/0-RTT/mTLS; no revocation (CRL/OCSP). (Cloudflare specifically resets bare HTTP/1.1 connections lacking ALPN `h2` — a server policy; github.com confirms client correctness.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)