### PR TITLE
docs(CHANGELOG): attribute fd_read_into to 0.510.0, which shipped it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
-## [current]
+## [0.510.0]
 
 ### Added
 


### PR DESCRIPTION
The 0.510.0 release left `## [current]` unrenamed, so `VERSION` said `0.510.0` while the newest CHANGELOG heading was `[current]` — and the *next* release would have claimed `fd_read_into` as 0.511.0.

## Not a missing feature — a race

`release.yml:173-176` does perform the rename. The problem is timing: the release workflow branches from `main` **when it starts**.

```
19:38:05  feat(io): fd_read_into committed
20:02:45  #1476 merged to main
20:03:03  #1475 merged  (chore: release 0.510.0)   ← 18 seconds later
```

The release branch was cut before #1476 landed, so its `grep -q '## [current]'` correctly found nothing to rename — the previous `[current]` had just been consumed by the backfill (#1474) and the new entry did not exist yet. The workflow behaved exactly as written; the **window** is the problem.

## This PR

Corrects the attribution only: `## [current]` → `## [0.510.0]`, one line. `VERSION` and the newest heading now agree, and no duplicate heading is created.

Verified after the change: `VERSION` = `0.510.0`, newest heading = `## [0.510.0]`, and the only duplicate headings in the file are the two pre-existing ones (`[0.435.0]`, `[0.497.0]`) which this does not touch.

## The window itself

Filed as #1477, along with the two sibling failure modes in the same family — the pipeline silently shipping a release with *no* section (which is how 0.506.0–0.509.0 ended up empty), and the blind `sed` being able to create a duplicate heading (which is how those two pre-existing duplicates arose). Three cheap independent guards suggested there; not attempted here, since a release-pipeline change wants its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
