### PR TITLE
test(nightly): gate on FFmpeg, and find libs in the multiarch dir

### DIFF
--- a/tests/cachyos/nightly.sh
+++ b/tests/cachyos/nightly.sh
@@ -102,7 +102,8 @@ have_dep() {
     case "$kind" in
         cmd) for c in "$@"; do command -v "$c" >/dev/null 2>&1 && return 0; done ;;
         lib) for l in "$@"; do
-                 for d in /usr/lib /usr/lib64 /usr/local/lib /lib; do
+                 for d in /usr/lib /usr/lib64 /usr/local/lib /lib \
+                          "/usr/lib/$(uname -m)-linux-gnu"; do
                      [ -e "$d/$l" ] && return 0
                      ls "$d/$l".* >/dev/null 2>&1 && return 0
                  done
@@ -133,6 +134,8 @@ require_deps() {
         "lua|cmd|lua|lua5.4|lua5.3"                      \
         "tcl|cmd|tclsh"                                  \
         "duktape|lib|libduktape.so"                      \
+        "ffmpeg|lib|libavcodec.so"                       \
+        "ffmpeg-swr|lib|libswresample.so"                \
         "go|cmd|go"                                      \
         "nodejs|cmd|node"                                \
         "java|cmd|java"                                  \


### PR DESCRIPTION
Two changes to the CachyOS nightly's dependency gate. One file, `tests/cachyos/nightly.sh`, four added lines.

## 1. FFmpeg is now a required dependency

`contrib/avcodec` landed in 0.509.0 and its audio half in 0.513.0. Its `contrib-check` entry **SKIPs** when pkg-config cannot find the FFmpeg libraries — so without a gate entry the nightly would report a **green run whose avcodec test never actually executed**.

That is precisely the failure mode the gate exists to prevent: a dedicated build box should test everything, so an absent library is a provisioning bug rather than a silent skip. Both `libavcodec` and `libswresample` are listed, since 0.513.0 made all five FFmpeg libs a required set.

## 2. `have_dep`'s `lib` kind now searches the multiarch directory

On Debian and Ubuntu, `/usr/lib/<arch>-linux-gnu` is the **only** place these libraries live. Verified here:

```
$ ls /usr/lib/x86_64-linux-gnu/libavcodec.so     → present
$ ls /usr/lib/libavcodec.so /usr/lib64/...       → nothing
```

So a Debian-shaped box would have reported *every* `lib` dependency as MISSING. Arch has no multiarch dir, so the extra path is a harmless no-op on the box this script actually runs on.

## Verified on both shapes, not assumed

| box | result |
|---|---|
| Debian 12 (dev machine) | `ffmpeg`, `ffmpeg-swr`, `sqlite`, `expat` → all **dep OK** |
| CachyOS (the nightly box) | same four **dep OK** |

Worth noting: **FFmpeg is already installed on the CachyOS box**, so this turns the avcodec gate *on* rather than turning the nightly red. The pre-existing `sqlite`/`expat` entries still resolve on both, so the matcher change regresses nothing.

## On `[skip actions]`

Bare in the commit subject, deliberately **not** in the PR title (the title becomes the merge-commit subject and would no-op the release).

It is correct here in a way it was **not** in #1483: that branch carried the token on its head commit while shipping 244 lines of C, which silenced CI for the whole PR. This branch is `tests/cachyos/` end to end — a single shell script, self-run on its own box rather than by GitHub Actions — so there is nothing for the matrix to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
