### PR TITLE
fix(tinyweb+std.json): WS/SSE server repair, #1447 json leak, schema_api showcase, CachyOS nightly

### DIFF
--- a/contrib/tinyweb/README.md
+++ b/contrib/tinyweb/README.md
@@ -67,7 +67,8 @@ leaf — its block, if any, is a request-time handler, not more DSL.
 
 - `module.ae` — The library
 - `ws_client.ae` — WebSocket client
-- `ws_handshake.c` — SHA-1 + Base64 for WebSocket accept key (C extern)
+- `ws_handshake.c` — SHA-1 + Base64 for the WebSocket accept key, plus
+  `ws_unmask` (RFC 6455 §5.3 frame unmasking) — C externs
 - `example_app.ae` — HTTP endpoints with filters and nested paths
 - `example_composition.ae` — Modular composition, deep nesting, auth filters
 - `example_websocket.ae` — HTTP + WebSocket server with echo handler
@@ -76,3 +77,6 @@ leaf — its block, if any, is a request-time handler, not more DSL.
 - `example_auth.ae` — Cookie parsing + filter-to-endpoint attributes
 - `test_spec.ae` — DSL registration unit tests
 - `test_integration.ae` — HTTP round-trip integration tests
+- `test_websocket.ae` — WebSocket codec round-trip (handshake, client-frame
+  unmasking, and extended-length server framing). Needs the C extern:
+  `ae run test_websocket.ae --extra ws_handshake.c`

--- a/contrib/tinyweb/README.md
+++ b/contrib/tinyweb/README.md
@@ -43,6 +43,51 @@ server_start(server)
 - **Error callbacks** — `on_error`, `on_server_error`, `on_ws_timeout`, `on_ws_error`
 - **Statistics** — `on_stats(server) |stats| { ... }`
 - **Config** — `with_timeout`, `with_backlog`, `with_ws_backlog`, `with_keep_alive`
+- **Declarative JSON APIs** (`schema_api`) — mount a [`std.schema`](../../std/schema/)
+  resource as a validated JSON API; see below.
+
+## Declarative JSON APIs — `schema_api` + `std.schema`
+
+`contrib/tinyweb/schema_api` bridges [`std.schema`](../../std/schema/) (typed,
+composable validation — inspired by Zod/Pydantic/io-ts/Ash) to the router. You
+declare a resource once and mount it; every write request is JSON-parsed and
+validated **before** your handler runs. Invalid bodies never reach the handler —
+they get a JSON:API `422` with per-field, coded errors; malformed JSON a `400`.
+
+```aether
+user = schema.record() {
+    schema.field("name",  schema.STR)   { schema.trim(); schema.present(); schema.len(1, 60) }
+    schema.field("email", schema.STR)   { schema.trim(); schema.lowercase(); schema.email() }
+    schema.field("age",   schema.INT)   { schema.positive(); schema.max(120) }
+    schema.field("role",  schema.STR)   { schema.one_of("admin,user"); schema.default_to("user") }
+    schema.field("score", schema.FLOAT) { schema.min(0) }
+}
+
+registry = list.new()
+server = tinyweb.web_server_host("127.0.0.1", 8080) {
+    u = schema_api.json_api("/users", user) {
+        schema_api.create() |req, res, ctx| {
+            // body already parsed, coerced, and normalized — just handle it
+            tinyweb.response_write_status(res, "{\"ok\":true}", 201)
+        }
+    }
+    list.add(registry, u)
+    schema_api.openapi_route("/openapi.json", registry)   // FastAPI-style aggregate
+}
+```
+
+Every mounted resource **projects itself**, not just gates requests:
+
+- `GET {prefix}/schema` — auto-serves the resource's **draft-07 JSON Schema**
+  (`std.schema.to_json_schema`): `enum`, `format:email`, `minimum`/`maximum`,
+  `default`, `required`, …
+- `GET /openapi.json` (via `openapi_route`) — an aggregate **OpenAPI 3.0**
+  document for every resource: `paths` + `components.schemas`, `$ref`-linked.
+
+The validator is HTTP-agnostic — the same `record` validates a config file or a
+CLI arg set off the web entirely. Runnable demo: `example_schema_api.ae`. The
+JSON:API error envelopes and the schema/OpenAPI docs are built with `strbuilder`
+(leak-clean; avoids the `std.json` builder-nesting leak, upstream #1447).
 
 ## DSL semantics
 
@@ -75,6 +120,10 @@ leaf — its block, if any, is a request-time handler, not more DSL.
 - `example_static.ae` — Static file serving
 - `example_sse.ae` — Server-Sent Events + chunked transfer
 - `example_auth.ae` — Cookie parsing + filter-to-endpoint attributes
+- `example_schema_api.ae` — Declarative JSON API: rich `std.schema` validation +
+  transforms + coercion, auto `/schema` (draft-07) and `/openapi.json` (OpenAPI 3.0)
+- `schema_api/` — the `std.schema`-backed JSON API layer (`json_api`, `openapi_route`)
+- `test_schema_api.ae` — schema_api integration tests (validation + schema/OpenAPI endpoints)
 - `test_spec.ae` — DSL registration unit tests
 - `test_integration.ae` — HTTP round-trip integration tests
 - `test_websocket.ae` — WebSocket codec round-trip (handshake, client-frame

--- a/contrib/tinyweb/example_schema_api.ae
+++ b/contrib/tinyweb/example_schema_api.ae
@@ -1,0 +1,163 @@
+// Showcase: declarative JSON APIs with tinyweb.schema_api + std.schema.
+//
+// This demonstrates the FULL std.schema surface through the web layer — the
+// aspects the minimal test doesn't show:
+//   - rich validators: email, one_of, len, positive
+//   - transforms:      trim + lowercase (the value is NORMALIZED, not just checked)
+//   - default_to:      an absent field is filled, not rejected
+//   - coercion:        FLOAT/INT/BOOL from JSON scalars (Pydantic-style)
+//   - refine:          a custom predicate closure
+//   - "parse, don't validate": the handler READS the coerced/normalized values,
+//     it doesn't re-check anything (Zod / io-ts philosophy)
+//   - projection:      GET {resource}/schema serves the resource's draft-07
+//     JSON Schema, and GET /openapi.json serves an aggregate OpenAPI 3.0 doc
+//     built from every mounted resource (FastAPI-style; the Ash idea that a
+//     declarative resource is a projectable artifact, not just a gate)
+//
+// Run:  ae run contrib/tinyweb/example_schema_api.ae
+//
+// Credits (all MIT): Zod, Pydantic, io-ts, Ash — see std/schema/README.md.
+
+import contrib.tinyweb
+import contrib.tinyweb.schema_api
+import std.schema
+import std.list
+import std.http(http_post_raw, http_get_raw, http_response_status_code,
+    http_response_body_str, http_response_free)
+import std.string(string_starts_with)
+
+extern exit(code: int)
+extern sleep(ms: int)
+
+// A "user" handler that runs ONLY on a validated body — it can trust the
+// values are typed and normalized, and just read them back.
+handle_create_user(req: ptr, res: ptr, ctx: ptr) {
+    // In a real app you'd read the parsed values from ctx; here we just confirm
+    // the happy path was reached (validation + transforms already applied).
+    tinyweb.response_write_status(res, "{\"data\":{\"type\":\"users\",\"created\":true}}", 201)
+}
+
+handle_create_order(req: ptr, res: ptr, ctx: ptr) {
+    tinyweb.response_write_status(res, "{\"data\":{\"type\":\"orders\",\"created\":true}}", 201)
+}
+
+// ---- server actor (blocking accept loop off the main thread) ----
+message StartSrv { srv: ptr }
+
+actor SrvActor {
+    state s = 0
+    receive {
+        StartSrv(srv) -> {
+            s = srv
+            tinyweb.tw_start(srv)
+        }
+    }
+}
+actor Sched {
+    state x = 0
+    receive { Ping() -> { x = 1 } }
+}
+message Ping {}
+
+fn get(path: string) -> ptr {
+    return http_get_raw("http://127.0.0.1:18096${path}")
+}
+fn post(path: string, body: string) -> ptr {
+    return http_post_raw("http://127.0.0.1:18096${path}", body, "application/json")
+}
+
+fn show(label: string, resp: ptr) {
+    st = http_response_status_code(resp)
+    body = http_response_body_str(resp)
+    print("  ${label}: ${st}\n")
+    print("    ${body}\n")
+    http_response_free(resp)
+}
+
+main() {
+    print("=== tinyweb.schema_api showcase ===\n\n")
+
+    // A user resource exercising the rich std.schema surface.
+    user = schema.record() {
+        schema.field("name", schema.STR) {
+            schema.trim() // normalize: strip whitespace
+            schema.present()
+            schema.len(1, 60)
+        }
+        schema.field("email", schema.STR) {
+            schema.trim()
+            schema.lowercase() // normalize: canonical lowercase
+            schema.email()
+        }
+        schema.field("age", schema.INT) {
+            schema.positive()
+            schema.max(120)
+        }
+        schema.field("role", schema.STR) {
+            schema.one_of("admin,user,guest")
+            schema.default_to("user") // absent -> "user", not an error
+        }
+        schema.field("score", schema.FLOAT) {
+            schema.min(0) // FLOAT coercion + bound
+        }
+        schema.field("coupon", schema.STR) {
+            schema.refine(| v: string | {
+                    if string_starts_with(v, "SAVE") == 1 {
+                        return 1
+                    }
+                    return 0
+                })
+            schema.default_to("SAVE0")
+        }
+    }
+
+    // A second resource, to make the aggregate OpenAPI doc non-trivial.
+    order = schema.record() {
+        schema.field("sku", schema.STR) { schema.present() }
+        schema.field("qty", schema.INT) { schema.positive() }
+    }
+
+    // Mount both as JSON APIs and collect the groups for the OpenAPI aggregate.
+    registry = list.new()
+    server = tinyweb.web_server_host("127.0.0.1", 18096) {
+        u = schema_api.json_api("/users", user) {
+            schema_api.create() | req: ptr, res: ptr, ctx: ptr | {
+                handle_create_user(req, res, ctx)
+            }
+        }
+        o = schema_api.json_api("/orders", order) {
+            schema_api.create() | req: ptr, res: ptr, ctx: ptr | {
+                handle_create_order(req, res, ctx)
+            }
+        }
+        list.add(registry, u)
+        list.add(registry, o)
+        schema_api.openapi_route("/openapi.json", registry)
+    }
+
+    spawn(Sched())
+    a = spawn(SrvActor())
+    a ! StartSrv { srv: server }
+    sleep(500)
+
+    // 1. Valid create — trims/lowercases email, defaults role+coupon, coerces score.
+    print("1. valid user (email has whitespace+caps; role/coupon omitted):\n")
+    show("POST /users/", post("/users/", "{\"name\":\"  Ada \",\"email\":\" Ada@EXAMPLE.com \",\"age\":30,\"score\":9.5}"))
+
+    // 2. Invalid — age not positive, bad email, coupon fails refine, role not in set.
+    print("\n2. invalid user (multiple failures, each with a code):\n")
+    show("POST /users/", post("/users/", "{\"name\":\"\",\"email\":\"nope\",\"age\":-3,\"role\":\"wizard\",\"score\":-1,\"coupon\":\"NOPE\"}"))
+
+    // 3. The resource's own JSON Schema (draft-07), served automatically.
+    print("\n3. GET /users/schema  (auto-served draft-07 JSON Schema):\n")
+    show("GET /users/schema", get("/users/schema"))
+
+    // 4. The aggregate OpenAPI 3.0 document for the whole API.
+    print("\n4. GET /openapi.json  (FastAPI-style aggregate):\n")
+    show("GET /openapi.json", get("/openapi.json"))
+
+    schema.schema_free(user)
+    schema.schema_free(order)
+    print("\n=== showcase complete ===\n")
+    exit(0)
+}

--- a/contrib/tinyweb/module.ae
+++ b/contrib/tinyweb/module.ae
@@ -9,6 +9,7 @@ import std.map
 import std.http
 import std.tcp
 import std.string
+import std.bytes
 
 exports (
     ALL, GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, CONNECT, TRACE,
@@ -215,6 +216,10 @@ const WS_OPCODE_PONG   = 10
 // ---------------------------------------------------------------------------
 extern ws_generate_accept_key(client_key: string) -> string
 extern ws_base64_encode(data: ptr, len: int) -> string
+// Unmask a client->server frame payload in place (RFC 6455 §5.3): returns a
+// fresh copy of payload with payload[i] ^= mask_key[i % 4]. `len` is the frame's
+// declared payload length (payloads may contain NUL bytes).
+extern ws_unmask(payload: string, mask_key: string, len: int) -> string
 
 // ---------------------------------------------------------------------------
 // Route / Filter registration data structures
@@ -518,25 +523,45 @@ _record_stats(srv: ptr, stats: ptr) {
 ws_send_frame(sock: ptr, payload: string) {
     len = string.length(payload)
 
-    // Build frame header: FIN=1, opcode=text(1)
-    // For len < 126: 2-byte header [0x81, len]
-    // For len 126..65535: 4-byte header [0x81, 126, len>>8, len&0xFF]
+    // Assemble the whole frame in a NUL-safe bytes buffer and send it in ONE
+    // write. Two bugs are avoided here:
+    //   1. Header octets are RAW bytes (0x81, the length bytes), never ASCII
+    //      digits — the old from_int(129) emitted "129" and corrupted frames.
+    //   2. A length high-byte of 0 (e.g. for a 166-byte payload) is a NUL;
+    //      building the header with string.concat / strlen-based tcp.write
+    //      truncated there, corrupting every frame >=126 bytes. A bytes buffer
+    //      + length-aware write_n is NUL-safe.
+    // Sending in one write also avoids TCP fragmentation splitting the header
+    // across a peer's fixed-size reads. 0x81 = FIN | opcode=text(1).
+    //   len <  126     : 2-byte header [0x81, len]
+    //   len 126..65535 : 4-byte header [0x81, 126, len>>8, len&0xFF]
+    hdr_len = 2
+    if len >= 126 { hdr_len = 4 }
+    total = hdr_len + len
+    buf = bytes.new(total)
+    bytes.set(buf, 0, 129)
     if len < 126 {
-        hdr = string.concat(string.from_int(129), string.from_int(len))
-        // Send as raw bytes via TCP
-        tcp.write(sock, hdr)
+        bytes.set(buf, 1, len)
     } else {
-        hdr = string.concat(string.from_int(129), string.from_int(126))
-        hdr = string.concat(hdr, string.from_int(len / 256))
-        hdr = string.concat(hdr, string.from_int(len - (len / 256) * 256))
-        tcp.write(sock, hdr)
+        bytes.set(buf, 1, 126)
+        bytes.set(buf, 2, len / 256)
+        bytes.set(buf, 3, len - (len / 256) * 256)
     }
-    tcp.write(sock, payload)
+    for (i = 0; i < len; i++) {
+        bytes.set(buf, hdr_len + i, string.char_at(payload, i))
+    }
+    frame = bytes.finish(buf, total)
+    tcp.write_n(sock, frame, total)
 }
 
-// Send a close frame (opcode 8, empty payload)
+// Send a close frame (opcode 8, empty payload): [0x88, 0x00]. Raw octets in a
+// bytes buffer — from_int would emit "136"/"0" as text and corrupt the frame.
 ws_send_close(sock: ptr) {
-    tcp.write(sock, string.concat(string.from_int(136), string.from_int(0)))
+    buf = bytes.new(2)
+    bytes.set(buf, 0, 136)
+    bytes.set(buf, 1, 0)
+    frame = bytes.finish(buf, 2)
+    tcp.write_n(sock, frame, 2)
 }
 
 // ---------------------------------------------------------------------------
@@ -548,9 +573,9 @@ ws_send_close(sock: ptr) {
 // ---------------------------------------------------------------------------
 
 ws_read_frame(sock: ptr) {
-    // Read 2-byte header
-    hdr = tcp.read(sock, 2)
-    if hdr == 0 { return "" }
+    // Read 2-byte header. tcp.read returns (data, err).
+    hdr, herr = tcp.read(sock, 2)
+    if herr != "" { return "" }
 
     byte0 = string.char_at(hdr, 0)
     byte1 = string.char_at(hdr, 1)
@@ -561,8 +586,8 @@ ws_read_frame(sock: ptr) {
 
     // Extended payload length
     if payload_len == 126 {
-        ext = tcp.read(sock, 2)
-        if ext == 0 { return "" }
+        ext, eerr = tcp.read(sock, 2)
+        if eerr != "" { return "" }
         payload_len = string.char_at(ext, 0) * 256 + string.char_at(ext, 1)
     }
 
@@ -575,22 +600,21 @@ ws_read_frame(sock: ptr) {
     // Read masking key (4 bytes) if masked
     mask_key = ""
     if masked == 1 {
-        mask_key = tcp.read(sock, 4)
-        if mask_key == 0 { return "" }
+        mkey, merr = tcp.read(sock, 4)
+        if merr != "" { return "" }
+        mask_key = mkey
     }
 
     // Read payload
     if payload_len == 0 { return "" }
-    payload = tcp.read(sock, payload_len)
-    if payload == 0 { return "" }
+    payload, perr = tcp.read(sock, payload_len)
+    if perr != "" { return "" }
 
     // Unmask: payload[i] ^= mask_key[i % 4]
-    // (Client-to-server frames are always masked per RFC 6455)
+    // (Client-to-server frames are always masked per RFC 6455.) Done in C for
+    // byte-exactness and speed — see ws_unmask in ws_handshake.c.
     if masked == 1 {
-        // XOR unmasking done byte-by-byte
-        // In a production impl this would be a C extern for speed
-        // For now, return as-is — the TCP layer handles raw bytes
-        // TODO: implement ws_unmask extern in C for proper unmasking
+        return ws_unmask(payload, mask_key, payload_len)
     }
 
     return payload
@@ -604,19 +628,21 @@ ws_read_frame(sock: ptr) {
 // ---------------------------------------------------------------------------
 
 ws_handle_client(client: ptr, ws_handlers: ptr) {
-    // Read the HTTP upgrade request
-    request_data = tcp.read(client, 4096)
-    if request_data == 0 {
+    // Read the HTTP upgrade request. tcp.read returns (data, err).
+    request_data, rerr = tcp.read(client, 4096)
+    if rerr != "" {
         tcp.close(client)
         return
     }
 
-    // Extract path from "GET /path HTTP/1.1"
+    // Extract path from "GET /path HTTP/1.1". array_get returns a BORROWED
+    // pointer into parts' storage, so mint an owned copy before array_free
+    // (else ws_path dangles — the documented string_array_get lifetime trap).
     parts = string.split(request_data, " ")
     n_parts = string.array_size(parts)
     ws_path = ""
     if n_parts >= 2 {
-        ws_path = string.array_get(parts, 1)
+        ws_path = string.concat(string.array_get(parts, 1), "")
     }
     string.array_free(parts)
 
@@ -645,19 +671,20 @@ ws_handle_client(client: ptr, ws_handlers: ptr) {
     response = string.concat(response, "\r\n\r\n")
     tcp.write(client, response)
 
-    // Find handler for this path
-    handler = 0
+    // Find the boxed handler for this path (keep it BOXED; unbox at call time —
+    // a bare `handler = unbox_closure(...)` can't be stored in a plain slot and
+    // then invoked, and mixing it with an int-init leaks/segfaults).
+    hboxed = null
     n_ws = list.size(ws_handlers)
     for (i = 0; i < n_ws; i++) {
         entry, _ = list.get(ws_handlers, i)
         entry_path, _ = map.get(entry, "path")
         if (ws_path == entry_path) {
             hboxed, _ = map.get(entry, "handler")
-            handler = unbox_closure(hboxed)
         }
     }
 
-    if handler == 0 {
+    if hboxed == null {
         // 404 — no handler registered for this path
         ws_send_frame(client, "Error: 404")
         ws_send_close(client)
@@ -674,6 +701,7 @@ ws_handle_client(client: ptr, ws_handlers: ptr) {
         } else {
             // Call handler: (message, sender_socket, ctx)
             // sender_socket is the raw TCP socket — use ws_send_frame() to reply
+            handler = unbox_closure(hboxed)
             call(handler, msg, client, 0)
         }
     }
@@ -687,8 +715,8 @@ ws_accept_loop(tcp_server: ptr, ws_handlers: ptr) {
     // production would spawn per-connection (Tiny uses virtual threads)
     running = 1
     for (running == 1; running == 1; running = running) {
-        client = tcp.accept(tcp_server)
-        if client != 0 {
+        client, aerr = tcp.accept(tcp_server)
+        if aerr == "" {
             ws_handle_client(client, ws_handlers)
         } else {
             running = 0
@@ -744,35 +772,36 @@ sse_close(stream: ptr) {
 // Handle an SSE client connection: parse the HTTP request, send headers,
 // then call the registered handler with the raw socket as "stream"
 sse_handle_client(client: ptr, sse_handlers: ptr) {
-    // Read the HTTP request
-    request_data = tcp.read(client, 4096)
-    if request_data == 0 {
+    // Read the HTTP request. tcp.read returns (data, err).
+    request_data, rerr = tcp.read(client, 4096)
+    if rerr != "" {
         tcp.close(client)
         return
     }
 
-    // Extract path from "GET /path HTTP/1.1"
+    // Extract path from "GET /path HTTP/1.1". Mint an owned copy before
+    // array_free — array_get returns a borrowed pointer into parts' storage.
     parts = string.split(request_data, " ")
     n_parts = string.array_size(parts)
     req_path = ""
     if n_parts >= 2 {
-        req_path = string.array_get(parts, 1)
+        req_path = string.concat(string.array_get(parts, 1), "")
     }
     string.array_free(parts)
 
-    // Find handler for this path
-    handler = 0
+    // Find the boxed handler for this path (unbox at call time — see
+    // ws_handle_client for why we keep it boxed rather than storing unboxed).
+    hboxed = null
     n_sse = list.size(sse_handlers)
     for (i = 0; i < n_sse; i++) {
         entry, _ = list.get(sse_handlers, i)
         entry_path, _ = map.get(entry, "path")
         if (req_path == entry_path) {
             hboxed, _ = map.get(entry, "handler")
-            handler = unbox_closure(hboxed)
         }
     }
 
-    if handler == 0 {
+    if hboxed == null {
         tcp.write(client, "HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\n\r\nNot Found")
         tcp.close(client)
         return
@@ -783,6 +812,7 @@ sse_handle_client(client: ptr, sse_handlers: ptr) {
 
     // Call handler with the raw socket as "stream"
     // Handler uses sse_send(stream, data) to push events
+    handler = unbox_closure(hboxed)
     call(handler, client)
 
     // Handler returned — close the connection
@@ -792,8 +822,8 @@ sse_handle_client(client: ptr, sse_handlers: ptr) {
 sse_accept_loop(tcp_server: ptr, sse_handlers: ptr) {
     running = 1
     for (running == 1; running == 1; running = running) {
-        client = tcp.accept(tcp_server)
-        if client != 0 {
+        client, aerr = tcp.accept(tcp_server)
+        if aerr == "" {
             sse_handle_client(client, sse_handlers)
         } else {
             running = 0

--- a/contrib/tinyweb/schema_api/module.ae
+++ b/contrib/tinyweb/schema_api/module.ae
@@ -32,7 +32,8 @@
 //   tinyweb.server_start(server)
 
 exports(
-    json_api, create, index, show, update, destroy
+    json_api, create, index, show, update, destroy,
+    openapi_route
 )
 
 import std.schema
@@ -41,6 +42,7 @@ import std.map
 import std.json
 import std.list(list_new, list_add_raw, list_get_raw, list_size)
 import std.string(string_length, string_concat, string_equals)
+import std.strbuilder
 
 // tinyweb's own DSL surface (this module is a sibling under contrib/tinyweb).
 import contrib.tinyweb(
@@ -55,6 +57,11 @@ struct ApiGroup {
     resource: ptr // *std.schema.Schema (opaque ptr here)
     prefix: string
 }
+
+// An ApiGroup carries the mount prefix + resource, so a list of the groups
+// returned by json_api() is all openapi_route() needs to enumerate the API into
+// one OpenAPI document — no module-global registry required (the caller already
+// holds each group; it just passes the list).
 
 // json_api(prefix, schema) { create(...); show(...); ... }
 // Container builder: opens a tinyweb path() at `prefix`, attaches a validating
@@ -79,6 +86,18 @@ json_api(_ctx: ptr, prefix: string, resource: ptr) -> ptr {
     }
     filter(grp_ctx, PATCH, ".*") | req: ptr, res: ptr, ctx: ptr | {
         return validate_body(res, req, resource)
+    }
+
+    // Auto-mount GET {prefix}/schema — the resource's own draft-07 JSON Schema
+    // (std.schema.to_json_schema). "A declarative resource is a projectable
+    // artifact": the same declaration that validates requests also serves its
+    // contract. Registered before the user's show() route so /schema isn't
+    // swallowed by a GET /(\w+) id matcher.
+    end_point(grp_ctx, GET, "/schema") | req: ptr, res: ptr, ctx: ptr | {
+        js = schema.to_json_schema(resource)
+        response_set_header(res, "Content-Type", "application/schema+json")
+        response_json(res, js)
+        string.string_free(js)
     }
 
     return g
@@ -157,49 +176,71 @@ fn json_object_to_input(obj: ptr) -> ptr {
 }
 
 // ---- JSON:API error rendering ----
+//
+// Built with strbuilder rather than the JSON DOM: json.obj()/set nested-object
+// trees leak on json_free (upstream std.json bug #1447), and these envelopes
+// nest (errors[].source.pointer). strbuilder sidesteps it and is leak-clean.
+
+// Append a JSON-escaped string literal (quotes included) to the builder.
+fn json_str_into(b: ptr, s: string) {
+    strbuilder.append(b, "\"")
+    n = string_length(s)
+    i = 0
+    while i < n {
+        c = string.char_at(s, i)
+        if c == 34 {
+            strbuilder.append(b, "\\\"")
+        } else if c == 92 {
+            strbuilder.append(b, "\\\\")
+        } else if c == 10 {
+            strbuilder.append(b, "\\n")
+        } else if c == 9 {
+            strbuilder.append(b, "\\t")
+        } else {
+            strbuilder.append_byte(b, c)
+        }
+        i = i + 1
+    }
+    strbuilder.append(b, "\"")
+}
 
 fn write_error(res: ptr, status: int, title: string, detail: string) {
-    err_node = json.obj()
-    errors_arr = json.arr()
-    d = json.obj()
-    _ = json.set(d, "status", json.str(int_to_str(status)))
-    _ = json.set(d, "title", json.str(title))
-    _ = json.set(d, "detail", json.str(detail))
-    _ = json.push(errors_arr, d)
-    _ = json.set(err_node, "errors", errors_arr)
-    out, _ = json.encode(err_node)
+    b = strbuilder.new(128)
+    strbuilder.append(b, "{\"errors\":[{\"status\":")
+    json_str_into(b, "${status}")
+    strbuilder.append(b, ",\"title\":")
+    json_str_into(b, title)
+    strbuilder.append(b, ",\"detail\":")
+    json_str_into(b, detail)
+    strbuilder.append(b, "}]}")
+    out = strbuilder.finish(b)
     response_set_header(res, "Content-Type", "application/vnd.api+json")
     response_write_status(res, out, status)
-    json.json_free(err_node)
+    // `out` is a plain char* from finish(); tracker-reclaimed on scope exit.
 }
 
 fn write_validation_errors(res: ptr, errors: ptr) {
-    err_node = json.obj()
-    errors_arr = json.arr()
+    b = strbuilder.new(256)
+    strbuilder.append(b, "{\"errors\":[")
     n = schema.error_count(errors)
     i = 0
     while i < n {
-        d = json.obj()
-        _ = json.set(d, "status", json.str("422"))
-        _ = json.set(d, "code", json.str(schema.error_code(errors, i)))
-        _ = json.set(d, "title", json.str("Validation Error"))
-        _ = json.set(d, "detail", json.str(schema.error_message(errors, i)))
-        // JSON:API source pointer for the offending field
-        src = json.obj()
-        _ = json.set(src, "pointer", json.str(string_concat("/data/attributes/", schema.error_field(errors, i))))
-        _ = json.set(d, "source", src)
-        _ = json.push(errors_arr, d)
+        if i > 0 {
+            strbuilder.append(b, ",")
+        }
+        strbuilder.append(b, "{\"status\":\"422\",\"code\":")
+        json_str_into(b, schema.error_code(errors, i))
+        strbuilder.append(b, ",\"title\":\"Validation Error\",\"detail\":")
+        json_str_into(b, schema.error_message(errors, i))
+        strbuilder.append(b, ",\"source\":{\"pointer\":")
+        json_str_into(b, "/data/attributes/${schema.error_field(errors, i)}")
+        strbuilder.append(b, "}}")
         i = i + 1
     }
-    _ = json.set(err_node, "errors", errors_arr)
-    out, _ = json.encode(err_node)
+    strbuilder.append(b, "]}")
+    out = strbuilder.finish(b)
     response_set_header(res, "Content-Type", "application/vnd.api+json")
     response_write_status(res, out, 422)
-    json.json_free(err_node)
-}
-
-fn int_to_str(n: int) -> string {
-    return "${n}"
 }
 
 // ---- Leaf route builders (run inside a json_api() block; _ctx is *ApiGroup) ----
@@ -232,4 +273,118 @@ update(_ctx: ptr, handler: fn) {
 destroy(_ctx: ptr, handler: fn) {
     g = _ctx as *ApiGroup
     end_point(g.ctx, DELETE, "/(\\w+)", handler)
+}
+
+// ---- OpenAPI aggregate (FastAPI-style /openapi.json) ----
+
+// Derive a schema name from a mount prefix: "/users" -> "Users".
+fn schema_name_for(prefix: string) -> string {
+    // drop a leading '/', capitalize first char
+    p = prefix
+    if string_length(p) > 0 && string.char_at(p, 0) == 47 { // '/'
+        p = string.substring(p, 1, string_length(p))
+    }
+    if string_length(p) == 0 {
+        return "Resource"
+    }
+    first = string.char_at(p, 0)
+    if first >= 97 && first <= 122 { // a-z -> upper
+        first = first - 32
+    }
+    rest = string.substring(p, 1, string_length(p))
+    return string_concat(string.from_char(first), rest)
+}
+
+// Build an OpenAPI 3.0 document from a list of ApiGroups (the values returned by
+// json_api()). Each resource's draft-07 schema (std.schema.to_json_schema)
+// becomes a components.schemas entry, and its CRUD routes become paths
+// referencing it. Built with strbuilder (not the JSON DOM) so it is leak-clean
+// by construction. Returns an owned string.
+fn build_openapi(groups: ptr) -> string {
+    b = strbuilder.new(512)
+    strbuilder.append(b, "{\"openapi\":\"3.0.3\",")
+    strbuilder.append(b, "\"info\":{\"title\":\"Aether tinyweb API\",\"version\":\"1.0.0\"},")
+
+    n = 0
+    if groups != null {
+        n = list_size(groups)
+    }
+
+    // paths
+    strbuilder.append(b, "\"paths\":{")
+    i = 0
+    while i < n {
+        m = list_get_raw(groups, i) as *ApiGroup
+        name = schema_name_for(m.prefix)
+        if i > 0 {
+            strbuilder.append(b, ",")
+        }
+        // collection path: GET (list) + POST (create, validated against schema)
+        strbuilder.append(b, "\"")
+        strbuilder.append(b, m.prefix)
+        strbuilder.append(b, "/\":{\"get\":{\"summary\":\"list ")
+        strbuilder.append(b, name)
+        strbuilder.append(b, "\"},\"post\":{\"summary\":\"create ")
+        strbuilder.append(b, name)
+        strbuilder.append(b, "\",\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/")
+        strbuilder.append(b, name)
+        strbuilder.append(b, "\"}}}}}},")
+        // schema doc path
+        strbuilder.append(b, "\"")
+        strbuilder.append(b, m.prefix)
+        strbuilder.append(b, "/schema\":{\"get\":{\"summary\":\"JSON Schema for ")
+        strbuilder.append(b, name)
+        strbuilder.append(b, "\"}}")
+        name_free(name)
+        i = i + 1
+    }
+    strbuilder.append(b, "},")
+
+    // components.schemas — embed each resource's draft-07 schema verbatim
+    strbuilder.append(b, "\"components\":{\"schemas\":{")
+    i = 0
+    while i < n {
+        m = list_get_raw(groups, i) as *ApiGroup
+        name = schema_name_for(m.prefix)
+        js = schema.to_json_schema(m.resource)
+        if i > 0 {
+            strbuilder.append(b, ",")
+        }
+        strbuilder.append(b, "\"")
+        strbuilder.append(b, name)
+        strbuilder.append(b, "\":")
+        strbuilder.append(b, js)
+        string.string_free(js)
+        name_free(name)
+        i = i + 1
+    }
+    strbuilder.append(b, "}}}")
+
+    raw = strbuilder.finish(b)
+    return string_concat(raw, "")
+}
+
+// schema_name_for returns an owned string in the general case; free it.
+fn name_free(s: string) {
+    string.string_free(s)
+}
+
+// openapi_route(path, groups) — mount GET <path> serving one aggregate OpenAPI
+// document for the given resources. `groups` is a *List of the ApiGroup values
+// returned by json_api(). FastAPI-style; call once at the server root:
+//
+//   users = schema_api.json_api("/users", user_schema) { ... }
+//   orders = schema_api.json_api("/orders", order_schema) { ... }
+//   reg = list.new(); list.add(reg, users); list.add(reg, orders)
+//   schema_api.openapi_route("/openapi.json", reg)
+//
+// (Passing the groups explicitly avoids a module-global registry — the caller
+// already holds each group.)
+openapi_route(_ctx: ptr, route_path: string, groups: ptr) {
+    end_point(_ctx, GET, route_path) | req: ptr, res: ptr, ctx: ptr | {
+        doc = build_openapi(groups)
+        response_set_header(res, "Content-Type", "application/json")
+        response_json(res, doc)
+        string.string_free(doc)
+    }
 }

--- a/contrib/tinyweb/test_schema_api.ae
+++ b/contrib/tinyweb/test_schema_api.ae
@@ -9,8 +9,9 @@
 import contrib.tinyweb
 import contrib.tinyweb.schema_api
 import std.schema
-import std.http(http_post_raw, http_response_status_code, http_response_body_str,
-    http_response_free)
+import std.http(http_post_raw, http_get_raw, http_response_status_code,
+    http_response_body_str, http_response_free)
+import std.list
 import std.string(string_contains)
 
 extern exit(code: int)
@@ -70,6 +71,9 @@ fn chk_body(resp: ptr, needle: string, want: int, label: string) {
 fn post(path: string, body: string) -> ptr {
     return http_post_raw("http://127.0.0.1:18092${path}", body, "application/json")
 }
+fn get(path: string) -> ptr {
+    return http_get_raw("http://127.0.0.1:18092${path}")
+}
 
 main() {
     print("=== tinyweb.schema_api ===\n\n")
@@ -84,12 +88,15 @@ main() {
         }
     }
 
+    registry = list.new()
     server = tinyweb.web_server_host("127.0.0.1", 18092) {
-        schema_api.json_api("/users", user) {
+        u = schema_api.json_api("/users", user) {
             schema_api.create() | req: ptr, res: ptr, ctx: ptr | {
                 handle_create(req, res, ctx)
             }
         }
+        list.add(registry, u)
+        schema_api.openapi_route("/openapi.json", registry)
     }
 
     spawn(SchedHelper())
@@ -108,6 +115,12 @@ main() {
 
     // 4. malformed JSON -> 400
     chk(post("/users/", "{\"age\":"), 400, "malformed JSON -> 400")
+
+    // 5. auto-served draft-07 JSON Schema for the resource
+    chk_body(get("/users/schema"), "\"$schema\"", 200, "GET /schema -> draft-07 JSON Schema")
+
+    // 6. aggregate OpenAPI 3.0 document
+    chk_body(get("/openapi.json"), "\"openapi\":\"3.0.3\"", 200, "GET /openapi.json -> OpenAPI doc")
 
     schema.schema_free(user)
     print("\nAll PASS\n")

--- a/contrib/tinyweb/test_websocket.ae
+++ b/contrib/tinyweb/test_websocket.ae
@@ -1,0 +1,209 @@
+// TinyWeb WebSocket codec + roundtrip tests — guards the frame/lifetime fixes.
+//
+// Exercises the REAL contrib.tinyweb WebSocket path end to end over a loopback
+// TCP connection (server accept loop in an actor; client in main):
+//
+//   1. handshake      — Sec-WebSocket-Accept computed + 101 returned. Reaching
+//                        the message loop at all also proves path routing: a
+//                        garbage request path (the array_get borrowed-pointer
+//                        use-after-free) would 404 and no echo would come back.
+//   2. small frame    — a masked client frame is UNMASKED (RFC 6455 §5.3) and
+//                        echoed back in a 2-byte-header server frame, intact.
+//   3. LARGE frame    — a >=126-byte reply uses the 4-byte extended header, and
+//                        a length high-byte of 0 must NOT truncate the frame
+//                        (the string.concat/NUL bug that corrupted every big
+//                        frame). This is the core regression.
+//
+// Build/run: ae run test_websocket.ae --extra ws_handshake.c
+//
+// Self-contained: no python, no external ws client. The client side builds a
+// masked text frame and parses server frames by hand so the test depends only
+// on the module under test.
+
+import contrib.tinyweb
+import std.tcp
+import std.list
+import std.list(list_new)
+import std.map
+import std.map(map_new)
+import std.string
+import std.bytes
+
+const PORT = 8231
+
+// ---- handler: echo back a payload whose size we control via the message ----
+// "big"   -> a >126-byte reply (exercises extended-length framing)
+// "small" -> a short reply
+// anything else -> echoed verbatim (proves unmasking produced the right bytes)
+fn reply_for(msg: string) -> string {
+    if string.contains(msg, "big") == 1 {
+        // 200 'x' chars — safely over the 126 extended-length threshold.
+        s = ""
+        for (i = 0; i < 200; i ++) { s = string.concat(s, "x") }
+        return s
+    }
+    return "echo:${msg}"
+}
+
+// ---- server, run from an actor so main can act as the client ----
+message StartWs { srv: ptr }
+message Noop {}
+actor WsActor {
+    state s = 0
+    receive { StartWs(srv) -> {
+            s = srv
+            ws_tcp, _ = map.get(srv, "tcp")
+            handlers, _ = map.get(srv, "handlers")
+            tinyweb.ws_accept_loop(ws_tcp, handlers)
+        } }
+}
+// A second actor keeps the scheduler ticking while the server actor blocks in
+// the accept loop (mirrors test_integration.ae's SchedHelper).
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+// ---- client-side WebSocket helpers (build/parse frames by hand) ----
+
+// mask key bytes 0x01 0x02 0x03 0x04, indexed by i % 4.
+fn mask_byte(i: int) -> int {
+    m = i - ((i / 4) * 4) // i % 4
+    if m == 0 { return 1 }
+    if m == 1 { return 2 }
+    if m == 2 { return 3 }
+    return 4
+}
+
+// Send a masked client text frame in ONE write. The frame is assembled in a
+// bytes buffer (NUL-safe: a masked byte or the mask key can be 0x00, which
+// string.concat/strlen would truncate). Sending it as one write_n also avoids
+// TCP fragmentation splitting the header across the server's fixed-size reads.
+// Payloads stay < 126 bytes so the client header is 2 bytes + 4 mask bytes.
+fn send_client_frame(sock: ptr, payload: string) {
+    len = string.length(payload)
+    total = 6 + len
+    buf = bytes.new(total)
+    bytes.set(buf, 0, 129) // 0x81 FIN|text
+    bytes.set(buf, 1, 128 + len) // mask bit | len
+    bytes.set(buf, 2, 1) // mask key 0x01020304
+    bytes.set(buf, 3, 2)
+    bytes.set(buf, 4, 3)
+    bytes.set(buf, 5, 4)
+    for (i = 0; i < len; i ++) {
+        b = string.char_at(payload, i)
+        bytes.set(buf, 6 + i, b ^ mask_byte(i))
+    }
+    frame = bytes.finish(buf, total)
+    tcp.write_n(sock, frame, total)
+}
+
+// Read exactly n bytes from sock into a returned string, looping over read_n
+// (a single read_n may return fewer bytes than requested — TCP is a stream).
+fn read_exact(sock: ptr, n: int) -> string {
+    acc = bytes.new(n)
+    got = 0
+    for (got < n; got < n; got = got) {
+        chunk, m, err = tcp.read_n(sock, n - got)
+        if err != "" { return "" }
+        for (j = 0; j < m; j ++) {
+            bytes.set(acc, got + j, string.char_at(chunk, j))
+        }
+        got = got + m
+    }
+    return bytes.finish(acc, n)
+}
+
+// Receive one server text frame and return its payload. Server frames are
+// unmasked. Reads the 2-byte header, then the extended length if present, then
+// the payload — each with read_exact so partial TCP segments are reassembled.
+fn recv_server_frame(sock: ptr) -> string {
+    hdr = read_exact(sock, 2)
+    if hdr == "" { return "" }
+    b1 = string.char_at(hdr, 1)
+    plen = b1 - ((b1 / 128) * 128) // strip mask bit (server won't set it)
+    if plen == 126 {
+        ext = read_exact(sock, 2)
+        plen = string.char_at(ext, 0) * 256 + string.char_at(ext, 1)
+    }
+    if plen == 0 { return "" }
+    return read_exact(sock, plen)
+}
+
+fn assert_eq(label: string, got: string, want: string) -> int {
+    if got == want {
+        println("  [OK] ${label}")
+        return 0
+    }
+    println("  [FAIL] ${label}: got [${got}] want [${want}]")
+    return 1
+}
+
+main() {
+    println("=== TinyWeb WebSocket codec roundtrip ===")
+
+    // Register a /ws handler using the module's real ws_entry shape.
+    handlers = list_new()
+    entry = map_new()
+    map.put(entry, "path", "/ws")
+    map.put(entry, "handler", box_closure(| msg: string, sender: ptr, ctx: ptr | {
+                tinyweb.ws_send_frame(sender, reply_for(msg))
+            }))
+    list.add(handlers, entry)
+
+    ws_tcp, err = tcp.listen(PORT)
+    if err != "" {
+        println("FAIL: bind ${PORT}: ${err}")
+        return
+    }
+    srv = map_new()
+    map.put(srv, "tcp", ws_tcp)
+    map.put(srv, "handlers", handlers)
+    spawn(SchedHelper())
+    a = spawn(WsActor())
+    a ! StartWs { srv: srv }
+    sleep(500) // let the accept loop come up before we connect
+
+    // ---- client: connect + handshake ----
+    sock, cerr = tcp.connect("127.0.0.1", PORT)
+    if cerr != "" {
+        println("FAIL: connect: ${cerr}")
+        return
+    }
+    // Minimal upgrade request. The key is arbitrary; the server echoes an
+    // accept but we don't validate it here (handshake success == 101 + frames).
+    req = "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
+    tcp.write(sock, req)
+    resp, _ = tcp.read(sock, 4096)
+    fails = 0
+    if string.contains(resp, "101") == 1 {
+        println("  [OK] handshake returned 101")
+    } else {
+        println("  [FAIL] handshake: ${resp}")
+        fails = fails + 1
+    }
+
+    // ---- test 1: small masked frame -> server unmasks -> echoes ----
+    send_client_frame(sock, "small")
+    fails = fails + assert_eq("small frame roundtrip (unmask + 2-byte header)", recv_server_frame(sock), "echo:small")
+
+    // ---- test 2: LARGE reply -> extended-length header, no NUL truncation ----
+    send_client_frame(sock, "big")
+    big = recv_server_frame(sock)
+    if string.length(big) == 200 {
+        println("  [OK] large frame length 200 (extended header, no NUL truncation)")
+    } else {
+        println("  [FAIL] large frame length: got ${string.length(big)} want 200")
+        fails = fails + 1
+    }
+
+    tcp.close(sock)
+
+    if fails == 0 {
+        println("ALL PASS")
+        exit(0)
+    } else {
+        println("${fails} FAILED")
+        exit(1)
+    }
+}

--- a/contrib/tinyweb/ws_handshake.c
+++ b/contrib/tinyweb/ws_handshake.c
@@ -88,6 +88,21 @@ char* ws_base64_encode(const uint8_t *data, int len) {
 
 static const char *WS_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
+// ---- WebSocket frame unmasking (RFC 6455 §5.3) ----
+// Client-to-server frames are always masked: payload[i] ^= mask_key[i % 4].
+// Returns a freshly malloc'd NUL-terminated copy of the unmasked payload.
+// `len` is the true payload byte length (payloads may contain NUL bytes, so we
+// do NOT rely on strlen — the caller passes the frame's declared length).
+char* ws_unmask(const char *payload, const char *mask_key, int len) {
+    if (len < 0) len = 0;
+    char *out = (char *)malloc((size_t)len + 1);
+    for (int i = 0; i < len; i++) {
+        out[i] = (char)((unsigned char)payload[i] ^ (unsigned char)mask_key[i & 3]);
+    }
+    out[len] = '\0';
+    return out;
+}
+
 char* ws_generate_accept_key(const char *client_key) {
     size_t key_len = strlen(client_key);
     size_t magic_len = strlen(WS_MAGIC);

--- a/std/json/aether_json.c
+++ b/std/json/aether_json.c
@@ -1606,6 +1606,27 @@ static void heap_free_tree(JsonValue* v) {
     aether_caps_free(v, sizeof(JsonValue));
 }
 
+/* Reclaim a donated builder value after its contents were deep-copied into a
+ * container's arena (object_set / array_add). Two shapes:
+ *  - value->arena set: the value acquired its own arena (e.g. json.obj() that
+ *    later had children set into it). arena_destroy frees the arena's contents,
+ *    but the JsonValue STRUCT itself is a separate heap_new allocation
+ *    (JV_FLAG_HEAP_STRUCT — "v->arena is set but the struct still sits on the
+ *    heap") and must be freed too, or it leaks (#1447). Snapshot the flag
+ *    before arena_destroy since for a parsed root the struct can live inside
+ *    the arena; a builder value never does, but be defensive.
+ *  - no arena: a plain heap tree — heap_free_tree reclaims struct + children. */
+static void free_donated_value(JsonValue* value) {
+    if (!value) return;
+    if (value->arena) {
+        int heap_struct = (value->flags & JV_FLAG_HEAP_STRUCT) != 0;
+        arena_destroy(value->arena);
+        if (heap_struct) aether_caps_free(value, sizeof(JsonValue));
+    } else {
+        heap_free_tree(value);
+    }
+}
+
 int json_array_add_raw(JsonValue* arr, JsonValue* value) {
     if (!arr || arr->type != JSON_ARRAY || !value) return 0;
     if (!ensure_container_arena(arr)) return 0;
@@ -1617,8 +1638,7 @@ int json_array_add_raw(JsonValue* arr, JsonValue* value) {
     arr->data.arr.items[arr->data.arr.count++] = copy;
 
     // The caller passed ownership to us. Free the incoming tree.
-    if (value->arena) arena_destroy(value->arena);
-    else              heap_free_tree(value);
+    free_donated_value(value);
 
     return 1;
 }
@@ -1641,8 +1661,7 @@ int json_object_set_raw(JsonValue* obj, const char* key, JsonValue* value) {
             if (blk->key_lens[i] == k32 &&
                 memcmp(blk->keys[i], key, k32) == 0) {
                 blk->values[i] = copy;
-                if (value->arena) arena_destroy(value->arena);
-                else              heap_free_tree(value);
+                free_donated_value(value);
                 return 1;
             }
         }
@@ -1659,8 +1678,7 @@ int json_object_set_raw(JsonValue* obj, const char* key, JsonValue* value) {
     blk->key_lens[idx] = k32;
     blk->values[idx] = copy;
 
-    if (value->arena) arena_destroy(value->arena);
-    else              heap_free_tree(value);
+    free_donated_value(value);
     return 1;
 }
 

--- a/tests/cachyos/README.md
+++ b/tests/cachyos/README.md
@@ -1,0 +1,33 @@
+# CachyOS nightly
+
+`nightly.sh` is a **self-run** nightly build for a rolling-release Arch box
+(CachyOS), the sibling of [`tests/freebsd/nightly.sh`](../freebsd/nightly.sh):
+a platform the GitHub Actions matrix can't cover.
+
+Its value is the **toolchain**: CachyOS ships GCC/Clang several major versions
+ahead of the Ubuntu-22.04 CI box, so building HEAD there surfaces newer-compiler
+`-Werror` promotions and warnings before they reach anyone. It also does the one
+thing the portable CI never does — **type-checks every `contrib/*/module.ae`**
+(the gap that let tinyweb's DSL silently rot; see the contrib-coverage issue).
+
+## What it does
+
+1. Syncs `origin/main` → HEAD in a clean tree, pinning `PATH`/`AE`/`AETHERC`/
+   `AETHER_HOME` to the freshly-built compiler (never a version-managed `ae` on
+   `PATH`).
+2. A **fail-on-missing-deps** gate — a dedicated build box should test
+   everything, so an absent contrib dependency is a provisioning bug that turns
+   the run RED (the opposite of `contrib_build.sh`'s probe-and-skip).
+3. `make ci` → `make contrib` → `make contrib-host-check` → a `contrib` `ae
+   check` sweep, each timed (ms) and recorded.
+4. Publishes a topline pass/fail table to the **`nightly-results`** orphan
+   branch (no shared history, no CI triggered) and writes a dated summary + log
+   locally (last 14 kept).
+
+## Running it
+
+Cron isn't installed on CachyOS by default; use a **systemd --user timer** (see
+the header comment in `nightly.sh`). Provision the contrib deps first — package
+installs plus the `aether-lang-dev/factor-language` fork build — and export the
+`AETHER_*` dep env vars in the timer environment. The gate stays RED until every
+dep is present, by design.

--- a/tests/cachyos/nightly.sh
+++ b/tests/cachyos/nightly.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# tests/cachyos/nightly.sh — self-run nightly HEAD build of Aether on a
+# rolling-release Arch box (CachyOS: GCC 16 / Clang 22, ~5 GCC majors newer than
+# the Ubuntu-22.04 GitHub CI box).
+#
+# NOT a GitHub Actions runner — the sibling of tests/freebsd/nightly.sh for a
+# platform the CI matrix can't cover. Cron it (or a systemd --user timer, since
+# CachyOS ships no crond) on a dedicated build box; it syncs origin/main to
+# HEAD, runs `make ci` + contrib, type-checks every contrib module, and — the
+# thing GitHub CI never does — exercises the whole thing under a much newer
+# toolchain. Surfaces -Werror promotions / new warnings before they hit anyone.
+# It publishes a topline pass/fail table to the `nightly-results` orphan branch.
+#
+# Install (systemd --user timer example):
+#   ~/.config/systemd/user/aether-nightly.service  ->  ExecStart=<this script>
+#   ~/.config/systemd/user/aether-nightly.timer    ->  OnCalendar=*-*-* 03:17:00
+#   loginctl enable-linger $USER   (so the timer fires without an active login)
+#
+# POLICY: fail-on-missing-deps. A dedicated build box should test EVERYTHING, so
+# a missing contrib dependency is a provisioning bug that turns the nightly RED
+# (deliberately the opposite of contrib_build.sh's probe-and-skip). Provisioning:
+#   - pacman -S --needed sqlite expat python ruby perl lua tcl duktape go nodejs
+#       jdk-openjdk tinygo racket
+#     (racket ships the CS embedding headers/lib/boot images — no source build)
+#   - build the aether-lang-dev/factor-language fork: `./build.sh net-bootstrap`
+#     (NOT `update`/`self-update` — those git-pull and fail on a shallow clone).
+#     NB the fork's `libfactor.a` is actually an ELF shared object; symlink
+#     `libfactor.so -> libfactor.a` for AETHER_FACTOR_SONAME.
+#
+# Toolchain + dep env (set in the timer/cron environment; see AETHER_* below):
+#   AETHER_REPO, AETHER_RACKET_INCLUDE/_LIB/_BOOT_DIR,
+#   AETHER_FACTOR_SONAME, AETHER_FACTOR_IMAGE
+# The script pins PATH/AE/AETHERC/AETHER_HOME to the tree it builds, so a
+# version-managed `ae` on PATH (e.g. /usr/local/bin) is never used.
+
+set -u
+
+REPO="${AETHER_REPO:-$HOME/scm/AetherThings/aether}"
+OUTDIR="${AETHER_NIGHTLY_OUT:-$HOME/aether-nightly}"
+STAMP="$(date +%Y-%m-%d_%H%M)"
+LOG="$OUTDIR/nightly_${STAMP}.log"
+SUMMARY="$OUTDIR/nightly_${STAMP}.summary.txt"
+RESULTS_TSV="$OUTDIR/results_${STAMP}.tsv"
+STEPS_TSV="$OUTDIR/steps_${STAMP}.tsv"
+# Orphan branch (no shared history, no CI) used purely to publish topline
+# results. Set AETHER_NIGHTLY_PUBLISH=0 to skip the push.
+RESULTS_BRANCH="${AETHER_NIGHTLY_BRANCH:-nightly-results}"
+RESULTS_REMOTE="${AETHER_NIGHTLY_REMOTE:-origin}"
+
+mkdir -p "$OUTDIR"
+cd "$REPO" || { echo "no repo at $REPO" > "$SUMMARY"; exit 1; }
+
+# --- toolchain isolation --------------------------------------------------
+# This box has a version-managed `ae`/`aetherc` on PATH (/usr/local/bin ->
+# ~/.aether/versions/v0.417.0). The nightly must test the compiler IT builds,
+# never that stale managed one. The pipeline already calls tools by absolute
+# path ($REPO/build/ae), but belt-and-suspenders against any bare `ae`/`aetherc`
+# a make recipe / contrib script / bridge build might invoke: put $REPO/build
+# FIRST on PATH and export explicit AE/AETHERC pointing at the freshly-built
+# binaries. AETHER_HOME is pinned to the repo so no ~/.aether managed state or
+# a stray `current` symlink can redirect resolution.
+export PATH="$REPO/build:$PATH"
+export AE="$REPO/build/ae"
+export AETHERC="$REPO/build/aetherc"
+export AETHER_HOME="$REPO"
+
+{
+    echo "===================================================================="
+    echo "Aether nightly — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "host:   $(uname -a)"
+    echo "distro: $(. /etc/os-release 2>/dev/null; echo "$PRETTY_NAME")"
+    echo "gcc:    $(gcc --version | head -1)"
+    echo "clang:  $(clang --version | head -1)"
+    echo "===================================================================="
+} > "$LOG"
+
+# --- sync to HEAD (clean; never carry local state into a nightly) ---
+git fetch -q origin 2>>"$LOG"
+git checkout -q main 2>>"$LOG"
+git reset -q --hard origin/main 2>>"$LOG"
+git clean -qfdx -e 'aether-nightly*' 2>>"$LOG" || true
+HEAD_LINE="$(git log --oneline -1)"
+echo "HEAD: $HEAD_LINE" >> "$LOG"
+
+# --- Dependency gate: this is a dedicated build box, so a MISSING contrib
+# --- dependency is a provisioning FAILURE, not a skip. (Deliberately the
+# --- opposite of contrib_build.sh / contrib_host_demos.sh, which probe-and-
+# --- skip because portable CI runners can't have every language.) Any gap
+# --- here turns the nightly RED and names what to install/build.
+# A dep is satisfied if EITHER a command is on PATH OR a matching library/
+# header exists (many bridges link a .so and never ship a CLI, e.g. duktape,
+# sqlite, expat). Args after the kind are candidates; any one present = OK.
+have_dep() {
+    kind="$1"; shift
+    case "$kind" in
+        cmd) for c in "$@"; do command -v "$c" >/dev/null 2>&1 && return 0; done ;;
+        lib) for l in "$@"; do
+                 for d in /usr/lib /usr/lib64 /usr/local/lib /lib; do
+                     [ -e "$d/$l" ] && return 0
+                     ls "$d/$l".* >/dev/null 2>&1 && return 0
+                 done
+             done ;;
+    esac
+    return 1
+}
+
+require_deps() {
+    missing=0
+    # "<pkg>|<kind>|<candidate...>"  — kind: cmd (PATH) or lib (shared object).
+    set --                                              \
+        "sqlite|lib|libsqlite3.so"                       \
+        "expat|lib|libexpat.so"                          \
+        "python|cmd|python3"                             \
+        "ruby|cmd|ruby"                                  \
+        "perl|cmd|perl"                                  \
+        "lua|cmd|lua|lua5.4|lua5.3"                      \
+        "tcl|cmd|tclsh"                                  \
+        "duktape|lib|libduktape.so"                      \
+        "go|cmd|go"                                      \
+        "nodejs|cmd|node"                                \
+        "java|cmd|java"                                  \
+        "tinygo|cmd|tinygo"                              \
+        "racket|cmd|racket"
+    pkg_specs="$*"
+    for spec in $pkg_specs; do
+        pkg="${spec%%|*}"; rest="${spec#*|}"
+        kind="${rest%%|*}"; cands="${rest#*|}"
+        # candidates are '|'-joined; hand them to have_dep as separate args
+        oldIFS="$IFS"; IFS='|'
+        # shellcheck disable=SC2086
+        set -- $cands
+        IFS="$oldIFS"
+        if have_dep "$kind" "$@"; then
+            echo "  dep OK:   $pkg"
+        else
+            echo "  dep MISS: $pkg — none of [$cands] found ($kind)"
+            missing=$((missing+1))
+        fi
+    done
+    # Fork/source-built bridges: gated on their runtime env var being set.
+    # "<label>:<ENVVAR>" — label first, envvar last (labels may have spaces).
+    set --                                                        \
+        "factor (aether-lang fork libfactor+image):AETHER_FACTOR_SONAME" \
+        "racket-CS embedding tree:AETHER_RACKET_INCLUDE"
+    for spec in "$@"; do
+        label="${spec%:*}"; var="${spec##*:}"
+        val="$(eval "printf '%s' \"\${$var:-}\"")"
+        if [ -n "$val" ]; then
+            echo "  dep OK:   $label ($var set)"
+        else
+            echo "  dep MISS: $label — $var unset (build required, see TODO)"
+            missing=$((missing+1))
+        fi
+    done
+    if [ "$missing" -gt 0 ]; then
+        echo "  => $missing required contrib dependency(ies) MISSING — provisioning failure"
+        return 1
+    fi
+    return 0
+}
+
+# Type-check every contrib/*/module.ae (plus any test/example .ae beside it).
+# Returns nonzero if any module fails to compile — the contrib-rot guard.
+# NOTE: `make ci` ends with clean/release-archive steps that wipe build/, so
+# the `ae` binary is gone by the time this runs — (re)build it first.
+contrib_ae_check() {
+    local rc=0 mod out ae name t0 t1 want got
+    ae="$PWD/build/ae"
+    # `make ci` ends by wiping build/, so the sweep (re)builds ae from current
+    # source before type-checking contrib.
+    echo "  (building current ae for the sweep)"
+    if ! make -j"$(nproc)" ae stdlib >/dev/null 2>>"$LOG"; then
+        echo "  ae-check ABORT: could not build ae for the sweep"
+        return 1
+    fi
+    if [ ! -x "$ae" ]; then
+        echo "  ae-check ABORT: build/ae still absent after build"
+        return 1
+    fi
+    # Staleness guard on the COMPILED version. Note `ae version` prints the
+    # version MANAGER's active install (from ~/.aether/active_version), NOT the
+    # compiled-in version — so it can read e.g. 0.417.0 for a correctly-built
+    # 0.500.0 binary. Check the version string compiled into the binary instead
+    # (VERSION-file value must appear in `strings build/ae`).
+    want="$(cat VERSION 2>/dev/null)"
+    if [ -n "$want" ] && ! strings "$ae" 2>/dev/null | grep -qxF "$want"; then
+        echo "  ae-check ABORT: built ae does not carry VERSION=$want (stale build?)"
+        return 1
+    fi
+    echo "  (sweep ae built at VERSION ${want:-unknown})"
+
+    # Per-module topline row -> $RESULTS_TSV: "<module>\t<PASS|FAIL>\t<ms>".
+    # One row per contrib MODULE (module.ae), not every helper .ae, so the
+    # published table stays topline. publish_results() renders these to markdown.
+    : > "$RESULTS_TSV"
+    for mod in $(find contrib -name module.ae | sort); do
+        name="$(dirname "${mod#contrib/}")"   # e.g. tinyweb, host/python
+        t0="$(now_ms)"
+        if out="$("$ae" check "$mod" 2>&1)"; then
+            status="PASS"; echo "  ae-check OK: $mod"
+        else
+            status="FAIL"; rc=1
+            echo "  ae-check FAIL: $mod"
+            echo "$out" | grep -iE "error" | head -5
+        fi
+        t1="$(now_ms)"
+        printf '%s\t%s\t%s\n' "$name" "$status" "$((t1 - t0))" >> "$RESULTS_TSV"
+    done
+    return $rc
+}
+
+# Render RESULTS_TSV to markdown and publish it to the orphan results branch.
+# Uses git plumbing (hash-object/mktree/commit-tree) so it NEVER checks out or
+# touches the working tree — safe to call from a repo that's mid-build. The
+# branch keeps only the latest snapshot (single commit, force-pushed).
+# Render both the top-level STEPS and the per-module sweep to markdown. The
+# headline reflects the OVERALL run outcome (the `fails` counter across all
+# steps), so a failed dependency gate / make ci turns the dashboard RED even
+# when every module type-checks. Times are milliseconds.
+render_row() { # <name> <PASS|FAIL> <ms>
+    if [ "$2" = "PASS" ]; then
+        echo "| \`$1\` | ✅ PASS | $3 |"
+    else
+        echo "| \`$1\` | ❌ FAIL | $3 |"
+    fi
+}
+
+publish_results() {
+    [ "${AETHER_NIGHTLY_PUBLISH:-1}" = "0" ] && { echo "  (publish skipped)"; return 0; }
+
+    md="$OUTDIR/RESULTS_${STAMP}.md"
+    {
+        echo "# Aether contrib nightly — results"
+        echo ""
+        echo "Nightly HEAD build on CachyOS (newer GCC/Clang than the GitHub CI box)."
+        echo "Orphan branch (\`$RESULTS_BRANCH\`, no shared history, no CI). Latest snapshot only."
+        echo ""
+        echo "- **run:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "- **HEAD:** $(git log --oneline -1)"
+        echo "- **toolchain:** $(gcc --version | head -1) / $(clang --version | head -1)"
+        echo "- **host:** $(. /etc/os-release 2>/dev/null; echo "$PRETTY_NAME"), kernel $(uname -r)"
+        echo ""
+        # Truthful headline: overall pass/fail is driven by `fails` (all steps),
+        # NOT just the module sweep — that was the bug that published green on a
+        # red run.
+        if [ "${fails:-0}" -eq 0 ]; then
+            echo "## ✅ ALL GREEN"
+        else
+            echo "## ❌ ${fails} step(s) FAILED"
+        fi
+        echo ""
+        echo "### Pipeline steps"
+        echo ""
+        echo "| step | status | ms |"
+        echo "|------|--------|----|"
+        if [ -s "$STEPS_TSV" ]; then
+            while IFS="$(printf '\t')" read -r n s t; do
+                [ -z "$n" ] && continue
+                render_row "$n" "$s" "$t"
+            done < "$STEPS_TSV"
+        fi
+        echo ""
+        echo "### Contrib module type-check (\`ae check\`)"
+        echo ""
+        echo "| module | status | ms |"
+        echo "|--------|--------|----|"
+        if [ -s "$RESULTS_TSV" ]; then
+            # failures first, then passes, each alphabetical
+            awk -F'\t' '$2=="FAIL"' "$RESULTS_TSV" | sort | while IFS="$(printf '\t')" read -r n s t; do
+                render_row "$n" "FAIL" "$t"
+            done
+            awk -F'\t' '$2=="PASS"' "$RESULTS_TSV" | sort | while IFS="$(printf '\t')" read -r n s t; do
+                render_row "$n" "PASS" "$t"
+            done
+        else
+            echo "| _(sweep did not run)_ | ❌ FAIL | 0 |"
+        fi
+    } > "$md"
+
+    # Commit the single file onto the orphan branch via plumbing, then push.
+    blob="$(git hash-object -w "$md")"
+    tree="$(printf '100644 blob %s\tRESULTS.md\n' "$blob" | git mktree)"
+    parent=""
+    # fetch current tip so we could parent onto it — but this branch is
+    # snapshot-only, so we deliberately commit with NO parent (stays 1 commit).
+    commit="$(printf 'chore(nightly): results %s\n' "$STAMP" | git commit-tree "$tree")"
+    if git push -f "$RESULTS_REMOTE" "$commit:refs/heads/$RESULTS_BRANCH" 2>>"$LOG"; then
+        echo "  results published to $RESULTS_REMOTE/$RESULTS_BRANCH"
+    else
+        echo "  results publish FAILED (see log) — run itself still reported below"
+    fi
+}
+
+run_step() {
+    name="$1"; shift
+    echo "" >> "$LOG"
+    echo "############### $name ###############" >> "$LOG"
+    if "$@" >> "$LOG" 2>&1; then
+        echo "  [OK]   $name"
+        return 0
+    else
+        rc=$?
+        echo "  [FAIL] $name (exit $rc)"
+        return 1
+    fi
+}
+
+# Wall-clock milliseconds (date +%s only has second resolution, which made every
+# sub-second step report 0s — the "suspicious all-zero" symptom).
+now_ms() { date +%s%3N; }
+
+# run_and_record <label> <cmd...> — run a top-level step, time it in ms, append
+# "<label>\t<PASS|FAIL>\t<ms>" to STEPS_TSV, and count failures in `fails`. This
+# is what makes the published dashboard reflect the REAL outcome (gate/ci/etc.),
+# not just the per-module sweep.
+run_and_record() {
+    label="$1"; shift
+    t0="$(now_ms)"
+    if run_step "$label" "$@"; then
+        st="PASS"
+    else
+        st="FAIL"; fails=$((fails + 1))
+    fi
+    t1="$(now_ms)"
+    printf '%s\t%s\t%s\n' "$label" "$st" "$((t1 - t0))" >> "$STEPS_TSV"
+}
+
+# Thin wrappers so make steps are named commands run_and_record can invoke.
+make_ci_step() { make ci; }
+make_contrib_step() { make contrib; }
+make_host_check_step() { make contrib-host-check; }
+
+fails=0
+{
+    echo "Aether nightly summary — $STAMP"
+    echo "HEAD: $HEAD_LINE"
+    echo "toolchain: $(gcc --version | head -1) / $(clang --version | head -1)"
+    echo ""
+    # Record each top-level step's outcome to STEPS_TSV ("<step>\t<PASS|FAIL>\t<secs>")
+    # so the published dashboard reflects the REAL run outcome, not just the
+    # per-module sweep. (A failed dependency gate must turn the dashboard red.)
+    : > "$STEPS_TSV"
+    run_and_record "contrib dependency gate" require_deps
+    run_and_record "make ci" make_ci_step
+    run_and_record "make contrib" make_contrib_step
+    run_and_record "make contrib-host-check" make_host_check_step
+    # `make ci` and `make contrib` never compile the contrib Aether code
+    # (test-ae globs only tests/*, `make contrib` builds C shims). This sweep
+    # is the ONLY thing that type-checks every contrib module under the newer
+    # toolchain — the exact gap that let tinyweb's DSL rot (issue #1442).
+    run_and_record "contrib ae-check sweep" contrib_ae_check
+    echo ""
+    echo "--- publishing topline results to $RESULTS_REMOTE/$RESULTS_BRANCH ---"
+    publish_results
+    echo ""
+    # Surface the signal Nic cares about most: new warnings/errors from the
+    # newer toolchain, deduped, with counts.
+    echo "--- warning/error lines (newer-toolchain signal) ---"
+    grep -hoE "(error|warning):.*" "$LOG" 2>/dev/null \
+        | sed -E 's/[0-9]+/N/g' | sort | uniq -c | sort -rn | head -40
+    echo ""
+    if [ "$fails" -eq 0 ]; then
+        echo "RESULT: ALL GREEN on CachyOS HEAD"
+    else
+        echo "RESULT: $fails step(s) FAILED — see $LOG"
+    fi
+} > "$SUMMARY" 2>&1
+
+# keep the last 14 nightlies, prune older
+ls -1t "$OUTDIR"/nightly_*.log 2>/dev/null | tail -n +15 | xargs -r rm -f
+ls -1t "$OUTDIR"/nightly_*.summary.txt 2>/dev/null | tail -n +15 | xargs -r rm -f
+ls -1t "$OUTDIR"/results_*.tsv 2>/dev/null | tail -n +15 | xargs -r rm -f
+ls -1t "$OUTDIR"/steps_*.tsv 2>/dev/null | tail -n +15 | xargs -r rm -f
+ls -1t "$OUTDIR"/RESULTS_*.md 2>/dev/null | tail -n +15 | xargs -r rm -f
+
+echo ""
+echo "Summary written: $SUMMARY"
+cat "$SUMMARY"
+exit "$fails"

--- a/tests/regression/test_json_builder.ae
+++ b/tests/regression/test_json_builder.ae
@@ -45,6 +45,42 @@ main() {
 
     json.free(root)
 
+    // Regression (#1447): a nested object attached into a parent that has
+    // already acquired an arena (props -> p, both built with json.obj()) must be
+    // fully reclaimed by a single json.free(root). object_set/array_add
+    // deep-copy the donated value into the parent's arena and then free the
+    // original; when that original had its OWN arena (from an earlier set into
+    // it), arena_destroy freed the arena but leaked the heap-allocated
+    // JsonValue struct wrapper. free_donated_value now frees the struct too.
+    // The leak is caught by the valgrind CI gate on this test; here we also
+    // assert the nested tree encodes correctly.
+    r2 = json.obj()
+    props = json.obj()
+    age = json.obj()
+    _ = json.set(age, "type", json.str("integer"))
+    _ = json.set(props, "age", age) // props now has an arena
+    _ = json.set(r2, "properties", props) // donating an arena-bearing value
+    items = json.arr()
+    inner = json.obj()
+    _ = json.set(inner, "k", json.num(1.0))
+    _ = json.push(items, inner) // array_add of an arena-bearing value
+    _ = json.set(r2, "items", items)
+
+    out2, err2 = json.encode(r2)
+    if err2 != "" {
+        println("  FAIL: nested encode error '${err2}'")
+        exit(1)
+    }
+    expected2 = "{\"properties\":{\"age\":{\"type\":\"integer\"}},\"items\":[{\"k\":1}]}"
+    if string_equals(out2, expected2) != 1 {
+        println("  FAIL: nested encoded mismatch")
+        println("    got:      ${out2}")
+        println("    expected: ${expected2}")
+        exit(1)
+    }
+    json.free(r2)
+    println("  PASS (nested, #1447): ${out2}")
+
     println("  PASS: ${out}")
     println("=== test_json_builder passed ===")
 }


### PR DESCRIPTION
Four related pieces, bundled at the maintainer's request. Three fixes plus a
showcase/test-infra addition — all reviewable independently.

---

## 1. `fix(tinyweb)` — repair the WebSocket/SSE server path

The tinyweb WebSocket and SSE **server** paths had never run a live connection.
The existing examples call only `tw_start`, which binds the WS/SSE listener but
then blocks in the HTTP accept loop — so `ws_accept_loop` / `sse_accept_loop`
(and everything they call) were dead code that had rotted as the `std.tcp` /
closure APIs evolved. Standing up the loop directly surfaced six defects:

1. **`tcp.read` / `tcp.accept` tuple drift** — the stdlib now returns
   `(data, err)` / `(client, err)`; the WS/SSE readers and both accept loops
   still used the old scalar `== 0` form (type errors / segfaults).
2. **Boxed-closure dispatch** — the handler was `unbox_closure`'d into an
   int-typed slot and then invoked (leak / segfault); now kept boxed and
   unboxed at call time (matches the working HTTP `dsl_dispatch` path).
3. **`ws_read_frame` never unmasked** — client→server frames are masked
   (RFC 6455 §5.3); the code had a `TODO` and returned masked bytes. Added a
   `ws_unmask` C extern (`payload[i] ^= mask_key[i % 4]`).
4. **`ws_send_frame` sent ASCII header bytes** — `from_int(129)` produced the
   string `"129"` instead of the octet `0x81`; every frame was malformed.
5. **Extended-length frames (≥126 bytes) truncated at a NUL** — a length
   high-byte of `0` is a NUL, and `string.concat`/strlen-based `tcp.write`
   dropped the rest of the header. Frames are now assembled in a NUL-safe
   `bytes` buffer and sent in one length-aware `write_n` (also avoids TCP
   fragmentation splitting the header across a peer's reads).
6. **Use-after-free on the request path** — `ws_path` / `req_path` were borrowed
   pointers from `string.array_get` used after `string.array_free` (a garbage
   path → spurious 404); now copied before the array is freed.

`test_websocket.ae` — a self-contained round-trip test (server accept loop in an
actor, hand-rolled masked client in `main`) covering the handshake, client-frame
unmasking, and extended-length framing:

```
=== TinyWeb WebSocket codec roundtrip ===
  [OK] handshake returned 101
  [OK] small frame roundtrip (unmask + 2-byte header)
  [OK] large frame length 200 (extended header, no NUL truncation)
ALL PASS
```

Reverting the unmask fix → `got [echo:robhm]` (masked garbage); reverting the
framing fix → the big frame comes back length 0. Both fail the test.

---

## 2. `fix(std.json)` — free the heap struct of arena-bearing donated values (#1447)

Builder values (`json.obj()` / `json.arr()`) that had acquired their own arena —
via an earlier `set`/`push` into them — leaked their heap-allocated `JsonValue`
struct when attached to a parent. `object_set_raw` / `array_add_raw` deep-copy
the value into the parent's arena and then `arena_destroy(value->arena)`, which
frees the arena's contents but **not** the separate `heap_new`'d struct wrapper
(`JV_FLAG_HEAP_STRUCT`). Every nested builder object/array leaked 32 bytes. Fix:
a `free_donated_value()` helper that also frees the heap struct on the arena
branch, applied at all three donation sites. `test_json_builder` gains a nested
case now under the valgrind CI gate (reverting the fix leaks 160 bytes).

---

## 3. `feat(tinyweb)` — schema_api showcase + OpenAPI

`schema_api` forwarded a full `std.schema` resource but the showcase exercised
only `min`/`max`/`present` (~15% of the library) and never showed
`to_json_schema`. Now:

- `schema_api.openapi_route(path, groups)` — a FastAPI-style aggregate
  **OpenAPI 3.0** document (`paths` + `components.schemas`, `$ref`-linked).
- `json_api` auto-mounts `GET {prefix}/schema` serving the resource's **draft-07
  JSON Schema** (`std.schema.to_json_schema`).
- `example_schema_api.ae` — runnable demo using email/one_of/len/positive,
  trim+lowercase transforms, `default_to`, FLOAT coercion, and `refine`, the
  handler **reading** the coerced/normalized values ("parse, don't validate").
- JSON:API error envelopes rebuilt with `strbuilder` (leak-clean; avoids the
  #1447 builder-nesting pattern). `test_schema_api.ae` +2 cases; README section.

---

## 4. `tests/cachyos/nightly.sh` (+README) — self-run nightly for a rolling-release box

Sibling of `tests/freebsd/nightly.sh` for a platform the CI matrix can't cover:
a newer-toolchain (GCC 16 / Clang 22) build of HEAD that also **type-checks every
`contrib/*/module.ae`** — the coverage gap that let tinyweb silently rot.
Fail-on-missing-deps; pins `PATH`/`AE`/`AETHERC`/`AETHER_HOME` to the tree it
builds; publishes a topline table to the `nightly-results` orphan branch.

---

## Testing
- `HARDEN=1 make ci` clean (compiler/stdlib under `-fstack-protector-all` +
  `_FORTIFY_SOURCE=2`); `test_json_builder` (incl. the new nested case) passes
  and is valgrind-clean via the CI gate.
- tinyweb: `test_websocket.ae` and `test_schema_api.ae` both pass. These live in
  `contrib/`, which is **not** in the `test-ae` discovery glob
  (`tests/{syntax,compiler,integration,regression}`), so they can't affect the
  CI matrix. Run manually with `--extra contrib/tinyweb/ws_handshake.c`.

## Notes / scope
- `contrib/tinyweb/module.ae` is intentionally left un-`ae fmt`'d — it was
  already fmt-dirty on `main` (contrib is not fmt-gated), and a whole-file
  reformat would bury these fixes in whitespace churn.
- A structural gap remains (not addressed here): tinyweb still can't run the HTTP
  loop and the WS/SSE loop *concurrently* — passing the DSL-built server map
  across an actor message boundary corrupts its nested closure entries.

## Type of Change
- [x] Bug fix (tinyweb WS/SSE server path; `std.json` #1447)
- [x] New feature (tinyweb schema_api OpenAPI/schema endpoints + showcase)
- [x] Test infrastructure (CachyOS nightly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
