### PR TITLE
ci: fail the release instead of shipping it unrecorded (#1477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,78 @@ jobs:
   # `make ci` only ever compiles the platform branch matching its
   # runner, so this is the only job that reads the FreeBSD #ifdefs.
   # ============================================================
+  # ============================================================
+  # CHANGELOG guard (#1477)
+  #
+  # The release workflow turns a `## [current]` section into the version
+  # heading. When no such section exists it used to rename nothing and ship
+  # silently: releases 0.506.0 through 0.509.0 went out with no CHANGELOG
+  # section at all, four releases of real work recorded nowhere, including a
+  # Windows packaging fix. The release side now fails loudly, but that catches
+  # it at release time, when the work has already merged and the author has
+  # moved on.
+  #
+  # This catches it at the point it can still be fixed cheaply: a PR that
+  # changes shipped code has to say what changed. Escape hatch for the genuine
+  # exceptions (pure refactors, test-only work, CI plumbing): put
+  # [skip changelog] in the PR title or any commit message.
+  # ============================================================
+  ci-changelog:
+    name: CHANGELOG entry present
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Require a CHANGELOG entry for code changes
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        set -eu
+
+        changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+        # Only shipped code counts. Docs, tests and CI plumbing can land
+        # without a user-visible entry.
+        code=$(printf '%s\n' "$changed" | grep -E '^(std|runtime|compiler|contrib|tools)/' || true)
+        if [ -z "$code" ]; then
+          echo "No shipped-code changes; nothing to record."
+          exit 0
+        fi
+
+        if printf '%s\n' "$changed" | grep -q '^CHANGELOG\.md$'; then
+          echo "CHANGELOG.md is updated."
+          exit 0
+        fi
+
+        # Explicit opt-out, in the PR title or any commit on the branch.
+        if printf '%s' "$PR_TITLE" | grep -qi '\[skip changelog\]'; then
+          echo "PR title opts out with [skip changelog]."
+          exit 0
+        fi
+        if git log --pretty=%B "$BASE_SHA..$HEAD_SHA" | grep -qi '\[skip changelog\]'; then
+          echo "A commit opts out with [skip changelog]."
+          exit 0
+        fi
+
+        echo "::error::This PR changes shipped code but does not touch CHANGELOG.md."
+        echo ""
+        echo "The release workflow renames a '## [current]' section into the"
+        echo "version heading. With no entry there is nothing to rename, which"
+        echo "is how 0.506.0 through 0.509.0 shipped with no CHANGELOG at all."
+        echo ""
+        echo "Add your entry under '## [current]', or put [skip changelog] in"
+        echo "the PR title if this genuinely needs no user-visible note."
+        echo ""
+        echo "Code files changed:"
+        printf '%s\n' "$code" | sed 's/^/  /'
+        exit 1
+
   ci-freebsd-cross:
     name: FreeBSD / cross-compile (x86_64)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,10 +170,41 @@ jobs:
         echo "$VERSION" > VERSION
         git add VERSION
 
-        # Replace [current] with the actual version in CHANGELOG.md
-        if grep -q '## \[current\]' CHANGELOG.md; then
+        # Turn [current] into this version's heading (#1477).
+        #
+        # This used to be a bare `if grep -q ... ; then rename; fi`, which does
+        # exactly what it says and silently ships a release with no CHANGELOG
+        # section when the condition is false. Releases 0.506.0 through 0.509.0
+        # went out that way: four releases of real work, including a Windows
+        # packaging fix, recorded nowhere. The file is what a downstream
+        # consumer reads to decide whether to upgrade, so silence is the one
+        # outcome that must not be available.
+        #
+        # An intentionally empty release is still possible, it just has to say
+        # so: put [skip changelog] in the release-trigger commit message.
+        SKIP_CHANGELOG=0
+        if git log -1 --pretty=%B | grep -qi '\[skip changelog\]'; then
+          SKIP_CHANGELOG=1
+        fi
+
+        if grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+          echo "::error::CHANGELOG.md already has a '## [${VERSION}]' heading."
+          echo "A blind rename would create a second one; ## [0.435.0] and"
+          echo "## [0.497.0] are both duplicated on main from exactly this."
+          exit 1
+        fi
+
+        if grep -q '^## \[current\]' CHANGELOG.md; then
           sed -i "s/## \[current\]/## [${VERSION}]/" CHANGELOG.md
           git add CHANGELOG.md
+        elif [ "$SKIP_CHANGELOG" = "1" ]; then
+          echo "No [current] section, and the trigger commit says [skip changelog]."
+        else
+          echo "::error::No '## [current]' section in CHANGELOG.md, so ${VERSION}"
+          echo "would ship with nothing recorded. Add the entry under a"
+          echo "'## [current]' heading, or put [skip changelog] in the"
+          echo "release-trigger commit if this release is genuinely empty."
+          exit 1
         fi
 
         # Only commit if there are staged changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Changed
+
+- **The release pipeline fails instead of shipping an unrecorded release**
+  (#1477). The CHANGELOG rename was `if grep -q '## [current]'; then rename;
+  fi`, which does exactly what it says and silently ships a release with no
+  section when the condition is false. Releases 0.506.0 through 0.509.0 went
+  out that way, four releases of real work recorded nowhere, including a
+  Windows packaging fix. Three guards: the release now fails when there is no
+  `[current]` to rename, fails rather than creating a duplicate heading (which
+  is how `## [0.435.0]` and `## [0.497.0]` each came to appear twice), and a CI
+  job requires a CHANGELOG entry on any PR touching shipped code, which is what
+  makes a `[current]` section exist to be renamed in the first place. All three
+  have an explicit `[skip changelog]` opt-out, because a genuinely empty
+  release should have to say so rather than be indistinguishable from an
+  oversight.
+
+## [current]'; then rename;
+  fi`, which does exactly what it says and silently ships a release with no
+  section when the condition is false. Releases 0.506.0 through 0.509.0 went
+  out that way, four releases of real work recorded nowhere, including a
+  Windows packaging fix. Three guards: the release now fails when there is no
+  `[current]` to rename, fails rather than creating a duplicate heading (which
+  is how `## [0.435.0]` and `## [0.497.0]` each came to appear twice), and a CI
+  job requires a CHANGELOG entry on any PR touching shipped code, which is what
+  makes a `[current]` section exist to be renamed in the first place. All three
+  have an explicit `[skip changelog]` opt-out, because a genuinely empty
+  release should have to say so rather than be indistinguishable from an
+  oversight.
+
 ## [0.513.0]
 
 ### Added


### PR DESCRIPTION
**Scope changed after testing.** This started as three fixes; two were wrong and are reverted. What ships is #1477. The findings on the other two are below and will go back on their issues.

## What ships: #1477, the release pipeline

The CHANGELOG rename was `if grep -q '## [current]'; then rename; fi` — which does exactly what it says and silently ships a release with **no section at all** when false. Releases 0.506.0 through 0.509.0 went out that way: four releases of real work recorded nowhere, including a Windows packaging fix.

Three guards, each with a `[skip changelog]` opt-out so a genuinely empty release has to *say* so:

1. **Fail when there is no `[current]`** to rename.
2. **Fail rather than create a duplicate heading** — `## [0.435.0]` and `## [0.497.0]` each appear twice on main from exactly this.
3. **A CI job requiring a CHANGELOG entry** on any PR touching `std/`, `runtime/`, `compiler/`, `contrib/` or `tools/`. This is the guard that makes a `[current]` section exist to be renamed at all. Docs-only and test-only PRs pass untouched.

The workflow can't run locally, so the guard logic was extracted and exercised against all four release scenarios and all five CI scenarios, including both failure modes that actually bit.

## What does not ship, and why

### #1439 — my fix was wrong

I made a bare function passed to a `ptr` parameter box, matching what assignment into a `ptr` field already did. It fixed the reported segfault. It also **caused three regressions** that all pass on main:

| Test | main | with my fix |
|---|---|---|
| `crypto_mlkem` | PASS | **exit 139 (SIGSEGV)** |
| `http_server_ops` | PASS | FAIL |
| `http_middleware_d1` | PASS | FAIL |

Bisected by disabling only the autobox: `crypto_mlkem` goes 139 → 0. Real code passes a bare function to a `ptr` parameter and needs the **real address**; boxing hands it a heap struct instead. The issue ranked autoboxing third, behind a diagnostic, noting it "costs an allocation even when not needed" — the sharper objection is that it is not merely wasteful but wrong for those callers, and the issue's preference was correct.

So #1439 wants option 1 or 2 (diagnose at `unbox_closure`, or at the fn→ptr coercion), not option 3. The design question that remains is avoiding false positives on the legitimate raw-address uses `crypto_mlkem` demonstrates.

### #1461 — root-caused, fix not landed

Worth keeping, because the issue's own body has the wrong cause. It blames `stringify`; bisecting shows **parse alone leaks the identical 16 bytes**:

```
p_parse   1 leak / 16 bytes    # parse only
p_full    1 leak / 16 bytes    # parse + stringify
p_nofree  0 leaks              # parse, NOT freeing perr
```

`aether_uniform_heap_str` returns its argument untouched on the heap path (an AetherString) but a **plain malloc'd copy** on the non-heap path, so the slot's representation depends on which branch ran. `string.free()` is `string_release`, a deliberate no-op on magic-less pointers so it stays safe on literals. Net effect: **freeing the slot as documented leaks; not freeing it is fine**, because the codegen tracker uses the magic-dispatching `aether_heap_str_free`.

My fix made both paths mint an AetherString. That is the wrong shape: consumers read the slot as a raw data pointer (`aether_bytes_get` dereferences it), so it must stay a plain `char*`. The promising direction is instead to lower `string.free(x)` to `aether_heap_str_free` when the compiler already tracks `x` as a heap string — the provenance is known at that point, so it fixes the leak without changing any representation or risking a literal being freed.

Also found and deliberately not touched: the stdlib declares `string_new_with_length(length: int)` where the C definition takes `size_t`. Correcting it collides with user code that declares the same extern, so it needs its own issue and a deprecation.

### #1447 — already fixed

Does not reproduce: 1000 build/free cycles leak nothing, where a live bug would be ~64KB. Commit `e7d17676` fixed it; the issue was never closed.

## Verification

230/230 unit tests, `crypto_mlkem` / `http_server_ops` / `http_middleware_d1` back to passing, fmt gate clean. The branch now differs from main only in `.github/workflows/`, so there is no runtime or compiler change to regress.
