### PR TITLE
test(worker): wait on time, not on a spin count, so Windows CI stops flaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`test_worker` flaked on Windows CI** with "detached worker drained pending".
+  The test waited for the pool thread by counting iterations rather than time,
+  and hot-spun on `worker.drain(0)` while it counted. Two million mutex-takes
+  elapse in a fraction of a second, so on a two-core runner the cap could expire
+  before the pool thread was ever scheduled, and the spinning was itself part of
+  why it was not scheduled. The waits are now bounded by wall-clock time and
+  sleep between polls, so the test stops competing with the thread it is waiting
+  for. The comment above the loop already described this flake; it is now fixed
+  rather than described.
+
 ## [0.522.0]
 
 ### Fixed

--- a/tests/regression/test_worker.ae
+++ b/tests/regression/test_worker.ae
@@ -31,6 +31,27 @@ fn ck(cond: bool, msg: string) -> int {
     return 0
 }
 
+// Wait for the worker pool to finish, bounded by TIME rather than by a spin
+// count. The old loops counted iterations, but what they are waiting for is the
+// pool thread being scheduled, which is wall-clock. On a two-core Windows
+// runner 2,000,000 mutex-takes elapse in a fraction of a second, so the cap
+// could expire before the pool thread ever ran: the "detached worker drained
+// pending" flake. sleep() between polls also stops this thread competing with
+// the one it is waiting for, which is what starved it.
+wait_drained(timeout_ms: int) -> int {
+    waited = 0
+    while worker.pending() > 0 && waited < timeout_ms {
+        _ = worker.drain(0)
+        sleep(1)
+        waited = waited + 1
+    }
+    _ = worker.drain(0)
+    if worker.pending() == 0 {
+        return 1
+    }
+    return 0
+}
+
 main() {
     fails = 0
     t = bytes.new(4) // shared tally buffer
@@ -69,11 +90,7 @@ main() {
 
     // Pump until the completion has been delivered. drain() runs completions on
     // THIS thread; spin until pending() drains.
-    spins = 0
-    while worker.pending() > 0 && spins < 10000000 {
-        _ = worker.drain(0)
-        spins = spins + 1
-    }
+    wait_drained(10000)
     fails = fails + ck(bytes.get(t, 0) == 1, "one completion delivered")
     fails = fails + ck(bytes.get(t, 1) == 9, "captured heap string length read off-thread (9)")
     fails = fails + ck(bytes.get(t, 2) == 100, "result marker carried to done")
@@ -98,11 +115,7 @@ main() {
         )
         n = n + 1
     }
-    spins = 0
-    while worker.pending() > 0 && spins < 10000000 {
-        _ = worker.drain(0)
-        spins = spins + 1
-    }
+    wait_drained(10000)
     fails = fails + ck(bytes.get(t, 0) == 16, "all 16 concurrent completions delivered")
 
     // ---- detached worker: runs, no post-back, nothing to drain ----
@@ -116,17 +129,8 @@ main() {
     )
     fails = fails + ck(d_ok, "detached worker launched")
     // Wait for the detached pool thread to run its closure and self-decrement
-    // pending. A pure busy-spin on this thread can STARVE the pool thread on a
-    // contended/slow CI runner (both threads hot) so the fixed spin cap
-    // expired before the worker was scheduled — the "detached worker drained
-    // pending" flake on Windows CI. worker.drain(0) takes the worker mutex each
-    // call, yielding a scheduling point so the pool thread makes progress; the
-    // bound is large but the yield means we almost never approach it.
-    spins = 0
-    while worker.pending() > 0 && spins < 2000000 {
-        worker.drain(0)
-        spins = spins + 1
-    }
+    // pending.
+    wait_drained(10000)
     fails = fails + ck(worker.pending() == 0, "detached worker drained pending")
 
     bytes.free(t)


### PR DESCRIPTION
`test_worker` failed on the **MINGW64** leg with `detached worker drained
pending`, while **UCRT64 passed on the same commit**. Same code, same runner
image, different result: a timing flake, not a defect in the worker pool.

## Cause

All three waits in the test counted iterations for something that depends on
wall-clock scheduling:

```aether
spins = 0
while worker.pending() > 0 && spins < 2000000 {
    worker.drain(0)
    spins = spins + 1
}
```

Each iteration takes the worker mutex, so two million of them elapse in a
fraction of a second. On a two-core runner the cap can expire before the pool
thread is scheduled even once. Worse, the loop is hot: it keeps a core busy
competing with the very thread it is waiting for.

The comment above that loop already described this flake, and an earlier attempt
to mitigate it by using `drain(0)` as a yield point. That was not enough,
because the bound stayed in iterations.

## Fix

One helper, used by all three waits, bounded by time and sleeping between polls
so the pool thread gets the core:

```aether
wait_drained(timeout_ms: int) -> int {
    waited = 0
    while worker.pending() > 0 && waited < timeout_ms {
        _ = worker.drain(0)
        sleep(1)
        waited = waited + 1
    }
    _ = worker.drain(0)
    if worker.pending() == 0 { return 1 }
    return 0
}
```

The assertions after each wait are unchanged, so a pool that genuinely fails to
drain still fails the test; only the patience is now measured in the same units
as the thing being waited for. Normal completion is a millisecond or two.

## Verification

- Six consecutive local runs pass.
- 230/230 C unit tests; `fmt_gate` clean.

Honest limit: the flake only reproduces on a contended Windows runner, so local
runs cannot prove it gone. The argument is structural: a ten-second wall-clock
bound cannot expire before a healthy pool thread is scheduled, and the test no
longer burns a core while waiting.
