### PR TITLE
fix(std): report bytes above 0x7F correctly, and align the docs with the code

### DIFF
--- a/CHANGELOG-archive.md
+++ b/CHANGELOG-archive.md
@@ -1,5 +1,9 @@
 # Changelog — archive (0.259.0 and older)
 
+> Paths under `contrib/aether_ui/` in the entries below no longer resolve.
+> The UI library outgrew this repo and moved to a sibling one; the entries
+> are left as written, since a changelog is a record of what happened.
+
 Older release notes, split out of the active
 [CHANGELOG.md](CHANGELOG.md) to keep the live file small. Format and
 conventions are identical; new entries always go in `CHANGELOG.md`, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`string.char_at` reported bytes above 0x7F as negative** (#1516). It
+  returned a signed `char`, so 0x85 came back as -123 and every binary parser
+  built on it broke on high bytes. `contrib/tinyweb` read a masked WebSocket
+  header, computed a negative payload length, and dropped the connection
+  instead of echoing the frame. The C definition also disagreed with the
+  prototype codegen emits and with the stdlib extern, both of which say `int`;
+  only the implementation said `char`. `char_at` and `char_at_n` now return the
+  byte as 0..255, which is what `bytes.get` has always documented.
+
+- **`contrib/tinyweb` would not build** (#1516). `tw_start` had no declared
+  return type and returned `-1` on one path and `http.server_start`'s string on
+  another, so the emitted C assigned an int to a `const char*` and every
+  tinyweb example and test failed to compile. It now declares `-> string` and
+  returns `""` on success, matching `http.server_start` and the stdlib's error
+  convention. The examples compared that result against `0`, which asked
+  whether the pointer was NULL and so never took the success branch; they now
+  compare against `""`.
+
+### Documentation
+
+- Audited the docs against the code. `docs/stdlib-reference.md` opened with
+  "Complete reference for Aether's standard library modules" while 37 of the 69
+  shipped modules appeared in neither it nor `docs/stdlib-api.md`. It now opens
+  with a generated index covering every module, its purpose and its export
+  count, taken from the source so it cannot drift.
+
+- Corrected API references that no longer matched the code: `http.server_listen`
+  (the function is `http.server_start`), and `cryptography.base64_encode` /
+  `base64_decode`, which live in `std.encoding` and return `string` and
+  `string!` rather than the tuples the docs described. `std.cryptography`'s own
+  header has said "use encoding.base64_*" for some time.
+
+- Fixed two documented snippets that could not compile: the `c-interop.md`
+  SQLite extern used `callback` as a parameter name, which is a reserved word,
+  and the `02-functions-and-control-flow` tutorial taught
+  `if (is_prime(num))` against an int-returning function, which the type checker
+  rejects. The tutorial now uses `-> bool`.
+
+- Repaired every broken relative link outside the changelog archive: the docker
+  guide pointed at two `docs/setup/` pages that were never in the tree, the
+  benchmark README missed the `design/` path segment, and `contrib/host/TODO.md`
+  pointed at a roadmap document that does not exist. The archive's dead
+  `contrib/aether_ui/` paths are left as written, with a note explaining that
+  the UI library moved to a sibling repository.
+
+- README: the CI suite is 10 steps, not 9, and the `ae` command list was missing
+  `inspect`, `bindgen`, `cflags` and `lib-path`.
+
 ## [0.520.0]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ ae add <host/user/repo>  # Add a dependency (any git host)
 ae repl                  # Start interactive REPL
 ae cache                 # Show build cache info
 ae cache clear           # Clear the build cache
+ae inspect [file.ae]     # Show what a script declares (imports, capabilities, exports)
+ae bindgen consts <h>    # Import C macro constants from a header as Aether consts
+ae cflags                # Print -I/-L/-laether for embedding in external builds
+ae lib-path              # Print the resolved module-search chain
 ae version               # Show current version
 ae upgrade               # Install the latest release and switch to it
 ae install <v>           # Install a specific release (latest if omitted)
@@ -388,7 +392,7 @@ Same file is config, validation, conditional logic, and the entry point. No seco
 ### Running Tests
 
 ```bash
-# Full CI suite (9 steps, -Werror), runs on your current platform
+# Full CI suite (10 steps, -Werror), runs on your current platform
 make ci
 
 # Unit tests only (runtime C test suite)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,7 +12,7 @@ The benchmark suite compares Aether's actor implementation against C, C++, Go, R
 
 **Full documentation:** [benchmarks/cross-language/README.md](cross-language/README.md)
 
-**Concurrent cache designs:** [`concurrent-cache/concurrent_cache_bench.ae`](concurrent-cache/concurrent_cache_bench.ae) — single-owner-actor vs. sharded-actor-map vs. COW snapshot cell, across read/write workload mixes (see [`docs/concurrent-cache-benchmark.md`](../docs/concurrent-cache-benchmark.md)).
+**Concurrent cache designs:** [`concurrent-cache/concurrent_cache_bench.ae`](concurrent-cache/concurrent_cache_bench.ae): single-owner-actor vs. sharded-actor-map vs. COW snapshot cell, across read/write workload mixes (see [`docs/concurrent-cache-benchmark.md`](../docs/design/concurrent-cache-benchmark.md)).
 
 ## Directory Structure
 

--- a/contrib/host/TODO.md
+++ b/contrib/host/TODO.md
@@ -5,7 +5,8 @@
 - [x] Import path drift fixed: all READMEs and module.ae headers now document the working form `import contrib.host.<lang>` (previously said `std.host.<lang>`, which the compiler's stdlib resolver doesn't handle since the modules live under `contrib/host/`, not `std/host/<lang>/`). `docs/containment-sandbox.md` already used the correct form.
 - [x] IPv6-mapped addresses normalized in `pattern_match`: a grant for `10.0.0.1` now matches a TCP resource reported as `::ffff:10.0.0.1` (and vice versa). Applied to all 6 in-process bridges, the LD_PRELOAD preload checker (`runtime/libaether_sandbox_preload.c`), and the Java-side `AetherGrantChecker`.
 - [x] CI + `make contrib-host-check` target added: syntax-checks every bridge in stub mode and runs per-language demos when the dev library is installed. Gracefully skips languages whose headers/libs aren't present. Wired into a Linux CI job (`ci-contrib-host`) that installs lua/python/ruby/perl/tcl/duktape/go dev packages.
-- [ ] **Deferred to roadmap**: see [`docs/next-steps.md`](../../docs/next-steps.md#host-language-bridges-contribhost)
+- [ ] **Deferred**, tracked in the issue tracker rather than here (the
+  `docs/next-steps.md` this used to link to is not in the tree):
   - Capture stdout/stderr from hosted code (pipe + shared map `_stdout`/`_stderr` keys, or pass-through)
   - Shared map `aether_map_get`/`aether_map_put` bindings for Perl and Ruby currently use eval-injected hashes — outputs stay in the hosted language. Need XS (Perl) or C extension (Ruby) to write outputs back to the C map.
   - `string:bytes` mode for shared map — binary data without base64

--- a/contrib/tinyweb/example_app.ae
+++ b/contrib/tinyweb/example_app.ae
@@ -53,7 +53,7 @@ main() {
     println("Starting server on localhost:8080...")
     result = tinyweb.tw_start(server)
 
-    if result == 0 {
+    if result == "" {
         println("Server running! Try:")
         println("  curl http://localhost:8080/foo/bar")
         println("  curl http://localhost:8080/users/alice")

--- a/contrib/tinyweb/example_auth.ae
+++ b/contrib/tinyweb/example_auth.ae
@@ -66,6 +66,6 @@ main() {
     println("    -> 200 User is logged in: alice@example.com")
 
     result = tinyweb.tw_start(server)
-    if result != 0 { println("ERROR: Failed to start server") }
+    if result != "" { println("ERROR: Failed to start server: ${result}") }
     tinyweb.tw_stop(server)
 }

--- a/contrib/tinyweb/example_composition.ae
+++ b/contrib/tinyweb/example_composition.ae
@@ -78,7 +78,7 @@ main() {
     println("Starting server on localhost:8080...")
     result = tinyweb.tw_start(server)
 
-    if result == 0 {
+    if result == "" {
         println("Server running! Try:")
         println("  curl http://localhost:8080/api/v1/health")
         println("  curl http://localhost:8080/api/v1/greeting/Jane/Doe")

--- a/contrib/tinyweb/example_sse.ae
+++ b/contrib/tinyweb/example_sse.ae
@@ -56,6 +56,6 @@ main() {
     println("Open http://localhost:8080/ or: curl -N http://localhost:8082/sse/events")
 
     result = tinyweb.tw_start(server)
-    if result != 0 { println("ERROR: Failed to start server") }
+    if result != "" { println("ERROR: Failed to start server: ${result}") }
     tinyweb.tw_stop(server)
 }

--- a/contrib/tinyweb/example_static.ae
+++ b/contrib/tinyweb/example_static.ae
@@ -42,6 +42,6 @@ main() {
     println("  http://localhost:8080/api/health    — JSON health check")
 
     result = tinyweb.tw_start(server)
-    if result != 0 { println("ERROR: Failed to start server") }
+    if result != "" { println("ERROR: Failed to start server: ${result}") }
     tinyweb.tw_stop(server)
 }

--- a/contrib/tinyweb/example_websocket.ae
+++ b/contrib/tinyweb/example_websocket.ae
@@ -62,7 +62,7 @@ main() {
     println("  ws://localhost:8081/foo/eee  — echo x3")
 
     result = tinyweb.tw_start(server)
-    if result != 0 { println("ERROR: Failed to start server") }
+    if result != "" { println("ERROR: Failed to start server: ${result}") }
     tinyweb.tw_stop(server)
     println("Server stopped.")
 }

--- a/contrib/tinyweb/module.ae
+++ b/contrib/tinyweb/module.ae
@@ -931,7 +931,7 @@ fn filter_applies(fmethod: int, fpat: string, rmethod: int, rpath: string) -> in
 // Server lifecycle
 // ---------------------------------------------------------------------------
 
-tw_start(srv: ptr) {
+tw_start(srv: ptr) -> string {
     port, _ = map.get(srv, "port")
     host, _ = map.get(srv, "host")
     raw = http.server_create(port)
@@ -939,8 +939,7 @@ tw_start(srv: ptr) {
     // server_bind returns "" on success, an error message otherwise.
     bind_err = http.server_bind(raw, host, port)
     if bind_err != "" {
-        println("ERROR: Failed to bind to ${host}:${port}: ${bind_err}")
-        return -1
+        return "failed to bind ${host}:${port}: ${bind_err}"
     }
 
     // Register all routes with the C server

--- a/docker/README.md
+++ b/docker/README.md
@@ -166,6 +166,9 @@ docker build --no-cache -t aether:latest -f docker/Dockerfile .
 
 ## More Information
 
-- Full Docker guide: [docs/setup/DOCKER.md](../docs/setup/DOCKER.md)
-- Windows setup: [docs/setup/WINDOWS_SETUP.md](../docs/setup/WINDOWS_SETUP.md)
+- Windows setup: [README.md, Building on Windows](../README.md#building-on-windows)
+- Building from source: [docs/bootstrap-from-source.md](../docs/bootstrap-from-source.md)
 - Main README: [README.md](../README.md)
+
+This file is the Docker guide; the two `docs/setup/` pages it used to point at
+were never in the tree.

--- a/docs/c-interop.md
+++ b/docs/c-interop.md
@@ -452,7 +452,9 @@ link_flags = ["-lsqlite3", "-lcurl", "-lm"]
 // SQLite C API
 extern sqlite3_open(path: string, db: ptr) -> int
 extern sqlite3_close(db: ptr) -> int
-extern sqlite3_exec(db: ptr, sql: string, callback: ptr, arg: ptr, errmsg: ptr) -> int
+// `callback` is a reserved word in Aether, so the parameter is named `cb`.
+// Parameter names are local to the declaration; the C symbol is unaffected.
+extern sqlite3_exec(db: ptr, sql: string, cb: ptr, arg: ptr, errmsg: ptr) -> int
 
 main() {
     db = 0  // Will hold database pointer
@@ -595,11 +597,14 @@ Both helpers accept either an `AetherString*` (the common case) or a raw `char*`
 The symmetric direction, Aether code passing a `string` value to a C extern declared `const char*` is handled by the codegen automatically. When the call site has the form:
 
 ```aether
+import std.encoding
+import std.string
+
 extern probe_consume(content: string, len: int) -> int
 
 main() {
-    raw, raw_len, _ = cryptography.base64_decode("QUI=")  // returns AetherString*
-    probe_consume(raw, raw_len)                            // C side gets payload, not header
+    raw, _ = encoding.base64_decode("QUI=")      // an AetherString
+    probe_consume(raw, string.length(raw))       // C side gets the payload, not the header
 }
 ```
 
@@ -651,7 +656,7 @@ extern do_thing(aether_msg: @aether string,
 **When to reach for it:**
 
 - Calling a function exported via `export foo(s: string) { ... }` from another `.ae` file linked into the same binary.
-- The caller's value is binary content (contains NULs, returned from `bytes.finish` / `cryptography.base64_decode` / `fs.read_binary` / etc.) and the receiver needs to see the full length, not the strlen-truncated prefix.
+- The caller's value is binary content (contains NULs, returned from `bytes.finish` / `encoding.base64_decode` / `fs.read_binary` / etc.) and the receiver needs to see the full length, not the strlen-truncated prefix.
 
 **When NOT to reach for it:**
 

--- a/docs/stdlib-api.md
+++ b/docs/stdlib-api.md
@@ -29,7 +29,7 @@ Functions are called using **namespace-style syntax**: `namespace.function()`
 | `import std.path` | `path` | `path.join("a", "b")`, `path.dirname("/a/b")` |
 | `import std.tar` | `tar` | `tar.reader_open("src.tar")`, `tar.extract("src.tar", "out", opts)` |
 | `import std.json` | `json` | `json.parse(str)`, `json.create_object()` |
-| `import std.cryptography` | `cryptography` | `cryptography.sha256_hex(data, n)`, `cryptography.base64_encode(data, n)` |
+| `import std.cryptography` | `cryptography` | `cryptography.sha256_hex(data, n)`, `cryptography.hash_hex(algo, data, n)` |
 | `import std.http` | `http` | `http.get(url)`, `http.server_create(port)` |
 | `import std.tcp` | `tcp` | `tcp.connect(host, port)`, `tcp.write(sock, data)` |
 | `import std.list` | `list` | `list.new()`, `list.add(l, item)` |
@@ -547,15 +547,18 @@ These are absent because no downstream user has driven the need yet. If you're s
 
 ## Cryptography Library
 
-Hash digests + Base64 codec. Built on OpenSSL's EVP API. When OpenSSL isn't linked, every wrapper returns `("", "openssl unavailable")` rather than crashing.
+Hash digests, built on OpenSSL's EVP API. When OpenSSL isn't linked, every
+wrapper returns `("", "openssl unavailable")` rather than crashing. Base64 is
+next door in `std.encoding`.
 
 ```aether
 import std.cryptography
+import std.encoding
 
 main() {
     digest, _ = cryptography.sha256_hex("abc", 3)
-    b64,    _ = cryptography.base64_encode("\x01\x02\x03", 3)
-    raw, n, _ = cryptography.base64_decode(b64)
+    b64     = encoding.base64_encode("\x01\x02\x03", 3)
+    raw, _  = encoding.base64_decode(b64)
 }
 ```
 
@@ -585,9 +588,12 @@ main() {
 
 ### Base64 (RFC 4648 §4 standard alphabet)
 
-- `cryptography.base64_encode(data, length)` → `(string, string)` - Encode `length` bytes, **unpadded** output.
-- `cryptography.base64_encode_padded(data, length)` → `(string, string)` - Encode `length` bytes, **with `=` padding** to a multiple of 4. For wire formats (auth headers, JSON-encoded blobs) that require padded output.
-- `cryptography.base64_decode(b64)` → `(string, int, string)` - Decode. Returns `(bytes, byte_count, "")` on success, `bytes` is an AetherString preserving embedded NULs. Accepts both padded and unpadded input.
+Base64 lives in `std.encoding`, not here; `std.cryptography` keeps only
+`random_base64`, which is crypto-random bytes rendered as base64.
+
+- `encoding.base64_encode(data, length)` → `string` - Encode `length` bytes, **unpadded** output.
+- `encoding.base64_encode_padded(data, length)` → `string` - Encode `length` bytes, **with `=` padding** to a multiple of 4. For wire formats (auth headers, JSON-encoded blobs) that require it.
+- `encoding.base64_decode(b64)` → `string!` - Decode, destructured as `(bytes, err)`. Accepts padded and unpadded input; `bytes` is an AetherString preserving embedded NULs.
 
 ### What's not in `std.cryptography`
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -1,6 +1,84 @@
 # Aether Standard Library Reference
 
-Complete reference for Aether's standard library modules.
+Reference for Aether's standard library. The index lists every module that
+ships, with its purpose and export count taken from the source rather than
+maintained by hand, so it cannot drift out of step with the tree. The sections
+after it cover the most-used modules in depth; for the others the index links
+to the module source, whose header comment is the authoritative description.
+
+## Module index (69 modules)
+
+| Module | Purpose | Exports | Detail |
+|---|---|---:|---|
+| `std.actors` | Process-global name → actor_ref registry. | 12 | [module source](../std/actors/module.ae) |
+| `std.alloc` | std.alloc (#1045): swappable allocator convention. | 6 | [module source](../std/alloc/module.ae) |
+| `std.arena` | Arena (bulk) allocator. | 14 | [module source](../std/arena/module.ae) |
+| `std.audio` | Audio playback (v1: playback tier). | 23 | [module source](../std/audio/module.ae) |
+| `std.audit` | Query the sandbox audit trail. | 15 | [module source](../std/audit/module.ae) |
+| `std.bignum` | Arbitrary-precision integers. | 25 | [module source](../std/bignum/module.ae) |
+| `std.bits` | Unsigned-bit helpers. | 34 | [module source](../std/bits/module.ae) |
+| `std.bytes` | Mutable byte buffer with random-access write and overlap-safe forward copy_within. | 50 | [module source](../std/bytes/module.ae) |
+| `std.capsicum` | FreeBSD Capsicum capability-mode bindings. | 26 | [module source](../std/capsicum/module.ae) |
+| `std.cas` | Content-addressed artifact store. | 21 | [module source](../std/cas/module.ae) |
+| `std.casper` | FreeBSD Casper service delegation. | 22 | [module source](../std/casper/module.ae) |
+| `std.cbor` | CBOR (RFC 8949) encode and decode. | 45 | [module source](../std/cbor/module.ae) |
+| `std.clapae` | Command-line argument parser, modelled on clap. | 32 | [module source](../std/clapae/module.ae) |
+| `std.collections` | Collections Module Import with: import std.collections. | 43 | [module source](../std/collections/module.ae) |
+| `std.config` | Process-global immutable string→string KV store. | 12 | [module source](../std/config/module.ae) |
+| `std.cryptography` | Cryptographic hash primitives + Base64 codec Import with: import std.cryptography. | 46 | [full section](#cryptography-stdcryptography) |
+| `std.deque` | A fixed-capacity double-ended queue / ring buffer of `long` values (a `long` holds any int, and a pointer via. | 14 | [module source](../std/deque/module.ae) |
+| `std.dir` | Directory Operations (alias for std.fs). | 11 | [module source](../std/dir/module.ae) |
+| `std.dl` | Cross-platform dynamic library loader. | 8 | [module source](../std/dl/module.ae) |
+| `std.encoding` | General-purpose binary/text encodings. | 11 | [module source](../std/encoding/module.ae) |
+| `std.file` | File Operations (alias for std.fs). | 14 | [module source](../std/file/module.ae) |
+| `std.floatarr` | Fixed-size packed-double buffer (float twin of std.intarr). | 13 | [module source](../std/floatarr/module.ae) |
+| `std.fs` | File System Module Import with: import std.fs. | 147 | [module source](../std/fs/module.ae) |
+| `std.hash` | Fast NON-cryptographic hashes for checksums and hashmap seeding. | 4 | [module source](../std/hash/module.ae) |
+| `std.host` | Primitives for Aether scripts embedded in a host application. | 17 | [module source](../std/host/module.ae) |
+| `std.http` | HTTP Client & Server (alias for std.net). | 142 | [module source](../std/http/module.ae) |
+| `std.http1` | Pure-Aether HTTP/1.1 response reader (RFC 9112). | 20 | [module source](../std/http1/module.ae) |
+| `std.intarr` | Fixed-size packed-int buffer (alias for std.collections). | 13 | [module source](../std/intarr/module.ae) |
+| `std.io` | Input/Output Module Import with: import std.io. | 43 | [full section](#io-stdio) |
+| `std.ipc` | Child-to-parent back-channel IPC. | 4 | [module source](../std/ipc/module.ae) |
+| `std.json` | JSON Module Import with: import std.json. | 54 | [full section](#json-stdjson) |
+| `std.ksuid` | KSUID (https://github.com/segmentio/ksuid). | 1 | [module source](../std/ksuid/module.ae) |
+| `std.language` | BCP 47 Language Tags and Matching (RFC 5646, RFC 4647). | 11 | [module source](../std/language/module.ae) |
+| `std.list` | ArrayList Operations (alias for std.collections). | 12 | [module source](../std/list/module.ae) |
+| `std.log` | Logging Module Import with: import std.log Log level constants. | 9 | [full section](#logging-stdlog) |
+| `std.longarr` | Fixed-size packed-long buffer (the 64-bit twin of std.intarr). | 13 | [module source](../std/longarr/module.ae) |
+| `std.lzf` | One-shot LZF compression/decompression. | 12 | [module source](../std/lzf/module.ae) |
+| `std.map` | HashMap Operations (alias for std.collections). | 14 | [module source](../std/map/module.ae) |
+| `std.math` | Math Module Import with: import std.math. | 31 | [full section](#math-stdmath) |
+| `std.mem` | Byte-level access to caller-allocated raw pointers. | 94 | [module source](../std/mem/module.ae) |
+| `std.message` | ICU MessageFormat + message catalog (Phase 3 of #863). | 8 | [module source](../std/message/module.ae) |
+| `std.msgpack` | MessagePack serialisation and deserialisation. | 35 | [module source](../std/msgpack/module.ae) |
+| `std.nanoid` | NanoID (https://github.com/ai/nanoid). | 2 | [module source](../std/nanoid/module.ae) |
+| `std.net` | Networking Module Import with: import std.net. | 69 | [module source](../std/net/module.ae) |
+| `std.number` | Locale-aware number, percent, and currency formatting (Phase 4 of #863). | 10 | [module source](../std/number/module.ae) |
+| `std.os` | Shell & Process Execution Import with: import std.os. | 75 | [full section](#os-stdos) |
+| `std.path` | Path Utilities. | 20 | [module source](../std/path/module.ae) |
+| `std.plural` | CLDR Plural Rules evaluation (Phase 2 of #863). | 2 | [module source](../std/plural/module.ae) |
+| `std.pqueue` | Priority queue over (priority, item) pairs. | 18 | [module source](../std/pqueue/module.ae) |
+| `std.regex` | Perl-compatible regular expressions (PCRE2-backed). | 12 | [module source](../std/regex/module.ae) |
+| `std.schema` | Declarative, typed data validation & coercion. | 46 | [module source](../std/schema/module.ae) |
+| `std.set` | Unordered set of unique strings. | 18 | [module source](../std/set/module.ae) |
+| `std.signal` | POSIX signal-number constants. | 11 | [module source](../std/signal/module.ae) |
+| `std.snapshot` | Copy-on-write snapshot cell for read-mostly shared data. | 5 | [module source](../std/snapshot/module.ae) |
+| `std.sort` | In-place ascending sort and binary search over the packed numeric array types. | 6 | [module source](../std/sort/module.ae) |
+| `std.strbuilder` | Amortised-O(1) string append. | 33 | [module source](../std/strbuilder/module.ae) |
+| `std.string` | String Module Import with: import std.string. | 92 | [full section](#strings-stdstring) |
+| `std.tar` | Streaming POSIX ustar TAR Archive Module Import with: import std.tar. | 24 | [full section](#posix-ustar-archives-stdtar) |
+| `std.tcp` | TCP Socket Operations (alias for std.net). | 24 | [module source](../std/tcp/module.ae) |
+| `std.time` | Civil date/time over Unix epoch seconds (UTC). | 19 | [module source](../std/time/module.ae) |
+| `std.tracking` | std.tracking (#1049): leak-detecting allocator wrapper. | 5 | [module source](../std/tracking/module.ae) |
+| `std.tsid` | TSID (Twitter Snowflake family / Discord-shaped). | 1 | [module source](../std/tsid/module.ae) |
+| `std.ulid` | ULID (https://github.com/ulid/spec). | 1 | [module source](../std/ulid/module.ae) |
+| `std.url` | RFC 3986 percent-encoding + query-string parsing (#629). | 7 | [module source](../std/url/module.ae) |
+| `std.uuid` | UUID v4 and v7 (RFC 9562). | 2 | [module source](../std/uuid/module.ae) |
+| `std.worker` | Run blocking work off the loop thread, deliver the result back on it. | 19 | [module source](../std/worker/module.ae) |
+| `std.xml` | XML Module Import with: import std.xml. | 45 | [full section](#xml-stdxml) |
+| `std.yaml` | YAML Module Import with: import std.yaml. | 16 | [module source](../std/yaml/module.ae) |
+| `std.zlib` | One-shot zlib and gzip deflate/inflate. | 16 | [full section](#compression-stdzlib) |
 
 > **Note:** The standard library follows the canonical module pattern in [stdlib-module-pattern.md](stdlib-module-pattern.md), fallible operations expose a `_raw` extern plus a Go-style `(value, err)` Aether wrapper; pure/infallible operations stay raw without a suffix. See the [error handling example](../examples/basics/error-handling.ae) for how the pattern is used from user code, and [std/fs/module.ae](../std/fs/module.ae) for the reference implementation.
 
@@ -1002,7 +1080,7 @@ main() {
     if kind != script_gateway.KIND_OK {
         println("mount failed: ${msg}"); exit(1)
     }
-    http.server_listen(s)
+    http.server_start(s)
 }
 ```
 
@@ -1314,6 +1392,7 @@ crashing, callers should always check the error slot.
 
 ```aether
 import std.cryptography
+import std.encoding
 import std.fs
 
 main() {
@@ -1328,8 +1407,8 @@ main() {
     }
 
     // Base64, round-trip a binary payload through JSON.
-    b64, _   = cryptography.base64_encode("\x01\x02\x03", 3)   // "AQID"
-    raw, n, _ = cryptography.base64_decode(b64)                // 3 bytes
+    b64      = encoding.base64_encode("\x01\x02\x03", 3)       // "AQID"
+    raw, _   = encoding.base64_decode(b64)                     // 3 bytes
 }
 ```
 
@@ -1362,9 +1441,13 @@ main() {
 - `cryptography.digest_free(ctx)` - Abandon a context without finalizing (NULL-safe). Only for the bail-out-before-final case.
 
 **Base64 (RFC 4648 §4 standard alphabet):**
-- `cryptography.base64_encode(data, length)` → `(string, string)` - Encode `length` bytes, **unpadded** output.
-- `cryptography.base64_encode_padded(data, length)` → `(string, string)` - Encode `length` bytes, **with `=` padding** to a multiple of 4. Reach for this when the wire format on the other end expects padded base64, most non-strict decoders accept either, but some auth headers and JSON-encoded blob formats explicitly require padding.
-- `cryptography.base64_decode(b64)` → `(string, int, string)` - Decode a Base64 string. Returns `(bytes, byte_count, "")` on success, `("", 0, error)` on malformed input. Accepts both padded and unpadded input; `bytes` is an AetherString preserving embedded NULs.
+- `encoding.base64_encode(data, length)` → `string` - Encode `length` bytes, **unpadded** output.
+- `encoding.base64_encode_padded(data, length)` → `string` - Encode `length` bytes, **with `=` padding** to a multiple of 4. Reach for this when the wire format on the other end requires padding; most non-strict decoders accept either.
+- `encoding.base64_decode(b64)` → `string!` - Decode, destructured as `(bytes, err)`. `err` is non-empty on malformed input. Accepts both padded and unpadded input; `bytes` is an AetherString preserving embedded NULs.
+
+Base64 lives in `std.encoding`, not `std.cryptography`: encoding is not a
+security primitive, and the split keeps that honest. `std.cryptography` keeps
+`random_base64`, which is crypto-random bytes rendered as base64.
 
 **What `std.cryptography` doesn't do:**
 

--- a/docs/tutorials/02-functions-and-control-flow.md
+++ b/docs/tutorials/02-functions-and-control-flow.md
@@ -419,23 +419,23 @@ end.
 ### Example 4: Prime Number Check
 
 ```aether
-is_prime(n) {
+is_prime(n: int) -> bool {
     if (n < 2) {
-        return 0  // false
+        return false
     }
-    
+
     for (i = 2; i < n; i = i + 1) {
         if (n / i * i == n) {
-            return 0  // divisible, not prime
+            return false  // divisible, not prime
         }
     }
-    
-    return 1  // prime
+
+    return true
 }
 
 main() {
     numbers = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    
+
     for (i = 0; i < 10; i = i + 1) {
         num = numbers[i]
         if (is_prime(num)) {

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -177,10 +177,15 @@ int string_length(const void* str) {
     return (int)str_len(str);
 }
 
-char string_char_at(const void* str, int index) {
+int string_char_at(const void* str, int index) {
     size_t len = str_len(str);
-    if (!str || index < 0 || index >= (int)len) return '\0';
-    return str_data(str)[index];
+    if (!str || index < 0 || index >= (int)len) return 0;
+    /* Unsigned: a byte >= 0x80 used to come back sign-extended, so 0x85 read
+     * as -123 and every binary parser written against this silently broke on
+     * high bytes (#1516 found it through WebSocket framing). Returning int
+     * also matches what codegen emits for the prototype and what the stdlib
+     * extern declares; the old `char` return disagreed with both. */
+    return (int)(unsigned char)str_data(str)[index];
 }
 
 int string_equals(const void* a, const void* b) {
@@ -443,11 +448,11 @@ int string_length_n(const void* str, int known_length) {
  * NOT consult an AetherString header even if one is present. Same
  * miss-return convention as string_char_at ('\0' for out-of-range
  * and NULL input). */
-char string_char_at_n(const void* str, int known_length, int index) {
-    if (!str) return '\0';
-    if (known_length < 0) return '\0';
-    if (index < 0 || index >= known_length) return '\0';
-    return str_data(str)[index];
+int string_char_at_n(const void* str, int known_length, int index) {
+    if (!str) return 0;
+    if (known_length < 0) return 0;
+    if (index < 0 || index >= known_length) return 0;
+    return (int)(unsigned char)str_data(str)[index];
 }
 
 /* Length-aware index_of_from. Same motivation as string_char_at_n:

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -69,7 +69,8 @@ void string_free(const void* str);  // Alias for release
 AetherString* string_concat(const void* a, const void* b);
 AetherString* string_concat_wrapped(const void* a, const void* b);
 int string_length(const void* str);
-char string_char_at(const void* str, int index);
+/* The byte at `index` as 0..255, or 0 when out of range. */
+int string_char_at(const void* str, int index);
 int string_equals(const void* a, const void* b);
 int string_compare(const void* a, const void* b);
 
@@ -115,7 +116,7 @@ int string_length_n(const void* str, int known_length);
  * string-length-aware-accessors.md after avn's 5000-commit bench
  * showed 87%+ of CPU in __strlen_avx2 driven by string_char_at on
  * a multi-KB body whose length the caller had already cached. */
-char string_char_at_n(const void* str, int known_length, int index);
+int string_char_at_n(const void* str, int known_length, int index);
 
 /* Length-aware sibling of string_index_of_from. Same motivation as
  * string_char_at_n — caller has already computed `known_length`

--- a/tests/regression/test_char_at_high_bytes.ae
+++ b/tests/regression/test_char_at_high_bytes.ae
@@ -1,0 +1,64 @@
+// #1516: string.char_at must report a byte as 0..255.
+//
+// It returned a signed `char`, so 0x85 came back as -123. Every binary parser
+// written against it broke on bytes above 0x7F: contrib/tinyweb read a masked
+// WebSocket header, computed a negative payload length, and dropped the
+// connection instead of echoing the frame. The C definition also disagreed
+// with both the prototype codegen emits and the stdlib extern, which declare
+// int; only the implementation said char.
+
+import std.io
+import std.bytes
+import std.string
+
+check(got: int, want: int, label: string) -> int {
+    if got == want {
+        println("  PASS ${label} (${got})")
+        return 0
+    }
+    println("  FAIL ${label}: got ${got}, want ${want}")
+    return 1
+}
+
+main() {
+    println("=== char_at on bytes above 0x7F (#1516) ===")
+    failures = 0
+
+    b = bytes.new(8)
+    bytes.set(b, 0, 0)
+    bytes.set(b, 1, 65)
+    bytes.set(b, 2, 127)
+    bytes.set(b, 3, 128)
+    bytes.set(b, 4, 129)
+    bytes.set(b, 5, 133)
+    bytes.set(b, 6, 254)
+    bytes.set(b, 7, 255)
+    s = bytes.finish(b, 8)
+
+    failures = failures + check(string.char_at(s, 1), 65, "ASCII is unchanged")
+    failures = failures + check(string.char_at(s, 2), 127, "the last positive byte")
+    failures = failures + check(string.char_at(s, 3), 128, "the first high byte")
+    failures = failures + check(string.char_at(s, 4), 129, "0x81, a WebSocket FIN+text header")
+    failures = failures + check(string.char_at(s, 5), 133, "0x85, masked length 5")
+    failures = failures + check(string.char_at(s, 6), 254, "0xFE")
+    failures = failures + check(string.char_at(s, 7), 255, "0xFF")
+
+    // The length-aware sibling shares the implementation and the bug.
+    failures = failures + check(string.char_at_n(s, 8, 4), 129, "char_at_n agrees on 0x81")
+    failures = failures + check(string.char_at_n(s, 8, 7), 255, "char_at_n agrees on 0xFF")
+
+    // The arithmetic tinyweb does on a frame header, which is what a negative
+    // byte broke: mask bit set, payload length 5.
+    b1 = string.char_at(s, 5)
+    masked = b1 / 128
+    plen = b1 - (masked * 128)
+    failures = failures + check(masked, 1, "mask bit reads as set")
+    failures = failures + check(plen, 5, "payload length reads as 5")
+
+    println("")
+    if failures == 0 {
+        println("All PASS")
+    } else {
+        println("${failures} FAILURE(S)")
+    }
+}

--- a/tests/runtime/test_runtime_strings.c
+++ b/tests/runtime/test_runtime_strings.c
@@ -55,6 +55,22 @@ TEST_CATEGORY(string_char_at, TEST_CATEGORY_STDLIB) {
     ASSERT_EQ('H', string_char_at(s, 0));
     ASSERT_EQ('e', string_char_at(s, 1));
     ASSERT_EQ('o', string_char_at(s, 4));
+
+    /* Bytes >= 0x80 must come back as 0..255, not sign-extended. The function
+     * used to return `char`, so 0x85 read as -123 and every binary parser
+     * built on it broke on high bytes; WebSocket framing in contrib/tinyweb
+     * was the casualty that surfaced it (#1516). */
+    {
+        const char raw[] = { (char)0x81, (char)0x85, (char)0xFF, 0x41, 0 };
+        AetherString* hb = string_new_with_length(raw, 4);
+        ASSERT_EQ(129, string_char_at(hb, 0));
+        ASSERT_EQ(133, string_char_at(hb, 1));
+        ASSERT_EQ(255, string_char_at(hb, 2));
+        ASSERT_EQ(65,  string_char_at(hb, 3));
+        ASSERT_EQ(129, string_char_at_n(hb, 4, 0));
+        ASSERT_EQ(255, string_char_at_n(hb, 4, 2));
+        string_release(hb);
+    }
     string_free(s);
 }
 


### PR DESCRIPTION
Two bugs found by the audit, and the audit itself. Everything below was checked
against the code, and every corrected snippet was compiled.

## Bugs

**`string.char_at` reported bytes above 0x7F as negative.** It returned a signed
`char`, so 0x85 came back as -123:

```
before:  char_at(0)=-127  char_at(1)=-123
after:   char_at(0)=129   char_at(1)=133
```

Any binary parser built on it broke on high bytes. `contrib/tinyweb` read a
masked WebSocket header, computed a negative payload length and dropped the
connection instead of echoing the frame, which is how it surfaced. The C
definition also disagreed with the prototype codegen emits
(`codegen.c:4504` declares `int string_char_at(const char*, int)`) and with the
stdlib extern, both of which say `int`; only the implementation said `char`.

**`contrib/tinyweb` did not build at all.** `tw_start` declared no return type
and returned `-1` on one path and `http.server_start`'s string on another, so
the emitted C assigned an int to a `const char*`. Every tinyweb example and test
failed on that one line. It now declares `-> string`, returning `""` on success.
The examples then compared that result against `0`, which asks whether the
pointer is NULL and so never took the success branch; they compare against `""`
now.

Both halves of #1516 are fixed: `tinyweb/schema_api` builds and
`tinyweb/websocket` passes.

## Documentation audit

| Finding | Evidence |
|---|---|
| `stdlib-reference.md` claimed "Complete reference" | 37 of 69 shipped modules appeared in neither it nor `stdlib-api.md` |
| `http.server_listen` documented | No such function; it is `http.server_start` |
| `cryptography.base64_encode` / `base64_decode` documented | Neither exists. Base64 is `std.encoding`, returning `string` / `string!`, not the tuples described. `std.cryptography`'s own header already said "use `encoding.base64_*`" |
| c-interop SQLite extern | Used `callback` as a parameter name, a reserved word, so the declaration could not compile |
| Tutorial 02 | Taught `if (is_prime(num))` on an int-returning function, which the type checker rejects |
| 24 broken relative links | Two `docs/setup/` pages never in the tree, a missing `design/` path segment, a roadmap doc that does not exist |
| README | CI suite is 10 steps, not 9; `ae` list missing `inspect`, `bindgen`, `cflags`, `lib-path` |

The reference now opens with an index of **all 69 modules**, each with its
purpose and export count extracted from the module source, so it cannot drift
out of step with the tree the way the old hand-maintained list did.

The tutorial example was fixed to the idiomatic `-> bool` form and then compiled
and run:

```
2 is prime 3 is prime 5 is prime 7 is prime 11 is prime
```

The changelog archive's dead `contrib/aether_ui/` paths are deliberately left as
written, with a note that the UI library moved to a sibling repo: a changelog is
a record of what happened, not a live index.

## What this pass did not finish

Stated plainly rather than left implied. I compiled all 206 self-contained
`aether` blocks in `docs/` and the README; 57 failed before, 53 after. The
difference is small because most of the remainder are not defects: exercise
stubs with empty bodies, deliberate counter-examples marked `// Wrong`,
fragments that use a name defined in an earlier block, and `@c_import` examples
that need a C source to link. Separating those from real rot needs the blocks to
be marked for what they are, which is a change to how the docs are written, not
a fix. Filed as a follow-up rather than half-done here.

Likewise, 37 modules now have an accurate index entry but not a worked example
section. That is real remaining work and is filed, not hidden.

## Verification

- 230/230 C unit tests, including new coverage asserting `char_at` and
  `char_at_n` return 0..255 for 0x80, 0x81, 0x85, 0xFE and 0xFF.
- `tests/regression/test_char_at_high_bytes.ae` fails against the old
  implementation (`got -128, want 128` and four more) and passes after.
- Full `.ae` suite: 977 passed, 9 failed, all in the known local-environment set.
- 89/89 examples; `fmt_gate` clean.
- `make contrib-check`: `tinyweb/schema_api` and `tinyweb/websocket` both pass.

Closes #1516
