### PR TITLE
fix(codegen): reclaim nested-function tuple-destructure error strings (#1311)

### DIFF
--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1081,6 +1081,9 @@ int is_heap_string_expr(CodeGenerator* gen, ASTNode* expr) {
  * Skips nested function / closure scopes (their assignments are in
  * a different lexical frame). Stops at the first heap-source
  * assignment to `var_name`. */
+static int function_def_returns_heap_at(CodeGenerator* gen, ASTNode* fn_def,
+                                         int position);
+
 int body_assigns_var_from_heap(CodeGenerator* gen, ASTNode* node,
                                const char* var_name) {
     if (!node || !var_name) return 0;
@@ -1094,6 +1097,42 @@ int body_assigns_var_from_heap(CodeGenerator* gen, ASTNode* node,
         node->child_count > 0 && node->children[0] &&
         is_heap_string_expr(gen, node->children[0])) {
         return 1;
+    }
+    /* `var_name` bound by a tuple destructure — `a, err = g(...)`. It is heap
+     * iff g's tuple position for `var_name` is heap-classified. Without this,
+     * an error slot fed from a callee's heap tracked-empty (e.g. asn1.read_oid
+     * returning `strbuilder.finish(sb), err` where `err` came from
+     * `read_tagged`'s heap `""`) is seen as non-heap, so the destructure site
+     * sets `_heap_<err> = 0` and the byte leaks at every nested read_* call
+     * (issue #1311). Children layout: last is the RHS call, the rest are the
+     * target var nodes at their tuple positions. */
+    if (node->type == AST_TUPLE_DESTRUCTURE && node->child_count >= 2) {
+        int vc = node->child_count - 1;
+        ASTNode* rhs = node->children[node->child_count - 1];
+        for (int j = 0; j < vc; j++) {
+            ASTNode* tgt = node->children[j];
+            if (tgt && tgt->value && strcmp(tgt->value, var_name) == 0) {
+                if (rhs && rhs->type == AST_FUNCTION_CALL && rhs->value &&
+                    gen && gen->program) {
+                    char fn_norm[256];
+                    const char* fn = codegen_normalise_callee(rhs->value,
+                                                              fn_norm,
+                                                              sizeof(fn_norm));
+                    ASTNode* callee = find_function_definition_by_name(gen->program, fn);
+                    if (callee) {
+                        if (function_def_returns_heap_at(gen, callee, j)) return 1;
+                    } else {
+                        ASTNode* ext = find_extern_declaration_by_name(gen->program, fn);
+                        if (ext && ext->node_type &&
+                            ext->node_type->tuple_heap_flags &&
+                            j < ext->node_type->tuple_count &&
+                            ext->node_type->tuple_heap_flags[j]) {
+                            return 1;
+                        }
+                    }
+                }
+            }
+        }
     }
     for (int i = 0; i < node->child_count; i++) {
         if (body_assigns_var_from_heap(gen, node->children[i], var_name)) return 1;

--- a/tests/leaks_known.txt
+++ b/tests/leaks_known.txt
@@ -19,9 +19,9 @@ test_cryptography_hmac_md4_md5 122
 # test_rsa_pkcs1 uses std.cryptography.random_bytes (OpenSSL RAND) for
 # PKCS#1 v1.5 type-2 padding, so it inherits the same OPENSSL_cleanup
 # atexit false-positive as the entry above (memory returned to the OS at
-# exit; leaks(1) --atExit samples before atexit handlers run). The small
-# remainder is the Aether heap-string-tracker's empty-string ("") quirk on
-# cross-module (ptr, string) success returns — 1 byte each, exit-only,
-# documented in feedback_aether_heap_string_no_manual_free; tracked for a
-# compiler fix. Cap covers both with no headroom for a real regression.
+# exit; leaks(1) --atExit samples before atexit handlers run). The
+# heap-string-tracker's empty-string ("") quirk on cross-module (ptr, string)
+# success returns (issue #1311, 1 byte per nested asn1 read_*) is now FIXED in
+# codegen (nested tuple-destructure error slots are heap-classified), so the
+# remaining count is the OpenSSL atexit artifact only. Cap kept as a ceiling.
 test_rsa_pkcs1 130


### PR DESCRIPTION
Fixes #1311 — the heap-tracker leaking a function's success-path empty error string when the `(value, error)` tuple is destructured **inside a non-main function**. That's the entire std `(ptr, string)` convention every `std.cryptography.asn1` consumer (`pem`, `rsa`, `tls13_cert`, …) is built on, so a certificate parse leaked dozens of unreclaimable 1-byte blocks.

## Root cause

`function_def_returns_heap_at` OR-folds each tuple-return position's heap-ness across a function's return sites. For a bare-identifier return like `return strbuilder.finish(sb), err`, position 1 (`err`) is heap iff `body_assigns_var_from_heap` says so. But that helper only recognised a var made heap via a plain `AST_VARIABLE_DECLARATION` — it was **blind to a var bound by a tuple destructure** (`content, err = read_tagged(r, 0x06)`). So `err` (which holds the heap tracked-empty `""` that `read_tagged`→`read_tlv` malloc'd) classified non-heap, the destructure site set `_heap_<err> = 0`, and the byte was never freed at scope exit.

## Fix

Teach `body_assigns_var_from_heap` the `AST_TUPLE_DESTRUCTURE` shape: trace the target var to its tuple position and consult the callee's `function_def_returns_heap_at` (or an extern's `tuple_heap_flags`) for that position.

**Safe by construction:** the change only ever *promotes* a position to heap. `emit_tuple_return_position` already malloc-duplicates a literal returned in a heap-classified position, and the existing passthrough veto still guards `return g(...)` shapes — so there's no double-free or free-of-literal risk. Over-classifying costs at most one malloc-dup of a literal.

## Verification

- The issue's exact repro: **1 byte lost → "All heap blocks were freed."**
- A 50-nested-read stress (`read_oid` × 50 in a helper): **50 bytes → 0.**
- `make test` (runtime C): **235 passed, 0 failed.**
- `make examples`: **88 passed, 0 failed.**
- `make test-ae`: 916 pass. The 8 failures are all pre-existing and unrelated to heap tracking — the untracked `issue1046` WIP (unimplemented sum-type syntax; fails identically on clean `main`), the known `#1252` format-diagnostic issue, and flaky port-binding proxy/h2 shell tests ("Failed to bind socket").

`tests/leaks_known.txt`: updated `test_rsa_pkcs1`'s note — its residual is now the OpenSSL atexit false-positive only (the #1311 quirk it documented is fixed).

## Impact

Every `std.cryptography.asn1` consumer becomes leak-clean for the tracked-empty pattern — the residual noted across the TLS 1.3 work (cert validation, resumption, alerts/0-RTT/OCSP) was exactly this, and is now gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)