### PR TITLE
Nightly-box fixes: -llz4 for distro Racket CS embeds; install-prefix override for coverage smoke

### DIFF
--- a/tests/integration/ci_coverage_smoke/test_ci_coverage_smoke.sh
+++ b/tests/integration/ci_coverage_smoke/test_ci_coverage_smoke.sh
@@ -27,10 +27,16 @@ fi
 # its own location; for this test we just need libaether.a + headers.
 # Skip if we can't find a complete install — the coverage path is
 # only meaningful after `make install`.
-PREFIX="$HOME/.local"
+# AETHER_INSTALL_PREFIX overrides where that install is looked for: CI/
+# nightly boxes install the just-built tree to a dedicated prefix (e.g.
+# ~/.nightlyAether) so this test never links fresh codegen against
+# whatever stale toolchain happens to live in ~/.local — that mismatch
+# presents as `undefined reference to string_alloc_inline` here while
+# the tree itself is fine.
+PREFIX="${AETHER_INSTALL_PREFIX:-$HOME/.local}"
 if [ ! -f "$PREFIX/lib/aether/libaether.a" ] || \
    [ ! -d "$PREFIX/include/aether" ]; then
-    echo "  [SKIP] ci_coverage_smoke: no install at $PREFIX (run 'make install PREFIX=\$HOME/.local')"
+    echo "  [SKIP] ci_coverage_smoke: no install at $PREFIX (run 'make install PREFIX=$PREFIX')"
     exit 0
 fi
 

--- a/tests/integration/host_racket/test_host_racket.sh
+++ b/tests/integration/host_racket/test_host_racket.sh
@@ -71,6 +71,14 @@ for d in $(find "$ROOT/runtime" "$ROOT/std" -type d 2>/dev/null); do
 done
 RKLIBS="-lm -ldl -lpthread -lrt -lncurses -lz"
 [ "$(uname -s)" = "Darwin" ] && RKLIBS="-lm -ldl -lpthread -lncurses -lz"
+# Distro-packaged Racket CS 9.x (e.g. Arch racket 9.2) links ChezScheme's
+# compress-io against the SYSTEM liblz4, leaving LZ4F_*/LZ4_* undefined in
+# libracketcs.a; a self-built tree bundles lz4 and has none. Probe the
+# archive and link what it actually needs, so both kinds keep working.
+if command -v nm >/dev/null 2>&1 && \
+        nm "$AETHER_RACKET_LIB" 2>/dev/null | grep -q ' U LZ4'; then
+    RKLIBS="$RKLIBS -llz4"
+fi
 if ! $CC -O2 -I"$ROOT" $INCS -I"$AETHER_RACKET_INCLUDE" \
         "$GEN_C" "$TMPDIR_T/host_racket.o" "$ROOT/build/libaether.a" \
         "$AETHER_RACKET_LIB" -rdynamic $RKLIBS \

--- a/tests/integration/host_rhombus/test_host_rhombus.sh
+++ b/tests/integration/host_rhombus/test_host_rhombus.sh
@@ -61,6 +61,12 @@ for d in $(find "$ROOT/runtime" "$ROOT/std" -type d 2>/dev/null); do
 done
 RKLIBS="-lm -ldl -lpthread -lrt -lncurses -lz"
 [ "$(uname -s)" = "Darwin" ] && RKLIBS="-lm -ldl -lpthread -lncurses -lz"
+# Distro-packaged Racket CS 9.x references the system liblz4 (see the
+# identical probe in test_host_racket.sh for the full story).
+if command -v nm >/dev/null 2>&1 && \
+        nm "$AETHER_RACKET_LIB" 2>/dev/null | grep -q ' U LZ4'; then
+    RKLIBS="$RKLIBS -llz4"
+fi
 if ! $CC -O2 -I"$ROOT" $INCS -I"$AETHER_RACKET_INCLUDE" \
         "$GEN_C" "$TMPDIR_T/host_racket.o" "$ROOT/build/libaether.a" \
         "$AETHER_RACKET_LIB" -rdynamic $RKLIBS \


### PR DESCRIPTION
Fixes two of the four failures inside the CachyOS nightly's red `make ci` step (2026-08-14 RESULTS.md).

## host_racket / host_rhombus: `-llz4` when the archive needs it

Arch's `racket 9.2` package links ChezScheme's `compress-io` against the **system** liblz4, leaving 11 undefined `LZ4F_*`/`LZ4_*` references in `/usr/lib/libracketcs.a`; a self-built embedding tree bundles lz4 and has none. The embed link line in both host tests now probes the archive with `nm` and appends `-llz4` only when it actually carries external LZ4 refs — so distro and self-built packagings both link.

Verified on the nightly box itself (Arch racket 9.2): link failure gone, and with the box's env now also providing `AETHER_RACKET_COLLECTS`/`AETHER_RACKET_CONFIG` (distro racket needs its system collects to boot — added to the nightly's systemd unit) plus a user-scope `raco pkg install rhombus`, **both tests fully PASS** end-to-end there.

## ci_coverage_smoke: `AETHER_INSTALL_PREFIX` override

The test hardcoded `$HOME/.local` as the install it exercises, silently linking **fresh** `aetherc` codegen against whatever stale toolchain lives there — presenting as `undefined reference to string_alloc_inline` while the tree is fine. Reproduced identically on the dev box and the nightly box, both with months-old installs; against a fresh install it passes.

`AETHER_INSTALL_PREFIX` now overrides the location (default unchanged). The nightly script gains a `make install PREFIX=$HOME/.nightlyAether` step before `make ci` and exports the override, so the coverage test always exercises the tree under test and the box's real installs stay untouched.

(The remaining two nightly failures are tracked separately: `version_stamp` is the `ae --version`-reads-`~/.aether/active_version` semantic, and the fourth was the same coverage failure counted here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)