### PR TITLE
feat(tls13): mutual TLS — decline + present a client certificate

### DIFF
--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -50,7 +50,8 @@ extern malloc(size: int) -> ptr
 extern free(p: ptr)
 
 exports(
-    cert_verify_content, verify_cert_verify, verify_cert_verify_rsa_pss, parse_certificate, free_leaf,
+    cert_verify_content, client_cert_verify_content, sign_client_cert_verify_ecdsa_p256,
+    verify_cert_verify, verify_cert_verify_rsa_pss, parse_certificate, free_leaf,
     LeafCert,
     leaf_not_before, leaf_not_before_len, leaf_not_after, leaf_not_after_len,
     leaf_dns_count, leaf_dns_name,
@@ -87,23 +88,65 @@ extern string_char_at_n(str: string, known_length: int, index: int) -> int
 //   64 bytes of 0x20  ||  context-string  ||  0x00  ||  transcript_hash
 // Returns the content buffer (caller frees) and its length.
 cert_verify_content(transcript_hash: ptr, th_len: int) -> (ptr, int) {
-    ctx_len = string.length("TLS 1.3, server CertificateVerify")
+    return cert_verify_content_ctx("TLS 1.3, server CertificateVerify", transcript_hash, th_len)
+}
+
+// The CLIENT CertificateVerify content (mTLS): identical shape but the context
+// string is "TLS 1.3, client CertificateVerify" (RFC 8446 §4.4.3).
+client_cert_verify_content(transcript_hash: ptr, th_len: int) -> (ptr, int) {
+    return cert_verify_content_ctx("TLS 1.3, client CertificateVerify", transcript_hash, th_len)
+}
+
+// Sign a client CertificateVerify with an ECDSA-P256 client key (mTLS). Builds
+// the §4.4.3 client content, SHA-256-hashes it, ECDSA-signs with `priv` (32-byte
+// scalar) and per-message nonce `k` (32 bytes), and returns the DER
+// ECDSA-Sig-Value SEQUENCE { r INTEGER, s INTEGER } (caller frees). This is the
+// signature that goes in the client CertificateVerify handshake message under
+// SignatureScheme ecdsa_secp256r1_sha256 (0x0403).
+sign_client_cert_verify_ecdsa_p256(priv: ptr, transcript_hash: ptr, th_len: int, k: ptr) -> ptr {
+    content, clen = client_cert_verify_content(transcript_hash, th_len)
+    digest = sha256_of_bytes(content, clen)
+    r32, s32 = p256.ecdsa_sign(priv, digest, k)
+    // DER-encode as SEQUENCE { INTEGER r, INTEGER s }.
+    rbn = bignum.from_bytes_unsigned(r32, 32)
+    sbn = bignum.from_bytes_unsigned(s32, 32)
+    rder = asn1.encode_integer(rbn)
+    sder = asn1.encode_integer(sbn)
+    body = bytes.new(bytes.length(rder) + bytes.length(sder))
+    if bytes.length(body) > 0 { bytes.set(body, bytes.length(body) - 1, 0) }
+    bytes.copy_from_bytes(body, 0, rder, 0, bytes.length(rder))
+    bytes.copy_from_bytes(body, bytes.length(rder), sder, 0, bytes.length(sder))
+    // NOTE: asn1.encode_sequence -> wrap_tlv CONSUMES (frees) `body`, so we must
+    // NOT free it again here (double-free). rder/sder are our own copies.
+    sig = asn1.encode_sequence(body)
+    bytes.free(content); bytes.free(digest)
+    bytes.free(r32); bytes.free(s32)
+    bignum.free(rbn); bignum.free(sbn)
+    bytes.free(rder); bytes.free(sder)
+    return sig
+}
+
+// Generic §4.4.3 signed content with an explicit context string:
+//   64 bytes of 0x20 || ctx_str || 0x00 || transcript_hash
+fn cert_verify_content_ctx(ctx_str: string, transcript_hash: ptr, th_len: int) -> (ptr, int) {
+    ctx_len = string.length(ctx_str)
     total = 64 + ctx_len + 1 + th_len
     out = bytes.new(total)
     bytes.set(out, total - 1, 0) // force full zero-fill
-
-    // 64 spaces (0x20)
     i = 0
     while i < 64 {
         bytes.set(out, i, 0x20)
         i = i + 1
     }
     off = 64
-    off = server_context(out, off)
-    // separator 0x00
+    ci = 0
+    while ci < ctx_len {
+        bytes.set(out, off + ci, string_char_at_n(ctx_str, ctx_len, ci) & 0xFF)
+        ci = ci + 1
+    }
+    off = off + ctx_len
     bytes.set(out, off, 0)
     off = off + 1
-    // transcript hash
     j = 0
     while j < th_len {
         bytes.set(out, off + j, bytes.get(transcript_hash, j) & 0xFF)

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -16,8 +16,8 @@
 //   - server CertificateVerify: ECDSA-P256 or RSA-PSS-rsae-SHA256
 //   - full chain validation (see SERVER AUTHENTICATION below)
 //   - session resumption (PSK) + 0-RTT early data; TLS alerts; OCSP-staple
-//     revocation check; mTLS: sends an empty Certificate on CertificateRequest
-//     (correct decline; presenting a client cert is a follow-up)
+//     revocation check; mTLS via connect_mtls (presents an ECDSA-P256 client
+//     cert + CertificateVerify) or an empty-cert decline on connect()
 //
 // SERVER AUTHENTICATION. connect() fails closed unless ALL of the following
 // hold, in order (RFC 8446 §4.4.3 + RFC 5280/6125):
@@ -60,8 +60,8 @@
 // auth failure (not a silent RST); close_conn sends close_notify; conn_recv
 // surfaces inbound alerts as typed errors. REVOCATION: a stapled OCSP response
 // (RFC 6960) saying revoked fails the handshake closed (status parsed, not
-// responder-signature-verified). Remaining limits: mTLS declines (empty Certificate) but does not yet PRESENT a
-// client cert + CertificateVerify; OCSP is
+// responder-signature-verified). Remaining limits: mTLS presents an ECDSA-P256 client cert only (no RSA/Ed25519
+// client key yet, single-cert chain); OCSP is
 // stapling-only (no CRL / no OCSP fetch); no responder-sig verification.
 //
 // This module separates the PURE state machine (transcript, key derivation,
@@ -109,7 +109,7 @@ exports(
     finished_key, finished_verify_data,
     hs_msg_type, hs_msg_len, hs_msg_total,
     HS_ENCRYPTED_EXTENSIONS, HS_CERTIFICATE, HS_CERTIFICATE_VERIFY, HS_FINISHED,
-    connect, connect_pq, connect_resume, connect_resume_0rtt, close_conn, conn_send, conn_recv,
+    connect, connect_mtls, connect_pq, connect_resume, connect_resume_0rtt, close_conn, conn_send, conn_recv,
     conn_get_ticket, free_ticket, SessionTicket,
     ticket_len, ticket_nonce_len, ticket_lifetime, ticket_max_early_data,
     verify_flight_auth
@@ -609,6 +609,20 @@ fn ecdhe_shared(group: int, priv: ptr, server_ks: ptr, server_ks_len: int) -> (p
 // and chain to a trusted anchor — failing closed on any of them — before the
 // Finished MACs confirm both sides agree on keys.
 connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
+    return connect_ex(host, port, x25519_priv, null, 0, null)
+}
+
+// Mutual-TLS connect: like connect(), but when the server sends a
+// CertificateRequest the client presents `client_cert` (leaf DER) + a
+// CertificateVerify signed with `client_key` (a 32-byte ECDSA-P256 scalar;
+// SignatureScheme ecdsa_secp256r1_sha256). All the same server authentication
+// applies. If the server does NOT request a client cert, behaves exactly like
+// connect() (the cert/key are simply unused).
+connect_mtls(host: string, port: int, x25519_priv: ptr, client_cert: ptr, client_cert_len: int, client_key: ptr) -> (ptr, string) {
+    return connect_ex(host, port, x25519_priv, client_cert, client_cert_len, client_key)
+}
+
+fn connect_ex(host: string, port: int, x25519_priv: ptr, client_cert: ptr, client_cert_len: int, client_key: ptr) -> (ptr, string) {
     sock = net.tcp_connect_raw(host, port)
     if sock == null { return null, "connect failed" }
     // Initial key exchange group is x25519, using the caller's private scalar.
@@ -754,8 +768,7 @@ connect(host: string, port: int, x25519_priv: ptr) -> (ptr, string) {
 
     // Derive keys from the (classical) 32-byte ECDHE secret and run the shared
     // post-ServerHello handshake tail (flight read, auth, Finished).
-    result, result_err = run_handshake_tail(sock, rio, tr, host, shared, 32,
-        parsed.cipher_suite)
+    result, result_err = run_handshake_tail(sock, rio, tr, host, shared, 32, parsed.cipher_suite, client_cert, client_cert_len, client_key)
 
     bytes.free(shared)
     if parsed.key_share != null { bytes.free(parsed.key_share) }
@@ -869,7 +882,7 @@ connect_pq(host: string, port: int) -> (ptr, string) {
             result_err = sherr2
             if string.equals(sherr2, "") == 1 { result_err = "PQ key exchange failed" }
         } else {
-            result, result_err = run_handshake_tail(sock, rio, tr, host, shared, shared_len, parsed.cipher_suite)
+            result, result_err = run_handshake_tail(sock, rio, tr, host, shared, shared_len, parsed.cipher_suite, null, 0, null)
             bytes.free(shared)
         }
     }
@@ -894,7 +907,8 @@ connect_pq(host: string, port: int) -> (ptr, string) {
 // Returns (conn, "") or (null, err). Does NOT free `shared`, `tr`, sh/shrec,
 // or the ClientHello — the caller does.
 fn run_handshake_tail(sock: ptr, rio: ptr, tr: ptr, host: string,
-    shared: ptr, shared_len: int, cipher_suite: int) -> (ptr, string) {
+    shared: ptr, shared_len: int, cipher_suite: int,
+    client_cert: ptr, client_cert_len: int, client_key: ptr) -> (ptr, string) {
     rec_aead, rec_key_len, hash_algo, hash_len, suite_err = suite_params(cipher_suite)
     if string.equals(suite_err, "") != 1 { return null, suite_err }
 
@@ -975,19 +989,40 @@ fn run_handshake_tail(sock: ptr, rio: ptr, tr: ptr, host: string,
                 s_ap = tls13_ks.traffic_secret(hash_algo, ms, "s ap traffic", th_sf, hash_len)
 
                 // Mutual TLS: if the server sent a CertificateRequest, the client
-                // MUST send its own Certificate before Finished (RFC 8446 §4.4.2).
-                // With no client cert configured we send an EMPTY Certificate (the
-                // correct decline). It is folded into the transcript so the client
-                // Finished MAC (computed next, over th_cvd) covers it — but AFTER
-                // th_sf, so it does not disturb the app-traffic keys.
-                // (Presenting a real client cert + CertificateVerify is next.)
+                // MUST send its own Certificate before Finished (RFC 8446 §4.4.2),
+                // folded into the transcript AFTER th_sf (so it doesn't disturb
+                // the app-traffic keys). Two cases:
+                //   - client_cert + client_key given: present the cert, then a
+                //     CertificateVerify signing the transcript through the client
+                //     Certificate with the client key (§4.4.3, "client" context).
+                //   - otherwise: send an EMPTY Certificate (the correct decline).
                 if flight_has_cert_request(fl, fllen) == 1 {
-                    ccert = build_empty_certificate()
-                    ccert_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, ccert, bytes.length(ccert))
-                    ccert_s = bytes.to_string(ccert_rec, bytes.length(ccert_rec))
-                    net.tcp_send_n_raw(sock, ccert_s, bytes.length(ccert_rec))
-                    transcript_add(tr, ccert, bytes.length(ccert))
-                    bytes.free(ccert); bytes.free(ccert_rec)
+                    if client_cert != null && client_key != null {
+                        ccert = build_client_certificate(client_cert, client_cert_len)
+                        ccert_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, ccert, bytes.length(ccert))
+                        ccert_s = bytes.to_string(ccert_rec, bytes.length(ccert_rec))
+                        net.tcp_send_n_raw(sock, ccert_s, bytes.length(ccert_rec))
+                        transcript_add(tr, ccert, bytes.length(ccert))
+                        // CertificateVerify: sign the transcript-through-client-
+                        // Certificate. ECDSA-P256 only in this cut.
+                        th_ccv = transcript_hash_algo(tr, hash_algo)
+                        knonce = rand_into(32)
+                        cvsig = tls13_cert.sign_client_cert_verify_ecdsa_p256(client_key, th_ccv, hash_len, knonce)
+                        ccv = build_cert_verify_msg(0x0403, cvsig, bytes.length(cvsig))
+                        ccv_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, ccv, bytes.length(ccv))
+                        ccv_s = bytes.to_string(ccv_rec, bytes.length(ccv_rec))
+                        net.tcp_send_n_raw(sock, ccv_s, bytes.length(ccv_rec))
+                        transcript_add(tr, ccv, bytes.length(ccv))
+                        bytes.free(th_ccv); bytes.free(knonce); bytes.free(cvsig)
+                        bytes.free(ccert); bytes.free(ccert_rec); bytes.free(ccv); bytes.free(ccv_rec)
+                    } else {
+                        ccert = build_empty_certificate()
+                        ccert_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, ccert, bytes.length(ccert))
+                        ccert_s = bytes.to_string(ccert_rec, bytes.length(ccert_rec))
+                        net.tcp_send_n_raw(sock, ccert_s, bytes.length(ccert_rec))
+                        transcript_add(tr, ccert, bytes.length(ccert))
+                        bytes.free(ccert); bytes.free(ccert_rec)
+                    }
                 }
                 // Client Finished MAC is over the transcript through the client
                 // Certificate (if any) — RFC 8446 §4.4.4.
@@ -1185,6 +1220,61 @@ fn flight_has_early_data_ext(fl: ptr, flen: int) -> int {
         p = p + 4 + ml
     }
     return 0
+}
+
+// A client Certificate message (RFC 8446 §4.4.2) carrying ONE certificate:
+// type 11, body = context<1>(empty) || certificate_list<3> where the single
+// CertificateEntry is cert_data<3> || extensions<2>(empty). `cert_der` is the
+// client's leaf certificate DER. (Single-cert chain; intermediates would append
+// more entries — out of scope for the first cut.)
+fn build_client_certificate(cert_der: ptr, cert_len: int) -> ptr {
+    // entry = cert_data<3>(cert) + extensions<2>(0) = 3 + cert_len + 2
+    entry_len = 3 + cert_len + 2
+    // body = context<1>(0) + certificate_list<3>(entry) = 1 + 3 + entry_len
+    body_len = 1 + 3 + entry_len
+    total = 4 + body_len
+    m = bytes.new(total)
+    bytes.set(m, total - 1, 0)
+    bytes.set(m, 0, HS_CERTIFICATE)
+    bytes.set(m, 1, (body_len >> 16) & 0xFF)
+    bytes.set(m, 2, (body_len >> 8) & 0xFF)
+    bytes.set(m, 3, body_len & 0xFF)
+    p = 4
+    bytes.set(m, p, 0)                              // certificate_request_context<1> empty
+    p = p + 1
+    bytes.set(m, p, (entry_len >> 16) & 0xFF)       // certificate_list<3> length
+    bytes.set(m, p + 1, (entry_len >> 8) & 0xFF)
+    bytes.set(m, p + 2, entry_len & 0xFF)
+    p = p + 3
+    bytes.set(m, p, (cert_len >> 16) & 0xFF)        // cert_data<3> length
+    bytes.set(m, p + 1, (cert_len >> 8) & 0xFF)
+    bytes.set(m, p + 2, cert_len & 0xFF)
+    p = p + 3
+    bytes.copy_from_bytes(m, p, cert_der, 0, cert_len)
+    p = p + cert_len
+    bytes.set(m, p, 0)                              // extensions<2> empty
+    bytes.set(m, p + 1, 0)
+    return m
+}
+
+// A client CertificateVerify message (RFC 8446 §4.4.3): type 15, body =
+// SignatureScheme(2) || signature<2>. `scheme` is the code point (e.g. 0x0403);
+// `sig`/`sig_len` is the DER signature.
+fn build_cert_verify_msg(scheme: int, sig: ptr, sig_len: int) -> ptr {
+    body_len = 2 + 2 + sig_len
+    total = 4 + body_len
+    m = bytes.new(total)
+    bytes.set(m, total - 1, 0)
+    bytes.set(m, 0, HS_CERTIFICATE_VERIFY)
+    bytes.set(m, 1, (body_len >> 16) & 0xFF)
+    bytes.set(m, 2, (body_len >> 8) & 0xFF)
+    bytes.set(m, 3, body_len & 0xFF)
+    bytes.set(m, 4, (scheme >> 8) & 0xFF)
+    bytes.set(m, 5, scheme & 0xFF)
+    bytes.set(m, 6, (sig_len >> 8) & 0xFF)
+    bytes.set(m, 7, sig_len & 0xFF)
+    bytes.copy_from_bytes(m, 8, sig, 0, sig_len)
+    return m
 }
 
 fn build_finished_msg(vd: ptr) -> ptr {

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -1110,12 +1110,12 @@ fn flight_has_cert_request(fl: ptr, flen: int) -> int {
 fn build_empty_certificate() -> ptr {
     m = bytes.new(8)
     bytes.set(m, 7, 0)
-    bytes.set(m, 0, HS_CERTIFICATE)   // msg type 11
-    bytes.set(m, 1, 0)                // uint24 length = 4
+    bytes.set(m, 0, HS_CERTIFICATE) // msg type 11
+    bytes.set(m, 1, 0) // uint24 length = 4
     bytes.set(m, 2, 0)
     bytes.set(m, 3, 4)
-    bytes.set(m, 4, 0)                // certificate_request_context<1> = empty
-    bytes.set(m, 5, 0)                // certificate_list<3> = empty (len 0)
+    bytes.set(m, 4, 0) // certificate_request_context<1> = empty
+    bytes.set(m, 5, 0) // certificate_list<3> = empty (len 0)
     bytes.set(m, 6, 0)
     bytes.set(m, 7, 0)
     return m
@@ -1240,19 +1240,19 @@ fn build_client_certificate(cert_der: ptr, cert_len: int) -> ptr {
     bytes.set(m, 2, (body_len >> 8) & 0xFF)
     bytes.set(m, 3, body_len & 0xFF)
     p = 4
-    bytes.set(m, p, 0)                              // certificate_request_context<1> empty
+    bytes.set(m, p, 0) // certificate_request_context<1> empty
     p = p + 1
-    bytes.set(m, p, (entry_len >> 16) & 0xFF)       // certificate_list<3> length
+    bytes.set(m, p, (entry_len >> 16) & 0xFF) // certificate_list<3> length
     bytes.set(m, p + 1, (entry_len >> 8) & 0xFF)
     bytes.set(m, p + 2, entry_len & 0xFF)
     p = p + 3
-    bytes.set(m, p, (cert_len >> 16) & 0xFF)        // cert_data<3> length
+    bytes.set(m, p, (cert_len >> 16) & 0xFF) // cert_data<3> length
     bytes.set(m, p + 1, (cert_len >> 8) & 0xFF)
     bytes.set(m, p + 2, cert_len & 0xFF)
     p = p + 3
     bytes.copy_from_bytes(m, p, cert_der, 0, cert_len)
     p = p + cert_len
-    bytes.set(m, p, 0)                              // extensions<2> empty
+    bytes.set(m, p, 0) // extensions<2> empty
     bytes.set(m, p + 1, 0)
     return m
 }

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -16,7 +16,8 @@
 //   - server CertificateVerify: ECDSA-P256 or RSA-PSS-rsae-SHA256
 //   - full chain validation (see SERVER AUTHENTICATION below)
 //   - session resumption (PSK) + 0-RTT early data; TLS alerts; OCSP-staple
-//     revocation check; no mTLS
+//     revocation check; mTLS: sends an empty Certificate on CertificateRequest
+//     (correct decline; presenting a client cert is a follow-up)
 //
 // SERVER AUTHENTICATION. connect() fails closed unless ALL of the following
 // hold, in order (RFC 8446 §4.4.3 + RFC 5280/6125):
@@ -59,7 +60,8 @@
 // auth failure (not a silent RST); close_conn sends close_notify; conn_recv
 // surfaces inbound alerts as typed errors. REVOCATION: a stapled OCSP response
 // (RFC 6960) saying revoked fails the handshake closed (status parsed, not
-// responder-signature-verified). Remaining limits: no mTLS; OCSP is
+// responder-signature-verified). Remaining limits: mTLS declines (empty Certificate) but does not yet PRESENT a
+// client cert + CertificateVerify; OCSP is
 // stapling-only (no CRL / no OCSP fetch); no responder-sig verification.
 //
 // This module separates the PURE state machine (transcript, key derivation,
@@ -116,6 +118,7 @@ exports(
 // Handshake message types (RFC 8446 §4) seen in the server's flight.
 const HS_ENCRYPTED_EXTENSIONS = 8
 const HS_CERTIFICATE = 11
+const HS_CERTIFICATE_REQUEST = 13
 const HS_CERTIFICATE_VERIFY = 15
 const HS_FINISHED = 20
 
@@ -961,13 +964,37 @@ fn run_handshake_tail(sock: ptr, rio: ptr, tr: ptr, host: string,
                 send_alert_hs(sock, fctx, ALERT_LEVEL_FATAL, ALERT_DECRYPT_ERROR)
                 tls13_record.free_ctx(fctx)
             } else {
+                cli_hs_ctx = tls13_record.new_aead(rec_aead, hs_client_key(keys), rec_key_len, hs_client_iv(keys))
+                // Application-traffic secrets are derived over the transcript
+                // through the SERVER Finished (RFC 8446 §7.1), i.e. BEFORE any
+                // client message. Capture th_sf first so the app keys match the
+                // server's regardless of a client Certificate that follows.
                 th_sf = transcript_hash_algo(tr, hash_algo)
                 ms = tls13_ks.master_secret(hash_algo, hs_handshake_secret(keys))
                 c_ap = tls13_ks.traffic_secret(hash_algo, ms, "c ap traffic", th_sf, hash_len)
                 s_ap = tls13_ks.traffic_secret(hash_algo, ms, "s ap traffic", th_sf, hash_len)
-                cvd = finished_verify_data_algo(hs_client_secret(keys), th_sf, hash_len, hash_algo, hash_len)
+
+                // Mutual TLS: if the server sent a CertificateRequest, the client
+                // MUST send its own Certificate before Finished (RFC 8446 §4.4.2).
+                // With no client cert configured we send an EMPTY Certificate (the
+                // correct decline). It is folded into the transcript so the client
+                // Finished MAC (computed next, over th_cvd) covers it — but AFTER
+                // th_sf, so it does not disturb the app-traffic keys.
+                // (Presenting a real client cert + CertificateVerify is next.)
+                if flight_has_cert_request(fl, fllen) == 1 {
+                    ccert = build_empty_certificate()
+                    ccert_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, ccert, bytes.length(ccert))
+                    ccert_s = bytes.to_string(ccert_rec, bytes.length(ccert_rec))
+                    net.tcp_send_n_raw(sock, ccert_s, bytes.length(ccert_rec))
+                    transcript_add(tr, ccert, bytes.length(ccert))
+                    bytes.free(ccert); bytes.free(ccert_rec)
+                }
+                // Client Finished MAC is over the transcript through the client
+                // Certificate (if any) — RFC 8446 §4.4.4.
+                th_cvd = transcript_hash_algo(tr, hash_algo)
+                cvd = finished_verify_data_algo(hs_client_secret(keys), th_cvd, hash_len, hash_algo, hash_len)
+                bytes.free(th_cvd)
                 cfin = build_finished_msg(cvd)
-                cli_hs_ctx = tls13_record.new_aead(rec_aead, hs_client_key(keys), rec_key_len, hs_client_iv(keys))
                 cfin_rec = tls13_record.seal_record(cli_hs_ctx, tls13_record.CONTENT_HANDSHAKE, cfin, bytes.length(cfin))
                 cfs = bytes.to_string(cfin_rec, bytes.length(cfin_rec))
                 net.tcp_send_n_raw(sock, cfs, bytes.length(cfin_rec))
@@ -1024,6 +1051,39 @@ fn flight_complete(fl: ptr, flen: int) -> int {
         }
     }
     return 0
+}
+
+// Did the server send a CertificateRequest (type 13) in this flight? That is
+// the mutual-TLS ask — the client must then send its own Certificate (empty if
+// it has none) before its Finished (RFC 8446 §4.3.2 / §4.4.2).
+fn flight_has_cert_request(fl: ptr, flen: int) -> int {
+    p = 0
+    while p + 4 <= flen {
+        mt = bytes.get(fl, p) & 0xFF
+        ml = ((bytes.get(fl, p + 1) & 0xFF) << 16) | ((bytes.get(fl, p + 2) & 0xFF) << 8) | (bytes.get(fl, p + 3) & 0xFF)
+        if p + 4 + ml > flen { return 0 }
+        if mt == HS_CERTIFICATE_REQUEST { return 1 }
+        p = p + 4 + ml
+    }
+    return 0
+}
+
+// An empty client Certificate message (RFC 8446 §4.4.2): handshake type 11,
+// body = certificate_request_context<1> (empty) || certificate_list<3> (empty).
+// Sent when the server sent a CertificateRequest but we have no client cert —
+// the correct decline, letting the server decide whether to proceed.
+fn build_empty_certificate() -> ptr {
+    m = bytes.new(8)
+    bytes.set(m, 7, 0)
+    bytes.set(m, 0, HS_CERTIFICATE)   // msg type 11
+    bytes.set(m, 1, 0)                // uint24 length = 4
+    bytes.set(m, 2, 0)
+    bytes.set(m, 3, 4)
+    bytes.set(m, 4, 0)                // certificate_request_context<1> = empty
+    bytes.set(m, 5, 0)                // certificate_list<3> = empty (len 0)
+    bytes.set(m, 6, 0)
+    bytes.set(m, 7, 0)
+    return m
 }
 
 // Fold every complete handshake message in the flight into the transcript, in

--- a/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
+++ b/tests/integration/crypto_tls13_cert/test_tls13_cert.ae
@@ -81,6 +81,31 @@ fn der_int(out: ptr, off: int, mag32: ptr) -> int {
 }
 
 // Wrap (r32,s32) into a DER  SEQUENCE { INTEGER r, INTEGER s }.
+// Parse a DER ECDSA-Sig-Value SEQUENCE { INTEGER r, INTEGER s } into two
+// fresh 32-byte big-endian buffers (right-aligned, sign byte stripped).
+fn read_der_int_at(sig: ptr, off: int) -> (ptr, int) {
+    // sig[off] == 0x02 (INTEGER), sig[off+1] == length
+    ilen = bytes.get(sig, off + 1) & 0xFF
+    istart = off + 2
+    // strip a leading 0x00 sign byte
+    if ilen > 0 {
+        if (bytes.get(sig, istart) & 0xFF) == 0 { istart = istart + 1; ilen = ilen - 1 }
+    }
+    out = bytes.new(32)
+    z = 0
+    while z < 32 { bytes.set(out, z, 0); z = z + 1 }
+    dst = 32 - ilen
+    k = 0
+    while k < ilen { bytes.set(out, dst + k, bytes.get(sig, istart + k) & 0xFF); k = k + 1 }
+    return out, off + 2 + (bytes.get(sig, off + 1) & 0xFF)
+}
+fn split_der_ecdsa(sig: ptr) -> (ptr, ptr) {
+    // sig[0]=0x30 (SEQUENCE), sig[1]=seq_len, then INTEGER r, INTEGER s.
+    r, next = read_der_int_at(sig, 2)
+    s, _ = read_der_int_at(sig, next)
+    return r, s
+}
+
 fn der_ecdsa_sig(r32: ptr, s32: ptr) -> (ptr, int) {
     tmp = bytes.new(80)
     bytes.set(tmp, 79, 0)
@@ -184,6 +209,25 @@ main() {
     } else {
         println("FAIL ecdsa-p256 accepted wrong transcript"); total_ok = 0
     }
+
+    // --- mTLS: CLIENT CertificateVerify sign round-trip (RFC 8446 §4.4.3) ---
+    // Sign the client content with the client key, then verify the DER sig is a
+    // valid ECDSA-P256 signature over SHA-256(client content).
+    ccv_sig = tls13_cert.sign_client_cert_verify_ecdsa_p256(priv, th, 32, knonce)
+    ccv_content, ccv_clen = tls13_cert.client_cert_verify_content(th, 32)
+    ccv_digest = sha256b(ccv_content, ccv_clen)
+    // The client content differs from the server content (context string), so a
+    // sig over the CLIENT content must verify with the client digest...
+    crr, css = split_der_ecdsa(ccv_sig)
+    if p256.ecdsa_verify(px, py, ccv_digest, crr, css) == 1 {
+        println("ok   client CertificateVerify signs + verifies")
+    } else { println("FAIL client CertificateVerify sig"); total_ok = 0 }
+    // ...and must NOT verify against the SERVER content (different context).
+    if p256.ecdsa_verify(px, py, digest, crr, css) == 0 {
+        println("ok   client sig does not verify under server context")
+    } else { println("FAIL client sig verified under server context"); total_ok = 0 }
+    bytes.free(ccv_sig); bytes.free(ccv_content); bytes.free(ccv_digest)
+    bytes.free(crr); bytes.free(css)
     bytes.free(priv)
     bytes.free(px)
     bytes.free(py)

--- a/tests/integration/crypto_tls13_client/README.md
+++ b/tests/integration/crypto_tls13_client/README.md
@@ -46,6 +46,8 @@ default). This was verified end-to-end against `openssl s_server`:
 | self-signed | self-signed, `SAN=localhost` | rejected — does not chain to a trusted anchor |
 | wrong host | CA-signed, `SAN=example.com`, connect as `localhost` | rejected — not valid for the requested hostname |
 | expired | CA-signed, `notAfter=2020` | rejected — certificate expired |
+| mTLS optional (`s_server -verify 1`) | server requests a client cert | **CONNECTED** — client sends an empty Certificate (declines), server proceeds |
+| mTLS required (`s_server -Verify 1`) | server *requires* a client cert | rejected — server alerts "peer did not return a certificate"; client surfaces it as `tls alert` |
 
 Reproduce a rejection, e.g. self-signed:
 


### PR DESCRIPTION
Adds mutual-TLS (client certificate) support to the pure-Aether TLS 1.3 client. Two commits, two capabilities:

## 1. CertificateRequest handling — empty-cert decline (`98c1f310`)
When the server sends a **CertificateRequest** (type 13), RFC 8446 §4.4.2 requires the client to send its own Certificate before Finished. `connect()` now scans the server flight for a CertificateRequest and, with no client cert configured, sends an **empty Certificate** (the correct decline) folded into the transcript.

## 2. Present a client certificate — `connect_mtls` (`6dbd6641`)
`connect_mtls(host, port, x25519_priv, client_cert, client_cert_len, client_key)` presents an **ECDSA-P256 leaf Certificate + a CertificateVerify** signed with the client key (§4.4.3, context `"TLS 1.3, client CertificateVerify"`) when the server requests one. Without a client cert, it behaves exactly like `connect()`.

`std.cryptography.tls13_cert` gains `client_cert_verify_content` and `sign_client_cert_verify_ecdsa_p256` (SHA-256 → `p256.ecdsa_sign` → DER `SEQUENCE{r,s}`); `cert_verify_content` is refactored onto a shared `cert_verify_content_ctx`.

### Transcript ordering (the subtle part)
The app-traffic secrets derive over the transcript through the **server** Finished (`th_sf`); the client Certificate / CertificateVerify are folded in **after** that point so the client Finished MAC covers them without disturbing the app keys. When no CertificateRequest arrives, the classical / PQ / resume paths are byte-for-byte unchanged.

## Verification
- **Live** against `openssl s_server`:
  - `-Verify 1` (client cert **required**): server logs `depth=0 CN = aether-client, verify return:1` — our cert + CertVerify signature accepted; handshake completes.
  - `-verify 1` (client cert **optional**): empty-cert decline still connects, HTTP 200.
  - `-Verify 1` with no client cert: server alerts "peer did not return a certificate"; client surfaces it as a typed `tls alert` (fail-closed).
- **Regression**: classical `github.com` still `HANDSHAKE OK` + HTTP 200 after the `connect`→`connect_ex` refactor.
- **CI**: cert test gains a client-CertVerify sign→verify round-trip (verifies under the *client* context; does **not** under the *server* context). All five TLS suites (hs / client / record / cert / ks) pass.
- **Leak**: the offline sign path is valgrind-clean (`0 errors, all heap blocks freed`); fixes a double-free where `asn1.encode_sequence` already consumes its body buffer.

## Limits (documented in the module header)
ECDSA-P256 client key only (no RSA/Ed25519 client key yet); single-cert client chain (no intermediates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)