### PR TITLE
fix(std.fs): MNT_NODEV is not universal; probe the macro, not the platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,33 @@ next version number before tagging the release.
   artifact), and report the actual cause when the server cannot start
   instead of a bare "failed".
 
+## [current]
+
+### Fixed
+
+- **FreeBSD build break in `fs.mounts`.** `MNT_NODEV` was used unguarded in
+  the BSD `getmntinfo` backend. FreeBSD deprecated that flag and removed the
+  macro in FreeBSD 10, while macOS and OpenBSD still define it, so the
+  fallback path had never been compiled anywhere and the break only appeared
+  on FreeBSD. The flag is now probed with `#ifdef` rather than keyed on the
+  platform, so a future removal elsewhere degrades to omitting the option
+  instead of failing the build.
+- **NetBSD was claimed but never buildable.** It sat in the same
+  `getmntinfo` branch, but there the call fills a `struct statvfs` and the
+  flag field is `f_flag`, not `f_flags`, so that body could not have
+  compiled. NetBSD now falls through to the unsupported branch and reports
+  the error, matching the module's convention of degrading rather than
+  fabricating, instead of shipping a shape nobody has built.
+
+### Added
+
+- **`make ci-optional-macros`, a portability probe, now step 10 of `make
+  ci`.** It recompiles the affected sources with each guarded platform macro
+  forced absent, so both sides of every `#ifdef` are built on every run.
+  This reproduces the FreeBSD failure above on any host: verified by
+  reintroducing the bug and watching the probe fail, then restoring the fix
+  and watching it pass. Registering a new guarded macro is one line.
+
 ## [0.469.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ Keep checked-in Aether source canonically formatted; CI enforces this
 Run the full CI suite locally, this is the same suite that GitHub Actions runs:
 
 ```bash
-make ci          # Full 9-step suite with -Werror (compiler, tests, examples, smoke tests)
+make ci          # Full 10-step suite with -Werror (compiler, tests, examples, smoke tests)
 HARDEN=1 make ci # Hardened-build sweep (-fstack-protector-all + _FORTIFY_SOURCE=2);
                  # required for any PR that touches C in compiler/, runtime/, or std/.
                  # Catches unchecked memcpy / printf-format-injection bugs early.

--- a/Makefile
+++ b/Makefile
@@ -2118,37 +2118,40 @@ ci: clean
 	@echo "  Parallel: $(NPROC) jobs (build) / $(NPROC) (.ae tests) / $${SH_NPROC:-1} (shell tests)"
 	@echo "==================================="
 	@echo ""
-	@echo "[0/9] Restoring miniaudio object cache (if valid)..."
+	@echo "[0/10] Restoring miniaudio object cache (if valid)..."
 	@$(MAKE) audio-cache-restore
 	@echo ""
-	@echo "[1/9] Building compiler (-Werror)..."
+	@echo "[1/10] Building compiler (-Werror)..."
 	@$(MAKE) -j$(NPROC) compiler EXTRA_CFLAGS=-Werror
 	@$(MAKE) audio-cache-save
 	@echo ""
-	@echo "[2/9] Building ae CLI..."
+	@echo "[2/10] Building ae CLI..."
 	@$(MAKE) -j$(NPROC) ae
 	@echo ""
-	@echo "[3/9] Building stdlib..."
+	@echo "[3/10] Building stdlib..."
 	@$(MAKE) -j$(NPROC) stdlib
 	@echo ""
-	@echo "[4/9] Running C unit tests..."
+	@echo "[4/10] Running C unit tests..."
 	@$(MAKE) -j$(NPROC) test
 	@echo ""
-	@echo "[5/9] Running .ae integration tests..."
+	@echo "[5/10] Running .ae integration tests..."
 	@$(MAKE) test-ae
 	@echo ""
-	@echo "[6/9] Building examples..."
+	@echo "[6/10] Building examples..."
 	@$(MAKE) examples
 	@echo ""
-	@echo "[7/9] Install smoke test..."
+	@echo "[7/10] Install smoke test..."
 	@$(MAKE) test-install
 	@echo ""
-	@echo "[8/9] ae test smoke check..."
+	@echo "[8/10] ae test smoke check..."
 	@AETHER_HOME="" ./build/ae test examples/basics/hello.ae 2>&1 | tail -1
 	@echo "  [PASS] ae test runs correctly"
 	@echo ""
-	@echo "[9/9] Release archive smoke test..."
+	@echo "[9/10] Release archive smoke test..."
 	@$(MAKE) test-release-archive
+	@echo ""
+	@echo "[10/10] Optional-macro portability probe..."
+	@$(MAKE) ci-optional-macros
 	@echo ""
 	@echo "==================================="
 	@echo "  CI PASSED — all checks green"
@@ -2258,7 +2261,7 @@ asan-check: clean
 	  fi
 	@echo "✓ ASan clean — no memory errors detected"
 
-.PHONY: all compiler lsp apkg ae profiler docgen docs-server docs docs-serve test test-build test-valgrind test-asan test-macos-leaks test-memory test-manual-runtime test-cross test-install test-release-archive benchmark benchmark-ui examples run compile repl clean help self-test install stats stdlib stdlib-asan stdlib-memory stdlib-dbg ci ci-windows docker-ci docker-ci-windows docker-build-ci valgrind-check asan-check ci-coop ci-wasm ci-embedded ci-portability docker-ci-wasm docker-ci-embedded contrib-host-check contrib install-contrib stdlib-cov ci-coverage ci-coverage-clean ci-coverage-html
+.PHONY: ci-optional-macros all compiler lsp apkg ae profiler docgen docs-server docs docs-serve test test-build test-valgrind test-asan test-macos-leaks test-memory test-manual-runtime test-cross test-install test-release-archive benchmark benchmark-ui examples run compile repl clean help self-test install stats stdlib stdlib-asan stdlib-memory stdlib-dbg ci ci-windows docker-ci docker-ci-windows docker-build-ci valgrind-check asan-check ci-coop ci-wasm ci-embedded ci-portability docker-ci-wasm docker-ci-embedded contrib-host-check contrib install-contrib stdlib-cov ci-coverage ci-coverage-clean ci-coverage-html
 
 # Cross-language benchmark UI (alias for benchmark)
 benchmark-ui: benchmark
@@ -2558,6 +2561,46 @@ docker-ci-embedded:
 	docker run --rm -v $(PWD):/aether -w /aether aether-embedded make ci-embedded
 
 # Run ALL portability checks (native coop + Docker WASM + Docker embedded)
+# Optional-macro portability probe. Some platform macros this tree keys on
+# exist on one BSD and not another: FreeBSD 10 removed MNT_NODEV while macOS
+# and OpenBSD still define it, and that difference broke the FreeBSD build
+# after passing macOS CI, because the fallback path had never been compiled
+# anywhere. This target compiles the affected sources with each such macro
+# forced absent, so both sides of every #ifdef are built on every run.
+#
+# The undef goes before the LAST match of the anchor, not the first: these
+# files carry a no-op stub of the same function for platforms without the
+# feature, and that stub sits ABOVE the system include that defines the
+# macro, so undefining there would be silently reversed by the include.
+#
+# Add a line here whenever you guard a new optional platform macro.
+ci-optional-macros:
+	@echo "=== Optional-macro portability probe ==="
+	@mkdir -p build/portability
+	@fail=0; \
+	for probe in "std/fs/aether_fs.c:MNT_NODEV:fs_try_mounts(void) {"; do \
+	    src=$${probe%%:*}; rest=$${probe#*:}; \
+	    macro=$${rest%%:*}; anchor=$${rest#*:}; \
+	    out="build/portability/$$(basename $$src)"; \
+	    awk -v a="$$anchor" -v m="$$macro" \
+	        'NR==FNR { if (index($$0, a)) last=FNR; next } \
+	         FNR==last { print "#undef " m } { print }' \
+	        "$$src" "$$src" > "$$out"; \
+	    printf '  %-28s without %s ... ' "$$(basename $$src)" "$$macro"; \
+	    if $(CC) -std=c11 -Werror -fsyntax-only \
+	             -I"$$(dirname $$src)" $(CFLAGS) "$$out" \
+	             2>build/portability/err.log; then \
+	        echo "OK"; \
+	    else \
+	        echo "FAILED"; sed 's/^/      /' build/portability/err.log; fail=1; \
+	    fi; \
+	done; \
+	if [ $$fail -ne 0 ]; then \
+	    echo "  A guarded platform macro's fallback path does not compile."; \
+	    exit 1; \
+	fi
+	@echo "  All optional-macro fallback paths compile."
+
 ci-portability: ci-coop docker-ci-wasm docker-ci-embedded
 	@echo ""
 	@echo "==================================="

--- a/Makefile
+++ b/Makefile
@@ -2587,7 +2587,7 @@ ci-optional-macros:
 	         FNR==last { print "#undef " m } { print }' \
 	        "$$src" "$$src" > "$$out"; \
 	    printf '  %-28s without %s ... ' "$$(basename $$src)" "$$macro"; \
-	    if $(CC) -std=c11 -Werror -fsyntax-only \
+	    if $(CC) -std=gnu11 -Werror -fsyntax-only \
 	             -I"$$(dirname $$src)" $(CFLAGS) "$$out" \
 	             2>build/portability/err.log; then \
 	        echo "OK"; \

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Same file is config, validation, conditional logic, and the entry point. No seco
 ### Running Tests
 
 ```bash
-# Full CI suite (9 steps, -Werror), runs on your current platform
+# Full CI suite (10 steps, -Werror), runs on your current platform
 make ci
 
 # Unit tests only (runtime C test suite)

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -131,10 +131,10 @@ void fs_watch_close(void* w) { (void)w; }
 #include <sys/statvfs.h>     // statvfs() for fs_try_statvfs (#1117)
 #endif
 #include <stddef.h>           // offsetof for the mount-table getters (#1118)
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/param.h>
 #include <sys/ucred.h>
-#include <sys/mount.h>        // getmntinfo() for fs_try_mounts (#1118)
+#include <sys/mount.h>        // getmntinfo() for fs_try_mounts
 #endif
 
 #ifdef _WIN32
@@ -1130,16 +1130,32 @@ int fs_try_mounts(void) {
     }
     fclose(fp);
     return s_mount_count;
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+    /* macOS / FreeBSD / OpenBSD share the `struct statfs` getmntinfo(3).
+     * NetBSD is deliberately NOT in this list: there getmntinfo fills a
+     * `struct statvfs` and the flag field is `f_flag`, not `f_flags`, so
+     * this body would not compile. It falls through to the unsupported
+     * branch and reports the error rather than shipping a shape nobody
+     * has built, which is how the MNT_NODEV break below reached CI. */
     struct statfs* mntbuf = NULL;
     int n = getmntinfo(&mntbuf, MNT_NOWAIT);
     if (n <= 0) return -1;
     for (int i = 0; i < n; i++) {
+        /* MNT_NODEV is not universal: FreeBSD deprecated it (it became a
+         * no-op) and removed the macro in FreeBSD 10, while macOS and
+         * OpenBSD still define it. Probe the macro, not the platform, so
+         * a future removal elsewhere degrades to omitting the flag
+         * instead of failing the build. */
+#ifdef MNT_NODEV
+        const char* nodev_opt = (mntbuf[i].f_flags & MNT_NODEV) ? ",nodev" : "";
+#else
+        const char* nodev_opt = "";
+#endif
         char opts[128];
         snprintf(opts, sizeof(opts), "%s%s%s%s",
                  (mntbuf[i].f_flags & MNT_RDONLY) ? "ro" : "rw",
                  (mntbuf[i].f_flags & MNT_NOSUID) ? ",nosuid" : "",
-                 (mntbuf[i].f_flags & MNT_NODEV)  ? ",nodev"  : "",
+                 nodev_opt,
                  (mntbuf[i].f_flags & MNT_NOEXEC) ? ",noexec" : "");
         if (!fs_mounts_append(mntbuf[i].f_mntfromname, mntbuf[i].f_mntonname,
                               mntbuf[i].f_fstypename, opts)) {


### PR DESCRIPTION
Fixes the FreeBSD build break:

```
std/fs/aether_fs.c:1142:39: error: use of undeclared identifier 'MNT_NODEV'
```

## Why macOS CI did not catch it

`MNT_NODEV` is not universal. FreeBSD deprecated it (it became a no-op) and **removed the macro in FreeBSD 10**, while macOS and OpenBSD still define it. The `getmntinfo` backend used it unguarded, so the branch compiled everywhere it was tested and failed only where the macro is gone. The flag is now probed with `#ifdef` rather than keyed on the platform, so a future removal on another BSD degrades to omitting the option instead of breaking the build.

## NetBSD was claimed but could never have compiled

Auditing the same branch turned up a second latent break. NetBSD was listed alongside macOS/FreeBSD/OpenBSD, but there `getmntinfo` fills a **`struct statvfs`**, and the flag field is **`f_flag`**, not `f_flags`. That body could not have built on NetBSD.

Rather than ship an untested second shape, NetBSD now falls through to the unsupported branch and reports the error, which is this module's stated convention (degrade, never fabricate). Claiming support that had never been compiled is what produced this bug in the first place.

## The gate: `make ci-optional-macros`, step 10 of `make ci`

A one-platform macro difference slipping through a green CI is a *class* of bug, not an incident. The new target recompiles the affected sources with each guarded platform macro **forced absent**, so both sides of every `#ifdef` are built on every run, on any host. Registering a new guarded macro is one line.

Two things worth noting about it:

- **It is verified to catch this exact bug, not merely to pass.** I reintroduced the original code and confirmed the probe fails with the same `use of undeclared identifier MNT_NODEV` error, then restored the fix and confirmed it passes.
- **The first version of the probe was wrong and silently passed.** It undefined the macro before the *first* match of its anchor, which is the no-op stub of the same function near the top of the file, sitting **above** the `<sys/mount.h>` include that defines the macro, so the include simply re-defined it. It now targets the last match. Worth knowing because a portability gate that always passes is worse than none.

## Verification

- with the bug reintroduced: probe **fails** with the original FreeBSD error; with the fix: **passes**
- `make test` 229/229; `tests/regression/test_std_fs_mounts.ae` passes (11 real mounts on macOS)
- `-Werror` and MinGW cross-compile clean on the changed TU
- README and CONTRIBUTING updated from "9-step" to "10-step" so the documented suite matches
