### PR TITLE
fix(build): release/install generate the stdlib-symbols header; FreeBSD toolchain selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1575,7 +1575,7 @@ LTO_FLAG = $(shell \
 	else echo -flto; fi)
 
 # Release build with optimizations and warnings as errors
-release: clean
+release: clean $(STDLIB_SYMS_HEADER)
 	@echo "==================================="
 	@echo "Building Optimized Release"
 	@echo "==================================="

--- a/install.sh
+++ b/install.sh
@@ -144,8 +144,15 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
         fi
     fi
 
-    # Detect make command (prefer make, fall back to mingw32-make on Windows)
-    if command -v make >/dev/null 2>&1; then
+    # Detect make command. The Makefile is GNU make syntax (ifeq, $(shell),
+    # pattern rules), so we need GNU make specifically. Prefer `gmake` when it
+    # exists — it is the GNU make binary on every BSD, and on Linux `gmake` and
+    # `make` are the same program. Falling back to bare `make` picks BSD make on
+    # FreeBSD/*BSD, which then dies with a confusing "Invalid line ifeq" parse
+    # error mid-build (asks/install-sh-picks-bsd-make-on-freebsd.md).
+    if command -v gmake >/dev/null 2>&1; then
+        MAKE_CMD="gmake"
+    elif command -v make >/dev/null 2>&1; then
         MAKE_CMD="make"
     elif command -v mingw32-make >/dev/null 2>&1; then
         MAKE_CMD="mingw32-make"
@@ -162,15 +169,38 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
         exit 1
     fi
 
-    # Show what compiler we found
-    if command -v gcc >/dev/null 2>&1; then
-        CC_VERSION=$(gcc --version 2>&1 | head -1)
+    # Resolve the C compiler we'll hand to make. The Makefile hardcodes
+    # `CC := gcc` (Makefile:136), but FreeBSD/macOS ship no gcc — the system
+    # compiler is `cc` (-> clang). Prefer an explicit $CC, else gcc, else the
+    # POSIX `cc`, else clang, and pass it through as `CC=` so the build uses a
+    # compiler that actually exists (asks/install-sh-picks-bsd-make-on-freebsd.md
+    # ask 3). `cc` is gcc on Linux and clang on the BSDs/macOS.
+    if [ -n "${CC:-}" ]; then
+        CC_BIN="$CC"
+    elif command -v gcc >/dev/null 2>&1; then
+        CC_BIN="gcc"
+    elif command -v cc >/dev/null 2>&1; then
+        CC_BIN="cc"
     elif command -v clang >/dev/null 2>&1; then
-        CC_VERSION=$(clang --version 2>&1 | head -1)
+        CC_BIN="clang"
     else
-        CC_VERSION=$(cc --version 2>&1 | head -1)
+        CC_BIN="cc"
     fi
-    ok "  C compiler: $CC_VERSION"
+    CC_VERSION=$("$CC_BIN" --version 2>&1 | head -1)
+    ok "  C compiler: $CC_VERSION  (CC=$CC_BIN)"
+
+    # Verify the chosen make is GNU make, not just *a* make. On BSD, `make` is
+    # BSD make, which cannot parse this GNU Makefile; catch that here with an
+    # actionable message instead of a mid-build "Invalid line ifeq" parse error.
+    # (mingw32-make on Windows is GNU make, so it passes this probe.)
+    if ! "$MAKE_CMD" --version 2>/dev/null | head -1 | grep -qi 'gnu make'; then
+        error "Error: '$MAKE_CMD' is not GNU make (the Makefile is GNU make syntax)."
+        echo "  Found: $("$MAKE_CMD" --version 2>&1 | head -1)"
+        echo "  Install GNU make and re-run:"
+        echo "    FreeBSD/*BSD: pkg install gmake   (then this script prefers gmake)"
+        echo "    Linux:        it is already 'make'"
+        exit 1
+    fi
     ok "  make: $($MAKE_CMD --version 2>&1 | head -1)"
     echo ""
 
@@ -181,14 +211,15 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
         git fetch --tags --quiet 2>/dev/null || true
     fi
 
-    # Build
+    # Build. Pass CC= explicitly so a box with no gcc (FreeBSD/macOS) uses the
+    # resolved system compiler instead of the Makefile's hardcoded `gcc`.
     info "Building Aether..."
-    $MAKE_CMD compiler 2>&1 | tail -1
-    $MAKE_CMD ae 2>&1 | tail -1
+    $MAKE_CMD CC="$CC_BIN" compiler 2>&1 | tail -1
+    $MAKE_CMD CC="$CC_BIN" ae 2>&1 | tail -1
 
     # Build precompiled stdlib
     info "Building standard library..."
-    $MAKE_CMD stdlib 2>&1 | tail -1
+    $MAKE_CMD CC="$CC_BIN" stdlib 2>&1 | tail -1
 
     # Build the language server too so the editor extension's LSP
     # client can wire up out of the box (go-to-def, hover,
@@ -199,7 +230,7 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
     # install: the editor extension falls back to syntax-only mode
     # and the user still has a working `ae` / `aetherc`.
     info "Building language server..."
-    if ! $MAKE_CMD lsp 2>&1 | tail -1; then
+    if ! $MAKE_CMD CC="$CC_BIN" lsp 2>&1 | tail -1; then
         warn "  lsp build failed — editor extension will fall back to syntax-only mode."
     fi
 

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1989,16 +1989,26 @@ void build_gcc_cmd(char* cmd, size_t size,
             return;
         }
     } else {
-        cc = "gcc";
-        // Pre-flight check: ensure gcc (or cc) is available
-        if (system("command -v gcc >/dev/null 2>&1") != 0 &&
-            system("command -v cc >/dev/null 2>&1") != 0) {
-            fprintf(stderr, "Error: C compiler not found (gcc or cc).\n");
+        // No $AE_CC/$CC override: prefer `gcc`, but fall back to the POSIX
+        // `cc` when gcc is absent. FreeBSD/macOS ship no gcc at all — the
+        // system compiler is `cc` (-> clang) — so defaulting hard to "gcc"
+        // made `ae build` fail out of the box there even though `cc` works
+        // (asks/install-sh-picks-bsd-make-on-freebsd.md, ask 4). `cc` is gcc
+        // on Linux and clang on FreeBSD/macOS, so this is a no-op where gcc
+        // exists and a fix where it doesn't.
+        if (system("command -v gcc >/dev/null 2>&1") == 0) {
+            cc = "gcc";
+        } else if (system("command -v cc >/dev/null 2>&1") == 0) {
+            cc = "cc";
+        } else {
+            fprintf(stderr, "Error: no C compiler found (looked for gcc, then cc).\n");
+            fprintf(stderr, "Set $CC to your compiler, or install one:\n");
 #ifdef __APPLE__
-            fprintf(stderr, "Install Xcode Command Line Tools: xcode-select --install\n");
+            fprintf(stderr, "  Xcode Command Line Tools: xcode-select --install\n");
 #else
-            fprintf(stderr, "Install GCC: sudo apt install gcc  (Debian/Ubuntu)\n");
-            fprintf(stderr, "             sudo dnf install gcc  (Fedora)\n");
+            fprintf(stderr, "  Debian/Ubuntu: sudo apt install gcc\n");
+            fprintf(stderr, "  Fedora:        sudo dnf install gcc\n");
+            fprintf(stderr, "  FreeBSD:       cc ships with the base system\n");
 #endif
             snprintf(cmd, size, "false");
             return;


### PR DESCRIPTION
Three related build/toolchain fixes, bundled in one PR (one CI run). **Not `[skip actions]`** — this changes the Makefile and `tools/ae.c` (the driver's compiler selection, cross-platform), exactly the kind of change that must run the full matrix.

## 1. `make release` / `make install` fails on a fresh tree — missing generated header

#1366 added `#include "aether_stdlib_symbols.h"` (a *generated* header) to `codegen.c`. The normal `compiler` target depends on the generator rule, but the **`release` target** (which `make install` uses) had only `release: clean` as its prerequisite:

```
compiler/codegen/codegen.c:7:10: fatal error: aether_stdlib_symbols.h: No such file or directory
make: *** [Makefile:1592: release] Error 1
```

**Fix:** `release: clean $(STDLIB_SYMS_HEADER)`. The header lives in `compiler/codegen/` (not `build/`), so `clean` doesn't remove it; the release path now generates-then-compiles. Verified from a fully clean state (header + `build/` deleted → `Generated ...aether_stdlib_symbols.h` → `Release build complete`).

## 2 & 3. FreeBSD: `install.sh` picks BSD make; `ae build` hardcodes gcc

From `asks/install-sh-picks-bsd-make-on-freebsd.md` (a FreeBSD 15 / GhostBSD box upgrading the toolchain). FreeBSD ships **no gcc** (system compiler is `cc` → clang) and `/usr/bin/make` is **BSD make**, which can't parse this GNU Makefile.

**install.sh (asks 1-3):**
- **Prefer `gmake`** over bare `make` (GNU make on every BSD; == `make` on Linux). Bare `make` on FreeBSD died mid-build with `Invalid line "ifeq"`.
- **Verify it's GNU make** (probe `--version` for "gnu make") — turns a confusing mid-build parse error into a one-line actionable message. `mingw32-make` passes (it *is* GNU make).
- **Resolve CC** (`$CC` → gcc → cc → clang) and pass `CC=` to every make invocation, so a gcc-less box uses the system compiler instead of the Makefile's hardcoded `CC := gcc`.

**tools/ae.c (ask 4):** `ae build`/`ae run` C backend now honors `$AE_CC`/`$CC`, else prefers `gcc` when present, else falls back to **`cc`**. Defaulting hard to `gcc` made `ae build` fail out of the box on FreeBSD/macOS even though `cc` works. No-op where gcc exists (Linux); a fix where it doesn't. The not-found message now lists gcc + cc and notes FreeBSD's base `cc`.

## Deferred (not in this PR)
Ask 5 ("say exactly which compiler failed / surface spawn stderr") is partly addressed by ask 4 (the FreeBSD "Build failed. with nothing" was the missing-gcc *spawn* failure, now avoided). A deeper "always name the C compiler + exit code on any failure" is a separate diagnostics change worth its own review.

## Verification
- Full build clean; `release` builds from a fresh header-deleted tree.
- `install.sh`: `bash -n` clean; detection logic on Linux picks `gmake`, passes the GNU-make probe, resolves `CC=gcc`.
- ae-driver gcc→cc fallback confirmed against the exact shell probes under a gcc-less PATH (`gcc rc=127`, `cc rc=0` → selects `cc`); normal Linux gcc build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)