### PR TITLE
fix(nightly): refresh the $HOME/.local install, and fetch tags when syncing

### DIFF
--- a/tests/cachyos/README.md
+++ b/tests/cachyos/README.md
@@ -15,16 +15,16 @@ half of the coverage gap that actually catches that class of bug.
 
 ## What it does
 
-1. Syncs `origin/main` → HEAD in a clean tree, pinning `PATH`/`AE`/`AETHERC`/
-   `AETHER_HOME` to the freshly-built compiler (never a version-managed `ae` on
-   `PATH`).
+1. Syncs `origin/main` → HEAD in a clean tree (**`--tags`**, see below), pinning
+   `PATH`/`AE`/`AETHERC`/`AETHER_HOME` to the freshly-built compiler (never a
+   version-managed `ae` on `PATH`).
 2. A **fail-on-missing-deps** gate — a dedicated build box should test
    everything, so an absent contrib dependency is a provisioning bug that turns
    the run RED (the opposite of `contrib_build.sh`'s probe-and-skip).
-3. `make ci` → `make contrib` → `make contrib-host-check` → a `contrib` `ae
-   check` sweep → `make contrib-check-valgrind` (build + run every contrib
-   `test_*.ae`, valgrind-gating the leak-clean ones), each timed (ms) and
-   recorded.
+3. `make ci` → **`make install` + a freshness check** → `make contrib` → `make
+   contrib-host-check` → a `contrib` `ae check` sweep → `make
+   contrib-check-valgrind` (build + run every contrib `test_*.ae`,
+   valgrind-gating the leak-clean ones), each timed (ms) and recorded.
 4. Publishes a topline pass/fail table to the **`nightly-results`** orphan
    branch (no shared history, no CI triggered) and writes a dated summary + log
    locally (last 14 kept).
@@ -36,6 +36,38 @@ the header comment in `nightly.sh`). Provision the contrib deps first — packag
 installs plus the `aether-lang-dev/factor-language` fork build — and export the
 `AETHER_*` dep env vars in the timer environment. The gate stays RED until every
 dep is present, by design.
+
+### Why the nightly installs, and why it fetches tags
+
+Two failure modes that both read as "the compiler on this box is broken" and are
+neither.
+
+**The install drifts.** A few tests link the *installed* artifacts rather than
+the build tree — `ci_coverage_smoke` is the current one, and it *skips* when no
+install is present. So deleting the install silences a test instead of fixing
+it. Left unrefreshed it rots: a Jul-19 install against an Aug-8 tree failed with
+
+    undefined reference to `aether_unwind_forget'
+
+because the symbol was added in between. The nightly log shows only `gcc
+--coverage link failed` without the linker's line, which reads like a bug in
+this box's newer GCC. It is not. Hence `make install PREFIX=$HOME/.local` as a
+pipeline step (never sudo), plus a freshness check so the failure surfaces as
+one line rather than a mystery.
+
+**Tags are the version, not the `VERSION` file.** The Makefile takes the highest
+`git tag` as authoritative and falls back to `VERSION` only for tarballs. A
+fetch without `--tags` therefore leaves the tree at the newest *commits* but the
+previous *tag*, and the build correctly stamps the older version — which then
+looks like a stale build to anything comparing against the `VERSION` file. Seen
+2026-08-08 at 0.505.0's merge commit with `v0.504.0` as the newest local tag.
+
+Related trap when reading versions by hand: **`ae --version` reports the version
+*manager's* active install** (`~/.aether/active_version`), not the version
+compiled into the binary you just ran. On this box that state reads `0.417.0`,
+so a correctly built 0.505.0 binary still *says* 0.417.0. Both the sweep guard
+and the install check use `strings` against the compiled-in value for this
+reason.
 
 ### The `de_DE.UTF-8` locale
 

--- a/tests/cachyos/nightly.sh
+++ b/tests/cachyos/nightly.sh
@@ -76,7 +76,13 @@ export AETHER_HOME="$REPO"
 } > "$LOG"
 
 # --- sync to HEAD (clean; never carry local state into a nightly) ---
-git fetch -q origin 2>>"$LOG"
+# --tags matters: the Makefile takes the highest git TAG as the authoritative
+# version (the VERSION file is only a tarball fallback), so a fetch without tags
+# builds and stamps the PREVIOUS release even though the commits are current.
+# Seen 2026-08-08: tree at 0.505.0's merge commit, newest local tag v0.504.0,
+# binaries stamped 0.504.0 — which then reads as a stale build to anything
+# comparing against the VERSION file.
+git fetch -q --tags --prune origin 2>>"$LOG"
 git checkout -q main 2>>"$LOG"
 git reset -q --hard origin/main 2>>"$LOG"
 git clean -qfdx -e 'aether-nightly*' 2>>"$LOG" || true
@@ -347,6 +353,74 @@ make_host_check_step() { make contrib-host-check; }
 # let tinyweb's WebSocket server path rot (it type-checked fine, ran broken).
 make_contrib_check_step() { make contrib-check-valgrind; }
 
+# Refresh the $HOME/.local install from the tree we just built.
+#
+# Why this is a pipeline step and not a provisioning chore: a handful of tests
+# link against the INSTALLED artifacts rather than the build tree —
+# ci_coverage_smoke is the current one, and it skips outright when no install
+# is present, so simply deleting the install would silence a test rather than
+# fix it. Left unrefreshed, the install silently drifts behind the tree and
+# fails with a mystery linker error instead:
+#
+#     undefined reference to `aether_unwind_forget'
+#
+# (Seen 2026-08-08: a Jul-19 install against an Aug-8 tree. The symbol had been
+# added in between. The nightly log shows only "gcc --coverage link failed"
+# without the linker's line, which makes it very easy to misread as a compiler
+# bug on this box's newer GCC — it is not.)
+#
+# Refreshing every run makes that drift impossible by construction.
+#
+# PREFIX is under $HOME deliberately: this must never need sudo. The OTHER
+# install on this box — the root-owned /usr/local/bin/ae that shadows PATH — is
+# not ours to touch, which is exactly why the pinning block above puts
+# $REPO/build first on PATH rather than trusting whatever is installed.
+make_install_step() { make install PREFIX="$HOME/.local"; }
+
+# Assert the refresh actually took. Deliberately separate from the install step
+# so the summary distinguishes "install failed" from "install succeeded but
+# produced something stale".
+#
+# Checks the COMPILED-IN version, exactly as contrib_ae_check does above, and
+# for the same reason: `ae --version` prints the version MANAGER's active
+# install (from ~/.aether/active_version), not the version compiled into the
+# binary you just ran. On this box that state reads 0.417.0, so a correctly
+# built and installed 0.504.0 binary still SAYS 0.417.0. Comparing against
+# `ae --version` here would report STALE forever.
+#
+# Also verifies the archive, since that is what the drift actually broke:
+# ci_coverage_smoke links $PREFIX/lib/aether/libaether.a, and a Jul-19 archive
+# against an Aug-8 tree fails with `undefined reference to aether_unwind_forget`
+# — a linker error that reads like a compiler bug if you do not know to look
+# here. Comparing mtimes catches that class directly.
+verify_install_step() {
+    # Take the version the way the Makefile does — the highest git TAG is
+    # authoritative, with the VERSION file only a tarball fallback. Reading the
+    # VERSION file here instead would produce false STALE reports whenever the
+    # sync fetched commits but not tags (`git pull` does not always bring tags),
+    # since the build would legitimately stamp the older tag.
+    want="$(cd "$REPO" && git tag -l 'v*.*.*' 2>/dev/null \
+              | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)"
+    [ -n "$want" ] || want="$(cat "$REPO/VERSION" 2>/dev/null)"
+    installed_ae="$HOME/.local/bin/ae"
+    installed_lib="$HOME/.local/lib/aether/libaether.a"
+
+    if [ ! -x "$installed_ae" ] || [ ! -f "$installed_lib" ]; then
+        echo "  install verify: no install at \$HOME/.local (ae and/or libaether.a missing)"
+        return 1
+    fi
+    if [ -n "$want" ] && ! strings "$installed_ae" 2>/dev/null | grep -qxF "$want"; then
+        echo "  install verify: installed ae does not carry VERSION=$want (stale install?)"
+        return 1
+    fi
+    if [ "$REPO/build/libaether.a" -nt "$installed_lib" ]; then
+        echo "  install verify: installed libaether.a is OLDER than the freshly built one"
+        return 1
+    fi
+    echo "  install verify: \$HOME/.local carries VERSION ${want:-unknown}, archive current"
+    return 0
+}
+
 fails=0
 {
     echo "Aether nightly summary — $STAMP"
@@ -359,6 +433,12 @@ fails=0
     : > "$STEPS_TSV"
     run_and_record "contrib dependency gate" require_deps
     run_and_record "make ci" make_ci_step
+    # Refresh $HOME/.local from the tree we just built, then prove it took.
+    # Runs AFTER `make ci` (which builds everything) and BEFORE the sweeps, so
+    # anything linking against the installed artifacts sees today's toolchain
+    # rather than whatever was installed weeks ago. See make_install_step.
+    run_and_record "make install (PREFIX=\$HOME/.local)" make_install_step
+    run_and_record "install freshness check" verify_install_step
     run_and_record "make contrib" make_contrib_step
     run_and_record "make contrib-host-check" make_host_check_step
     # `make ci` and `make contrib` never compile the contrib Aether code


### PR DESCRIPTION
Two root causes behind a RED on Paul's CachyOS nightly. Both present as *"the newer compiler on this box is broken"* and neither is — which is the main reason this is worth writing down rather than just patching.

Scope is `tests/cachyos/` only: no compiler, runtime or stdlib code. Safe for `[skip actions]` by the usual rule, but left off so the matrix runs anyway.

## 1. The installed toolchain drifts behind the tree

A few tests link the **installed** artifacts rather than the build tree — `ci_coverage_smoke` is the current one. It *skips* when no install is present, so **deleting the install silences a test rather than fixing it**. Left unrefreshed it rots. A Jul-19 install against an Aug-8 tree failed with:

```
undefined reference to `aether_unwind_forget'
```

…because that symbol landed in between. The nightly log surfaces only `gcc --coverage link failed` **without the linker's line**, which reads like a GCC 16 problem on a box whose whole purpose is exercising a newer GCC. I misdiagnosed it exactly that way before reproducing it.

**Fix:** `make install PREFIX=$HOME/.local` as a pipeline step, after `make ci`, before the sweeps — drift becomes impossible by construction. `PREFIX` is under `$HOME` deliberately: this must never need sudo.

A separate `install freshness check` step asserts the refresh took, so the summary distinguishes *"install failed"* from *"install succeeded but produced something stale"*.

## 2. `git fetch` without `--tags` builds the previous version

The Makefile takes the highest **git tag** as authoritative (`VERSION := $(shell git tag -l ...)`), falling back to the `VERSION` file only for tarballs. Fetching commits without tags leaves the tree at current HEAD but the *previous* tag — so the build correctly stamps the **older** version, which then reads as a stale build to anything comparing against the `VERSION` file.

Seen 2026-08-08: HEAD at 0.505.0's merge commit, newest local tag `v0.504.0`, binaries stamped 0.504.0.

**Fix:** `git fetch --tags --prune`. The freshness check reads the version the same way the Makefile does, so it cannot produce the inverse false positive.

## A trap worth knowing

**`ae --version` reports the version *manager's* active install** (`~/.aether/active_version`), **not** the version compiled into the binary you just ran. On that box the managed state reads `0.417.0`, so a correctly built 0.505.0 binary still *says* 0.417.0.

`contrib_ae_check` already knew this and used `strings` — I re-derived it the hard way after writing a check that would have reported STALE forever. The new check now does the same. Both the README and an inline comment record it.

## Verification (on the box)

| | before | after |
|---|---|---|
| `install freshness check` | — | ✅ `carries VERSION 0.505.0, archive current` |
| `nm libaether.a \| grep aether_unwind_forget` | 0 | **1** |
| `ci_coverage_smoke` | ❌ FAIL | ✅ **PASS** |

That clears 2 of the 3 nightly failures. The third is the load-sensitive network shell tests, which are a separate known issue.

## Also

`tests/cachyos/README.md` gains a *"Why the nightly installs, and why it fetches tags"* section covering both failure modes and the `ae --version` trap, and the pipeline-step list is updated.

Related context: `/usr/local/bin/{ae,aetherc}` — a root-owned install that shadowed PATH on that box — was removed by hand during this work. The nightly's existing PATH pinning already defended against it; removing it just takes the trap away from anyone running commands there interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
