### PR TITLE
fix: locale-independent access-log month, and 11 ctype calls passing signed char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ version number before tagging the release.
 
 ### Fixed
 
+- **HTTP access log no longer emits a locale-dependent month name** — the
+  Combined Log Format timestamp was built with `strftime`'s `%b`, which renders
+  the *locale's* abbreviated month. CLF is a parseable interchange format
+  (GoAccess, AWStats, Logstash, Splunk) whose month is defined as the English
+  three-letter abbreviation, so a server embedded in a host that had called
+  `setlocale(LC_ALL, "")` wrote `08/Mär/2026` and broke every downstream parser
+  — corrupting archived logs, where nothing round-trips to reveal the damage.
+  Now formatted from a static English table, which removes the locale
+  dependency rather than pinning a locale around the call. The three remaining
+  `strftime` sites are numeric-only and carry a comment saying so. Follow-up to
+  the `LC_NUMERIC` float fix; found by the audit in #1463.
+
+- **Undefined behaviour in eleven `ctype` calls** — `isalpha`/`isdigit`/
+  `tolower` and friends take an `int` that must be `EOF` or representable as
+  `unsigned char`. Plain `char` is signed on every platform Aether ships, so any
+  byte ≥ 0x80 — every UTF-8 continuation byte — arrived negative and indexed
+  outside the ctype table. Reachable today: a non-ASCII identifier reaches
+  `isalpha()` with a negative argument in the lexer, and `levenshtein_distance`
+  runs over arbitrary identifier text for "did you mean?" suggestions. The
+  codebase already cast at 24 of 35 sites; the remaining eleven (nine in
+  `compiler/parser/lexer.c`, two in `compiler/aether_diagnostics.c`) now match.
+  No behaviour change — glibc happened to tolerate it; musl and the MSVC CRT are
+  entitled not to.
+
 - **Float text conversion no longer follows `LC_NUMERIC`** — `std.string` and
   `std.json` produce and consume *machine* text (wire formats, JSON, config,
   round-trips), so their decimal separator must be `.` regardless of the

--- a/compiler/aether_diagnostics.c
+++ b/compiler/aether_diagnostics.c
@@ -68,7 +68,14 @@ int levenshtein_distance(const char* s1, const char* s2) {
     
     for (int i = 1; i <= len1; i++) {
         for (int j = 1; j <= len2; j++) {
-            int cost = (tolower(s1[i-1]) == tolower(s2[j-1])) ? 0 : 1;
+            /* (unsigned char) casts are required, not cosmetic: plain `char`
+             * is signed on every platform we ship, so a byte >= 0x80 — any
+             * UTF-8 continuation byte in an identifier — arrives negative and
+             * indexes outside the ctype table, which is undefined behaviour.
+             * Reachable here because this runs over arbitrary identifier text
+             * to produce "did you mean?" suggestions. */
+            int cost = (tolower((unsigned char)s1[i-1]) ==
+                        tolower((unsigned char)s2[j-1])) ? 0 : 1;
             
             int deletion = matrix[i-1][j] + 1;
             int insertion = matrix[i][j-1] + 1;

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -271,7 +271,7 @@ Token* read_number() {
             // Hex literal: 0x[0-9a-fA-F]+
             buffer[i++] = advance(); // '0'
             buffer[i++] = advance(); // 'x'
-            while (current_pos < source_length && (isxdigit(peek()) || peek() == '_')) {
+            while (current_pos < source_length && (isxdigit((unsigned char)peek()) || peek() == '_')) {
                 if (peek() == '_') { advance(); continue; }
                 if (i >= capacity - 1) { capacity *= 2; char* nb = realloc(buffer, capacity); if (!nb) { free(buffer); return create_token(TOKEN_ERROR, "out of memory", current_line, current_column); } buffer = nb; }
                 buffer[i++] = advance();
@@ -311,7 +311,7 @@ Token* read_number() {
 
     // Decimal literal (with optional dot for floats)
     // Don't consume '.' if followed by another '.' (range operator '..')
-    while (current_pos < source_length && (isdigit(peek()) || (peek() == '.' && (current_pos + 1 >= source_length || source[current_pos + 1] != '.')))) {
+    while (current_pos < source_length && (isdigit((unsigned char)peek()) || (peek() == '.' && (current_pos + 1 >= source_length || source[current_pos + 1] != '.')))) {
         if (i >= capacity - 1) {
             capacity *= 2;
             char* new_buf = realloc(buffer, capacity);
@@ -352,7 +352,7 @@ Token* read_number() {
         }
 
         while (current_pos < source_length &&
-               (isdigit(peek()) || (peek() == '.' && (current_pos + 1 >= source_length || source[current_pos + 1] != '.')))) {
+               (isdigit((unsigned char)peek()) || (peek() == '.' && (current_pos + 1 >= source_length || source[current_pos + 1] != '.')))) {
             if (i >= capacity - 1) {
                 capacity *= 2;
                 char* new_buf = realloc(buffer, capacity);
@@ -374,7 +374,7 @@ Token* read_identifier() {
     char* buffer = malloc(capacity);
     int i = 0;
     
-    while (current_pos < source_length && (isalnum(peek()) || peek() == '_')) {
+    while (current_pos < source_length && (isalnum((unsigned char)peek()) || peek() == '_')) {
         if (i >= capacity - 1) {
             capacity *= 2;
             char* new_buf = realloc(buffer, capacity);
@@ -471,7 +471,7 @@ Token* read_raw_identifier(void) {
     char* buffer = malloc(capacity);
     int i = 0;
 
-    while (current_pos < source_length && (isalnum(peek()) || peek() == '_')) {
+    while (current_pos < source_length && (isalnum((unsigned char)peek()) || peek() == '_')) {
         if (i >= capacity - 1) {
             capacity *= 2;
             char* new_buf = realloc(buffer, capacity);
@@ -528,12 +528,12 @@ Token* next_token() {
     }
 
     // Handle numbers
-    if (isdigit(c)) {
+    if (isdigit((unsigned char)c)) {
         return read_number();
     }
-    
+
     // Handle identifiers and keywords
-    if (isalpha(c) || c == '_') {
+    if (isalpha((unsigned char)c) || c == '_') {
         return read_identifier();
     }
     
@@ -618,11 +618,11 @@ Token* next_token() {
                 // Content is a literal string (no interpolation).
                 // Preserves all whitespace and newlines exactly.
                 // Use regular "..." strings for interpolation.
-                if (isalpha(peek()) || peek() == '_') {
+                if (isalpha((unsigned char)peek()) || peek() == '_') {
                     // Read the marker name
                     char marker[MAX_IDENTIFIER_LENGTH];
                     int mlen = 0;
-                    while ((isalnum(peek()) || peek() == '_') && mlen < MAX_IDENTIFIER_LENGTH - 1) {
+                    while ((isalnum((unsigned char)peek()) || peek() == '_') && mlen < MAX_IDENTIFIER_LENGTH - 1) {
                         marker[mlen++] = advance();
                     }
                     marker[mlen] = '\0';

--- a/std/log/aether_log.c
+++ b/std/log/aether_log.c
@@ -73,6 +73,9 @@ static void get_timestamp(char* buffer, size_t size) {
 #else
     localtime_r(&now, &tm_buf);
 #endif
+    /* Numeric-only conversions — no locale-sensitive specifier, so plain
+     * strftime is safe here. Do NOT add %b/%a/%p: those emit the locale's
+     * month/day/AM-PM names and would make log output environment-dependent. */
     strftime(buffer, size, "%Y-%m-%d %H:%M:%S", &tm_buf);
 }
 

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -818,6 +818,35 @@ typedef struct {
     int   own_fp;       /* 1 if we opened it (need to fclose); 0 for stderr */
 } AccessLogState;
 
+/* Format a Common/Combined Log Format timestamp: "DD/MMM/YYYY:HH:MM:SS +0000".
+ *
+ * Written by hand rather than with strftime's %b, which emits the *locale's*
+ * abbreviated month name. CLF's month is defined as the English three-letter
+ * abbreviation — this is a parseable interchange format (GoAccess, AWStats,
+ * Logstash, Splunk), not human-facing text. An Aether server embedded in a host
+ * that had called setlocale(LC_ALL, "") would otherwise write "08/Mär/2026" and
+ * break every downstream parser, and unlike a bad response the damage lands in
+ * archived logs where nothing round-trips it to reveal the corruption.
+ *
+ * Same class of bug as the LC_NUMERIC float conversions fixed in #1459. A static
+ * table removes the locale dependency outright rather than pinning a locale
+ * around the call, which is the right trade when the format is specified in
+ * terms of English names rather than "the C locale's names".
+ *
+ * Not static: covered directly by tests/runtime/test_http_server.c. */
+void http_format_clf_time(char* out, size_t out_size, const struct tm* tmv) {
+    static const char* const kMonthsEn[12] = {
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+    if (!out || out_size == 0) return;
+    if (!tmv) { out[0] = '\0'; return; }
+    int mon = (tmv->tm_mon >= 0 && tmv->tm_mon < 12) ? tmv->tm_mon : 0;
+    snprintf(out, out_size, "%02d/%s/%04d:%02d:%02d:%02d +0000",
+             tmv->tm_mday, kMonthsEn[mon], tmv->tm_year + 1900,
+             tmv->tm_hour, tmv->tm_min, tmv->tm_sec);
+}
+
 static void access_log_hook(HttpRequest* req, HttpServerResponse* res,
                             long duration_us, void* user_data) {
     AccessLogState* st = (AccessLogState*)user_data;
@@ -845,6 +874,9 @@ static void access_log_hook(HttpRequest* req, HttpServerResponse* res,
 
     if (strcmp(st->format, "json") == 0) {
         char ts[32];
+        /* Numeric-only conversions: no locale-sensitive specifier here, so
+         * plain strftime is safe. Do NOT add %b/%a/%p to this format — they
+         * are locale-dependent and this string goes on the wire. */
         strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tmv);
         fprintf(st->fp,
                 "{\"ts\":\"%s\",\"method\":\"%s\",\"path\":\"%s\","
@@ -856,7 +888,7 @@ static void access_log_hook(HttpRequest* req, HttpServerResponse* res,
     } else {
         /* Combined: <ip> - - [DD/MMM/YYYY:HH:MM:SS +0000] "METHOD PATH HTTP/X.Y" status bytes "REF" "UA" */
         char ts[64];
-        strftime(ts, sizeof(ts), "%d/%b/%Y:%H:%M:%S +0000", &tmv);
+        http_format_clf_time(ts, sizeof(ts), &tmv);
         const char* ip = req ? http_get_header(req, "X-Forwarded-For") : NULL;
         if (!ip) ip = "-";
         fprintf(st->fp,

--- a/std/net/aether_http_server.h
+++ b/std/net/aether_http_server.h
@@ -4,6 +4,8 @@
 #include "../string/aether_string.h"
 #include "../../runtime/scheduler/multicore_scheduler.h"
 #include <stdatomic.h>
+#include <stddef.h>  // size_t
+#include <time.h>    // struct tm (http_format_clf_time)
 
 // HTTP Request
 typedef struct {
@@ -704,5 +706,11 @@ const char* http_request_http_version(HttpRequest* req);
 int         http_request_header_count(HttpRequest* req);
 const char* http_request_header_name(HttpRequest* req, int index);
 const char* http_request_header_value(HttpRequest* req, int index);
+
+// Format a Common/Combined Log Format timestamp: "DD/MMM/YYYY:HH:MM:SS +0000".
+// The month is always the English three-letter abbreviation, never the
+// locale's — CLF is a parseable interchange format. Exposed (rather than
+// static) so the locale-independence can be tested directly.
+void http_format_clf_time(char* out, size_t out_size, const struct tm* tmv);
 
 #endif

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -295,7 +295,9 @@ char* os_now_utc_iso8601_raw(void) {
     if (!gmtime_r(&now, &tm_buf)) return strdup("");
 #endif
     char buf[32];
-    /* "YYYY-MM-DDThh:mm:ssZ" — 20 bytes + NUL, fits buf easily. */
+    /* "YYYY-MM-DDThh:mm:ssZ" — 20 bytes + NUL, fits buf easily.
+     * Numeric-only conversions, so no locale sensitivity. Do NOT add
+     * %b/%a/%p — this is an ISO-8601 wire format, not human-facing text. */
     if (strftime(buf, sizeof buf, "%Y-%m-%dT%H:%M:%SZ", &tm_buf) == 0) {
         return strdup("");
     }

--- a/tests/runtime/test_http_server.c
+++ b/tests/runtime/test_http_server.c
@@ -1,5 +1,8 @@
 #include "test_harness.h"
 #include <string.h>
+#include <stdio.h>
+#include <locale.h>
+#include <time.h>
 #include "../../std/net/aether_http_server.h"
 
 // HTTP Server Tests - Real tests for implemented functionality
@@ -254,4 +257,66 @@ TEST(http_server_post_with_oversized_content_length_clamps_safely) {
     ASSERT_NOT_NULL(req->body);
     ASSERT_EQ(0, memcmp(req->body, "{\"name\":\"John Doe\"}", 19));
     http_request_free(req);
+}
+
+/* Combined Log Format timestamps must be locale-independent.
+ *
+ * The month in CLF is the English three-letter abbreviation; it is a parseable
+ * interchange format, not human-facing text. This previously used strftime's
+ * %b, which emits the *locale's* month name — so a server embedded in a host
+ * that had called setlocale(LC_ALL, "") wrote "08/Mär/2026" and broke every
+ * downstream log parser. Regression guard for that (issue #1463, sibling of the
+ * LC_NUMERIC float fix in #1459).
+ *
+ * The locale switch is best-effort: CI images generally ship only C/POSIX, in
+ * which case the ambient-locale half is a no-op and the C-locale assertions
+ * still run. That is deliberate — an unavailable locale must not fail the test,
+ * but it must also not make it vacuous, hence the unconditional checks first. */
+TEST(http_clf_time_is_locale_independent) {
+    struct tm tmv;
+    memset(&tmv, 0, sizeof tmv);
+    tmv.tm_year = 126;  /* 2026 */
+    tmv.tm_mon  = 2;    /* March — the month that differs in de_DE ("Mär") */
+    tmv.tm_mday = 8;
+    tmv.tm_hour = 13;
+    tmv.tm_min  = 5;
+    tmv.tm_sec  = 7;
+
+    char ts[64];
+    http_format_clf_time(ts, sizeof ts, &tmv);
+    ASSERT_STREQ("08/Mar/2026:13:05:07 +0000", ts);
+
+    /* Every month renders as its English abbreviation. */
+    static const char* const expect[12] = {
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+    for (int m = 0; m < 12; m++) {
+        char buf[64];
+        tmv.tm_mon = m;
+        http_format_clf_time(buf, sizeof buf, &tmv);
+        ASSERT_EQ(0, memcmp(buf + 3, expect[m], 3));
+    }
+    tmv.tm_mon = 2;
+
+    /* Now the actual regression: under a comma-decimal / non-English locale the
+     * output must be byte-identical. Skipped silently where the locale is not
+     * installed (see comment above). */
+    const char* had = setlocale(LC_ALL, NULL);
+    char saved[128];
+    snprintf(saved, sizeof saved, "%s", had ? had : "C");
+    if (setlocale(LC_ALL, "de_DE.UTF-8") || setlocale(LC_ALL, "de_DE.utf8")) {
+        char under_locale[64];
+        http_format_clf_time(under_locale, sizeof under_locale, &tmv);
+        ASSERT_STREQ("08/Mar/2026:13:05:07 +0000", under_locale);
+        setlocale(LC_ALL, saved);
+    }
+
+    /* Defensive: an out-of-range tm_mon must not index off the table. */
+    tmv.tm_mon = 99;
+    http_format_clf_time(ts, sizeof ts, &tmv);
+    ASSERT_EQ(0, memcmp(ts + 3, "Jan", 3));
+    tmv.tm_mon = -1;
+    http_format_clf_time(ts, sizeof ts, &tmv);
+    ASSERT_EQ(0, memcmp(ts + 3, "Jan", 3));
 }


### PR DESCRIPTION
Implements the audit filed as #1463 — the follow-up to #1459, which fixed float text conversion following `LC_NUMERIC` and deliberately scoped out the other locale-sensitive libc calls.

Two real bugs. `strcasecmp` was reviewed and deliberately left alone (reasoning in #1463).

## 1. The HTTP access log emitted a locale-dependent month ⚠️

`std/net/aether_http_server.c` built its Combined Log Format timestamp with `strftime`'s `%d/%b/%Y`, and **`%b` renders the *locale's* abbreviated month name**.

CLF is a parseable interchange format — GoAccess, AWStats, Logstash, Splunk — whose month is specified as the English three-letter abbreviation. A server embedded in a host that had called `setlocale(LC_ALL, "")` wrote a month no parser recognises:

| platform / locale | before | after |
|---|---|---|
| glibc, `de_DE.UTF-8` | `08/Mär/2026` | `08/Mar/2026` ✅ |
| msvcrt, German | `08/Mrz/2026` | `08/Mar/2026` ✅ |
| C locale (both) | `08/Mar/2026` | `08/Mar/2026` (unchanged) |

Windows testing turned up something worth knowing: msvcrt says `Mrz` where glibc says `Mär`, so the broken output varied **per platform as well as per locale**.

This is arguably worse than the JSON bug in #1459: the damage lands in **archived logs**, where nothing round-trips it to reveal the corruption.

**Fix:** format from a static English table, extracted as `http_format_clf_time()` so it is directly testable. A table removes the locale dependency outright rather than pinning a locale around the call — the right trade when the format is defined in terms of *English* names rather than "the C locale's names".

The three other `strftime` sites (`std/log`, the JSON access-log branch, `std/os`) are numeric-only (`%Y-%m-%d %H:%M:%S`) and therefore safe. Each now carries a comment saying so, so a future edit doesn't casually add `%b`/`%a`/`%p`.

## 2. Eleven `ctype` calls passed a plain `char` — undefined behaviour ⚠️

`isalpha`/`isdigit`/`tolower` and friends take an `int` that must be **`EOF` or representable as `unsigned char`**. Plain `char` is signed on every platform Aether ships, so any byte ≥ 0x80 — every UTF-8 continuation byte — arrived negative and indexed outside the ctype table.

**Reachable, not theoretical.** A non-ASCII identifier reaches `isalpha()` with `c == -61` today:

```
$ printf 'main() {\n    éx = 1\n}\n' > t.ae && ae build t.ae
error[E0100]: <?>
```

It only *appears* fine because glibc's ctype table has padding below index 0. That is luck; musl and the MSVC CRT are entitled to differ. `levenshtein_distance` is the more insidious of the two files — it runs over arbitrary identifier text to produce "did you mean?" suggestions.

**The codebase already knew the rule: 24 of 35 ctype calls cast correctly.** The remaining eleven now match — nine via `char peek()` in the lexer, two in the diagnostics Levenshtein loop.

**Judgment call:** `peek()` still returns `char` rather than `int`. It has **72 call sites**, and the targeted casts give identical safety for a fraction of the diff and risk.

## Tests

`http_clf_time_is_locale_independent` (`tests/runtime/test_http_server.c`) asserts the English abbreviation for all twelve months, re-checks under a switched locale where one is installed, and clamps out-of-range `tm_mon`.

**Verified failing with the `%b` form restored and passing with the fix** — not merely asserted.

Worth noting: the `combined` format previously had **no test at all**; only `json` was covered by `http_server_observability`. That gap is why this survived.

## Verification

- `make ci` — C suite **230 passed / 0 failed**, including the new test. The four `.ae` failures are the known load-sensitive network shell tests: each **passes in isolation** on an idle machine (verified individually, including `http_server_observability`, which I checked specifically because it exercises the access log I touched). A different subset fails per run; `http_server_h2` is the one constant and is [pre-existing on `main`](https://github.com/aether-lang-dev/aether/issues/1463), reproduced in a clean worktree.
- **End-to-end against the shipped artifact** — linked the real `http_format_clf_time` out of `build/libaether.a` (not a transcription) and confirmed `08/Mar/2026` under `de_DE.UTF-8`, with `%b` alongside showing `08/Mär/2026`.
- **winbaz / MINGW64** — CLF fix confirmed under `German_Germany.1252`.
- ctype behaviour unchanged on every reachable path: non-ASCII identifiers, UTF-8 in strings and comments, and the typo-suggestion path all produce identical diagnostics.

Closes #1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
