### PR TITLE
feat(std.http.proxy): trailing-block config-IS-code DSL for pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ next version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **`std.http.proxy` gains a trailing-block "config IS code" DSL** for pool
+  setup, alongside the existing positional API. `proxy.pool(algo, ...) { ... }`
+  runs first and returns the pool ptr, which becomes the block's
+  `builder_context()`; the child calls (`upstream`, `health`, `breaker`,
+  `rate_limit`, `cookie_name`, `drain`) configure that live pool. Body-first
+  ordering means the pool already exists when the children run — thin,
+  allocation-free sugar over the same functions, no recording/replay. Both
+  surfaces drive the identical pool. Example:
+  `examples/stdlib/http-reverse-proxy-pool-dsl.ae`; regression:
+  `tests/regression/test_proxy_pool_dsl.ae`.
+
 ### Fixed
 
 - **Repository URLs pointed at the pre-rename organisation.** Every

--- a/examples/stdlib/http-reverse-proxy-pool-dsl.ae
+++ b/examples/stdlib/http-reverse-proxy-pool-dsl.ae
@@ -1,0 +1,95 @@
+// Reverse-proxy demo — the SAME enterprise stack as
+// http-reverse-proxy-pool.ae, but the pool is assembled with the
+// trailing-block "config IS code" DSL instead of positional calls.
+//
+// The pool's shape reads top-to-bottom like a config file — the block is
+// ordinary Aether (you can compute weights, read env vars, branch), and every
+// line maps to the same std.http.proxy function the positional form calls. No
+// framework, no YAML, no sidecar.
+//
+//   p = proxy.pool("weighted_rr", 30, 0, 0) {
+//       upstream(...)   health(...)   breaker(...)   rate_limit(...)
+//   }
+//
+// Both this file and http-reverse-proxy-pool.ae drive the identical pool; pick
+// whichever reads better for you. Run exactly the same way:
+//
+//     ae build examples/stdlib/http-reverse-proxy-pool-dsl.ae -o /tmp/proxy
+//     /tmp/proxy
+//     # three upstreams you control, e.g.:
+//     python3 -m http.server 9001 &
+//     python3 -m http.server 9002 &
+//     python3 -m http.server 9003 &
+//     curl -i http://localhost:8080/api/
+//     curl http://localhost:8080/proxy-metrics
+//
+// See docs/http-reverse-proxy.md for the full reference.
+
+import std.http
+import std.http.proxy
+
+const PORT = 8080
+
+handle_metrics(req: ptr, res: ptr, ud: ptr) {
+    body = proxy.pool_metrics_text(ud)
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain; version=0.0.4")
+    http.response_set_body(res, body)
+}
+
+main() {
+    server = http.server_create(PORT)
+    if server == 0 {
+        println("server_create failed")
+        return
+    }
+    http.server_set_keepalive(server, 1, 0, 30000ms)
+
+    // ---- Pool, as a config block --------------------------------
+    // pool(...) runs first and returns the pool ptr; the block then
+    // configures that live pool. Weighted round-robin (A ~3/6, B ~2/6,
+    // C ~1/6), health probes every 5s (2 OK up / 2 fail down), breaker
+    // opens after 5 consecutive failures for 30s, 200 rps/upstream
+    // burst 50.
+    pool = proxy.pool("weighted_rr", 30, 0, 0) {
+        upstream("http://localhost:9001", 3)
+        upstream("http://localhost:9002", 2)
+        upstream("http://localhost:9003", 1)
+        health("/health", 200, 5000, 2000, 2, 2)
+        breaker(5, 30000, 1)
+        rate_limit(200, 50)
+    }
+    if pool == 0 {
+        println("pool_new failed")
+        return
+    }
+
+    // ---- Cache + per-mount options (unchanged from the positional
+    // example — these hang off `opts`, not the pool) --------------
+    cache = proxy.cache_new(1000, 65536, 60, "method_url_vary")
+    if cache == 0 {
+        println("cache_new failed")
+        return
+    }
+    opts = proxy.opts_new()
+    proxy.opts_bind_cache(opts, cache)
+    proxy.opts_set_xforwarded(opts, 1, 1, 1)
+    proxy.opts_set_body_cap(opts, 8 * 1024 * 1024)
+    proxy.opts_set_retry_policy(opts, 3, 100)
+    proxy.opts_set_trace_inject(opts, 1)
+
+    // ---- Metrics endpoint + mount -------------------------------
+    http.server_get(server, "/proxy-metrics", handle_metrics, pool)
+    err = proxy.mount(server, "/api", pool, opts)
+    if err != "" {
+        println("mount: ${err}")
+        return
+    }
+
+    println("listening on http://localhost:${PORT}/api/  (DSL-configured pool: 3 upstreams 3:2:1, cache, breaker, retry, rate-limit, traceparent inject)")
+    println("prometheus metrics at http://localhost:${PORT}/proxy-metrics")
+    start_err = http.server_start(server)
+    if start_err != "" {
+        println("server_start: ${start_err}")
+    }
+}

--- a/std/http/proxy/module.ae
+++ b/std/http/proxy/module.ae
@@ -17,13 +17,23 @@
 //         http.server_start(server)
 //     }
 //
-// Pool form (load balancing, health checks, cache):
+// Pool form (load balancing, health checks, cache) — positional:
 //
 //     pool = proxy.upstream_pool_new("weighted_rr", 30, 5000, 100)
 //     proxy.upstream_add(pool, "http://10.0.0.1:8080", 3)
 //     proxy.upstream_add(pool, "http://10.0.0.2:8080", 1)
 //     proxy.health_checks_enable(pool, "/health", 200, 5000, 1000, 2, 3)
 //     proxy.breaker_configure(pool, 5, 30000, 1)
+//
+// ...or the same pool as a "config IS code" trailing block (see the DSL
+// section at the bottom of this module):
+//
+//     pool = proxy.pool("weighted_rr", 30, 5000, 100) {
+//         upstream("http://10.0.0.1:8080", 3)
+//         upstream("http://10.0.0.2:8080", 1)
+//         health("/health", 200, 5000, 1000, 2, 3)
+//         breaker(5, 30000, 1)
+//     }
 //
 //     cache = proxy.cache_new(1000, 65536, 60, "method_url_vary")
 //
@@ -48,6 +58,8 @@ exports(
     opts_set_retry_policy, opts_set_trace_inject,
     mount, mount_methods, mount_match, mount_simple,
     pool_metrics_text,
+    // Trailing-block "config IS code" DSL over the pool API (see bottom).
+    pool, upstream, health, breaker, rate_limit, cookie_name, drain,
 )
 
 // ---- Raw externs ----
@@ -375,4 +387,98 @@ mount_simple(server: ptr,
     request_timeout_sec: int) -> string {
     return aether_proxy_use_simple_proxy(server, path_prefix, upstream_url,
         request_timeout_sec)
+}
+
+// ---- "config IS code" trailing-block DSL ------------------------------------
+//
+// The positional pool API above is complete, but a reverse proxy is config-
+// shaped — a reader gets more from a nested block than from a run of positional
+// ints. This DSL is a thin, allocation-free sugar over the same functions,
+// using Aether's Immediate trailing-block form: `pool(...)` runs first and
+// returns the pool ptr, which becomes the block's builder_context(); the child
+// calls (`upstream`, `health`, `breaker`, ...) read that context and configure
+// the live pool. Body-first ordering means the pool already exists when the
+// children run — no recording/replay.
+//
+//     p = proxy.pool("weighted_rr", 30, 0, 0) {
+//         upstream("http://localhost:9001", 3)
+//         upstream("http://localhost:9002", 2)
+//         upstream("http://localhost:9003", 1)
+//         health("/health", 200, 5000, 2000, 2, 2)   // probe /health every 5s
+//         breaker(5, 30000, 1)                        // 5 fails → open 30s
+//         rate_limit(100, 0)                          // 100 rps/upstream
+//     }
+//
+// `pool` returns the same ptr as `upstream_pool_new` (null on bad algo/inputs),
+// so `p` is used exactly as before (mount, pool_metrics_text, free). The child
+// setters are ergonomic: they apply to the current context and drop the
+// underlying `-> string` error (a config block favours readability). When you
+// need to inspect a per-line error (e.g. a duplicate upstream URL), call the
+// positional functions directly — both surfaces drive the same pool.
+
+// The block's context head: create the pool, return it (pushed as context).
+pool(lb_algo: string,
+    request_timeout_sec: int,
+    dial_timeout_ms: int,
+    max_inflight_per_up: int) -> ptr {
+    return upstream_pool_new(lb_algo, request_timeout_sec, dial_timeout_ms,
+        max_inflight_per_up)
+}
+
+// Add a weighted upstream to the pool under construction.
+upstream(base_url: string, weight: int) {
+    p = builder_context()
+    if p != null {
+        _ = upstream_add(p, base_url, weight)
+    }
+}
+
+// Enable health probing on the pool under construction. Same argument order as
+// health_checks_enable: probe_path, expect_status, interval_ms, timeout_ms,
+// healthy_threshold, unhealthy_threshold.
+health(probe_path: string,
+    expect_status: int,
+    interval_ms: int,
+    timeout_ms: int,
+    healthy_threshold: int,
+    unhealthy_threshold: int) {
+    p = builder_context()
+    if p != null {
+        _ = health_checks_enable(p, probe_path, expect_status, interval_ms,
+            timeout_ms, healthy_threshold, unhealthy_threshold)
+    }
+}
+
+// Configure the circuit breaker: failure_threshold, open_duration_ms,
+// half_open_max.
+breaker(failure_threshold: int, open_duration_ms: int, half_open_max: int) {
+    p = builder_context()
+    if p != null {
+        _ = breaker_configure(p, failure_threshold, open_duration_ms, half_open_max)
+    }
+}
+
+// Per-upstream token-bucket rate limit: max_rps, burst (0 burst = max_rps).
+rate_limit(max_rps: int, burst: int) {
+    p = builder_context()
+    if p != null {
+        _ = rate_limit_set(p, max_rps, burst)
+    }
+}
+
+// Cookie name for the cookie_hash LB algorithm.
+cookie_name(name: string) {
+    p = builder_context()
+    if p != null {
+        _ = pool_set_cookie_name(p, name)
+    }
+}
+
+// Mark an upstream as draining at construction time (rarely needed in a fresh
+// pool, but symmetric with the positional API).
+drain(base_url: string) {
+    p = builder_context()
+    if p != null {
+        _ = upstream_drain(p, base_url)
+    }
 }

--- a/tests/regression/test_proxy_pool_dsl.ae
+++ b/tests/regression/test_proxy_pool_dsl.ae
@@ -1,0 +1,78 @@
+// Regression test for the std.http.proxy trailing-block "config IS code" DSL.
+//
+// The DSL (proxy.pool(...) { upstream(...) health(...) breaker(...) ... }) is a
+// thin sugar over the positional pool API using Aether's Immediate trailing-
+// block form: pool(...) runs first and returns the pool ptr, which becomes the
+// block's builder_context(); the child calls configure that live pool. This
+// test asserts the child setters actually reach the live pool — by re-adding an
+// upstream the DSL block already added and observing the duplicate-URL error,
+// and by confirming a fresh URL still adds cleanly.
+//
+// (It deliberately avoids proxy.pool_metrics_text for the assertion: that
+// function returns a raw, non-@heap char* that leaks on free — a pre-existing
+// ownership quirk unrelated to this DSL — and this test must stay leak-clean
+// for the CI gate.)
+
+import std.http.proxy
+import std.string
+
+extern exit(code: int)
+
+main() {
+    total_ok = 1
+
+    // Build a pool via the DSL. pool(...) runs first (creates the pool),
+    // then the block configures it through builder_context().
+    p = proxy.pool("weighted_rr", 30, 0, 0) {
+        upstream("http://localhost:9001", 3)
+        upstream("http://localhost:9002", 2)
+        upstream("http://localhost:9003", 1)
+        breaker(5, 30000, 1)
+        rate_limit(100, 0)
+    }
+    if p == 0 {
+        println("FAIL: DSL pool is null")
+        exit(1)
+    }
+    println("ok   DSL pool constructed")
+
+    // Proof the DSL children reached the live pool: re-adding a URL the block
+    // already added must fail with the duplicate-URL error (upstream_add
+    // returns non-empty on a duplicate). If the DSL upstream() had been a
+    // no-op, this add would SUCCEED (empty error) instead.
+    dup = proxy.upstream_add(p, "http://localhost:9001", 3)
+    if string.equals(dup, "") != 1 {
+        println("ok   DSL-added upstream is present (duplicate rejected)")
+    } else {
+        println("FAIL DSL upstream() did not add 9001 (duplicate accepted)")
+        total_ok = 0
+    }
+
+    // A brand-new URL still adds cleanly on the DSL-built pool.
+    fresh = proxy.upstream_add(p, "http://localhost:9004", 1)
+    if string.equals(fresh, "") == 1 {
+        println("ok   fresh upstream adds to DSL pool")
+    } else {
+        println("FAIL fresh upstream rejected: ${fresh}")
+        total_ok = 0
+    }
+
+    // Reconfiguring the breaker on the DSL pool returns success (proves the
+    // pool is a real, live pool the positional API also drives).
+    berr = proxy.breaker_configure(p, 3, 15000, 1)
+    if string.equals(berr, "") == 1 {
+        println("ok   breaker reconfigurable on DSL pool")
+    } else {
+        println("FAIL breaker_configure on DSL pool: ${berr}")
+        total_ok = 0
+    }
+
+    proxy.upstream_pool_free(p)
+
+    if total_ok == 1 {
+        println("proxy_pool_dsl: all checks pass")
+    } else {
+        println("proxy_pool_dsl: FAILURES")
+        exit(1)
+    }
+}


### PR DESCRIPTION
The reverse proxy is the most config-shaped surface in the stdlib, but it only exposed a **positional API** — bare ints like `breaker_configure(pool, 5, 30000, 1)` where the argument meanings aren't self-documenting. Aether's headline feature is the **config-IS-code trailing-block DSL** (how `aeo`'s compose surface and aether-ui work), yet the proxy — the natural showcase — didn't use it. This adds it.

## The DSL
```aether
pool = proxy.pool("weighted_rr", 30, 0, 0) {
    upstream("http://localhost:9001", 3)
    upstream("http://localhost:9002", 2)
    upstream("http://localhost:9003", 1)
    health("/health", 200, 5000, 2000, 2, 2)   // probe /health every 5s
    breaker(5, 30000, 1)                        // 5 fails -> open 30s
    rate_limit(200, 50)                         // 200 rps/upstream
}
```
Reads like a config file, but it's ordinary Aether — compute weights, read env vars, branch. `pool` returns the same ptr as `upstream_pool_new`, used exactly as before (mount, metrics, free).

## How it works (no new C, no allocation)
Immediate trailing-block form: `pool(...)` runs **first** and returns the pool ptr, which becomes the block's `builder_context()`; the child setters read that context and configure the **live** pool. Body-first ordering means the pool exists when the children run — thin sugar over the existing functions, no recording/replay. The positional API is untouched (and keeps the per-line error strings the DSL drops for readability).

## In the PR
- `std/http/proxy/module.ae` — `pool` + `upstream`/`health`/`breaker`/`rate_limit`/`cookie_name`/`drain` + a DSL doc section; quick-start shows both forms.
- `examples/stdlib/http-reverse-proxy-pool-dsl.ae` — the website's enterprise-stack example, pool as a config block (sibling to the positional one).
- `tests/regression/test_proxy_pool_dsl.ae` — asserts the DSL children reach the live pool (duplicate-upstream rejection); leak-clean under valgrind.

## Verified
DSL pool byte-for-byte equivalent to positional (same metrics). Regression passes, 0 valgrind leaks, clean -Werror build, fmt clean, existing proxy test green.

## Note (pre-existing, not fixed here)
`proxy.pool_metrics_text` returns a raw non-@heap char* that leaks on free (reproduces on main, unrelated to this DSL). The test avoids it; worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)