### PR TITLE
fix(install): keep the .exe suffix on Windows, and prove the install can compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1696,8 +1696,17 @@ install: $(VERSION_HEADER) release ae stdlib
 	@echo "Installing Aether to $(PREFIX)"
 	@echo "==================================="
 	@install -d $(PREFIX)/bin
-	@install -m 755 build/ae$(EXE_EXT) $(PREFIX)/bin/ae
-	@install -m 755 build/aetherc-release$(EXE_EXT) $(PREFIX)/bin/aetherc
+	@# Install WITH $(EXE_EXT) on both sides. Dropping it on the
+	@# destination (which this used to do) is fatal on Windows: `ae`
+	@# looks for its compiler as "aetherc" EXE_EXT — i.e. aetherc.exe —
+	@# next to itself, so an extensionless install leaves `ae` unable to
+	@# find `aetherc` even though the two sit in the same directory.
+	@# `ae --version` keeps working (it never needs the compiler), so the
+	@# box reports a healthy toolchain while every compile fails with the
+	@# misleading "Aether compiler not found ... set AETHER_HOME".
+	@# EXE_EXT is empty on POSIX, so this is a no-op there.
+	@install -m 755 build/ae$(EXE_EXT) $(PREFIX)/bin/ae$(EXE_EXT)
+	@install -m 755 build/aetherc-release$(EXE_EXT) $(PREFIX)/bin/aetherc$(EXE_EXT)
 	@install -d $(PREFIX)/lib/aether
 	@install -m 644 build/libaether.a $(PREFIX)/lib/aether/
 	@# Version stamp next to libaether.a. `ae build` reads this and
@@ -1802,6 +1811,29 @@ install: $(VERSION_HEADER) release ae stdlib
 	@# a no-op so we never break the install summary.
 	@if [ -n "$$SUDO_USER" ] && [ -d build ]; then \
 		chown -R "$$SUDO_USER:$$(id -gn $$SUDO_USER 2>/dev/null || echo $$SUDO_USER)" build 2>/dev/null || true; \
+	fi
+	@# Prove the INSTALLED ae can actually reach its compiler, by
+	@# compiling something. `ae version` is not sufficient: it never needs
+	@# aetherc, so it reports a healthy toolchain even when `ae` cannot
+	@# find the compiler at all — which is exactly how the Windows
+	@# extensionless-install bug shipped, presenting as 57 red spec suites
+	@# rather than a failed install. A trivial `ae build` exercises the
+	@# lookup that actually matters.
+	@# Non-fatal by design: a sandboxed or read-only TMPDIR must not fail
+	@# an otherwise good install. It prints a loud warning instead.
+	@tmpd="$${TMPDIR:-/tmp}/ae-install-check-$$$$"; \
+	if mkdir -p "$$tmpd" 2>/dev/null; then \
+	  printf 'main() {\n    println("ok")\n}\n' > "$$tmpd/smoke.ae"; \
+	  if "$(PREFIX)/bin/ae$(EXE_EXT)" build "$$tmpd/smoke.ae" -o "$$tmpd/smoke$(EXE_EXT)" >"$$tmpd/out.txt" 2>&1; then \
+	    echo "✓ Install check: the installed ae found aetherc and compiled a test program"; \
+	  else \
+	    echo "!! Install check FAILED: the installed ae could not compile."; \
+	    echo "!! `ae version` may still work — it does not need the compiler."; \
+	    echo "!! Check that $(PREFIX)/bin holds ae$(EXE_EXT) AND aetherc$(EXE_EXT):"; \
+	    ls -l "$(PREFIX)/bin" 2>/dev/null | sed 's/^/!!   /'; \
+	    sed 's/^/!!   /' "$$tmpd/out.txt" 2>/dev/null | head -12; \
+	  fi; \
+	  rm -rf "$$tmpd" 2>/dev/null || true; \
 	fi
 	@echo "✓ Installed successfully"
 	@echo ""

--- a/asks/windows-make-install-drops-exe-suffix.md
+++ b/asks/windows-make-install-drops-exe-suffix.md
@@ -1,0 +1,114 @@
+# Windows: `make install` installs `ae`/`aetherc` without `.exe`, so `ae` can never find its compiler
+
+**From:** the aether-ui line (2026-08-08) · **Where it bit:** winbaz
+(Windows 11 / MSYS2 MINGW64). A freshly built, successfully installed
+toolchain cannot compile anything, and the whole aether-ui spec matrix comes
+back red.
+
+## Symptom
+
+`make install` reports success:
+
+```
+===================================
+Installing Aether to /usr/local
+===================================
+✓ Installed successfully
+```
+
+`ae --version` works. Any actual compile does not:
+
+```
+$ ae run hello.ae
+Error: Aether compiler not found.
+
+If you downloaded a release ZIP, make sure to:
+  1. Extract the ZIP (e.g. to C:\aether)
+  ...
+Or set AETHER_HOME to the extraction folder:
+  set AETHER_HOME=C:\aether
+```
+
+The AETHER_HOME advice is a red herring — setting it changes nothing, because
+the problem is a filename, not a search root.
+
+## Cause
+
+`Makefile` lines 1699–1700 read the built artifacts **with** the extension and
+install them **without** it:
+
+```make
+@install -m 755 build/ae$(EXE_EXT)               $(PREFIX)/bin/ae
+@install -m 755 build/aetherc-release$(EXE_EXT)  $(PREFIX)/bin/aetherc
+```
+
+So on MINGW the install directory ends up holding:
+
+```
+-rwxr-xr-x  585744 ae          <- no .exe
+-rwxr-xr-x 1535476 aetherc     <- no .exe
+```
+
+But `tools/ae.c` looks for the compiler **with** `EXE_EXT`, which is `".exe"`
+on Windows (`tools/ae.c:30`):
+
+```c
+snprintf(tc.compiler, sizeof(tc.compiler), "%s/aetherc" EXE_EXT, exe_dir);
+if (path_exists(tc.compiler)) goto found_root;
+```
+
+Every sibling-of-`ae` strategy therefore misses. The one fallback that would
+match, Strategy 5, hardcodes POSIX paths with no extension:
+
+```c
+const char* standard_paths[] = {
+    "/usr/local/bin/aetherc",
+    "/usr/bin/aetherc",
+    NULL
+};
+```
+
+`/usr/local/bin` is an MSYS mount, not a native Windows path, so `path_exists`
+does not resolve it from a native-Windows binary either. Result: `ae` is
+installed next to `aetherc` and still cannot find it.
+
+## Why it is worse than it looks
+
+`ae --version` keeps working throughout, because that path never needs the
+compiler. So the box reports a healthy, correctly-versioned toolchain while
+every compile fails. On this line it presented as **57 spec suites red with
+0 pass / 0 fail each** — every suite dying at launch — which looks like a
+harness or environment failure, not a packaging one.
+
+It also invites exactly the wrong repair. Copying the extensionless binaries
+to `.exe` names appears to fix it, and then *blocks the next real install*:
+
+```
+install: cannot create regular file '/usr/local/bin/ae': File exists
+make: *** [Makefile:1699: install] Error 1
+```
+
+— which itself reports through `make` as a failure that is easy to miss if
+the output is piped.
+
+## Fix
+
+Install with the extension, matching what `ae.c` looks for:
+
+```make
+@install -m 755 build/ae$(EXE_EXT)               $(PREFIX)/bin/ae$(EXE_EXT)
+@install -m 755 build/aetherc-release$(EXE_EXT)  $(PREFIX)/bin/aetherc$(EXE_EXT)
+```
+
+Worth also making Strategy 5 in `tools/ae.c` append `EXE_EXT`, so a
+hand-placed install still resolves.
+
+A smoke check that would have caught it: the install target already runs
+`ae version` (Makefile ~1043) as verification. `ae version` does not need
+the compiler. Running `ae run` on a trivial file instead — or `ae build` —
+would have failed loudly at install time on Windows.
+
+## Not the same as
+
+`aeb`'s Windows fan-out bug (`aetherc` invoked with no arguments) — that is
+downstream of this and separate.

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1009,9 +1009,12 @@ static void discover_toolchain(void) {
     }
 
     // Strategy 5: Standard install paths
+    /* EXE_EXT so a hand-placed install resolves on Windows too. These are
+     * POSIX-shaped paths, but under MSYS2 they are real mount points, and a
+     * caller can equally have dropped the toolchain there deliberately. */
     const char* standard_paths[] = {
-        "/usr/local/bin/aetherc",
-        "/usr/bin/aetherc",
+        "/usr/local/bin/aetherc" EXE_EXT,
+        "/usr/bin/aetherc" EXE_EXT,
         NULL
     };
     for (int i = 0; standard_paths[i]; i++) {


### PR DESCRIPTION
Implements the fix for `asks/windows-make-install-drops-exe-suffix.md` (reported from the aether-ui line; the ask itself is included in this PR — it was committed onto an already-merged branch and never reached `main`).

## The bug

`make install` read the built artifacts **with** the extension and installed them **without** it:

```make
@install -m 755 build/ae$(EXE_EXT)              $(PREFIX)/bin/ae
@install -m 755 build/aetherc-release$(EXE_EXT) $(PREFIX)/bin/aetherc
```

But `tools/ae.c:859` looks for its compiler as `"aetherc" EXE_EXT` — i.e. `aetherc.exe`. So on Windows every sibling-of-`ae` lookup missed, and `ae` could not find `aetherc` **even though the two sat in the same directory**.

## Why it was expensive to diagnose

`ae --version` never needs the compiler, so it kept reporting a healthy, correctly-versioned toolchain while every compile failed with:

```
Error: Aether compiler not found. ... set AETHER_HOME=C:\aether
```

`AETHER_HOME` is a red herring — the problem is a filename, not a search root. On the aether-ui line it presented as **57 spec suites red, 0 pass / 0 fail each**, which reads as a harness or environment failure rather than a packaging one.

It also invited the wrong repair: hand-copying the extensionless binaries to `.exe` names appears to work, then blocks the *next* install with `cannot create regular file: File exists` — and copies the 10 MB **debug** `aetherc` over the 1.5 MB release one.

## Changes

1. **Install with `$(EXE_EXT)` on both sides.** `EXE_EXT` is empty on POSIX, so this is a no-op there and a fix on Windows.
2. **`tools/ae.c` Strategy 5** — the `/usr/local/bin`, `/usr/bin` fallback — now appends `EXE_EXT`, so a hand-placed install resolves on Windows too.
3. **The install target now compiles a trivial program with the installed `ae`.** This is the important one: the previous verification was `ae version`, which is *structurally incapable* of catching this class of bug because it never touches the compiler. Non-fatal by design (a read-only `TMPDIR` must not fail an otherwise good install), but it prints a loud warning plus a listing of `$(PREFIX)/bin`.

## Verification — on the machine that had the bug

Full build + install to a clean prefix on **winbaz** (Win11 / MSYS2 MINGW64):

```
✓ Install check: the installed ae found aetherc and compiled a test program
✓ Installed successfully
=== what landed in bin/ ===
 585744 ae.exe
1535515 aetherc.exe        <- the RELEASE binary, not the 10MB debug one
```

And the negative test — renaming `aetherc.exe` back to `aetherc` reproduces the original failure exactly, while `ae --version` stays cheerful:

```
$ mv aetherc.exe aetherc && ae.exe build neg.ae
Error: Aether compiler not found. ...
$ ae.exe --version
ae 0.506.0 (Aether Language)      <- the trap, confirmed
```

That is both halves of the ask reproduced and then fixed.

**Linux:** `make install PREFIX=…` unchanged, new check passes. `make ci` — C suite **230/230**, `.ae` suite **975/976**. The single failure is `integration_http_server_h2`, which is [pre-existing on `main`](https://github.com/aether-lang-dev/aether/issues) and unrelated — separately diagnosed in `pesky_bug.md` (it is an h2 connection-reuse bug, not the "50-stream" concurrency issue its name suggests).

## Note

`~/CLAUDE_NOTES.md` on winbaz has been updated: the `make install` section now records this as fixed and describes the new check, and a stale claim that `~/aether` was the good checkout has been corrected — that directory no longer exists; `~/scm/aether` is the only tree and it builds and installs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
