### PR TITLE
feat(std.language): BCP 47 language tags + matching — Phase 1 of i18n (#863)

### DIFF
--- a/std/language/module.ae
+++ b/std/language/module.ae
@@ -1,6 +1,6 @@
 // std.language — BCP 47 Language Tags and Matching (RFC 5646, RFC 4647)
 
-import std.string (*)
+import std.string(*)
 import std.bytes
 import std.strbuilder
 import std.list
@@ -472,7 +472,11 @@ fn match_strings(m: *Matcher, preferred: string) -> string {
         while i < sz {
             p = list_get_raw(pref_list, i)
             if p != null {
-                heap.free(p)
+                // Cast to the struct type so heap.free emits the typed
+                // destructor that also releases the owned `tag` string field.
+                // On a raw `ptr` it degrades to a plain free() and leaks tag.
+                pref = p as *Preferred
+                heap.free(pref)
             }
             i = i + 1
         }
@@ -529,14 +533,23 @@ fn match_strings(m: *Matcher, preferred: string) -> string {
         i = i + 1
     }
 
-    sorted_pref = string_seq_empty()
+    // Build the sorted tag sequence WITHOUT a self-referential rebind
+    // (`x = cons(h, x)`): that shape makes codegen suppress freeing the old
+    // handle to avoid a double-free, but string_seq_cons takes an independent
+    // retain on its tail, so each intermediate cell leaks. Cons into a fresh
+    // `acc`, then drop the previous `prev` local (its ref is now held by the
+    // new cell) before advancing — one live handle at a time, no leak.
+    prev = string_seq_empty()
     i = sz - 1
     while i >= 0 {
         p = list_get_raw(pref_list, i)
         pref = p as *Preferred
-        sorted_pref = string_seq_cons(pref.tag, sorted_pref)
+        acc = string_seq_cons(pref.tag, prev)
+        string_seq_free(prev)
+        prev = acc
         i = i - 1
     }
+    sorted_pref = prev
     defer string_seq_free(sorted_pref)
 
     res = match_tags(m, sorted_pref)

--- a/std/language/module.ae
+++ b/std/language/module.ae
@@ -1,0 +1,544 @@
+// std.language — BCP 47 Language Tags and Matching (RFC 5646, RFC 4647)
+
+import std.string (*)
+import std.bytes
+import std.strbuilder
+import std.list
+
+exports(
+    Tag, parse, language, script, region, base,
+    Matcher, matcher_create, matcher_free, match_tags, match_strings
+)
+
+type Tag = distinct string
+
+struct Matcher {
+    supported: *StringSeq
+}
+
+struct Preferred {
+    tag: string
+    q: float
+}
+
+fn is_alpha_char(c: int) -> int {
+    if (c >= 97 && c <= 122) || (c >= 65 && c <= 90) {
+        return 1
+    }
+    return 0
+}
+
+fn is_digit_char(c: int) -> int {
+    if c >= 48 && c <= 57 {
+        return 1
+    }
+    return 0
+}
+
+fn is_alnum_char(c: int) -> int {
+    if is_alpha_char(c) == 1 || is_digit_char(c) == 1 {
+        return 1
+    }
+    return 0
+}
+
+fn is_alpha(s: string) -> int {
+    len = string_length(s)
+    if len == 0 {
+        return 0
+    }
+    i = 0
+    while i < len {
+        c = string_char_at(s, i)
+        if is_alpha_char(c) == 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+fn is_digit(s: string) -> int {
+    len = string_length(s)
+    if len == 0 {
+        return 0
+    }
+    i = 0
+    while i < len {
+        c = string_char_at(s, i)
+        if is_digit_char(c) == 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+fn is_alnum(s: string) -> int {
+    len = string_length(s)
+    if len == 0 {
+        return 0
+    }
+    i = 0
+    while i < len {
+        c = string_char_at(s, i)
+        if is_alnum_char(c) == 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+fn to_title_case(s: string) -> string {
+    len = string_length(s)
+    if len == 0 {
+        return ""
+    }
+    buf = bytes.new(len)
+    c0 = string_char_at(s, 0)
+    if c0 >= 97 && c0 <= 122 {
+        bytes.set(buf, 0, c0 - 32)
+    } else {
+        bytes.set(buf, 0, c0)
+    }
+    i = 1
+    while i < len {
+        ci = string_char_at(s, i)
+        if ci >= 65 && ci <= 90 {
+            bytes.set(buf, i, ci + 32)
+        } else {
+            bytes.set(buf, i, ci)
+        }
+        i = i + 1
+    }
+    return bytes.finish(buf, len)
+}
+
+fn parse(s: string) -> (string, string) {
+    if string_length(s) == 0 {
+        return "", "empty language tag"
+    }
+
+    // Normalize structure: replace underscores with hyphens
+    norm = string_replace_all(s, "_", "-")
+
+    // Validate that we don't have leading, trailing, or double hyphens
+    if string_starts_with(norm, "-") == 1 || string_ends_with(norm, "-") == 1 || string_contains(norm, "--") == 1 {
+        return "", "invalid language tag structure"
+    }
+
+    parts = string_split_to_seq(norm, "-")
+    if string_seq_is_empty(parts) == 1 {
+        string_seq_free(parts)
+        return "", "empty language tag"
+    }
+    defer string_seq_free(parts)
+
+    first = string_seq_head(parts)
+    first_len = string_length(first)
+
+    is_private_use = 0
+    if string_equals(first, "x") == 1 || string_equals(first, "X") == 1 {
+        is_private_use = 1
+    }
+
+    if is_private_use == 0 {
+        if first_len < 2 || first_len > 8 || is_alpha(first) == 0 {
+            // Check grandfathered i-
+            if first_len == 1 && (string_equals(first, "i") == 1 || string_equals(first, "I") == 1) {
+                // valid grandfathered prefix
+            } else {
+                return "", "invalid primary language subtag"
+            }
+        }
+    }
+
+    b = strbuilder.new(32)
+    defer catch strbuilder.free(b)
+
+    parsed_script = 0
+    parsed_region = 0
+    in_extension = 0
+    in_private_use_zone = 0
+    idx = 0
+
+    curr = parts
+    while string_seq_is_empty(curr) == 0 {
+        subtag = string_seq_head(curr)
+        sub_len = string_length(subtag)
+
+        if sub_len == 0 {
+            return "", "invalid empty subtag"
+        }
+
+        canonicalized = ""
+
+        if is_private_use == 1 {
+            canonicalized = string_to_lower(subtag)
+        } else if in_private_use_zone == 1 {
+            canonicalized = string_to_lower(subtag)
+        } else if in_extension == 1 {
+            if sub_len == 1 {
+                if string_equals(subtag, "x") == 1 || string_equals(subtag, "X") == 1 {
+                    in_private_use_zone = 1
+                    in_extension = 0
+                    canonicalized = "x"
+                } else {
+                    if is_alnum(subtag) == 0 {
+                        return "", "invalid extension singleton"
+                    }
+                    canonicalized = string_to_lower(subtag)
+                }
+            } else {
+                if sub_len < 2 || sub_len > 8 || is_alnum(subtag) == 0 {
+                    return "", "invalid extension subtag"
+                }
+                canonicalized = string_to_lower(subtag)
+            }
+        } else {
+            if idx == 0 {
+                canonicalized = string_to_lower(subtag)
+            } else {
+                if sub_len == 1 {
+                    if string_equals(subtag, "x") == 1 || string_equals(subtag, "X") == 1 {
+                        in_private_use_zone = 1
+                        canonicalized = "x"
+                    } else {
+                        if is_alnum(subtag) == 0 {
+                            return "", "invalid extension singleton"
+                        }
+                        in_extension = 1
+                        canonicalized = string_to_lower(subtag)
+                    }
+                } else {
+                    matched = 0
+                    if parsed_script == 0 && parsed_region == 0 && sub_len == 4 && is_alpha(subtag) == 1 {
+                        canonicalized = to_title_case(subtag)
+                        parsed_script = 1
+                        matched = 1
+                    }
+
+                    if matched == 0 && parsed_region == 0 {
+                        if sub_len == 2 && is_alpha(subtag) == 1 {
+                            canonicalized = string_to_upper(subtag)
+                            parsed_region = 1
+                            matched = 1
+                        } else if sub_len == 3 && is_digit(subtag) == 1 {
+                            canonicalized = subtag
+                            parsed_region = 1
+                            matched = 1
+                        }
+                    }
+
+                    if matched == 0 {
+                        is_var = 0
+                        if sub_len >= 5 && sub_len <= 8 && is_alnum(subtag) == 1 {
+                            is_var = 1
+                        } else if sub_len == 4 && is_digit_char(string_char_at(subtag, 0)) == 1 && is_alnum(subtag) == 1 {
+                            is_var = 1
+                        }
+                        if is_var == 1 {
+                            canonicalized = string_to_lower(subtag)
+                            matched = 1
+                        }
+                    }
+
+                    if matched == 0 && parsed_script == 0 && parsed_region == 0 && sub_len == 3 && is_alpha(subtag) == 1 {
+                        canonicalized = string_to_lower(subtag)
+                        matched = 1
+                    }
+
+                    if matched == 0 {
+                        if is_alnum(subtag) == 1 {
+                            canonicalized = string_to_lower(subtag)
+                        } else {
+                            return "", "invalid subtag"
+                        }
+                    }
+                }
+            }
+        }
+
+        if idx > 0 {
+            strbuilder.append_byte(b, 45) // '-'
+        }
+        strbuilder.append(b, canonicalized)
+
+        curr = string_seq_tail(curr)
+        idx = idx + 1
+    }
+
+    res = strbuilder.finish(b)
+    return res, ""
+}
+
+fn language(tag: Tag) -> string {
+    s = tag as string
+    parts = string_split_to_seq(s, "-")
+    defer string_seq_free(parts)
+    if string_seq_is_empty(parts) == 1 {
+        return ""
+    }
+    return string_copy(string_seq_head(parts))
+}
+
+fn script(tag: Tag) -> string {
+    s = tag as string
+    parts = string_split_to_seq(s, "-")
+    defer string_seq_free(parts)
+    curr = parts
+    idx = 0
+    while string_seq_is_empty(curr) == 0 {
+        subtag = string_seq_head(curr)
+        sub_len = string_length(subtag)
+        if idx > 0 {
+            if sub_len == 4 && is_alpha(subtag) == 1 {
+                c0 = string_char_at(subtag, 0)
+                c1 = string_char_at(subtag, 1)
+                c2 = string_char_at(subtag, 2)
+                c3 = string_char_at(subtag, 3)
+                if c0 >= 65 && c0 <= 90 && c1 >= 97 && c1 <= 122 && c2 >= 97 && c2 <= 122 && c3 >= 97 && c3 <= 122 {
+                    return string_copy(subtag)
+                }
+            }
+            if sub_len == 2 {
+                c0 = string_char_at(subtag, 0)
+                c1 = string_char_at(subtag, 1)
+                if c0 >= 65 && c0 <= 90 && c1 >= 65 && c1 <= 90 {
+                    break
+                }
+            }
+            if sub_len == 3 && is_digit(subtag) == 1 {
+                break
+            }
+            if sub_len == 1 {
+                break
+            }
+        }
+        curr = string_seq_tail(curr)
+        idx = idx + 1
+    }
+    return ""
+}
+
+fn region(tag: Tag) -> string {
+    s = tag as string
+    parts = string_split_to_seq(s, "-")
+    defer string_seq_free(parts)
+    curr = parts
+    idx = 0
+    while string_seq_is_empty(curr) == 0 {
+        subtag = string_seq_head(curr)
+        sub_len = string_length(subtag)
+        if idx > 0 {
+            if sub_len == 2 {
+                c0 = string_char_at(subtag, 0)
+                c1 = string_char_at(subtag, 1)
+                if c0 >= 65 && c0 <= 90 && c1 >= 65 && c1 <= 90 {
+                    return string_copy(subtag)
+                }
+            }
+            if sub_len == 3 && is_digit(subtag) == 1 {
+                return string_copy(subtag)
+            }
+            if sub_len == 1 {
+                break
+            }
+        }
+        curr = string_seq_tail(curr)
+        idx = idx + 1
+    }
+    return ""
+}
+
+fn base(tag: Tag) -> Tag {
+    return language(tag) as Tag
+}
+
+fn matcher_create(supported: *StringSeq) -> *Matcher {
+    m = heap.new(Matcher)
+    m.supported = string_seq_retain(supported)
+    return m
+}
+
+fn matcher_free(m: *Matcher) {
+    if m != null {
+        string_seq_free(m.supported)
+        heap.free(m)
+    }
+}
+
+fn find_last_hyphen(s: string) -> int {
+    len = string_length(s)
+    i = len - 1
+    while i >= 0 {
+        if string_char_at(s, i) == 45 { // '-'
+            return i
+        }
+        i = i - 1
+    }
+    return -1
+}
+
+fn match_tags(m: *Matcher, preferred: *StringSeq) -> string {
+    if m == null || string_seq_is_empty(m.supported) == 1 {
+        return ""
+    }
+
+    fallback = string_seq_head(m.supported)
+    if string_seq_is_empty(preferred) == 1 {
+        fallback_tag_str, _ = parse(fallback)
+        return fallback_tag_str
+    }
+
+    // First pass: strict Lookup matching (truncating from the end of each preferred tag)
+    curr_pref = preferred
+    while string_seq_is_empty(curr_pref) == 0 {
+        p_str = string_seq_head(curr_pref)
+        p_tag_str, p_err = parse(p_str)
+        if p_err == "" {
+            t_str = string_copy(p_tag_str)
+            while string_length(t_str) > 0 {
+                curr_supp = m.supported
+                while string_seq_is_empty(curr_supp) == 0 {
+                    s_str = string_seq_head(curr_supp)
+                    s_tag_str, s_err = parse(s_str)
+                    if s_err == "" {
+                        if string_equals(t_str, s_tag_str) == 1 {
+                            return string_copy(s_tag_str)
+                        }
+                    }
+                    curr_supp = string_seq_tail(curr_supp)
+                }
+
+                last_idx = find_last_hyphen(t_str)
+                if last_idx >= 0 {
+                    t_str = string_substring(t_str, 0, last_idx)
+                } else {
+                    t_str = ""
+                }
+            }
+        }
+        curr_pref = string_seq_tail(curr_pref)
+    }
+
+    // Second pass: fallback to primary language matching (base language)
+    curr_pref = preferred
+    while string_seq_is_empty(curr_pref) == 0 {
+        p_str = string_seq_head(curr_pref)
+        p_tag_str, p_err = parse(p_str)
+        if p_err == "" {
+            p_tag = p_tag_str as Tag
+            p_lang = language(p_tag)
+            curr_supp = m.supported
+            while string_seq_is_empty(curr_supp) == 0 {
+                s_str = string_seq_head(curr_supp)
+                s_tag_str, s_err = parse(s_str)
+                if s_err == "" {
+                    s_tag = s_tag_str as Tag
+                    s_lang = language(s_tag)
+                    if string_equals(p_lang, s_lang) == 1 {
+                        return string_copy(s_tag_str)
+                    }
+                }
+                curr_supp = string_seq_tail(curr_supp)
+            }
+        }
+        curr_pref = string_seq_tail(curr_pref)
+    }
+
+    fallback_tag_str, _ = parse(fallback)
+    return fallback_tag_str
+}
+
+fn match_strings(m: *Matcher, preferred: string) -> string {
+    if m == null || string_seq_is_empty(m.supported) == 1 {
+        return ""
+    }
+
+    fallback = string_seq_head(m.supported)
+    if string_length(preferred) == 0 {
+        fallback_tag_str, _ = parse(fallback)
+        return fallback_tag_str
+    }
+
+    parts = string_split_to_seq(preferred, ",")
+    defer string_seq_free(parts)
+    pref_list = list_new()
+    defer {
+        i = 0
+        sz = list_size(pref_list)
+        while i < sz {
+            p = list_get_raw(pref_list, i)
+            if p != null {
+                heap.free(p)
+            }
+            i = i + 1
+        }
+        list_free(pref_list)
+    }
+
+    curr = parts
+    while string_seq_is_empty(curr) == 0 {
+        part = string_seq_head(curr)
+        trimmed = string_trim(part)
+        if string_length(trimmed) > 0 {
+            subparts = string_split_to_seq(trimmed, ";")
+            tag_str = ""
+            q_val = 1.0
+
+            if string_seq_is_empty(subparts) == 0 {
+                tag_str = string_trim(string_seq_head(subparts))
+                tail = string_seq_tail(subparts)
+                if string_seq_is_empty(tail) == 0 {
+                    q_str = string_trim(string_seq_head(tail))
+                    stripped, ok = strip_prefix(q_str, "q=")
+                    if ok == 1 {
+                        q_val = to_float(stripped) or 1.0
+                    }
+                }
+            }
+
+            if string_length(tag_str) > 0 {
+                p = heap.new(Preferred)
+                p.tag = string_copy(tag_str)
+                p.q = q_val
+                list_add_raw(pref_list, p)
+            }
+            string_seq_free(subparts)
+        }
+        curr = string_seq_tail(curr)
+    }
+
+    sz = list_size(pref_list)
+    i = 0
+    while i < sz {
+        j = i + 1
+        while j < sz {
+            pi = list_get_raw(pref_list, i)
+            pj = list_get_raw(pref_list, j)
+            pref_i = pi as *Preferred
+            pref_j = pj as *Preferred
+            if pref_j.q > pref_i.q {
+                list_set(pref_list, i, pref_j)
+                list_set(pref_list, j, pref_i)
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    sorted_pref = string_seq_empty()
+    i = sz - 1
+    while i >= 0 {
+        p = list_get_raw(pref_list, i)
+        pref = p as *Preferred
+        sorted_pref = string_seq_cons(pref.tag, sorted_pref)
+        i = i - 1
+    }
+    defer string_seq_free(sorted_pref)
+
+    res = match_tags(m, sorted_pref)
+    return res
+}

--- a/tests/regression/test_language.ae
+++ b/tests/regression/test_language.ae
@@ -1,0 +1,201 @@
+// Regression test for std.language: BCP 47 parsing, canonicalization, and Matcher.
+
+import std.language
+import std.string
+
+main() {
+    print("=== std.language ===\n\n")
+
+    // 1. Parsing & Canonicalization
+    t1_str, err1 = language.parse("en-us")
+    if err1 != "" {
+        print("FAIL: parse(\"en-us\") err=${err1}\n")
+        exit(1)
+    }
+    t1 = t1_str as Tag
+    if string_equals(t1 as string, "en-US") != 1 {
+        print("FAIL: parse(\"en-us\") canonicalized to ${t1 as string}\n")
+        exit(1)
+    }
+    print("PASS: parse basic\n")
+
+    t2_str, err2 = language.parse("ZH-HANS-cn")
+    if err2 != "" {
+        print("FAIL: parse(\"ZH-HANS-cn\") err=${err2}\n")
+        exit(1)
+    }
+    t2 = t2_str as Tag
+    if string_equals(t2 as string, "zh-Hans-CN") != 1 {
+        print("FAIL: parse(\"ZH-HANS-cn\") canonicalized to ${t2 as string}\n")
+        exit(1)
+    }
+    print("PASS: parse script and region case folding\n")
+
+    t3_str, err3 = language.parse("X-private-tag")
+    if err3 != "" {
+        print("FAIL: parse(\"X-private-tag\") err=${err3}\n")
+        exit(1)
+    }
+    t3 = t3_str as Tag
+    if string_equals(t3 as string, "x-private-tag") != 1 {
+        print("FAIL: parse(\"X-private-tag\") canonicalized to ${t3 as string}\n")
+        exit(1)
+    }
+    print("PASS: parse pure privateuse\n")
+
+    t4_str, err4 = language.parse("en_US")
+    if err4 != "" {
+        print("FAIL: parse(\"en_US\") err=${err4}\n")
+        exit(1)
+    }
+    t4 = t4_str as Tag
+    if string_equals(t4 as string, "en-US") != 1 {
+        print("FAIL: parse(\"en_US\") canonicalized to ${t4 as string}\n")
+        exit(1)
+    }
+    print("PASS: parse underscore normalization\n")
+
+    // 2. Reject Invalid Tags
+    _, err_empty = language.parse("")
+    if err_empty == "" {
+        print("FAIL: parse(\"\") did not error\n")
+        exit(1)
+    }
+    print("PASS: parse reject empty\n")
+
+    _, err_double = language.parse("en--US")
+    if err_double == "" {
+        print("FAIL: parse(\"en--US\") did not error\n")
+        exit(1)
+    }
+    print("PASS: parse reject double hyphens\n")
+
+    _, err_lead = language.parse("-en")
+    if err_lead == "" {
+        print("FAIL: parse(\"-en\") did not error\n")
+        exit(1)
+    }
+    print("PASS: parse reject leading hyphen\n")
+
+    _, err_trail = language.parse("en-")
+    if err_trail == "" {
+        print("FAIL: parse(\"en-\") did not error\n")
+        exit(1)
+    }
+    print("PASS: parse reject trailing hyphen\n")
+
+    _, err_short = language.parse("e")
+    if err_short == "" {
+        print("FAIL: parse(\"e\") did not error\n")
+        exit(1)
+    }
+    print("PASS: parse reject too short primary subtag\n")
+
+    _, err_num = language.parse("123")
+    if err_num == "" {
+        print("FAIL: parse(\"123\") did not error\n")
+        exit(1)
+    }
+    print("PASS: parse reject numeric primary subtag\n")
+
+    // 3. Component Extraction
+    lang_t2 = language.language(t2)
+    if string_equals(lang_t2, "zh") != 1 {
+        print("FAIL: language(zh-Hans-CN)=${lang_t2}\n")
+        exit(1)
+    }
+    print("PASS: extract language\n")
+
+    script_t2 = language.script(t2)
+    if string_equals(script_t2, "Hans") != 1 {
+        print("FAIL: script(zh-Hans-CN)=${script_t2}\n")
+        exit(1)
+    }
+    print("PASS: extract script\n")
+
+    region_t2 = language.region(t2)
+    if string_equals(region_t2, "CN") != 1 {
+        print("FAIL: region(zh-Hans-CN)=${region_t2}\n")
+        exit(1)
+    }
+    print("PASS: extract region\n")
+
+    base_t2 = language.base(t2)
+    if string_equals(base_t2 as string, "zh") != 1 {
+        print("FAIL: base(zh-Hans-CN)=${base_t2 as string}\n")
+        exit(1)
+    }
+    print("PASS: extract base\n")
+
+    // 4. Matcher
+    let supported: *StringSeq = ["zh-Hans-CN", "en-US", "da"]
+    m = language.matcher_create(supported)
+    defer language.matcher_free(m)
+
+    // Match exact preferred
+    let pref1: *StringSeq = ["en-US", "zh-Hans"]
+    res1 = language.match_tags(m, pref1)
+    if string_equals(res1, "en-US") != 1 {
+        print("FAIL: match_tags exact, got ${res1}\n")
+        exit(1)
+    }
+    print("PASS: match_tags exact\n")
+
+    // Match with truncation
+    let pref2: *StringSeq = ["en-US-California"]
+    res2 = language.match_tags(m, pref2)
+    if string_equals(res2, "en-US") != 1 {
+        print("FAIL: match_tags truncated, got ${res2}\n")
+        exit(1)
+    }
+    print("PASS: match_tags truncated\n")
+
+    // Match with fallback to primary language
+    let pref3: *StringSeq = ["zh-HK"]
+    res3 = language.match_tags(m, pref3)
+    if string_equals(res3, "zh-Hans-CN") != 1 {
+        print("FAIL: match_tags fallback to primary, got ${res3}\n")
+        exit(1)
+    }
+    print("PASS: match_tags primary fallback\n")
+
+    // Match empty preference falls back to first supported
+    let pref_empty: *StringSeq = []
+    res_empty = language.match_tags(m, pref_empty)
+    if string_equals(res_empty, "zh-Hans-CN") != 1 {
+        print("FAIL: match_tags empty preference, got ${res_empty}\n")
+        exit(1)
+    }
+    print("PASS: match_tags empty preference fallback\n")
+
+    // 5. match_strings (Accept-Language / comma-separated tags with weights)
+    res_str1 = language.match_strings(m, "da, en-gb;q=0.8, en;q=0.7")
+    if string_equals(res_str1, "da") != 1 {
+        print("FAIL: match_strings da, got ${res_str1}\n")
+        exit(1)
+    }
+    print("PASS: match_strings sorted list (da highest q)\n")
+
+    res_str2 = language.match_strings(m, "en-gb;q=0.7, da;q=0.9, en;q=0.8")
+    if string_equals(res_str2, "da") != 1 {
+        print("FAIL: match_strings da;q=0.9, got ${res_str2}\n")
+        exit(1)
+    }
+    print("PASS: match_strings sorted list (da;q=0.9 highest q)\n")
+
+    res_str3 = language.match_strings(m, "en-US-California;q=0.9")
+    if string_equals(res_str3, "en-US") != 1 {
+        print("FAIL: match_strings truncated option, got ${res_str3}\n")
+        exit(1)
+    }
+    print("PASS: match_strings truncated option\n")
+
+    res_str4 = language.match_strings(m, "fr;q=0.9")
+    if string_equals(res_str4, "zh-Hans-CN") != 1 {
+        print("FAIL: match_strings unsupported, got ${res_str4}\n")
+        exit(1)
+    }
+    print("PASS: match_strings unsupported fallback\n")
+
+    print("\nAll PASS\n")
+}

--- a/tests/regression/test_language.ae
+++ b/tests/regression/test_language.ae
@@ -3,6 +3,29 @@
 import std.language
 import std.string
 
+// Build a *StringSeq leak-cleanly. Multi-element `["a","b","c"]` literals hit a
+// codegen bug where the inner cons temporaries' refs are never dropped (they
+// leak even with string_seq_free); build via explicit cons + tail-drop instead.
+// (Tracked as a compiler bug; unrelated to std.language.)
+fn seq3(a: string, b: string, c: string) -> *StringSeq {
+    t0 = string_seq_empty()
+    t1 = string_seq_cons(c, t0)
+    string_seq_free(t0)
+    t2 = string_seq_cons(b, t1)
+    string_seq_free(t1)
+    t3 = string_seq_cons(a, t2)
+    string_seq_free(t2)
+    return t3
+}
+fn seq2(a: string, b: string) -> *StringSeq {
+    t0 = string_seq_empty()
+    t1 = string_seq_cons(b, t0)
+    string_seq_free(t0)
+    t2 = string_seq_cons(a, t1)
+    string_seq_free(t1)
+    return t2
+}
+
 main() {
     print("=== std.language ===\n\n")
 
@@ -13,6 +36,7 @@ main() {
         exit(1)
     }
     t1 = t1_str as Tag
+    defer string_free(t1 as string)
     if string_equals(t1 as string, "en-US") != 1 {
         print("FAIL: parse(\"en-us\") canonicalized to ${t1 as string}\n")
         exit(1)
@@ -25,6 +49,7 @@ main() {
         exit(1)
     }
     t2 = t2_str as Tag
+    defer string_free(t2 as string)
     if string_equals(t2 as string, "zh-Hans-CN") != 1 {
         print("FAIL: parse(\"ZH-HANS-cn\") canonicalized to ${t2 as string}\n")
         exit(1)
@@ -37,6 +62,7 @@ main() {
         exit(1)
     }
     t3 = t3_str as Tag
+    defer string_free(t3 as string)
     if string_equals(t3 as string, "x-private-tag") != 1 {
         print("FAIL: parse(\"X-private-tag\") canonicalized to ${t3 as string}\n")
         exit(1)
@@ -49,6 +75,7 @@ main() {
         exit(1)
     }
     t4 = t4_str as Tag
+    defer string_free(t4 as string)
     if string_equals(t4 as string, "en-US") != 1 {
         print("FAIL: parse(\"en_US\") canonicalized to ${t4 as string}\n")
         exit(1)
@@ -121,19 +148,23 @@ main() {
     print("PASS: extract region\n")
 
     base_t2 = language.base(t2)
+    defer string_free(base_t2 as string)
     if string_equals(base_t2 as string, "zh") != 1 {
         print("FAIL: base(zh-Hans-CN)=${base_t2 as string}\n")
         exit(1)
     }
     print("PASS: extract base\n")
 
-    // 4. Matcher
-    let supported: *StringSeq = ["zh-Hans-CN", "en-US", "da"]
+    // 4. Matcher. matcher_create RETAINS `supported`, so the test still owns
+    // its reference and frees it; matcher_free drops the matcher's ref.
+    supported = seq3("zh-Hans-CN", "en-US", "da")
+    defer string_seq_free(supported)
     m = language.matcher_create(supported)
     defer language.matcher_free(m)
 
     // Match exact preferred
-    let pref1: *StringSeq = ["en-US", "zh-Hans"]
+    pref1 = seq2("en-US", "zh-Hans")
+    defer string_seq_free(pref1)
     res1 = language.match_tags(m, pref1)
     if string_equals(res1, "en-US") != 1 {
         print("FAIL: match_tags exact, got ${res1}\n")
@@ -143,6 +174,7 @@ main() {
 
     // Match with truncation
     let pref2: *StringSeq = ["en-US-California"]
+    defer string_seq_free(pref2)
     res2 = language.match_tags(m, pref2)
     if string_equals(res2, "en-US") != 1 {
         print("FAIL: match_tags truncated, got ${res2}\n")
@@ -152,6 +184,7 @@ main() {
 
     // Match with fallback to primary language
     let pref3: *StringSeq = ["zh-HK"]
+    defer string_seq_free(pref3)
     res3 = language.match_tags(m, pref3)
     if string_equals(res3, "zh-Hans-CN") != 1 {
         print("FAIL: match_tags fallback to primary, got ${res3}\n")
@@ -161,6 +194,7 @@ main() {
 
     // Match empty preference falls back to first supported
     let pref_empty: *StringSeq = []
+    defer string_seq_free(pref_empty)
     res_empty = language.match_tags(m, pref_empty)
     if string_equals(res_empty, "zh-Hans-CN") != 1 {
         print("FAIL: match_tags empty preference, got ${res_empty}\n")


### PR DESCRIPTION
Implements **Phase 1** of the i18n RFC (#863): a `std.language` module for BCP 47 language tag parsing/canonicalization (RFC 5646) and matching (RFC 4647). This is the RFC's recommended first slice — self-contained, **no CLDR data**, the cleanest possible starting point.

Original implementation by **Google Jules** (from issue #863's design); I rebased it onto current main and shaped it up to pass CI (leak fixes + fmt).

## Surface (`std.language`)

- `Tag = distinct string`; `parse(s) -> (Tag_str, err)` — canonicalizes (language lowercase, script Titlecase, region UPPERCASE, `_`→`-`), rejects empty / double-hyphen / leading-trailing hyphen / too-short / numeric-primary.
- Accessors: `language`, `script`, `region`, `base`.
- `Matcher` + `matcher_create` / `matcher_free` / `match_tags(m, preferred)` / `match_strings(m, accept_language)` — RFC 4647 lookup with truncation fallback and `q`-weighted Accept-Language parsing.

## Shape-up done for merge

Jules's code built and its tests passed, but it leaked (304 bytes / 11 blocks under valgrind — the macOS leak gate + valgrind CI would reject it). Fixed:

**Two real module leaks:**
1. `match_strings` freed each `Preferred` via `heap.free(p)` where `p` was a raw `ptr`, so codegen emitted a plain `free()` instead of the typed destructor and never released the `p.tag` copy → cast to `*Preferred` before freeing.
2. The sorted-tag accumulator used the self-referential `sorted_pref = cons(tag, sorted_pref)` rebind, which makes codegen suppress freeing the old handle while `cons` independently retains the tail → each intermediate cell leaked. Rebuilt with a non-self-referential cons-into-fresh + drop-previous pattern.

**Test hygiene:** freed the `*StringSeq` inputs and the `Tag` returns the test dropped.

**Pre-existing codegen bug found + worked around:** multi-element `*StringSeq` literals (`["a","b","c"]`) leak their inner cons cells regardless of `string_seq_free` (reproduced with a bare literal, no std.language involved) — filed as **#1417**. The test builds those seqs via explicit `cons` helpers to stay leak-clean until #1417 lands.

## Verification

- **valgrind: 0 leaks** on the module + test.
- All `test_language.ae` cases pass (parse/canonicalize/reject, accessors, `match_tags`, `match_strings`).
- fmt gate clean; full `-Werror` build green; unrelated seq tests unaffected. Pure-Aether module (no C) — auto-discovered, no Makefile entry.

## Scope note (per the RFC)

This is only Phase 1 (tags + matching). Later phases — plural rules, ICU MessageFormat, number/currency, collation — remain open design/porting work under #863. Known lenient-vs-strict-RFC edges (e.g. non-canonical input to accessors, unstable q-tie sort) are documented in-review and fine for a matching-focused first slice; can tighten in a follow-up.

Closes #863 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)