### PR TITLE
docs(readme): prebuilt-binary install path + drop stale version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,25 @@ See [Performance Benchmarks](docs/performance-benchmarks.md) for methodology and
 
 ### Install
 
-**Linux / macOS, remote one-liner (no clone):**
+**Linux / macOS / FreeBSD, prebuilt binary (no toolchain, no build):**
+
+Every [release](https://github.com/aether-lang-org/aether/releases/latest) ships a ready-to-run tarball (`ae` + `aetherc` + stdlib) named `aether-<version>-<platform>.tar.gz`, where `<platform>` is one of `linux-x86_64`, `macos-arm64`, `macos-x86_64`, `freebsd-x86_64`. Grab the URL for your platform from the [latest release](https://github.com/aether-lang-org/aether/releases/latest), then extract and add its `bin/` to your `PATH`:
+
+```bash
+# Example (substitute the current version + your platform from the Releases page):
+VER=0.458.0; PLATFORM=linux-x86_64
+curl -fsSL "https://github.com/aether-lang-org/aether/releases/download/v${VER}/aether-${VER}-${PLATFORM}.tar.gz" | tar xz -C ~/.local
+export PATH="$HOME/.local/bin:$PATH"     # add to ~/.bashrc / ~/.zshrc to persist
+ae version
+```
+
+**Linux / macOS, build from source (remote one-liner, no clone):**
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/aether-lang-org/aether/main/get.sh | sh
 ```
 
-Fetches a pinned source tarball, builds the toolchain (Aether compiles to C, so the only prerequisites are a C compiler + GNU make, no tests run), and installs to `~/.local` (sudo-free). Pin a version with `AETHER_REF=v0.185.0`, or change the prefix with `PREFIX=/usr/local` (system-wide; needs sudo). Add `~/.local/bin` to your `PATH` if it isn't already.
+Fetches a pinned source tarball, builds the toolchain (Aether compiles to C, so the only prerequisites are a C compiler + GNU make, no tests run), and installs to `~/.local` (sudo-free). Pin a version with `AETHER_REF=<tag>` (see the [releases page](https://github.com/aether-lang-org/aether/releases) for tags), or change the prefix with `PREFIX=/usr/local` (system-wide; needs sudo). Add `~/.local/bin` to your `PATH` if it isn't already.
 
 **Linux / macOS, full clone install** (editor extension, `ae version` management, shell-PATH setup, `~/.aether` layout):
 
@@ -130,11 +142,13 @@ GCC is downloaded automatically the first time you run a program (~80 MB, one-ti
 **All platforms, install, upgrade, and switch versions:**
 
 ```bash
+ae version list              # see all available releases (newest first)
 ae upgrade                   # install the latest release and switch to it
-ae install v0.25.0           # install a specific release (latest if omitted)
-ae use v0.25.0               # switch to an installed version
-ae version list              # see all available releases
+ae install                   # install the latest release (or `ae install <tag>` for a specific one)
+ae use <tag>                 # switch to an already-installed version
 ```
+
+Run `ae version list` (or check the [latest release](https://github.com/aether-lang-org/aether/releases/latest)) to find the current tag; there's no need to hard-code one.
 
 (The longer `ae version install <v>` / `ae version use <v>` forms still
 work and are equivalent to `ae install` / `ae use`.)


### PR DESCRIPTION
Two Quick Start accuracy fixes, both verified against the actual v0.458.0 release.

## 1. Add the prebuilt-binary install path (Linux / macOS / FreeBSD)

Quick Start only offered **build-from-source** paths for Linux/macOS (`get.sh`, `clone + install.sh`) — both need a C compiler + make. But every release ships a **ready-to-run tarball** (`bin/ae` + `aetherc` + `lib/` + stdlib), which is the fastest path for someone who just wants to *use* Aether — and the one the **Windows** instructions already document. This asymmetry meant Linux/macOS users were told to build from source unnecessarily.

Adds a "prebuilt binary (no toolchain, no build)" option, symmetric with Windows, covering `linux-x86_64` / `macos-arm64` / `macos-x86_64` / `freebsd-x86_64`. The download URL and extraction layout are **verified**:
- `https://github.com/.../releases/download/v0.458.0/aether-0.458.0-linux-x86_64.tar.gz` → HTTP 200
- tarball extracts `bin/ae` at top level, so `tar xz -C ~/.local` yields `~/.local/bin/ae` and the `PATH` line is correct.

(An earlier draft used `releases/latest/download/aether-linux-x86_64.tar.gz` — that 404s, because the assets are version-named; the committed version uses the working versioned URL with a `VER`/`PLATFORM` substitution and points to the Releases page for the current tag.)

## 2. Drop stale hardcoded version numbers

`v0.185.0` (AETHER_REF example) and `v0.25.0` (`ae install`/`ae use` examples) are ancient (current is 0.458.0) and read as abandoned. Replaced with:
- `AETHER_REF=<tag>` + a link to the releases page,
- a version-management block that teaches `ae version list` / the latest-release link to find the current tag rather than naming one,
- `ae install` with no arg = latest (confirmed in `ae.c`).

No hardcoded `v0.NN` remains in the README.

## Scope

README only. The `ae` subcommands, `get.sh`, and `install.sh` were all re-verified to exist and match their descriptions; `docs/bootstrap-from-source.md` was checked and is still needed (it serves the from-HEAD/downstream-consumer case Quick Start deliberately doesn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)