### PR TITLE
feat(std.string): add string.join — linear-cost sequence join (#1346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ next version number before tagging the release.
 
 ### Added
 
+- **`std.string.join(seq, sep)`** — linear-cost join of a `*StringSeq` with a
+  separator, the complement to `string.split` / `split_to_seq` (issue #1346).
+  One pass to size, one allocation, one pass to copy — the guaranteed-O(n)
+  escape from the `d = "${d}${piece}"` accumulation trap (which re-copies the
+  whole prefix every iteration, O(n²)). For incremental building where the
+  pieces aren't already a sequence, `std.strbuilder` (amortized-O(1) append)
+  covers the builder half of #1346; `std.string` now points at both up front.
+  Regression: `tests/regression/test_string_join.ae`.
 - **`fs.mounts()` and `fs.block_info(dev)`** (#1118). Mount enumeration
   with per-entry source/point/fstype/options accessors: Linux
   `/proc/self/mountinfo` (octal escapes decoded), macOS and the BSDs

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -672,6 +672,49 @@ void string_array_free(AetherStringArray* arr) {
 struct StringSeq;  /* forward decl — full def in std/collections/aether_stringseq.h */
 extern struct StringSeq* string_seq_cons(const char* head, struct StringSeq* tail);
 extern void string_seq_free(struct StringSeq* s);
+extern const char* string_seq_head(struct StringSeq* s);
+extern struct StringSeq* string_seq_tail(struct StringSeq* s);
+extern int string_seq_length(struct StringSeq* s);
+
+/* Join a *StringSeq into one string with `sep` between elements — the
+ * linear-cost complement to string_split (issue #1346). Two passes: size
+ * the result (sum of element lengths + sep_len*(n-1)), allocate ONE cap-aware
+ * buffer, then copy. Returns a magic AetherString* (heap-owned; the @heap
+ * extern makes the caller own it, reclaimed at scope exit). Empty seq -> "".
+ * Both elements and `sep` may be magic AetherString* or plain char* (str_len/
+ * str_data unwrap either), so the join is binary-safe. */
+void* string_join(struct StringSeq* seq, const void* sep) {
+    int n = string_seq_length(seq);
+    if (n <= 0) return string_empty();
+    size_t sep_len = str_len(sep);
+    /* Pass 1: total size. */
+    size_t total = 0;
+    struct StringSeq* cur = seq;
+    for (int i = 0; i < n && cur; i++) {
+        total += str_len(string_seq_head(cur));
+        cur = string_seq_tail(cur);
+    }
+    total += sep_len * (size_t)(n - 1);
+    /* One allocation (+1 for the NUL terminator string_adopt expects). */
+    char* buf = (char*)aether_caps_malloc(total + 1);
+    if (!buf) return NULL;
+    /* Pass 2: copy elements, interleaving the separator. */
+    size_t off = 0;
+    cur = seq;
+    const char* sep_data = str_data(sep);
+    for (int i = 0; i < n && cur; i++) {
+        if (i > 0 && sep_len > 0) {
+            memcpy(buf + off, sep_data, sep_len);
+            off += sep_len;
+        }
+        const void* h = string_seq_head(cur);
+        size_t hl = str_len(h);
+        if (hl > 0) { memcpy(buf + off, str_data(h), hl); off += hl; }
+        cur = string_seq_tail(cur);
+    }
+    buf[off] = '\0';
+    return string_adopt_caps_buffer(buf, off, total + 1);
+}
 
 void* string_split_to_seq(const void* str, const void* delimiter) {
     AetherStringArray* arr = string_split(str, delimiter);

--- a/std/string/module.ae
+++ b/std/string/module.ae
@@ -1,5 +1,13 @@
 // std.string - String Module
 // Import with: import std.string
+//
+// Building strings incrementally? Do NOT loop `d = "${d}${piece}"` /
+// `string.concat(d, piece)` — each iteration re-copies the whole prefix, so the
+// loop is O(n²) in total bytes (issue #1346). Use one of the linear-cost tools:
+//   - `string.join(seq, sep)` (below) when the pieces are already a *StringSeq.
+//   - `std.strbuilder` (`strbuilder.new` / `append` / `finish`) for a growing
+//     accumulator — amortized-O(1) append via a 2×-doubling buffer, the
+//     Java-StringBuilder / Go-strings.Builder shape.
 
 exports(
     string_new, string_from_cstr, string_from_literal,
@@ -14,7 +22,7 @@ exports(
     string_char_at_n, string_index_of_from_n,
     string_from_char, string_to_upper, string_to_lower, string_trim,
     string_split, string_array_size, string_array_get, string_array_free,
-    string_split_to_seq,
+    string_split_to_seq, string_join,
     string_seq_empty, string_seq_cons, string_seq_head, string_seq_tail,
     string_seq_is_empty, string_seq_length, string_seq_retain, string_seq_free,
     string_seq_from_array, string_seq_to_array,
@@ -238,6 +246,18 @@ extern string_array_free(arr: ptr)
 // with "", delimiter longer than input → single-cell list with the
 // whole input, trailing/leading delimiters produce empty pieces.
 extern string_split_to_seq(str: string, delimiter: string) -> *StringSeq
+
+// Join a sequence into one string with `sep` between elements — the
+// linear-cost complement to string_split (issue #1346). O(total bytes):
+// one pass to size the result, one allocation, one pass to copy. Empty
+// sequence → "". The natural pair for `string_split` / `string_split_to_seq`:
+//   parts = string.split_to_seq("a,b,c", ",")
+//   whole = string.join(parts, "-")          // "a-b-c"
+// Prefer this over a `d = "${d}${piece}"` accumulation loop, which re-copies
+// the whole prefix every iteration (O(n²)). For incremental building where the
+// pieces aren't already a sequence, reach for std.strbuilder (amortized append).
+// Result is @heap (caller-owned, reclaimed at scope exit).
+extern string_join(seq: *StringSeq, sep: string) -> string @heap
 
 // Cons-cell construction + destructuring. Names mirror the C
 // runtime symbols; users call them via dot-notation `string.seq_X(...)`

--- a/tests/regression/test_string_join.ae
+++ b/tests/regression/test_string_join.ae
@@ -1,0 +1,91 @@
+// Regression test for string.join (issue #1346) — the linear-cost complement
+// to string.split / string.split_to_seq. Joins a *StringSeq with a separator
+// between elements in O(total bytes): one pass to size, one allocation, one
+// pass to copy. This is the guaranteed-linear escape from the O(n²)
+// `d = "${d}${piece}"` accumulation trap.
+//
+// Surface under test:
+//   - basic join with a single-char and a multi-char separator
+//   - empty separator (pure concatenation)
+//   - single-element sequence (no separator emitted)
+//   - empty sequence -> ""
+//   - split -> join round-trip
+//   - a separator that itself contains the delimiter
+//   - a longer sequence (order + separator placement)
+
+import std.string
+
+extern exit(code: int)
+
+fn expect(got: string, want: string, label: string) {
+    if string.equals(got, want) != 1 {
+        println("FAIL ${label}: got '${got}' want '${want}'")
+        exit(1)
+    }
+    println("ok   ${label}")
+}
+
+main() {
+    // ---- basic: single-char separator ----
+    p1 = string.split_to_seq("a,b,c", ",")
+    j1 = string.join(p1, "-")
+    string.seq_free(p1)
+    expect(j1, "a-b-c", "single-char sep")
+
+    // ---- multi-char separator ----
+    p2 = string.split_to_seq("a,b,c", ",")
+    j2 = string.join(p2, " <-> ")
+    string.seq_free(p2)
+    expect(j2, "a <-> b <-> c", "multi-char sep")
+
+    // ---- empty separator = concatenation ----
+    p3 = string.split_to_seq("x,y,z", ",")
+    j3 = string.join(p3, "")
+    string.seq_free(p3)
+    expect(j3, "xyz", "empty sep")
+
+    // ---- single element: no separator emitted ----
+    p4 = string.split_to_seq("solo", ",")
+    j4 = string.join(p4, "|")
+    string.seq_free(p4)
+    expect(j4, "solo", "single element")
+
+    // ---- empty sequence -> "" ----
+    e = string.seq_empty()
+    j5 = string.join(e, ",")
+    expect(j5, "", "empty seq")
+
+    // ---- split -> join round-trip reproduces the original ----
+    original = "one/two/three/four"
+    p6 = string.split_to_seq(original, "/")
+    j6 = string.join(p6, "/")
+    string.seq_free(p6)
+    expect(j6, original, "split-join round-trip")
+
+    // ---- separator containing the split delimiter ----
+    p7 = string.split_to_seq("a,b", ",")
+    j7 = string.join(p7, ",,")
+    string.seq_free(p7)
+    expect(j7, "a,,b", "sep contains delimiter")
+
+    // ---- longer sequence: order + placement ----
+    p8 = string.split_to_seq("1,2,3,4,5", ",")
+    j8 = string.join(p8, ".")
+    string.seq_free(p8)
+    expect(j8, "1.2.3.4.5", "longer sequence")
+
+    // ---- cons-built sequence (not from split) ----
+    // Build back-to-front, dropping each intermediate local as the next cons
+    // takes its own retained ref (the canonical *StringSeq ownership dance).
+    t0 = string.seq_empty()
+    t1 = string.seq_cons("gamma", t0)
+    t2 = string.seq_cons("beta", t1)
+    string.seq_free(t1)
+    t3 = string.seq_cons("alpha", t2)
+    string.seq_free(t2)
+    j9 = string.join(t3, ", ")
+    string.seq_free(t3)
+    expect(j9, "alpha, beta, gamma", "cons-built sequence")
+
+    println("string_join: all checks pass")
+}


### PR DESCRIPTION
Closes #1346.

## The trap
The idiomatic `d = "${d}${piece}"` accumulation loop re-copies the whole prefix every iteration → **O(n²)** in total bytes. Invisible at small n, catastrophic at large n (the issue's real case: aether-ui's `vg.text_paths` wedged a GTK main loop building SVG path data one outline point at a time). `std.string` had `split` but **no join and no builder** — no linear-cost escape in its surface.

## What this adds
**`string.join(seq, sep)`** — joins a `*StringSeq` with a separator between elements in **O(total bytes)**: one pass to size, one cap-aware allocation, one pass to copy. The natural complement to `string.split` / `split_to_seq`:

```aether
parts = string.split_to_seq("a,b,c", ",")
whole = string.join(parts, "-")          // "a-b-c"
```

- Elements and separator may each be a magic `AetherString*` or a plain `char*` (`str_len`/`str_data` unwrap either) → **binary-safe**.
- Empty sequence → `""`; single element emits no separator.
- Result is `@heap` (caller-owned, reclaimed at scope exit). **Leak-clean under valgrind.**

## The builder half of #1346 — already shipped
The issue also asked for an amortized-append builder. That already exists as **`std.strbuilder`** (`new` / `append` / `finish`, 2×-doubling buffer — the Java-`StringBuilder` / Go-`strings.Builder` shape). Rather than duplicate it under a new `sb_*` surface, `std.string` now **points at both `string.join` and `std.strbuilder` up front** (module header + the `join` doc), so the linear-cost tools are discoverable from exactly where the O(n²) trap is reached.

## Verification
- `tests/regression/test_string_join.ae` — 9 cases: single/multi-char sep, empty sep, single element, empty seq, split→join round-trip, separator-contains-delimiter, longer sequence, cons-built sequence. All pass.
- valgrind: 0 leaks. Clean **and** `HARDEN=1` `-Werror` builds pass. 229 C unit tests + string regression suite green; fmt gate clean.

## Note
The optional compiler peephole from the issue (recognise dying-`s` self-append and lower to in-place growth) is **not** included here — it's a separate, larger codegen change; the stdlib tools land first as the explicit guaranteed-linear path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)