### PR TITLE
fix(build): stamp the version from the tree, and rebuild when it changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,6 +314,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ needs.tag.outputs.tag || github.ref }}
+        # Full history + all tags. A shallow checkout of a tag does not
+        # reliably give `git tag -l` the current tag set, which used to let the
+        # Makefile stamp binaries with an older version (see Makefile:66).
+        # Belt-and-braces now that VERSION is authoritative, but this job
+        # compiles the UPLOADED artifacts so it should not be the thin one.
+        fetch-depth: 0
         fetch-tags: true
 
     # -- Linux ---
@@ -497,6 +503,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ needs.tag.outputs.tag || github.ref }}
+        # Full history + all tags. A shallow checkout of a tag does not
+        # reliably give `git tag -l` the current tag set, which used to let the
+        # Makefile stamp binaries with an older version (see Makefile:66).
+        # Belt-and-braces now that VERSION is authoritative, but this job
+        # compiles the UPLOADED artifacts so it should not be the thin one.
+        fetch-depth: 0
         fetch-tags: true
 
     - name: Setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **The built toolchain reported the wrong version.** `v0.516.0` shipped an
+  `ae --version` that said `0.417.0`. The binary compiled current sources
+  correctly — it was the right toolchain, mislabelling itself — but anything
+  keying off the banner recorded the wrong number, including aeb's
+  content-addressed cache key.
+
+  Two independent causes, both fixed:
+
+  1. **The Makefile preferred the highest `git tag` over the `VERSION` file.**
+     Tag visibility depends on clone depth, and `release.yml`'s build jobs
+     check out shallow, so the visible set could be stale and `tail -1` land on
+     an *older* tag — overriding a correct `VERSION`. The tree a tag points at
+     always carries the right number (`git show v0.516.0:VERSION` → `0.516.0`),
+     so the tree is now authoritative and tags are consulted only for an
+     untagged dev checkout. `fetch-depth: 0` added to the `build` and
+     `build-freebsd` jobs as defence in depth.
+
+  2. **A `VERSION` bump did not rebuild the objects that bake it in.** The
+     version arrives as `-DAETHER_VERSION` on the command line rather than
+     through an `#include`, so `-MMD` never saw it and every object stayed
+     "up to date" — leaving a binary that reported the previous version. The
+     version-bearing objects now depend on the generated `aether_version.h`,
+     which is already regenerated whenever `VERSION` changes.
+
+  New `tests/integration/version_stamp/` asserts `ae --version` matches the
+  `VERSION` file, so a mislabelled build fails CI rather than shipping.
+
 ## [0.516.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,37 @@ else
 NPROC ?= $(shell sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
 endif
 
-# Version: prefer highest git tag (authoritative), fall back to VERSION file (tarballs)
+# Version: the VERSION FILE IN THIS TREE is authoritative; the highest git tag
+# is only a fallback for an untagged dev checkout.
+#
+# This ordering used to be reversed ("prefer highest git tag"), which mislabels
+# a tagged release build. `git tag -l` reports the tags VISIBLE IN THIS CLONE,
+# and release.yml's build jobs check out shallow, so the visible set can be
+# stale or partial — `tail -1` then lands on an OLDER tag and overrides the
+# correct VERSION file. Measured: v0.516.0 shipped an `ae --version` saying
+# 0.417.0, while `git show v0.516.0:VERSION` said 0.516.0 all along. The tree
+# was right and the tag scan was wrong.
+#
+# For a tagged build the two should be identical, so preferring the tree costs
+# nothing and is immune to clone depth. For a tarball there is no git at all.
+# Only an untagged dev checkout — where VERSION is still the 0.0.0 placeholder
+# — consults tags, so `make` on a plain main still reports a real-ish number.
+#
+# One arm now, not two: `cat` covers Windows too (the WINDOWS_NATIVE split
+# existed because `git tag` shell-outs are awkward under cmd.exe; a file read
+# is not). WINDOWS_NATIVE keeps `type` since cmd.exe has no `cat`.
 ifdef WINDOWS_NATIVE
 VERSION := $(shell type VERSION 2>nul || echo 0.0.0)
 else
+VERSION := $(shell cat VERSION 2>/dev/null | tr -d '[:space:]')
+ifeq ($(VERSION),)
+VERSION := 0.0.0
+endif
+ifeq ($(VERSION),0.0.0)
 VERSION := $(shell git tag -l 'v*.*.*' 2>/dev/null | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
 ifeq ($(VERSION),)
-VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0")
+VERSION := 0.0.0
+endif
 endif
 endif
 
@@ -571,6 +595,20 @@ STD_OBJS = $(STD_SRC:%.c=$(OBJ_DIR)/%.o)
 STD_REACTOR_OBJS = $(STD_REACTOR_SRC:%.c=$(OBJ_DIR)/%.o)
 COLLECTIONS_OBJS = $(COLLECTIONS_SRC:%.c=$(OBJ_DIR)/%.o)
 TEST_OBJS = $(TEST_SRC:%.c=$(OBJ_DIR)/%.o)
+
+# The version is injected as -DAETHER_VERSION on the command line, NOT via an
+# #include, so -MMD cannot see it: bump VERSION and every object still looks up
+# to date, leaving a binary that reports the PREVIOUS version. Measured: a tree
+# whose generated header said 0.516.0 produced an `ae --version` of 0.515.0,
+# because build/obj/tools/ae_version.o was hours older than the header and
+# nothing told make to rebuild it.
+#
+# $(VERSION_HEADER) is regenerated whenever VERSION changes (rule above), so
+# making the version-bearing objects depend on it is the cheap, honest link
+# between "the version changed" and "recompile the things that bake it in".
+$(OBJ_DIR)/tools/ae_version.o: $(VERSION_HEADER)
+$(OBJ_DIR)/tools/ae.o: $(VERSION_HEADER)
+$(OBJ_DIR)/compiler/aetherc.o: $(VERSION_HEADER)
 
 # Dependency files (include test objects so header changes trigger test recompilation)
 DEPS = $(COMPILER_OBJS:.o=.d) $(RUNTIME_OBJS:.o=.d) $(STD_OBJS:.o=.d) $(COLLECTIONS_OBJS:.o=.d) $(TEST_OBJS:.o=.d) $(TOOLS_OBJS:.o=.d)

--- a/tests/integration/version_stamp/test_version_stamp.sh
+++ b/tests/integration/version_stamp/test_version_stamp.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# The built toolchain must report the VERSION in the tree it was compiled from.
+#
+# Two bugs made it report something else, both measured on real releases:
+#
+#  1. The Makefile preferred the highest `git tag -l` over the VERSION file. Tag
+#     visibility depends on CLONE DEPTH, and release.yml's build jobs check out
+#     shallow, so the visible set could be stale and `tail -1` land on an OLDER
+#     tag — overriding a correct VERSION. v0.516.0 shipped an `ae --version`
+#     saying 0.417.0 while `git show v0.516.0:VERSION` said 0.516.0 all along.
+#
+#  2. The version is injected as -DAETHER_VERSION on the command line, not via
+#     an #include, so -MMD could not see it: bumping VERSION left every object
+#     looking up to date and the binary reporting the PREVIOUS version.
+#
+# This asserts the property both bugs broke: `ae --version` == the VERSION file.
+# It deliberately does NOT re-run make (too slow for the .ae suite) — it checks
+# the already-built binary, which is what CI and a developer actually ship.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -n "${EXE_EXT:-}" ] && AE="$AE$EXE_EXT"
+
+if [ ! -x "$AE" ]; then
+    echo "  [SKIP] version_stamp: $AE not built"
+    exit 0
+fi
+if [ ! -f "$ROOT/VERSION" ]; then
+    echo "  [SKIP] version_stamp: no VERSION file (tarball layout?)"
+    exit 0
+fi
+
+want="$(tr -d '[:space:]' < "$ROOT/VERSION")"
+got="$("$AE" --version 2>&1 | head -1 | sed -n 's/^ae \([0-9][0-9.]*\).*/\1/p')"
+
+if [ -z "$got" ]; then
+    echo "  [FAIL] version_stamp: could not parse a version from \`ae --version\`:"
+    "$AE" --version 2>&1 | head -2 | sed 's/^/      /'
+    exit 1
+fi
+
+if [ "$want" != "$got" ]; then
+    echo "  [FAIL] version_stamp: ae reports $got, VERSION file says $want"
+    echo "      The binary is mislabelled. Either the Makefile picked a git tag"
+    echo "      over the tree (Makefile:66), or a stale object was not rebuilt"
+    echo "      after a VERSION change (see the \$(VERSION_HEADER) deps)."
+    exit 1
+fi
+
+echo "  [PASS] version_stamp: ae reports $got, matching the VERSION file"
+exit 0


### PR DESCRIPTION
Implements `version_stamp_bug.md`. The note was accurate on every point, and chasing it turned up a **second, independent cause** producing the identical symptom.

## Bug 1 — the one in the note

**Reproduced, not inferred.** A depth-1 checkout of `v0.516.0` whose visible tag set contained only `v0.417.0`:

```
tags visible:   v0.417.0
VERSION file:   0.516.0   ← the tree is RIGHT
Makefile picks: 0.417.0   ← what gets stamped
```

`git tag -l` reports the tags visible *in this clone*, and `release.yml`'s build jobs check out shallow, so `tail -1` can land on an older tag and override a correct `VERSION`.

Fixed with the note's recommended ordering — the tree is authoritative, tags are a fallback only for an untagged dev checkout. All three paths verified: the stale-tag checkout now yields `0.516.0`, a normal checkout reads the tree, and a `0.0.0` placeholder still falls back to tags.

**One extension to the note:** it named the `build` job as shallow. **`build-freebsd` is too**, and it also compiles uploaded artifacts — so FreeBSD releases had the same exposure. Both now have `fetch-depth: 0`. `publish` is also shallow but reads `cat VERSION` directly, so it is already tree-authoritative and is left alone.

## Bug 2 — found while verifying bug 1

After fixing the Makefile, the generated header said `0.516.0` and `ae --version` **still said `0.515.0`**.

Not stale-build noise. The version arrives as **`-DAETHER_VERSION` on the command line**, not through an `#include` — so `-MMD` never sees it and every object stays "up to date" across a version change. `build/obj/tools/ae_version.o` was *hours* older than the header it should have tracked.

The version-bearing objects now depend on `$(VERSION_HEADER)`, which is already regenerated whenever `VERSION` changes. Proved it end to end:

```
$ echo 0.999.0 > VERSION && make ae
$ ./build/ae --version
ae 0.999.0 (Aether Language)      ← before, it kept the old number
```

This is also a plausible second explanation for the CachyOS box reporting `0.417.0`, which I had previously attributed solely to `~/.aether/active_version` state.

## Guard

`tests/integration/version_stamp/` asserts `ae --version` matches the `VERSION` file, and SKIPs cleanly where either is absent.

**Verified it fails on a mislabelled binary** — and its failure message names *both* causes, so the next person does not have to re-derive them:

```
[FAIL] version_stamp: ae reports 0.516.0, VERSION file says 0.777.0
    Either the Makefile picked a git tag over the tree (Makefile:66), or a
    stale object was not rebuilt after a VERSION change.
```

## Verification

- `make ci` — C suite **230/230**; `.ae` **980/981** with `[PASS] integration_version_stamp`, count up to 981. The one failure is `integration_http_server_h2`, pre-existing and diagnosed in `pesky_bug.md`.
- Release-workflow YAML validated after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
