### PR TITLE
test(contrib): run contrib tests (not just type-check) in CI + nightly

### DIFF
--- a/.github/scripts/contrib_check.sh
+++ b/.github/scripts/contrib_check.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# contrib_check.sh — build + RUN every contrib test_*.ae (not just type-check).
+#
+# The nightly used to only `ae check` (type-check) contrib modules — which is
+# exactly what failed to catch the tinyweb WebSocket server rot (it compiled
+# fine; it was runtime-broken). This runs the actual tests, so runtime and (with
+# VALGRIND=1) leak regressions surface.
+#
+# Usage:
+#   .github/scripts/contrib_check.sh            # build + run each test
+#   VALGRIND=1 .github/scripts/contrib_check.sh # ... under valgrind (leak gate)
+#
+# Assumes ./build/ae is already built (the Makefile target depends on it).
+# Exits nonzero if any contrib test fails to build, fails at runtime, or (under
+# valgrind) leaks. Each test binary is expected to self-terminate — the tinyweb
+# server tests run an in-process client+server and exit(0)/exit(1) on their own.
+set -u
+
+AE="./build/ae"
+EXE_EXT="${EXE_EXT:-}"
+VALGRIND="${VALGRIND:-0}"
+VG="valgrind --leak-check=full --error-exitcode=99 --errors-for-leak-kinds=definite"
+
+rc=0
+run_dir="build/contrib-check"
+mkdir -p "$run_dir"
+
+# Each entry: "<label>|<test.ae>|<extra C files>|<leakgate>".
+#   leakgate = "leak" : under VALGRIND=1 this test is also a LEAK gate.
+#   leakgate = "run"  : run for correctness only; excluded from the leak gate.
+# Extra C files are passed via --extra. Keep this table in sync as contrib
+# modules gain tests.
+#
+# Why some tests are run-only under valgrind: the tinyweb tests were written to
+# `exit()` on completion (and the server tests keep an actor blocked in an
+# accept loop), so the process is torn down without running scope-end heap
+# cleanup — valgrind reports the still-live buffers as "leaks" even though the
+# code is correct. Those tests are gated for RUNTIME correctness (the thing that
+# actually caught the WS rot); making them leak-clean is separate follow-up
+# work. i18n/collate was written leak-clean by design, so it IS leak-gated.
+TW="contrib/tinyweb"
+I18N="contrib/i18n"
+TESTS=(
+  "tinyweb/spec|$TW/test_spec.ae||run"
+  "tinyweb/inventory|$TW/test_inventory.ae|$TW/ws_handshake.c|run"
+  "tinyweb/integration|$TW/test_integration.ae|$TW/ws_handshake.c|run"
+  "tinyweb/schema_api|$TW/test_schema_api.ae|$TW/ws_handshake.c|run"
+  "tinyweb/websocket|$TW/test_websocket.ae|$TW/ws_handshake.c|run"
+  "i18n/collate|$I18N/collate/test_collate.ae|$I18N/aether_i18n.c $I18N/utf8proc/utf8proc.c $I18N/ducet/ducet_data.c|leak"
+)
+
+# Kill any stray cache/test binaries squatting ports before we start (aborted
+# server tests orphan busy-looping binaries — the hidden cause of bind flakes).
+reap_orphans() {
+  pkill -9 -f 'contrib-check/' 2>/dev/null || true
+}
+reap_orphans
+
+for entry in "${TESTS[@]}"; do
+  IFS='|' read -r label src extras leakgate <<< "$entry"
+
+  if [ ! -f "$src" ]; then
+    printf '  SKIP  %-22s (%s not found)\n' "$label" "$src"
+    continue
+  fi
+
+  safe="$(echo "$label" | tr '/' '_')"
+  out="$run_dir/${safe}${EXE_EXT}"
+  log="$run_dir/${safe}.log"
+  # assemble --extra flags
+  extra_flags=""
+  for c in $extras; do extra_flags="$extra_flags --extra $c"; done
+
+  if ! berr="$("$AE$EXE_EXT" build "$src" $extra_flags -o "$out" 2>&1)"; then
+    printf '  FAIL  %-22s (build)\n' "$label"
+    echo "$berr" | grep -iE "error" | head -5
+    rc=1
+    continue
+  fi
+
+  # Run (optionally under valgrind), detached from any tty, with a hard timeout
+  # so a hung server test can never wedge the nightly. Valgrind applies only to
+  # tests flagged as a leak gate (see the table's leakgate column).
+  use_vg=0
+  [ "$VALGRIND" = "1" ] && [ "$leakgate" = "leak" ] && use_vg=1
+  if [ "$use_vg" = "1" ]; then
+    runner="$VG $out"
+  else
+    runner="$out"
+  fi
+  if timeout 120 $runner > "$log" 2>&1 < /dev/null; then
+    if [ "$use_vg" = "1" ]; then
+      printf '  PASS  %-22s (run + valgrind)\n' "$label"
+    elif [ "$VALGRIND" = "1" ]; then
+      printf '  PASS  %-22s (run; leak-gate n/a)\n' "$label"
+    else
+      printf '  PASS  %-22s (run)\n' "$label"
+    fi
+  else
+    code=$?
+    if [ "$code" = "99" ]; then
+      printf '  FAIL  %-22s (valgrind: leak/error)\n' "$label"
+      grep -E "definitely lost|ERROR SUMMARY" "$log" | tail -3
+    elif [ "$code" = "124" ]; then
+      printf '  FAIL  %-22s (timeout — did not terminate)\n' "$label"
+    else
+      printf '  FAIL  %-22s (run, exit %s)\n' "$label" "$code"
+      grep -iE "fail" "$log" | head -5
+    fi
+    rc=1
+  fi
+  reap_orphans
+done
+
+vg_note=""
+[ "$VALGRIND" = "1" ] && vg_note=" (valgrind)"
+if [ "$rc" = "0" ]; then
+  echo "contrib-check: all contrib tests passed${vg_note}"
+else
+  echo "contrib-check: one or more contrib tests FAILED"
+fi
+exit $rc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,15 +246,18 @@ jobs:
       run: make contrib-host-check
 
   # ============================================================
-  # contrib/i18n check — build + run the collation regression
-  # test (Phase 5 of #863). utf8proc.c + the generated DUCET
-  # table are vendored (nothing fetched at build time — no
-  # supply-chain surface), and compile in <1s combined, so no
-  # object cache is warranted (measured; see the Makefile note).
-  # Linux-only; the module is pure Aether + portable C.
+  # contrib runtime check — build + RUN every contrib test_*.ae
+  # (tinyweb, i18n/collation, …), not just type-check them. This
+  # is the coverage `make ci` lacks (contrib isn't in the test-ae
+  # glob) and the class of bug type-checking misses: tinyweb's
+  # WebSocket server path type-checked fine but was runtime-broken.
+  # Runs under valgrind where the test is leak-clean by design.
+  # All C is vendored (utf8proc/DUCET committed) so nothing is
+  # fetched at build time. Linux-only; contrib here is pure Aether
+  # + portable C.
   # ============================================================
-  ci-contrib-i18n:
-    name: contrib/i18n collation (Linux)
+  ci-contrib:
+    name: contrib runtime tests (Linux)
     runs-on: ubuntu-22.04
 
     steps:
@@ -265,11 +268,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc make valgrind
 
-    - name: Build + run collation test
-      run: make contrib-i18n-check
-
-    - name: Valgrind the collation test (leak gate)
-      run: valgrind --leak-check=full --error-exitcode=99 ./build/test_collate
+    - name: Build + run all contrib tests (valgrind-gated where leak-clean)
+      run: make contrib-check-valgrind
 
   # ============================================================
   # Windows CI — MinGW via MSYS2

--- a/Makefile
+++ b/Makefile
@@ -729,6 +729,19 @@ contrib-i18n-check: compiler ae stdlib
 	@echo "contrib-i18n: running collate test"
 	@./build/test_collate$(EXE_EXT)
 
+# contrib-check: build + RUN every contrib test_*.ae (not just type-check).
+# This is the runtime-coverage gate the nightly was missing — type-checking
+# alone let the tinyweb WebSocket server path rot (compiled fine, runtime-
+# broken). The table of tests + their --extra C files lives in
+# .github/scripts/contrib_check.sh. contrib-check-valgrind runs each under
+# valgrind as a leak gate (for the dedicated nightly build box).
+.PHONY: contrib-check contrib-check-valgrind
+contrib-check: compiler ae stdlib
+	@EXE_EXT='$(EXE_EXT)' bash .github/scripts/contrib_check.sh
+
+contrib-check-valgrind: compiler ae stdlib
+	@EXE_EXT='$(EXE_EXT)' VALGRIND=1 bash .github/scripts/contrib_check.sh
+
 # Compiler target (incremental build with object files)
 compiler: $(COMPILER_OBJS) $(STD_OBJS) $(COLLECTIONS_OBJS) $(OBJ_DIR)/runtime/aether_sandbox.o $(OBJ_DIR)/runtime/aether_resource_caps.o $(IO_POLLER_OBJS) | $(VERSION_HEADER) $(STDLIB_SYMS_HEADER)
 	@echo "Linking compiler..."

--- a/tests/cachyos/README.md
+++ b/tests/cachyos/README.md
@@ -6,9 +6,12 @@ a platform the GitHub Actions matrix can't cover.
 
 Its value is the **toolchain**: CachyOS ships GCC/Clang several major versions
 ahead of the Ubuntu-22.04 CI box, so building HEAD there surfaces newer-compiler
-`-Werror` promotions and warnings before they reach anyone. It also does the one
-thing the portable CI never does — **type-checks every `contrib/*/module.ae`**
-(the gap that let tinyweb's DSL silently rot; see the contrib-coverage issue).
+`-Werror` promotions and warnings before they reach anyone. It also does the
+things the portable CI never does — **type-checks every `contrib/*/module.ae`**
+*and* **builds + runs every contrib `test_*.ae`** (under valgrind where the test
+is leak-clean by design). Type-checking alone let tinyweb's WebSocket server
+path rot — it compiled fine but was runtime-broken — so running the tests is the
+half of the coverage gap that actually catches that class of bug.
 
 ## What it does
 
@@ -19,7 +22,9 @@ thing the portable CI never does — **type-checks every `contrib/*/module.ae`**
    everything, so an absent contrib dependency is a provisioning bug that turns
    the run RED (the opposite of `contrib_build.sh`'s probe-and-skip).
 3. `make ci` → `make contrib` → `make contrib-host-check` → a `contrib` `ae
-   check` sweep, each timed (ms) and recorded.
+   check` sweep → `make contrib-check-valgrind` (build + run every contrib
+   `test_*.ae`, valgrind-gating the leak-clean ones), each timed (ms) and
+   recorded.
 4. Publishes a topline pass/fail table to the **`nightly-results`** orphan
    branch (no shared history, no CI triggered) and writes a dated summary + log
    locally (last 14 kept).

--- a/tests/cachyos/nightly.sh
+++ b/tests/cachyos/nightly.sh
@@ -6,9 +6,10 @@
 # NOT a GitHub Actions runner — the sibling of tests/freebsd/nightly.sh for a
 # platform the CI matrix can't cover. Cron it (or a systemd --user timer, since
 # CachyOS ships no crond) on a dedicated build box; it syncs origin/main to
-# HEAD, runs `make ci` + contrib, type-checks every contrib module, and — the
-# thing GitHub CI never does — exercises the whole thing under a much newer
-# toolchain. Surfaces -Werror promotions / new warnings before they hit anyone.
+# HEAD, runs `make ci` + contrib, type-checks AND runs every contrib module's
+# tests (under valgrind where leak-clean), and — the thing GitHub CI never does
+# — exercises the whole thing under a much newer toolchain. Surfaces -Werror
+# promotions / new warnings + runtime & leak rot before they hit anyone.
 # It publishes a topline pass/fail table to the `nightly-results` orphan branch.
 #
 # Install (systemd --user timer example):
@@ -329,6 +330,11 @@ run_and_record() {
 make_ci_step() { make ci; }
 make_contrib_step() { make contrib; }
 make_host_check_step() { make contrib-host-check; }
+# Build + RUN every contrib test_*.ae, under valgrind where the test is
+# leak-clean by design (see .github/scripts/contrib_check.sh). This is the
+# RUNTIME coverage the type-check sweep can't provide — the class of bug that
+# let tinyweb's WebSocket server path rot (it type-checked fine, ran broken).
+make_contrib_check_step() { make contrib-check-valgrind; }
 
 fails=0
 {
@@ -346,9 +352,14 @@ fails=0
     run_and_record "make contrib-host-check" make_host_check_step
     # `make ci` and `make contrib` never compile the contrib Aether code
     # (test-ae globs only tests/*, `make contrib` builds C shims). This sweep
-    # is the ONLY thing that type-checks every contrib module under the newer
-    # toolchain — the exact gap that let tinyweb's DSL rot (issue #1442).
+    # type-checks every contrib module under the newer toolchain — the gap that
+    # let tinyweb's DSL rot (issue #1442).
     run_and_record "contrib ae-check sweep" contrib_ae_check
+    # ...and this RUNS each contrib test (under valgrind where leak-clean),
+    # catching runtime + leak rot that type-checking alone misses — the deeper
+    # half of the same #1442 gap (the WS server path type-checked but was
+    # runtime-broken until it was actually exercised).
+    run_and_record "contrib test run (+valgrind)" make_contrib_check_step
     echo ""
     echo "--- publishing topline results to $RESULTS_REMOTE/$RESULTS_BRANCH ---"
     publish_results


### PR DESCRIPTION
## Summary

Make CI and the CachyOS nightly **run** contrib tests, not just type-check them.

Both only ever did `ae check` (type-check) on `contrib/*/module.ae`. That is
exactly what failed to catch the tinyweb WebSocket server rot — it compiled
clean but was runtime-broken (six defects, fixed in #1449). Type-checking cannot
find that class of bug; running the tests can. This closes the deeper half of
the contrib-coverage gap (#1442).

## What's added

- **`make contrib-check`** / **`make contrib-check-valgrind`**, driven by
  `.github/scripts/contrib_check.sh` — a table of every contrib `test_*.ae` with
  the `--extra` C files it needs (tinyweb → `ws_handshake.c`; i18n → the
  utf8proc + DUCET sources). Each test is built and **run**, with a hard timeout
  and port-squat reaping so a server test can't wedge the run.
- **`ci-contrib`** job (broadened from the i18n-only job) runs
  `make contrib-check-valgrind` on **every PR** — so contrib runtime rot is
  caught immediately, not only on the nightly.
- **CachyOS nightly** gains a "contrib test run (+valgrind)" step after the
  type-check sweep (README/header updated to match).

## The valgrind scope (deliberate + documented)

The leak gate applies only to tests that are **leak-clean by design**
(`i18n/collate` today). The pre-existing tinyweb tests `exit()` on completion
(and the server tests keep an actor blocked in an accept loop), so the process
is torn down before scope-end heap cleanup runs — valgrind reports the
still-live buffers as "leaks" even though the code is correct. Those tests are
gated for **runtime correctness** (the thing that actually catches the WS-class
bug) and excluded from the leak gate with a `leakgate` flag + a comment
explaining why. Hardening them to be leak-clean is separate follow-up work.

## Verification

```
$ make contrib-check-valgrind
  PASS  tinyweb/spec           (run; leak-gate n/a)
  PASS  tinyweb/inventory      (run; leak-gate n/a)
  PASS  tinyweb/integration    (run; leak-gate n/a)
  PASS  tinyweb/schema_api     (run; leak-gate n/a)
  PASS  tinyweb/websocket      (run; leak-gate n/a)
  PASS  i18n/collate           (run + valgrind)
contrib-check: all contrib tests passed (valgrind)
```

All C is vendored (utf8proc/DUCET committed), so nothing is fetched at build
time — no supply-chain surface in the new job.

## Type of Change
- [x] Test infrastructure (contrib runtime coverage; CI job + nightly step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
