### PR TITLE
feat(std.schema): defaults, transforms, more checks, and to_json_schema()

### DIFF
--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -525,7 +525,10 @@ Coming from Go's `json.Unmarshal`, Java's Jackson, Python's `json.load` + datacl
 - No streaming parse. The whole document is buffered into the arena before the tree is walkable. Documents into the tens of MB are fine; for multi-gigabyte JSON, use a different tool.
 - Strict RFC 8259 only: no JSON5, comments, or trailing commas.
 - Compact output only on stringify; wrap with a separate prettier if you need one.
-- No JSON Schema validation. Validate by hand or build it on top.
+- Declarative validation lives in `std.schema` (typed records, composable
+  validators, `parse -> (values, errors)`, and `to_json_schema()` to emit a
+  draft-07 JSON Schema). It does not itself *consume* external JSON Schema
+  documents — validate against a `std.schema` record, or build that on top.
 - No arbitrary-precision numbers. Numbers are `int` or `double`; the parser falls through to `strtod` for correctly-rounded IEEE-754 on edge cases (16+ significant digits, huge exponents), but there's no `BigDecimal` / `decimal.Decimal` equivalent for financial precision.
 - Hard-coded depth limit of 256, as DoS protection against deeply nested JSON bombs. Not configurable; rare to hit in practice.
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -1212,7 +1212,10 @@ Coming from Go's `json.Unmarshal`, Java's Jackson, Python's `json.load` + datacl
 - **No streaming parse.** The whole document is buffered into the arena before the tree is walkable. For multi-gigabyte JSON, use a different tool. Documents into the tens of MB are fine.
 - **No JSON5 / comments / trailing commas.** Strict RFC 8259 only.
 - **No pretty-print on stringify.** Compact output only. Wrap with a separate prettier if you need one.
-- **No JSON Schema validation.** Validate by hand or build it on top.
+- **Declarative validation is `std.schema`** — typed records, composable
+  validators, `parse -> (values, errors)`, and `to_json_schema()` to *emit* a
+  draft-07 JSON Schema. It does not *consume* external JSON Schema documents;
+  validate against a `std.schema` record, or build that on top.
 - **No arbitrary-precision numbers.** Numbers are `int` or `double`; the parser falls through to `strtod` for correctly-rounded IEEE-754 on edge cases but there's no `BigDecimal` / `decimal.Decimal` equivalent for financial precision.
 
 ### Other structured-data formats

--- a/std/schema/README.md
+++ b/std/schema/README.md
@@ -83,11 +83,40 @@ Rules are composable builder calls inside a `field(…) { … }` block:
 | `present()`                 | any               | value must be non-empty                             |
 | `one_of("a,b,c")`           | any               | value must be one of the comma-separated set        |
 | `email()`                   | STR               | value must look like an email address               |
+| `positive()`                | INT/FLOAT         | value `> 0`                                         |
+| `nonneg()`                  | INT/FLOAT         | value `>= 0`                                        |
+| `pattern("kind:needle")`    | STR               | `contains` / `prefix` / `suffix` match (no regex)   |
+| `one_of("a,b,c")`           | any               | value must be one of the comma-separated set        |
+| `email()`                   | STR               | value must look like an email address               |
 | `optional()`                | any               | absence is not an error (rules skipped when absent) |
+| `default_to("v")`           | any               | when absent, fill `"v"` instead of erroring (implies optional) |
 | `refine(\|v: string\| { … })` | any             | custom predicate: return `1` to pass, `0` to fail   |
 
+**Transforms** rewrite the canonical value in declaration order (before the
+checks that follow them) and never fail — the "parse, don't validate" payoff of
+getting a normalized value back:
+
+| Transform     | Effect                          |
+|---------------|---------------------------------|
+| `trim()`      | strip surrounding whitespace    |
+| `lowercase()` | lowercase the value             |
+| `uppercase()` | uppercase the value             |
+
+```aether
+schema.field("email", schema.STR) {
+    schema.trim()        // "  Ada@X.COM " ...
+    schema.lowercase()   // ... -> "ada@x.com" in the returned values
+    schema.email()
+}
+schema.field("plan", schema.STR) {
+    schema.default_to("free")
+    schema.one_of("free,pro,enterprise")
+}
+```
+
 `refine` takes a closure — use it for any check the built-ins don't cover
-(the module intentionally carries no regex dependency):
+(the module intentionally carries no regex dependency; `pattern()` handles the
+common contains/prefix/suffix cases without one):
 
 ```aether
 schema.field("even", schema.INT) {
@@ -121,6 +150,39 @@ Errors carry a stable, machine-readable `code` (mirroring Zod's vocabulary):
 | `invalid_format` | `email` (and other format checks)            |
 | `custom`         | a `refine` predicate returned `0`            |
 
+## JSON Schema projection
+
+A schema is a *description*, not just a gate. `to_json_schema(s)` emits a
+standard **draft-07 JSON Schema** string, so the same declaration can drive
+OpenAPI docs, other-language validators, or form generators (the idea behind
+Zod's `z.toJSONSchema()`).
+
+```aether
+s = schema.record() {
+    schema.field("age", schema.INT)  { schema.min(18); schema.max(120) }
+    schema.field("role", schema.STR) { schema.one_of("admin,user"); schema.optional() }
+    schema.field("plan", schema.STR) { schema.default_to("free") }
+}
+js = schema.to_json_schema(s)   // owned string — free with string_free
+```
+
+produces:
+
+```json
+{"$schema":"http://json-schema.org/draft-07/schema#","type":"object",
+ "properties":{
+   "age":{"type":"integer","minimum":18,"maximum":120},
+   "role":{"type":"string","enum":["admin","user"]},
+   "plan":{"type":"string","default":"free"}},
+ "required":["age"]}
+```
+
+Constraint mapping: `min`/`max` → `minimum`/`maximum` (or `minLength`/`maxLength`
+for `STR`), `len` → `minLength`/`maxLength`, `one_of` → `enum`, `email` →
+`"format":"email"`, `positive` → `exclusiveMinimum:0`, `nonneg` → `minimum:0`,
+`default_to` → `default` (and the field drops out of `required`). It *emits*
+JSON Schema; it does not consume external JSON Schema documents.
+
 ## API reference
 
 ### Types
@@ -129,13 +191,19 @@ Errors carry a stable, machine-readable `code` (mirroring Zod's vocabulary):
 ### Builders
 - `record() -> ptr` — start a schema; the trailing block declares its fields
 - `field(name, type) -> ptr` — declare a field; the trailing block adds its rules
-- `min(n)`, `max(n)`, `len(lo, hi)`, `present()`, `optional()`,
-  `one_of(set)`, `email()`, `refine(fn)`
+- checks: `min(n)`, `max(n)`, `len(lo, hi)`, `present()`, `positive()`,
+  `nonneg()`, `one_of(set)`, `email()`, `pattern("kind:needle")`, `refine(fn)`
+- transforms: `trim()`, `lowercase()`, `uppercase()`
+- field modifiers: `optional()`, `default_to("v")`
 
 ### Parse
 - `parse(schema, input) -> (values, errors)` — `input` is a `*Map` of
   `string → string`; returns a coerced value-map and an error list (both always
   non-null, both owned by the caller)
+
+### Projection
+- `to_json_schema(schema) -> string` — emit a draft-07 JSON Schema (owned
+  string; free with `string_free`)
 
 ### Result helpers
 - `ok(errors) -> int` — `1` if there are no errors

--- a/std/schema/module.ae
+++ b/std/schema/module.ae
@@ -46,8 +46,13 @@ exports(
     // builders
     record, field,
     min, max, len, present, optional, one_of, email, refine,
+    default_to, positive, nonneg, pattern,
+    // transforms
+    trim, lowercase, uppercase,
     // parse + result helpers
     parse, ok, error_count, error_field, error_code, error_message,
+    // projection
+    to_json_schema,
     // introspection
     schema_free, values_free, errors_free
 )
@@ -58,8 +63,10 @@ exports(
 import std.map
 import std.map(map_new, map_has, map_free)
 import std.list(list_new, list_add_raw, list_get_raw, list_size, list_free)
+import std.strbuilder
 import std.string(string_length, string_equals, string_concat, string_char_at,
-    string_contains, string_index_of, string_to_lower, string_free,
+    string_contains, string_index_of, string_to_lower, string_to_upper,
+    string_trim, string_ends_with, string_free, string_substring,
     string_starts_with, to_int, to_float)
 
 // box_closure() mallocs a two-word _AeClosure box; free it with libc free.
@@ -72,6 +79,9 @@ const FLOAT = 2
 const BOOL = 3
 
 // ---- Rule kinds ----
+// Rules split into two families, applied in declaration order during parse:
+//   TRANSFORMS (>= RULE_XFORM_FIRST) rewrite the canonical value (trim/case).
+//   CHECKS (< RULE_XFORM_FIRST) validate it and may push an error.
 const RULE_MIN = 0 // numeric >=  (ival) / string length >= for STR
 const RULE_MAX = 1 // numeric <=  (ival) / string length <= for STR
 const RULE_LEN = 2 // string length in [ival, ival2]
@@ -79,6 +89,14 @@ const RULE_PRESENT = 3 // non-empty
 const RULE_ONE_OF = 4 // value in comma-separated set (sval)
 const RULE_EMAIL = 5 // basic email shape
 const RULE_REFINE = 6 // custom closure predicate (fn value:string -> int)
+const RULE_POSITIVE = 7 // numeric > 0
+const RULE_NONNEG = 8 // numeric >= 0
+const RULE_PATTERN = 9 // substring/prefix/suffix contains (sval "kind:needle")
+// -- transforms (rewrite the value; never fail) --
+const RULE_XFORM_FIRST = 100
+const RULE_TRIM = 100 // strip surrounding whitespace
+const RULE_LOWER = 101 // lowercase
+const RULE_UPPER = 102 // uppercase
 
 struct Rule {
     kind: int
@@ -92,6 +110,8 @@ struct Field {
     name: string
     ty: int
     is_optional: int
+    has_default: int // 1 if default_val supplies an absent field
+    default_val: string // value substituted when the field is absent
     rules: ptr // *List of *Rule
 }
 
@@ -129,6 +149,8 @@ field(_ctx: ptr, name: string, ty: int) -> ptr {
     f.name = name
     f.ty = ty
     f.is_optional = 0
+    f.has_default = 0
+    f.default_val = ""
     f.rules = list_new()
     list_add_raw(s.fields, f)
     return f
@@ -186,6 +208,51 @@ email(_ctx: ptr) {
 // custom predicate: fn(value: string) -> int (1 = ok, 0 = fail)
 refine(_ctx: ptr, predicate: fn) {
     add_rule(_ctx, RULE_REFINE, 0, 0, "", box_closure(predicate))
+}
+
+// Supply a value when the field is absent from the input (implies optional:
+// an absent field is filled with `v` rather than erroring). A present field is
+// validated normally; the default only fires on absence.
+default_to(_ctx: ptr, v: string) {
+    f = _ctx as *Field
+    f.has_default = 1
+    f.default_val = v
+    f.is_optional = 1
+}
+
+// numeric > 0
+positive(_ctx: ptr) {
+    add_rule(_ctx, RULE_POSITIVE, 0, 0, "", null)
+}
+
+// numeric >= 0
+nonneg(_ctx: ptr) {
+    add_rule(_ctx, RULE_NONNEG, 0, 0, "", null)
+}
+
+// Lightweight string pattern match without a regex dependency. `spec` is
+// "kind:needle" where kind is one of contains / prefix / suffix, e.g.
+// pattern("prefix:SAVE") or pattern("contains:@"). For full regex, use refine().
+pattern(_ctx: ptr, spec: string) {
+    add_rule(_ctx, RULE_PATTERN, 0, 0, spec, null)
+}
+
+// -- transforms: rewrite the canonical value (applied in declaration order,
+//    before checks that follow them; they never fail) --
+
+// strip surrounding whitespace
+trim(_ctx: ptr) {
+    add_rule(_ctx, RULE_TRIM, 0, 0, "", null)
+}
+
+// lowercase the value
+lowercase(_ctx: ptr) {
+    add_rule(_ctx, RULE_LOWER, 0, 0, "", null)
+}
+
+// uppercase the value
+uppercase(_ctx: ptr) {
+    add_rule(_ctx, RULE_UPPER, 0, 0, "", null)
 }
 
 // ---------------------------------------------------------------------------
@@ -362,7 +429,77 @@ fn apply_rule(errors: ptr, r: *Rule, f: *Field, v: string) -> int {
         }
         return 0
     }
+    if k == RULE_POSITIVE {
+        if f.ty == FLOAT {
+            fv, _ = to_float(v)
+            if fv <= 0.0 {
+                push_error(errors, f.name, "too_small", "${f.name} must be positive")
+                return 1
+            }
+        } else {
+            iv, _ = to_int(v)
+            if iv <= 0 {
+                push_error(errors, f.name, "too_small", "${f.name} must be positive")
+                return 1
+            }
+        }
+        return 0
+    }
+    if k == RULE_NONNEG {
+        if f.ty == FLOAT {
+            fv, _ = to_float(v)
+            if fv < 0.0 {
+                push_error(errors, f.name, "too_small", "${f.name} must be non-negative")
+                return 1
+            }
+        } else {
+            iv, _ = to_int(v)
+            if iv < 0 {
+                push_error(errors, f.name, "too_small", "${f.name} must be non-negative")
+                return 1
+            }
+        }
+        return 0
+    }
+    if k == RULE_PATTERN {
+        // spec is "kind:needle" — kind in {contains, prefix, suffix}
+        colon = string_index_of(r.sval, ":")
+        matched = 0
+        if colon > 0 {
+            kind_s = string_substring(r.sval, 0, colon)
+            needle = string_substring(r.sval, colon + 1, string_length(r.sval))
+            if string_equals(kind_s, "contains") == 1 {
+                matched = string_contains(v, needle)
+            } else if string_equals(kind_s, "prefix") == 1 {
+                matched = string_starts_with(v, needle)
+            } else if string_equals(kind_s, "suffix") == 1 {
+                matched = string_ends_with(v, needle)
+            }
+            string_free(kind_s)
+            string_free(needle)
+        }
+        if matched != 1 {
+            push_error(errors, f.name, "invalid_format", "${f.name} does not match pattern ${r.sval}")
+            return 1
+        }
+        return 0
+    }
     return 0
+}
+
+// Apply a transform rule to `v`, returning a freshly-owned (magic) string.
+// The caller owns the result and must free the previous value if it owned it.
+fn apply_transform(kind: int, v: string) -> string {
+    if kind == RULE_TRIM {
+        return string_trim(v)
+    }
+    if kind == RULE_LOWER {
+        return string_to_lower(v)
+    }
+    if kind == RULE_UPPER {
+        return string_to_upper(v)
+    }
+    return string_concat(v, "") // identity copy (keeps ownership uniform)
 }
 
 // parse(schema, input_map) -> (values_map, errors_list)
@@ -383,7 +520,11 @@ parse(schema_ptr: ptr, input: ptr) -> (ptr, ptr) {
         present_in = map_has(input, f.name)
 
         if present_in == 0 {
-            if f.is_optional == 0 {
+            if f.has_default == 1 {
+                // absent + default → supply it. map.put auto-routes a string
+                // value to the owning sibling, so values_free reclaims it.
+                map.put(values, f.name, string_concat(f.default_val, ""))
+            } else if f.is_optional == 0 {
                 push_error(errors, f.name, "missing", "${f.name} is required")
             }
             i = i + 1
@@ -400,13 +541,20 @@ parse(schema_ptr: ptr, input: ptr) -> (ptr, ptr) {
             continue
         }
 
-        // 2. run rules (short-circuit on first failure per field)
+        // 2. run rules in declaration order. Transforms rewrite `cur` (owning a
+        //    fresh string each step); checks validate it. `cur` starts as an
+        //    owned copy of `typed` so ownership is uniform and freeable.
+        cur = string_concat(typed, "")
         rsz = list_size(f.rules)
         j = 0
         failed = 0
         while j < rsz {
             r = list_get_raw(f.rules, j) as *Rule
-            if apply_rule(errors, r, f, typed) == 1 {
+            if r.kind >= RULE_XFORM_FIRST {
+                next = apply_transform(r.kind, cur)
+                string_free(cur)
+                cur = next
+            } else if apply_rule(errors, r, f, cur) == 1 {
                 failed = 1
                 break
             }
@@ -414,7 +562,10 @@ parse(schema_ptr: ptr, input: ptr) -> (ptr, ptr) {
         }
 
         if failed == 0 {
-            map.put(values, f.name, typed)
+            // map.put auto-routes the owned string `cur` to the owning sibling.
+            map.put(values, f.name, cur)
+        } else {
+            string_free(cur)
         }
         i = i + 1
     }
@@ -467,6 +618,179 @@ error_message(errors: ptr, idx: int) -> string {
 }
 
 // ---------------------------------------------------------------------------
+// Projection — emit a standard JSON Schema document (Zod's z.toJSONSchema()).
+//
+// A schema is a description, not just a gate: to_json_schema() turns a record
+// into a draft-07 JSON Schema string so the same declaration drives OpenAPI
+// docs, other-language validators, or form generators. Constraints map as:
+//   min/max      -> minimum/maximum (numeric)  or minLength/maxLength (STR)
+//   len(lo,hi)   -> minLength/maxLength
+//   one_of       -> enum
+//   email        -> "format": "email"
+//   pattern      -> description hint (our lightweight kind:needle isn't regex)
+//   positive     -> exclusiveMinimum: 0   |  nonneg -> minimum: 0
+//   present/!opt -> listed in "required"
+// ---------------------------------------------------------------------------
+
+fn json_type_for(ty: int) -> string {
+    if ty == INT {
+        return "integer"
+    }
+    if ty == FLOAT {
+        return "number"
+    }
+    if ty == BOOL {
+        return "boolean"
+    }
+    return "string"
+}
+
+// Minimal JSON string escaping for values we emit (field names, enum items,
+// defaults). Handles the characters that would break a JSON string literal.
+fn json_escape_into(b: ptr, s: string) {
+    n = string_length(s)
+    i = 0
+    while i < n {
+        c = string_char_at(s, i)
+        if c == 34 { // "
+            strbuilder.append(b, "\\\"")
+        } else if c == 92 { // backslash
+            strbuilder.append(b, "\\\\")
+        } else if c == 10 {
+            strbuilder.append(b, "\\n")
+        } else if c == 9 {
+            strbuilder.append(b, "\\t")
+        } else {
+            strbuilder.append_byte(b, c)
+        }
+        i = i + 1
+    }
+}
+
+fn append_kv_str(b: ptr, key: string, val: string) {
+    strbuilder.append(b, "\"")
+    strbuilder.append(b, key)
+    strbuilder.append(b, "\":\"")
+    json_escape_into(b, val)
+    strbuilder.append(b, "\"")
+}
+
+// to_json_schema(schema) -> owned JSON string (draft-07). Caller frees with
+// string_free. Built directly with strbuilder (no JSON DOM) so it is leak-clean
+// by construction and carries no ownership entanglement.
+to_json_schema(schema_ptr: ptr) -> string {
+    s = schema_ptr as *Schema
+    b = strbuilder.new(256)
+    strbuilder.append(b, "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",")
+    strbuilder.append(b, "\"type\":\"object\",\"properties\":{")
+
+    fsz = list_size(s.fields)
+    i = 0
+    while i < fsz {
+        f = list_get_raw(s.fields, i) as *Field
+        is_str = f.ty == STR
+        if i > 0 {
+            strbuilder.append(b, ",")
+        }
+        strbuilder.append(b, "\"")
+        strbuilder.append(b, f.name)
+        strbuilder.append(b, "\":{")
+        append_kv_str(b, "type", json_type_for(f.ty))
+
+        rsz = list_size(f.rules)
+        j = 0
+        while j < rsz {
+            r = list_get_raw(f.rules, j) as *Rule
+            k = r.kind
+            if k == RULE_MIN {
+                if is_str {
+                    strbuilder.append(b, ",\"minLength\":")
+                } else {
+                    strbuilder.append(b, ",\"minimum\":")
+                }
+                strbuilder.append_long(b, r.ival)
+            } else if k == RULE_MAX {
+                if is_str {
+                    strbuilder.append(b, ",\"maxLength\":")
+                } else {
+                    strbuilder.append(b, ",\"maximum\":")
+                }
+                strbuilder.append_long(b, r.ival)
+            } else if k == RULE_LEN {
+                strbuilder.append(b, ",\"minLength\":")
+                strbuilder.append_long(b, r.ival)
+                strbuilder.append(b, ",\"maxLength\":")
+                strbuilder.append_long(b, r.ival2)
+            } else if k == RULE_ONE_OF {
+                strbuilder.append(b, ",\"enum\":[")
+                set_s = r.sval
+                start = 0
+                slen = string_length(set_s)
+                first = 1
+                pos = 0
+                while pos <= slen {
+                    if pos == slen || string_char_at(set_s, pos) == 44 { // ','
+                        item = string_substring(set_s, start, pos)
+                        if first == 0 {
+                            strbuilder.append(b, ",")
+                        }
+                        strbuilder.append(b, "\"")
+                        json_escape_into(b, item)
+                        strbuilder.append(b, "\"")
+                        string_free(item)
+                        first = 0
+                        start = pos + 1
+                    }
+                    pos = pos + 1
+                }
+                strbuilder.append(b, "]")
+            } else if k == RULE_EMAIL {
+                strbuilder.append(b, ",\"format\":\"email\"")
+            } else if k == RULE_POSITIVE {
+                strbuilder.append(b, ",\"exclusiveMinimum\":0")
+            } else if k == RULE_NONNEG {
+                strbuilder.append(b, ",\"minimum\":0")
+            } else if k == RULE_PATTERN {
+                strbuilder.append(b, ",\"description\":\"matches ")
+                json_escape_into(b, r.sval)
+                strbuilder.append(b, "\"")
+            }
+            j = j + 1
+        }
+
+        if f.has_default == 1 {
+            strbuilder.append(b, ",")
+            append_kv_str(b, "default", f.default_val)
+        }
+        strbuilder.append(b, "}")
+        i = i + 1
+    }
+
+    strbuilder.append(b, "},\"required\":[")
+    first_req = 1
+    i = 0
+    while i < fsz {
+        f = list_get_raw(s.fields, i) as *Field
+        if f.is_optional == 0 && f.has_default == 0 {
+            if first_req == 0 {
+                strbuilder.append(b, ",")
+            }
+            strbuilder.append(b, "\"")
+            json_escape_into(b, f.name)
+            strbuilder.append(b, "\"")
+            first_req = 0
+        }
+        i = i + 1
+    }
+    strbuilder.append(b, "]}")
+
+    // strbuilder.finish returns a plain char*; mint an owned magic string so the
+    // caller can string_free it (and the plain char* is tracker-reclaimed).
+    raw = strbuilder.finish(b)
+    return string_concat(raw, "")
+}
+
+// ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------
 
@@ -497,8 +821,9 @@ schema_free(schema_ptr: ptr) {
     heap.free(s)
 }
 
-// The values map holds borrowed pointers into the schema/input strings; free
-// only the map spine.
+// The values map now OWNS each stored value (parse stores coerced/transformed/
+// defaulted strings via map_put_string_owned). map_free reclaims both the spine
+// and every owned value.
 values_free(values: ptr) {
     if values != null {
         map_free(values)

--- a/tests/regression/test_schema.ae
+++ b/tests/regression/test_schema.ae
@@ -6,7 +6,7 @@
 import std.schema
 import std.map(map_new, map_put_raw, map_free)
 import std.map
-import std.string(string_equals, to_int)
+import std.string(string_equals, to_int, string_contains, string_free)
 
 extern exit(code: int)
 
@@ -243,6 +243,89 @@ main() {
     schema.errors_free(uerr)
     map_free(uin)
     schema.schema_free(acct)
+
+    // ---- defaults + transforms + new checks (positive/nonneg/pattern) ----
+    ext = schema.record() {
+        schema.field("email", schema.STR) {
+            schema.trim()
+            schema.lowercase()
+            schema.email()
+        }
+        schema.field("plan", schema.STR) {
+            schema.default_to("free")
+            schema.one_of("free,pro,enterprise")
+        }
+        schema.field("qty", schema.INT) {
+            schema.positive()
+        }
+        schema.field("code", schema.STR) {
+            schema.pattern("prefix:SAVE")
+        }
+    }
+
+    // transforms normalize; default supplies absent plan
+    din = map_new()
+    put(din, "email", "  Ada@Example.COM  ")
+    put(din, "qty", "3")
+    put(din, "code", "SAVE10")
+    dv, de = schema.parse(ext, din)
+    if schema.ok(de) != 1 {
+        fail("ext: expected ok, first=${schema.error_code(de, 0)}")
+    }
+    d_email, _ = map.get(dv, "email")
+    d_plan, _ = map.get(dv, "plan")
+    if string_equals(d_email, "ada@example.com") != 1 {
+        fail("transform: email not trimmed+lowered: '${d_email}'")
+    }
+    if string_equals(d_plan, "free") != 1 {
+        fail("default: plan not defaulted: '${d_plan}'")
+    }
+    print("PASS: transforms (trim+lowercase) and default applied\n")
+    schema.values_free(dv)
+    schema.errors_free(de)
+    map_free(din)
+
+    // positive check fails on <= 0
+    dn = map_new()
+    put(dn, "email", "a@b.co")
+    put(dn, "qty", "0")
+    put(dn, "code", "SAVE1")
+    expect_err("positive rejects 0", ext, dn, "qty", "too_small")
+    map_free(dn)
+
+    // pattern (prefix) rejects wrong prefix
+    dp = map_new()
+    put(dp, "email", "a@b.co")
+    put(dp, "qty", "1")
+    put(dp, "code", "NOPE")
+    expect_err("pattern prefix mismatch", ext, dp, "code", "invalid_format")
+    map_free(dp)
+
+    // ---- to_json_schema projection ----
+    js = schema.to_json_schema(ext)
+    // spot-check a few required fragments rather than the whole string
+    if string_contains(js, "\"$schema\"") != 1 {
+        fail("json_schema: missing $schema")
+    }
+    if string_contains(js, "\"format\":\"email\"") != 1 {
+        fail("json_schema: email format not emitted")
+    }
+    if string_contains(js, "\"enum\":[\"free\",\"pro\",\"enterprise\"]") != 1 {
+        fail("json_schema: one_of not emitted as enum: ${js}")
+    }
+    if string_contains(js, "\"exclusiveMinimum\":0") != 1 {
+        fail("json_schema: positive not emitted: ${js}")
+    }
+    if string_contains(js, "\"default\":\"free\"") != 1 {
+        fail("json_schema: default not emitted")
+    }
+    // defaulted/optional fields excluded from required; email + qty + code kept
+    if string_contains(js, "\"required\":[\"email\",\"qty\",\"code\"]") != 1 {
+        fail("json_schema: required set wrong: ${js}")
+    }
+    print("PASS: to_json_schema emits draft-07 with constraints\n")
+    string_free(js)
+    schema.schema_free(ext)
 
     print("\nAll PASS\n")
 }


### PR DESCRIPTION
## Description

Additive extensions to `std.schema` (merged in #1440). Nothing removed; the
existing API is unchanged. Drawn from Zod / Pydantic (Ash-inspired shape stays).

**Tier 1 — field ergonomics:**
- `default_to("v")` — supply a value when the field is absent (implies optional)
- transforms `trim()` / `lowercase()` / `uppercase()` — rewrite the canonical
  value in declaration order before later checks (the "parse, don't validate"
  payoff: you get a normalized value back). They wrap `std.string`.
- checks `positive()` / `nonneg()` (numeric) and `pattern("kind:needle")` — a
  regex-free `contains`/`prefix`/`suffix` match; `refine()` stays the escape hatch.

**Tier 2 — projection (`to_json_schema()`, Zod's `z.toJSONSchema()`):**
- emit a **draft-07 JSON Schema** string from a record, so one declaration can
  drive OpenAPI docs / other-language validators / form generators. Constraints
  map to `minimum`/`maximum`/`minLength`/`maxLength`/`enum`/`format`/
  `exclusiveMinimum`/`default`, with optional+defaulted fields dropped from
  `required`. Built with `strbuilder` (no JSON DOM) so it's leak-clean by
  construction.

The values map now **owns** its coerced/transformed/defaulted strings;
`values_free` reclaims them. Docs updated: `std/schema/README.md` gets the new
validators/transforms + a JSON Schema section, and the two stale "No JSON Schema
validation" notes in `docs/stdlib-{api,reference}.md` now point at `std.schema`.

**Deferred:** nested records + arrays (a recursive value model + JSON-tree input
contract) — best driven by a concrete consumer (nested JSON bodies in
`tinyweb.schema_api`); filed as a follow-up issue.

## Verified before opening

- Confirmed none of this already existed in `std/` or core (docs explicitly said
  "No JSON Schema validation... build it on top"); transforms **call**
  `std.string`, they don't reimplement.
- Regression test extended (transforms, default, positive, pattern,
  `to_json_schema` fragments) → **All PASS**
- **valgrind: 0 leaks** (transform ownership + owning values-map balance)
- `ae fmt --check std examples tests` clean; README snippet + `example.ae` run
  verbatim
- No C touched, so `HARDEN=1` not required.

## Type of Change
- [x] New feature (additive `std.schema` extensions)

## Checklist
- [x] Code follows style guidelines
- [x] Tests added; all pass; valgrind-clean
- [x] Documentation updated (README + stdlib docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
