### PR TITLE
fix: restore -Wformat on mainline builds; modernize ws_client; harden canonical_repo_url

### DIFF
--- a/contrib/tinyweb/ws_client.ae
+++ b/contrib/tinyweb/ws_client.ae
@@ -2,16 +2,16 @@
 
 import std.tcp
 import std.string
+import std.map
 
 // ---------------------------------------------------------------------------
 // WebSocket Client
 // ---------------------------------------------------------------------------
 
-// Connect to a WebSocket server. Returns a client map or 0 on failure.
-// Connect to a WebSocket server. Returns a client map or 0 on failure.
+// Connect to a WebSocket server. Returns a client map, or 0 on failure.
 ws_client_connect(host: string, port: int, ws_path: string, origin: string) {
-    sock = tcp.connect(host, port)
-    if sock == 0 { return 0 }
+    sock, err = tcp.connect(host, port)
+    if err != "" { return 0 }
 
     client = map_new()
     map_put(client, "sock", sock)
@@ -22,8 +22,7 @@ ws_client_connect(host: string, port: int, ws_path: string, origin: string) {
     return client
 }
 
-// Perform the WebSocket upgrade handshake.
-// Perform the WebSocket upgrade handshake. Returns 0 on success.
+// Perform the WebSocket upgrade handshake. Returns 0 on success, -1 on failure.
 ws_client_handshake(client: ptr) -> int {
     sock, _ = map.get(client, "sock")
     host, _ = map.get(client, "host")
@@ -31,8 +30,8 @@ ws_client_handshake(client: ptr) -> int {
     ws_path, _ = map.get(client, "path")
     origin, _ = map.get(client, "origin")
 
-    // Build HTTP upgrade request
-    // Fixed Sec-WebSocket-Key (accept key is only validated by the client)
+    // Build HTTP upgrade request.
+    // Fixed Sec-WebSocket-Key (the accept key is only validated by the client).
     request = "GET ${ws_path} HTTP/1.1\r\n"
     request = string.concat(request, "Host: ${host}:${port}\r\n")
     request = string.concat(request, "Upgrade: websocket\r\n")
@@ -41,72 +40,75 @@ ws_client_handshake(client: ptr) -> int {
     request = string.concat(request, "Sec-WebSocket-Version: 13\r\n")
     request = string.concat(request, "Origin: ${origin}\r\n\r\n")
 
-    tcp.send(sock, request)
+    _, werr = tcp.write(sock, request)
+    if werr != "" { return -1 }
 
-    // Read handshake response
-    response = tcp.receive(sock, 1024)
-    if response == 0 { return -1 }
+    // Read handshake response.
+    response, rerr = tcp.read(sock, 1024)
+    if rerr != "" { return -1 }
 
-    // Verify "101 Switching Protocols"
+    // Verify "101 Switching Protocols".
     if string.contains(response, "101 Switching Protocols") == 1 {
         return 0
     }
     return -1
 }
 
-// Send a text message over the WebSocket connection.
 // Send a text message. Client-to-server frames must be masked (RFC 6455).
-ws_client_send(client: ptr, message: string) {
+ws_client_send(client: ptr, msg: string) {
     sock, _ = map.get(client, "sock")
-    len = string.length(message)
+    len = string.length(msg)
 
-    // Frame header: FIN=1, opcode=text(1), MASK=1
-    // For simplicity, use a fixed mask key (0x00000000 = no-op XOR)
-    // A production impl would use random mask bytes
+    // Frame header: FIN=1, opcode=text(1), MASK=1.
+    // For simplicity, use a fixed all-zero mask key (0x00000000 = no-op XOR).
+    // A production impl would use random mask bytes.
     if len < 126 {
         // [0x81, 0x80|len, mask(4 bytes)]
         hdr = string.concat(string.from_int(129), string.from_int(128 + len))
-        tcp.send(sock, hdr)
+        _, _ = tcp.write(sock, hdr)
         // 4-byte mask key (all zeros = payload unchanged)
-        tcp.send(sock, string.concat(string.concat(string.from_int(0), string.from_int(0)),
-                                      string.concat(string.from_int(0), string.from_int(0))))
+        _, _ = tcp.write(sock, string.concat(string.concat(string.from_int(0), string.from_int(0)),
+                string.concat(string.from_int(0), string.from_int(0))))
     }
-    tcp.send(sock, message)
+    _, _ = tcp.write(sock, msg)
 }
 
-// Receive messages in a loop until stop_phrase is seen or connection closes.
-// Receive messages until stop_phrase or disconnect. Returns 1 if stopped, 0 if closed.
+// Receive messages in a loop until stop_phrase is seen or the connection
+// closes. Returns 1 if stopped on stop_phrase, 0 if the connection closed.
 ws_client_receive(client: ptr, stop_phrase: string, handler: fn) -> int {
     sock, _ = map.get(client, "sock")
     running = 1
     result = 0
 
-    for (running == 1; running == 1; running = running) {
-        // Read 2-byte frame header
-        hdr = tcp.receive(sock, 2)
-        if hdr == 0 { running = 0 } else {
+    while running == 1 {
+        // Read 2-byte frame header.
+        hdr, herr = tcp.read(sock, 2)
+        if herr != "" {
+            running = 0
+        } else {
             byte1 = string.char_at(hdr, 1)
-            payload_len = byte1 - ((byte1 / 128) * 128)  // byte1 & 0x7F
+            payload_len = byte1 - ((byte1 / 128) * 128) // byte1 & 0x7F
 
-            // Extended payload length
+            // Extended payload length.
             if payload_len == 126 {
-                ext = tcp.receive(sock, 2)
-                if ext == 0 { running = 0 }
-                if running == 1 {
-                    payload_len = char_at(ext) * 256 + string.char_at(ext, 1)
+                ext, eerr = tcp.read(sock, 2)
+                if eerr != "" {
+                    running = 0
+                } else {
+                    payload_len = string.char_at(ext, 0) * 256 + string.char_at(ext, 1)
                 }
             }
 
             if running == 1 && payload_len > 0 {
-                payload = tcp.receive(sock, payload_len)
-                if payload == 0 {
+                payload, perr = tcp.read(sock, payload_len)
+                if perr != "" {
                     running = 0
                 } else {
-                    if str_eq(payload, stop_phrase) == 1 {
+                    if string.equals(payload, stop_phrase) == 1 {
                         result = 1
                         running = 0
                     } else {
-                        // Call handler with the message
+                        // Call the handler with the message.
                         call(handler, payload)
                     }
                 }
@@ -117,13 +119,12 @@ ws_client_receive(client: ptr, stop_phrase: string, handler: fn) -> int {
     return result
 }
 
-// Close the WebSocket connection.
-// Close the connection (sends a masked close frame)
+// Close the connection (sends a masked close frame).
 ws_client_close(client: ptr) {
     sock, _ = map.get(client, "sock")
-    // Send masked close frame: [0x88, 0x80, mask(4 zeros)]
-    tcp.send(sock, string.concat(string.from_int(136), string.from_int(128)))
-    tcp.send(sock, string.concat(string.concat(string.from_int(0), string.from_int(0)),
-                                  string.concat(string.from_int(0), string.from_int(0))))
+    // Masked close frame: [0x88, 0x80, mask(4 zeros)]
+    _, _ = tcp.write(sock, string.concat(string.from_int(136), string.from_int(128)))
+    _, _ = tcp.write(sock, string.concat(string.concat(string.from_int(0), string.from_int(0)),
+            string.concat(string.from_int(0), string.from_int(0))))
     tcp.close(sock)
 }

--- a/tests/integration/canonical_repo_url/test_canonical_repo_url.sh
+++ b/tests/integration/canonical_repo_url/test_canonical_repo_url.sh
@@ -18,24 +18,37 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 cd "$ROOT" || exit 1
 
-# Assembled from parts so this file does not itself contain the literal it
-# searches for, which would make the check fail on its own source.
-STALE_OWNER='nicolasmd87'
-STALE="$STALE_OWNER/aether"
+# Every owner the project has moved away from. GitHub keeps each old path alive
+# as a rename redirect, so a stale reference keeps working right up until someone
+# claims the freed name — at which point anything that fetches from it lands on a
+# repo the project no longer controls. Guard against all of them, not just the
+# oldest:
+#   - nicolasmd87    : the original owner (pre-org)
+#   - aether-lang-org: renamed to aether-lang-dev by Nic
+# The owner strings are spliced from parts at runtime so this source file does
+# not itself contain a stale "owner/aether" literal and trip its own check.
+ORG_SUFFIX='org'
+STALE_OWNERS="nicolasmd87 aether-lang-${ORG_SUFFIX}"
 
-hits=$(grep -rn "$STALE" \
-        --exclude-dir=.git \
-        --exclude-dir=build \
-        --exclude-dir=target \
-        --exclude=CHANGELOG.md \
-        --exclude=CHANGELOG-archive.md \
-        . 2>/dev/null | grep -v '^\./benchmarks/json/corpus/')
+hits=""
+for owner in $STALE_OWNERS; do
+    stale="$owner/aether"
+    found=$(grep -rn "$stale" \
+            --exclude-dir=.git \
+            --exclude-dir=build \
+            --exclude-dir=target \
+            --exclude=CHANGELOG.md \
+            --exclude=CHANGELOG-archive.md \
+            . 2>/dev/null | grep -Ev '^\.?/?benchmarks/json/corpus/')
+    [ -n "$found" ] && hits="${hits}${found}
+"
+done
 
-if [ -n "$hits" ]; then
+if [ -n "$(printf '%s' "$hits" | tr -d '[:space:]')" ]; then
     echo "  [FAIL] canonical_repo_url: stale repository path still referenced"
-    echo "$hits" | sed 's/^/        /' | head -12
-    echo "        Use the current path; a rename redirect is not a durable target"
-    echo "        for anything that downloads and installs binaries."
+    printf '%s' "$hits" | sed '/^$/d; s/^/        /' | head -12
+    echo "        Use the current path (aether-lang-dev/aether); a rename redirect"
+    echo "        is not a durable target for anything that downloads/installs."
     exit 1
 fi
 

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2084,8 +2084,16 @@ void build_gcc_cmd(char* cmd, size_t size,
     // Coverage builds skip -pipe — gcov works fine with it, but it
     // adds nothing when -O0 -g is already forced. Keeping the flag
     // string short helps the cmd-buffer size budget.
+    //
+    // -Wformat must be present here too: the -pipe path is the mainline
+    // (non-static) build, and it previously hardcoded the opt string inline,
+    // dropping the -Wformat that opt_flags() carries. Without it the C
+    // compiler's printf-family format checks (mapped to the .ae source via
+    // #line) never run on a normal `ae build` — regressing #1252. Keep this in
+    // sync with opt_flags(); user cflags still append after, so -Wno-format
+    // remains an opt-out.
     const char* base_opt = g_coverage ? opt_flags(optimize)
-                          : (optimize ? "-O2 -pipe" : "-O0 -g -pipe");
+                          : (optimize ? "-O2 -pipe -Wformat" : "-O0 -g -pipe -Wformat");
     const char* trace_def = g_trace ? " -DAETHER_TRACE" : "";
     if (user_cflags[0])
         snprintf(opt, sizeof(opt), "%s%s %s%s", emit_lib_flags, base_opt, user_cflags, trace_def);


### PR DESCRIPTION
## Description

Two rot fixes surfaced by a newer-toolchain nightly build (GCC 16 / Clang 22 on
CachyOS), both invisible to the current CI matrix (Ubuntu-22.04 GCC 11).

### 1. Restore `-Wformat` on the mainline build path (`tools/ae.c`) — regresses #1252

`ae build`'s mainline (`-pipe`, non-static) path hardcoded its optimization
flags inline — `"-O2 -pipe"` / `"-O0 -g -pipe"` — and dropped the `-Wformat`
that `opt_flags()` carries. So a normal `ae build` **never ran the C compiler's
printf-family format checks**, silently regressing #1252
(`wformat_extern_literal`). The interop lowering and `#line` mapping were already
correct (contrary to the test's "the void* cast is back" comment — the cast is
gone; only the flag was missing). The static-build path was unaffected because
it already routes through `opt_flags()`.

Fix: add `-Wformat` to both non-coverage branches, kept in sync with
`opt_flags()`. A format bug in an extern `printf` call now warns again,
attributed to the `.ae` source line. `-Wformat` is a plain warning (not coupled
to `-Werror`), and a sample of `examples/` builds with **no new warnings**, so
this re-enables the diagnostic without breaking any current build. User cflags
still append after, so `-Wno-format` remains an opt-out.

Not GCC-16-specific — reproduced on GCC 12 as well; it was off for everyone.

### 2. Modernize `contrib/tinyweb/ws_client.ae`

An orphaned WebSocket-client helper (nothing imports it) that had rotted against
three stdlib evolutions and no longer compiled:

- a reserved-keyword parameter (`message`)
- a missing `import std.map` (it uses `map_new`/`map_put`/`map.get`)
- the `std.tcp` API's move from `send`/`receive` to `write`/`read` with
  `(value, err)` tuple returns — plus stale `char_at(x)` / `str_eq` calls and
  single-value `sock == 0` / `resp == 0` checks

Ported to the current APIs; it now type-checks clean (`ae check` passes). Pure
repair — no consumers, no downstream impact.

### 3. Harden the `canonical_repo_url` guard (`tests/integration/canonical_repo_url`)

The stale-repo-path test had two problems:

- It only checked the **oldest** owner (`nicolasmd87`). The project has since been
  renamed again (`aether-lang-org` → `aether-lang-dev`), and `aether-lang-org` is
  now itself a live GitHub rename-redirect — the exact hazard the test exists to
  catch. Extended it to guard **every** stale owner (`nicolasmd87`,
  `aether-lang-org`); owner strings are spliced from parts so the test source
  doesn't self-match.
- The `benchmarks/json/corpus/` exclusion assumed `grep -rn .` emits a leading
  `./`, which is environment-dependent. Where grep omits it, the JSON fixture
  (legitimately containing a stale URL as parser test data) leaked through and
  failed the check spuriously. Made the exclusion prefix-agnostic
  (`^\.?/?benchmarks/...`).

Verified: passes on the current tree, and a planted `aether-lang-org/aether`
reference is correctly caught and reported.

## How these were found

Neither the `test-ae` sweep nor `make contrib` compiles `contrib/*/module.ae`
Aether code (see #1442), so both defects were invisible to CI. A nightly HEAD
build on a rolling-release box (newer GCC + a `contrib` `ae check` sweep)
surfaced them.

## Type of Change
- [x] Bug fix (compiler tooling: `-Wformat` flag; contrib rot)

## Testing
- [x] `tests/integration/wformat_extern_literal` now PASSes; `printf("%s", 42)`
      warns at the `.ae` line on a normal `ae build`
- [x] `ae check contrib/tinyweb/ws_client.ae` → clean; full `contrib` ae-check
      sweep 30/30
- [x] `HARDEN=1 make ci`: compiler/stdlib build clean under
      `-fstack-protector-all` + `_FORTIFY_SOURCE=2` (`tools/` C change is
      hardened-safe); 972 passed. The sole failure is `http_server_h2`'s
      50-stream stress, which is a **curl 7.88 / nghttp2 1.52 quirk on the test
      box** — it passes on curl 8.21 / nghttp2 1.70, the server code is untouched
      by this PR, and it's unrelated to these changes.
- [x] `examples/` sample builds with no new format warnings

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added (why `-Wformat` must live on the `-pipe` path too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
