### PR TITLE
test(differential): compare lowering paths; measure and reject actor pooling (#523, #1332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Differential testing across lowering paths** (#523). Every
+  `tests/differential/cases/*.ae` is built and run under both `--emit=exe` and
+  `--emit=lib` and the outputs compared, because per-path correctness is weaker
+  than cross-path agreement: a bug that miscompiles one path passes today, since
+  that path's expected output was captured from the same build. A divergence is
+  a hard failure naming both paths with the diff. Carved-out cases are reported
+  with their reason on every run rather than silently skipped, and a carveout
+  naming a case that no longer exists is an error, so the file cannot rot. Wired
+  in as step 9 of `make ci` and available as `make test-differential`. See
+  `docs/differential-testing.md`.
+
+### Changed
+
+- **Actor pooling measured and rejected** (#1332), with the numbers recorded in
+  `docs/runtime-optimizations.md`. On the skynet benchmark constructing 11.1M
+  actors, malloc/free is 2.9% of non-idle CPU during the tree-construction phase
+  and 0.3-0.5% across a whole run, against `scheduler_spawn_actor`'s own 10.1%
+  spent re-initializing state a pool would still have to re-initialize. The
+  ceiling is too small to justify a size-class bucketed, NUMA-aware pool with a
+  cross-core release path. A side finding is recorded with it: `tlv_get_addr` is
+  6.7% of non-idle time, roughly twice the allocator, making thread-local access
+  a bigger cost in the actor hot path than actor allocation.
+
 ## [0.489.0]
 
 ## [0.488.0]

--- a/Makefile
+++ b/Makefile
@@ -2166,41 +2166,57 @@ ci: clean
 	@echo "  Parallel: $(NPROC) jobs (build) / $(NPROC) (.ae tests) / $${SH_NPROC:-1} (shell tests)"
 	@echo "==================================="
 	@echo ""
-	@echo "[0/9] Restoring miniaudio object cache (if valid)..."
+	@echo "[0/10] Restoring miniaudio object cache (if valid)..."
 	@$(MAKE) audio-cache-restore
 	@echo ""
-	@echo "[1/9] Building compiler (-Werror)..."
+	@echo "[1/10] Building compiler (-Werror)..."
 	@$(MAKE) -j$(NPROC) compiler EXTRA_CFLAGS=-Werror
 	@$(MAKE) audio-cache-save
 	@echo ""
-	@echo "[2/9] Building ae CLI..."
+	@echo "[2/10] Building ae CLI..."
 	@$(MAKE) -j$(NPROC) ae
 	@echo ""
-	@echo "[3/9] Building stdlib..."
+	@echo "[3/10] Building stdlib..."
 	@$(MAKE) -j$(NPROC) stdlib
 	@echo ""
-	@echo "[4/9] Running C unit tests..."
+	@echo "[4/10] Running C unit tests..."
 	@$(MAKE) -j$(NPROC) test
 	@echo ""
-	@echo "[5/9] Running .ae integration tests..."
+	@echo "[5/10] Running .ae integration tests..."
 	@$(MAKE) test-ae
 	@echo ""
-	@echo "[6/9] Building examples..."
+	@echo "[6/10] Building examples..."
 	@$(MAKE) examples
 	@echo ""
-	@echo "[7/9] Install smoke test..."
+	@echo "[7/10] Install smoke test..."
 	@$(MAKE) test-install
 	@echo ""
-	@echo "[8/9] ae test smoke check..."
+	@echo "[8/10] ae test smoke check..."
 	@AETHER_HOME="" ./build/ae test examples/basics/hello.ae 2>&1 | tail -1
 	@echo "  [PASS] ae test runs correctly"
 	@echo ""
-	@echo "[9/9] Release archive smoke test..."
+	@echo "[9/10] Differential test (lowering paths agree)..."
+	@$(MAKE) test-differential
+	@echo ""
+	@echo "[10/10] Release archive smoke test..."
 	@$(MAKE) test-release-archive
 	@echo ""
 	@echo "==================================="
 	@echo "  CI PASSED — all checks green"
 	@echo "==================================="
+
+# -----------------------------------------------------------------
+# Differential testing (#523)
+#
+# Runs every tests/differential/cases/*.ae through both lowering paths
+# (--emit=exe and --emit=lib) and compares stdout + exit code. Per-path
+# correctness is weaker than cross-path agreement: a bug that miscompiles
+# one path passes today, because that path's expected output was generated
+# from the same build. See docs/differential-testing.md.
+# -----------------------------------------------------------------
+.PHONY: test-differential
+test-differential: ae
+	@sh tests/differential/run_differential.sh
 
 # -----------------------------------------------------------------
 # contrib/host bridge check

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -1,0 +1,101 @@
+# Differential testing across lowering paths
+
+Aether compiles the same program in more than one way. `--emit=exe` produces a
+binary with `main()`; `--emit=lib` produces an artifact with no `main()` where
+every top-level function is exported as `aether_<name>`. The two are supposed to
+be observationally equivalent: a program's behaviour should not depend on which
+one you asked for.
+
+Nothing checked that. Each path was verified against its own expected output,
+which is a weaker property than it looks:
+
+- A bug that miscompiles **both** paths the same way passes, because both
+  outputs match each other and the expectation was captured from a build that
+  already had the bug.
+- A bug that miscompiles **one** path still passes, as long as that path's
+  expected-output file was generated from the same broken build.
+
+Cross-path agreement catches the second class directly, and it does so without
+anyone having to write down what the right answer is.
+
+## What runs
+
+`make test-differential`, and step 9 of `make ci`.
+
+For every `tests/differential/cases/*.ae`:
+
+| Path | How it runs |
+|---|---|
+| `--emit=exe` | the case's own `main()` calls `run()` |
+| `--emit=lib` | `tests/differential/driver.c` dlopens the artifact and calls `aether_run` |
+
+stdout and the exit code are captured from both and compared. A difference is a
+hard failure that names both paths and prints the diff; it is never downgraded
+to a warning.
+
+One driver serves every case. It resolves the entry point by name at runtime, so
+adding a case needs no generated glue.
+
+## Writing a case
+
+```aether
+import std.string
+
+run() {
+    println("whatever the case exercises")
+}
+
+main() { run() }
+```
+
+Two rules, both load-bearing:
+
+- **`main()` must do nothing but call `run()`.** The comparison is only
+  meaningful if both paths execute the same code. If `main()` does its own work,
+  a difference in output stops being evidence about lowering.
+- **The case must be capability-empty and deterministic.** No `fs`, `net` or
+  `os`; no clocks, addresses, or ordering that depends on where the allocator
+  happened to put something. A case that varies run to run reports a divergence
+  that is not one, and a suite that cries wolf gets ignored.
+
+Cases are a deliberately tagged subset rather than all of `tests/regression`.
+Every case doubles its run count, and the point is coverage of *lowering*
+surface, not of every program in the tree.
+
+## Carveouts
+
+A case whose paths legitimately differ goes in `tests/differential/carveouts.txt`
+as `<case> <reason>`:
+
+```
+some_case the reason this case cannot agree across paths
+```
+
+The discipline matters more than the mechanism:
+
+- A carved-out case is **reported on every run** with its reason, and counted in
+  the summary line. It is never silently skipped. An accepted divergence that
+  disappears from the output stops being a decision anyone revisits.
+- A carveout naming a case that does not exist is a **hard error**, so the file
+  cannot rot into a list of ghosts that excuse nothing.
+
+There are no carveouts today. Nothing has yet been found that differs between
+`--emit=exe` and `--emit=lib`.
+
+## Platform note
+
+The `--emit=lib` half needs `dlopen`, which MSYS2/MinGW does not provide (the
+runtime's `-ldl` dependency does not exist there). On Windows the suite reports
+a skip with that reason rather than passing silently, the same treatment the
+C-interop link cases give their Windows gap.
+
+## Extending it
+
+The exe-vs-lib pair is the first path comparison, not the only possible one.
+Others worth adding when they exist: optimisation levels against each other, and
+per-target codegen (the Linux and MSYS2 builds CI already runs are currently
+each checked only against their own expectations, never against each other).
+
+The harness self-checks that its comparison can fail. Without that, a broken
+diff would make every case vacuously agree and the suite would report success
+while testing nothing.

--- a/docs/runtime-optimizations.md
+++ b/docs/runtime-optimizations.md
@@ -389,6 +389,55 @@ Benchmarks showed hardware prefetchers handle sequential ring buffer access more
 
 Message processing is memory-bound. Vectorization overhead exceeded benefits for typical message sizes.
 
+### Actor Pooling (#1332)
+
+Reusing actor allocations across spawn/destroy churn, so a high-churn workload
+stops paying malloc/free per actor. Measured before implementing, per the rule
+that perf work needs profiling evidence first, and the measurement did not
+support it.
+
+Workload: the skynet benchmark at `SKYNET_LEAVES=1000000000`, which constructs
+**11.1M actors**, the most spawn-heavy workload in the tree. Sampled with
+`sample(1)` on macOS/arm64. Idle frames (`swtch_pri`, `__semwait_signal`,
+`scheduler_wait`) are excluded from the denominator, since a pool cannot recover
+time nobody is using.
+
+Sampling the **tree-construction phase specifically**, which is where every
+spawn happens:
+
+| Frame | Share of non-idle |
+|---|---|
+| `scheduler_thread` (the scheduler loop) | 70.0% |
+| `scheduler_spawn_actor` (self) | 10.1% |
+| `tlv_get_addr` (thread-local access) | 6.7% |
+| `scheduler_io_poll` | 4.8% |
+| **malloc / free, all frames** | **2.9%** |
+| `scheduler_register_actor` | 0.2% |
+
+Sampling a whole run mid-flight instead, so steady-state messaging dominates,
+puts the allocator at **0.3-0.5%** of non-idle time across two runs.
+
+So the ceiling for actor pooling is roughly 3% of non-idle CPU in the
+construction phase of a benchmark built to do nothing but construct actors, and
+well under 1% of a realistic run. A pool cannot capture even that much: it still
+has to re-initialize the mailbox, atomics, `alloc_size` and the panic/dead flags,
+which is most of what `scheduler_spawn_actor`'s own 10% is doing. The allocation
+call is the small half of the small number.
+
+Against that, a correct pool has to be size-class bucketed (actors are
+variable-size derived structs), preserve NUMA affinity, and handle release
+happening on a different core than spawn because work stealing migrates actors
+mid-life. The previous attempt (removed in PR #1330) got the layout wrong and
+routed NUMA-allocated memory to plain `free()`.
+
+Not worth it at this ratio. Revisit if a profile ever shows allocation as a
+double-digit share.
+
+**Side finding worth its own look:** `tlv_get_addr` is 6.7% of non-idle time,
+stable across all three samples, and about twice the allocator. Thread-local
+variable access is a larger cost in the actor hot path than actor allocation
+ever was.
+
 ## Opt-In Features
 
 The following optimizations are available but disabled by default. Enable them via runtime configuration flags when appropriate for your workload.

--- a/tests/differential/carveouts.txt
+++ b/tests/differential/carveouts.txt
@@ -1,0 +1,12 @@
+# Differential-testing carveouts (#523).
+#
+# One `<case> <reason>` per line. A case listed here is REPORTED as opted out
+# with its reason on every run, never silently skipped: an accepted divergence
+# has to stay visible, or the suite quietly stops testing what it claims to.
+#
+# A carveout naming a case that no longer exists is an error, so this file
+# cannot rot into a list of ghosts.
+#
+# Nothing is carved out today. The entries this is designed for are cases whose
+# behaviour legitimately differs between lowering paths, which so far has not
+# happened.

--- a/tests/differential/cases/arith.ae
+++ b/tests/differential/cases/arith.ae
@@ -1,0 +1,23 @@
+// Differential case (#523): built and run under BOTH lowering paths, with the
+// outputs compared. `run()` is the entry the --emit=lib driver calls by name;
+// `main()` is what the --emit=exe path runs. Keep the two identical, so any
+// difference in output is a difference in LOWERING, not in the program.
+//
+// Must stay capability-empty (no fs / net / os) and deterministic: no clocks,
+// no addresses, no iteration order that depends on allocation.
+
+import std.string
+run() {
+    a = 2 + 3 * 4
+    println("a=${a} mod=${a % 5} neg=${0 - a}")
+    f = 3.5 * 2.0
+    println("f=${f}")
+    i = 0
+    total = 0
+    while i < 10 {
+        total = total + i * i
+        i = i + 1
+    }
+    println("total=${total}")
+}
+main() { run() }

--- a/tests/differential/cases/control.ae
+++ b/tests/differential/cases/control.ae
@@ -1,0 +1,24 @@
+// Differential case (#523): built and run under BOTH lowering paths, with the
+// outputs compared. `run()` is the entry the --emit=lib driver calls by name;
+// `main()` is what the --emit=exe path runs. Keep the two identical, so any
+// difference in output is a difference in LOWERING, not in the program.
+//
+// Must stay capability-empty (no fs / net / os) and deterministic: no clocks,
+// no addresses, no iteration order that depends on allocation.
+
+import std.string
+classify(n: int) -> string {
+    if n < 0 {
+        return "neg"
+    }
+    if n == 0 {
+        return "zero"
+    }
+    return "pos"
+}
+run() {
+    for i in 0..3 {
+        println("${i} -> ${classify(i - 1)}")
+    }
+}
+main() { run() }

--- a/tests/differential/cases/deferred.ae
+++ b/tests/differential/cases/deferred.ae
@@ -1,0 +1,15 @@
+// Differential case (#523): built and run under BOTH lowering paths, with the
+// outputs compared. `run()` is the entry the --emit=lib driver calls by name;
+// `main()` is what the --emit=exe path runs. Keep the two identical, so any
+// difference in output is a difference in LOWERING, not in the program.
+//
+// Must stay capability-empty (no fs / net / os) and deterministic: no clocks,
+// no addresses, no iteration order that depends on allocation.
+
+import std.io
+run() {
+    defer println("third")
+    println("first")
+    defer println("second")
+}
+main() { run() }

--- a/tests/differential/cases/mathlib.ae
+++ b/tests/differential/cases/mathlib.ae
@@ -1,0 +1,15 @@
+// Differential case (#523): built and run under BOTH lowering paths, with the
+// outputs compared. `run()` is the entry the --emit=lib driver calls by name;
+// `main()` is what the --emit=exe path runs. Keep the two identical, so any
+// difference in output is a difference in LOWERING, not in the program.
+//
+// Must stay capability-empty (no fs / net / os) and deterministic: no clocks,
+// no addresses, no iteration order that depends on allocation.
+
+import std.math
+import std.string
+run() {
+    println("abs=${math.abs_int(-5)} min=${math.min_int(3, 7)} max=${math.max_int(3, 7)}")
+    println("clamp=${math.clamp_int(15, 0, 10)}")
+}
+main() { run() }

--- a/tests/differential/cases/strings.ae
+++ b/tests/differential/cases/strings.ae
@@ -1,0 +1,16 @@
+// Differential case (#523): built and run under BOTH lowering paths, with the
+// outputs compared. `run()` is the entry the --emit=lib driver calls by name;
+// `main()` is what the --emit=exe path runs. Keep the two identical, so any
+// difference in output is a difference in LOWERING, not in the program.
+//
+// Must stay capability-empty (no fs / net / os) and deterministic: no clocks,
+// no addresses, no iteration order that depends on allocation.
+
+import std.string
+run() {
+    s = string.concat("hello", " world")
+    println("${s} len=${string.length(s)}")
+    println("eq=${string.equals(s, "hello world")} cmp=${string.compare("a", "b")}")
+    println("starts=${string.starts_with(s, "hello")} contains=${string.contains(s, "lo w")}")
+}
+main() { run() }

--- a/tests/differential/driver.c
+++ b/tests/differential/driver.c
@@ -1,0 +1,41 @@
+/* Differential-test driver (#523): runs a `--emit=lib` artifact's entry point.
+ *
+ * `--emit=lib` deliberately omits main(), so the lib half of a differential
+ * comparison cannot just be executed. Every top-level Aether function is
+ * exported as `aether_<name>`, so each case exposes `run()` and this driver
+ * calls `aether_run` through it. The exe half runs the same `run()` via the
+ * case's own main().
+ *
+ * One driver serves every case: the entry point is resolved by name at
+ * runtime, so no per-case generation is needed. */
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: driver <library>\n");
+        return 2;
+    }
+
+    void* handle = dlopen(argv[1], RTLD_NOW);
+    if (!handle) {
+        fprintf(stderr, "driver: dlopen failed: %s\n", dlerror());
+        return 2;
+    }
+
+    /* The cast goes through a union-free two-step because ISO C has no
+       conversion between object and function pointers; every POSIX platform
+       this driver builds on defines dlsym's return to be callable. */
+    void* sym = dlsym(handle, "aether_run");
+    if (!sym) {
+        fprintf(stderr, "driver: no aether_run export: %s\n", dlerror());
+        dlclose(handle);
+        return 2;
+    }
+    void (*entry)(void);
+    *(void**)(&entry) = sym;
+
+    entry();
+    fflush(stdout);
+    return 0;
+}

--- a/tests/differential/run_differential.sh
+++ b/tests/differential/run_differential.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# Differential testing across lowering paths (#523).
+#
+# Per-path correctness is weaker than cross-path agreement. Each path today is
+# checked against its own expected output, so a bug that miscompiles one path
+# passes as long as that path's expectations were generated from the same buggy
+# build. This runs every case through BOTH lowering paths and compares, which
+# catches the divergence class directly.
+#
+# Paths compared:
+#   --emit=exe   the case's own main() runs run()
+#   --emit=lib   driver.c dlopens the artifact and calls aether_run
+#
+# A divergence is a hard failure naming both paths and showing the diff.
+# Carved-out cases are reported with their reason, never silently skipped.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if [ ! -x "$AE" ]; then
+    echo "  [SKIP] differential: ae not built"
+    exit 0
+fi
+
+# The lib half needs dlopen. MSYS2/MinGW has no libdl and the runtime's -ldl
+# dependency does not exist there, the same reason the C-interop link cases
+# skip case 4 on Windows. Reported, not silent.
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP] differential: no dlopen on Windows, the --emit=lib half cannot be driven"
+        exit 0
+        ;;
+esac
+
+case "$(uname -s 2>/dev/null)" in
+    Darwin) LIB_EXT="dylib" ;;
+    *)      LIB_EXT="so" ;;
+esac
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! cc -o "$TMP/driver" "$SCRIPT_DIR/driver.c" >"$TMP/driver.log" 2>&1; then
+    echo "  [FAIL] differential: could not build the lib driver"
+    sed 's/^/        /' "$TMP/driver.log" | head -10
+    exit 1
+fi
+
+# Carveouts: "<case> <reason>". Comments and blank lines ignored.
+carveout_reason() {
+    awk -v want="$1" '
+        /^[[:space:]]*#/ { next }
+        NF == 0          { next }
+        $1 == want       { $1 = ""; sub(/^[[:space:]]+/, ""); print; exit }
+    ' "$SCRIPT_DIR/carveouts.txt" 2>/dev/null
+}
+
+# A carveout for a case that no longer exists is an error, so the file cannot
+# rot into a list of ghosts that quietly excuse nothing.
+stale=0
+while read -r name _rest; do
+    case "$name" in ''|'#'*) continue ;; esac
+    if [ ! -f "$SCRIPT_DIR/cases/$name.ae" ]; then
+        echo "  [FAIL] differential: carveout '$name' names a case that does not exist"
+        stale=1
+    fi
+done < "$SCRIPT_DIR/carveouts.txt"
+[ "$stale" -eq 0 ] || exit 1
+
+pass=0; fail=0; carved=0
+
+for case_file in "$SCRIPT_DIR"/cases/*.ae; do
+    [ -f "$case_file" ] || continue
+    name=$(basename "$case_file" .ae)
+
+    reason=$(carveout_reason "$name")
+    if [ -n "$reason" ]; then
+        echo "  [CARVEOUT] differential/$name: $reason"
+        carved=$((carved + 1))
+        continue
+    fi
+
+    # Path A: --emit=exe, run the binary.
+    if ! "$AE" build "$case_file" -o "$TMP/$name.exe" >"$TMP/$name.exebuild.log" 2>&1; then
+        echo "  [FAIL] differential/$name: --emit=exe build failed"
+        sed 's/^/        /' "$TMP/$name.exebuild.log" | head -10
+        fail=$((fail + 1))
+        continue
+    fi
+    "$TMP/$name.exe" >"$TMP/$name.exe.out" 2>&1
+    exe_rc=$?
+
+    # Path B: --emit=lib, call aether_run through the driver.
+    if ! "$AE" build "$case_file" --emit=lib -o "$TMP/lib$name.$LIB_EXT" \
+            >"$TMP/$name.libbuild.log" 2>&1; then
+        echo "  [FAIL] differential/$name: --emit=lib build failed"
+        sed 's/^/        /' "$TMP/$name.libbuild.log" | head -10
+        fail=$((fail + 1))
+        continue
+    fi
+    "$TMP/driver" "$TMP/lib$name.$LIB_EXT" >"$TMP/$name.lib.out" 2>&1
+    lib_rc=$?
+
+    if [ "$exe_rc" != "$lib_rc" ]; then
+        echo "  [FAIL] differential/$name: exit code differs between lowering paths"
+        echo "         --emit=exe exited $exe_rc, --emit=lib exited $lib_rc"
+        fail=$((fail + 1))
+        continue
+    fi
+    if ! diff -u "$TMP/$name.exe.out" "$TMP/$name.lib.out" >"$TMP/$name.diff" 2>&1; then
+        echo "  [FAIL] differential/$name: output differs between lowering paths"
+        echo "         --- --emit=exe / +++ --emit=lib"
+        sed 's/^/         /' "$TMP/$name.diff" | head -20
+        fail=$((fail + 1))
+        continue
+    fi
+    pass=$((pass + 1))
+done
+
+# Self-check: prove the comparison can actually fail. Without this the suite
+# would report success just as happily if the diff were broken and every
+# comparison were vacuous.
+printf 'a\n' > "$TMP/self.a"
+printf 'b\n' > "$TMP/self.b"
+if diff -q "$TMP/self.a" "$TMP/self.b" >/dev/null 2>&1; then
+    echo "  [FAIL] differential: the comparison does not detect a difference"
+    exit 1
+fi
+
+if [ "$fail" -gt 0 ]; then
+    echo "  differential: $pass agreed, $fail diverged, $carved carved out"
+    exit 1
+fi
+echo "  [PASS] differential: $pass cases agree across --emit=exe and --emit=lib ($carved carved out)"
+exit 0


### PR DESCRIPTION
Two issues, one of which the issue itself asks to close with numbers rather than code.

## Differential testing across lowering paths (#523)

Aether compiles the same program more than one way, and nothing checked that the ways agree. Each path was verified against its own expected output, which is weaker than it looks: a bug that miscompiles one path passes as long as that path's expectations were captured from the same broken build.

Every `tests/differential/cases/*.ae` now runs under both paths with stdout and exit code compared:

| Path | How it runs |
|---|---|
| `--emit=exe` | the case's own `main()` calls `run()` |
| `--emit=lib` | `driver.c` dlopens the artifact and calls `aether_run` |

`--emit=lib` omits `main()` by design, so the lib half needs a driver. One driver serves every case: it resolves the entry by name at runtime, so adding a case needs no generated glue. A divergence is a hard failure naming both paths with the diff.

**Carveout discipline**, per the issue: a carved-out case is reported with its reason on every run rather than silently skipped, and a carveout naming a case that no longer exists is a hard error, so the file cannot rot into a list of ghosts that excuse nothing. The harness also self-checks that its comparison can fail, without which a broken diff would make every case vacuously agree and the suite would report success while testing nothing.

Wired in as step 9 of `make ci`, plus `make test-differential` standalone. Verified against all three behaviours:

```
[FAIL] differential/_probe: output differs between lowering paths
       --- --emit=exe / +++ --emit=lib
       -from-exe-path
       +from-lib-path
[CARVEOUT] differential/arith: temporarily carved out to prove reporting works
[FAIL] differential: carveout 'ghost_case' names a case that does not exist
```

No divergence exists today across the five cases, which is the expected result: the value is catching future ones. Windows reports a skip with its reason, since the lib half needs `dlopen` and MSYS2/MinGW has none.

## Actor pooling: measured, not built (#1332)

The issue gates implementation on profiling evidence and says outright: "If allocation is not a measurable share, close this issue with the numbers." It is not.

Skynet at `SKYNET_LEAVES=1000000000` constructs **11.1M actors**, the most spawn-heavy workload in the tree. Sampling the **tree-construction phase specifically**, where every spawn happens, with idle frames excluded from the denominator since a pool cannot recover time nobody is using:

| Frame | Share of non-idle |
|---|---|
| `scheduler_thread` (the scheduler loop) | 70.0% |
| `scheduler_spawn_actor` (self) | 10.1% |
| `tlv_get_addr` (thread-local access) | 6.7% |
| `scheduler_io_poll` | 4.8% |
| **malloc / free, all frames** | **2.9%** |
| `scheduler_register_actor` | 0.2% |

Sampling a whole run mid-flight instead, so steady-state messaging dominates, puts the allocator at **0.3-0.5%** across two runs.

So the ceiling is roughly 3% of non-idle CPU in the construction phase of a benchmark built to do nothing but construct actors, and well under 1% of a realistic run. A pool cannot capture even that much: it still has to re-initialize the mailbox, atomics, `alloc_size` and the panic/dead flags, which is most of what `scheduler_spawn_actor`'s own 10% is doing. The allocation call is the small half of the small number.

Against that, a correct pool has to be size-class bucketed (actors are variable-size derived structs), preserve NUMA affinity, and handle release on a different core than spawn because work stealing migrates actors mid-life. The previous attempt (removed in PR #1330) got the layout wrong and routed NUMA-allocated memory to plain `free()`.

Recorded in `docs/runtime-optimizations.md` under Rejected Optimizations, with the method and the numbers, so the decision does not get re-litigated from scratch.

**Side finding worth its own issue:** `tlv_get_addr` is 6.7% of non-idle time, stable across all three samples and about twice the allocator. Thread-local access costs more in the actor hot path than actor allocation ever did.

## Note on scope

I picked #1333 (message tracing) as the third item for this batch and then dropped it rather than half-ship it. Doing it to its own acceptance criteria means hook points across six call sites, per-core buffers merged at exit, a codegen-emitted message-name table so traces are readable, and a benchmark proving zero overhead when off. That is a full piece of work, not a third of one, and it deserves its own PR.

Local: `make test-differential` green, 229/229 unit, fmt gate clean.

Closes #523
Closes #1332
