### PR TITLE
feat(std.plural): CLDR plural rules — Phase 2 of i18n (#863)

### DIFF
--- a/std/plural/module.ae
+++ b/std/plural/module.ae
@@ -1,0 +1,142 @@
+// std.plural — CLDR Plural Rules evaluation (Phase 2 of #863)
+
+import std.string(*)
+import std.language
+
+exports(
+    plural_category, plural_category_decimal
+)
+
+fn plural_en(n: float, i: long, v: int, w: int, f: long, t: long) -> string {
+    if i == 1 && v == 0 {
+        return "one"
+    }
+    return "other"
+}
+
+fn plural_fr(n: float, i: long, v: int, w: int, f: long, t: long) -> string {
+    if i == 0 || i == 1 {
+        return "one"
+    }
+    return "other"
+}
+
+fn plural_ru(n: float, i: long, v: int, w: int, f: long, t: long) -> string {
+    if v == 0 {
+        mod10 = i % 10
+        mod100 = i % 100
+        if mod10 == 1 && mod100 != 11 {
+            return "one"
+        }
+        if mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14) {
+            return "few"
+        }
+        if mod10 == 0 || (mod10 >= 5 && mod10 <= 9) || (mod100 >= 11 && mod100 <= 14) {
+            return "many"
+        }
+    }
+    return "other"
+}
+
+fn plural_ar(n: float, i: long, v: int, w: int, f: long, t: long) -> string {
+    if n == 0.0 {
+        return "zero"
+    }
+    if n == 1.0 {
+        return "one"
+    }
+    if n == 2.0 {
+        return "two"
+    }
+    if v == 0 {
+        mod100 = i % 100
+        if mod100 >= 3 && mod100 <= 10 {
+            return "few"
+        }
+        if mod100 >= 11 && mod100 <= 99 {
+            return "many"
+        }
+    }
+    return "other"
+}
+
+fn plural_ja_zh(n: float, i: long, v: int, w: int, f: long, t: long) -> string {
+    return "other"
+}
+
+fn plural_pl(n: float, i: long, v: int, w: int, f: long, t: long) -> string {
+    if v == 0 {
+        if i == 1 {
+            return "one"
+        }
+        mod10 = i % 10
+        mod100 = i % 100
+        if mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14) {
+            return "few"
+        }
+        if (mod10 == 0 || mod10 == 1) || (mod10 >= 5 && mod10 <= 9) || (mod100 >= 12 && mod100 <= 14) {
+            return "many"
+        }
+    }
+    return "other"
+}
+
+fn plural_category(lang_tag: string, n: int) -> string {
+    abs_n = n
+    if abs_n < 0 {
+        abs_n = -abs_n
+    }
+    return plural_category_decimal(lang_tag, abs_n as float, abs_n as long, 0, 0, 0, 0)
+}
+
+fn plural_category_decimal(lang_tag: string, n: float, i: long, v: int, w: int, f: long, t: long) -> string {
+    if string_length(lang_tag) == 0 {
+        return "other"
+    }
+
+    canonical, err = language.parse(lang_tag)
+    if err != "" {
+        return "other"
+    }
+
+    t_tag = canonical as Tag
+    base_lang = language.language(t_tag)
+
+    abs_n = n
+    if abs_n < 0.0 {
+        abs_n = -abs_n
+    }
+    abs_i = i
+    if abs_i < 0 {
+        abs_i = -abs_i
+    }
+    abs_f = f
+    if abs_f < 0 {
+        abs_f = -abs_f
+    }
+    abs_t = t
+    if abs_t < 0 {
+        abs_t = -abs_t
+    }
+
+    result = "other"
+
+    if string_equals(base_lang, "en") == 1 {
+        result = plural_en(abs_n, abs_i, v, w, abs_f, abs_t)
+    } else if string_equals(base_lang, "fr") == 1 {
+        result = plural_fr(abs_n, abs_i, v, w, abs_f, abs_t)
+    } else if string_equals(base_lang, "ru") == 1 {
+        result = plural_ru(abs_n, abs_i, v, w, abs_f, abs_t)
+    } else if string_equals(base_lang, "ar") == 1 {
+        result = plural_ar(abs_n, abs_i, v, w, abs_f, abs_t)
+    } else if string_equals(base_lang, "ja") == 1 || string_equals(base_lang, "zh") == 1 {
+        result = plural_ja_zh(abs_n, abs_i, v, w, abs_f, abs_t)
+    } else if string_equals(base_lang, "pl") == 1 {
+        result = plural_pl(abs_n, abs_i, v, w, abs_f, abs_t)
+    }
+
+    canonical = ""
+    base_lang = ""
+
+    return result
+}

--- a/tests/regression/test_plural.ae
+++ b/tests/regression/test_plural.ae
@@ -1,0 +1,100 @@
+// Standalone regression test for std.plural
+
+import std.plural
+import std.string
+
+fn assert_category(lang: string, n: int, expected: string) {
+    res = plural.plural_category(lang, n)
+    if string_equals(res, expected) != 1 {
+        print("FAIL: plural_category(\"${lang}\", ${n}) expected ${expected}, got ${res}\n")
+        exit(1)
+    }
+}
+
+fn assert_category_decimal(lang: string, n: float, i: long, v: int, w: int, f: long, t: long, expected: string) {
+    res = plural.plural_category_decimal(lang, n, i, v, w, f, t)
+    if string_equals(res, expected) != 1 {
+        print("FAIL: plural_category_decimal(\"${lang}\", ...) expected ${expected}, got ${res}\n")
+        exit(1)
+    }
+}
+
+main() {
+    print("=== std.plural ===\n\n")
+
+    // 1. English (en) Tests
+    assert_category("en", 1, "one")
+    assert_category("en", 0, "other")
+    assert_category("en", 2, "other")
+    assert_category("en", 100, "other")
+    assert_category("en", -1, "one")
+    assert_category_decimal("en", 1.0, 1, 1, 0, 0, 0, "other")
+    assert_category_decimal("en", 1.5, 1, 1, 1, 5, 5, "other")
+    assert_category_decimal("en", -1.0, -1, 1, 0, 0, 0, "other")
+    print("PASS: en rules\n")
+
+    // 2. French (fr) Tests
+    assert_category("fr", 0, "one")
+    assert_category("fr", 1, "one")
+    assert_category("fr", 2, "other")
+    assert_category("fr", 100, "other")
+    assert_category("fr", -1, "one")
+    assert_category_decimal("fr", 1.5, 1, 1, 1, 5, 5, "one")
+    assert_category_decimal("fr", 2.0, 2, 1, 0, 0, 0, "other")
+    print("PASS: fr rules\n")
+
+    // 3. Russian (ru) Tests
+    assert_category("ru", 1, "one")
+    assert_category("ru", 21, "one")
+    assert_category("ru", 11, "many")
+    assert_category("ru", 2, "few")
+    assert_category("ru", 4, "few")
+    assert_category("ru", 12, "many")
+    assert_category("ru", 14, "many")
+    assert_category("ru", 5, "many")
+    assert_category("ru", 10, "many")
+    assert_category_decimal("ru", 1.5, 1, 1, 1, 5, 5, "other")
+    print("PASS: ru rules\n")
+
+    // 4. Arabic (ar) Tests
+    assert_category("ar", 0, "zero")
+    assert_category_decimal("ar", 0.0, 0, 1, 0, 0, 0, "zero")
+    assert_category("ar", 1, "one")
+    assert_category("ar", 2, "two")
+    assert_category("ar", 3, "few")
+    assert_category("ar", 10, "few")
+    assert_category("ar", 11, "many")
+    assert_category("ar", 99, "many")
+    assert_category("ar", 100, "other")
+    assert_category_decimal("ar", 1.5, 1, 1, 1, 5, 5, "other")
+    print("PASS: ar rules\n")
+
+    // 5. Japanese & Chinese (ja, zh) Tests
+    assert_category("ja", 1, "other")
+    assert_category("ja", 100, "other")
+    assert_category("zh", 1, "other")
+    assert_category("zh", 100, "other")
+    print("PASS: ja / zh rules\n")
+
+    // 6. Polish (pl) Tests
+    assert_category("pl", 1, "one")
+    assert_category("pl", 2, "few")
+    assert_category("pl", 4, "few")
+    assert_category("pl", 12, "many")
+    assert_category("pl", 14, "many")
+    assert_category("pl", 22, "few")
+    assert_category("pl", 5, "many")
+    assert_category("pl", 0, "many")
+    assert_category_decimal("pl", 1.5, 1, 1, 1, 5, 5, "other")
+    print("PASS: pl rules\n")
+
+    // 7. Locale Fallbacks and Edge Cases
+    assert_category("en-US", 1, "one")
+    assert_category("fr-FR", 1, "one")
+    assert_category("ru-RU", 2, "few")
+    assert_category("de", 1, "other") // unknown falls back to other-only
+    assert_category("invalid--tag", 1, "other") // invalid structure falls back to other-only
+    print("PASS: fallback tags and invalid tags\n")
+
+    print("\nAll PASS\n")
+}


### PR DESCRIPTION
Implements **Phase 2** of the i18n RFC (#863): a pure-Aether CLDR plural-rules module. This is the algorithm phase that follows Phase 1's `std.language` (#1418) — small hard-coded rule tables, no full CLDR data (that's Phase 4).

Original implementation by **Google Jules**; I brought it down from the fork, rebased onto current main, and verified it against the CLDR spec + the CI gates.

## Surface (`std.plural`)

- `plural_category(lang_tag, n: int) -> string` — the plural category (`zero`/`one`/`two`/`few`/`many`/`other`) for an integer.
- `plural_category_decimal(lang_tag, n: float, i, v, w, f, t) -> string` — the full CLDR-operand form, so `1.0` vs `1` differ correctly (the `v` operand matters).
- Locales: **en, fr, ru, ar, ja/zh, pl** — chosen to span the interesting rule shapes (one/other, Slavic three-form, Arabic six-way, Polish `many`).
- Unknown / region-qualified tags fall back to base language via `std.language` (`en-US` → `en`), then to `other`.

## Correctness — independently verified against CLDR

Green tests alone don't prove plural rules right, so I cross-checked each rule against the CLDR plural-rules chart and probed the tricky boundaries directly:

| Case | Result |
|---|---|
| `en 1` / `en 1.0` | `one` / `other` (the v-operand distinction) |
| `ru` 1/11/21/2/22/12/5/111 | one/many/one/few/few/many/many/many (three-form + the 11–14 exception) |
| `ar` 0/1/2/3/103/11/100 | zero/one/two/few/few/many/other (full six-way) |
| `pl` 1/2/22/5/12 | one/few/few/many/many |
| `en-US 1`, `zh-Hans-CN 5`, `xx 3` | one / other / other |

All correct.

## Gates (the ones that needed a repair round in Phase 1 — clean here)

- **valgrind: 0 leaks, 0 errors** on the module + test (Jules internalized the Phase-1 leak tips — freed all `string_split_to_seq`/owned strings, no self-referential seq rebind, no multi-element seq literals).
- All `test_plural.ae` cases pass (boundaries, decimal operands `en 1.5`→other / `fr 1.5`→one, negatives, fallback).
- fmt gate clean; full `-Werror` build green; unrelated regressions (`test_language`, seq/string tests) unaffected. Pure-Aether module (no C) — auto-discovered, no Makefile entry.

## Scope

Phase 2 is *only* plural-rule evaluation for the starter locale set. Minor known limits (fine for this slice): modern CLDR adds `many` for compact/large numbers in fr and others — not covered; full-locale coverage is a data phase, not this one.

Part of #863 (Phase 2). Does **not** close the RFC — Phases 3–5 (MessageFormat/catalog, number/currency, collation) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)