### PR TITLE
feat(tls13): broad reach — ALPN, AES-256-GCM-SHA384, secp256r1 + HRR (#1298)

### DIFF
--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -36,10 +36,12 @@
 // The CertificateVerify accepts ECDSA-P256 and RSA-PSS-rsae-SHA256; the chain
 // signature verify additionally handles RSA-PKCS#1-SHA256 and ECDSA-P384-SHA384
 // (common on modern intermediates/roots). The record layer negotiates
-// ChaCha20-Poly1305 or AES-128-GCM, and the ClientHello sends SNI. Verified
-// end-to-end against a real public HTTPS server (github.com): X25519 handshake,
-// full chain authentication (leaf→intermediate→root, mixed P-256/P-384),
-// hostname + validity, and a decrypted HTTP/1.1 200 response.
+// ChaCha20-Poly1305, AES-128-GCM, or AES-256-GCM-SHA384 (the key schedule is
+// hash-parameterised: SHA-256 or SHA-384). The ClientHello sends SNI and offers
+// ALPN http/1.1. Verified end-to-end against real HTTPS servers: github.com
+// (ChaCha20) and openssl s_server on every suite incl. AES-256-GCM-SHA384 —
+// X25519 handshake, full chain authentication, hostname + validity, decrypted
+// HTTP response.
 //
 // Remaining limits: X25519-only key exchange, no HelloRetryRequest, no
 // resumption/0-RTT/mTLS, no revocation (CRL/OCSP).
@@ -97,22 +99,27 @@ const HS_CERTIFICATE          = 11
 const HS_CERTIFICATE_VERIFY   = 15
 const HS_FINISHED             = 20
 
-// Record-cipher key lengths for the two negotiable suites.
+// Record-cipher key lengths for the negotiable suites.
 const CHACHA_KEY_LEN  = 32
 const AES_128_KEY_LEN = 16
+const AES_256_KEY_LEN = 32
 
-// Map a negotiated cipher_suite to its record AEAD id (for tls13_record) and
-// AEAD key length. Both suites use SHA-256, a 12-byte nonce, and a 16-byte tag,
-// so only the cipher + key length differ. Returns (aead_id, key_len, "") or
-// (0, 0, err) for an unsupported suite.
-fn suite_params(cipher_suite: int) -> (int, int, string) {
+// Map a negotiated cipher_suite to its record AEAD id, AEAD key length, key-
+// schedule hash algo, and that hash's length. Returns (aead, key_len, hash_algo,
+// hash_len, "") or (0,0,"",0,err) for an unsupported suite. The SHA-256 suites
+// use 32-byte secrets; TLS_AES_256_GCM_SHA384 uses SHA-384 (48-byte secrets)
+// throughout the key schedule and a 32-byte AES-256 record key.
+fn suite_params(cipher_suite: int) -> (int, int, string, int, string) {
     if cipher_suite == tls13_hs.TLS_CHACHA20_POLY1305_SHA256 {
-        return tls13_record.AEAD_CHACHA20_POLY1305, CHACHA_KEY_LEN, ""
+        return tls13_record.AEAD_CHACHA20_POLY1305, CHACHA_KEY_LEN, "sha256", 32, ""
     }
     if cipher_suite == tls13_hs.TLS_AES_128_GCM_SHA256 {
-        return tls13_record.AEAD_AES_128_GCM, AES_128_KEY_LEN, ""
+        return tls13_record.AEAD_AES_128_GCM, AES_128_KEY_LEN, "sha256", 32, ""
     }
-    return 0, 0, "server chose an unsupported cipher suite"
+    if cipher_suite == tls13_hs.TLS_AES_256_GCM_SHA384 {
+        return tls13_record.AEAD_AES_256_GCM, AES_256_KEY_LEN, "sha384", 48, ""
+    }
+    return 0, 0, "", 0, "server chose an unsupported cipher suite"
 }
 
 // ---- transcript hash accumulator ----
@@ -149,9 +156,16 @@ transcript_add(t: ptr, msg: ptr, msg_len: int) {
 
 // SHA-256 of the accumulated transcript so far (fresh 32-byte buffer; caller
 // frees). Uses the streaming update_bytes path (sha256_bytes takes a string).
+// Transcript-Hash with an explicit algorithm ("sha256" or "sha384", matching
+// the negotiated cipher suite). transcript_hash keeps the sha256 default for
+// the existing pure-piece tests.
 transcript_hash(t: ptr) -> ptr {
+    return transcript_hash_algo(t, "sha256")
+}
+
+transcript_hash_algo(t: ptr, algo: string) -> ptr {
     tt = t as *Transcript
-    ctx, err = sha2.new("sha256")
+    ctx, err = sha2.new(algo)
     if err != "" { return null }
     sha2.update_bytes(ctx, tt.buf, tt.len)
     return sha2.final_bytes(ctx)
@@ -184,16 +198,22 @@ struct HsKeys {
 // `ecdhe` is the 32-byte X25519 shared secret; `th` is Transcript-Hash(CH..SH).
 // All output buffers are fresh (freed via free_hs_keys).
 derive_handshake_keys(ecdhe: ptr, ec_len: int, th: ptr, th_len: int, key_len: int) -> ptr {
-    early = tls13_ks.early_secret("sha256")
-    hs = tls13_ks.handshake_secret("sha256", early, ecdhe, ec_len)
+    return derive_handshake_keys_algo(ecdhe, ec_len, th, th_len, key_len, "sha256")
+}
 
-    c_hs = tls13_ks.traffic_secret("sha256", hs, "c hs traffic", th, th_len)
-    s_hs = tls13_ks.traffic_secret("sha256", hs, "s hs traffic", th, th_len)
+// hash_algo is the key-schedule hash ("sha256" or "sha384") from the negotiated
+// suite. derive_handshake_keys keeps the sha256 default for the pure tests.
+derive_handshake_keys_algo(ecdhe: ptr, ec_len: int, th: ptr, th_len: int, key_len: int, hash_algo: string) -> ptr {
+    early = tls13_ks.early_secret(hash_algo)
+    hs = tls13_ks.handshake_secret(hash_algo, early, ecdhe, ec_len)
 
-    ck = tls13_ks.write_key("sha256", c_hs, key_len)
-    civ = tls13_ks.write_iv("sha256", c_hs)
-    sk = tls13_ks.write_key("sha256", s_hs, key_len)
-    siv = tls13_ks.write_iv("sha256", s_hs)
+    c_hs = tls13_ks.traffic_secret(hash_algo, hs, "c hs traffic", th, th_len)
+    s_hs = tls13_ks.traffic_secret(hash_algo, hs, "s hs traffic", th, th_len)
+
+    ck = tls13_ks.write_key(hash_algo, c_hs, key_len)
+    civ = tls13_ks.write_iv(hash_algo, c_hs)
+    sk = tls13_ks.write_key(hash_algo, s_hs, key_len)
+    siv = tls13_ks.write_iv(hash_algo, s_hs)
 
     k = malloc(56) as *HsKeys
     k.client_hs_secret = c_hs
@@ -217,19 +237,28 @@ derive_handshake_keys(ecdhe: ptr, ec_len: int, th: ptr, th_len: int, key_len: in
 // server's Finished with the server hs secret, and sends its own computed with
 // the client hs secret.
 
-// finished_key(traffic_secret32) -> 32-byte key (caller frees).
+// finished_key(traffic_secret) -> Hash.length key. The sha256/32 default keeps
+// the existing tests; _algo takes the negotiated hash + its length.
 finished_key(secret: ptr) -> ptr {
+    return finished_key_algo(secret, "sha256", 32)
+}
+
+finished_key_algo(secret: ptr, hash_algo: string, hlen: int) -> ptr {
     empty = bytes.new(1)
     bytes.set(empty, 0, 0)
-    fk = tls13_kdf.expand_label("sha256", secret, 32, "finished", empty, 0, 32)
+    fk = tls13_kdf.expand_label(hash_algo, secret, hlen, "finished", empty, 0, hlen)
     bytes.free(empty)
     return fk
 }
 
-// finished_verify_data(traffic_secret32, transcript_hash32) -> 32-byte MAC.
+// finished_verify_data(traffic_secret, transcript_hash) -> Hash.length MAC.
 finished_verify_data(secret: ptr, th: ptr, th_len: int) -> ptr {
-    fk = finished_key(secret)
-    vd = hmac.hmac_sha256(fk, 32, th, th_len)
+    return finished_verify_data_algo(secret, th, th_len, "sha256", 32)
+}
+
+finished_verify_data_algo(secret: ptr, th: ptr, th_len: int, hash_algo: string, hlen: int) -> ptr {
+    fk = finished_key_algo(secret, hash_algo, hlen)
+    vd = hmac.hmac_bytes(hash_algo, fk, hlen, th, th_len)
     bytes.free(fk)
     return vd
 }
@@ -479,8 +508,8 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
         cleanup_hello(pub, rnd, sid, ch); transcript_free(tr); recio_free(rio); net.tcp_close(sock)
         return null, agerr
     }
-    // Negotiate the record AEAD from the server's chosen cipher suite.
-    rec_aead, rec_key_len, suite_err = suite_params(parsed.cipher_suite)
+    // Negotiate the record AEAD + key-schedule hash from the chosen suite.
+    rec_aead, rec_key_len, hash_algo, hash_len, suite_err = suite_params(parsed.cipher_suite)
     if string.equals(suite_err, "") != 1 {
         if parsed.key_share != null { bytes.free(parsed.key_share) }
         bytes.free(shared); bytes.free(sh); bytes.free(shrec)
@@ -488,8 +517,8 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
         return null, suite_err
     }
 
-    th_chsh = transcript_hash(tr)
-    keys = derive_handshake_keys(shared, 32, th_chsh, 32, rec_key_len)
+    th_chsh = transcript_hash_algo(tr, hash_algo)
+    keys = derive_handshake_keys_algo(shared, 32, th_chsh, hash_len, rec_key_len, hash_algo)
     srv_ctx = tls13_record.new_aead(rec_aead, hs_server_key(keys), rec_key_len, hs_server_iv(keys))
 
     // Read + decrypt the server flight, adding each handshake message to the
@@ -533,7 +562,7 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     // Fold the whole flight into the transcript in wire order, capturing the
     // transcript hash BEFORE the final Finished (for the server Finished MAC).
     if string.equals(ferr, "") == 1 {
-        th_before_finished, th_through_cert = add_flight_capture_prefinished(tr, fl, fllen)
+        th_before_finished, th_through_cert = add_flight_capture_prefinished(tr, fl, fllen, hash_algo)
         server_verify_data, svd_len = extract_server_finished(fl, fllen)
     }
 
@@ -551,26 +580,26 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
             // chain, so we must not proceed as if the server were trusted.
             auth_err = "cannot load system trust store"
         } else {
-            auth_err = authenticate_server(fl, fllen, th_through_cert, host, anchors)
+            auth_err = authenticate_server(fl, fllen, th_through_cert, hash_len, host, anchors)
             tls13_cert.free_anchors(anchors)
         }
         if string.equals(auth_err, "") != 1 {
             result_err = auth_err
         } else {
         // Verify server Finished: HMAC(server_finished_key, th_before_finished).
-        expected = finished_verify_data(hs_server_secret(keys), th_before_finished, 32)
-        if bytes_equal(expected, server_verify_data, 32) != 1 {
+        expected = finished_verify_data_algo(hs_server_secret(keys), th_before_finished, hash_len, hash_algo, hash_len)
+        if bytes_equal(expected, server_verify_data, hash_len) != 1 {
             result_err = "server Finished MAC verification failed"
         } else {
             // Handshake authenticated. Derive application keys and send the
             // client Finished. th_sf = Transcript-Hash(CH..server Finished).
-            th_sf = transcript_hash(tr)
-            ms = tls13_ks.master_secret("sha256", hs_handshake_secret(keys))
-            c_ap = tls13_ks.traffic_secret("sha256", ms, "c ap traffic", th_sf, 32)
-            s_ap = tls13_ks.traffic_secret("sha256", ms, "s ap traffic", th_sf, 32)
+            th_sf = transcript_hash_algo(tr, hash_algo)
+            ms = tls13_ks.master_secret(hash_algo, hs_handshake_secret(keys))
+            c_ap = tls13_ks.traffic_secret(hash_algo, ms, "c ap traffic", th_sf, hash_len)
+            s_ap = tls13_ks.traffic_secret(hash_algo, ms, "s ap traffic", th_sf, hash_len)
 
             // Client Finished over th_sf, encrypted with the CLIENT handshake keys.
-            cvd = finished_verify_data(hs_client_secret(keys), th_sf, 32)
+            cvd = finished_verify_data_algo(hs_client_secret(keys), th_sf, hash_len, hash_algo, hash_len)
             cfin = build_finished_msg(cvd)
             cli_hs_ctx = tls13_record.new_aead(rec_aead, hs_client_key(keys), rec_key_len, hs_client_iv(keys))
             cfin_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, cfin, bytes.length(cfin))
@@ -578,10 +607,10 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
             net.tcp_send_n_raw(sock, cfs, bytes.length(cfin_rec))
 
             // Application record contexts (fresh sequence numbers per key).
-            ck = tls13_ks.write_key("sha256", c_ap, rec_key_len)
-            civ = tls13_ks.write_iv("sha256", c_ap)
-            sk = tls13_ks.write_key("sha256", s_ap, rec_key_len)
-            siv = tls13_ks.write_iv("sha256", s_ap)
+            ck = tls13_ks.write_key(hash_algo, c_ap, rec_key_len)
+            civ = tls13_ks.write_iv(hash_algo, c_ap)
+            sk = tls13_ks.write_key(hash_algo, s_ap, rec_key_len)
+            siv = tls13_ks.write_iv(hash_algo, s_ap)
 
             conn = malloc(32) as *ClientConn
             conn.sock = sock
@@ -639,7 +668,7 @@ fn flight_complete(fl: ptr, flen: int) -> int {
 // wire order, AND return the transcript hash captured just BEFORE the final
 // Finished message (needed for the server Finished MAC). The transcript ends
 // up including the Finished (needed for app keys + client Finished).
-fn add_flight_capture_prefinished(tr: ptr, fl: ptr, flen: int) -> (ptr, ptr) {
+fn add_flight_capture_prefinished(tr: ptr, fl: ptr, flen: int, hash_algo: string) -> (ptr, ptr) {
     fin_off = last_msg_offset(fl, flen)
     th_pre = null
     th_cert = null
@@ -653,14 +682,14 @@ fn add_flight_capture_prefinished(tr: ptr, fl: ptr, flen: int) -> (ptr, ptr) {
             if p + total > flen { cont = 0 } else {
                 // Capture the pre-Finished transcript hash right before adding
                 // the last (Finished) message.
-                if p == fin_off { th_pre = transcript_hash(tr) }
+                if p == fin_off { th_pre = transcript_hash_algo(tr, hash_algo) }
                 sub = bytes.new(total)
                 bytes.set(sub, total-1, 0)
                 bytes.copy_from_bytes(sub, 0, fl, p, total)
                 transcript_add(tr, sub, total)
                 bytes.free(sub)
                 // Snapshot the hash THROUGH Certificate (used by CertificateVerify).
-                if mt == HS_CERTIFICATE { th_cert = transcript_hash(tr) }
+                if mt == HS_CERTIFICATE { th_cert = transcript_hash_algo(tr, hash_algo) }
                 p = p + total
             }
         }
@@ -859,7 +888,7 @@ fn trust_store_path() -> string {
     return debian
 }
 
-fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anchors: ptr) -> string {
+fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, th_len: int, host: string, anchors: ptr) -> string {
     // The full parsed leaf is kept alive for the whole function so that, after
     // the CertificateVerify signature check, we can run RFC 5280/6125 policy
     // (validity window, hostname/SAN, chain to a trusted anchor) over it.
@@ -941,12 +970,12 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, host: string, anch
                     if leaf_px == null {
                         err = "ECDSA CertificateVerify but leaf is not an EC cert"
                     } else {
-                        ok = tls13_cert.verify_cert_verify(cv_scheme, leaf_px, leaf_py, th_thru_cert, 32, cv_sig, cv_sig_len)
+                        ok = tls13_cert.verify_cert_verify(cv_scheme, leaf_px, leaf_py, th_thru_cert, th_len, cv_sig, cv_sig_len)
                         if ok != 1 { err = "CertificateVerify signature invalid" }
                     }
                 } else {
                     if cv_scheme == tls13_cert.SCHEME_RSA_PSS_RSAE_SHA256 {
-                        ok = tls13_cert.verify_cert_verify_rsa_pss(leaf.spki_key, leaf.spki_key_len, th_thru_cert, 32, cv_sig, cv_sig_len)
+                        ok = tls13_cert.verify_cert_verify_rsa_pss(leaf.spki_key, leaf.spki_key_len, th_thru_cert, th_len, cv_sig, cv_sig_len)
                         if ok != 1 { err = "CertificateVerify signature invalid" }
                     } else {
                         err = "unsupported CertificateVerify scheme (only ECDSA-P256 and RSA-PSS-SHA256 handled)"
@@ -1073,5 +1102,5 @@ verify_flight_auth(fl: ptr, flen: int, th_thru_cert: ptr) -> string {
     // Signature-only mode (anchors == null): checks Certificate +
     // CertificateVerify but not the RFC 5280/6125 policy. connect() enforces
     // the full policy via a loaded trust store.
-    return authenticate_server(fl, flen, th_thru_cert, "", null)
+    return authenticate_server(fl, flen, th_thru_cert, 32, "", null)
 }

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -9,12 +9,12 @@
 //   and sha2 (transcript hash).
 //
 // Subset (matches #1298):
-//   - TLS 1.3 only, X25519 key exchange
+//   - TLS 1.3 only; x25519 + secp256r1 key exchange
 //   - cipher suites: TLS_CHACHA20_POLY1305_SHA256 and TLS_AES_128_GCM_SHA256
 //     (negotiated from the ServerHello)
 //   - server CertificateVerify: ECDSA-P256 or RSA-PSS-rsae-SHA256
 //   - full chain validation (see SERVER AUTHENTICATION below)
-//   - no resumption / 0-RTT / mTLS / HelloRetryRequest
+//   - no resumption / 0-RTT / mTLS
 //
 // SERVER AUTHENTICATION. connect() fails closed unless ALL of the following
 // hold, in order (RFC 8446 §4.4.3 + RFC 5280/6125):
@@ -43,8 +43,10 @@
 // X25519 handshake, full chain authentication, hostname + validity, decrypted
 // HTTP response.
 //
-// Remaining limits: X25519-only key exchange, no HelloRetryRequest, no
-// resumption/0-RTT/mTLS, no revocation (CRL/OCSP).
+// Key exchange: x25519 and secp256r1 (both key_shares pre-offered, so a
+// P-256-preferring server completes without a round-trip; HelloRetryRequest is
+// handled as a fallback). Remaining limits: no resumption/0-RTT/mTLS, no
+// revocation (CRL/OCSP).
 //
 // This module separates the PURE state machine (transcript, key derivation,
 // flight assembly — offline-testable) from the SOCKET DRIVER (connect + the
@@ -66,6 +68,7 @@ import std.string
 import std.cryptography.sha2
 import std.cryptography.hmac
 import std.cryptography.x25519
+import std.cryptography.p256
 import std.cryptography.tls13_kdf
 import std.cryptography.tls13_ks
 import std.cryptography.tls13_hs
@@ -379,6 +382,27 @@ const RECIO_MAX_TIMEOUT_RETRIES = 50
 
 // Read exactly one complete TLS record. Returns (record_bytes, total_len, "")
 // where record_bytes is a fresh buffer of the whole record (header + payload),
+// Like recio_next but skips any ChangeCipherSpec records (content type 0x14),
+// which a TLS 1.3 server may interleave for middlebox compatibility (notably
+// right after a HelloRetryRequest). Returns the next non-CCS record.
+fn recio_next_hs(r: *RecordIO) -> (ptr, int, string) {
+    looking = 1
+    rec = null
+    rlen = 0
+    err = ""
+    while looking == 1 {
+        rec, rlen, err = recio_next(r)
+        if string.equals(err, "") != 1 { looking = 0 } else {
+            if (bytes.get(rec, 0) & 0xFF) == 0x14 {
+                bytes.free(rec)   // skip CCS
+            } else {
+                looking = 0
+            }
+        }
+    }
+    return rec, rlen, err
+}
+
 // or (null, 0, err). Blocks (via recio_fill) until a full record is available.
 fn recio_next(r: *RecordIO) -> (ptr, int, string) {
     loop = 1
@@ -449,6 +473,73 @@ fn cleanup_hello(pub: ptr, rnd: ptr, sid: ptr, ch: ptr) {
     bytes.free(pub); bytes.free(rnd); bytes.free(sid); bytes.free(ch)
 }
 
+// The key-schedule hash name for a cipher suite (without the full suite_params
+// tuple), used during the HRR transcript rewrite before AEAD selection.
+fn hash_algo_for_suite(cipher_suite: int) -> string {
+    if cipher_suite == tls13_hs.TLS_AES_256_GCM_SHA384 { return "sha384" }
+    return "sha256"
+}
+
+// RFC 8446 §4.4.1: after a HelloRetryRequest the transcript's first ClientHello
+// is replaced by a synthetic "message_hash" handshake message wrapping the hash
+// of CH1:  0xFE || 0x00 0x00 || Hash.len || Hash(CH1). The transcript currently
+// holds exactly CH1; reset it to that synthetic message.
+fn rewrite_transcript_for_hrr(tr: ptr, ch1: ptr, ch1_len: int, hash_algo: string) {
+    ch1_hash = transcript_hash_algo(tr, hash_algo)   // Hash(CH1) — tr holds CH1 only
+    hlen = bytes.length(ch1_hash)
+    synthetic = bytes.new(4 + hlen)
+    bytes.set(synthetic, 4 + hlen - 1, 0)
+    bytes.set(synthetic, 0, 0xFE)     // handshake type: message_hash
+    bytes.set(synthetic, 1, 0)
+    bytes.set(synthetic, 2, 0)
+    bytes.set(synthetic, 3, hlen & 0xFF)
+    bytes.copy_from_bytes(synthetic, 4, ch1_hash, 0, hlen)
+    // Reset the accumulator to just the synthetic message.
+    tt = tr as *Transcript
+    tt.len = 0
+    transcript_add(tr, synthetic, 4 + hlen)
+    bytes.free(ch1_hash)
+    bytes.free(synthetic)
+}
+
+// Build the client key_share public value for `group` from a 32-byte private
+// scalar. x25519 -> the 32-byte public; secp256r1 -> 04 || X(32) || Y(32) (the
+// 65-byte uncompressed point). Returns (pubkey, pubkey_len).
+fn keyshare_for_group(group: int, priv: ptr) -> (ptr, int) {
+    if group == tls13_hs.GROUP_SECP256R1 {
+        px, py = p256.scalar_mult_base(priv)
+        pt = bytes.new(65)
+        bytes.set(pt, 64, 0)
+        bytes.set(pt, 0, 0x04)
+        bytes.copy_from_bytes(pt, 1, px, 0, 32)
+        bytes.copy_from_bytes(pt, 33, py, 0, 32)
+        bytes.free(px); bytes.free(py)
+        return pt, 65
+    }
+    // default: x25519
+    pub = x25519.base_point(priv)
+    return pub, 32
+}
+
+// Compute the ECDHE shared secret for `group` from our private scalar and the
+// server's key_share. x25519 -> agree(); secp256r1 -> ECDH x-coordinate from
+// the server's uncompressed point. Returns (shared, "") or (null, err).
+fn ecdhe_shared(group: int, priv: ptr, server_ks: ptr, server_ks_len: int) -> (ptr, string) {
+    if group == tls13_hs.GROUP_SECP256R1 {
+        if server_ks_len != 65 { return null, "secp256r1 key_share not a 65-byte point" }
+        if (bytes.get(server_ks, 0) & 0xFF) != 0x04 { return null, "secp256r1 key_share not uncompressed" }
+        sx = bytes.new(32); bytes.set(sx, 31, 0)
+        sy = bytes.new(32); bytes.set(sy, 31, 0)
+        bytes.copy_from_bytes(sx, 0, server_ks, 1, 32)
+        bytes.copy_from_bytes(sy, 0, server_ks, 33, 32)
+        sh = p256.ecdh(priv, sx, sy)
+        bytes.free(sx); bytes.free(sy)
+        if sh == null { return null, "secp256r1 ECDH failed" }
+        return sh, ""
+    }
+    return x25519.agree(priv, server_ks)
+}
+
 // ---- full handshake ----
 //
 // connect(host, port, x25519_priv32) -> (ClientConn ptr, "") on a completed,
@@ -468,10 +559,23 @@ fn cleanup_hello(pub: ptr, rnd: ptr, sid: ptr, ch: ptr) {
 connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     sock = net.tcp_connect_raw(host, port)
     if sock == null { return null, "connect failed" }
-    pub = x25519.base_point(x25519_priv)
+    // Initial key exchange group is x25519, using the caller's private scalar.
+    // On a HelloRetryRequest we may switch to secp256r1 with a fresh scalar.
+    cur_group = tls13_hs.GROUP_X25519
+    cur_priv = x25519_priv        // NOT owned here (caller's); P-256 retry owns its own
+    own_priv = 0                  // 1 once we allocate a retry scalar we must free
+    // Offer BOTH an x25519 and a secp256r1 key_share up front, so a server that
+    // prefers P-256 completes without a HelloRetryRequest round-trip. We keep
+    // the P-256 ephemeral private in case the server selects secp256r1.
+    p256_priv = rand_into(32)
+    x_pub, x_pub_len = keyshare_for_group(tls13_hs.GROUP_X25519, x25519_priv)
+    p_pub, p_pub_len = keyshare_for_group(tls13_hs.GROUP_SECP256R1, p256_priv)
+    pub = x_pub                   // primary keyshare (x25519); cleanup frees this
+    pub_len = x_pub_len
     rnd = rand_into(32)
     sid = rand_into(32)
-    ch = tls13_hs.client_hello_sni(rnd, sid, 32, pub, host)
+    ch = tls13_hs.client_hello_full(rnd, sid, 32, tls13_hs.GROUP_X25519, x_pub, x_pub_len, tls13_hs.GROUP_SECP256R1, p_pub, p_pub_len, host)
+    bytes.free(p_pub)             // copied into the CH; keep only p256_priv
     ch_len = bytes.length(ch)
     tr = transcript_new()
     transcript_add(tr, ch, ch_len)
@@ -482,8 +586,8 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     }
     rio = recio_new(sock)
 
-    // ServerHello.
-    shrec, shlen, sherr = recio_next(rio)
+    // ServerHello (may be a HelloRetryRequest we answer once).
+    shrec, shlen, sherr = recio_next_hs(rio)
     if string.equals(sherr, "") != 1 {
         cleanup_hello(pub, rnd, sid, ch); transcript_free(tr); recio_free(rio); net.tcp_close(sock)
         return null, sherr
@@ -492,7 +596,6 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     sh = bytes.new(sh_msg_len)
     bytes.set(sh, sh_msg_len - 1, 0)
     bytes.copy_from_bytes(sh, 0, shrec, 5, sh_msg_len)
-    transcript_add(tr, sh, sh_msg_len)
     parsed = tls13_hs.ShParsed { version: 0, cipher_suite: 0, group: 0, key_share: null, key_share_len: 0, is_hello_retry: 0 }
     perr = tls13_hs.parse_server_hello(sh, sh_msg_len, &parsed)
     if string.equals(perr, "") != 1 {
@@ -501,11 +604,91 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
         return null, perr
     }
 
-    shared, agerr = x25519.agree(x25519_priv, parsed.key_share)
+    if parsed.is_hello_retry == 1 {
+        // RFC 8446 §4.4.1: replace CH1 in the transcript with the synthetic
+        // message_hash(Hash(CH1)), then append the HRR and the second CH.
+        rewrite_transcript_for_hrr(tr, ch, ch_len, hash_algo_for_suite(parsed.cipher_suite))
+        transcript_add(tr, sh, sh_msg_len)
+
+        retry_group = parsed.group
+        rp = null
+        if retry_group == tls13_hs.GROUP_SECP256R1 {
+            rp = rand_into(32)
+        } else {
+            // Server asked to retry a group we don't support (or echoed x25519,
+            // which shouldn't happen after a HRR); give up.
+            bytes.free(sh); bytes.free(shrec)
+            cleanup_hello(pub, rnd, sid, ch); transcript_free(tr); recio_free(rio); net.tcp_close(sock)
+            return null, "HelloRetryRequest asked for an unsupported group"
+        }
+        cleanup_hello(pub, rnd, sid, ch)      // free CH1 + its keyshare/nonces
+        bytes.free(sh); bytes.free(shrec)
+
+        cur_group = retry_group
+        cur_priv = rp
+        own_priv = 1
+        pub2, pub2_len = keyshare_for_group(cur_group, cur_priv)
+        rnd = rand_into(32)
+        sid = rand_into(32)
+        ch = tls13_hs.client_hello_full(rnd, sid, 32, cur_group, pub2, pub2_len, 0, null, 0, host)
+        ch_len = bytes.length(ch)
+        transcript_add(tr, ch, ch_len)
+        serr2 = send_plaintext_handshake(sock, ch, ch_len)
+        if string.equals(serr2, "") != 1 {
+            cleanup_hello(pub2, rnd, sid, ch); bytes.free(cur_priv)
+            transcript_free(tr); recio_free(rio); net.tcp_close(sock)
+            return null, serr2
+        }
+        pub = pub2   // so later cleanup frees the right keyshare
+
+        // Read the real ServerHello.
+        shrec, shlen, sherr = recio_next_hs(rio)
+        if string.equals(sherr, "") != 1 {
+            cleanup_hello(pub, rnd, sid, ch); bytes.free(cur_priv)
+            transcript_free(tr); recio_free(rio); net.tcp_close(sock)
+            return null, sherr
+        }
+        sh_msg_len = shlen - 5
+        sh = bytes.new(sh_msg_len)
+        bytes.set(sh, sh_msg_len - 1, 0)
+        bytes.copy_from_bytes(sh, 0, shrec, 5, sh_msg_len)
+        perr = tls13_hs.parse_server_hello(sh, sh_msg_len, &parsed)
+        if string.equals(perr, "") != 1 {
+            bytes.free(sh); bytes.free(shrec)
+            cleanup_hello(pub, rnd, sid, ch); bytes.free(cur_priv)
+            transcript_free(tr); recio_free(rio); net.tcp_close(sock)
+            return null, perr
+        }
+        if parsed.is_hello_retry == 1 {
+            bytes.free(sh); bytes.free(shrec)
+            cleanup_hello(pub, rnd, sid, ch); bytes.free(cur_priv)
+            transcript_free(tr); recio_free(rio); net.tcp_close(sock)
+            return null, "server sent a second HelloRetryRequest"
+        }
+    }
+
+    transcript_add(tr, sh, sh_msg_len)
+
+    // Select the private key matching the group the server chose. In the
+    // non-HRR path we offered both x25519 and secp256r1 shares; pick whichever
+    // the server's key_share names. (After a HRR, cur_group/cur_priv are already
+    // the retried group and own_priv==1.)
+    if own_priv == 0 {
+        if parsed.group == tls13_hs.GROUP_SECP256R1 {
+            cur_group = tls13_hs.GROUP_SECP256R1
+            cur_priv = p256_priv
+        } else {
+            cur_group = tls13_hs.GROUP_X25519
+            cur_priv = x25519_priv
+        }
+    }
+
+    shared, agerr = ecdhe_shared(cur_group, cur_priv, parsed.key_share, parsed.key_share_len)
     if string.equals(agerr, "") != 1 {
         if parsed.key_share != null { bytes.free(parsed.key_share) }
         bytes.free(sh); bytes.free(shrec)
-        cleanup_hello(pub, rnd, sid, ch); transcript_free(tr); recio_free(rio); net.tcp_close(sock)
+        cleanup_hello(pub, rnd, sid, ch); if own_priv == 1 { bytes.free(cur_priv) }
+        transcript_free(tr); recio_free(rio); net.tcp_close(sock)
         return null, agerr
     }
     // Negotiate the record AEAD + key-schedule hash from the chosen suite.
@@ -639,6 +822,8 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
     if parsed.key_share != null { bytes.free(parsed.key_share) }
     bytes.free(sh); bytes.free(shrec)
     cleanup_hello(pub, rnd, sid, ch); transcript_free(tr)
+    if own_priv == 1 { bytes.free(cur_priv) }   // P-256 retry scalar (HRR path)
+    bytes.free(p256_priv)                       // the pre-offered P-256 ephemeral
     if result == null {
         recio_free(rio); net.tcp_close(sock)
     }

--- a/std/cryptography/tls13_hs/module.ae
+++ b/std/cryptography/tls13_hs/module.ae
@@ -10,10 +10,9 @@
 //
 // Subset encoded/negotiated:
 //   - legacy_version 0x0303, real version via supported_versions = 0x0304
-//   - one cipher suite: TLS_CHACHA20_POLY1305_SHA256 (0x1303)
-//     (AES-128-GCM 0x1301 is offered too so real servers have a common suite)
-//   - supported_groups: x25519 (0x001d)
-//   - key_share: one x25519 KeyShareEntry (our 32-byte public key)
+//   - cipher suites: ChaCha20-Poly1305, AES-128-GCM, AES-256-GCM-SHA384
+//   - supported_groups: x25519 (0x001d), secp256r1 (0x0017)
+//   - key_share: x25519 and/or secp256r1 KeyShareEntry(s); SNI + ALPN http/1.1
 //   - signature_algorithms: ecdsa_secp256r1_sha256 (0x0403),
 //     rsa_pss_rsae_sha256 (0x0804), ed25519 (0x0807)
 //
@@ -36,10 +35,10 @@ extern string_length(s: string) -> int
 extern string_char_at_n(str: string, known_length: int, index: int) -> int
 
 exports (
-    client_hello, client_hello_sni, parse_server_hello,
+    client_hello, client_hello_sni, client_hello_full, parse_server_hello,
     ShParsed,
     TLS_CHACHA20_POLY1305_SHA256, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
-    GROUP_X25519
+    GROUP_X25519, GROUP_SECP256R1
 )
 
 // Cipher suites (RFC 8446 appendix B.4).
@@ -48,7 +47,8 @@ const TLS_AES_256_GCM_SHA384       = 0x1302
 const TLS_CHACHA20_POLY1305_SHA256 = 0x1303
 
 // Named groups (RFC 8446 §4.2.7).
-const GROUP_X25519 = 0x001d
+const GROUP_X25519    = 0x001d
+const GROUP_SECP256R1 = 0x0017
 
 // Signature schemes (RFC 8446 §4.2.3).
 const SIG_ECDSA_P256_SHA256 = 0x0403
@@ -137,7 +137,17 @@ client_hello(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr) -> ptr
 // (RFC 6066 §3). CDNs require SNI to select the right certificate. An empty
 // host omits the extension (identical to the bare client_hello).
 client_hello_sni(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, host: string) -> ptr {
-    // Generous fixed buffer; this CH is ~200 bytes + the hostname.
+    return client_hello_full(random, session_id, sid_len, GROUP_X25519, x25519_pub, 32, 0, null, 0, host)
+}
+
+// Build a ClientHello offering both x25519 and secp256r1 in supported_groups,
+// carrying a key_share for `group` (its `pubkey`/`pubkey_len`) and optionally a
+// second key_share for `group2` (pass group2=0 to omit). Offering both shares
+// lets a server that prefers the other group complete without a
+// HelloRetryRequest. x25519 share = 32-byte public; secp256r1 share = 65-byte
+// uncompressed point (0x04 || X || Y). The HRR retry path uses a single share.
+client_hello_full(random: ptr, session_id: ptr, sid_len: int, group: int, pubkey: ptr, pubkey_len: int, group2: int, pubkey2: ptr, pubkey2_len: int, host: string) -> ptr {
+    // Generous fixed buffer; this CH is ~230 bytes + the hostname.
     buf = bytes.new(1024)
     bytes.set(buf, 1023, 0)   // force full zero-fill
 
@@ -189,11 +199,13 @@ client_hello_sni(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, ho
     off = put8(buf, off, 2)       // list len
     off = put16(buf, off, 0x0304) // TLS 1.3
 
-    // supported_groups (10): { x25519 }
+    // supported_groups (10): { x25519, secp256r1 } — offer both so a server
+    // that won't do x25519 can HelloRetryRequest secp256r1.
     off = put16(buf, off, 10)
-    off = put16(buf, off, 4)      // ext body len
-    off = put16(buf, off, 2)      // list len
+    off = put16(buf, off, 6)      // ext body len = 2 (list len) + 2*2
+    off = put16(buf, off, 4)      // list len
     off = put16(buf, off, GROUP_X25519)
+    off = put16(buf, off, GROUP_SECP256R1)
 
     // signature_algorithms (13): { ecdsa_p256_sha256, rsa_pss_rsae_sha256, ed25519 }
     off = put16(buf, off, 13)
@@ -213,13 +225,23 @@ client_hello_sni(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, ho
     off = put8(buf, off, 8)           // ProtocolName length
     off = put_ascii(buf, off, "http/1.1")
 
-    // key_share (51): one x25519 KeyShareEntry { group, key<len> }
+    // key_share (51): a KeyShareEntry {group, key<len>} for `group`, plus an
+    // optional second entry (group2/pubkey2) so we can pre-offer both x25519 and
+    // secp256r1 and let the server pick without a HelloRetryRequest round-trip.
+    entry1 = 2 + 2 + pubkey_len
+    shares_len = entry1
+    if group2 != 0 { shares_len = shares_len + 2 + 2 + pubkey2_len }
     off = put16(buf, off, 51)
-    off = put16(buf, off, 38)     // ext body: 2 (client_shares len) + 2+2+32
-    off = put16(buf, off, 36)     // client_shares len = 2+2+32
-    off = put16(buf, off, GROUP_X25519)
-    off = put16(buf, off, 32)     // key length
-    off = put_bytes(buf, off, x25519_pub, 32)
+    off = put16(buf, off, 2 + shares_len)  // ext body: client_shares<2> + entries
+    off = put16(buf, off, shares_len)      // client_shares length
+    off = put16(buf, off, group)
+    off = put16(buf, off, pubkey_len)
+    off = put_bytes(buf, off, pubkey, pubkey_len)
+    if group2 != 0 {
+        off = put16(buf, off, group2)
+        off = put16(buf, off, pubkey2_len)
+        off = put_bytes(buf, off, pubkey2, pubkey2_len)
+    }
 
     // fill extensions length
     ext_total = off - ext_start
@@ -258,8 +280,10 @@ parse_server_hello(msg: ptr, len: int, out: *ShParsed) -> string {
     // legacy_version (2) — ignored, real version is in supported_versions
     if p + 2 > len { return "server hello: truncated version" }
     p = p + 2
-    // random[32]
+    // random[32] — a HelloRetryRequest is a ServerHello whose random equals the
+    // special SHA-256("HelloRetryRequest") sentinel (RFC 8446 §4.1.3).
     if p + 32 > len { return "server hello: truncated random" }
+    if is_hrr_random(msg, p) == 1 { out.is_hello_retry = 1 }
     p = p + 32
     // legacy_session_id_echo<0..32>
     if p + 1 > len { return "server hello: truncated session id len" }
@@ -292,20 +316,27 @@ parse_server_hello(msg: ptr, len: int, out: *ShParsed) -> string {
             out.version = get16(msg, p)
         }
         if ext_type == 51 {
-            // key_share (server form: single KeyShareEntry { group, key<len> })
-            if ext_len < 4 { return "server hello: bad key_share" }
-            out.group = get16(msg, p)
-            ks_len = get16(msg, p + 2)
-            if 4 + ks_len > ext_len { return "server hello: key_share overrun" }
-            ks = bytes.new(ks_len)
-            if ks_len > 0 { bytes.set(ks, ks_len - 1, 0) }
-            j = 0
-            while j < ks_len {
-                bytes.set(ks, j, bytes.get(msg, p + 4 + j) & 0xFF)
-                j = j + 1
+            if out.is_hello_retry == 1 {
+                // HRR key_share carries only the selected group (2 bytes),
+                // no key — it tells the client which group to retry with.
+                if ext_len < 2 { return "server hello: bad HRR key_share" }
+                out.group = get16(msg, p)
+            } else {
+                // key_share (server form: single KeyShareEntry {group, key<len>})
+                if ext_len < 4 { return "server hello: bad key_share" }
+                out.group = get16(msg, p)
+                ks_len = get16(msg, p + 2)
+                if 4 + ks_len > ext_len { return "server hello: key_share overrun" }
+                ks = bytes.new(ks_len)
+                if ks_len > 0 { bytes.set(ks, ks_len - 1, 0) }
+                j = 0
+                while j < ks_len {
+                    bytes.set(ks, j, bytes.get(msg, p + 4 + j) & 0xFF)
+                    j = j + 1
+                }
+                out.key_share = ks
+                out.key_share_len = ks_len
             }
-            out.key_share = ks
-            out.key_share_len = ks_len
         }
         p = p + ext_len
     }
@@ -314,4 +345,30 @@ parse_server_hello(msg: ptr, len: int, out: *ShParsed) -> string {
         return "server hello: not TLS 1.3 (no supported_versions=0x0304)"
     }
     return ""
+}
+
+// The HelloRetryRequest sentinel random = SHA-256("HelloRetryRequest")
+// (RFC 8446 §4.1.3). Returns 1 if the 32 bytes at msg[off..off+32) match.
+fn is_hrr_random(msg: ptr, off: int) -> int {
+    // RFC 8446 §4.1.3 HelloRetryRequest special Random =
+    // SHA-256("HelloRetryRequest"):
+    // CF 21 AD 74 E5 9A 61 11 BE 1D FA 3A 06 B4 4E 8C
+    // 84 5C 76 30 04 8B 15 D5 A0 0D 20 3A 15 D5 B2 6E
+    hrr = bytes.new(32)
+    bytes.set(hrr, 0, 0xCF); bytes.set(hrr, 1, 0x21); bytes.set(hrr, 2, 0xAD); bytes.set(hrr, 3, 0x74)
+    bytes.set(hrr, 4, 0xE5); bytes.set(hrr, 5, 0x9A); bytes.set(hrr, 6, 0x61); bytes.set(hrr, 7, 0x11)
+    bytes.set(hrr, 8, 0xBE); bytes.set(hrr, 9, 0x1D); bytes.set(hrr, 10, 0xFA); bytes.set(hrr, 11, 0x3A)
+    bytes.set(hrr, 12, 0x06); bytes.set(hrr, 13, 0xB4); bytes.set(hrr, 14, 0x4E); bytes.set(hrr, 15, 0x8C)
+    bytes.set(hrr, 16, 0x84); bytes.set(hrr, 17, 0x5C); bytes.set(hrr, 18, 0x76); bytes.set(hrr, 19, 0x30)
+    bytes.set(hrr, 20, 0x04); bytes.set(hrr, 21, 0x8B); bytes.set(hrr, 22, 0x15); bytes.set(hrr, 23, 0xD5)
+    bytes.set(hrr, 24, 0xA0); bytes.set(hrr, 25, 0x0D); bytes.set(hrr, 26, 0x20); bytes.set(hrr, 27, 0x3A)
+    bytes.set(hrr, 28, 0x15); bytes.set(hrr, 29, 0xD5); bytes.set(hrr, 30, 0xB2); bytes.set(hrr, 31, 0x6E)
+    same = 1
+    i = 0
+    while i < 32 {
+        if (bytes.get(msg, off + i) & 0xFF) != (bytes.get(hrr, i) & 0xFF) { same = 0 }
+        i = i + 1
+    }
+    bytes.free(hrr)
+    return same
 }

--- a/std/cryptography/tls13_hs/module.ae
+++ b/std/cryptography/tls13_hs/module.ae
@@ -38,12 +38,13 @@ extern string_char_at_n(str: string, known_length: int, index: int) -> int
 exports (
     client_hello, client_hello_sni, parse_server_hello,
     ShParsed,
-    TLS_CHACHA20_POLY1305_SHA256, TLS_AES_128_GCM_SHA256,
+    TLS_CHACHA20_POLY1305_SHA256, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
     GROUP_X25519
 )
 
 // Cipher suites (RFC 8446 appendix B.4).
 const TLS_AES_128_GCM_SHA256       = 0x1301
+const TLS_AES_256_GCM_SHA384       = 0x1302
 const TLS_CHACHA20_POLY1305_SHA256 = 0x1303
 
 // Named groups (RFC 8446 §4.2.7).
@@ -99,6 +100,17 @@ fn put_bytes(b: ptr, off: int, src: ptr, src_len: int) -> int {
     return off + src_len
 }
 
+// Append the ASCII bytes of a string; returns the new offset.
+fn put_ascii(b: ptr, off: int, s: string) -> int {
+    n = string_length(s)
+    i = 0
+    while i < n {
+        bytes.set(b, off + i, string_char_at_n(s, n, i) & 0xFF)
+        i = i + 1
+    }
+    return off + n
+}
+
 // ---- readers ----
 
 fn get8(b: ptr, off: int) -> int {
@@ -140,10 +152,11 @@ client_hello_sni(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, ho
     off = put8(buf, off, sid_len)
     off = put_bytes(buf, off, session_id, sid_len)
 
-    // cipher_suites<2..2^16-2>: offer ChaCha20-Poly1305 then AES-128-GCM
-    off = put16(buf, off, 4)                        // 2 suites * 2 bytes
+    // cipher_suites<2..2^16-2>: ChaCha20-Poly1305, AES-128-GCM, AES-256-GCM
+    off = put16(buf, off, 6)                        // 3 suites * 2 bytes
     off = put16(buf, off, TLS_CHACHA20_POLY1305_SHA256)
     off = put16(buf, off, TLS_AES_128_GCM_SHA256)
+    off = put16(buf, off, TLS_AES_256_GCM_SHA384)
 
     // legacy_compression_methods<1..2^8-1> = { 0 (null) }
     off = put8(buf, off, 1)
@@ -189,6 +202,16 @@ client_hello_sni(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, ho
     off = put16(buf, off, SIG_ECDSA_P256_SHA256)
     off = put16(buf, off, SIG_RSA_PSS_RSAE_SHA256)
     off = put16(buf, off, SIG_ED25519)
+
+    // application_layer_protocol_negotiation (16): offer "http/1.1"
+    // (RFC 7301). Many CDNs reset a bare connection that omits ALPN or that
+    // doesn't offer a protocol they serve; http/1.1 is the safe common one.
+    // ext body = ProtocolNameList<2> ; entry = len<1> || name.
+    off = put16(buf, off, 16)         // extension_type = ALPN
+    off = put16(buf, off, 11)         // ext body len = 2 + 1 + 8
+    off = put16(buf, off, 9)          // ProtocolNameList length = 1 + 8
+    off = put8(buf, off, 8)           // ProtocolName length
+    off = put_ascii(buf, off, "http/1.1")
 
     // key_share (51): one x25519 KeyShareEntry { group, key<len> }
     off = put16(buf, off, 51)

--- a/std/cryptography/tls13_record/module.ae
+++ b/std/cryptography/tls13_record/module.ae
@@ -48,7 +48,7 @@ exports (
     RecordCtx, OpenedRecord,
     CONTENT_HANDSHAKE, CONTENT_APPLICATION_DATA, CONTENT_ALERT,
     TAG_LEN, RECORD_HEADER_LEN,
-    AEAD_CHACHA20_POLY1305, AEAD_AES_128_GCM
+    AEAD_CHACHA20_POLY1305, AEAD_AES_128_GCM, AEAD_AES_256_GCM
 )
 
 // Which AEAD a record context uses. TLS 1.3's two mainstream suites:
@@ -57,6 +57,7 @@ exports (
 // Both use a 12-byte nonce and a 16-byte tag, so only the cipher differs.
 const AEAD_CHACHA20_POLY1305 = 0
 const AEAD_AES_128_GCM       = 1
+const AEAD_AES_256_GCM       = 2
 
 const CONTENT_ALERT            = 21
 const CONTENT_HANDSHAKE        = 22
@@ -101,7 +102,7 @@ new_aead(aead_id: int, key: ptr, key_len: int, iv12: ptr) -> ptr {
     ctx.seq = 0
     ctx.aead = aead_id
     ctx.aes_ctx = null
-    if aead_id == AEAD_AES_128_GCM {
+    if aead_id == AEAD_AES_128_GCM || aead_id == AEAD_AES_256_GCM {
         ctx.aes_ctx = aes.new_encryptor(k, key_len)
     }
     return ctx as ptr
@@ -171,7 +172,7 @@ seal_record(ctx: ptr, content_type: int, plaintext: ptr, pt_len: int) -> ptr {
     nonce = nonce_for(c.iv, c.seq)
 
     enc = null
-    if c.aead == AEAD_AES_128_GCM {
+    if c.aead == AEAD_AES_128_GCM || c.aead == AEAD_AES_256_GCM {
         enc = aes.gcm_seal(c.aes_ctx, nonce, aad, RECORD_HEADER_LEN, inner, inner_len)
     } else {
         enc = chacha20poly1305.aead_seal(c.key, nonce, aad, RECORD_HEADER_LEN, inner, inner_len)
@@ -206,7 +207,7 @@ struct OpenedRecord {
 // Dispatch AEAD-Open to the negotiated cipher. Returns (inner_plaintext, "")
 // or (null, err) exactly like the underlying aead_open primitives.
 fn aead_open_dispatch(c: *RecordCtx, nonce: ptr, aad: ptr, ctbuf: ptr, ct_len: int) -> (ptr, string) {
-    if c.aead == AEAD_AES_128_GCM {
+    if c.aead == AEAD_AES_128_GCM || c.aead == AEAD_AES_256_GCM {
         return aes.gcm_open(c.aes_ctx, nonce, aad, RECORD_HEADER_LEN, ctbuf, ct_len)
     }
     return chacha20poly1305.aead_open(c.key, nonce, aad, RECORD_HEADER_LEN, ctbuf, ct_len)

--- a/tests/integration/crypto_tls13_hs/test_tls13_hs.ae
+++ b/tests/integration/crypto_tls13_hs/test_tls13_hs.ae
@@ -10,6 +10,29 @@ import std.string
 import std.io
 
 extern exit(code: int)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+extern string_length(s: string) -> int
+
+fn hexval(h: int) -> int {
+    if h >= 48 && h <= 57 { return h - 48 }
+    if h >= 97 && h <= 102 { return h - 87 }
+    if h >= 65 && h <= 70 { return h - 55 }
+    return 0
+}
+fn from_hex(s: string) -> ptr {
+    sl = string_length(s)
+    n = sl / 2
+    b = bytes.new(n)
+    if n > 0 { bytes.set(b, n - 1, 0) }
+    i = 0
+    while i < n {
+        b_hi = hexval(string_char_at_n(s, sl, i * 2))
+        b_lo = hexval(string_char_at_n(s, sl, i * 2 + 1))
+        bytes.set(b, i, (b_hi << 4) | b_lo)
+        i = i + 1
+    }
+    return b
+}
 
 fn g8(b: ptr, off: int) -> int { return bytes.get(b, off) & 0xFF }
 fn g16(b: ptr, off: int) -> int { return ((bytes.get(b, off) & 0xFF) << 8) | (bytes.get(b, off + 1) & 0xFF) }
@@ -157,6 +180,38 @@ main() {
     } else {
         println("ok   SH rejects malformed (${berr})")
     }
+
+    // --- HelloRetryRequest detection (RFC 8446 §4.1.3 special random) ---
+    // A minimal HRR: version 0303 + the SHA-256("HelloRetryRequest") random +
+    // empty sid + cipher 1301 + comp 00 + exts{ supported_versions, key_share=
+    // secp256r1(0x0017) }.
+    hrr = from_hex("020000340303cf21ad74e59a6111be1dfa3a06b44e8c845c7630048b15d5a00d203a15d5b26e00130100000c002b00020304003300020017")
+    hp = tls13_hs.ShParsed { version: 0, cipher_suite: 0, group: 0, key_share: null, key_share_len: 0, is_hello_retry: 0 }
+    herr = tls13_hs.parse_server_hello(hrr, bytes.length(hrr), &hp)
+    if string.equals(herr, "") == 1 {
+        if hp.is_hello_retry == 1 {
+            if hp.group == tls13_hs.GROUP_SECP256R1 {
+                println("ok   HelloRetryRequest detected, group = secp256r1")
+            } else { println("FAIL HRR group ${hp.group}"); total_ok = 0 }
+        } else { println("FAIL HRR not detected as retry"); total_ok = 0 }
+    } else { println("FAIL HRR parse: ${herr}"); total_ok = 0 }
+    if hp.key_share != null { bytes.free(hp.key_share) }
+    bytes.free(hrr)
+
+    // --- dual-keyshare ClientHello offers both x25519 and secp256r1 ---
+    // A secp256r1 65-byte uncompressed point placeholder (0x04 || 64 bytes).
+    p256pt = bytes.new(65)
+    p256pt_i = 0
+    while p256pt_i < 65 { bytes.set(p256pt, p256pt_i, 0x11); p256pt_i = p256pt_i + 1 }
+    bytes.set(p256pt, 0, 0x04)
+    dual = tls13_hs.client_hello_full(random, sid, 32, tls13_hs.GROUP_X25519, pub, 32, tls13_hs.GROUP_SECP256R1, p256pt, 65, "example.com")
+    // The CH must be a valid handshake message and larger than a single-share
+    // CH (it carries an extra 4 + 65 = 69-byte key_share entry + SNI).
+    if g8(dual, 0) == 1 {
+        println("ok   dual-keyshare CH builds (msg_type = client_hello, ${bytes.length(dual)} bytes)")
+    } else { println("FAIL dual CH msg_type ${g8(dual, 0)}"); total_ok = 0 }
+    bytes.free(p256pt)
+    bytes.free(dual)
 
     bytes.free(random)
     bytes.free(sid)

--- a/tests/integration/crypto_tls13_record/test_tls13_record.ae
+++ b/tests/integration/crypto_tls13_record/test_tls13_record.ae
@@ -183,6 +183,39 @@ main() {
     } else {
         println("FAIL AES-128-GCM record round-trip"); total_ok = 0
     }
+
+    // --- AES-256-GCM AEAD selection round-trips (32-byte key) ---
+    a2key = bytes.new(32)
+    a2i = 0
+    while a2i < 32 { bytes.set(a2key, a2i, (a2i * 9 + 1) & 0xFF); a2i = a2i + 1 }
+    a2iv = bytes.new(12)
+    a2j = 0
+    while a2j < 12 { bytes.set(a2iv, a2j, (a2j * 5 + 2) & 0xFF); a2j = a2j + 1 }
+    a2send = tls13_record.new_aead(tls13_record.AEAD_AES_256_GCM, a2key, 32, a2iv)
+    a2recv = tls13_record.new_aead(tls13_record.AEAD_AES_256_GCM, a2key, 32, a2iv)
+    a2msg = bytes.new(40)
+    a2m = 0
+    while a2m < 40 { bytes.set(a2msg, a2m, 65 + (a2m % 26)); a2m = a2m + 1 }
+    a2rec = tls13_record.seal_record(a2send, tls13_record.CONTENT_APPLICATION_DATA, a2msg, 40)
+    a2o = tls13_record.OpenedRecord { content_type: 0, plaintext: null, plaintext_len: 0 }
+    a2err = tls13_record.open_record(a2recv, a2rec, bytes.length(a2rec), &a2o)
+    a2ok = 1
+    if string.equals(a2err, "") != 1 { a2ok = 0 }
+    else {
+        if a2o.plaintext_len != 40 { a2ok = 0 }
+        if a2ok == 1 {
+            if to_hex(a2o.plaintext, 40) != to_hex(a2msg, 40) { a2ok = 0 }
+        }
+    }
+    if a2ok == 1 {
+        println("ok   AES-256-GCM record round-trips (32-byte key)")
+    } else {
+        println("FAIL AES-256-GCM record round-trip"); total_ok = 0
+    }
+    if a2o.plaintext != null { bytes.free(a2o.plaintext) }
+    tls13_record.free_ctx(a2send)
+    tls13_record.free_ctx(a2recv)
+    bytes.free(a2key); bytes.free(a2iv); bytes.free(a2msg); bytes.free(a2rec)
     if ao.plaintext != null { bytes.free(ao.plaintext) }
     tls13_record.free_ctx(asend)
     tls13_record.free_ctx(arecv)


### PR DESCRIPTION
Broadens the pure-Aether TLS 1.3 client so `connect()` works against essentially any mainstream HTTPS server. Verified end-to-end against a spread of real sites, no OpenSSL anywhere.

## What's new

**ALPN** — the ClientHello offers `application_layer_protocol_negotiation` = http/1.1 (RFC 7301). Protocol hygiene; needed by servers/CDNs that reset bare connections.

**AES-256-GCM-SHA384** (0x1302) — the third mainstream suite, *preferred* by big sites (Google, example.com). The key schedule was already hash-agnostic in tls13_ks/tls13_kdf; this threads the negotiated hash (SHA-256 **or** SHA-384) and its length through the client — transcript hash, handshake + application key derivation, and both Finished MACs. `suite_params` now returns `(aead, key_len, hash_algo, hash_len)`; tls13_record gains `AEAD_AES_256_GCM`.

**secp256r1 key exchange + HelloRetryRequest** — for servers that require P-256 ECDHE:
- The ClientHello now offers **both** x25519 and secp256r1 in supported_groups **and pre-shares a key_share for each**, so a P-256-preferring server completes in one round trip (no HRR). connect() keeps both ephemerals and picks the one matching the server's chosen group.
- HRR is handled as a fallback (RFC 8446 §4.1.3/§4.4.1): detect the `SHA-256("HelloRetryRequest")` sentinel random, rewrite the transcript to the synthetic `message_hash(CH1)`, resend a single-share CH for the requested group, and skip the middlebox-compat ChangeCipherSpec before the real ServerHello.

## Coverage now

| Layer | Supported |
|-------|-----------|
| Key exchange | x25519, secp256r1 (both pre-offered; HRR fallback) |
| Record AEAD | ChaCha20-Poly1305, AES-128-GCM, AES-256-GCM-SHA384 |
| Key schedule hash | SHA-256, SHA-384 |
| Server CertificateVerify | ECDSA-P256, RSA-PSS-rsae-SHA256 |
| Chain signatures | RSA-PKCS#1-SHA256, ECDSA-P256-SHA256, ECDSA-P384-SHA384 |

## End-to-end verification (real sites + s_server)

- **github.com** (ChaCha20, x25519) → HANDSHAKE OK + HTTP/1.1 200
- **www.google.com** (AES-256-GCM-SHA384, x25519) → HANDSHAKE OK + HTTP/1.1 200
- **example.com** (AES-256-GCM-SHA384) → handshake authenticated
- **openssl s_server -groups P-256** → HANDSHAKE OK + decrypted HTTP 200 (P-256 ECDHE path)
- **openssl s_server -ciphersuites TLS_AES_256_GCM_SHA384** → full end-to-end (from the prior PR)

## Tests

AES-256-GCM validated against a NIST vector (ciphertext) + a record round-trip in the tls13_record regression. The tls13_hs regression gains HelloRetryRequest-detection (correct RFC sentinel + secp256r1 group) and dual-keyshare-CH assertions. All four TLS suites (hs / client / record / cert) pass.

## Remaining limits

No resumption/0-RTT/mTLS; no revocation (CRL/OCSP). (Cloudflare specifically still resets bare HTTP/1.1 connections lacking ALPN `h2` — offering http/1.1 isn't enough for it; that's an HTTP/2 requirement, out of scope for TLS.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)