### PR TITLE
Wycheproof wave 4: RSA decrypt families — unreduced-ciphertext malleability fixed (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+- Wycheproof wave 4 (#739): RSA decryption families — RSAES-PKCS#1 v1.5
+  (67 Bleichenbacher-shaped cases) and RSA-OAEP 2048/SHA-256 (37 Manger-
+  shaped cases; the 8 labelled cases are counted-skipped — `decrypt_oaep`
+  has no label parameter yet). Own CI suite slot: every case is a
+  private-key modexp.
+
+### Fixed
+- `std.cryptography.rsa`: `decrypt_oaep` and `decrypt_pkcs1` accepted
+  UNREDUCED ciphertexts — c + n decrypts identically after the mod-n
+  exponentiation (the ciphertext-side twin of 0.535.0's signature
+  malleability fix; RFC 8017 §7.1.2/§7.2.2 step 1 requires exactly
+  k octets with c < n). The existing range gate now guards both decrypt
+  paths. Caught by Wycheproof rsa_oaep tcId 27 ("added n to c").
+
 ## [0.536.0]
 
 ### Added

--- a/std/cryptography/rsa/module.ae
+++ b/std/cryptography/rsa/module.ae
@@ -210,6 +210,9 @@ encrypt_pkcs1(k: ptr, msg: ptr) -> (ptr, string) {
 // (null, err). (Not constant-time — a hardening follow-up.)
 decrypt_pkcs1(k: ptr, ct: ptr) -> (ptr, string) {
     klen = modulus_bytes(k)
+    if sig_in_range(k, ct) != 1 {
+        return null, "ciphertext out of range"
+    }
     block = raw_decrypt(k, ct)
     // expect 0x00 0x02 PS 0x00 M
     ok = 1
@@ -263,11 +266,12 @@ sign_pkcs1(k: ptr, di: ptr) -> (ptr, string) {
     return s, ""
 }
 
-// RFC 8017 §8.2.2 step 1: the signature must be EXACTLY k octets and its
-// integer value must be < n. raw_encrypt reduces mod n, so without this
-// check s+n (a distinct byte string, same residue) verifies too —
-// signature malleability, caught by Wycheproof rsa_signature tcId 244
-// ("the signature is not reduced").
+// RFC 8017 range gate, used for BOTH signatures (§8.2.2 step 1) and
+// ciphertexts (§7.1.2/§7.2.2 step 1): the input must be EXACTLY k octets
+// and its integer value must be < n. The raw modexp reduces mod n, so
+// without this check s+n / c+n (distinct byte strings, same residue)
+// verify/decrypt identically — malleability, caught by Wycheproof
+// rsa_signature tcId 244 and rsa_oaep tcId 27 ("added n to c").
 sig_in_range(k: ptr, sig: ptr) -> int {
     kk = k as *RsaKey
     if bytes.length(sig) != modulus_bytes(k) { return 0 }
@@ -421,6 +425,9 @@ decrypt_oaep(k: ptr, ct: ptr) -> {
     hlen = oaep_hlen()
     if bytes.length(ct) != klen {
         return null, "ciphertext length mismatch"
+    }
+    if sig_in_range(k, ct) != 1 {
+        return null, "ciphertext out of range"
     }
     if klen < 2 * hlen + 2 {
         return null, "modulus too small for OAEP"

--- a/tests/integration/wycheproof/test_wycheproof_rsa_decrypt.sh
+++ b/tests/integration/wycheproof/test_wycheproof_rsa_decrypt.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Wycheproof adversarial vector suites — RSA decryption families.
+#
+# Own harness slot (180s per-test budget): each case is a full-size
+# private-key modexp (~1-2s at CI's -O0), unlike the cheap public-op
+# verify families in test_wycheproof_asym.sh.
+#   rsaes-pkcs1 2048   full 67 cases  (Bleichenbacher padding shapes)
+#   rsa-oaep 2048      full 37 cases  (Manger shapes; 8 label cases
+#                      counted-skipped: decrypt_oaep has no label param)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$ROOT" || exit 1
+
+AE="$ROOT/build/ae"
+[ -n "${EXE_EXT:-}" ] && AE="$AE$EXE_EXT"
+[ -x "$AE" ] || { echo "  [FAIL] wycheproof_rsa_decrypt: build/ae missing (run make)"; exit 1; }
+
+rc=0
+for drv in wp_rsa_decrypt_pkcs1 wp_rsa_oaep; do
+    out="$("$AE" run "tests/integration/wycheproof/$drv.ae" 2>&1)"
+    if printf '%s' "$out" | grep -q "^ALL PASS"; then
+        printf '%s\n' "$out" | grep "^wycheproof" | sed 's/^/  [PASS] /'
+    else
+        echo "  [FAIL] wycheproof $drv:"
+        printf '%s\n' "$out" | tail -12 | sed 's/^/        /'
+        rc=1
+    fi
+done
+exit $rc

--- a/tests/integration/wycheproof/wp_rsa_decrypt_pkcs1.ae
+++ b/tests/integration/wycheproof/wp_rsa_decrypt_pkcs1.ae
@@ -1,0 +1,143 @@
+// Wycheproof adversarial vectors — RSAES-PKCS#1 v1.5 decrypt (#739).
+//
+// RsaesPkcs1Decrypt schema: 2048-bit key, private key from the vector.
+// The Bleichenbacher family: mangled 00 02 padding, wrong prefixes,
+// short padding, ciphertext out of range — all must fail uniformly.
+//   "valid"   -> decrypt MUST succeed and yield msg.
+//   "invalid" -> decrypt MUST fail.
+
+import std.cryptography.rsa
+import std.bignum
+import std.fs
+import std.json
+import std.bytes
+import std.string
+import std.io
+
+extern exit(code: int)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+extern string_length(s: string) -> int
+
+fn hexval(h: int) -> int {
+    if h >= 48 && h <= 57 { return h - 48 }
+    if h >= 97 && h <= 102 { return h - 87 }
+    if h >= 65 && h <= 70 { return h - 55 }
+    return 0
+}
+
+fn from_hex(s: string) -> ptr {
+    slen = string_length(s)
+    n = slen / 2
+    b = bytes.new(n)
+    if n == 0 { return b }
+    i = 0
+    while i < n {
+        hi = hexval(string_char_at_n(s, slen, i * 2))
+        lo = hexval(string_char_at_n(s, slen, i * 2 + 1))
+        bytes.set(b, i, (hi << 4) | lo)
+        i = i + 1
+    }
+    return b
+}
+
+// DER DigestInfo for SHA-256: 19-byte fixed prefix + 32-byte hash
+// (mirrors sha256_digestinfo in std.cryptography.tls13_cert).
+fn sha256_digestinfo(hash32: ptr) -> ptr {
+    di = bytes.new(51)
+    pfx = from_hex("3031300d060960864801650304020105000420")
+    i = 0
+    while i < 19 { bytes.set(di, i, bytes.get(pfx, i)) i = i + 1 }
+    i = 0
+    while i < 32 { bytes.set(di, 19 + i, bytes.get(hash32, i)) i = i + 1 }
+    bytes.free(pfx)
+    return di
+}
+
+main() {
+    doc, ferr = fs.read("tests/vectors/wycheproof/rsa_pkcs1_2048_test.json")
+    if ferr != "" {
+        println("FAIL: cannot read vector file: ${ferr}")
+        exit(1)
+    }
+    root, jerr = json.parse(doc)
+    if jerr != "" {
+        println("FAIL: vector JSON parse: ${jerr}")
+        exit(1)
+    }
+
+    groups = json.json_object_get_raw(root, "testGroups")
+    ngroups = json.array_size(groups)
+
+    passed = 0
+    rejected_invalid = 0
+    failed = 0
+    gi = 0
+    while gi < ngroups {
+        g = json.array_get_raw(groups, gi)
+        pkobj = json.json_object_get_raw(g, "privateKey")
+        mod_hex = json.json_get_string_raw(json.json_object_get_raw(pkobj, "modulus"))
+        exp_hex = json.json_get_string_raw(json.json_object_get_raw(pkobj, "publicExponent"))
+        d_hex = json.json_get_string_raw(json.json_object_get_raw(pkobj, "privateExponent"))
+        mb = from_hex(mod_hex)
+        eb = from_hex(exp_hex)
+        db = from_hex(d_hex)
+        n = bignum.from_bytes_unsigned(mb, string_length(mod_hex) / 2)
+        e = bignum.from_bytes_unsigned(eb, string_length(exp_hex) / 2)
+        dd = bignum.from_bytes_unsigned(db, string_length(d_hex) / 2)
+        bytes.free(mb)
+        bytes.free(eb)
+        bytes.free(db)
+        k = rsa.key_from_components(n, e, dd)
+
+        tests = json.json_object_get_raw(g, "tests")
+        nt = json.array_size(tests)
+        ti = 0
+        while ti < nt {
+            t = json.array_get_raw(tests, ti)
+            tc_id = json.json_get_int(json.json_object_get_raw(t, "tcId"))
+            res = json.json_get_string_raw(json.json_object_get_raw(t, "result"))
+            msg_hex = json.json_get_string_raw(json.json_object_get_raw(t, "msg"))
+            ct_hex = json.json_get_string_raw(json.json_object_get_raw(t, "ct"))
+            ct = from_hex(ct_hex)
+            pt, derr = rsa.decrypt_pkcs1(k, ct)
+            if res == "valid" {
+                if pt == null {
+                    println("FAIL tcId=${tc_id} (valid): decrypt rejected: ${derr}")
+                    failed = failed + 1
+                } else {
+                    want = from_hex(msg_hex)
+                    want_len = string_length(msg_hex) / 2
+                    good = 1
+                    if bytes.length(pt) != want_len { good = 0 }
+                    if good == 1 {
+                        i2 = 0
+                        while i2 < want_len {
+                            if bytes.get(pt, i2) != bytes.get(want, i2) { good = 0 }
+                            i2 = i2 + 1
+                        }
+                    }
+                    if good == 1 { passed = passed + 1 } else {
+                        println("FAIL tcId=${tc_id} (valid): plaintext mismatch")
+                        failed = failed + 1
+                    }
+                    bytes.free(want)
+                    bytes.free(pt)
+                }
+            } else {
+                if pt == null { rejected_invalid = rejected_invalid + 1 } else {
+                    println("FAIL tcId=${tc_id} (invalid): decrypt ACCEPTED mangled padding")
+                    failed = failed + 1
+                    bytes.free(pt)
+                }
+            }
+            bytes.free(ct)
+            ti = ti + 1
+        }
+        rsa.key_free(k)
+        gi = gi + 1
+    }
+
+    println("wycheproof rsaes_pkcs1_2048: ${passed} valid ok, ${rejected_invalid} invalid rejected, ${failed} failed")
+    if failed > 0 { exit(1) }
+    println("ALL PASS")
+}

--- a/tests/integration/wycheproof/wp_rsa_oaep.ae
+++ b/tests/integration/wycheproof/wp_rsa_oaep.ae
@@ -1,0 +1,156 @@
+// Wycheproof adversarial vectors — RSA-OAEP decrypt (#739).
+//
+// RsaesOaepDecrypt schema: 2048-bit key, SHA-256, MGF1-SHA256, empty
+// label. Exercises the DECRYPTION side (private key from the vector):
+// mangled padding, modified lHash/seed, ciphertext out of range —
+// Manger-attack-shaped inputs that must all fail uniformly.
+//   "valid"   -> decrypt MUST succeed and yield msg.
+//   "invalid" -> decrypt MUST fail.
+// Cases with a non-empty label are counted skipped-unsupported:
+// decrypt_oaep has no label parameter (empty lHash hardcoded) — an API
+// gap noted in #739, not silently dropped.
+
+import std.cryptography.rsa
+import std.bignum
+import std.fs
+import std.json
+import std.bytes
+import std.string
+import std.io
+
+extern exit(code: int)
+extern string_char_at_n(str: string, known_length: int, index: int) -> int
+extern string_length(s: string) -> int
+
+fn hexval(h: int) -> int {
+    if h >= 48 && h <= 57 { return h - 48 }
+    if h >= 97 && h <= 102 { return h - 87 }
+    if h >= 65 && h <= 70 { return h - 55 }
+    return 0
+}
+
+fn from_hex(s: string) -> ptr {
+    slen = string_length(s)
+    n = slen / 2
+    b = bytes.new(n)
+    if n == 0 { return b }
+    i = 0
+    while i < n {
+        hi = hexval(string_char_at_n(s, slen, i * 2))
+        lo = hexval(string_char_at_n(s, slen, i * 2 + 1))
+        bytes.set(b, i, (hi << 4) | lo)
+        i = i + 1
+    }
+    return b
+}
+
+// DER DigestInfo for SHA-256: 19-byte fixed prefix + 32-byte hash
+// (mirrors sha256_digestinfo in std.cryptography.tls13_cert).
+fn sha256_digestinfo(hash32: ptr) -> ptr {
+    di = bytes.new(51)
+    pfx = from_hex("3031300d060960864801650304020105000420")
+    i = 0
+    while i < 19 { bytes.set(di, i, bytes.get(pfx, i)) i = i + 1 }
+    i = 0
+    while i < 32 { bytes.set(di, 19 + i, bytes.get(hash32, i)) i = i + 1 }
+    bytes.free(pfx)
+    return di
+}
+
+main() {
+    doc, ferr = fs.read("tests/vectors/wycheproof/rsa_oaep_2048_sha256_mgf1sha256_test.json")
+    if ferr != "" {
+        println("FAIL: cannot read vector file: ${ferr}")
+        exit(1)
+    }
+    root, jerr = json.parse(doc)
+    if jerr != "" {
+        println("FAIL: vector JSON parse: ${jerr}")
+        exit(1)
+    }
+
+    groups = json.json_object_get_raw(root, "testGroups")
+    ngroups = json.array_size(groups)
+
+    passed = 0
+    rejected_invalid = 0
+    skipped_label = 0
+    failed = 0
+    gi = 0
+    while gi < ngroups {
+        g = json.array_get_raw(groups, gi)
+        pkobj = json.json_object_get_raw(g, "privateKey")
+        mod_hex = json.json_get_string_raw(json.json_object_get_raw(pkobj, "modulus"))
+        exp_hex = json.json_get_string_raw(json.json_object_get_raw(pkobj, "publicExponent"))
+        d_hex = json.json_get_string_raw(json.json_object_get_raw(pkobj, "privateExponent"))
+        mb = from_hex(mod_hex)
+        eb = from_hex(exp_hex)
+        db = from_hex(d_hex)
+        n = bignum.from_bytes_unsigned(mb, string_length(mod_hex) / 2)
+        e = bignum.from_bytes_unsigned(eb, string_length(exp_hex) / 2)
+        dd = bignum.from_bytes_unsigned(db, string_length(d_hex) / 2)
+        bytes.free(mb)
+        bytes.free(eb)
+        bytes.free(db)
+        k = rsa.key_from_components(n, e, dd)
+
+        tests = json.json_object_get_raw(g, "tests")
+        nt = json.array_size(tests)
+        ti = 0
+        while ti < nt {
+            t = json.array_get_raw(tests, ti)
+            tc_id = json.json_get_int(json.json_object_get_raw(t, "tcId"))
+            res = json.json_get_string_raw(json.json_object_get_raw(t, "result"))
+            msg_hex = json.json_get_string_raw(json.json_object_get_raw(t, "msg"))
+            ct_hex = json.json_get_string_raw(json.json_object_get_raw(t, "ct"))
+            label_hex = json.json_get_string_raw(json.json_object_get_raw(t, "label"))
+
+            if string_length(label_hex) > 0 {
+                skipped_label = skipped_label + 1
+                ti = ti + 1
+                continue
+            }
+
+            ct = from_hex(ct_hex)
+            pt, derr = rsa.decrypt_oaep(k, ct)
+            if res == "valid" {
+                if pt == null {
+                    println("FAIL tcId=${tc_id} (valid): decrypt rejected: ${derr}")
+                    failed = failed + 1
+                } else {
+                    want = from_hex(msg_hex)
+                    want_len = string_length(msg_hex) / 2
+                    good = 1
+                    if bytes.length(pt) != want_len { good = 0 }
+                    if good == 1 {
+                        i2 = 0
+                        while i2 < want_len {
+                            if bytes.get(pt, i2) != bytes.get(want, i2) { good = 0 }
+                            i2 = i2 + 1
+                        }
+                    }
+                    if good == 1 { passed = passed + 1 } else {
+                        println("FAIL tcId=${tc_id} (valid): plaintext mismatch")
+                        failed = failed + 1
+                    }
+                    bytes.free(want)
+                    bytes.free(pt)
+                }
+            } else {
+                if pt == null { rejected_invalid = rejected_invalid + 1 } else {
+                    println("FAIL tcId=${tc_id} (invalid): decrypt ACCEPTED mangled padding")
+                    failed = failed + 1
+                    bytes.free(pt)
+                }
+            }
+            bytes.free(ct)
+            ti = ti + 1
+        }
+        rsa.key_free(k)
+        gi = gi + 1
+    }
+
+    println("wycheproof rsa_oaep_2048_sha256: ${passed} valid ok, ${rejected_invalid} invalid rejected, ${skipped_label} skipped (label unsupported), ${failed} failed")
+    if failed > 0 { exit(1) }
+    println("ALL PASS")
+}

--- a/tests/vectors/wycheproof/rsa_oaep_2048_sha256_mgf1sha256_test.json
+++ b/tests/vectors/wycheproof/rsa_oaep_2048_sha256_mgf1sha256_test.json
@@ -1,0 +1,484 @@
+{
+  "algorithm": "RSAES-OAEP",
+  "schema": "rsaes_oaep_decrypt_schema_v1.json",
+  "numberOfTests": 37,
+  "header": [
+    "Test vectors of type RsaOeapDecrypt check decryption with OAEP."
+  ],
+  "notes": {
+    "Constructed": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector (i.e. seed and label) has been constructed so that the padded plaintext em has some special properties."
+    },
+    "EncryptionWithLabel": {
+      "bugType": "FUNCTIONALITY",
+      "description": "RSA-OAEP allows an optional parameter label, that is associated with the message. This test vector contains a ciphertext that was encrypted with a non-empty label."
+    },
+    "InvalidCiphertext": {
+      "bugType": "MISSING_STEP",
+      "description": "The test vector contains an invalid ciphertext. The test vectors distinguish between InvalidOaepPadding (cases where returning information about the error can lead to Manger's attack) and InvalidCiphertext (cases where the ciphertext is malformed and a decryption should not even be attempted.)"
+    },
+    "InvalidOaepPadding": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "The test vector contains an invalid OAEP padding. Implementations must ensure that different error conditions cannot be distinguished, since otherwise Manger's attack against OAEP may be possible. ",
+      "links": [
+        "https://www.iacr.org/archive/crypto2001/21390229.pdf"
+      ],
+      "cves": [
+        "CVE-2020-26939"
+      ]
+    },
+    "Normal": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a pseudorandomly generated, valid test case. Implementations are expected to pass this test."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "RsaesOaepDecrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "keySize": 2048,
+      "sha": "SHA-256",
+      "mgf": "MGF1",
+      "mgfSha": "SHA-256",
+      "privateKey": {
+        "modulus": "00a2b451a07d0aa5f96e455671513550514a8a5b462ebef717094fa1fee82224e637f9746d3f7cafd31878d80325b6ef5a1700f65903b469429e89d6eac8845097b5ab393189db92512ed8a7711a1253facd20f79c15e8247f3d3e42e46e48c98e254a2fe9765313a03eff8f17e1a029397a1fa26a8dce26f490ed81299615d9814c22da610428e09c7d9658594266f5c021d0fceca08d945a12be82de4d1ece6b4c03145b5d3495d4ed5411eb878daf05fd7afc3e09ada0f1126422f590975a1969816f48698bcbba1b4d9cae79d460d8f9f85e7975005d9bc22c4e5ac0f7c1a45d12569a62807d3b9a02e5a530e773066f453d1f5b4c2e9cf7820283f742b9d5",
+        "privateExponent": "24cdc62317f5d72a6f6ba6cc9632899b01d1ff28867d72f61688995bc855a4e420a8405250089bdb13cf8e09543827b748b9d27fbb2b4d9e20af8c5a6a862796d1a4cc18ad16ea678bc1bd4a83bbbe9c5e57453b5ce7388e41a3ba4ce2b77b4438a229e954f720dae0353dc088ac8a76b26dc276f8e1b7851ddd6398ad16ff2e78195123b9b036e945c38c9d12434f6df76fe22359eb3e1ac9c011678fc926fad3ae475a4fffff55feb2d147e9c894f4c0e29a599e762462482d968bf42780945fc0d2c31c573c4431b8f4fe8b8c67bec815abd44f7a86edca1c2308737358d2c2ae5e2e0e2dadf730980262377e58b13b7d9992060a0bc870ccfdb4a9319ee1",
+        "publicExponent": "010001",
+        "prime1": "00dc431050f782e894fb5248247d98cb7d58b8d1e24f3b55d041c56e4de086b0d5bb028bda42eeb5d234d5681e5809d415e6a289ad4cfbf78f978f6c35814f50eebff1c5b80a69f788e81e6bab5ddaa78369d659d143ec6f17e79813a575cfad9c569156b90113e2e9110ad9e7b48a1c9348a6e653321191290ea36cfb3a5b18f1",
+        "prime2": "00bd1a81e7977f9898122273ae3222b598ea5fb19eb4eabc38308a5e32196603b2e500ffb79f5b886816611debc472fac45544070beb057c941378a6868af3b7a03d3f9880ec47d5e089b94fbde542aba9ae8d72c57088d7abf5b131f39098f7bc160f90536abc9492fd4e06f3ed7299d4b97bb03677207d95669f140cfbc20f25",
+        "exponent1": "00a94b528b28f291599121d91952ffd1c7f21d7c1479d99d478885fb161870ee1218bf08472612dbe5497e8d9c650688e09c786961ae3e2c354dc48ae34514759c4c23c4588488961dc06b414e61c0e1e7fbbd2923d31532fe289f96da220711e58c14019808e00414276933bb07e4efb9b4a9b37656917205209f33f09515d7c1",
+        "exponent2": "3af0e72a933aef09ff2503df78bafed531c02ff1a2bc437c540cdcbd4ad35435cf511763596543480629b114ca7f780ff7efa32ea0cb6e000d6d9ea1f2ef71fd9cf9948422a165557e37e755edfe70d90b920502eb478bc98a63f788ce3a0f856d6ede7251a383bfa8fa480a81a925af7b3cc538c4bab8c9f7597ffb68011d8d",
+        "coefficient": "2640fbfbcfefb163ee7a87b6483a66ee41f956d90fa8a7939bfc042ee0924b1b7993d0445f758d51933e85179c0320b0c968b48a91c38b5be923e1097c0c562f88d42294b6a2759bafa5428a74f1270874e45f6fcc60f21602de5eccd143cf31241f5921b5ad3983fb54ef17be3b285367e50c999c67247b552fe4bfce945f7b"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100a2b451a07d0aa5f96e455671513550514a8a5b462ebef717094fa1fee82224e637f9746d3f7cafd31878d80325b6ef5a1700f65903b469429e89d6eac8845097b5ab393189db92512ed8a7711a1253facd20f79c15e8247f3d3e42e46e48c98e254a2fe9765313a03eff8f17e1a029397a1fa26a8dce26f490ed81299615d9814c22da610428e09c7d9658594266f5c021d0fceca08d945a12be82de4d1ece6b4c03145b5d3495d4ed5411eb878daf05fd7afc3e09ada0f1126422f590975a1969816f48698bcbba1b4d9cae79d460d8f9f85e7975005d9bc22c4e5ac0f7c1a45d12569a62807d3b9a02e5a530e773066f453d1f5b4c2e9cf7820283f742b9d502030100010282010024cdc62317f5d72a6f6ba6cc9632899b01d1ff28867d72f61688995bc855a4e420a8405250089bdb13cf8e09543827b748b9d27fbb2b4d9e20af8c5a6a862796d1a4cc18ad16ea678bc1bd4a83bbbe9c5e57453b5ce7388e41a3ba4ce2b77b4438a229e954f720dae0353dc088ac8a76b26dc276f8e1b7851ddd6398ad16ff2e78195123b9b036e945c38c9d12434f6df76fe22359eb3e1ac9c011678fc926fad3ae475a4fffff55feb2d147e9c894f4c0e29a599e762462482d968bf42780945fc0d2c31c573c4431b8f4fe8b8c67bec815abd44f7a86edca1c2308737358d2c2ae5e2e0e2dadf730980262377e58b13b7d9992060a0bc870ccfdb4a9319ee102818100dc431050f782e894fb5248247d98cb7d58b8d1e24f3b55d041c56e4de086b0d5bb028bda42eeb5d234d5681e5809d415e6a289ad4cfbf78f978f6c35814f50eebff1c5b80a69f788e81e6bab5ddaa78369d659d143ec6f17e79813a575cfad9c569156b90113e2e9110ad9e7b48a1c9348a6e653321191290ea36cfb3a5b18f102818100bd1a81e7977f9898122273ae3222b598ea5fb19eb4eabc38308a5e32196603b2e500ffb79f5b886816611debc472fac45544070beb057c941378a6868af3b7a03d3f9880ec47d5e089b94fbde542aba9ae8d72c57088d7abf5b131f39098f7bc160f90536abc9492fd4e06f3ed7299d4b97bb03677207d95669f140cfbc20f2502818100a94b528b28f291599121d91952ffd1c7f21d7c1479d99d478885fb161870ee1218bf08472612dbe5497e8d9c650688e09c786961ae3e2c354dc48ae34514759c4c23c4588488961dc06b414e61c0e1e7fbbd2923d31532fe289f96da220711e58c14019808e00414276933bb07e4efb9b4a9b37656917205209f33f09515d7c10281803af0e72a933aef09ff2503df78bafed531c02ff1a2bc437c540cdcbd4ad35435cf511763596543480629b114ca7f780ff7efa32ea0cb6e000d6d9ea1f2ef71fd9cf9948422a165557e37e755edfe70d90b920502eb478bc98a63f788ce3a0f856d6ede7251a383bfa8fa480a81a925af7b3cc538c4bab8c9f7597ffb68011d8d0281802640fbfbcfefb163ee7a87b6483a66ee41f956d90fa8a7939bfc042ee0924b1b7993d0445f758d51933e85179c0320b0c968b48a91c38b5be923e1097c0c562f88d42294b6a2759bafa5428a74f1270874e45f6fcc60f21602de5eccd143cf31241f5921b5ad3983fb54ef17be3b285367e50c999c67247b552fe4bfce945f7b",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCitFGgfQql+W5F\nVnFRNVBRSopbRi6+9xcJT6H+6CIk5jf5dG0/fK/TGHjYAyW271oXAPZZA7RpQp6J\n1urIhFCXtas5MYnbklEu2KdxGhJT+s0g95wV6CR/PT5C5G5IyY4lSi/pdlMToD7/\njxfhoCk5eh+iao3OJvSQ7YEplhXZgUwi2mEEKOCcfZZYWUJm9cAh0PzsoI2UWhK+\ngt5NHs5rTAMUW100ldTtVBHrh42vBf16/D4JraDxEmQi9ZCXWhlpgW9IaYvLuhtN\nnK551GDY+fheeXUAXZvCLE5awPfBpF0SVppigH07mgLlpTDncwZvRT0fW0wunPeC\nAoP3QrnVAgMBAAECggEAJM3GIxf11ypva6bMljKJmwHR/yiGfXL2FoiZW8hVpOQg\nqEBSUAib2xPPjglUOCe3SLnSf7srTZ4gr4xaaoYnltGkzBitFupni8G9SoO7vpxe\nV0U7XOc4jkGjukzit3tEOKIp6VT3INrgNT3AiKyKdrJtwnb44beFHd1jmK0W/y54\nGVEjubA26UXDjJ0SQ09t92/iI1nrPhrJwBFnj8km+tOuR1pP//9V/rLRR+nIlPTA\n4ppZnnYkYkgtlov0J4CUX8DSwxxXPEQxuPT+i4xnvsgVq9RPeobtyhwjCHNzWNLC\nrl4uDi2t9zCYAmI3flixO32ZkgYKC8hwzP20qTGe4QKBgQDcQxBQ94LolPtSSCR9\nmMt9WLjR4k87VdBBxW5N4Iaw1bsCi9pC7rXSNNVoHlgJ1BXmoomtTPv3j5ePbDWB\nT1Duv/HFuApp94joHmurXdqng2nWWdFD7G8X55gTpXXPrZxWkVa5ARPi6REK2ee0\nihyTSKbmUzIRkSkOo2z7OlsY8QKBgQC9GoHnl3+YmBIic64yIrWY6l+xnrTqvDgw\nil4yGWYDsuUA/7efW4hoFmEd68Ry+sRVRAcL6wV8lBN4poaK87egPT+YgOxH1eCJ\nuU+95UKrqa6NcsVwiNer9bEx85CY97wWD5BTaryUkv1OBvPtcpnUuXuwNncgfZVm\nnxQM+8IPJQKBgQCpS1KLKPKRWZEh2RlS/9HH8h18FHnZnUeIhfsWGHDuEhi/CEcm\nEtvlSX6NnGUGiOCceGlhrj4sNU3EiuNFFHWcTCPEWISIlh3Aa0FOYcDh5/u9KSPT\nFTL+KJ+W2iIHEeWMFAGYCOAEFCdpM7sH5O+5tKmzdlaRcgUgnzPwlRXXwQKBgDrw\n5yqTOu8J/yUD33i6/tUxwC/xorxDfFQM3L1K01Q1z1EXY1llQ0gGKbEUyn94D/fv\noy6gy24ADW2eofLvcf2c+ZSEIqFlVX4351Xt/nDZC5IFAutHi8mKY/eIzjoPhW1u\n3nJRo4O/qPpICoGpJa97PMU4xLq4yfdZf/toAR2NAoGAJkD7+8/vsWPueoe2SDpm\n7kH5VtkPqKeTm/wELuCSSxt5k9BEX3WNUZM+hRecAyCwyWi0ipHDi1vpI+EJfAxW\nL4jUIpS2onWbr6VCinTxJwh05F9vzGDyFgLeXszRQ88xJB9ZIbWtOYP7VO8Xvjso\nU2flDJmcZyR7VS/kv86UX3s=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA-OAEP-256",
+        "n": "orRRoH0KpfluRVZxUTVQUUqKW0YuvvcXCU-h_ugiJOY3-XRtP3yv0xh42AMltu9aFwD2WQO0aUKeidbqyIRQl7WrOTGJ25JRLtincRoSU_rNIPecFegkfz0-QuRuSMmOJUov6XZTE6A-_48X4aApOXofomqNzib0kO2BKZYV2YFMItphBCjgnH2WWFlCZvXAIdD87KCNlFoSvoLeTR7Oa0wDFFtdNJXU7VQR64eNrwX9evw-Ca2g8RJkIvWQl1oZaYFvSGmLy7obTZyuedRg2Pn4Xnl1AF2bwixOWsD3waRdElaaYoB9O5oC5aUw53MGb0U9H1tMLpz3ggKD90K51Q",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "JM3GIxf11ypva6bMljKJmwHR_yiGfXL2FoiZW8hVpOQgqEBSUAib2xPPjglUOCe3SLnSf7srTZ4gr4xaaoYnltGkzBitFupni8G9SoO7vpxeV0U7XOc4jkGjukzit3tEOKIp6VT3INrgNT3AiKyKdrJtwnb44beFHd1jmK0W_y54GVEjubA26UXDjJ0SQ09t92_iI1nrPhrJwBFnj8km-tOuR1pP__9V_rLRR-nIlPTA4ppZnnYkYkgtlov0J4CUX8DSwxxXPEQxuPT-i4xnvsgVq9RPeobtyhwjCHNzWNLCrl4uDi2t9zCYAmI3flixO32ZkgYKC8hwzP20qTGe4Q",
+        "p": "3EMQUPeC6JT7UkgkfZjLfVi40eJPO1XQQcVuTeCGsNW7AovaQu610jTVaB5YCdQV5qKJrUz794-Xj2w1gU9Q7r_xxbgKafeI6B5rq13ap4Np1lnRQ-xvF-eYE6V1z62cVpFWuQET4ukRCtnntIock0im5lMyEZEpDqNs-zpbGPE",
+        "q": "vRqB55d_mJgSInOuMiK1mOpfsZ606rw4MIpeMhlmA7LlAP-3n1uIaBZhHevEcvrEVUQHC-sFfJQTeKaGivO3oD0_mIDsR9XgiblPveVCq6mujXLFcIjXq_WxMfOQmPe8Fg-QU2q8lJL9Tgbz7XKZ1Ll7sDZ3IH2VZp8UDPvCDyU",
+        "dp": "qUtSiyjykVmRIdkZUv_Rx_IdfBR52Z1HiIX7Fhhw7hIYvwhHJhLb5Ul-jZxlBojgnHhpYa4-LDVNxIrjRRR1nEwjxFiEiJYdwGtBTmHA4ef7vSkj0xUy_iifltoiBxHljBQBmAjgBBQnaTO7B-TvubSps3ZWkXIFIJ8z8JUV18E",
+        "dq": "OvDnKpM67wn_JQPfeLr-1THAL_GivEN8VAzcvUrTVDXPURdjWWVDSAYpsRTKf3gP9--jLqDLbgANbZ6h8u9x_Zz5lIQioWVVfjfnVe3-cNkLkgUC60eLyYpj94jOOg-FbW7eclGjg7-o-kgKgaklr3s8xTjEurjJ91l_-2gBHY0",
+        "qi": "JkD7-8_vsWPueoe2SDpm7kH5VtkPqKeTm_wELuCSSxt5k9BEX3WNUZM-hRecAyCwyWi0ipHDi1vpI-EJfAxWL4jUIpS2onWbr6VCinTxJwh05F9vzGDyFgLeXszRQ88xJB9ZIbWtOYP7VO8XvjsoU2flDJmcZyR7VS_kv86UX3s"
+      },
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "",
+          "ct": "6e62bf24d95aff6868afec2a92a445b6458f16f688c19fe1212f66a63137831653cedd359d8cff4dd485d77dfd55812c181373201f54aafd65730d2a304e623455d51125d891e65d97fce52341cae45fb64c38a384a1c621e2713ee6794633f029a9fd4d774f56551eac2176162e162640f25eab873a3451c475570f19228bcede4c67c370a75ed7fabccd538c9819eff182481b10d42f1a9f6a05373b8cf9b71818d467bd3b8ebacb619e8ad42916e600c043effceb3855bc48a629e60ae886f51b2a7876b0e623fb2ce68af4b039242f963adb0e4240aed0ed07f65f1ee7c0cc77d210d0c2d1dc10c81b881aa0c9c9e9499665cf2970d2ccfeeb3191531765",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "ct": "207180c340658b5154ae45d2e4e7326a0997c683a26b595e536a29333c4b66149af85e029d5419a39e3a147b221516ffd86b6b4b66c3e0c4c49fe8c57a2f5c37b8704b9b592b80db9cd788a4ed51ab4f0a1cbed63bd18d1f06a22f225866b0c2c417cb23473b7ba4250b1353bd2e5b4f0f937cd2efe5fa38db3c295f7748b970088657db4aa9a76e1ee6fbff166ec1861d00d085326c7384bdd1bc2f400d4f74dbdfadaf3fdc46073e668573e02030b9eb5af58eb540c66677a771194479ec0098d858a2ea45d0ba1e6b32440dfbac745000554d51a17684ca964b02a74d479f1d432ef763ef4059715a4348cfe36a215359712f25b6977903be4adb92febbf6",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "54657374",
+          "ct": "5eab3f0741e63986ed647d53e1cd71df041986900803d0f99c68355d249a15a47dc5b4f70a191477654299e5a2731f3b4eec76dea18262fc696ac794e5f66cbfcddac4472c578e246c26707598055584540b839836b1404c5611ae558a984cee8fd036cea924e0be2474a940f61e0acc14fcae95ebdc59942a9ce9af9a9c81999f7f6815f057ffdc2533cb15d6391d1e2d95f16f9c04209c889a4c359c7d2926d28a66e2b030a416b928d2825627998e5191fb4983a6e65024262d94fc09187a2d78162122433251d1bfcc8e507d06eba2d229c10031261da32ab8ccd15f1c5f9fbf07ed158483d736a110af4b44d6a4da60d6cb519b4454213cf9f0dc560f2b",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "313233343030",
+          "ct": "0da290b0bf71a1141b2adc62b5b42b07fc52520cb05d1f39ccca7b7c22d379a6c2f2d93143d057050140527a1e5638243938b531ec3de7014b0151301e49b9fa433482a02abdfd94193dc9c70157e557776a69ded01ecbeac405133595c61165a428b6284729a4746b47d2bbaca9d7432c3b5693591cfee488eb3c68ddb6cde0dd61cfc6952423f994abecee34f5683732b29934a2c498ad48cdd30c149177189f48eefd9cc7232df18be11ff5f7e3af7319e3115997c599e2d8f7f4f663dcc40032d403436d3058a5ea66473660f0e195281ec6eba997d2a951ca6ca5f3c112715c89da1d3dfb20a21940594ed10ade90ed7452b753757d7241cb8a803c373a",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 5,
+          "comment": "",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "4d657373616765",
+          "ct": "121196e51a3f4476bfb6adddfdeb3a25dad72d1ea315d652f331a43631ad36724b3d14532110dc44e407b1184618f115677b33751fb0e8786ba220cfa7fc3fce22822eabdd4fc2761c7f34a04e8f13c1021c31adc123a32d871f0da6cdacab9c020222da52afd5c307a6e55e4566944403fda426ee2c6c973ccaaafe2d081ed8c5b1dc00662424e395faed86c9ae19a3a95950c83d2a9ad5c7e7f670faeb123acef07fe7795ad298aafe543504d7811336b3e2ecb1622bc90599a185b34700f8f4c52a651d73ea57e8cfa80e61d9da61f36951c7194ae4dee3c6e67b5757a39685dd3fe01cb87620a54666ff8132e93d7081d38ddc9f079431075e96cca78f59",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "61",
+          "ct": "7ae8e4f5494393be144d81517f11baf4b634bb68b2f0ea9b30731035e8cbf4283c0ca99120f60b75ef685e989fecd7a5dc524cb66292a0ab87ebc61e67baca1a8aed99350edee045dfdd029406acb707d85dec9555169cf7ec5118d8f29d182f205e2859a8dcc5122bed640ad0ef128deb21785efaa20f92067dc216cf40c15bd7130e2c094131917950a816da814c5990fa6beed709a0218f4ddca2473796e1b44cff6d7ed601c574a784d0865d3afe5fec023ebe71bca881da5637e3d1d17238c20a5bd0075bac018f07898f74b9e6dc0fa3d5f8d0b274dfef3e6720d8396b34a81ac2e64da5b3e5d7666323ed7c56e8bdd179f3c6b2cf05bcac402513dd87",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 7,
+          "comment": "",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "e0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+          "ct": "096958786ee7972050d67a9e4b69d6c6af7db7cc674386df725770dd29129b826e39552330104c8d71e6cc3a3014dd2f61b54153af51b0438d447ee939f9e3c13bb8b00a37dea6a068f6c9d27e848b1be7a1eeeb3ee50b78036fba95ae46948ca5b13f356ea24db10f60dc09e4b8bad8f766b668ef72524432080a0ce00ed676d6d5e354984b1078520412525848156d06f0652469f95791baa3d9a798ae537094f76f976faecd5c9ce0c930a75910c63dacf63485cb4b5e7bdbcf4d80e74037eaa1a8fe4b52930bec6be99cf6ac88cf5878dbf6859d456a95dbc34654eec425de84ca2a535d517403a9aada827e7d0093ecfc97ed056a7652825e9a45cb2dcb",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "",
+          "flags": [
+            "EncryptionWithLabel"
+          ],
+          "msg": "313233343030",
+          "ct": "6583e2f176aa7e7f655d2c53497349c156c8851fb23325589e85fb83bfa857346caba222cdaa3234e71564154298c24dbb85e18822a1d5e7faa47863a64d76874a3cbc70f4d9f137426a344c473fac1dd7008a9973765e9f66c5b492535a647c273c4f78ceb5aa7ba963a2142f2ce4a81f804c002b9b2eabb3c75e80a3c6ceafe5384a544c672a5d28d32bb87115f43eb79775fd9b3f4a2f6e6a89368bdd95ef1d014877b60afdb1234acd57653a65459f01b2fbe381f22a739504b4897a7e6c33b6349b276db6083abad9c169405859b800c812237634b503de6ada43013c1d86697a135be78a9784576d796d62aa7819e2ea0e2d902ffdd9cfdd1ae66212ee",
+          "label": "0000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "",
+          "flags": [
+            "EncryptionWithLabel"
+          ],
+          "msg": "313233343030",
+          "ct": "a0443ba434156d0b503ec662f5eb5b10e20ad0cb8233720ee187ba986e4811dd312844d3edb26bfaf51b4b9268dc3c76072dd47c199d713c91824da23ff00481ee69e9d4cc543120fc33b7244bf0c1ad5fdd1ae9cbada7fe9a70ad0afaaaad8361e8dc4b3198ae661a84e275b60bf2ebb85e512da785d2fc3482294fa11967681d7bceffc08ce0e36f0a8af7fcfb1337186863c2c1c1b94c9ec9785cd3d94d15437c23b775677f3d29a4c9e52f13398fd14661160e5868bca97625aa6c7ecb07bbb479644def353f1f01a4c4100f9adb82c4f6a265a5ee962da58c3c042aa549c9d2de3008e7448e0c4b9b4ac8f5e4d8629873909bb995ccc0825fe87d81d596",
+          "label": "000102030405060708090a0b0c0d0e0f10111213",
+          "result": "valid"
+        },
+        {
+          "tcId": 10,
+          "comment": "",
+          "flags": [
+            "EncryptionWithLabel"
+          ],
+          "msg": "313233343030",
+          "ct": "26aa8e7931ed624bfd4077e3b83ec08de080483a61641e877f493fb7d0ae4dfebd4f05612a2e4869d20d440a64e928b13daa3b79da2ed674b99421df7e7f625a22b1c71136da27db699d3dd96e3364ee0cd2123ab6808930c6bc28a5dc307880d1ab4b03bcd6178a81b8ad52aafffbab387d40352dfea526abedca016c87e9e56ccc4c88e80f579da015b979bcdd88618b2a32ce072918b2e223535359f1ce4eaba5e692e6296b2140dc2304092ebd6f136a48092b3849082b57e70c93b54db55045dd6094ef3d2cfa8bc9e2fd2b1bbe0c7c603ad38d3f40c9eac8ae5e28cbbb031c38d93d3b2541d94eab3a1e8992a444ee4ce7b8d08c0b9a4f623d32fcba14",
+          "label": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "result": "valid"
+        },
+        {
+          "tcId": 11,
+          "comment": "Longest valid message size",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "78787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878",
+          "ct": "7efb69f1137d6a6e813b7ab75bf0400b3d07a442b88ab048675dc06b0215fc1a2e033263ec31a6c1d2eac56cb0470d69022a48131d1f000bbed70586b80cf6356465c8834daced7ea2a5ff8ef9c44d5ab828ffbf0556a6394752a4a28a70cae20084e1236f042f6c29de5cb34ef73acba5abcc7ccb3a26342701df3b9daa945d9fa5bf0b9b10306655e56370183f50fb8321f8f0cd1c72114791fca5df2166296b509b01a0b291c46110787cebe69d41b3b1e89590bc2f5e5d49ea24ae0f1207eef1aee54b9760553e80c5506a8a8a75732e92875025f0bfd5ead71e4340c8a9fa16dcd5a7dc96d8c4a7dc4e91f47a69366445c4695c8bad578ffe52bb672f65",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 12,
+          "comment": "first byte of l_hash modified",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "287d7108a1c6e7a18acb0045b20c57cdf2ac03456b44942764a7a9e9fdf3db481d7e202e4c8d733b56b9c1e93d71e791af8325c9363df789b252a5ed0eddc79e76fa41c2cb0a35618398217a390a5e6d99eed905d5554d19c1cf4e30bdf1c2fcc5148b641d71b3f1977b63d232648ddd935ec9499a53ac2fbcac55f462e91065adaa018a39c453ba759bd68b454074153421e2ce75cf149f748b5b84758df8a423d1c50c880af863f2a6df3cd465ca36aa2152b5771f3d507f4a4dd9f8006d80eca23537092287976f218a90df1e16d889fe31e79f7309f3224f613e9b52479fe73b7aad915319a3b62a5936649f7d015d7b09f7fa9f454f78a7c3dd4bf791e0",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "last byte of l_hash modified",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "8b65065af82770625d24917d13fd97ae13247cad97910a2651f95800165b76cc34bfe06cbf8c31a7d7ab4f41e05c45a25b90c606378c8e49c95a15ca11ae37e797a00f1b2680a6958c54396be4e1ceedcabc58d9f136b36867a2fefe648a9758f49634bfbcaa48717a116cba58c27539be10c56911aabe013e0329645e8308423c3aa42e0c9b1f4b5f546ddd9f90bf4d007dab52ac3879db755e4f2b96db5cf01950f39076f261f50b1bae137be500b03ceff6ea1bbd80b33424f7faba5cc6b86670fcb7db1a9b3c58bdfd7b75ba9f3ebd34ae32d320c757020a7324df7d3985bccfe0e81bb7f61bd98cb37219312299b4f274b2c90c52a8e1790f52e8fdd768",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "l_hash changed to all 0",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "356e91db9bd932c7b5726da288e2620cd79667c2e1d7aca562331ceaa6e4ab47665213ed75579abb147728bcff60787c95107f5be787c42e714d51627fcc8b4ea71c232c0c80ce6163cd0fbfa9dd7e8c1990176abc2705f4ffcf1d5c62393eab1c0ec8a653a90f27a968df8f4af622e96f663fceead8b0bf5dff65cd657a72b9c33265c5c2a8f7f9c614b9c2f8a95246970e6a778aca4b12552da47c274282ad9205ecd2264ae3c649597beaa35c141910e84233776d419448f55019a84e199a4867d68bf213f47b0316d50079dab77299fbbe7fe8929906461c1103a97c2b3f1633c8ef03e820ec675e331cd1fda8ebfedf541d0f2b571f4eaf292ce0ab14c1",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "l_hash changed to all 1",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "5a6efdd2d211d50366885e177190ce1621ba110ee46530bd083ba76ed48992d85efd8f9ba964eb33e596e0c0bcb545f89e2c9592ed18495e8e5df1866fe30b27522a3ad9cf7124c4aa23f7c925900613c50b7c18872b4537a750419ae128e913e9a2d87c219e2cd01132972298028e54fe394ef9779d04543c72eec4c5732cadff0b954964706bc4085722b0c595162d11793ab29754837bf5d324e21814ea24b12fed441f20d22148ba5a987b6aa7c7d4ab5a33af8e6c9096c29777cb0d5cfe938a6ed5d30936a5a8f5fc435df14d1c439d1b9d274254e7b248bd20d21dc4652c1605d5a2929db018bd45794a523b217fe0a9a6b0704197ba8126fc8311556f",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "first byte of ps modified",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "52582e10264630e1584155f5e970b8eda9108a87370861cda12ee773411cf556db328c8a2a165d10f6f969ac61b170a75975fbdf9319d13c9535f30d621db19e41da3a04fe40874caf779c8f03bd5d1892e52925b183c118446ed9a335e9c1dc4519fb1253215e5f8d8ee6d49c0167af9d5ca5b1ace067af573e0be9a61beeccdac37b0e54f6b0f70576cb8a400d01136357a8576e81c119d3dd91c7b5cb343692a810362e1e6dc06c1746e071a903a2856b4446f10f78c670d617e5e24dc5c0e45caafbf8ffc4af6b3ef998fe1bfb59aacb16d98d7e389679939861a6722c4e29af731da99d17058d7a12ead0d3d576de796ad2ad596feada4c091f10748536",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "all bits in ps flipped",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "4b4546460b54697beb899b54f474079169b4f7e79d0299586d821bd9091e9c5d2603b96c1aeb2924e887b15b211b07a657a85629932f97f18acd5a9f15684c9959fa41a6d1c10eeca68b7b95179492e80927860b7fadce3eb4e1e8610adc709e25580d8c7ad95af1de3a94b4a09e3078b86e88ae9630388711d20e28c801131cd1f924dfeddd85a9d404ef5db9e6a887845b5aa4763fbb72f259985ccf7ee6fc8329bf1ded74e5112f8c16df81e8038443df4bacb2eae1b06a48f178cdf2257941ca5887db4dc5135f0a2d050f56ac94ad9ffd4a13925c85501976937e723979cc31fd48c4d68d06e4c9cee53517dcb18da61fe4347658df495508d6ea9d7282",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "ps terminated by 0xff",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "3f5e00347c36ceb79f400effcae92d331aa9f52539041c50dbbc6fd071912912692a16353378276a2c1596358c46f6232434a95a99c573d0b83e4a6e970a73e99ca13d734506e2a2a56744b1872bffd501a80ba7cf5494df6ff9b421cb10247e11d19ac9e60afe0dda87cb351c21ba554ea50b70f6eee4ffa949ae38694ef831020d4e599c6ff4493d07c7b6be06453b84143813a68dfe0fada2317a9f4040a3cf6308090b6bfaca36067312f41bc0c4c01ac00fdb5aee4395b04cdff82cb433b01cd3e70daafc7807b2f770226699e7535124a453f7ad2653bfb7cfe71e120dc37ba88a5be347ad134351c11ff1019b7e42d24b7a3890a8424fae53a10c0e11",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "ps is all zero",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "a166bf7b5c2cf1896c0b924a69233a0a585bd47ed7f2330654aa68806deb0ff68c6475050ab45c691bbbcc58dbc2f5c817729e8e195ebd39d48bd5e14977abae0829636831655917fb5a758fb43a8e505d6ce595f625970685f7ec81cb5592210f5d68c6e2e1ef26b4ef8c92bf44f077e1d5099f379cb8120ad185bf07877979ca81f251fb81be0ad3c14f4d7885fcec496f80033fd4279b6830a20cbdead27c0967e28d1e06ef4bd7ba89210ec0d696274a187dc2f13212f5adf06e9450eca398325cfda73431036ac21b087d373c9f575c941f8cb078961176e31859a61c49baf8ff4f817a11010448d6a0e40dcede1a5ac3befa4c6e9d9d67d8e8fd8b6de3",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "ps replaced by 0xff's",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "75829ac4d97848dfba21c1688e936cfc736f53fde5b91d5330b63a9968dd4f51c2f529fd8d8f84e4a908196fcc5deba21b5c7300d7381e07c4e0ea2184965169cc9464933ef5a840d86b1dbcc945c7547d9eab245ba64d24946a75961161c2b8f417daf11b163b1e5a5b02d45341384f37755248fa871e6a82f948ad6292f11445bf30596dcccec73a441cea5e5dc470016309a83b6c8f158536687ad2734d3ea1562d46e23bfe8cab498d19b0b104d97182aacf852b6db3c4670109b81af1bd99b483d92b3e4bd813edfa4d0513214dcc5bb4da768e86007c22f11e5fe6f4cb60b909958fb94dea660d3fff0b99db15c2d2e6c8df7478330dade8c517b90975",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "seed is all 0",
+          "flags": [],
+          "msg": "313233343030",
+          "ct": "8e5f01ff0c1775870715fd0366a8748531f8b00803df35e0e2308db63bbec4eca4e093351876b794213b904e5dde284a82d74abfcbfff94bc9a8300bea99edd07fe97d6e0b11219f85ac15acc404d37d3da16819a14a438f3f72f8178b312526232386e918a8a7e11fc38f4668c499a00480cf9d2d75aabc0198d3ba9ba345fba9105c6564df5f6ce796f14100d186abffe4d83d57969c1caddc7c7aa340b4d1bab23d9b3982278328ddebe648f5c52588738f3c56a88b3f34c890c03fafc27f485a17677a53e974dc1dd86f463a927f4328ac51bbc61705ae8abd7f45628957489e2defd8e043b955b118fb2a1c407d45893004aae0f945f06add1e45b41a03",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 22,
+          "comment": "seed is all 1",
+          "flags": [],
+          "msg": "313233343030",
+          "ct": "50c23e2ad6e3f3b10a5716cbf60efcc9f66d2c6f17bf050ba0153b877ba2755e8a0d54060034562266155744ef80547b8af777b0ff764fbb12baae49d02b4f6d65b6cd8f0a397839101d32ae163ff2e6072748d6b8017e5e73e332d53f4e91fe6233a82dbf54f3146b489803575c5ea37ab55a9ea7eae47ad4f1727d45822b569cd6e5d4b6ab759850948186616b5da2a9a316f57d899f91934bbb27edcdfa19532ba1c01f3724738daffdd88c9a18562ebcbc49185b0a817407903476d442c424c81b63aeb8f9d1b184756e0cc0a381eaba45a85c8bbc6770fd047ff1a6404a384599fbbd6a40b212a066e23f6a15cf13e42c0ea88c710e4d70c612074968e5",
+          "label": "",
+          "result": "valid"
+        },
+        {
+          "tcId": 23,
+          "comment": "First byte is 1",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "3f92a694661cae336cac7a3c5a6f67e0655d10218a64459739ab9664f2cec58978939512df621e6b92fe3429bb22c08b5103da648a7719e7e95a04e6b61601546955825d60f4c517619f851780ad17f1b8a955cf8c7f1a5e26ca4a0cc19cca751d0790d56e1140a4705e19274f638b7c16d9d3e423a7f787d02699235e3e9e4d543a954f9b1bce5411c8ebdcae86a4bb86c66818a0bab51a2b00383b318e53d95508bab1b19e388cd5a03cdceba0f7176c1782e19ef62cff69352d444b1ce0e1f339e96d8a65c07aa37f5f2cf33867f6c496e0da6cd79b3e2183b57064ce21a1b92072702e555a82cad75107fdfd8bd5e7ea5f119cfbbc1770e962fd0b781aff",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "m is 0",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "m is 1",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "m is n-1",
+          "flags": [
+            "InvalidOaepPadding"
+          ],
+          "msg": "313233343030",
+          "ct": "a2b451a07d0aa5f96e455671513550514a8a5b462ebef717094fa1fee82224e637f9746d3f7cafd31878d80325b6ef5a1700f65903b469429e89d6eac8845097b5ab393189db92512ed8a7711a1253facd20f79c15e8247f3d3e42e46e48c98e254a2fe9765313a03eff8f17e1a029397a1fa26a8dce26f490ed81299615d9814c22da610428e09c7d9658594266f5c021d0fceca08d945a12be82de4d1ece6b4c03145b5d3495d4ed5411eb878daf05fd7afc3e09ada0f1126422f590975a1969816f48698bcbba1b4d9cae79d460d8f9f85e7975005d9bc22c4e5ac0f7c1a45d12569a62807d3b9a02e5a530e773066f453d1f5b4c2e9cf7820283f742b9d4",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "added n to c",
+          "flags": [
+            "InvalidCiphertext"
+          ],
+          "msg": "313233343030",
+          "ct": "b056e2513c7c470d897032d406e97b5946dcad52df1c1650d61a1d7b0af59e8cfaec4d9e834d06d819b92a7d440d277e5039ab8aeff25043e98b281ae6ce0a91f8dfbbd1b4998fe5481671381b6a3952448b617ae606f06a0143561a040edaf3c972e611bd7cb814aa4761d38e4a007ca65af8fde6eb25d919d8bd9273cca7622984aa27994d049612424547775c5df75483962143522d075b8c55ea61b04583eb4c0358f9fbb902dedff30b7d8592b57094df4f6345668af53d1aea86fb36dd69b4434bacf8fc12c13802f5b03551ba8f207d4060a9f56e6b7e18c766eb82b6ce6ee0747fbe785c3c1c25fe7fb87de50032b172129fa41a69c3ce0e777ef10f",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "ciphertext not reduced",
+          "flags": [
+            "InvalidCiphertext"
+          ],
+          "msg": "313233343030",
+          "ct": "6ea4320bc5bcae709d0e4b9d67e7f0c248a65c5bc0762910e220ea96bdea088e20ce7ffb726a8fd87fa363249dc0ace75fdbe025b270dd72490cb164c468388117bd95624bddfb70c1f07f98a6b9ccf9cee3d2b5f5b3e79a6664568a788b3f1002fc9546d6b3a0fb5f3cfb14f70785dc542dbbbaffbb3b791f0a5906ace090a3c29d123db768ecce56f0dbf99956f070ce2ebe8209c2ff6de6064ac6247f81c4064960c516f684f9e740b00f361844d9c1bcb1553bed9b297462e8badd3d431a09b62c773b0071a8d734aae4de04bac45b7bf8555471e937b0a36f0c1bce595ec9b3d366c9109319a3501156a08c21393e31fcffa2c51b242dac9f813c8f968600",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "ciphertext is empty",
+          "flags": [
+            "InvalidCiphertext"
+          ],
+          "msg": "313233343030",
+          "ct": "",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "prepended bytes to ciphertext",
+          "flags": [
+            "InvalidCiphertext"
+          ],
+          "msg": "313233343030",
+          "ct": "00000da290b0bf71a1141b2adc62b5b42b07fc52520cb05d1f39ccca7b7c22d379a6c2f2d93143d057050140527a1e5638243938b531ec3de7014b0151301e49b9fa433482a02abdfd94193dc9c70157e557776a69ded01ecbeac405133595c61165a428b6284729a4746b47d2bbaca9d7432c3b5693591cfee488eb3c68ddb6cde0dd61cfc6952423f994abecee34f5683732b29934a2c498ad48cdd30c149177189f48eefd9cc7232df18be11ff5f7e3af7319e3115997c599e2d8f7f4f663dcc40032d403436d3058a5ea66473660f0e195281ec6eba997d2a951ca6ca5f3c112715c89da1d3dfb20a21940594ed10ade90ed7452b753757d7241cb8a803c373a",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "appended bytes to ciphertext",
+          "flags": [
+            "InvalidCiphertext"
+          ],
+          "msg": "313233343030",
+          "ct": "0da290b0bf71a1141b2adc62b5b42b07fc52520cb05d1f39ccca7b7c22d379a6c2f2d93143d057050140527a1e5638243938b531ec3de7014b0151301e49b9fa433482a02abdfd94193dc9c70157e557776a69ded01ecbeac405133595c61165a428b6284729a4746b47d2bbaca9d7432c3b5693591cfee488eb3c68ddb6cde0dd61cfc6952423f994abecee34f5683732b29934a2c498ad48cdd30c149177189f48eefd9cc7232df18be11ff5f7e3af7319e3115997c599e2d8f7f4f663dcc40032d403436d3058a5ea66473660f0e195281ec6eba997d2a951ca6ca5f3c112715c89da1d3dfb20a21940594ed10ade90ed7452b753757d7241cb8a803c373a0000",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "truncated ciphertext",
+          "flags": [
+            "InvalidCiphertext"
+          ],
+          "msg": "313233343030",
+          "ct": "a290b0bf71a1141b2adc62b5b42b07fc52520cb05d1f39ccca7b7c22d379a6c2f2d93143d057050140527a1e5638243938b531ec3de7014b0151301e49b9fa433482a02abdfd94193dc9c70157e557776a69ded01ecbeac405133595c61165a428b6284729a4746b47d2bbaca9d7432c3b5693591cfee488eb3c68ddb6cde0dd61cfc6952423f994abecee34f5683732b29934a2c498ad48cdd30c149177189f48eefd9cc7232df18be11ff5f7e3af7319e3115997c599e2d8f7f4f663dcc40032d403436d3058a5ea66473660f0e195281ec6eba997d2a951ca6ca5f3c112715c89da1d3dfb20a21940594ed10ade90ed7452b753757d7241cb8a803c373a",
+          "label": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "em represents a small integer",
+          "flags": [
+            "Constructed",
+            "EncryptionWithLabel"
+          ],
+          "msg": "c4fc4b065f4595751c7ff8bb99681d505b7d0f1730d404617940f4b5c3b01979ffcffd19e86f69450e5fc14d9bc27a1f39734fd5f8f663d2d87c444e3e15da8764709909679aaa553d98ddbb1ad7dcc8be04bb8751570b4e6cdc7a8f56b09a4af43053a393bd8f947d7625137e6d84f9b9c727475a98ea22efcf679ee0aa5258da88a08afc53bd8bfa19b0131d6f676fe198a9c6a1f84174fc69ccf8e34e3617f8ff6c4192075cd6668392523fbecedb27578e591dead78c80a89be589a1",
+          "ct": "18416ff48c3a78bc85e1f483d546052d84deac02ce86fcd197215f227b6dad58bc19394f46551111f858b08879bc37c620b1e81ebac4c75fdd71713ce75c24293fa39caf46294d28bf87a46da9a769a304157ea1fc71afc3bfb790da32e84d812a8946d1b3d211fb6972b3fe6674496b2d8056c1503d02fd4c2e607bfb1e6b26b35636b8b823757ee9ba3795d3af2dd8710b0a6da4dbb430bc69dc089f1563d34f0d79431d63e7b8d94c8234649b64223d1e0be17463401184a096feb9c81e226eec26c7e9f3f4357536633029ebc0349bc136d1206c6064fc51b6d2e79578f2b26439c5b3f6ffe1b515740b3c4b94a49430631292968eb50983251bbc7f0f89",
+          "label": "5a3564e9482a072bd99d0306d69a7f4595c49fb9c06b72250eed2b50ceddcc4700000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 34,
+          "comment": "em has low hamming weight",
+          "flags": [
+            "Constructed",
+            "EncryptionWithLabel"
+          ],
+          "msg": "03fd61590ddd05555a6d46d1e8925293fe46fa168cb06135c2e7c8d36551187e62016f40f3eb31751f3690f5da1aaba5c16ffa650b2e6c25f3763fe324929c4becc7fb28a383d66c31973c72eb13ff8c87a92b495f6f0619290f8675e9889f49d30d5e77b2115e8805eeeb1aa9324843a75e0bbe70538eefb7978a0ea7beb211e67bb075981673517518586eca5b04ef3ad6a3a978605fbc0e67af7fe412acfcb550d20c9900f4d71d7829a107cc51d663db54c57116959998f3946b4d43",
+          "ct": "23ee3b4df8ac632078167f2f97a736469c6e6b39ced4ddc552d31f0fbc7ccb478adabe56cac20cbec1a0084125aefde0bdb575d68bd74cfbdf5f3bfb4401fa573645c223568918aa911c1f5a01b3b0903e91d82e8c04194df4bdc5facb6959b4df23593c7925a827f029064c75a4bc3d2899649025670e70f3e01336fe961664563a3bb0c7bca66d7eed48326746a060c5d3f18a160abce399917ab2e2386d0f1c2d7c9105d16befc1b0bfd72606ec300a777ac550b1b0b807b7e46467db5bfe0eac8bcbebb2df47bc65fe42174368595b72650b770f47157d2d14c71cebcaaa5cf567ab803e2bcff5f4298c06b1983757abe02faf4c7c5f9141aface72ab98c",
+          "label": "b503d03521b4ffc4b855c94e911a6117f04c76c6fe8000f8031e705486ae641900000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 35,
+          "comment": "em has low hamming weight",
+          "flags": [
+            "Constructed",
+            "EncryptionWithLabel"
+          ],
+          "msg": "90fd851c721e936df0134ce13f2b7f4469d58f69f85f4bebe2726123cc742c1c43293f85f50b5c6d220f40c387a1f2bb2704a16508e267c6c4324a82191170e67cbf57f56dc02a706e3373e9dca1ca0f7703804c0093e9f8a2ae5502d2ccbf26dff3cd179b5b8f97959d5d2a9400b31b01ee09caa6013d198beb7e0979aed5263974591cca36ceceb252110e61bebdf0272386f9571be79fe3afc8478eb9e7155759ed20e2a2e537d98aeda18c374ed9b48be8624984ba4b15bfffff6cc9",
+          "ct": "94f4edda147a95cf29bb0402d0413e5421b5ae347c31b2ec3239bd808c4e5b609d0ce9d9c3a12e47eae6c5fe319288553ba25e8932d644a6387087b4e495ad4bc124596d9440ddd5376f2c1844e61a7c51bef528ad20065574198ace92d3402dcf4df8ff5d68c06dafe9302da4e075ab0e011bfc1bbaa55b4cc1bc30dc9b104539c21d60b6fc7044e0242591360751fbeb2883099602a900cb5320195cb7071819dbce2667a7532aacb2c9b96f3e726267b709c5c0877280f5d4efeb5d4155bf8751f9560db4bfaf8150a8f27b366c3935860aeb106bd88914b6bccf35bb6eaf9217254e6dacd88f0f1182d6cbe25635d4d9ad76a06687d2527ed7d9cbf50803",
+          "label": "3bd80a6378115c0c946b4e3af28c6c96d1110621e21e8633416e9c8ef0a73d4000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 36,
+          "comment": "em has low hamming weight",
+          "flags": [
+            "Constructed",
+            "EncryptionWithLabel"
+          ],
+          "msg": "0cf83d297f20f527983f3111716a68d0d33d97ee4f5d1822c9e5382398542bd532316db29d8a8f92bacae063aca1c1cd9bc272fec688b3f67956c662a5b2f895509fe6f2406f0674afb0f0472aa205a7d55a092a5ced1b1c1b92a7b93f9c695440a3257e007949d27098410454d4e39612c7dcabc85e19f3421734bb2717de00c041f569e8d43006005960af8f573e13867911989a4c678da8f15ca0278ebbb21742fe33b3613f22afca45ac09f815b50155ecab6eb07806bdfef37b5dd5",
+          "ct": "68825b60b53cc0bbc92e4ce994b0dd270bad0eb657e41acf26a9e3161c5254e4bd38b03e90d7453424e605a372bc185f3ae6ba9ff58fab0cc4c1cc158d7a1e8f1f0b30ac08789f7576fab2dae7e86dae60d9af793dc1b400c2d25a9d3357ba0d27361d74a1b4e1445147a45875901d70f3190a0b34defbdbec1cb9ed3014f15a1a0f9000d9b224fba944e791d303d816bafeb8e65dfc6d740d04719c4ab36c4bbf4ebea5fc45ead338825fc5a71dd6c25f8d8891a4f8d6e0b35483c75c1bd645c3cbe9dcf5a17ae5cd2abdfb132b2b37102122a9bfc42ceb3eac98f2af39905b9cece5d122b70c95239062ceeab798691dd2b88028047924d5ae814df78d555b",
+          "label": "48915cebf2a2ef9e5d5b92cce033b60456d72af1ba54f88f5074a36a643a317800000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 37,
+          "comment": "em has a large hamming weight",
+          "flags": [
+            "Constructed",
+            "EncryptionWithLabel"
+          ],
+          "msg": "2124d6fdfbbf77ac89f50a235b0af69edbdbe9ef3fcde36441d7022afdc8434431b893eba822cb82585384e36298df45b4b4415a3bdc494604305272f5e988f2cc14a56043421557d5e5dc958fd771e4d509126656d21222cb8e2e1052ba38286c5e3d0be0f4b1c978a61bd1e3652ccb63fea82ec46d6b64863c00b93a3243e2328f70f692aa65f73976335eec5b29a9542befa03d5e82aba9dc285af0913382d67aacd513bbf6f5095e4d5f9b5ebfb5ddc25cafd888addf9ffa068bd4eb",
+          "ct": "0ed3b1f6a9b200147e535042353768280244b3c831215928a2b2103df02b3613f43ecfdecc6a8f61ce0183b8c60980f82c3dde3a731ea25a0ca9b89e5f68a7cd6cf6c6475f591f24b7a89a885a46edb0ade49e37665219a6da9afbbf655943912636af85e0bc859f43d3c48b4e77c9d1c0d641a21fecf4957185b805aeb908c6387c9d1c8ad85a166c075942f0cf68ca70f8174a9d2a4e5589c7005e2c423ff97c97a208da51d9adc0cb4588a257c0a1d0feb02eb050f9980309abd09258570ab2c8186cc357a9f693107c84855ff6ee7936b71980de42883e3ee7c1c6ddbe03d16a1f1c5bc5f987e6de9cab329ed7a31b59cac467d7b6432cb40f616ac9d4a8",
+          "label": "02be339a2b399ffeaec99acfd80f50ebdfc8fe3021a9a432ddd4134b3466b4a800000000",
+          "result": "valid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/vectors/wycheproof/rsa_pkcs1_2048_test.json
+++ b/tests/vectors/wycheproof/rsa_pkcs1_2048_test.json
@@ -1,0 +1,1879 @@
+{
+  "algorithm": "RSAES-PKCS1-v1_5",
+  "schema": "rsaes_pkcs1_decrypt_schema_v1.json",
+  "numberOfTests": 67,
+  "header": [
+    "Test vectors of type RsaesPkcs1Decrypt are intended to check the decryption",
+    "of RSA encrypted ciphertexts."
+  ],
+  "notes": {
+    "InvalidCiphertextFormat": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "This is a test vector with an invalid ciphertext. "
+    },
+    "InvalidPkcs1Padding": {
+      "bugType": "CONFIDENTIALITY",
+      "description": "This is a test vector with an invalid PKCS #1 padding. Implementations must ensure that test vectors with different modifications cannot be distinguished from each other. For example it is a mistake if invalid paddings lead to distinguishable exceptions (RFC 8017 Section 7.2.2). A recommended test is to collect the exceptions thrown by all test vectors with the InvalidPkcs1Padding flag and check that these exceptions are all exactly identical.",
+      "effect": "An implementation that has a distinguishable reaction to different types of invalid PKCS #1 paddings frequently makes it easier to perform padding oracle attacks."
+    },
+    "Normal": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a pseudorandomly generated, valid test case. Implementations are expected to pass this test."
+    },
+    "SpecialCase": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a constructed special case. Such special cases check for arithmetic errors in the implementation. "
+    },
+    "SpecialCasePadding": {
+      "bugType": "FUNCTIONALITY",
+      "description": "This is a test vector where the padding string ps is not random. The ciphertext is still valid and decryption should not be affected."
+    },
+    "Sslv23Padding": {
+      "bugType": "FUNCTIONALITY",
+      "description": "SSL v3 would use this padding if rolled back to version 2. The padding is valid, it is simply a special case that was used to detect rollback attacks."
+    },
+    "CVE-2020-14967": {
+      "bugType": "KNOWN_BUG",
+      "description": "jsrsasign package before 8.0.18 for Node.js. Its RSA PKCS1 v1.5 decryption implementation does not detect ciphertext modification by prepending 0-bytes to ciphertexts.",
+      "cves": [
+        "CVE-2020-14967"
+      ]
+    },
+    "CVE-2021-3580": {
+      "bugType": "KNOWN_BUG",
+      "description": "Some implementations fail when the ciphertext is too long.",
+      "cves": [
+        "CVE-2021-3580"
+      ]
+    }
+  },
+  "testGroups": [
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00b3510a2bcd4ce644c5b594ae5059e12b2f054b658d5da5959a2fdf1871b808bc3df3e628d2792e51aad5c124b43bda453dca5cde4bcf28e7bd4effba0cb4b742bbb6d5a013cb63d1aa3a89e02627ef5398b52c0cfd97d208abeb8d7c9bce0bbeb019a86ddb589beb29a5b74bf861075c677c81d430f030c265247af9d3c9140ccb65309d07e0adc1efd15cf17e7b055d7da3868e4648cc3a180f0ee7f8e1e7b18098a3391b4ce7161e98d57af8a947e201a463e2d6bbca8059e5706e9dfed8f4856465ffa712ed1aa18e888d12dc6aa09ce95ecfca83cc5b0b15db09c8647f5d524c0f2e7620a3416b9623cadc0f097af573261c98c8400aa12af38e43cad84d",
+        "privateExponent": "1a502d0eea6c7b69e21d5839101f705456ed0ef852fb47fe21071f54c5f33c8ceb066c62d727e32d26c58137329f89d3195325b795264c195d85472f7507dbd0961d2951f935a26b34f0ac24d15490e1128a9b7138915bc7dbfa8fe396357131c543ae9c98507368d9ceb08c1c6198a3eda7aea185a0e976cd42c22d00f003d9f19d96ea4c9afcbfe1441ccc802cfb0689f59d804c6a4e4f404c15174745ed6cb8bc88ef0b33ba0d2a80e35e43bc90f350052e72016e75b00d357a381c9c0d467069ca660887c987766349fcc43460b4aa516bce079edd87ba164307b752c277ed9528ad3ba0bf1877349ed3b7966a6c240110409bf4d0fade0c68fdadd847fd",
+        "publicExponent": "010001",
+        "prime1": "00ec125cf37e310a2ff46263b9b2e0629d6390005ec88913d4fb71bd4dd856124498aaeba983d7ba2bd942e64d223feb7a23af4d605efeea6bd70d39afe99d35a3aa15e74a1768778093be0edd4a8d09b2def6dc9b67ff85764625c2e19236db4c401ce30a2572d3ecb4f969b7ad19c522c02d774465676e1a3776c54d6248348b",
+        "prime2": "00c2742abcd9897bd4b0b671f973fc82a8f84abf5705ff88dd41948623afe9dca60dc6543390767feaebeb539576ee8bfa61b5fcbca94a7cef75a09150c540fa9694dd8004ad23718c889049219369c99f4458d4afc148f6f07df87324a96d9cf7b385dd8622414a1832f9f29446f050c2d5a6407649dc41ab70e23b3dcc22c987",
+        "exponent1": "0096a9798d250263400bb6277342881627e07cecdf91187b01b89ff47314188a7c20fb24800156d2c85d5666e8df6ceff9f9804ddfad80ff5767de56ecc029c72bf6c717df9f64daafc29acf9dc7908f9a0ad67e20e8949936ccba18d021a2c4febb04349a2b2047c4901385b6e5d0c691d118b33f81802b32ac272ef09e42fad5",
+        "exponent2": "0554f41b0b87f68a45722b3be0cf4ab1e165034c1a91002ab8f29e9ef9e2dab6fee7b2455bafb42037e9d2f7e533f348a147412fd72080be7c2633f5d802c91c39e6bcece3e675e59995033c55737020dad9e8b30d04b828adfb9304ad54a11a35a4f50709876ac5b118236ba76a4d7c9a291dd9607b169de1d182385691999f",
+        "coefficient": "1c640189d9bfe8c623833210a76c420c6f44e5d760e259916cec2ae2b156456960fd95e2747660c389562250f055049cfab7e5c3039549384a7a2aaeb1c824d3af709482a8cf9b587022a00b1f0722db50f33cb26dc20dd2245d5265df61ee2983c938c2167dcee121fc4b4479c237e728cf633ab60a8c0ecd04fce7e3baa559"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100b3510a2bcd4ce644c5b594ae5059e12b2f054b658d5da5959a2fdf1871b808bc3df3e628d2792e51aad5c124b43bda453dca5cde4bcf28e7bd4effba0cb4b742bbb6d5a013cb63d1aa3a89e02627ef5398b52c0cfd97d208abeb8d7c9bce0bbeb019a86ddb589beb29a5b74bf861075c677c81d430f030c265247af9d3c9140ccb65309d07e0adc1efd15cf17e7b055d7da3868e4648cc3a180f0ee7f8e1e7b18098a3391b4ce7161e98d57af8a947e201a463e2d6bbca8059e5706e9dfed8f4856465ffa712ed1aa18e888d12dc6aa09ce95ecfca83cc5b0b15db09c8647f5d524c0f2e7620a3416b9623cadc0f097af573261c98c8400aa12af38e43cad84d0203010001028201001a502d0eea6c7b69e21d5839101f705456ed0ef852fb47fe21071f54c5f33c8ceb066c62d727e32d26c58137329f89d3195325b795264c195d85472f7507dbd0961d2951f935a26b34f0ac24d15490e1128a9b7138915bc7dbfa8fe396357131c543ae9c98507368d9ceb08c1c6198a3eda7aea185a0e976cd42c22d00f003d9f19d96ea4c9afcbfe1441ccc802cfb0689f59d804c6a4e4f404c15174745ed6cb8bc88ef0b33ba0d2a80e35e43bc90f350052e72016e75b00d357a381c9c0d467069ca660887c987766349fcc43460b4aa516bce079edd87ba164307b752c277ed9528ad3ba0bf1877349ed3b7966a6c240110409bf4d0fade0c68fdadd847fd02818100ec125cf37e310a2ff46263b9b2e0629d6390005ec88913d4fb71bd4dd856124498aaeba983d7ba2bd942e64d223feb7a23af4d605efeea6bd70d39afe99d35a3aa15e74a1768778093be0edd4a8d09b2def6dc9b67ff85764625c2e19236db4c401ce30a2572d3ecb4f969b7ad19c522c02d774465676e1a3776c54d6248348b02818100c2742abcd9897bd4b0b671f973fc82a8f84abf5705ff88dd41948623afe9dca60dc6543390767feaebeb539576ee8bfa61b5fcbca94a7cef75a09150c540fa9694dd8004ad23718c889049219369c99f4458d4afc148f6f07df87324a96d9cf7b385dd8622414a1832f9f29446f050c2d5a6407649dc41ab70e23b3dcc22c9870281810096a9798d250263400bb6277342881627e07cecdf91187b01b89ff47314188a7c20fb24800156d2c85d5666e8df6ceff9f9804ddfad80ff5767de56ecc029c72bf6c717df9f64daafc29acf9dc7908f9a0ad67e20e8949936ccba18d021a2c4febb04349a2b2047c4901385b6e5d0c691d118b33f81802b32ac272ef09e42fad50281800554f41b0b87f68a45722b3be0cf4ab1e165034c1a91002ab8f29e9ef9e2dab6fee7b2455bafb42037e9d2f7e533f348a147412fd72080be7c2633f5d802c91c39e6bcece3e675e59995033c55737020dad9e8b30d04b828adfb9304ad54a11a35a4f50709876ac5b118236ba76a4d7c9a291dd9607b169de1d182385691999f0281801c640189d9bfe8c623833210a76c420c6f44e5d760e259916cec2ae2b156456960fd95e2747660c389562250f055049cfab7e5c3039549384a7a2aaeb1c824d3af709482a8cf9b587022a00b1f0722db50f33cb26dc20dd2245d5265df61ee2983c938c2167dcee121fc4b4479c237e728cf633ab60a8c0ecd04fce7e3baa559",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCzUQorzUzmRMW1\nlK5QWeErLwVLZY1dpZWaL98YcbgIvD3z5ijSeS5RqtXBJLQ72kU9ylzeS88o571O\n/7oMtLdCu7bVoBPLY9GqOongJifvU5i1LAz9l9IIq+uNfJvOC76wGaht21ib6yml\nt0v4YQdcZ3yB1DDwMMJlJHr508kUDMtlMJ0H4K3B79Fc8X57BV19o4aORkjMOhgP\nDuf44eexgJijORtM5xYemNV6+KlH4gGkY+LWu8qAWeVwbp3+2PSFZGX/pxLtGqGO\niI0S3GqgnOlez8qDzFsLFdsJyGR/XVJMDy52IKNBa5YjytwPCXr1cyYcmMhACqEq\n845DythNAgMBAAECggEAGlAtDupse2niHVg5EB9wVFbtDvhS+0f+IQcfVMXzPIzr\nBmxi1yfjLSbFgTcyn4nTGVMlt5UmTBldhUcvdQfb0JYdKVH5NaJrNPCsJNFUkOES\niptxOJFbx9v6j+OWNXExxUOunJhQc2jZzrCMHGGYo+2nrqGFoOl2zULCLQDwA9nx\nnZbqTJr8v+FEHMyALPsGifWdgExqTk9ATBUXR0XtbLi8iO8LM7oNKoDjXkO8kPNQ\nBS5yAW51sA01ejgcnA1GcGnKZgiHyYd2Y0n8xDRgtKpRa84Hnt2HuhZDB7dSwnft\nlSitO6C/GHc0ntO3lmpsJAEQQJv00PreDGj9rdhH/QKBgQDsElzzfjEKL/RiY7my\n4GKdY5AAXsiJE9T7cb1N2FYSRJiq66mD17or2ULmTSI/63ojr01gXv7qa9cNOa/p\nnTWjqhXnShdod4CTvg7dSo0Jst723Jtn/4V2RiXC4ZI220xAHOMKJXLT7LT5abet\nGcUiwC13RGVnbho3dsVNYkg0iwKBgQDCdCq82Yl71LC2cflz/IKo+Eq/VwX/iN1B\nlIYjr+ncpg3GVDOQdn/q6+tTlXbui/phtfy8qUp873WgkVDFQPqWlN2ABK0jcYyI\nkEkhk2nJn0RY1K/BSPbwffhzJKltnPezhd2GIkFKGDL58pRG8FDC1aZAdkncQatw\n4js9zCLJhwKBgQCWqXmNJQJjQAu2J3NCiBYn4Hzs35EYewG4n/RzFBiKfCD7JIAB\nVtLIXVZm6N9s7/n5gE3frYD/V2feVuzAKccr9scX359k2q/Cms+dx5CPmgrWfiDo\nlJk2zLoY0CGixP67BDSaKyBHxJAThbbl0MaR0RizP4GAKzKsJy7wnkL61QKBgAVU\n9BsLh/aKRXIrO+DPSrHhZQNMGpEAKrjynp754tq2/ueyRVuvtCA36dL35TPzSKFH\nQS/XIIC+fCYz9dgCyRw55rzs4+Z15ZmVAzxVc3Ag2tnosw0EuCit+5MErVShGjWk\n9QcJh2rFsRgja6dqTXyaKR3ZYHsWneHRgjhWkZmfAoGAHGQBidm/6MYjgzIQp2xC\nDG9E5ddg4lmRbOwq4rFWRWlg/ZXidHZgw4lWIlDwVQSc+rflwwOVSThKeiquscgk\n069wlIKoz5tYcCKgCx8HIttQ8zyybcIN0iRdUmXfYe4pg8k4whZ9zuEh/EtEecI3\n5yjPYzq2CowOzQT85+O6pVk=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "s1EKK81M5kTFtZSuUFnhKy8FS2WNXaWVmi_fGHG4CLw98-Yo0nkuUarVwSS0O9pFPcpc3kvPKOe9Tv-6DLS3Qru21aATy2PRqjqJ4CYn71OYtSwM_ZfSCKvrjXybzgu-sBmobdtYm-sppbdL-GEHXGd8gdQw8DDCZSR6-dPJFAzLZTCdB-Ctwe_RXPF-ewVdfaOGjkZIzDoYDw7n-OHnsYCYozkbTOcWHpjVevipR-IBpGPi1rvKgFnlcG6d_tj0hWRl_6cS7RqhjoiNEtxqoJzpXs_Kg8xbCxXbCchkf11STA8udiCjQWuWI8rcDwl69XMmHJjIQAqhKvOOQ8rYTQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "GlAtDupse2niHVg5EB9wVFbtDvhS-0f-IQcfVMXzPIzrBmxi1yfjLSbFgTcyn4nTGVMlt5UmTBldhUcvdQfb0JYdKVH5NaJrNPCsJNFUkOESiptxOJFbx9v6j-OWNXExxUOunJhQc2jZzrCMHGGYo-2nrqGFoOl2zULCLQDwA9nxnZbqTJr8v-FEHMyALPsGifWdgExqTk9ATBUXR0XtbLi8iO8LM7oNKoDjXkO8kPNQBS5yAW51sA01ejgcnA1GcGnKZgiHyYd2Y0n8xDRgtKpRa84Hnt2HuhZDB7dSwnftlSitO6C_GHc0ntO3lmpsJAEQQJv00PreDGj9rdhH_Q",
+        "p": "7BJc834xCi_0YmO5suBinWOQAF7IiRPU-3G9TdhWEkSYquupg9e6K9lC5k0iP-t6I69NYF7-6mvXDTmv6Z01o6oV50oXaHeAk74O3UqNCbLe9tybZ_-FdkYlwuGSNttMQBzjCiVy0-y0-Wm3rRnFIsAtd0RlZ24aN3bFTWJINIs",
+        "q": "wnQqvNmJe9SwtnH5c_yCqPhKv1cF_4jdQZSGI6_p3KYNxlQzkHZ_6uvrU5V27ov6YbX8vKlKfO91oJFQxUD6lpTdgAStI3GMiJBJIZNpyZ9EWNSvwUj28H34cySpbZz3s4XdhiJBShgy-fKURvBQwtWmQHZJ3EGrcOI7PcwiyYc",
+        "dp": "lql5jSUCY0ALtidzQogWJ-B87N-RGHsBuJ_0cxQYinwg-ySAAVbSyF1WZujfbO_5-YBN362A_1dn3lbswCnHK_bHF9-fZNqvwprPnceQj5oK1n4g6JSZNsy6GNAhosT-uwQ0misgR8SQE4W25dDGkdEYsz-BgCsyrCcu8J5C-tU",
+        "dq": "BVT0GwuH9opFcis74M9KseFlA0wakQAquPKenvni2rb-57JFW6-0IDfp0vflM_NIoUdBL9cggL58JjP12ALJHDnmvOzj5nXlmZUDPFVzcCDa2eizDQS4KK37kwStVKEaNaT1BwmHasWxGCNrp2pNfJopHdlgexad4dGCOFaRmZ8",
+        "qi": "HGQBidm_6MYjgzIQp2xCDG9E5ddg4lmRbOwq4rFWRWlg_ZXidHZgw4lWIlDwVQSc-rflwwOVSThKeiquscgk069wlIKoz5tYcCKgCx8HIttQ8zyybcIN0iRdUmXfYe4pg8k4whZ9zuEh_EtEecI35yjPYzq2CowOzQT85-O6pVk"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "Message of length 0.",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "",
+          "ct": "5999ccb0cfdd584a3fd9daf247b9cd7314323f8bba4864258f98c6bafc068fe672641bab25ef5b1a7a2b88f67f12af3ca4fe3c493b2062bbb11ad3b1ba0640025c814326ff50ed52b176bd7f606ea9e209bcdcc67c0a0c4b8ed30b9959c57e90fd1efdf99895e2608095f92caff9070dec900fb96d5ce5efd2b2e66b80cff27d482d242b307cb813e7dc818fce31b67ac9a94501b5bc4621b547ba9d81808dd297d600dfc1a7deeb061570cde8894e398453328740adfd77cf76075a109d41ad296651ac817382424a4907d5a342d06cf19c09d5b37a147dd69045bf7d378e19dbbbbfb25282e3d9a4dc9793c8c32ab5a45c0b43dba4daca367b6eb5f4432a62",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "Message of length 20.",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "ct": "a9acec7e58761d9191249ff7ea5db499cadccc51d29f8e7fd0aa2cb9962095626f1cadae29666f04ce2afd4b650be59d071d06446d59107eb508cc60545727b0567dfb4f2f94ca60b939c60be111172f367dfd235516e4a60061648c67f5536650821ac2a60744be3cf6befa8f66e76a3e7c5fbc6dfa4dda55ecbdbffdc98d610de5667a4f485f6168b52bbe470e6014253874ce7b78e509937e0bc5f02857e1ad3cf55139bbe6dc7ac4b1ed5097bf781b7671ca9bb58187aa6c71c58ac0561c5aacf96c35deb24e395b6823de7fc96b8031b5906a34c4dc57e4f1226157b9abd849e1367dda014fbf9ed4ca515a7a04cf87787945007e4f63c0366a5bbc3489",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "Message of length 4.",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "54657374",
+          "ct": "4501b4d669e01b9ef2dc800aa1b06d49196f5a09fe8fbcd037323c60eaf027bfb98432be4e4a26c567ffec718bcbea977dd26812fa071c33808b4d5ebb742d9879806094b6fbeea63d25ea3141733b60e31c6912106e1b758a7fe0014f075193faa8b4622bfd5d3013f0a32190a95de61a3604711bc62945f95a6522bd4dfed0a994ef185b28c281f7b5e4c8ed41176d12d9fc1b837e6a0111d0132d08a6d6f0580de0c9eed8ed105531799482d1e466c68c23b0c222af7fc12ac279bc4ff57e7b4586d209371b38c4c1035edd418dc5f960441cb21ea2bedbfea86de0d7861e81021b650a1de51002c315f1e7c12debe4dcebf790caaa54a2f26b149cf9e77d",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "Message of length 6.",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "313233343030",
+          "ct": "455fe8c7c59d08c068b5ff739d8dab912b639c8e9eade5d0519d58f4ead7208d5a753b4a88fe771475adc82d10ab29ded28caf03f9034d3a111b520440c02276e1b6417c42eec0257f1f05482868987f2f75bd33d1ec3dbc799d7b5bf25c4a0543793a4d3ce305cc43646bc450344e624fd381e24d8e57ef2840dd9d576da554ba408ee6580159e6d88438a28d66250b3b3fe3bc6624406022a9e4ee2778c38230674f635f56b9d6adcf2be6bfab34a8a431169d769876422f7077ded31fa6f29993dd1972b2d2d24b0513a7a193f6a88d53c49cde2c030f85e3ddfbc9f99b4a667fd9c652382238166f3d39eb2b78de53ad24c97699fe5738a7a705a2ab141b",
+          "result": "valid"
+        },
+        {
+          "tcId": 5,
+          "comment": "Message of length 7.",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "4d657373616765",
+          "ct": "1cf861ef8b6c29474666605d3ddb663a259a9ae838417abcc7f7dd42d471d5f3812cdf90e3041c4c5bfd38ac1e4d95fd71661bddac45f5f8e3e89629a335bbf2eff116030f1c5ace8336cf7e94c2e8bf5a1d6116e54ec42b9da5fc651a41ac8fd38194e5029489cfde1f7fc850c0dfb3dc00021f74ae3847327c69afdb1355c7587bb93d5f4d2cfb35a7f70bcabd43eb32300585b6ee32f14a68c2a08434e923adb76dfcdf3ea5133edffa5ca20425083b28ecb045e69562b44286d320d87285e7a2e3bedded083c010401ae22c8f278b080112c4264a3cad3ed9fa31cf19e052aabbda9f8ecef1d64786258202bb61128b3140a355d65b982b0239764d77d24",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Message of length 1.",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "61",
+          "ct": "8122b33665648346f6cf728f285667cff7f3c20907e76438e64db81a6a5e74c34c5694fb5b4c826067bae94c5176e152eb16884d9c2b63d2ff41d06140c9c39469a4ae05cda86c81ccb208894266f6b24a0f79132f71521e10683faa05c8e68b77dd6c0c04cbfef55a9d1b68291c286e08907c3df029c52e15539027f534c7df8da5637db99355b24576b873c119ff1d74b3c913b70c48f366887ccbe6d206c11657401f41baad9290fe6ae01855a99891700d71775fb36237bd3597ad240fff4c03d1fe599cdec65baef11fbc4889575a55f255b51ec8298595dbcc89659382d35c2b85a941c33746a7937f3d18e27079fc3d2252904aa533fbfd2ebed2e059",
+          "result": "valid"
+        },
+        {
+          "tcId": 7,
+          "comment": "Message of length 32.",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "e0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+          "ct": "18e280e8b03d8588b923842d15fddb0493285ecd7ad2d9a9878045ce615ba07cb811fd4a0737e91ece5a63b70b1edc23e0da939ec654333eb77e956108b040bd6b92927e25a6922d1b92302036985915fedf9fb38431bbce1feee3ec42ff15bc4a4b6d10b3da41ec96667b81163b30b46eef4f46fb22f187da8fd536461e5594bf557a6dfc2337883bee8d6187192a3b4bea70398b01f3ea8c1547f6c57248243365b3c46b117924d8bb6845ea382c389c648d3e65ff0b8711bbe1a6fd3bea028f5808725f198cda0407a0ff46b5af261a37184547250f496800e697290e39d46d6bce67b767d73a63bd98f699c1828180abfd51a3048d050d496236edf1e99d",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "Longest valid message size",
+          "flags": [
+            "Normal"
+          ],
+          "msg": "7878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878",
+          "ct": "7e151b7b34e3b4abe045cf708640e61501c50fdca629aeca10259d45d15eeec6a2008b6336f57021ac6fdad9a6b29d65f098abff76f93722a8e23fb5e153db075005575dad6adccb7c020cd741c3419946b82d369a07fad5b0d55d51774f8991bd65e9e828d8f5a989c866a024a4a78434e9affd0af2c72f9185d450b627008a8a0968fc6373ca340410306a58921cce1207bb6f6c14e3d1f214304f9f6bb9199909e1610322e834b0ce9f55b1835d7623b82ef548545f984ea51466250159344dde902a0f021ba4baf26b16d8c6a42003f4d5dcae531187dc7e3f87c9e04470599eb623e04fca266e86f98cabb6866004e7fc80b36c3977456e51eb64f4b65f",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "The padding string is all 0.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "6e0d507f66e16d4b7373a504c6d48692aaa541fdd59eeb5d4a2cd91f6000ce9b5734a232d6541a78729ac82152d3a30b51950a24ae379a108ed20fa4ec7542fe2281c2dd5de685564d15182f3c73e9c0135ebc993f5acd240a343d3257997582328c31be215c7349375406aa78a3ac35327226839bee2f1a4a0f8e6e06986cb33806c93e0b0c1d6cfd23f4a68c1f2a38c74b8df70f280984a840c710c52279034d04f61e313d4bcd8b3b5c58468a44565a1acb2eefc6d49044be7163e64ed84b5e7991ecba274a3a7ee4defb842a86ac4cbf2d3bfc9cf870ae025a3e2fbc775916a59579763c06eb84ad8edd1d03787e609ad446de43ebed16330ab06716fa73",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "The padding string is all 1 bits.",
+          "flags": [
+            "SpecialCasePadding"
+          ],
+          "msg": "54657374",
+          "ct": "633546723d13ef2712561abfa5b477a36ce7c8dc5a9f43589ea289a15f749c89e4e3ba3ca6a615333e9bb5ff3efb62b32e7f11870c8bbeffe884a5ef2b1006045bd97bb29699084dac4212c217e10113232683445091fa7224abc02ad37feaf10d5b4af6f288fa01d85bcd944bf411ac56c0b7bf1037452f540f286114b14b2208fb4282b6829c594aa27ad5ef1dc67b5696ed2a4b9a4ee2354cc05315fff5e8a4e0e75675c1eed34d46effa73ea96e748340771dfec01dae937edd8924ece8470542a8251c31e9130e2c5f80152b4c66111df52f7e5f9b40835b44bf8e8e273b075dc04f758a30c24dc2c2abeaf639f4fca4dacd509250378ad0e5276374b99",
+          "result": "valid"
+        },
+        {
+          "tcId": 11,
+          "comment": "rsa_sslv23_padding",
+          "flags": [
+            "Sslv23Padding"
+          ],
+          "msg": "54657374",
+          "ct": "94a6ecdadcc3a9c5645d0410929ba8f01c89b8426b889d3064cf1811f2caaa1e1a55a29a1869a7d719226bcea637407bb80383e76b5966e2ea4d56fbb2fb325da12546071b65898b12e36d0ea0e47245930eb051cecc4b8dede18adb4f1ca318cf0e36820f1cfd4911f076e0f3fbf9c197a0ed32063f72405477888f13cbab4649e3c8df4f022a4109ecb91fbeedbc4df4d89ad9cacbbd7e8e27a2f1fe1813d3f1b537ecf41878f05918171504bf800631781a7c36451abbc32dda5b55f05f4ba7b5414089d9d679248cf042756a4f06c37c8b5a18a6ba8f97853cc6763235ee841d96e61f2d75c188ca53d222d3d925a3d701551758feb79ccf8709cb61b793",
+          "result": "valid"
+        },
+        {
+          "tcId": 12,
+          "comment": "Byte 0 of the padding string is 0. All bytes should be non-zero.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "6a8b8c01247d9d4d1c3bbaac58e077e37926854dc8bdb58fb7b98979ba9102934469836480a0b96a5b452e54dff55e77b52dc1cb93656f6802b7fbe06ca0923e38e549dabcdbce909fdd10d677d896384af75e7146794bfa009ebbb2d6890b1cfcad4698d297c759b0a01151bdfe1d48cf92e80896be923d02371930cafb155e543d9a21e52faf2395234e65d575fa9f5276c80ae4cd6ec18ac6d954ad043d2a46932763ca44476180b397215d95651fba63220998e06ab2dcc4935dadaae8660ac8c6356b871e0b1397af20d6fe937c3211e21559a3d0eb39c2949a96611b13740ae0c26ce67c373a9225a3c1773ec662ca20dee620c0acef1475b362ee9b9f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "Byte 1 of the padding string is 0. All bytes should be non-zero.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "84c149c378f3f12ce202bb561456257057709114ecbaa4c3a7dbfbcbfaf2fe9a19cebabd72e39474b6bd7871c3dae41a9c87c5cb2fafc2d06d49c60ac401ed1e125522d0854fe8fb8611f8efb90d2b89a14eaeb6e991f19329dd7d183ef72cf0543dabedcdecc9977cc9395e2629a1dc8d359b2bc0fea6ef250c4cfa2ac8ad22a6a587e32859a8c99e4f7cdf938527e9e0bb597721517067d83fab31457e52e7a11b0393135d30e619d7cc47caf970facdd8dc4bd613b151f93cc53c1307cef68feb5a67d32337cf2ff954be7a553d3f07c9f657aebd9e8d4ee99e8736c152804295f366a4ffaf2a72e29c2f87b03b28b99da1f6a7ee0d9364ef711eda4f0793",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "Byte 7 of the padding string is 0. All bytes should be non-zero.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "3307264f64d4ca8b62c4e7da4cac117262e5d3a3dbc19a529ac5167c1987bce56e358726d0ecfc6cb591a12bd5f7531cd2249439254c366ad3cb7a608f845e1eca931018295208ba5c6198027b22191224c4568856ab331e2acf530fc434870865d3321ac90327a8c61f27cac9859dac8e3c38d8453349d2ef8e4a7e8011f6badd1530eae710e0c60d35905f20d7a2d118e7ce18ebb220f04b4089778cbf091bcb3e02aca83b4b9ba5319c3069188c7b00c7d32ebe1dd6e6535b5f667ce972f00ba773d4cf6a556ccf65bacc1eca2312881caf6a89ff5d83960846a5d9dd31477dcc9ee4ae50ab0cb2e574a685bd9d7b7a74c7ca9876f08fd64d1d5f196786be",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "The padding string has been truncated.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "16d56b7a9e672e387016e8b1c9cff474d560faa8ca14a565fba086015c5f9d53b205c4ccfe77ed5f3d10a04a23bc031d9c7fc809668ceb5c4e31ba8760475de713413b1ae5666e93087e146a2607c00d6492ed095973c7ccd79996aa26023a2c6623f382e94a4c595fbb596be074f87559267186cc475175152277cccaf9513dcb95a1f6540bb633a9a65182f2a53838b85329c9544c24740b24b27ce5d760f051c47e6cc107c264bc1a87ba7bd2bf27675547bda28b3d2a7281d6732f9dbc3c20eecb280f2ba6f25cd49c930dcc3a413987ab4de0fe9314a61e092b3708c75c9bf96831df05e4dbe31f75b2ddaf3bde7f01c7940ec62758006a652871d72b75",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "The padding string has been removed.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "25f67bc6c1320a13fa91a23d4d1801cc73594161a7f344ffa195d6dd1894c1e39d6cd81866462d05e0e16c02459a3f1dc5f0ecc52657f70385fd0b33de214216a2298b4814550af1ecd929170bc69b74e08299bea50de33021468f4fe2a2e4a43233d6872d15379ccea03450145d909c5eb11ca5f524e17b2065768b9bb06438e81b0b8ca816bfcc7eddcffba59b33e2a0b4ad8df215c2eafa240e553f1526dad66038e54f305a6d3fd6460e781239c9dc424ab6df7f75bb4327d873d0e8d7ecab1b09b8779cb841e002ee45f8dbebd2d483de2d7136ae7e350580dc8a48bcd6359a677bccd689bbdf879f2520d8976fc2b92e64dda8e7399719a13b8182c739",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "The block type is 0.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "371e281730bbc289cd77a64ab49b370ed7900c48f5625615ff28beeeeabc860b4673ab16003fd5e13c89c8b6a0e5c9b732044981ddf2bc45d4613bf409cb2e98123ceb661c1093773d71c67fd198288d6e9b832596894834c3955799ea20e242b632335baf8e8787c104499fb5d0eaa331f05a8b46383dd13cc05f0518d05d9b03bdfdc2dbc9299a04210c33f5dbed3779fb1548ead0022622234a6a2ffe5ca42a43db40f272d6633c7151360b5b90e135283a6aaf69b0491edda637dea0989e3a5dd0c3aac267074662443c37ce1b3fd4b2e9743fb0d00dc136d8df10b6fd0b60d30c1399ab52d75e2db559d8faefc45008c2d9100ed08caa88bdc11aea04df",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "The block type is 1. This block type is used for signatures.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "92210e5bbf24d2cd9527f6e24ffafafdfee242b146539f3731715fff42092cc8f5a1a4919417c9df9a5a32e61201f4354a87ab06e97f827f69e6cc13e7b9c79515145f210713523e6f64def697406a4929b2e09c31890b695b7b8bb851a22c7b541c5dc53cc75954c0246eae5a12af304133f4dcdb90f8c6f54847165612f7ef70f51dd493899d6e09ae9fed16fb1f1225d09750177893c5e5482e3cd427931ffd3fef3e901d51f39aa17e34443a34754533a887474e19213a5e24298071495d18c6ac77dece094c56bb34ed8274f5d75f99162a58dfc4240f5393baae58f484ef0a0259b56ad647ad81fe88c91b75a36b1acc67a56ec379bba03a8be91dc0cd",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "The block type is 0xff.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "6dbc27d33371f8cb3c3a54185a687a66eea8114f26cd234617b2f567d6013e222f33d7fe05298b73f8bf20266483571a52b1da2c0b1a431c257c62ed441215f57cd2a4af4628eeb21a9cd66a350a161cce446f25224a9acbdcdd709b14b810fafb02f3879605402e3fa6404e6e9a13b3f4fd3bd0e6c32f188a367a94aea813aebf4bd31635e5843a27bf7300419365d00ab97cb535866ba521dd0a8460fbc368ab9337caeee54f719f8998b126a111ffc6cff6d3c43ced45e8dce6565c00bf0be00694c339f7fdbe064c60e040a95b5d5b4af15fb7f14e00da6a591f187277e0c453eef7ffcef2a4efab93afdaa58e0bc1bb25286d9ce202176f395e29f92136",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "The first byte of the encoded message is 1.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "794ab724aeb176c4415a597e9d69cb567cece4479e6e4c9c19530b0877b53719d7f6318be8e970874c4be19984c632825dee7a38561a6904e23c776ccce71128847c24d5609e6790e3c9112393660ffd208771916d2e80d2c2fb35ff7936bab6c03e07646f15d09a88fd2ff8e70b624c66da4eb7dae241907ef328697c219d1ff347ada945e24ab526b6cea4e6b7f386560ab56f16751f6e2de0f7922a8946ae9afb9ce95369418f540163827f452f5d2a5029a1ce417453324eb015fd83ca2147331c02c762c457fc52ca5f097610c60430b69b6b0fc1c0877513bdb51923bca03e9af9174d3094530a007253958bfed03606e6f75cb5854443eaa363614116",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "The first byte of the encoded message is 3.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "8c7b80188818f63e6a0110cf94a169c78a0db75917caaf47405e8384b79a8f40de94f28f749186c4f16aeffb66168ac7c319d47de699ccae0edcb51a6822f88e27e99a1a0bb39d292e7d6e0922c1d2fd649376d81160d15cce10fc7082b88e8cd80dff13a33b54b8c00178a35fbbca633f4987f117aa9ec8e5f123dadcf29700ed5dbdad05bcd8e990985d950b210edae1ca1f6ecabf50a27e4bb23d4e80bf3955852e2ca18fd3e3c2f570fbeece943ef5c10ed1265049eac0d5b549713368703ad02311193ba0d3dac6073eb799139229a4aa0bfbc25bd5e886ad213dc321131ed12cf1008ee8af3a1588d06c75d7cf7375998e5a03af0ec8aa92276bd51b21",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "Using signature padding instead of encryption padding.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "34bc8b1a4646f2db8b10fdae22d6b5cb300229114015f25293d4b28e8f58783e1c5e6894da18dea527e4d843b51cf984170d56853e45f6ac77b1179eb0aa74fc556cbd632d576524b820a2c74a4c8159885fa08937e9c73ca0385c7a19676f2789b62f7a8b359a29132d74bc2b850e2335b5c7da8bf52d8d6fadd83ff9db32239bb737e890a32d561b10e9163c2fe4d35624e3e5faf664374c972a8d2e5b873c9a465e108bbdff1296c5557f314026558441a055d4b9cbb54179356787bd4bd02015cb3bbe02633711f266e915a0b4591415983610a2714adce1b0716675b95877bcef618784f2b3cd23fcdd0636e5856edb96852a32c9632c2e6e4b9a6f881e",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "The byte after the padding string is not 0.",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "4629027bfdd6c33abda030f0cb3ac1b55bddddd11292520f142248bbd1efad14adcb7ec50d278471f4a98dc9a674c202d823677d2606cd639fda443d7c14f0aa35f472189abe1b639f0856743212aab46ae35160ab4e6c08a20e5b82210b07b6eed11a315ef1b1f831b52bfd3abc06382b51c41a665ca6428e4bb6bd0df7895d056b8c17093e73c8129916e3abab3f61ce9a94c9d2fd30902076104b0e7fbde8da601f6c1bcc56a0100104848da6e9fbb28d893274b40885b3003ec7781aa710c83fbf4d4bc197630b1455853c4d6d6050011a7f7377e9034d29e4396f52b24ee6875feef883274cb0842b4b177d3fa3b416095c6ff96f6de0d9123dd9ce6d31",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "Using no padding (rsp. an all-zero padding)",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "910ad40ae0d8af151f512354e1cf12af7c4851cff0b659026e90a9ec4dea6c1e4b2b33cbe8260501493df2e7fa2cd77f020a7cfac1ca379eed3fe6d003335653a5f022f6bf5010e5f58c41fc91253d75eac2072479d4bb3509e1351a66f700ff4ac470115490021734bb8099e66c35f904f09d167303e26163393ed556cdccdfae95f239ebf0bd361a8adad927fb9544ca30132195735cb026dd0dc66c6efa0db41b73fc1c917be384a430e0788f5f872785cd709f70793204753d7b207fbce2d0bfbab11d3d614b99bf87bcc9a34db639fd203c9c081ddeecb9c85221e03cb9171685dafcfeaba470c5f1921a6fe016ba4b816a2328eee9853fa6994ec313d8",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "Replacing encoded message em with a single byte",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "6294ddf0fcd137390cb2193e050b5f61bf0183972912dca88ddcef7d54388665a7ff9be1f074b5e33b55dbf7c4212554a4e6243d3974aef4d95794dc72261883a45842da69497a36ed22c3590b0110e857bd0fc729663df53c831836f890b2b2012c9f56fc6dff36daada1a1e1cb2d654fee868c7c6fd58435dc8edb95dfe0271787074c2be9aace1f33ebd07ee6112cfb62f52487934af0c22ac93dafccfb01c561b370f05f3e604e92e5380103ba91113d007ab97b21ff3feb22f37c1a358215467d0a0223d43792f4947aa30c38f14246d1db9918c94600e7d0a393079dec2d9ad368ef378b2fff72cdd7c572f11074caca0995ca3e576428f651e1cf3764",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "m = n-2",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "50bc2c3ad07baf0bb9037b704b4e81c97003c7ce644ac8ed0c52ef9b1d7f825695f44a46e204786e6f7fe52cf01ab4f098e438a1125a79f2e3f76add9a8e9ebf175e92c5aa81e99abd17c6871b26de6b40f81c45d43194136f687545a33d590caeed0916deea9cb44ef815aa1695d9f7178dfb47b4805b3e2f47ec1e3de933e5b3de2950dbf702f3d09d7120ff94f43082409169beb5814955e445aa4914ecafbb36efc82aeda8b5d005f042f7a58d50f06763681d40a88119fa4d7b21e4a372701de8f5a4ef18e30e99f4126fd031af5aa28cf4316b03150a2e0a66355ce17124b13bc586e918116c2355f3169c186a80a85c1302fe01b33d01fd3c61fba0e9",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "c = 0",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "c = 1",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "c = n-1",
+          "flags": [
+            "InvalidPkcs1Padding"
+          ],
+          "msg": "54657374",
+          "ct": "b3510a2bcd4ce644c5b594ae5059e12b2f054b658d5da5959a2fdf1871b808bc3df3e628d2792e51aad5c124b43bda453dca5cde4bcf28e7bd4effba0cb4b742bbb6d5a013cb63d1aa3a89e02627ef5398b52c0cfd97d208abeb8d7c9bce0bbeb019a86ddb589beb29a5b74bf861075c677c81d430f030c265247af9d3c9140ccb65309d07e0adc1efd15cf17e7b055d7da3868e4648cc3a180f0ee7f8e1e7b18098a3391b4ce7161e98d57af8a947e201a463e2d6bbca8059e5706e9dfed8f4856465ffa712ed1aa18e888d12dc6aa09ce95ecfca83cc5b0b15db09c8647f5d524c0f2e7620a3416b9623cadc0f097af573261c98c8400aa12af38e43cad84c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "c = n",
+          "flags": [
+            "CVE-2021-3580",
+            "InvalidCiphertextFormat"
+          ],
+          "msg": "54657374",
+          "ct": "b3510a2bcd4ce644c5b594ae5059e12b2f054b658d5da5959a2fdf1871b808bc3df3e628d2792e51aad5c124b43bda453dca5cde4bcf28e7bd4effba0cb4b742bbb6d5a013cb63d1aa3a89e02627ef5398b52c0cfd97d208abeb8d7c9bce0bbeb019a86ddb589beb29a5b74bf861075c677c81d430f030c265247af9d3c9140ccb65309d07e0adc1efd15cf17e7b055d7da3868e4648cc3a180f0ee7f8e1e7b18098a3391b4ce7161e98d57af8a947e201a463e2d6bbca8059e5706e9dfed8f4856465ffa712ed1aa18e888d12dc6aa09ce95ecfca83cc5b0b15db09c8647f5d524c0f2e7620a3416b9623cadc0f097af573261c98c8400aa12af38e43cad84d",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "ciphertext not reduced",
+          "flags": [
+            "InvalidCiphertextFormat"
+          ],
+          "msg": "54657374",
+          "ct": "0ac6c14d67716199a68880364156f49ed0dabec4fd470c709440004ecf94b8aac75aceaf22a363dd8e6a863d981b4db4a61cadd9196b2a81c7982c49457a0aea817936e4f5dfe6c7ef3693fe537dca4146d5b9fdd4ec5369f79d4d2a4e701a01c04c2992d2062e7ff784a660951e58cc502a819fdff9d904a9e67d99c626162b909482c84bd152f0df04fa56ef567667e76f6ede71a1c261687ab1f2c49de36a56e0ff7122885a775c2025fbc914bd1aa4df2dfdfb57238d05059c58f4fe3eabd24c2780ccd352ffc83c1b03a2f82bcd2f2b0cd2498fd79c1482467e009ebafc965376ff1df60775e5508f2ed4cca2bc20469c27a484866af41476b06a95dc9400",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "ciphertext is empty",
+          "flags": [
+            "InvalidCiphertextFormat"
+          ],
+          "msg": "54657374",
+          "ct": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "Prepended bytes to ciphertext",
+          "flags": [
+            "CVE-2020-14967",
+            "InvalidCiphertextFormat"
+          ],
+          "msg": "54657374",
+          "ct": "00004501b4d669e01b9ef2dc800aa1b06d49196f5a09fe8fbcd037323c60eaf027bfb98432be4e4a26c567ffec718bcbea977dd26812fa071c33808b4d5ebb742d9879806094b6fbeea63d25ea3141733b60e31c6912106e1b758a7fe0014f075193faa8b4622bfd5d3013f0a32190a95de61a3604711bc62945f95a6522bd4dfed0a994ef185b28c281f7b5e4c8ed41176d12d9fc1b837e6a0111d0132d08a6d6f0580de0c9eed8ed105531799482d1e466c68c23b0c222af7fc12ac279bc4ff57e7b4586d209371b38c4c1035edd418dc5f960441cb21ea2bedbfea86de0d7861e81021b650a1de51002c315f1e7c12debe4dcebf790caaa54a2f26b149cf9e77d",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "appended bytes to ciphertext",
+          "flags": [
+            "InvalidCiphertextFormat"
+          ],
+          "msg": "54657374",
+          "ct": "4501b4d669e01b9ef2dc800aa1b06d49196f5a09fe8fbcd037323c60eaf027bfb98432be4e4a26c567ffec718bcbea977dd26812fa071c33808b4d5ebb742d9879806094b6fbeea63d25ea3141733b60e31c6912106e1b758a7fe0014f075193faa8b4622bfd5d3013f0a32190a95de61a3604711bc62945f95a6522bd4dfed0a994ef185b28c281f7b5e4c8ed41176d12d9fc1b837e6a0111d0132d08a6d6f0580de0c9eed8ed105531799482d1e466c68c23b0c222af7fc12ac279bc4ff57e7b4586d209371b38c4c1035edd418dc5f960441cb21ea2bedbfea86de0d7861e81021b650a1de51002c315f1e7c12debe4dcebf790caaa54a2f26b149cf9e77d0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "truncated ciphertext",
+          "flags": [
+            "InvalidCiphertextFormat"
+          ],
+          "msg": "54657374",
+          "ct": "01b4d669e01b9ef2dc800aa1b06d49196f5a09fe8fbcd037323c60eaf027bfb98432be4e4a26c567ffec718bcbea977dd26812fa071c33808b4d5ebb742d9879806094b6fbeea63d25ea3141733b60e31c6912106e1b758a7fe0014f075193faa8b4622bfd5d3013f0a32190a95de61a3604711bc62945f95a6522bd4dfed0a994ef185b28c281f7b5e4c8ed41176d12d9fc1b837e6a0111d0132d08a6d6f0580de0c9eed8ed105531799482d1e466c68c23b0c222af7fc12ac279bc4ff57e7b4586d209371b38c4c1035edd418dc5f960441cb21ea2bedbfea86de0d7861e81021b650a1de51002c315f1e7c12debe4dcebf790caaa54a2f26b149cf9e77d",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00dd904590397808c4314329623d9013453843251b13b8b3c4fef54598112af3eb31c71103c6259951674e53bd93a7e36d19472e474ebe8028686d9529484d8bafea4a04ba19555667616c8478670594009c9bc6a3efe52274cba64c724747d7edc194e4fedde32a3289d94c31936e7e7a15d756f548492f5b345b927e8c618bdd550acb21a17ae148304383db9b3c7baa3e4c8bd8e844a884daa3e18d56998cb32f9bae4d41d56a18ddd4313c8089b75e9dbb9128470bac9b087fb61928ab0f8c4c89360b020899008d08e8bd31f907a807e8056ad6800dffdf9ed9d964a939e7e48114b84978551acb85c9df9196f3eff55286d6cd4b39a822a8a7763a18208f",
+        "privateExponent": "2bd68add0171ed921c0924dc0a40427fd4a4fc67821c6e7d50d0e8c730c665e2a843b1eb243e763a740d3c666b1bb1d4f9466b32b2b2e09a9e26e8777595da48a13ba9f9c45f6d2c214b9e5e504bfb3fafbce6adb31e8c15bde1968899efee1a5dcdff0d2a8bf2e27301eaa07882494610a23dd3644d0eb0a6086450e3a7bd4b5c446c01814be16c208619f8a5b7463fca583d936864bf74d96788aae8e5bae3c052a2b409df9a08eb9be76b3dbaba28863d5c56ee42eecdb85075e04de90b6dd3bd9408d7fa5694697c185162329ab9b57f21a84cab007c1c10d975f5491977fecf6c949f3a566d84be477ddaab02c0762d1b232f8a61910715a0ffa438a461",
+        "publicExponent": "010001",
+        "prime1": "00fdaca4addb17e53eea07b949213b57da50d659073864fd3c21e570eb450f9014fa43ce53b4ce4c55aca189ce93a8c1d66a8eb4ade27adaf764ad7577c11bf0baf166a54f080c5f0765a4b3fd394e6d660ab30254cb8999f0fd703877c71e4cef038acaf81f0891e7dd06d7fd5b2c014e6734766d18adb23cabae79998ff3e3b1",
+        "prime2": "00df984439aac267bb2288e53aba498e4825b001826bf9f80cf1c0a14507f388b36346b7dd58ea3714e9c0e5caf7ea56c73ac7415b2b0f07eb01a74a08537452be2ec918dea4da330255341e0e6ff34bb24ca24d95e369a5ba55e9bd1a7d0ba6aff1da718ceb106ee1c463a7fc30c11d7b885c76b65f28b0f3243e591cbe82983f",
+        "exponent1": "3c610e656f43b5c60ed03dd2e13d0dc1220292f83bfd15a56d6ffe3b91998db2e08aa91e95679115c75c3fbfd2b79543a2e34ab024bb17495146543267dd6da421774c1b8e8fdb429877e67b7c5b6580a7454a65c2788312b05038b091cd6d846a746bb13939c1f8cd4c26b6e02f8e340a2e9b8d861539da6506c75cbcbdd151",
+        "exponent2": "00ab2fe90c3db099baacb622cad3d57d19bfc10166d94488a560721b06bf0fb599a268825cf5b65c75a682096d5c620e0e7af21317b9dfc8302513ef9a704a9f0efcc2fa477bef931e361db0e55cd0e9239988a9de183ecaa3df2315a53217b986fba4434ba0acf437e6246678aedb2bb768af62343ea6e8d33eec7d4d848e7801",
+        "coefficient": "5382d97145a0123c383ede6b5ded217ce50a3751d0926148aa7895f501563d131abcc2ff222150b3e35e353fdb006232f1f521e2941eec51810a5db22c1af413bf324918cdf9e00c916ec791cb6ac3fbcb04fa26396f0540470abd929983172f484b102e21f44c8ab0867ec90a77d7f46a6ffe1046b8d4e7e2617c035bfe148a"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100dd904590397808c4314329623d9013453843251b13b8b3c4fef54598112af3eb31c71103c6259951674e53bd93a7e36d19472e474ebe8028686d9529484d8bafea4a04ba19555667616c8478670594009c9bc6a3efe52274cba64c724747d7edc194e4fedde32a3289d94c31936e7e7a15d756f548492f5b345b927e8c618bdd550acb21a17ae148304383db9b3c7baa3e4c8bd8e844a884daa3e18d56998cb32f9bae4d41d56a18ddd4313c8089b75e9dbb9128470bac9b087fb61928ab0f8c4c89360b020899008d08e8bd31f907a807e8056ad6800dffdf9ed9d964a939e7e48114b84978551acb85c9df9196f3eff55286d6cd4b39a822a8a7763a18208f0203010001028201002bd68add0171ed921c0924dc0a40427fd4a4fc67821c6e7d50d0e8c730c665e2a843b1eb243e763a740d3c666b1bb1d4f9466b32b2b2e09a9e26e8777595da48a13ba9f9c45f6d2c214b9e5e504bfb3fafbce6adb31e8c15bde1968899efee1a5dcdff0d2a8bf2e27301eaa07882494610a23dd3644d0eb0a6086450e3a7bd4b5c446c01814be16c208619f8a5b7463fca583d936864bf74d96788aae8e5bae3c052a2b409df9a08eb9be76b3dbaba28863d5c56ee42eecdb85075e04de90b6dd3bd9408d7fa5694697c185162329ab9b57f21a84cab007c1c10d975f5491977fecf6c949f3a566d84be477ddaab02c0762d1b232f8a61910715a0ffa438a46102818100fdaca4addb17e53eea07b949213b57da50d659073864fd3c21e570eb450f9014fa43ce53b4ce4c55aca189ce93a8c1d66a8eb4ade27adaf764ad7577c11bf0baf166a54f080c5f0765a4b3fd394e6d660ab30254cb8999f0fd703877c71e4cef038acaf81f0891e7dd06d7fd5b2c014e6734766d18adb23cabae79998ff3e3b102818100df984439aac267bb2288e53aba498e4825b001826bf9f80cf1c0a14507f388b36346b7dd58ea3714e9c0e5caf7ea56c73ac7415b2b0f07eb01a74a08537452be2ec918dea4da330255341e0e6ff34bb24ca24d95e369a5ba55e9bd1a7d0ba6aff1da718ceb106ee1c463a7fc30c11d7b885c76b65f28b0f3243e591cbe82983f0281803c610e656f43b5c60ed03dd2e13d0dc1220292f83bfd15a56d6ffe3b91998db2e08aa91e95679115c75c3fbfd2b79543a2e34ab024bb17495146543267dd6da421774c1b8e8fdb429877e67b7c5b6580a7454a65c2788312b05038b091cd6d846a746bb13939c1f8cd4c26b6e02f8e340a2e9b8d861539da6506c75cbcbdd15102818100ab2fe90c3db099baacb622cad3d57d19bfc10166d94488a560721b06bf0fb599a268825cf5b65c75a682096d5c620e0e7af21317b9dfc8302513ef9a704a9f0efcc2fa477bef931e361db0e55cd0e9239988a9de183ecaa3df2315a53217b986fba4434ba0acf437e6246678aedb2bb768af62343ea6e8d33eec7d4d848e78010281805382d97145a0123c383ede6b5ded217ce50a3751d0926148aa7895f501563d131abcc2ff222150b3e35e353fdb006232f1f521e2941eec51810a5db22c1af413bf324918cdf9e00c916ec791cb6ac3fbcb04fa26396f0540470abd929983172f484b102e21f44c8ab0867ec90a77d7f46a6ffe1046b8d4e7e2617c035bfe148a",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDdkEWQOXgIxDFD\nKWI9kBNFOEMlGxO4s8T+9UWYESrz6zHHEQPGJZlRZ05TvZOn420ZRy5HTr6AKGht\nlSlITYuv6koEuhlVVmdhbIR4ZwWUAJybxqPv5SJ0y6ZMckdH1+3BlOT+3eMqMonZ\nTDGTbn56FddW9UhJL1s0W5J+jGGL3VUKyyGheuFIMEOD25s8e6o+TIvY6ESohNqj\n4Y1WmYyzL5uuTUHVahjd1DE8gIm3Xp27kShHC6ybCH+2GSirD4xMiTYLAgiZAI0I\n6L0x+QeoB+gFataADf/fntnZZKk55+SBFLhJeFUay4XJ35GW8+/1UobWzUs5qCKo\np3Y6GCCPAgMBAAECggEAK9aK3QFx7ZIcCSTcCkBCf9Sk/GeCHG59UNDoxzDGZeKo\nQ7HrJD52OnQNPGZrG7HU+UZrMrKy4JqeJuh3dZXaSKE7qfnEX20sIUueXlBL+z+v\nvOatsx6MFb3hloiZ7+4aXc3/DSqL8uJzAeqgeIJJRhCiPdNkTQ6wpghkUOOnvUtc\nRGwBgUvhbCCGGfilt0Y/ylg9k2hkv3TZZ4iq6OW648BSorQJ35oI65vnaz26uiiG\nPVxW7kLuzbhQdeBN6Qtt072UCNf6VpRpfBhRYjKaubV/IahMqwB8HBDZdfVJGXf+\nz2yUnzpWbYS+R33aqwLAdi0bIy+KYZEHFaD/pDikYQKBgQD9rKSt2xflPuoHuUkh\nO1faUNZZBzhk/Twh5XDrRQ+QFPpDzlO0zkxVrKGJzpOowdZqjrSt4nra92StdXfB\nG/C68WalTwgMXwdlpLP9OU5tZgqzAlTLiZnw/XA4d8ceTO8Disr4HwiR590G1/1b\nLAFOZzR2bRitsjyrrnmZj/PjsQKBgQDfmEQ5qsJnuyKI5Tq6SY5IJbABgmv5+Azx\nwKFFB/OIs2NGt91Y6jcU6cDlyvfqVsc6x0FbKw8H6wGnSghTdFK+LskY3qTaMwJV\nNB4Ob/NLskyiTZXjaaW6Vem9Gn0Lpq/x2nGM6xBu4cRjp/wwwR17iFx2tl8osPMk\nPlkcvoKYPwKBgDxhDmVvQ7XGDtA90uE9DcEiApL4O/0VpW1v/juRmY2y4IqpHpVn\nkRXHXD+/0reVQ6LjSrAkuxdJUUZUMmfdbaQhd0wbjo/bQph35nt8W2WAp0VKZcJ4\ngxKwUDiwkc1thGp0a7E5OcH4zUwmtuAvjjQKLpuNhhU52mUGx1y8vdFRAoGBAKsv\n6Qw9sJm6rLYiytPVfRm/wQFm2USIpWByGwa/D7WZomiCXPW2XHWmggltXGIODnry\nExe538gwJRPvmnBKnw78wvpHe++THjYdsOVc0OkjmYip3hg+yqPfIxWlMhe5hvuk\nQ0ugrPQ35iRmeK7bK7dor2I0Pqbo0z7sfU2EjngBAoGAU4LZcUWgEjw4Pt5rXe0h\nfOUKN1HQkmFIqniV9QFWPRMavML/IiFQs+NeNT/bAGIy8fUh4pQe7FGBCl2yLBr0\nE78ySRjN+eAMkW7Hkctqw/vLBPomOW8FQEcKvZKZgxcvSEsQLiH0TIqwhn7JCnfX\n9Gpv/hBGuNTn4mF8A1v+FIo=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "3ZBFkDl4CMQxQyliPZATRThDJRsTuLPE_vVFmBEq8-sxxxEDxiWZUWdOU72Tp-NtGUcuR06-gChobZUpSE2Lr-pKBLoZVVZnYWyEeGcFlACcm8aj7-UidMumTHJHR9ftwZTk_t3jKjKJ2Uwxk25-ehXXVvVISS9bNFuSfoxhi91VCsshoXrhSDBDg9ubPHuqPkyL2OhEqITao-GNVpmMsy-brk1B1WoY3dQxPICJt16du5EoRwusmwh_thkoqw-MTIk2CwIImQCNCOi9MfkHqAfoBWrWgA3_357Z2WSpOefkgRS4SXhVGsuFyd-RlvPv9VKG1s1LOagiqKd2Ohggjw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "K9aK3QFx7ZIcCSTcCkBCf9Sk_GeCHG59UNDoxzDGZeKoQ7HrJD52OnQNPGZrG7HU-UZrMrKy4JqeJuh3dZXaSKE7qfnEX20sIUueXlBL-z-vvOatsx6MFb3hloiZ7-4aXc3_DSqL8uJzAeqgeIJJRhCiPdNkTQ6wpghkUOOnvUtcRGwBgUvhbCCGGfilt0Y_ylg9k2hkv3TZZ4iq6OW648BSorQJ35oI65vnaz26uiiGPVxW7kLuzbhQdeBN6Qtt072UCNf6VpRpfBhRYjKaubV_IahMqwB8HBDZdfVJGXf-z2yUnzpWbYS-R33aqwLAdi0bIy-KYZEHFaD_pDikYQ",
+        "p": "_aykrdsX5T7qB7lJITtX2lDWWQc4ZP08IeVw60UPkBT6Q85TtM5MVayhic6TqMHWao60reJ62vdkrXV3wRvwuvFmpU8IDF8HZaSz_TlObWYKswJUy4mZ8P1wOHfHHkzvA4rK-B8IkefdBtf9WywBTmc0dm0YrbI8q655mY_z47E",
+        "q": "35hEOarCZ7siiOU6ukmOSCWwAYJr-fgM8cChRQfziLNjRrfdWOo3FOnA5cr36lbHOsdBWysPB-sBp0oIU3RSvi7JGN6k2jMCVTQeDm_zS7JMok2V42mlulXpvRp9C6av8dpxjOsQbuHEY6f8MMEde4hcdrZfKLDzJD5ZHL6CmD8",
+        "dp": "PGEOZW9DtcYO0D3S4T0NwSICkvg7_RWlbW_-O5GZjbLgiqkelWeRFcdcP7_St5VDouNKsCS7F0lRRlQyZ91tpCF3TBuOj9tCmHfme3xbZYCnRUplwniDErBQOLCRzW2EanRrsTk5wfjNTCa24C-ONAoum42GFTnaZQbHXLy90VE",
+        "dq": "qy_pDD2wmbqstiLK09V9Gb_BAWbZRIilYHIbBr8PtZmiaIJc9bZcdaaCCW1cYg4OevITF7nfyDAlE--acEqfDvzC-kd775MeNh2w5VzQ6SOZiKneGD7Ko98jFaUyF7mG-6RDS6Cs9DfmJGZ4rtsrt2ivYjQ-pujTPux9TYSOeAE",
+        "qi": "U4LZcUWgEjw4Pt5rXe0hfOUKN1HQkmFIqniV9QFWPRMavML_IiFQs-NeNT_bAGIy8fUh4pQe7FGBCl2yLBr0E78ySRjN-eAMkW7Hkctqw_vLBPomOW8FQEcKvZKZgxcvSEsQLiH0TIqwhn7JCnfX9Gpv_hBGuNTn4mF8A1v-FIo"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 36,
+          "comment": "edge case for ciphertext",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "52a61193b56236922dde714383c6bfc5a3c3a4515707521ebc84220bed615b28cf50222c2cfb7da7e5bf8ed088333d360a1f95d428d0563c3757f400f582cccc1c06e43cb575545f0cdc6bf29c585d8feda2522234415317bc5d8641737b9cf657620499a1d4fd69e4fa109e068511cfee4d2b3c9f9904fb370cb28dbc7e0e",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00c6e320b47282afaf1c18f55f28aa278d401163529e605c1ec6ff403d25c726f547407e4cc128c1aaf397dee2e881c20144616ca16f3d9a1794a70ae05f9722e9feab650c21b886aacaa34163bd8254ea53a8c1dba6bb8eecba38aad49be9d6658230fb3950382a5dc8d5c0538e50f976e4ee673f8faa2ab8b3805605642c6d770579736e410c9ecb32e0559d82b6f22b3ac79cdf57ea9a3fd4b5e8df66bca92b8478b971afb0d6b185b642c362daaa79d330d14069b9e917a3f84433ac32b56cbe2760e9507bd39749d18a1b13e923c7efc9fad13d12568e5d910c1cbe9a6069d0fe80e3aa57bf5e74fa5d86433eaf5690175f13e4c3148c7300799244c566bf",
+        "privateExponent": "6148075f3c03a05b4eab069a1d11dd76c1b7bf9551d2603ccda95c8a8c47f54e5423bfa35b77cc030a5366ba267011acfcfd8a5d0c445d72db4b398eb632fee8e5a0803486e9f334e719238addcf3a29c3f1efa0b8d554fb85bae2144c8efc477a7eeae305d1f3271c6d313dad86fdfea1cbdac4c448bfccc84025d34d444de5e40dc37de6a4cf7255e38152ab049186834f23b75fda4e51f57b01b8958e6a846cf9fb82353f6772e5318b3020651259ecf3b9827285fa34be81d73be182fd8e96d7350e7b4832adac0b0362ec03c1c6d91339df584ef816b59b34c90e9b913feb24155a9869a20f2afff161a8b8fc112a80e89ac449e5dd6b167fc373bb6dc1",
+        "publicExponent": "010001",
+        "prime1": "00f85c32eb5dfbc82525ef2a6780ff035553bf7617e0acf37847dea5d648fd3603f644c1d2db25ee838d75eea86b65a374b5484bf09e99dd5116b0cf590633e6dd328cfd7bdcf8d81221ee5e08ea3109d52ceb385762d70681ea0638c766ae9aa2dcc341fff0240c1151d025719431ac1c7e7fc6a15c606b1ec018109fc58e6d93",
+        "prime2": "00cd015623de40a4601d40346cea7822e13c67bc6acca55b4b21264c454dfdcdda61f0f1d64776efb334143e1d4d4807383ba293515bc3c0f0d714cfa84c6edfcc4493b6802af1f8fb4b986d71efa7c37c9bf21821288218fedc8f269c0a633ea033e5603fef9426de60f3affc740f980158f04fb69936f1f2736f82be14a87da5",
+        "exponent1": "00c5e5c9992c895d00e4ca3f32bc61f748fd7399690b5924a3da38ba521654d5beb074373189f81ea6ea8867440257b9b85c5f204bba450649ffd7a150e19567c727e99a6e2134940f56c4365fca248b1e372db2f646c6e9e38913ae188d6461c996396c14c14827e981146751aa712e208257d4716d4752f3ecc300341f5a0f4b",
+        "exponent2": "5d0eaf4066e1e6fbae2b77e0bcea3dc30a3d789cee3a5d5f9433a3498e66986bfa2b7a4baf7300c9d2e9216d01a8a1865823ab45b22700cd1284e2e25d97b2c53197efaeec4f9c9acdacea795eb5439aabdb5032b505a13d07777faa3358eb93a31b0afedacce07bef7c8eb54525d2f5419f0c4031fa6c078778e5db4cdb52f5",
+        "coefficient": "7837896fa354433b8a407322a51a82247df121aad6ae72044bdebffdd32f990f135c1ac2c637346ead083b9d90a0d6880cd0af2f64af3c352d74b0e6b1411f8ad65d68c4ecc919b406129d49dece407c973e1bd068549313440615c7c3b02fc7f99d4dc700797d7536569b2fe692e125adf3cfffeab59ea0e0c383aeba764459"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100c6e320b47282afaf1c18f55f28aa278d401163529e605c1ec6ff403d25c726f547407e4cc128c1aaf397dee2e881c20144616ca16f3d9a1794a70ae05f9722e9feab650c21b886aacaa34163bd8254ea53a8c1dba6bb8eecba38aad49be9d6658230fb3950382a5dc8d5c0538e50f976e4ee673f8faa2ab8b3805605642c6d770579736e410c9ecb32e0559d82b6f22b3ac79cdf57ea9a3fd4b5e8df66bca92b8478b971afb0d6b185b642c362daaa79d330d14069b9e917a3f84433ac32b56cbe2760e9507bd39749d18a1b13e923c7efc9fad13d12568e5d910c1cbe9a6069d0fe80e3aa57bf5e74fa5d86433eaf5690175f13e4c3148c7300799244c566bf0203010001028201006148075f3c03a05b4eab069a1d11dd76c1b7bf9551d2603ccda95c8a8c47f54e5423bfa35b77cc030a5366ba267011acfcfd8a5d0c445d72db4b398eb632fee8e5a0803486e9f334e719238addcf3a29c3f1efa0b8d554fb85bae2144c8efc477a7eeae305d1f3271c6d313dad86fdfea1cbdac4c448bfccc84025d34d444de5e40dc37de6a4cf7255e38152ab049186834f23b75fda4e51f57b01b8958e6a846cf9fb82353f6772e5318b3020651259ecf3b9827285fa34be81d73be182fd8e96d7350e7b4832adac0b0362ec03c1c6d91339df584ef816b59b34c90e9b913feb24155a9869a20f2afff161a8b8fc112a80e89ac449e5dd6b167fc373bb6dc102818100f85c32eb5dfbc82525ef2a6780ff035553bf7617e0acf37847dea5d648fd3603f644c1d2db25ee838d75eea86b65a374b5484bf09e99dd5116b0cf590633e6dd328cfd7bdcf8d81221ee5e08ea3109d52ceb385762d70681ea0638c766ae9aa2dcc341fff0240c1151d025719431ac1c7e7fc6a15c606b1ec018109fc58e6d9302818100cd015623de40a4601d40346cea7822e13c67bc6acca55b4b21264c454dfdcdda61f0f1d64776efb334143e1d4d4807383ba293515bc3c0f0d714cfa84c6edfcc4493b6802af1f8fb4b986d71efa7c37c9bf21821288218fedc8f269c0a633ea033e5603fef9426de60f3affc740f980158f04fb69936f1f2736f82be14a87da502818100c5e5c9992c895d00e4ca3f32bc61f748fd7399690b5924a3da38ba521654d5beb074373189f81ea6ea8867440257b9b85c5f204bba450649ffd7a150e19567c727e99a6e2134940f56c4365fca248b1e372db2f646c6e9e38913ae188d6461c996396c14c14827e981146751aa712e208257d4716d4752f3ecc300341f5a0f4b0281805d0eaf4066e1e6fbae2b77e0bcea3dc30a3d789cee3a5d5f9433a3498e66986bfa2b7a4baf7300c9d2e9216d01a8a1865823ab45b22700cd1284e2e25d97b2c53197efaeec4f9c9acdacea795eb5439aabdb5032b505a13d07777faa3358eb93a31b0afedacce07bef7c8eb54525d2f5419f0c4031fa6c078778e5db4cdb52f50281807837896fa354433b8a407322a51a82247df121aad6ae72044bdebffdd32f990f135c1ac2c637346ead083b9d90a0d6880cd0af2f64af3c352d74b0e6b1411f8ad65d68c4ecc919b406129d49dece407c973e1bd068549313440615c7c3b02fc7f99d4dc700797d7536569b2fe692e125adf3cfffeab59ea0e0c383aeba764459",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDG4yC0coKvrxwY\n9V8oqieNQBFjUp5gXB7G/0A9Jccm9UdAfkzBKMGq85fe4uiBwgFEYWyhbz2aF5Sn\nCuBflyLp/qtlDCG4hqrKo0FjvYJU6lOowdumu47sujiq1Jvp1mWCMPs5UDgqXcjV\nwFOOUPl25O5nP4+qKrizgFYFZCxtdwV5c25BDJ7LMuBVnYK28is6x5zfV+qaP9S1\n6N9mvKkrhHi5ca+w1rGFtkLDYtqqedMw0UBpuekXo/hEM6wytWy+J2DpUHvTl0nR\nihsT6SPH78n60T0SVo5dkQwcvppgadD+gOOqV79edPpdhkM+r1aQF18T5MMUjHMA\neZJExWa/AgMBAAECggEAYUgHXzwDoFtOqwaaHRHddsG3v5VR0mA8zalcioxH9U5U\nI7+jW3fMAwpTZromcBGs/P2KXQxEXXLbSzmOtjL+6OWggDSG6fM05xkjit3POinD\n8e+guNVU+4W64hRMjvxHen7q4wXR8yccbTE9rYb9/qHL2sTESL/MyEAl001ETeXk\nDcN95qTPclXjgVKrBJGGg08jt1/aTlH1ewG4lY5qhGz5+4I1P2dy5TGLMCBlElns\n87mCcoX6NL6B1zvhgv2Oltc1DntIMq2sCwNi7APBxtkTOd9YTvgWtZs0yQ6bkT/r\nJBVamGmiDyr/8WGouPwRKoDomsRJ5d1rFn/Dc7ttwQKBgQD4XDLrXfvIJSXvKmeA\n/wNVU792F+Cs83hH3qXWSP02A/ZEwdLbJe6DjXXuqGtlo3S1SEvwnpndURawz1kG\nM+bdMoz9e9z42BIh7l4I6jEJ1SzrOFdi1waB6gY4x2aumqLcw0H/8CQMEVHQJXGU\nMawcfn/GoVxgax7AGBCfxY5tkwKBgQDNAVYj3kCkYB1ANGzqeCLhPGe8asylW0sh\nJkxFTf3N2mHw8dZHdu+zNBQ+HU1IBzg7opNRW8PA8NcUz6hMbt/MRJO2gCrx+PtL\nmG1x76fDfJvyGCEoghj+3I8mnApjPqAz5WA/75Qm3mDzr/x0D5gBWPBPtpk28fJz\nb4K+FKh9pQKBgQDF5cmZLIldAOTKPzK8YfdI/XOZaQtZJKPaOLpSFlTVvrB0NzGJ\n+B6m6ohnRAJXubhcXyBLukUGSf/XoVDhlWfHJ+mabiE0lA9WxDZfyiSLHjctsvZG\nxunjiROuGI1kYcmWOWwUwUgn6YEUZ1GqcS4gglfUcW1HUvPswwA0H1oPSwKBgF0O\nr0Bm4eb7rit34LzqPcMKPXic7jpdX5Qzo0mOZphr+it6S69zAMnS6SFtAaihhlgj\nq0WyJwDNEoTi4l2XssUxl++u7E+cms2s6nletUOaq9tQMrUFoT0Hd3+qM1jrk6Mb\nCv7azOB773yOtUUl0vVBnwxAMfpsB4d45dtM21L1AoGAeDeJb6NUQzuKQHMipRqC\nJH3xIarWrnIES96//dMvmQ8TXBrCxjc0bq0IO52QoNaIDNCvL2SvPDUtdLDmsUEf\nitZdaMTsyRm0BhKdSd7OQHyXPhvQaFSTE0QGFcfDsC/H+Z1NxwB5fXU2Vpsv5pLh\nJa3zz//qtZ6g4MODrrp2RFk=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "xuMgtHKCr68cGPVfKKonjUARY1KeYFwexv9APSXHJvVHQH5MwSjBqvOX3uLogcIBRGFsoW89mheUpwrgX5ci6f6rZQwhuIaqyqNBY72CVOpTqMHbpruO7Lo4qtSb6dZlgjD7OVA4Kl3I1cBTjlD5duTuZz-Pqiq4s4BWBWQsbXcFeXNuQQyeyzLgVZ2CtvIrOsec31fqmj_UtejfZrypK4R4uXGvsNaxhbZCw2LaqnnTMNFAabnpF6P4RDOsMrVsvidg6VB705dJ0YobE-kjx-_J-tE9ElaOXZEMHL6aYGnQ_oDjqle_XnT6XYZDPq9WkBdfE-TDFIxzAHmSRMVmvw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "YUgHXzwDoFtOqwaaHRHddsG3v5VR0mA8zalcioxH9U5UI7-jW3fMAwpTZromcBGs_P2KXQxEXXLbSzmOtjL-6OWggDSG6fM05xkjit3POinD8e-guNVU-4W64hRMjvxHen7q4wXR8yccbTE9rYb9_qHL2sTESL_MyEAl001ETeXkDcN95qTPclXjgVKrBJGGg08jt1_aTlH1ewG4lY5qhGz5-4I1P2dy5TGLMCBlElns87mCcoX6NL6B1zvhgv2Oltc1DntIMq2sCwNi7APBxtkTOd9YTvgWtZs0yQ6bkT_rJBVamGmiDyr_8WGouPwRKoDomsRJ5d1rFn_Dc7ttwQ",
+        "p": "-Fwy6137yCUl7ypngP8DVVO_dhfgrPN4R96l1kj9NgP2RMHS2yXug4117qhrZaN0tUhL8J6Z3VEWsM9ZBjPm3TKM_Xvc-NgSIe5eCOoxCdUs6zhXYtcGgeoGOMdmrpqi3MNB__AkDBFR0CVxlDGsHH5_xqFcYGsewBgQn8WObZM",
+        "q": "zQFWI95ApGAdQDRs6ngi4TxnvGrMpVtLISZMRU39zdph8PHWR3bvszQUPh1NSAc4O6KTUVvDwPDXFM-oTG7fzESTtoAq8fj7S5htce-nw3yb8hghKIIY_tyPJpwKYz6gM-VgP--UJt5g86_8dA-YAVjwT7aZNvHyc2-CvhSofaU",
+        "dp": "xeXJmSyJXQDkyj8yvGH3SP1zmWkLWSSj2ji6UhZU1b6wdDcxifgepuqIZ0QCV7m4XF8gS7pFBkn_16FQ4ZVnxyfpmm4hNJQPVsQ2X8okix43LbL2Rsbp44kTrhiNZGHJljlsFMFIJ-mBFGdRqnEuIIJX1HFtR1Lz7MMANB9aD0s",
+        "dq": "XQ6vQGbh5vuuK3fgvOo9wwo9eJzuOl1flDOjSY5mmGv6K3pLr3MAydLpIW0BqKGGWCOrRbInAM0ShOLiXZeyxTGX767sT5yazazqeV61Q5qr21AytQWhPQd3f6ozWOuToxsK_trM4HvvfI61RSXS9UGfDEAx-mwHh3jl20zbUvU",
+        "qi": "eDeJb6NUQzuKQHMipRqCJH3xIarWrnIES96__dMvmQ8TXBrCxjc0bq0IO52QoNaIDNCvL2SvPDUtdLDmsUEfitZdaMTsyRm0BhKdSd7OQHyXPhvQaFSTE0QGFcfDsC_H-Z1NxwB5fXU2Vpsv5pLhJa3zz__qtZ6g4MODrrp2RFk"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 37,
+          "comment": "edge case for ciphertext",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "f50d8c4dbfdd67f1018ef2bded1a74c6ddbf7db395af1b56a91507ee381689d9e06d1b71b783d895dd7a7289a20ccd5c2b5f38be6d248fde32fa02ba825047c14caf35f96873aad739a31f02b2433e871d1265c58245191cc5a1dfd299b160edcafc5ca7a37c056dbac9e7dd1195c20451",
+          "ct": "c6e320b47282afaf1c18f55f28aa278d401163529e605c1ec6ff403d25c726f547407e4cc128c1aaf397dee2e881c20144616ca16f3d9a1794a70ae05f9722e9feab650c21b886aacaa34163bd8254ea53a8c1dba6bb8eecba38aad49be9d6658230fb3950382a5dc8d5c0538e50f976e4ee673f8faa2ab8b3805605642c6d770579736e410c9ecb32e0559d82b6f22b3ac79cdf57ea9a3fd4b5e8df66bca92b8478b971afb0d6b185b642c362daaa79d330d14069b9e917a3f84433ac32b56cbe2760e9507bd39749d18a1b13e923c7efc9fad13d12568e5d910c1cbe9a6069d0fe80e3aa57bf5e74fa5d86433eaf5690175f13e4c3148c7300799244c566bd",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00a9cbdd7376863a8fa77931db45b29d3cd33842fabfb9b685e5f5c9ad15fe7844be23c7b5abb165f32d5d26e3db746cf09ee4c8b67b528ccdbdb20c3bf4f7a1f5ab1b93648d2c7d039d09f9a5b28393480b31c87b28fb4364c373a95d496ce442bca4aad4de1cc613d3bee9ed31a85957dcff15998c6df8f0e0b1182bf256538ce414bb1220c9a4e0bc666b2230033b7abd072cf9a3c302b424b32860604427904671678b11bec74f5dedc380b01ad4d5e228d717f80e862f3800da9f2edd0c30a900a2d8ffb292a74a092264df73ee7888258d8ba441296917d5b7742894060c318790a21fa23c4895d36f6ce5c22680505caf8c098905f4e0413e63512040e5",
+        "privateExponent": "01b73dea6206fab60368f9dc3fa0cdae74eaf36051ca2862437fdf95186d0d1d92b74d58145f534aa909713069c20c2cc54a460df402924a2cf1cce659341c669d5f46b6c427702ef66a08a40841049ebc803908a7921c6cfafda2f73e9bf3558a4ef6abf67f9f6fc95abb45ea93cb2d545e1e8381f4058937980a88bd26eaaab45797baed829d9d257d70d83d8f6d9c0ef82bdc4e28f27fc2d0140da014410d397d79a5b57eb802d3c441b3939e39932c56d8ab6ed5a7f61e823a7146139a8421e6c2726bdddf81cd4fbd1385c86375123c7f09686ebd554cd79dbf2c66ce86c8555800a226828c9a6a664329fc6e1245e359f6ae62b276852beb1ea9183f71",
+        "publicExponent": "010001",
+        "prime1": "00d24acefb79e15875c90fa375302ef16f14141ff50e760b5b529df6494bd507eb925530904d5f43db6cc00c5bb113148ad0d7ddfa027c857898866e9681fba9efd61e102a14daf9e13d19c13d29d0b85310d4757c6b31f6949132372bf2feeeba9c451478caa2ef6ce17648cfd46b13b08d8ce9017612c0296d36281936c17375",
+        "prime2": "00ceb3c37dde127b7a1539da1061da9a119f00d6e88cb2dc350a323d517efa6da3ea0e0d5a62cb5c95f2e2bc233ad4a68798fddbeb9ba914ff805287492082727e831a1a64938f119a57b80c4cf87348231265f5988f7ecfdaeed964567467fce6c0cbae5399f1674b3db04a0e54a97c43a5f6f8e0d66253a07d36d960269519b1",
+        "exponent1": "0db2bbcadbc4970b8d1e4caa7c8a0246170bbc8d2cf4f986685a4bc9b87bd6f93c5dfa3cdc1d618130934dfac70d14207abc25047d16f966c2a0b7216cb424fcaf78e3daa9e31db5d352132955c8f7c8c966dd844e4341e9a98f98d26f10b62247bda438be12610039ab87d0a9e893aec379b34fda0e1ca05631d9e8d28d4565",
+        "exponent2": "00c5f32da25a8bc4a853af857feed65479cf961439bc9485825df362f9aaead51906cad24adf15f5e2bc2a1b1679feb0446765a5b8eae76fee87cb8137ace480155c2421667451acffec459bb212b5043e621e36a715b4d205ce7b6e35c560d8b77ba713998871c104335da26e3af1dcc94425528eaf8096a9b9804f885f2aa6e1",
+        "coefficient": "6bebb7d6fd832d7d0494393ad36d69809d5dfd412a2ccc954f57f2ec8ba97a558375ec6815e48839f4caa896f5684eed3ad37a131f081d5f04144ac75897f3e876d28699927d249ba86ef8017b83bddf2d83e8a6ac8f3bf180c5ebe477a7032cb0123bf27c292678dc5bf51f1a92e278c965d77d4749ae08defbd2348b059316"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100a9cbdd7376863a8fa77931db45b29d3cd33842fabfb9b685e5f5c9ad15fe7844be23c7b5abb165f32d5d26e3db746cf09ee4c8b67b528ccdbdb20c3bf4f7a1f5ab1b93648d2c7d039d09f9a5b28393480b31c87b28fb4364c373a95d496ce442bca4aad4de1cc613d3bee9ed31a85957dcff15998c6df8f0e0b1182bf256538ce414bb1220c9a4e0bc666b2230033b7abd072cf9a3c302b424b32860604427904671678b11bec74f5dedc380b01ad4d5e228d717f80e862f3800da9f2edd0c30a900a2d8ffb292a74a092264df73ee7888258d8ba441296917d5b7742894060c318790a21fa23c4895d36f6ce5c22680505caf8c098905f4e0413e63512040e502030100010282010001b73dea6206fab60368f9dc3fa0cdae74eaf36051ca2862437fdf95186d0d1d92b74d58145f534aa909713069c20c2cc54a460df402924a2cf1cce659341c669d5f46b6c427702ef66a08a40841049ebc803908a7921c6cfafda2f73e9bf3558a4ef6abf67f9f6fc95abb45ea93cb2d545e1e8381f4058937980a88bd26eaaab45797baed829d9d257d70d83d8f6d9c0ef82bdc4e28f27fc2d0140da014410d397d79a5b57eb802d3c441b3939e39932c56d8ab6ed5a7f61e823a7146139a8421e6c2726bdddf81cd4fbd1385c86375123c7f09686ebd554cd79dbf2c66ce86c8555800a226828c9a6a664329fc6e1245e359f6ae62b276852beb1ea9183f7102818100d24acefb79e15875c90fa375302ef16f14141ff50e760b5b529df6494bd507eb925530904d5f43db6cc00c5bb113148ad0d7ddfa027c857898866e9681fba9efd61e102a14daf9e13d19c13d29d0b85310d4757c6b31f6949132372bf2feeeba9c451478caa2ef6ce17648cfd46b13b08d8ce9017612c0296d36281936c1737502818100ceb3c37dde127b7a1539da1061da9a119f00d6e88cb2dc350a323d517efa6da3ea0e0d5a62cb5c95f2e2bc233ad4a68798fddbeb9ba914ff805287492082727e831a1a64938f119a57b80c4cf87348231265f5988f7ecfdaeed964567467fce6c0cbae5399f1674b3db04a0e54a97c43a5f6f8e0d66253a07d36d960269519b10281800db2bbcadbc4970b8d1e4caa7c8a0246170bbc8d2cf4f986685a4bc9b87bd6f93c5dfa3cdc1d618130934dfac70d14207abc25047d16f966c2a0b7216cb424fcaf78e3daa9e31db5d352132955c8f7c8c966dd844e4341e9a98f98d26f10b62247bda438be12610039ab87d0a9e893aec379b34fda0e1ca05631d9e8d28d456502818100c5f32da25a8bc4a853af857feed65479cf961439bc9485825df362f9aaead51906cad24adf15f5e2bc2a1b1679feb0446765a5b8eae76fee87cb8137ace480155c2421667451acffec459bb212b5043e621e36a715b4d205ce7b6e35c560d8b77ba713998871c104335da26e3af1dcc94425528eaf8096a9b9804f885f2aa6e10281806bebb7d6fd832d7d0494393ad36d69809d5dfd412a2ccc954f57f2ec8ba97a558375ec6815e48839f4caa896f5684eed3ad37a131f081d5f04144ac75897f3e876d28699927d249ba86ef8017b83bddf2d83e8a6ac8f3bf180c5ebe477a7032cb0123bf27c292678dc5bf51f1a92e278c965d77d4749ae08defbd2348b059316",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCpy91zdoY6j6d5\nMdtFsp080zhC+r+5toXl9cmtFf54RL4jx7WrsWXzLV0m49t0bPCe5Mi2e1KMzb2y\nDDv096H1qxuTZI0sfQOdCfmlsoOTSAsxyHso+0Nkw3OpXUls5EK8pKrU3hzGE9O+\n6e0xqFlX3P8VmYxt+PDgsRgr8lZTjOQUuxIgyaTgvGZrIjADO3q9Byz5o8MCtCSz\nKGBgRCeQRnFnixG+x09d7cOAsBrU1eIo1xf4DoYvOADany7dDDCpAKLY/7KSp0oJ\nImTfc+54iCWNi6RBKWkX1bd0KJQGDDGHkKIfojxIldNvbOXCJoBQXK+MCYkF9OBB\nPmNRIEDlAgMBAAECggEAAbc96mIG+rYDaPncP6DNrnTq82BRyihiQ3/flRhtDR2S\nt01YFF9TSqkJcTBpwgwsxUpGDfQCkkos8czmWTQcZp1fRrbEJ3Au9moIpAhBBJ68\ngDkIp5IcbPr9ovc+m/NVik72q/Z/n2/JWrtF6pPLLVReHoOB9AWJN5gKiL0m6qq0\nV5e67YKdnSV9cNg9j22cDvgr3E4o8n/C0BQNoBRBDTl9eaW1frgC08RBs5OeOZMs\nVtirbtWn9h6COnFGE5qEIebCcmvd34HNT70ThchjdRI8fwlobr1VTNedvyxmzobI\nVVgAoiaCjJpqZkMp/G4SReNZ9q5isnaFK+seqRg/cQKBgQDSSs77eeFYdckPo3Uw\nLvFvFBQf9Q52C1tSnfZJS9UH65JVMJBNX0PbbMAMW7ETFIrQ1936AnyFeJiGbpaB\n+6nv1h4QKhTa+eE9GcE9KdC4UxDUdXxrMfaUkTI3K/L+7rqcRRR4yqLvbOF2SM/U\naxOwjYzpAXYSwCltNigZNsFzdQKBgQDOs8N93hJ7ehU52hBh2poRnwDW6Iyy3DUK\nMj1Rfvpto+oODVpiy1yV8uK8IzrUpoeY/dvrm6kU/4BSh0kggnJ+gxoaZJOPEZpX\nuAxM+HNIIxJl9ZiPfs/a7tlkVnRn/ObAy65TmfFnSz2wSg5UqXxDpfb44NZiU6B9\nNtlgJpUZsQKBgA2yu8rbxJcLjR5MqnyKAkYXC7yNLPT5hmhaS8m4e9b5PF36PNwd\nYYEwk036xw0UIHq8JQR9FvlmwqC3IWy0JPyveOPaqeMdtdNSEylVyPfIyWbdhE5D\nQempj5jSbxC2Ike9pDi+EmEAOauH0Knok67DebNP2g4coFYx2ejSjUVlAoGBAMXz\nLaJai8SoU6+Ff+7WVHnPlhQ5vJSFgl3zYvmq6tUZBsrSSt8V9eK8KhsWef6wRGdl\npbjq52/uh8uBN6zkgBVcJCFmdFGs/+xFm7IStQQ+Yh42pxW00gXOe241xWDYt3un\nE5mIccEEM12ibjrx3MlEJVKOr4CWqbmAT4hfKqbhAoGAa+u31v2DLX0ElDk6021p\ngJ1d/UEqLMyVT1fy7IupelWDdexoFeSIOfTKqJb1aE7tOtN6Ex8IHV8EFErHWJfz\n6HbShpmSfSSbqG74AXuDvd8tg+imrI878YDF6+R3pwMssBI78nwpJnjcW/UfGpLi\neMll131HSa4I3vvSNIsFkxY=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "qcvdc3aGOo-neTHbRbKdPNM4Qvq_ubaF5fXJrRX-eES-I8e1q7Fl8y1dJuPbdGzwnuTItntSjM29sgw79Peh9asbk2SNLH0DnQn5pbKDk0gLMch7KPtDZMNzqV1JbORCvKSq1N4cxhPTvuntMahZV9z_FZmMbfjw4LEYK_JWU4zkFLsSIMmk4LxmayIwAzt6vQcs-aPDArQksyhgYEQnkEZxZ4sRvsdPXe3DgLAa1NXiKNcX-A6GLzgA2p8u3QwwqQCi2P-ykqdKCSJk33PueIgljYukQSlpF9W3dCiUBgwxh5CiH6I8SJXTb2zlwiaAUFyvjAmJBfTgQT5jUSBA5Q",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "Abc96mIG-rYDaPncP6DNrnTq82BRyihiQ3_flRhtDR2St01YFF9TSqkJcTBpwgwsxUpGDfQCkkos8czmWTQcZp1fRrbEJ3Au9moIpAhBBJ68gDkIp5IcbPr9ovc-m_NVik72q_Z_n2_JWrtF6pPLLVReHoOB9AWJN5gKiL0m6qq0V5e67YKdnSV9cNg9j22cDvgr3E4o8n_C0BQNoBRBDTl9eaW1frgC08RBs5OeOZMsVtirbtWn9h6COnFGE5qEIebCcmvd34HNT70ThchjdRI8fwlobr1VTNedvyxmzobIVVgAoiaCjJpqZkMp_G4SReNZ9q5isnaFK-seqRg_cQ",
+        "p": "0krO-3nhWHXJD6N1MC7xbxQUH_UOdgtbUp32SUvVB-uSVTCQTV9D22zADFuxExSK0Nfd-gJ8hXiYhm6Wgfup79YeECoU2vnhPRnBPSnQuFMQ1HV8azH2lJEyNyvy_u66nEUUeMqi72zhdkjP1GsTsI2M6QF2EsApbTYoGTbBc3U",
+        "q": "zrPDfd4Se3oVOdoQYdqaEZ8A1uiMstw1CjI9UX76baPqDg1aYstclfLivCM61KaHmP3b65upFP-AUodJIIJyfoMaGmSTjxGaV7gMTPhzSCMSZfWYj37P2u7ZZFZ0Z_zmwMuuU5nxZ0s9sEoOVKl8Q6X2-ODWYlOgfTbZYCaVGbE",
+        "dp": "DbK7ytvElwuNHkyqfIoCRhcLvI0s9PmGaFpLybh71vk8Xfo83B1hgTCTTfrHDRQgerwlBH0W-WbCoLchbLQk_K9449qp4x2101ITKVXI98jJZt2ETkNB6amPmNJvELYiR72kOL4SYQA5q4fQqeiTrsN5s0_aDhygVjHZ6NKNRWU",
+        "dq": "xfMtolqLxKhTr4V_7tZUec-WFDm8lIWCXfNi-arq1RkGytJK3xX14rwqGxZ5_rBEZ2WluOrnb-6Hy4E3rOSAFVwkIWZ0Uaz_7EWbshK1BD5iHjanFbTSBc57bjXFYNi3e6cTmYhxwQQzXaJuOvHcyUQlUo6vgJapuYBPiF8qpuE",
+        "qi": "a-u31v2DLX0ElDk6021pgJ1d_UEqLMyVT1fy7IupelWDdexoFeSIOfTKqJb1aE7tOtN6Ex8IHV8EFErHWJfz6HbShpmSfSSbqG74AXuDvd8tg-imrI878YDF6-R3pwMssBI78nwpJnjcW_UfGpLieMll131HSa4I3vvSNIsFkxY"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 38,
+          "comment": "ciphertext has low hamming weight",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "636d26280a49b4207bd30e67e5e15ddb5455",
+          "ct": "01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00ac17529177c7575ed5e394f3380718e614c0105e81016588fb2f95ec4a327fc8e8af681c740024044a9cbaf1f97ba56d23a9f53391f54a84b2f8581f0cc928fcd4c55e067f8d3629a1fb018a1574466554a18df0121cfaa56703b17470a77e6f6909f4f89b865f11c6f9a951dd67cb73b146eb68aca6c0af6e56533f4ff8c31070d3607edc565d22ebb418d2a00a5b6fb58e29b4d464f0dfca6cb20881c323c9cf91a4fc2a437197f2579d9faaa016a42b59473412245f7640dced842587d6a62fa7c4cb6b57e39b73f0a545bc0e0d6501fa0af22ca162dc0327c4d6b3563fd4880b2010e7e9338a1d90b7cb8b8f410d72287d70bb2079c3a6dc51d6c6a8b807",
+        "privateExponent": "7e60a24231b43275729daec4ee6047e8af545cb10a0bfc849bf256273055e581a55f2b15ba1a6058c67252d7605f6d1cb91416fdc8325a8718e747cf8594348577bb79514c5a676c2b8829993e28258a449c5f9fedad5a641d42990ee9ac172db9f595f0fc45b18b5c93fbc422d41694df9b3545a984cbfc090b5c1722a38c9b50698cac516d5aa16d89864c8568a2956ecd7db8369490e28d3764de0078d20753db4285afff292fba35d5def72959e712f7ab5e40db81d1c89f8c842e97abb25e25f59e78bfe712cbbfd760206e4ecfb001094eef8e238844432086b30dac2b4e7ddd4a725218f45193dd14d4fecc5f683cc4fb4f4418acec3b8da900dec1",
+        "publicExponent": "010001",
+        "prime1": "00e811b5a9c9e65a385fa5cf0e3f3408e613b4a33d270c70141f2359736f5e0cbcec22bc940320827ed227a4ece56876f6047be2475912f8ea86cef0dba1ba72dbc0d7970c549514ebea6e07edccf07a1cfa736e3256ac4829aefcff287c98188b1e4e6d6b3a4d5d15c6a8352694e609f542402afa0d30fb1e9ae11681dbb639df",
+        "prime2": "00bdd6474fce37443303a839a65bc9dab7d66e0ded2fa924ed8d30e8cf1604a6b589b7a3ce5a2cac20161d80c2052c4c8771ef7215adddfb6949cacf8833505055462c5430e283a8cc8b1cfb21827168bd245f7fba6d4aca3cab9888b12c6bf1e0972297b59859bc3522706eaee8f086ef0e655bb27c93b53146a8e19af7d796d9",
+        "exponent1": "313cf8af52a0264a49b8f36a916c67eaf109658d2708d38ae1646da9395ada17077f0345e037f89811dcc9785de04145478445695ff3cf8e6b15e332a668d9cfd865a5adbf107684eb9376e9348f5d4962b6350e47277c9423859859adbdd38f48d9d90b642e5feeabdcaa924a0b58d789bbf5a262441f33ca26b1d0d19e233f",
+        "exponent2": "0099d96417d85f4fe52c2c94f42ee56b5d9be9bb5da347a886e0eb6772153d15c2806714d932998bb1c15a8db4302f13a29d82d9e999ec1249e524f9863f57f292f979098e48b53d02f0273f9b8bb4cf96a238c732564acb95d9d797c846e100b8eca37b620fa381f56a00c6a2f8639e67753a4dd35c44f50e875e6ce083c5f419",
+        "coefficient": "009d7230cada81be92c5f9ce4fb4c973fe0c56a230d99f4b59bd3f3a867d548787a562e47f13a1327d6d88b61c68d564bcac123c0bd63fb4c4cad5174886dd28632a2326afc7f172055c6e0760515259561e67b8a24362a50ac758f7e3289cb5b915b445eef1e62ca603d56d39569e689bfec6911deb4c37b0c73337fd23156a6f"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100ac17529177c7575ed5e394f3380718e614c0105e81016588fb2f95ec4a327fc8e8af681c740024044a9cbaf1f97ba56d23a9f53391f54a84b2f8581f0cc928fcd4c55e067f8d3629a1fb018a1574466554a18df0121cfaa56703b17470a77e6f6909f4f89b865f11c6f9a951dd67cb73b146eb68aca6c0af6e56533f4ff8c31070d3607edc565d22ebb418d2a00a5b6fb58e29b4d464f0dfca6cb20881c323c9cf91a4fc2a437197f2579d9faaa016a42b59473412245f7640dced842587d6a62fa7c4cb6b57e39b73f0a545bc0e0d6501fa0af22ca162dc0327c4d6b3563fd4880b2010e7e9338a1d90b7cb8b8f410d72287d70bb2079c3a6dc51d6c6a8b80702030100010281ff7e60a24231b43275729daec4ee6047e8af545cb10a0bfc849bf256273055e581a55f2b15ba1a6058c67252d7605f6d1cb91416fdc8325a8718e747cf8594348577bb79514c5a676c2b8829993e28258a449c5f9fedad5a641d42990ee9ac172db9f595f0fc45b18b5c93fbc422d41694df9b3545a984cbfc090b5c1722a38c9b50698cac516d5aa16d89864c8568a2956ecd7db8369490e28d3764de0078d20753db4285afff292fba35d5def72959e712f7ab5e40db81d1c89f8c842e97abb25e25f59e78bfe712cbbfd760206e4ecfb001094eef8e238844432086b30dac2b4e7ddd4a725218f45193dd14d4fecc5f683cc4fb4f4418acec3b8da900dec102818100e811b5a9c9e65a385fa5cf0e3f3408e613b4a33d270c70141f2359736f5e0cbcec22bc940320827ed227a4ece56876f6047be2475912f8ea86cef0dba1ba72dbc0d7970c549514ebea6e07edccf07a1cfa736e3256ac4829aefcff287c98188b1e4e6d6b3a4d5d15c6a8352694e609f542402afa0d30fb1e9ae11681dbb639df02818100bdd6474fce37443303a839a65bc9dab7d66e0ded2fa924ed8d30e8cf1604a6b589b7a3ce5a2cac20161d80c2052c4c8771ef7215adddfb6949cacf8833505055462c5430e283a8cc8b1cfb21827168bd245f7fba6d4aca3cab9888b12c6bf1e0972297b59859bc3522706eaee8f086ef0e655bb27c93b53146a8e19af7d796d9028180313cf8af52a0264a49b8f36a916c67eaf109658d2708d38ae1646da9395ada17077f0345e037f89811dcc9785de04145478445695ff3cf8e6b15e332a668d9cfd865a5adbf107684eb9376e9348f5d4962b6350e47277c9423859859adbdd38f48d9d90b642e5feeabdcaa924a0b58d789bbf5a262441f33ca26b1d0d19e233f0281810099d96417d85f4fe52c2c94f42ee56b5d9be9bb5da347a886e0eb6772153d15c2806714d932998bb1c15a8db4302f13a29d82d9e999ec1249e524f9863f57f292f979098e48b53d02f0273f9b8bb4cf96a238c732564acb95d9d797c846e100b8eca37b620fa381f56a00c6a2f8639e67753a4dd35c44f50e875e6ce083c5f419028181009d7230cada81be92c5f9ce4fb4c973fe0c56a230d99f4b59bd3f3a867d548787a562e47f13a1327d6d88b61c68d564bcac123c0bd63fb4c4cad5174886dd28632a2326afc7f172055c6e0760515259561e67b8a24362a50ac758f7e3289cb5b915b445eef1e62ca603d56d39569e689bfec6911deb4c37b0c73337fd23156a6f",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCsF1KRd8dXXtXj\nlPM4BxjmFMAQXoEBZYj7L5XsSjJ/yOivaBx0ACQESpy68fl7pW0jqfUzkfVKhLL4\nWB8MySj81MVeBn+NNimh+wGKFXRGZVShjfASHPqlZwOxdHCnfm9pCfT4m4ZfEcb5\nqVHdZ8tzsUbraKymwK9uVlM/T/jDEHDTYH7cVl0i67QY0qAKW2+1jim01GTw38ps\nsgiBwyPJz5Gk/CpDcZfyV52fqqAWpCtZRzQSJF92QNzthCWH1qYvp8TLa1fjm3Pw\npUW8Dg1lAfoK8iyhYtwDJ8TWs1Y/1IgLIBDn6TOKHZC3y4uPQQ1yKH1wuyB5w6bc\nUdbGqLgHAgMBAAECgf9+YKJCMbQydXKdrsTuYEfor1RcsQoL/ISb8lYnMFXlgaVf\nKxW6GmBYxnJS12BfbRy5FBb9yDJahxjnR8+FlDSFd7t5UUxaZ2wriCmZPiglikSc\nX5/trVpkHUKZDumsFy259ZXw/EWxi1yT+8Qi1BaU35s1RamEy/wJC1wXIqOMm1Bp\njKxRbVqhbYmGTIVoopVuzX24NpSQ4o03ZN4AeNIHU9tCha//KS+6NdXe9ylZ5xL3\nq15A24HRyJ+MhC6Xq7JeJfWeeL/nEsu/12Agbk7PsAEJTu+OI4hEQyCGsw2sK059\n3UpyUhj0UZPdFNT+zF9oPMT7T0QYrOw7jakA3sECgYEA6BG1qcnmWjhfpc8OPzQI\n5hO0oz0nDHAUHyNZc29eDLzsIryUAyCCftInpOzlaHb2BHviR1kS+OqGzvDbobpy\n28DXlwxUlRTr6m4H7czwehz6c24yVqxIKa78/yh8mBiLHk5tazpNXRXGqDUmlOYJ\n9UJAKvoNMPsemuEWgdu2Od8CgYEAvdZHT843RDMDqDmmW8nat9ZuDe0vqSTtjTDo\nzxYEprWJt6POWiysIBYdgMIFLEyHce9yFa3d+2lJys+IM1BQVUYsVDDig6jMixz7\nIYJxaL0kX3+6bUrKPKuYiLEsa/HglyKXtZhZvDUicG6u6PCG7w5lW7J8k7UxRqjh\nmvfXltkCgYAxPPivUqAmSkm482qRbGfq8QlljScI04rhZG2pOVraFwd/A0XgN/iY\nEdzJeF3gQUVHhEVpX/PPjmsV4zKmaNnP2GWlrb8QdoTrk3bpNI9dSWK2NQ5HJ3yU\nI4WYWa29049I2dkLZC5f7qvcqpJKC1jXibv1omJEHzPKJrHQ0Z4jPwKBgQCZ2WQX\n2F9P5SwslPQu5Wtdm+m7XaNHqIbg62dyFT0VwoBnFNkymYuxwVqNtDAvE6Kdgtnp\nmewSSeUk+YY/V/KS+XkJjki1PQLwJz+bi7TPlqI4xzJWSsuV2deXyEbhALjso3ti\nD6OB9WoAxqL4Y55ndTpN01xE9Q6HXmzgg8X0GQKBgQCdcjDK2oG+ksX5zk+0yXP+\nDFaiMNmfS1m9PzqGfVSHh6Vi5H8ToTJ9bYi2HGjVZLysEjwL1j+0xMrVF0iG3Shj\nKiMmr8fxcgVcbgdgUVJZVh5nuKJDYqUKx1j34yictbkVtEXu8eYspgPVbTlWnmib\n/saRHetMN7DHMzf9IxVqbw==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "rBdSkXfHV17V45TzOAcY5hTAEF6BAWWI-y-V7Eoyf8jor2gcdAAkBEqcuvH5e6VtI6n1M5H1SoSy-FgfDMko_NTFXgZ_jTYpofsBihV0RmVUoY3wEhz6pWcDsXRwp35vaQn0-JuGXxHG-alR3WfLc7FG62ispsCvblZTP0_4wxBw02B-3FZdIuu0GNKgCltvtY4ptNRk8N_KbLIIgcMjyc-RpPwqQ3GX8ledn6qgFqQrWUc0EiRfdkDc7YQlh9amL6fEy2tX45tz8KVFvA4NZQH6CvIsoWLcAyfE1rNWP9SICyAQ5-kzih2Qt8uLj0ENcih9cLsgecOm3FHWxqi4Bw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "fmCiQjG0MnVyna7E7mBH6K9UXLEKC_yEm_JWJzBV5YGlXysVuhpgWMZyUtdgX20cuRQW_cgyWocY50fPhZQ0hXe7eVFMWmdsK4gpmT4oJYpEnF-f7a1aZB1CmQ7prBctufWV8PxFsYtck_vEItQWlN-bNUWphMv8CQtcFyKjjJtQaYysUW1aoW2JhkyFaKKVbs19uDaUkOKNN2TeAHjSB1PbQoWv_ykvujXV3vcpWecS96teQNuB0cifjIQul6uyXiX1nni_5xLLv9dgIG5Oz7ABCU7vjiOIREMghrMNrCtOfd1KclIY9FGT3RTU_sxfaDzE-09EGKzsO42pAN7B",
+        "p": "6BG1qcnmWjhfpc8OPzQI5hO0oz0nDHAUHyNZc29eDLzsIryUAyCCftInpOzlaHb2BHviR1kS-OqGzvDbobpy28DXlwxUlRTr6m4H7czwehz6c24yVqxIKa78_yh8mBiLHk5tazpNXRXGqDUmlOYJ9UJAKvoNMPsemuEWgdu2Od8",
+        "q": "vdZHT843RDMDqDmmW8nat9ZuDe0vqSTtjTDozxYEprWJt6POWiysIBYdgMIFLEyHce9yFa3d-2lJys-IM1BQVUYsVDDig6jMixz7IYJxaL0kX3-6bUrKPKuYiLEsa_HglyKXtZhZvDUicG6u6PCG7w5lW7J8k7UxRqjhmvfXltk",
+        "dp": "MTz4r1KgJkpJuPNqkWxn6vEJZY0nCNOK4WRtqTla2hcHfwNF4Df4mBHcyXhd4EFFR4RFaV_zz45rFeMypmjZz9hlpa2_EHaE65N26TSPXUlitjUORyd8lCOFmFmtvdOPSNnZC2QuX-6r3KqSSgtY14m79aJiRB8zyiax0NGeIz8",
+        "dq": "mdlkF9hfT-UsLJT0LuVrXZvpu12jR6iG4OtnchU9FcKAZxTZMpmLscFajbQwLxOinYLZ6ZnsEknlJPmGP1fykvl5CY5ItT0C8Cc_m4u0z5aiOMcyVkrLldnXl8hG4QC47KN7Yg-jgfVqAMai-GOeZ3U6TdNcRPUOh15s4IPF9Bk",
+        "qi": "nXIwytqBvpLF-c5PtMlz_gxWojDZn0tZvT86hn1Uh4elYuR_E6EyfW2Ithxo1WS8rBI8C9Y_tMTK1RdIht0oYyojJq_H8XIFXG4HYFFSWVYeZ7iiQ2KlCsdY9-MonLW5FbRF7vHmLKYD1W05Vp5om_7GkR3rTDewxzM3_SMVam8"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 39,
+          "comment": "ciphertext has high hamming weight",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "44fadc2b07145f74c552f37b2140338aef1b46d7d4aabcb041faf19f22d6d18fc40a5e9aa4fa7013ee7953f180323d4affd3adf4c358084b057e48ee001ff567f5f509d8d429aecdac397447893d81323132b141ed345e0c52a980d470deb3951b6feb4c",
+          "ct": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00c01f17440887a6016faad9d70d23e5290ebef6ee9b7707affc88fa85b0b66033e1cf2a82654518e2b732c2edbafa9d2b68b2fef78ed36d6c421c5bb2304711d98a5ab9aff8c48f8c35ecd5e0c721eede459832d83b92a7edfebaf163c1445a003b3300f8eea2ce43b88cad04c413b561006b7494810fc5b46c6598d3da90d044f5ef73754c3b14fbce33bf0269faacbae52328602b13e0dc7c485c02caa54b05821f5e6923c3c7b3bdfbf9f444aa3003cb031af78804b4702185a42b38ddc0bd1bebfe107685b40de763cb1797c95e0cbb41f92ba62e3f383103ab7cc01604c50c2776b022278da9b359e6c94badb7017ed3ac100a9afeec1218d28e839f2f1b",
+        "privateExponent": "50ef8824a0174d47039d0d427c85a7afc1478fcd7b6f0cad060d4ac4f16a136327f8d766b1750783d33bae44ea6553bb0ad3857813125ce1a38440d8f35fad5460e5d19e2185e517634c4fd9eeea0bb055cf457434bc96c43b70d3ea7b6be92279ce05d5d8ea7b4caa3d915215ac5bd7ee8e56418d91706f8ececa304dbe7e0e23c5ec42a029d1a60a1c9673e3a8bc942754d4d601f1847fb3539a3259c36c725f279c1ad4480f7186c1d641f377fa3d7ee90a5bf16b8f1c7d9f289b854cb77bfd0f41a028b9634cf3adda3b5567918d2b5d0aa08bc8ccec8d0b39c561f1c92aa6b200bb8824ff50067ef87c0f55e0a981655180aef3bc335c557a9be54e1fe1",
+        "publicExponent": "010001",
+        "prime1": "00efac2aa13cc58edb458882585cdcfead704eed622a314d923d56e3fd21924f99fe68d20bea1e2fabf67837ec6b52248a866fb6709f550643c720f631f9d860c42f66a8dbe1e36d6fe2330211c6b9b692ff2a0bae8c700f4da7a04e06388bc313e6b480949565a160940c4f0a4323d960fb89fee973960f1972108088e147418b",
+        "prime2": "00cd35a50245114f6bedf1e0b000c725f1e659b446a05faa14542ef088fe8555fe7c19c4e97e58bcedc9813eb7bf700b59494338b7208c24d256f73c6d72af2c05ad7776de913053eddfb44e0f7db687654a3ee89fe095c331d9bc2b01ae9cb520e8355eda2e5516dd2f4c4459bc16b40bd95174f11a548c3589984d4306f05ab1",
+        "exponent1": "00a06245e4c0163412e7e501d4bfcfe35d8cda44607c7ba1bd4aeeea826a04cedfee2f96e0023b510b7253e09884f8e31b0ffb91caabd4e9ec5144ed7b6406383b10bd522252772eb4c05a01f88353a3a99ab7383a0620b71cf01f861703a0035b3df76c5401e590a8606a1c3a71d37b943abf8da60b834f7767ad435655eaa921",
+        "exponent2": "00cd1996c8c3fb5f2402784417e54f262fb609665348ab14b4a8c71985f2cd957b7ad1ceab88aa6c7a4572361b34ed698a5ddd1fec784d59e8191f9677d5ae1b13b9a2b35e1442f73fc2dcd5404a678abfc40b4839b3203c2db0ef8f14694f1b01bed4c8eecc6c232402c7f970aebb0a4ce571b2addfa12d59bd2249e67a22f4a1",
+        "coefficient": "00d4b887f8d46a40a14d6582c7fb2eba4fbd715757ae88ba1f644a297483e364a1286503aeab798d30f4d2eae9710b5b71fcc2d132314da4daabd252020527312b3e9f7d4d8d3c4c8df4645720c337d10f3706c06d181c48bfaf35c18ec759da166e3c9312828fff9932bf227d8777dce56ff003301072c620e7380be48aeffb99"
+      },
+      "privateKeyPkcs8": "308204bf020100300d06092a864886f70d0101010500048204a9308204a50201000282010100c01f17440887a6016faad9d70d23e5290ebef6ee9b7707affc88fa85b0b66033e1cf2a82654518e2b732c2edbafa9d2b68b2fef78ed36d6c421c5bb2304711d98a5ab9aff8c48f8c35ecd5e0c721eede459832d83b92a7edfebaf163c1445a003b3300f8eea2ce43b88cad04c413b561006b7494810fc5b46c6598d3da90d044f5ef73754c3b14fbce33bf0269faacbae52328602b13e0dc7c485c02caa54b05821f5e6923c3c7b3bdfbf9f444aa3003cb031af78804b4702185a42b38ddc0bd1bebfe107685b40de763cb1797c95e0cbb41f92ba62e3f383103ab7cc01604c50c2776b022278da9b359e6c94badb7017ed3ac100a9afeec1218d28e839f2f1b02030100010282010050ef8824a0174d47039d0d427c85a7afc1478fcd7b6f0cad060d4ac4f16a136327f8d766b1750783d33bae44ea6553bb0ad3857813125ce1a38440d8f35fad5460e5d19e2185e517634c4fd9eeea0bb055cf457434bc96c43b70d3ea7b6be92279ce05d5d8ea7b4caa3d915215ac5bd7ee8e56418d91706f8ececa304dbe7e0e23c5ec42a029d1a60a1c9673e3a8bc942754d4d601f1847fb3539a3259c36c725f279c1ad4480f7186c1d641f377fa3d7ee90a5bf16b8f1c7d9f289b854cb77bfd0f41a028b9634cf3adda3b5567918d2b5d0aa08bc8ccec8d0b39c561f1c92aa6b200bb8824ff50067ef87c0f55e0a981655180aef3bc335c557a9be54e1fe102818100efac2aa13cc58edb458882585cdcfead704eed622a314d923d56e3fd21924f99fe68d20bea1e2fabf67837ec6b52248a866fb6709f550643c720f631f9d860c42f66a8dbe1e36d6fe2330211c6b9b692ff2a0bae8c700f4da7a04e06388bc313e6b480949565a160940c4f0a4323d960fb89fee973960f1972108088e147418b02818100cd35a50245114f6bedf1e0b000c725f1e659b446a05faa14542ef088fe8555fe7c19c4e97e58bcedc9813eb7bf700b59494338b7208c24d256f73c6d72af2c05ad7776de913053eddfb44e0f7db687654a3ee89fe095c331d9bc2b01ae9cb520e8355eda2e5516dd2f4c4459bc16b40bd95174f11a548c3589984d4306f05ab102818100a06245e4c0163412e7e501d4bfcfe35d8cda44607c7ba1bd4aeeea826a04cedfee2f96e0023b510b7253e09884f8e31b0ffb91caabd4e9ec5144ed7b6406383b10bd522252772eb4c05a01f88353a3a99ab7383a0620b71cf01f861703a0035b3df76c5401e590a8606a1c3a71d37b943abf8da60b834f7767ad435655eaa92102818100cd1996c8c3fb5f2402784417e54f262fb609665348ab14b4a8c71985f2cd957b7ad1ceab88aa6c7a4572361b34ed698a5ddd1fec784d59e8191f9677d5ae1b13b9a2b35e1442f73fc2dcd5404a678abfc40b4839b3203c2db0ef8f14694f1b01bed4c8eecc6c232402c7f970aebb0a4ce571b2addfa12d59bd2249e67a22f4a102818100d4b887f8d46a40a14d6582c7fb2eba4fbd715757ae88ba1f644a297483e364a1286503aeab798d30f4d2eae9710b5b71fcc2d132314da4daabd252020527312b3e9f7d4d8d3c4c8df4645720c337d10f3706c06d181c48bfaf35c18ec759da166e3c9312828fff9932bf227d8777dce56ff003301072c620e7380be48aeffb99",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDAHxdECIemAW+q\n2dcNI+UpDr727pt3B6/8iPqFsLZgM+HPKoJlRRjitzLC7br6nStosv73jtNtbEIc\nW7IwRxHZilq5r/jEj4w17NXgxyHu3kWYMtg7kqft/rrxY8FEWgA7MwD47qLOQ7iM\nrQTEE7VhAGt0lIEPxbRsZZjT2pDQRPXvc3VMOxT7zjO/Amn6rLrlIyhgKxPg3HxI\nXALKpUsFgh9eaSPDx7O9+/n0RKowA8sDGveIBLRwIYWkKzjdwL0b6/4QdoW0Dedj\nyxeXyV4Mu0H5K6YuPzgxA6t8wBYExQwndrAiJ42ps1nmyUuttwF+06wQCpr+7BIY\n0o6Dny8bAgMBAAECggEAUO+IJKAXTUcDnQ1CfIWnr8FHj817bwytBg1KxPFqE2Mn\n+NdmsXUHg9M7rkTqZVO7CtOFeBMSXOGjhEDY81+tVGDl0Z4hheUXY0xP2e7qC7BV\nz0V0NLyWxDtw0+p7a+kiec4F1djqe0yqPZFSFaxb1+6OVkGNkXBvjs7KME2+fg4j\nxexCoCnRpgoclnPjqLyUJ1TU1gHxhH+zU5oyWcNscl8nnBrUSA9xhsHWQfN3+j1+\n6Qpb8WuPHH2fKJuFTLd7/Q9BoCi5Y0zzrdo7VWeRjStdCqCLyMzsjQs5xWHxySqm\nsgC7iCT/UAZ++HwPVeCpgWVRgK7zvDNcVXqb5U4f4QKBgQDvrCqhPMWO20WIglhc\n3P6tcE7tYioxTZI9VuP9IZJPmf5o0gvqHi+r9ng37GtSJIqGb7Zwn1UGQ8cg9jH5\n2GDEL2ao2+HjbW/iMwIRxrm2kv8qC66McA9Np6BOBjiLwxPmtICUlWWhYJQMTwpD\nI9lg+4n+6XOWDxlyEICI4UdBiwKBgQDNNaUCRRFPa+3x4LAAxyXx5lm0RqBfqhRU\nLvCI/oVV/nwZxOl+WLztyYE+t79wC1lJQzi3IIwk0lb3PG1yrywFrXd23pEwU+3f\ntE4PfbaHZUo+6J/glcMx2bwrAa6ctSDoNV7aLlUW3S9MRFm8FrQL2VF08RpUjDWJ\nmE1DBvBasQKBgQCgYkXkwBY0EuflAdS/z+NdjNpEYHx7ob1K7uqCagTO3+4vluAC\nO1ELclPgmIT44xsP+5HKq9Tp7FFE7XtkBjg7EL1SIlJ3LrTAWgH4g1OjqZq3ODoG\nILcc8B+GFwOgA1s992xUAeWQqGBqHDpx03uUOr+NpguDT3dnrUNWVeqpIQKBgQDN\nGZbIw/tfJAJ4RBflTyYvtglmU0irFLSoxxmF8s2Ve3rRzquIqmx6RXI2GzTtaYpd\n3R/seE1Z6BkflnfVrhsTuaKzXhRC9z/C3NVASmeKv8QLSDmzIDwtsO+PFGlPGwG+\n1MjuzGwjJALH+XCuuwpM5XGyrd+hLVm9IknmeiL0oQKBgQDUuIf41GpAoU1lgsf7\nLrpPvXFXV66Iuh9kSil0g+NkoShlA66reY0w9NLq6XELW3H8wtEyMU2k2qvSUgIF\nJzErPp99TY08TI30ZFcgwzfRDzcGwG0YHEi/rzXBjsdZ2hZuPJMSgo//mTK/In2H\nd9zlb/ADMBByxiDnOAvkiu/7mQ==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "wB8XRAiHpgFvqtnXDSPlKQ6-9u6bdwev_Ij6hbC2YDPhzyqCZUUY4rcywu26-p0raLL-947TbWxCHFuyMEcR2Ypaua_4xI-MNezV4Mch7t5FmDLYO5Kn7f668WPBRFoAOzMA-O6izkO4jK0ExBO1YQBrdJSBD8W0bGWY09qQ0ET173N1TDsU-84zvwJp-qy65SMoYCsT4Nx8SFwCyqVLBYIfXmkjw8ezvfv59ESqMAPLAxr3iAS0cCGFpCs43cC9G-v-EHaFtA3nY8sXl8leDLtB-SumLj84MQOrfMAWBMUMJ3awIieNqbNZ5slLrbcBftOsEAqa_uwSGNKOg58vGw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "UO-IJKAXTUcDnQ1CfIWnr8FHj817bwytBg1KxPFqE2Mn-NdmsXUHg9M7rkTqZVO7CtOFeBMSXOGjhEDY81-tVGDl0Z4hheUXY0xP2e7qC7BVz0V0NLyWxDtw0-p7a-kiec4F1djqe0yqPZFSFaxb1-6OVkGNkXBvjs7KME2-fg4jxexCoCnRpgoclnPjqLyUJ1TU1gHxhH-zU5oyWcNscl8nnBrUSA9xhsHWQfN3-j1-6Qpb8WuPHH2fKJuFTLd7_Q9BoCi5Y0zzrdo7VWeRjStdCqCLyMzsjQs5xWHxySqmsgC7iCT_UAZ--HwPVeCpgWVRgK7zvDNcVXqb5U4f4Q",
+        "p": "76wqoTzFjttFiIJYXNz-rXBO7WIqMU2SPVbj_SGST5n-aNIL6h4vq_Z4N-xrUiSKhm-2cJ9VBkPHIPYx-dhgxC9mqNvh421v4jMCEca5tpL_KguujHAPTaegTgY4i8MT5rSAlJVloWCUDE8KQyPZYPuJ_ulzlg8ZchCAiOFHQYs",
+        "q": "zTWlAkURT2vt8eCwAMcl8eZZtEagX6oUVC7wiP6FVf58GcTpfli87cmBPre_cAtZSUM4tyCMJNJW9zxtcq8sBa13dt6RMFPt37ROD322h2VKPuif4JXDMdm8KwGunLUg6DVe2i5VFt0vTERZvBa0C9lRdPEaVIw1iZhNQwbwWrE",
+        "dp": "oGJF5MAWNBLn5QHUv8_jXYzaRGB8e6G9Su7qgmoEzt_uL5bgAjtRC3JT4JiE-OMbD_uRyqvU6exRRO17ZAY4OxC9UiJSdy60wFoB-INTo6matzg6BiC3HPAfhhcDoANbPfdsVAHlkKhgahw6cdN7lDq_jaYLg093Z61DVlXqqSE",
+        "dq": "zRmWyMP7XyQCeEQX5U8mL7YJZlNIqxS0qMcZhfLNlXt60c6riKpsekVyNhs07WmKXd0f7HhNWegZH5Z31a4bE7mis14UQvc_wtzVQEpnir_EC0g5syA8LbDvjxRpTxsBvtTI7sxsIyQCx_lwrrsKTOVxsq3foS1ZvSJJ5noi9KE",
+        "qi": "1LiH-NRqQKFNZYLH-y66T71xV1euiLofZEopdIPjZKEoZQOuq3mNMPTS6ulxC1tx_MLRMjFNpNqr0lICBScxKz6ffU2NPEyN9GRXIMM30Q83BsBtGBxIv681wY7HWdoWbjyTEoKP_5kyvyJ9h3fc5W_wAzAQcsYg5zgL5Irv-5k"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 40,
+          "comment": "ciphertext has high hamming weight",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "a4f7ea4da2d695750150d5c9889a6b4ad0a183184a9561b9dfe0afafaccf16010628cc51c68d5035919edaa1ed462d06c4b5feb649be3c60f7bdc1e4a964e758bb0541382b61b49a77314e08b3a88f65d3b5ca2d49b15ff8afa229f462535fcf7f3f20dc01d824927040446a8136cc22ef049b2c",
+          "ct": "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "009ed120a37de2127bb18615516cd7931182ad62d39d1ce99adb21d60b8b940830843ffc9537bda7be9760bd49fa61809ce9467a6e0baa28c479006465827e15c4ba08b2a1be1873e96bdfbdd2d129208ce4b15fef184dae5f3b874e0da757f2f1cbd7c43cd0445e6eb879cd292f2759df8c50de0c4a53bada3179f889f81936fe12bdd9c906d80781963781e877e4981ea4c394417965c24d82730c15a3c1ec338873b536552ae1f6d92fb39653a8ebad8338a8dd16492673a18d3c123edcdea1e100f15adc127e04ddf4c4acf2d1c44e875d65de40c4f51dde0249dd58528a371a7c764f0589d342d52bedae8e7e8889f17f9bc0c0c14237b34a8ef7c4b6b56b",
+        "privateExponent": "2b09c12e8d0e96b3ae88077ee960021adcaedff938ba7d13da0e7152efa04e17d7beff53f0a714ae3197a5b44685e5b4a002d96ab8fe83cdba7cc0b84184a9a18648951fffc3e0a580f6411ac053c4de699b27c44371c9af451285b46d8507f13eac5a21a0cee6485af5a7036223e7d70ccf5d5d3747397ba7acc60d9d8e37b875498d06e7ca08c93cde6d8d7263cc0c696032fe973750d617b979c7afc2628938a2bb3ef6d787955b198dd114bf6af63a28e0fd7d32c85aca53c0255972841f99c4a4707afbc05c329aeb3f3daa4325e80116fdeb38f8a452f1ad4280e324df9edb9c471dffb27b679381ee11b01a656e183aab9b5b480d7ef81d0a5a3a0d01",
+        "publicExponent": "010001",
+        "prime1": "00cede080639a5e44e156f5e205aca552678ce7eb0962e7a633da3827832de3b43310d183539b5d3716e60eb04bf26a4cd580a38ec8cd697ce544d4d7a47d3eae4625fa60a9138dbc8d397590e332277168281f8d09eddc95cf7254ec1bbe0165104f33eed294f3417ddfa05ce88ab961b354afda8f4fc075d805fd8f19762faef",
+        "prime2": "00c48987b8d0a44a9783e66ecbcdfa750364f8d39f8030b50a6f05b6cd464ee6bd36048a1173b1f745b977f01576c0170dc27cebed558d3af636e64bde2b4655ba4bd48520ca7174af8b2f5341e823871acc7b7f849b1d8b460a102d8e42e1889d9cc1195c685aac275c751ce5bc82836b624b17cf858f3693103dcbaaf9241d45",
+        "exponent1": "00a2ecfc24eb025ceda2b433ce07b3939cd948c93f0b09501b1950ce511cbf2aada0d44f5c9c373870fe1e16fb8611497af0fc1c19325350fc9028d1fc9cd5ab0a74f02035f26a75af95f67d8d5178b39266f736a0187f553882ee3f39165f47344851cc1dbd8b43dc0858027ac7e95c2fd1a95e5ed3942bb8d882a4baa220b2c1",
+        "exponent2": "2088234f143a1d9eb6d68dc06e77e6a6893026d76000aff6ea29a7f8928abce6d4ea2b7078161d380d5b2d026085ab4b3bc631c73742096077f5e6d8ff90c4dff16d5c1bf1669649f85ffd080bc4d5b839e0b75adbd2281b8fceddbb8e968666906be626c59f3c9fc74e1b5a6bb9aec7379df673034891600670342638d72181",
+        "coefficient": "1bcd11d65ef3e2c256bd5193dbf2bb5af368bc726838b0f391e785d8faca704f5b931e9fbfcbea61c76570355e4be513adb11df943afde22b5ce394a273397ee23e96116329e142cc731c9d606a1dbf0a7c37dde92216e011749a379266fa4d0b16395c2cdbdec7e0a52f5f16471f459c03fed5e6c1f2331564213a2ea34efbd"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a302010002820101009ed120a37de2127bb18615516cd7931182ad62d39d1ce99adb21d60b8b940830843ffc9537bda7be9760bd49fa61809ce9467a6e0baa28c479006465827e15c4ba08b2a1be1873e96bdfbdd2d129208ce4b15fef184dae5f3b874e0da757f2f1cbd7c43cd0445e6eb879cd292f2759df8c50de0c4a53bada3179f889f81936fe12bdd9c906d80781963781e877e4981ea4c394417965c24d82730c15a3c1ec338873b536552ae1f6d92fb39653a8ebad8338a8dd16492673a18d3c123edcdea1e100f15adc127e04ddf4c4acf2d1c44e875d65de40c4f51dde0249dd58528a371a7c764f0589d342d52bedae8e7e8889f17f9bc0c0c14237b34a8ef7c4b6b56b0203010001028201002b09c12e8d0e96b3ae88077ee960021adcaedff938ba7d13da0e7152efa04e17d7beff53f0a714ae3197a5b44685e5b4a002d96ab8fe83cdba7cc0b84184a9a18648951fffc3e0a580f6411ac053c4de699b27c44371c9af451285b46d8507f13eac5a21a0cee6485af5a7036223e7d70ccf5d5d3747397ba7acc60d9d8e37b875498d06e7ca08c93cde6d8d7263cc0c696032fe973750d617b979c7afc2628938a2bb3ef6d787955b198dd114bf6af63a28e0fd7d32c85aca53c0255972841f99c4a4707afbc05c329aeb3f3daa4325e80116fdeb38f8a452f1ad4280e324df9edb9c471dffb27b679381ee11b01a656e183aab9b5b480d7ef81d0a5a3a0d0102818100cede080639a5e44e156f5e205aca552678ce7eb0962e7a633da3827832de3b43310d183539b5d3716e60eb04bf26a4cd580a38ec8cd697ce544d4d7a47d3eae4625fa60a9138dbc8d397590e332277168281f8d09eddc95cf7254ec1bbe0165104f33eed294f3417ddfa05ce88ab961b354afda8f4fc075d805fd8f19762faef02818100c48987b8d0a44a9783e66ecbcdfa750364f8d39f8030b50a6f05b6cd464ee6bd36048a1173b1f745b977f01576c0170dc27cebed558d3af636e64bde2b4655ba4bd48520ca7174af8b2f5341e823871acc7b7f849b1d8b460a102d8e42e1889d9cc1195c685aac275c751ce5bc82836b624b17cf858f3693103dcbaaf9241d4502818100a2ecfc24eb025ceda2b433ce07b3939cd948c93f0b09501b1950ce511cbf2aada0d44f5c9c373870fe1e16fb8611497af0fc1c19325350fc9028d1fc9cd5ab0a74f02035f26a75af95f67d8d5178b39266f736a0187f553882ee3f39165f47344851cc1dbd8b43dc0858027ac7e95c2fd1a95e5ed3942bb8d882a4baa220b2c10281802088234f143a1d9eb6d68dc06e77e6a6893026d76000aff6ea29a7f8928abce6d4ea2b7078161d380d5b2d026085ab4b3bc631c73742096077f5e6d8ff90c4dff16d5c1bf1669649f85ffd080bc4d5b839e0b75adbd2281b8fceddbb8e968666906be626c59f3c9fc74e1b5a6bb9aec7379df673034891600670342638d721810281801bcd11d65ef3e2c256bd5193dbf2bb5af368bc726838b0f391e785d8faca704f5b931e9fbfcbea61c76570355e4be513adb11df943afde22b5ce394a273397ee23e96116329e142cc731c9d606a1dbf0a7c37dde92216e011749a379266fa4d0b16395c2cdbdec7e0a52f5f16471f459c03fed5e6c1f2331564213a2ea34efbd",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCe0SCjfeISe7GG\nFVFs15MRgq1i050c6ZrbIdYLi5QIMIQ//JU3vae+l2C9SfphgJzpRnpuC6ooxHkA\nZGWCfhXEugiyob4Yc+lr373S0SkgjOSxX+8YTa5fO4dODadX8vHL18Q80ERebrh5\nzSkvJ1nfjFDeDEpTutoxefiJ+Bk2/hK92ckG2AeBljeB6HfkmB6kw5RBeWXCTYJz\nDBWjwewziHO1NlUq4fbZL7OWU6jrrYM4qN0WSSZzoY08Ej7c3qHhAPFa3BJ+BN30\nxKzy0cROh11l3kDE9R3eAkndWFKKNxp8dk8FidNC1Svtro5+iInxf5vAwMFCN7NK\njvfEtrVrAgMBAAECggEAKwnBLo0OlrOuiAd+6WACGtyu3/k4un0T2g5xUu+gThfX\nvv9T8KcUrjGXpbRGheW0oALZarj+g826fMC4QYSpoYZIlR//w+ClgPZBGsBTxN5p\nmyfEQ3HJr0UShbRthQfxPqxaIaDO5kha9acDYiPn1wzPXV03Rzl7p6zGDZ2ON7h1\nSY0G58oIyTzebY1yY8wMaWAy/pc3UNYXuXnHr8JiiTiiuz7214eVWxmN0RS/avY6\nKOD9fTLIWspTwCVZcoQfmcSkcHr7wFwymus/PapDJegBFv3rOPikUvGtQoDjJN+e\n25xHHf+ye2eTge4RsBplbhg6q5tbSA1++B0KWjoNAQKBgQDO3ggGOaXkThVvXiBa\nylUmeM5+sJYuemM9o4J4Mt47QzENGDU5tdNxbmDrBL8mpM1YCjjsjNaXzlRNTXpH\n0+rkYl+mCpE428jTl1kOMyJ3FoKB+NCe3clc9yVOwbvgFlEE8z7tKU80F936Bc6I\nq5YbNUr9qPT8B12AX9jxl2L67wKBgQDEiYe40KRKl4PmbsvN+nUDZPjTn4AwtQpv\nBbbNRk7mvTYEihFzsfdFuXfwFXbAFw3CfOvtVY069jbmS94rRlW6S9SFIMpxdK+L\nL1NB6COHGsx7f4SbHYtGChAtjkLhiJ2cwRlcaFqsJ1x1HOW8goNrYksXz4WPNpMQ\nPcuq+SQdRQKBgQCi7Pwk6wJc7aK0M84Hs5Oc2UjJPwsJUBsZUM5RHL8qraDUT1yc\nNzhw/h4W+4YRSXrw/BwZMlNQ/JAo0fyc1asKdPAgNfJqda+V9n2NUXizkmb3NqAY\nf1U4gu4/ORZfRzRIUcwdvYtD3AhYAnrH6Vwv0aleXtOUK7jYgqS6oiCywQKBgCCI\nI08UOh2ettaNwG535qaJMCbXYACv9uopp/iSirzm1OorcHgWHTgNWy0CYIWrSzvG\nMcc3Qglgd/Xm2P+QxN/xbVwb8WaWSfhf/QgLxNW4OeC3WtvSKBuPzt27jpaGZpBr\n5ibFnzyfx04bWmu5rsc3nfZzA0iRYAZwNCY41yGBAoGAG80R1l7z4sJWvVGT2/K7\nWvNovHJoOLDzkeeF2PrKcE9bkx6fv8vqYcdlcDVeS+UTrbEd+UOv3iK1zjlKJzOX\n7iPpYRYynhQsxzHJ1gah2/Cnw33ekiFuARdJo3kmb6TQsWOVws297H4KUvXxZHH0\nWcA/7V5sHyMxVkITouo0770=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "ntEgo33iEnuxhhVRbNeTEYKtYtOdHOma2yHWC4uUCDCEP_yVN72nvpdgvUn6YYCc6UZ6bguqKMR5AGRlgn4VxLoIsqG-GHPpa9-90tEpIIzksV_vGE2uXzuHTg2nV_Lxy9fEPNBEXm64ec0pLydZ34xQ3gxKU7raMXn4ifgZNv4SvdnJBtgHgZY3geh35JgepMOUQXllwk2CcwwVo8HsM4hztTZVKuH22S-zllOo662DOKjdFkkmc6GNPBI-3N6h4QDxWtwSfgTd9MSs8tHEToddZd5AxPUd3gJJ3VhSijcafHZPBYnTQtUr7a6OfoiJ8X-bwMDBQjezSo73xLa1aw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "KwnBLo0OlrOuiAd-6WACGtyu3_k4un0T2g5xUu-gThfXvv9T8KcUrjGXpbRGheW0oALZarj-g826fMC4QYSpoYZIlR__w-ClgPZBGsBTxN5pmyfEQ3HJr0UShbRthQfxPqxaIaDO5kha9acDYiPn1wzPXV03Rzl7p6zGDZ2ON7h1SY0G58oIyTzebY1yY8wMaWAy_pc3UNYXuXnHr8JiiTiiuz7214eVWxmN0RS_avY6KOD9fTLIWspTwCVZcoQfmcSkcHr7wFwymus_PapDJegBFv3rOPikUvGtQoDjJN-e25xHHf-ye2eTge4RsBplbhg6q5tbSA1--B0KWjoNAQ",
+        "p": "zt4IBjml5E4Vb14gWspVJnjOfrCWLnpjPaOCeDLeO0MxDRg1ObXTcW5g6wS_JqTNWAo47IzWl85UTU16R9Pq5GJfpgqRONvI05dZDjMidxaCgfjQnt3JXPclTsG74BZRBPM-7SlPNBfd-gXOiKuWGzVK_aj0_AddgF_Y8Zdi-u8",
+        "q": "xImHuNCkSpeD5m7Lzfp1A2T405-AMLUKbwW2zUZO5r02BIoRc7H3Rbl38BV2wBcNwnzr7VWNOvY25kveK0ZVukvUhSDKcXSviy9TQegjhxrMe3-Emx2LRgoQLY5C4YidnMEZXGharCdcdRzlvIKDa2JLF8-FjzaTED3LqvkkHUU",
+        "dp": "ouz8JOsCXO2itDPOB7OTnNlIyT8LCVAbGVDOURy_Kq2g1E9cnDc4cP4eFvuGEUl68PwcGTJTUPyQKNH8nNWrCnTwIDXyanWvlfZ9jVF4s5Jm9zagGH9VOILuPzkWX0c0SFHMHb2LQ9wIWAJ6x-lcL9GpXl7TlCu42IKkuqIgssE",
+        "dq": "IIgjTxQ6HZ621o3AbnfmpokwJtdgAK_26imn-JKKvObU6itweBYdOA1bLQJghatLO8YxxzdCCWB39ebY_5DE3_FtXBvxZpZJ-F_9CAvE1bg54Lda29IoG4_O3buOloZmkGvmJsWfPJ_HThtaa7muxzed9nMDSJFgBnA0JjjXIYE",
+        "qi": "G80R1l7z4sJWvVGT2_K7WvNovHJoOLDzkeeF2PrKcE9bkx6fv8vqYcdlcDVeS-UTrbEd-UOv3iK1zjlKJzOX7iPpYRYynhQsxzHJ1gah2_Cnw33ekiFuARdJo3kmb6TQsWOVws297H4KUvXxZHH0WcA_7V5sHyMxVkITouo0770"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 41,
+          "comment": "ciphertext mod p,q has high hamming weight",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "0148726644c9d20762c9546d18d3c13c620f4b3b4073c68c4f9dca924acede084e66cc1e31cc7135b53b483fd32d866517aee3db019e56d161787ee6e873f6c4f08acfc58222871dd6ccec5e2dd1898990c6cd98340a12fb7f7b404d15a5dbc26bbcb2f18547ba2d62c5a5923f9ed5b90ceffd597e8dda192de98fc3c7ebc169863de9f56bdd549404a690b3ef50a59e29375557c88f",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00c7ac781ffb9a9f691c4dfe64e47de98b8f265e667d5fc2532668caf63921ead3d8440e605a89c7c017a722c9d654db1fe7de724689bb35d684fe038d018a3f4b47e0da7d79c09ab4b74660101b0b8cf5120d39718f0d1b11818c422220caf09a9324fede40ce3a9ab9c45ffb28f192688dd838c085c64df9eaa20429bd59c2757732ce09ae78179b99da63c1c94efec3426f81b63b8f31478f50f826ea378f391223d841aa55c72eda9094e88d658a0972d92468ce651573f0212244e04ad0d95d61f95924f65aa85c316771f18edb27e9a71a53e763c7786f14589514a7029791388fabe024e39ab31ec634a4dd85e334360791092a4d3a15d547ac40ca1fc7",
+        "privateExponent": "0dc7c66696abbe32b7e45e194277ba258a94a0513c77de6674b128c8c37aa6c54618b4514c0e543ddaa40b4f98be347d48385ef4a54ec9516bce481a742fc15c85b26c01dae4430913d9048a38039d0fd0d61ecfca8aa2029c493ccb342e2d5acdaaf0f80fcaebda7fd5a0b629c63a4f82f29840193b6d68411c3b6352111ecd7335809a380e647c57babc7ce9a1410011feda9ab0fdcfea820bbfde5652f6b1658bed43ee719d054939467846d98771019225eef193480995dc4fc6fd12ff6534f35027b8d15a7afe90187081886db0e7e3530cf60ea98ce5704291737b8e9b26b53e40a6508e34b91c136967f8e633e9ed95f65b89fc3e4d3fc88f491921e9",
+        "publicExponent": "010001",
+        "prime1": "00fa2be1bf12c6b55c095112496edb08a523ba9e24d4aed479bf4eea882f240a49e6c77d940c99755549cf30cebc218661a1791481a8a63dbab209f126cb43fd29a41ef05513a2e7c5258bf2b40b17e98abe31d52f2ef26db3c487609c6ab2b9e69a84f11d0860f09a62d6d52f524035af9530d78381d1954e632562b3a7d49113",
+        "prime2": "00cc536656010736f6ef6492a2da5bd075e7faa46db5dc67e11d7a7205d826c31de8371f502fc9d21c39d7e0df2983f491db457d0591b98b5259a911cd0a3788573d2a858874a76cfb440e2a477ed59f4c988332730c583e1db2b131273e132eac0590a49ec595d90198f75ee8f1cfd8c97d50b2a19f1956d60c8ffba9e30640fd",
+        "exponent1": "3d118533dd6380560d382b1c9de0fe0541e9863d3b65ca1c4624ff7f6af2834872fb739e364d27a540354196d5b9e151e7d6e4b899f0aad4ee2d1b1efb33879328ab1cc3c7dd56727bade3fb2b521502775736d123c6ae1cd9f6aa10c4c3083a50b1ef21c52fd4cbfb20b23db0f857a29aeaa75144d962771620c42d52e4c2dd",
+        "exponent2": "008ac43563418d81d1d121cfc8d45db8c4eac8b9b55ce6949239aff8126a0b614645787246c63dddf9977b3ad8b4dc4e5464c3dbb5d5935ac091ee160dd7db8138266d63851a1cbf1222d52ff7a0773a9a0d9644c407e542426f22920c61c72b525ef12e2c3a6a9b97cf286987f0fa44f40aacacb4c155b738e60d3f50d0c3658d",
+        "coefficient": "00ef71c5bc951d7c616ba48c913919480930a864450d893776eacf21844ccb0ae76eeff814eac5a9b50c2069d822e270adad94ed19fd6ef0de3f7154a6a412bc784f78ecb5c1cb09bd5540732566d3497605cce3a6e0ce69c95dd803f291183b275afc780971c1b507b22daf2fd060b05ae277269aa36489587d5a84ca22ad1975"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100c7ac781ffb9a9f691c4dfe64e47de98b8f265e667d5fc2532668caf63921ead3d8440e605a89c7c017a722c9d654db1fe7de724689bb35d684fe038d018a3f4b47e0da7d79c09ab4b74660101b0b8cf5120d39718f0d1b11818c422220caf09a9324fede40ce3a9ab9c45ffb28f192688dd838c085c64df9eaa20429bd59c2757732ce09ae78179b99da63c1c94efec3426f81b63b8f31478f50f826ea378f391223d841aa55c72eda9094e88d658a0972d92468ce651573f0212244e04ad0d95d61f95924f65aa85c316771f18edb27e9a71a53e763c7786f14589514a7029791388fabe024e39ab31ec634a4dd85e334360791092a4d3a15d547ac40ca1fc70203010001028201000dc7c66696abbe32b7e45e194277ba258a94a0513c77de6674b128c8c37aa6c54618b4514c0e543ddaa40b4f98be347d48385ef4a54ec9516bce481a742fc15c85b26c01dae4430913d9048a38039d0fd0d61ecfca8aa2029c493ccb342e2d5acdaaf0f80fcaebda7fd5a0b629c63a4f82f29840193b6d68411c3b6352111ecd7335809a380e647c57babc7ce9a1410011feda9ab0fdcfea820bbfde5652f6b1658bed43ee719d054939467846d98771019225eef193480995dc4fc6fd12ff6534f35027b8d15a7afe90187081886db0e7e3530cf60ea98ce5704291737b8e9b26b53e40a6508e34b91c136967f8e633e9ed95f65b89fc3e4d3fc88f491921e902818100fa2be1bf12c6b55c095112496edb08a523ba9e24d4aed479bf4eea882f240a49e6c77d940c99755549cf30cebc218661a1791481a8a63dbab209f126cb43fd29a41ef05513a2e7c5258bf2b40b17e98abe31d52f2ef26db3c487609c6ab2b9e69a84f11d0860f09a62d6d52f524035af9530d78381d1954e632562b3a7d4911302818100cc536656010736f6ef6492a2da5bd075e7faa46db5dc67e11d7a7205d826c31de8371f502fc9d21c39d7e0df2983f491db457d0591b98b5259a911cd0a3788573d2a858874a76cfb440e2a477ed59f4c988332730c583e1db2b131273e132eac0590a49ec595d90198f75ee8f1cfd8c97d50b2a19f1956d60c8ffba9e30640fd0281803d118533dd6380560d382b1c9de0fe0541e9863d3b65ca1c4624ff7f6af2834872fb739e364d27a540354196d5b9e151e7d6e4b899f0aad4ee2d1b1efb33879328ab1cc3c7dd56727bade3fb2b521502775736d123c6ae1cd9f6aa10c4c3083a50b1ef21c52fd4cbfb20b23db0f857a29aeaa75144d962771620c42d52e4c2dd028181008ac43563418d81d1d121cfc8d45db8c4eac8b9b55ce6949239aff8126a0b614645787246c63dddf9977b3ad8b4dc4e5464c3dbb5d5935ac091ee160dd7db8138266d63851a1cbf1222d52ff7a0773a9a0d9644c407e542426f22920c61c72b525ef12e2c3a6a9b97cf286987f0fa44f40aacacb4c155b738e60d3f50d0c3658d02818100ef71c5bc951d7c616ba48c913919480930a864450d893776eacf21844ccb0ae76eeff814eac5a9b50c2069d822e270adad94ed19fd6ef0de3f7154a6a412bc784f78ecb5c1cb09bd5540732566d3497605cce3a6e0ce69c95dd803f291183b275afc780971c1b507b22daf2fd060b05ae277269aa36489587d5a84ca22ad1975",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDHrHgf+5qfaRxN\n/mTkfemLjyZeZn1fwlMmaMr2OSHq09hEDmBaicfAF6ciydZU2x/n3nJGibs11oT+\nA40Bij9LR+DafXnAmrS3RmAQGwuM9RINOXGPDRsRgYxCIiDK8JqTJP7eQM46mrnE\nX/so8ZJojdg4wIXGTfnqogQpvVnCdXcyzgmueBebmdpjwclO/sNCb4G2O48xR49Q\n+CbqN485EiPYQapVxy7akJTojWWKCXLZJGjOZRVz8CEiROBK0NldYflZJPZaqFwx\nZ3Hxjtsn6acaU+djx3hvFFiVFKcCl5E4j6vgJOOasx7GNKTdheM0NgeRCSpNOhXV\nR6xAyh/HAgMBAAECggEADcfGZparvjK35F4ZQne6JYqUoFE8d95mdLEoyMN6psVG\nGLRRTA5UPdqkC0+YvjR9SDhe9KVOyVFrzkgadC/BXIWybAHa5EMJE9kEijgDnQ/Q\n1h7PyoqiApxJPMs0Li1azarw+A/K69p/1aC2KcY6T4LymEAZO21oQRw7Y1IRHs1z\nNYCaOA5kfFe6vHzpoUEAEf7amrD9z+qCC7/eVlL2sWWL7UPucZ0FSTlGeEbZh3EB\nkiXu8ZNICZXcT8b9Ev9lNPNQJ7jRWnr+kBhwgYhtsOfjUwz2DqmM5XBCkXN7jpsm\ntT5AplCONLkcE2ln+OYz6e2V9luJ/D5NP8iPSRkh6QKBgQD6K+G/Esa1XAlREklu\n2wilI7qeJNSu1Hm/TuqILyQKSebHfZQMmXVVSc8wzrwhhmGheRSBqKY9urIJ8SbL\nQ/0ppB7wVROi58Uli/K0Cxfpir4x1S8u8m2zxIdgnGqyueaahPEdCGDwmmLW1S9S\nQDWvlTDXg4HRlU5jJWKzp9SREwKBgQDMU2ZWAQc29u9kkqLaW9B15/qkbbXcZ+Ed\nenIF2CbDHeg3H1AvydIcOdfg3ymD9JHbRX0FkbmLUlmpEc0KN4hXPSqFiHSnbPtE\nDipHftWfTJiDMnMMWD4dsrExJz4TLqwFkKSexZXZAZj3Xujxz9jJfVCyoZ8ZVtYM\nj/up4wZA/QKBgD0RhTPdY4BWDTgrHJ3g/gVB6YY9O2XKHEYk/39q8oNIcvtznjZN\nJ6VANUGW1bnhUefW5LiZ8KrU7i0bHvszh5MoqxzDx91Wcnut4/srUhUCd1c20SPG\nrhzZ9qoQxMMIOlCx7yHFL9TL+yCyPbD4V6Ka6qdRRNlidxYgxC1S5MLdAoGBAIrE\nNWNBjYHR0SHPyNRduMTqyLm1XOaUkjmv+BJqC2FGRXhyRsY93fmXezrYtNxOVGTD\n27XVk1rAke4WDdfbgTgmbWOFGhy/EiLVL/egdzqaDZZExAflQkJvIpIMYccrUl7x\nLiw6apuXzyhph/D6RPQKrKy0wVW3OOYNP1DQw2WNAoGBAO9xxbyVHXxha6SMkTkZ\nSAkwqGRFDYk3durPIYRMywrnbu/4FOrFqbUMIGnYIuJwra2U7Rn9bvDeP3FUpqQS\nvHhPeOy1wcsJvVVAcyVm00l2BczjpuDOacld2APykRg7J1r8eAlxwbUHsi2vL9Bg\nsFridyaao2SJWH1ahMoirRl1\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "x6x4H_uan2kcTf5k5H3pi48mXmZ9X8JTJmjK9jkh6tPYRA5gWonHwBenIsnWVNsf595yRom7NdaE_gONAYo_S0fg2n15wJq0t0ZgEBsLjPUSDTlxjw0bEYGMQiIgyvCakyT-3kDOOpq5xF_7KPGSaI3YOMCFxk356qIEKb1ZwnV3Ms4JrngXm5naY8HJTv7DQm-BtjuPMUePUPgm6jePORIj2EGqVccu2pCU6I1ligly2SRozmUVc_AhIkTgStDZXWH5WST2WqhcMWdx8Y7bJ-mnGlPnY8d4bxRYlRSnApeROI-r4CTjmrMexjSk3YXjNDYHkQkqTToV1UesQMofxw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "DcfGZparvjK35F4ZQne6JYqUoFE8d95mdLEoyMN6psVGGLRRTA5UPdqkC0-YvjR9SDhe9KVOyVFrzkgadC_BXIWybAHa5EMJE9kEijgDnQ_Q1h7PyoqiApxJPMs0Li1azarw-A_K69p_1aC2KcY6T4LymEAZO21oQRw7Y1IRHs1zNYCaOA5kfFe6vHzpoUEAEf7amrD9z-qCC7_eVlL2sWWL7UPucZ0FSTlGeEbZh3EBkiXu8ZNICZXcT8b9Ev9lNPNQJ7jRWnr-kBhwgYhtsOfjUwz2DqmM5XBCkXN7jpsmtT5AplCONLkcE2ln-OYz6e2V9luJ_D5NP8iPSRkh6Q",
+        "p": "-ivhvxLGtVwJURJJbtsIpSO6niTUrtR5v07qiC8kCknmx32UDJl1VUnPMM68IYZhoXkUgaimPbqyCfEmy0P9KaQe8FUToufFJYvytAsX6Yq-MdUvLvJts8SHYJxqsrnmmoTxHQhg8Jpi1tUvUkA1r5Uw14OB0ZVOYyVis6fUkRM",
+        "q": "zFNmVgEHNvbvZJKi2lvQdef6pG213GfhHXpyBdgmwx3oNx9QL8nSHDnX4N8pg_SR20V9BZG5i1JZqRHNCjeIVz0qhYh0p2z7RA4qR37Vn0yYgzJzDFg-HbKxMSc-Ey6sBZCknsWV2QGY917o8c_YyX1QsqGfGVbWDI_7qeMGQP0",
+        "dp": "PRGFM91jgFYNOCscneD-BUHphj07ZcocRiT_f2ryg0hy-3OeNk0npUA1QZbVueFR59bkuJnwqtTuLRse-zOHkyirHMPH3VZye63j-ytSFQJ3VzbRI8auHNn2qhDEwwg6ULHvIcUv1Mv7ILI9sPhXoprqp1FE2WJ3FiDELVLkwt0",
+        "dq": "isQ1Y0GNgdHRIc_I1F24xOrIubVc5pSSOa_4EmoLYUZFeHJGxj3d-Zd7Oti03E5UZMPbtdWTWsCR7hYN19uBOCZtY4UaHL8SItUv96B3OpoNlkTEB-VCQm8ikgxhxytSXvEuLDpqm5fPKGmH8PpE9AqsrLTBVbc45g0_UNDDZY0",
+        "qi": "73HFvJUdfGFrpIyRORlICTCoZEUNiTd26s8hhEzLCudu7_gU6sWptQwgadgi4nCtrZTtGf1u8N4_cVSmpBK8eE947LXBywm9VUBzJWbTSXYFzOOm4M5pyV3YA_KRGDsnWvx4CXHBtQeyLa8v0GCwWuJ3JpqjZIlYfVqEyiKtGXU"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 42,
+          "comment": "ciphertext mod p,q has low hamming weight",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "30bc6828ea18265687b8bd3bae90a8c1",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00a6fa514e4abb5a0c7078f4db7a2edbded360d84197a9fd5d8c23d3e43641df5a9ac31b425001e766386751dbba10a824f969b5f05d2f5672ae22fad8f66ba21bc233ca72c87987565605be718e7871422f800a471c7f96044721d30f8f3ed55b5a103554270c5a99ef773602279c87e649f15d3d3aa1d6f8ed3f6308825b97434975f65359be75362bd95b6a6347b994951db1b2ad97ee12e21c8284f82392f6d08cf26470f76c4bbfbfc608d499a1b263968962134cff8010b2f15c3c7b19c0858c63e6f412727d196fc229d24651c839093466982a81bc2673f58b6e8625830eff0a22a3af66b9c9c1e47a99aa057ab8c0d16b16bb479a751ef3a3f1653c5f",
+        "privateExponent": "4c340ee9111801978db8d5de581b8c825bab65e64165f5d83c7d99551c21e1e202a12a0e905ede10fb8ac383e89d736f3458370d1429e764fcedbfd7465686abee6c1e6755f08880314ffbc2ed473041095680da453a40e780e301e4a6f600fee8d25ed421e1f4732e231485d5380d995e83858eccf4511c5781c71b7a0a7cb41d7238c3dab14a136d6c3bb829347dd5e7e45d8d76c0db0c55f384f9c118de3442573e992a1ad3f81e6b0475ee302609b22b4defaafe8339c29d371732cd66a1bcecc7c84da5aa58685b84cce664e9211fcc8b21bd81d4d1cec3471bd52a729e24785b4ea510ef638a6596b9ab2638904532df185642b823a04d7d6bd8fd73e1",
+        "publicExponent": "010001",
+        "prime1": "00e99c2ac2c9e1cabe0c54efccea49f9fbb1d4c0999ed8f3dcdd6b8300d83772ccfff4c9ddbfcfdda0c5ab01679bf0423b2b481488cde9e5307224fee2d37435183efe825d1870b8545e612f3ee8694817270f28f7a62ea122ae2fd0c30498af9ebf9c078f17e9ea065fabf753354b869b4110fcb4b82990950236b728d4ca4eaf",
+        "prime2": "00b6fb44ce7578f18a1c48e5d6a86e0768043e94cbbf56b38042fcb90b8a6b9d20c352b9cee2376ac317fa42cfb5bab87e05d7423f136efb2fe433a1ca7129645a2f3334d1dae55ab0265d8ec7a7f78f02cfe6dd269d1d1378716b03365d3922967438c1358075aaf3821c48eed9b59f85be1197b9c17f3fc52c5e77da9650d951",
+        "exponent1": "7120d0505e257ae207e4c5efecf1801e94229c56886735c91a6ceb16e89e09791ee6732f70a90001d0579ca98909937945df751a3ee56ab8c83e0434e2039f86ab52e2dca46e49c589a2f49739436ac6d38272eb62cda7f8bc73a95c1788bd5b5a1cfc481e63879228988580050a1b186a2d08c3977f8165b799b99f0b55213f",
+        "exponent2": "64ede1fd1374db9e378dca21061472c76017f8d10dc050107e6291db18c5d50cbe504227284633005b987203ca14ad30ee1dd6ef9dd3887fd91ad5b2298b104c625e9752edafb6bf14da642822b0fd542ac307d705b0850dd95992930906bbda4b4f06db70f8f68b8c87f77eafdd6b9944c6c56ef39931de9b639c2e98dd0d91",
+        "coefficient": "72949cbe1de1edc01c21d2bda3f13ad55e950c0823c928c9af117f004cb42e4a1ab01d7f139ab1578643c833e5c580b822044bdb03a31ea5ced1070ca9f198919264aec69ad137338ac7a7753f77846f4701f0b458acc22aab16ee8983c7efcfe9ffc1d17171c9906ffaa5c0623c2a496862ae30aae81a73f1166b21ee6ee153"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100a6fa514e4abb5a0c7078f4db7a2edbded360d84197a9fd5d8c23d3e43641df5a9ac31b425001e766386751dbba10a824f969b5f05d2f5672ae22fad8f66ba21bc233ca72c87987565605be718e7871422f800a471c7f96044721d30f8f3ed55b5a103554270c5a99ef773602279c87e649f15d3d3aa1d6f8ed3f6308825b97434975f65359be75362bd95b6a6347b994951db1b2ad97ee12e21c8284f82392f6d08cf26470f76c4bbfbfc608d499a1b263968962134cff8010b2f15c3c7b19c0858c63e6f412727d196fc229d24651c839093466982a81bc2673f58b6e8625830eff0a22a3af66b9c9c1e47a99aa057ab8c0d16b16bb479a751ef3a3f1653c5f0203010001028201004c340ee9111801978db8d5de581b8c825bab65e64165f5d83c7d99551c21e1e202a12a0e905ede10fb8ac383e89d736f3458370d1429e764fcedbfd7465686abee6c1e6755f08880314ffbc2ed473041095680da453a40e780e301e4a6f600fee8d25ed421e1f4732e231485d5380d995e83858eccf4511c5781c71b7a0a7cb41d7238c3dab14a136d6c3bb829347dd5e7e45d8d76c0db0c55f384f9c118de3442573e992a1ad3f81e6b0475ee302609b22b4defaafe8339c29d371732cd66a1bcecc7c84da5aa58685b84cce664e9211fcc8b21bd81d4d1cec3471bd52a729e24785b4ea510ef638a6596b9ab2638904532df185642b823a04d7d6bd8fd73e102818100e99c2ac2c9e1cabe0c54efccea49f9fbb1d4c0999ed8f3dcdd6b8300d83772ccfff4c9ddbfcfdda0c5ab01679bf0423b2b481488cde9e5307224fee2d37435183efe825d1870b8545e612f3ee8694817270f28f7a62ea122ae2fd0c30498af9ebf9c078f17e9ea065fabf753354b869b4110fcb4b82990950236b728d4ca4eaf02818100b6fb44ce7578f18a1c48e5d6a86e0768043e94cbbf56b38042fcb90b8a6b9d20c352b9cee2376ac317fa42cfb5bab87e05d7423f136efb2fe433a1ca7129645a2f3334d1dae55ab0265d8ec7a7f78f02cfe6dd269d1d1378716b03365d3922967438c1358075aaf3821c48eed9b59f85be1197b9c17f3fc52c5e77da9650d9510281807120d0505e257ae207e4c5efecf1801e94229c56886735c91a6ceb16e89e09791ee6732f70a90001d0579ca98909937945df751a3ee56ab8c83e0434e2039f86ab52e2dca46e49c589a2f49739436ac6d38272eb62cda7f8bc73a95c1788bd5b5a1cfc481e63879228988580050a1b186a2d08c3977f8165b799b99f0b55213f02818064ede1fd1374db9e378dca21061472c76017f8d10dc050107e6291db18c5d50cbe504227284633005b987203ca14ad30ee1dd6ef9dd3887fd91ad5b2298b104c625e9752edafb6bf14da642822b0fd542ac307d705b0850dd95992930906bbda4b4f06db70f8f68b8c87f77eafdd6b9944c6c56ef39931de9b639c2e98dd0d9102818072949cbe1de1edc01c21d2bda3f13ad55e950c0823c928c9af117f004cb42e4a1ab01d7f139ab1578643c833e5c580b822044bdb03a31ea5ced1070ca9f198919264aec69ad137338ac7a7753f77846f4701f0b458acc22aab16ee8983c7efcfe9ffc1d17171c9906ffaa5c0623c2a496862ae30aae81a73f1166b21ee6ee153",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCm+lFOSrtaDHB4\n9Nt6Ltve02DYQZep/V2MI9PkNkHfWprDG0JQAedmOGdR27oQqCT5abXwXS9Wcq4i\n+tj2a6IbwjPKcsh5h1ZWBb5xjnhxQi+ACkccf5YERyHTD48+1VtaEDVUJwxame93\nNgInnIfmSfFdPTqh1vjtP2MIgluXQ0l19lNZvnU2K9lbamNHuZSVHbGyrZfuEuIc\ngoT4I5L20IzyZHD3bEu/v8YI1JmhsmOWiWITTP+AELLxXDx7GcCFjGPm9BJyfRlv\nwinSRlHIOQk0Zpgqgbwmc/WLboYlgw7/CiKjr2a5ycHkepmqBXq4wNFrFrtHmnUe\n86PxZTxfAgMBAAECggEATDQO6REYAZeNuNXeWBuMglurZeZBZfXYPH2ZVRwh4eIC\noSoOkF7eEPuKw4PonXNvNFg3DRQp52T87b/XRlaGq+5sHmdV8IiAMU/7wu1HMEEJ\nVoDaRTpA54DjAeSm9gD+6NJe1CHh9HMuIxSF1TgNmV6DhY7M9FEcV4HHG3oKfLQd\ncjjD2rFKE21sO7gpNH3V5+RdjXbA2wxV84T5wRjeNEJXPpkqGtP4HmsEde4wJgmy\nK03vqv6DOcKdNxcyzWahvOzHyE2lqlhoW4TM5mTpIR/MiyG9gdTRzsNHG9Uqcp4k\neFtOpRDvY4pllrmrJjiQRTLfGFZCuCOgTX1r2P1z4QKBgQDpnCrCyeHKvgxU78zq\nSfn7sdTAmZ7Y89zda4MA2DdyzP/0yd2/z92gxasBZ5vwQjsrSBSIzenlMHIk/uLT\ndDUYPv6CXRhwuFReYS8+6GlIFycPKPemLqEiri/QwwSYr56/nAePF+nqBl+r91M1\nS4abQRD8tLgpkJUCNrco1MpOrwKBgQC2+0TOdXjxihxI5daobgdoBD6Uy79Ws4BC\n/LkLimudIMNSuc7iN2rDF/pCz7W6uH4F10I/E277L+QzocpxKWRaLzM00drlWrAm\nXY7Hp/ePAs/m3SadHRN4cWsDNl05IpZ0OME1gHWq84IcSO7ZtZ+FvhGXucF/P8Us\nXnfallDZUQKBgHEg0FBeJXriB+TF7+zxgB6UIpxWiGc1yRps6xbongl5HuZzL3Cp\nAAHQV5ypiQmTeUXfdRo+5Wq4yD4ENOIDn4arUuLcpG5JxYmi9Jc5Q2rG04Jy62LN\np/i8c6lcF4i9W1oc/EgeY4eSKJiFgAUKGxhqLQjDl3+BZbeZuZ8LVSE/AoGAZO3h\n/RN02543jcohBhRyx2AX+NENwFAQfmKR2xjF1Qy+UEInKEYzAFuYcgPKFK0w7h3W\n753TiH/ZGtWyKYsQTGJel1Ltr7a/FNpkKCKw/VQqwwfXBbCFDdlZkpMJBrvaS08G\n23D49ouMh/d+r91rmUTGxW7zmTHem2OcLpjdDZECgYBylJy+HeHtwBwh0r2j8TrV\nXpUMCCPJKMmvEX8ATLQuShqwHX8TmrFXhkPIM+XFgLgiBEvbA6Mepc7RBwyp8ZiR\nkmSuxprRNzOKx6d1P3eEb0cB8LRYrMIqqxbuiYPH78/p/8HRcXHJkG/6pcBiPCpJ\naGKuMKroGnPxFmsh7m7hUw==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "pvpRTkq7WgxwePTbei7b3tNg2EGXqf1djCPT5DZB31qawxtCUAHnZjhnUdu6EKgk-Wm18F0vVnKuIvrY9muiG8IzynLIeYdWVgW-cY54cUIvgApHHH-WBEch0w-PPtVbWhA1VCcMWpnvdzYCJ5yH5knxXT06odb47T9jCIJbl0NJdfZTWb51NivZW2pjR7mUlR2xsq2X7hLiHIKE-COS9tCM8mRw92xLv7_GCNSZobJjloliE0z_gBCy8Vw8exnAhYxj5vQScn0Zb8Ip0kZRyDkJNGaYKoG8JnP1i26GJYMO_woio69mucnB5HqZqgV6uMDRaxa7R5p1HvOj8WU8Xw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "TDQO6REYAZeNuNXeWBuMglurZeZBZfXYPH2ZVRwh4eICoSoOkF7eEPuKw4PonXNvNFg3DRQp52T87b_XRlaGq-5sHmdV8IiAMU_7wu1HMEEJVoDaRTpA54DjAeSm9gD-6NJe1CHh9HMuIxSF1TgNmV6DhY7M9FEcV4HHG3oKfLQdcjjD2rFKE21sO7gpNH3V5-RdjXbA2wxV84T5wRjeNEJXPpkqGtP4HmsEde4wJgmyK03vqv6DOcKdNxcyzWahvOzHyE2lqlhoW4TM5mTpIR_MiyG9gdTRzsNHG9Uqcp4keFtOpRDvY4pllrmrJjiQRTLfGFZCuCOgTX1r2P1z4Q",
+        "p": "6Zwqwsnhyr4MVO_M6kn5-7HUwJme2PPc3WuDANg3csz_9Mndv8_doMWrAWeb8EI7K0gUiM3p5TByJP7i03Q1GD7-gl0YcLhUXmEvPuhpSBcnDyj3pi6hIq4v0MMEmK-ev5wHjxfp6gZfq_dTNUuGm0EQ_LS4KZCVAja3KNTKTq8",
+        "q": "tvtEznV48YocSOXWqG4HaAQ-lMu_VrOAQvy5C4prnSDDUrnO4jdqwxf6Qs-1urh-BddCPxNu-y_kM6HKcSlkWi8zNNHa5VqwJl2Ox6f3jwLP5t0mnR0TeHFrAzZdOSKWdDjBNYB1qvOCHEju2bWfhb4Rl7nBfz_FLF532pZQ2VE",
+        "dp": "cSDQUF4leuIH5MXv7PGAHpQinFaIZzXJGmzrFuieCXke5nMvcKkAAdBXnKmJCZN5Rd91Gj7larjIPgQ04gOfhqtS4tykbknFiaL0lzlDasbTgnLrYs2n-LxzqVwXiL1bWhz8SB5jh5IomIWABQobGGotCMOXf4Flt5m5nwtVIT8",
+        "dq": "ZO3h_RN02543jcohBhRyx2AX-NENwFAQfmKR2xjF1Qy-UEInKEYzAFuYcgPKFK0w7h3W753TiH_ZGtWyKYsQTGJel1Ltr7a_FNpkKCKw_VQqwwfXBbCFDdlZkpMJBrvaS08G23D49ouMh_d-r91rmUTGxW7zmTHem2OcLpjdDZE",
+        "qi": "cpScvh3h7cAcIdK9o_E61V6VDAgjySjJrxF_AEy0LkoasB1_E5qxV4ZDyDPlxYC4IgRL2wOjHqXO0QcMqfGYkZJkrsaa0TczisendT93hG9HAfC0WKzCKqsW7omDx-_P6f_B0XFxyZBv-qXAYjwqSWhirjCq6Bpz8RZrIe5u4VM"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 43,
+          "comment": "special case ciphertext",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "5428c34ab4a93dedef450347e9b89b894fa6c6b1c07e0205f5b4505cf0e65954760e3ce92a170499dfc10d5f3b4ee72843bd394d04f0310db1f7dc47950ebe88b3d32492d7170814dde0e0564560740f6bc7c34a64a9547977b446e8f9edbec97246e113e6f86a2e81cdbdef6531016638196eaa8cab3cd7c6f6fbdc8a60e5b48698993310872429cf5baa34f32c6fd9320265",
+          "ct": "537d28a7255dad06383c7a6dbd176def69b06c20cbd4feaec611e9f21b20efad4d618da12800f3b31c33a8eddd0854127cb4daf82e97ab3957117d6c7b35d10de119e539643cc3ab2b02df38c73c38a117c005238e3fcb022390e987c79f6aadad081aaa13862d4cf7bb9b0113ce43f324f8ae9e9d50eb7c769fb184412dcba1a4bafb29acdf3a9b15ecadb531a3dcca4a8ed8d956cbf709710e41427c11c97b68467932387bb625dfdfe3046a4cd0d931cb44b109a67fc0085978ae1e3d8ce042c631f37a09393e8cb7e114e92328e41c849a334c1540de1339fac5b74312c1877f851151d7b35ce4e0f23d4cd502bd5c6068b58b5da3cd3a8f79d1f8b29e30",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00aca199738e9f86f0e76696188f4d366e6c900d11d0de3ed586f371172e2cfc94289d93411b51d82ca16f63a9e4586d8b0198418307093b1475660d055e4b2940662fee32a10ffefc62df6a2d8bb811eedcb461529ed548e6e094fe8c7a91703524b5af85add10113655c934bcd6b8dcc0d0ee6edcb08f8a84fe871f44f85b2aff13a968bc12a960f8c93877f1bf22d18ac581878a0e6e7643781c91c65ec0135cac31fba6dbb3cf36acf9e3168571edb6d26b02b5c011dd10b57462d0abeb0c2d3d4e0f89680f2834b117215c6d79b3ed938b657b45decedf1524b095dc6160c18dbe58cf8d0a251ec2f9f737bb81997cd863d94c535eec63ff5e6000d80fa13",
+        "privateExponent": "1de8594775dc196abf0c3cd0c072e60d376db575f2b3ae3b1c082cfd91186621dcef7fc575d0361d755270f7cc01ade8b93c018d8bb883adc5b10a6c75ab9bd7f65c336e3e0d2165e4534477e38ede3c7dac1a784fe02fa3202170003273e3f6b10771033ddbc9cdec6f9f6d308783a76853be9a4fe49bffbce84e65bf29308d956a7375fef2d1a41c60f980817d9a95f485ab29e441805c615cbe6ee17794231b5207c53a21f11ea2f16f576a43a9279702d8614ef8136cb0d69a105308bbe0e7707d88716c8970b4c4d5e3ce41a400b379bc2a5b6307a6063f641b38934fba06bc3af42e4b4d587086309882180bfff4d8974baf6fa3d17ee094a9454d2be1",
+        "publicExponent": "010001",
+        "prime1": "00ec7e4a7a3ea4aea022cf4b5caa6d9ff39f7c8285d6dd9789f90f4246217a3f4bb342a377046a216e214874d1d3b4ff599e1fe9b70d81ac5a2ed2bbd18a1ec5bba38431c26c614f5d474b5ca56d78c36a287c6880e3ff2d3d1430fe496c7c0df970df38f699b7919819b4872caefe2d6848a9766dbd013ccf8c9605a6e9c69f79",
+        "prime2": "00baded1cece65f6ca97df9c1b575c535806de637f7383a381477c682e6dc911a0264465311af636e13ba328a1f7dc8880dba49e683c6dcd7073bc138362d6afdf62ca0e626cee5ff9a325ab2eb0479190f8787d8bf7b4c3e7ed1b4b568abb9dfb26d4d16001392e392bd7eb2aa536109f273c0387056cdab409245cc43d3dc6eb",
+        "exponent1": "00d67690c3db1b2ce13bb010ffafee4a277c72454b6a56f99dbda700cae8811bf56253043a625e7c828adc52541651056017ed88dcdffac079e80c6316dad29d2e5453056cf32c2bf4c33aac81b88cd369e9dd2847fa7ae663857408a63d2322e91a5ad4258db0d2efc41fda95c2fbede1ac43418ab2e3f469a36c4923dcccaac1",
+        "exponent2": "2a7dbc0b60574314b21000791f1639454cda88995474dc5aeb1c58bc25ee90796ffa21605717214779be11e132710d00eff0b0ac570148b3873d7eda634119e09ba00241532fa8d724c7cdf2e1d6843d08a2ad39846bb0182e8c04477b6849f5efd078837203c484ef793b5a09131018805d5f17f69dd7e514271688f0bbf95d",
+        "coefficient": "00c017692b3af8ad0506fb23dc02f1d220c7b99d68b91e3f97901c10e9c772e537f5f6102720adf7a55e6beff690c7e48f0c122bdea81f56bd6561a336d73188e3ce213ac853f744f0ec5b8ec10a9b9b0433ecc4a37d9970779e0913bc4bd25d2111e89286ddcbacacd23a13e5d7e0358c35681d558faa484e8104a30938e38bb6"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100aca199738e9f86f0e76696188f4d366e6c900d11d0de3ed586f371172e2cfc94289d93411b51d82ca16f63a9e4586d8b0198418307093b1475660d055e4b2940662fee32a10ffefc62df6a2d8bb811eedcb461529ed548e6e094fe8c7a91703524b5af85add10113655c934bcd6b8dcc0d0ee6edcb08f8a84fe871f44f85b2aff13a968bc12a960f8c93877f1bf22d18ac581878a0e6e7643781c91c65ec0135cac31fba6dbb3cf36acf9e3168571edb6d26b02b5c011dd10b57462d0abeb0c2d3d4e0f89680f2834b117215c6d79b3ed938b657b45decedf1524b095dc6160c18dbe58cf8d0a251ec2f9f737bb81997cd863d94c535eec63ff5e6000d80fa130203010001028201001de8594775dc196abf0c3cd0c072e60d376db575f2b3ae3b1c082cfd91186621dcef7fc575d0361d755270f7cc01ade8b93c018d8bb883adc5b10a6c75ab9bd7f65c336e3e0d2165e4534477e38ede3c7dac1a784fe02fa3202170003273e3f6b10771033ddbc9cdec6f9f6d308783a76853be9a4fe49bffbce84e65bf29308d956a7375fef2d1a41c60f980817d9a95f485ab29e441805c615cbe6ee17794231b5207c53a21f11ea2f16f576a43a9279702d8614ef8136cb0d69a105308bbe0e7707d88716c8970b4c4d5e3ce41a400b379bc2a5b6307a6063f641b38934fba06bc3af42e4b4d587086309882180bfff4d8974baf6fa3d17ee094a9454d2be102818100ec7e4a7a3ea4aea022cf4b5caa6d9ff39f7c8285d6dd9789f90f4246217a3f4bb342a377046a216e214874d1d3b4ff599e1fe9b70d81ac5a2ed2bbd18a1ec5bba38431c26c614f5d474b5ca56d78c36a287c6880e3ff2d3d1430fe496c7c0df970df38f699b7919819b4872caefe2d6848a9766dbd013ccf8c9605a6e9c69f7902818100baded1cece65f6ca97df9c1b575c535806de637f7383a381477c682e6dc911a0264465311af636e13ba328a1f7dc8880dba49e683c6dcd7073bc138362d6afdf62ca0e626cee5ff9a325ab2eb0479190f8787d8bf7b4c3e7ed1b4b568abb9dfb26d4d16001392e392bd7eb2aa536109f273c0387056cdab409245cc43d3dc6eb02818100d67690c3db1b2ce13bb010ffafee4a277c72454b6a56f99dbda700cae8811bf56253043a625e7c828adc52541651056017ed88dcdffac079e80c6316dad29d2e5453056cf32c2bf4c33aac81b88cd369e9dd2847fa7ae663857408a63d2322e91a5ad4258db0d2efc41fda95c2fbede1ac43418ab2e3f469a36c4923dcccaac10281802a7dbc0b60574314b21000791f1639454cda88995474dc5aeb1c58bc25ee90796ffa21605717214779be11e132710d00eff0b0ac570148b3873d7eda634119e09ba00241532fa8d724c7cdf2e1d6843d08a2ad39846bb0182e8c04477b6849f5efd078837203c484ef793b5a09131018805d5f17f69dd7e514271688f0bbf95d02818100c017692b3af8ad0506fb23dc02f1d220c7b99d68b91e3f97901c10e9c772e537f5f6102720adf7a55e6beff690c7e48f0c122bdea81f56bd6561a336d73188e3ce213ac853f744f0ec5b8ec10a9b9b0433ecc4a37d9970779e0913bc4bd25d2111e89286ddcbacacd23a13e5d7e0358c35681d558faa484e8104a30938e38bb6",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCsoZlzjp+G8Odm\nlhiPTTZubJANEdDePtWG83EXLiz8lCidk0EbUdgsoW9jqeRYbYsBmEGDBwk7FHVm\nDQVeSylAZi/uMqEP/vxi32oti7gR7ty0YVKe1Ujm4JT+jHqRcDUkta+FrdEBE2Vc\nk0vNa43MDQ7m7csI+KhP6HH0T4Wyr/E6lovBKpYPjJOHfxvyLRisWBh4oObnZDeB\nyRxl7AE1ysMfum27PPNqz54xaFce220msCtcAR3RC1dGLQq+sMLT1OD4loDyg0sR\nchXG15s+2Ti2V7Rd7O3xUksJXcYWDBjb5Yz40KJR7C+fc3u4GZfNhj2UxTXuxj/1\n5gANgPoTAgMBAAECggEAHehZR3XcGWq/DDzQwHLmDTdttXXys647HAgs/ZEYZiHc\n73/FddA2HXVScPfMAa3ouTwBjYu4g63FsQpsdaub1/ZcM24+DSFl5FNEd+OO3jx9\nrBp4T+AvoyAhcAAyc+P2sQdxAz3byc3sb59tMIeDp2hTvppP5Jv/vOhOZb8pMI2V\nanN1/vLRpBxg+YCBfZqV9IWrKeRBgFxhXL5u4XeUIxtSB8U6IfEeovFvV2pDqSeX\nAthhTvgTbLDWmhBTCLvg53B9iHFsiXC0xNXjzkGkALN5vCpbYwemBj9kGziTT7oG\nvDr0LktNWHCGMJiCGAv/9NiXS69vo9F+4JSpRU0r4QKBgQDsfkp6PqSuoCLPS1yq\nbZ/zn3yChdbdl4n5D0JGIXo/S7NCo3cEaiFuIUh00dO0/1meH+m3DYGsWi7Su9GK\nHsW7o4QxwmxhT11HS1ylbXjDaih8aIDj/y09FDD+SWx8Dflw3zj2mbeRmBm0hyyu\n/i1oSKl2bb0BPM+MlgWm6cafeQKBgQC63tHOzmX2ypffnBtXXFNYBt5jf3ODo4FH\nfGgubckRoCZEZTEa9jbhO6MooffciIDbpJ5oPG3NcHO8E4Ni1q/fYsoOYmzuX/mj\nJasusEeRkPh4fYv3tMPn7RtLVoq7nfsm1NFgATkuOSvX6yqlNhCfJzwDhwVs2rQJ\nJFzEPT3G6wKBgQDWdpDD2xss4TuwEP+v7konfHJFS2pW+Z29pwDK6IEb9WJTBDpi\nXnyCitxSVBZRBWAX7Yjc3/rAeegMYxba0p0uVFMFbPMsK/TDOqyBuIzTaendKEf6\neuZjhXQIpj0jIukaWtQljbDS78Qf2pXC++3hrENBirLj9GmjbEkj3MyqwQKBgCp9\nvAtgV0MUshAAeR8WOUVM2oiZVHTcWuscWLwl7pB5b/ohYFcXIUd5vhHhMnENAO/w\nsKxXAUizhz1+2mNBGeCboAJBUy+o1yTHzfLh1oQ9CKKtOYRrsBgujARHe2hJ9e/Q\neINyA8SE73k7WgkTEBiAXV8X9p3X5RQnFojwu/ldAoGBAMAXaSs6+K0FBvsj3ALx\n0iDHuZ1ouR4/l5AcEOnHcuU39fYQJyCt96Vea+/2kMfkjwwSK96oH1a9ZWGjNtcx\niOPOITrIU/dE8OxbjsEKm5sEM+zEo32ZcHeeCRO8S9JdIRHokobdy6ys0joT5dfg\nNYw1aB1Vj6pIToEEowk444u2\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "rKGZc46fhvDnZpYYj002bmyQDRHQ3j7VhvNxFy4s_JQonZNBG1HYLKFvY6nkWG2LAZhBgwcJOxR1Zg0FXkspQGYv7jKhD_78Yt9qLYu4Ee7ctGFSntVI5uCU_ox6kXA1JLWvha3RARNlXJNLzWuNzA0O5u3LCPioT-hx9E-Fsq_xOpaLwSqWD4yTh38b8i0YrFgYeKDm52Q3gckcZewBNcrDH7ptuzzzas-eMWhXHtttJrArXAEd0QtXRi0KvrDC09Tg-JaA8oNLEXIVxtebPtk4tle0Xezt8VJLCV3GFgwY2-WM-NCiUewvn3N7uBmXzYY9lMU17sY_9eYADYD6Ew",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "HehZR3XcGWq_DDzQwHLmDTdttXXys647HAgs_ZEYZiHc73_FddA2HXVScPfMAa3ouTwBjYu4g63FsQpsdaub1_ZcM24-DSFl5FNEd-OO3jx9rBp4T-AvoyAhcAAyc-P2sQdxAz3byc3sb59tMIeDp2hTvppP5Jv_vOhOZb8pMI2VanN1_vLRpBxg-YCBfZqV9IWrKeRBgFxhXL5u4XeUIxtSB8U6IfEeovFvV2pDqSeXAthhTvgTbLDWmhBTCLvg53B9iHFsiXC0xNXjzkGkALN5vCpbYwemBj9kGziTT7oGvDr0LktNWHCGMJiCGAv_9NiXS69vo9F-4JSpRU0r4Q",
+        "p": "7H5Kej6krqAiz0tcqm2f8598goXW3ZeJ-Q9CRiF6P0uzQqN3BGohbiFIdNHTtP9Znh_ptw2BrFou0rvRih7Fu6OEMcJsYU9dR0tcpW14w2oofGiA4_8tPRQw_klsfA35cN849pm3kZgZtIcsrv4taEipdm29ATzPjJYFpunGn3k",
+        "q": "ut7Rzs5l9sqX35wbV1xTWAbeY39zg6OBR3xoLm3JEaAmRGUxGvY24TujKKH33IiA26SeaDxtzXBzvBODYtav32LKDmJs7l_5oyWrLrBHkZD4eH2L97TD5-0bS1aKu537JtTRYAE5Ljkr1-sqpTYQnyc8A4cFbNq0CSRcxD09xus",
+        "dp": "1naQw9sbLOE7sBD_r-5KJ3xyRUtqVvmdvacAyuiBG_ViUwQ6Yl58gorcUlQWUQVgF-2I3N_6wHnoDGMW2tKdLlRTBWzzLCv0wzqsgbiM02np3ShH-nrmY4V0CKY9IyLpGlrUJY2w0u_EH9qVwvvt4axDQYqy4_Rpo2xJI9zMqsE",
+        "dq": "Kn28C2BXQxSyEAB5HxY5RUzaiJlUdNxa6xxYvCXukHlv-iFgVxchR3m-EeEycQ0A7_CwrFcBSLOHPX7aY0EZ4JugAkFTL6jXJMfN8uHWhD0Ioq05hGuwGC6MBEd7aEn179B4g3IDxITveTtaCRMQGIBdXxf2ndflFCcWiPC7-V0",
+        "qi": "wBdpKzr4rQUG-yPcAvHSIMe5nWi5Hj-XkBwQ6cdy5Tf19hAnIK33pV5r7_aQx-SPDBIr3qgfVr1lYaM21zGI484hOshT90Tw7FuOwQqbmwQz7MSjfZlwd54JE7xL0l0hEeiSht3LrKzSOhPl1-A1jDVoHVWPqkhOgQSjCTjji7Y"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 44,
+          "comment": "ciphertext is a simple fraction",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "9d01acafe3375c444a74d3ed74166e8728eb6657c7644677579720aa8ffebe64f52e36b449f8a0fe79e07bd59e46aa48c83088ac38bf10a3e036158c198a2a3fed283b2710b632e0741f970969b475bc4ae8355e60c440f71f304a1363b24819a351d5147836febbe249d65ef3c483a76df46a019a2f3eecfdf0c18c0ab11de90313cd9af93a857dbaf8049c6efede83274440ece9c2103d00e942ca65a8efbebe6190d9e5ed61816804d941d027cccae2966854b38ea07bcef857e5fc3fb4aa5f3c4c56360007f972d5d6d6740a585d000df619d3466032930a856c2ee14db5e6960c8e9ffe79107e212cdd6e082eccb10a",
+          "ct": "171759da87532242dcbd4821488d4861c1d87a2479c655e945d02cb5de9799f5f6199413101e0caf24bcfa7319b91da481b3c717dbd894f9f7fe814964cdc5d2f5daab161c5d36346ec30a5d8e8e959df25fc107ce2fe831aeceafcd580dd9d6e862b0dc67c97786947a06788dc037794ba3bac7d6c1dd87f0d0acc4b65d0f05965884a3a6b57c50a3cd7b758907b45f877bace2102e28e61dac68cafdb0cafe635664f27d005bf03c809114e6d2d3ef06f18effdcd8f4b223506259765efbd632be128b67b268df2e6f99714325d7cf089110aedbb55d0556c76a164cb6534b36c0ab6fee98e4d0f8db7a76bac1d9b8328b928e6601092ff61caf0298175a39",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00af1d441122c45188e3b2daef70cacd253a0e611af2d17a60e703baba696e5ef2d7ca0d53eeeedaca1c079ddd3b0b0732e15a4839cd1daac35ddacd85b368f5721eee409a7983bbe3f2eb09a23632a8d700b1235fadde1ce1f05a8013a9bc05302e08027e8102e755877b59f65625d029312ed813e3960410ed419b787cd8235e002c26f1f7bd7e03754ec0fc12087edb85dc793757324ca90611a22364bba069f084fcfe7730a98f6f6b784e65b84643443e38b317af8cf99c7e4711f7303c7c323b3ca4b6b306b76bc9f554b9713fed313713d98438efcb3cc9c6d4958ba84bd80f2989e4e059005a6585ec18c6c6c887c143d9ed962303d6c74c21771184f3",
+        "privateExponent": "04a25021838eb7d2d90c85867aca8b1bd6302bd37aa3b84ad8c8962e8615ee55823b6117830610ec58e3be4f6cbdab45331fad33d32da7b44c6da1601a4ba1425e9092e6e39a8657a8d28410d927b8a4b3ea7c204229ba108a954285691692f9c61fab8a06e02cb206081ced0bcec55c89b2f526af306c02864331b38f0e366557a8cc24d24091cc1f770b9322efa3079e9c277d2e83880ff36dc12d77beda4dace4787e937a606faadf0978ea8ed35dee6adac9d6ab23505649c4d1d0cb4713bc7921ed24a8fc6c8f106022b31fedf242856e88723d43c70358203008f2e9f04d5b62915eb8fd1297d7e4409f4be9ecd73d29defea51781ec6d22d3378d8c39",
+        "publicExponent": "010001",
+        "prime1": "00ea1586f2fbdfde7f7b5bf8640a757e897716cd7e7c3426b9c3df106bf6ad36242b10021cc4c23b2e7dff3114c0f66623cfe9df6e9946099e45b1b75447da1331a5cbeb40b0191901e4fb296438fc6c9db4d2f496ec5a891ee6c3ac1ae205a8bc3621642f7f58c701236354e1dff558d327d3fe91645f531ac3374938cffaba9b",
+        "prime2": "00bf825d735ff9e5da51a9b5f413dbfc1367fa0affc08a031db2b0b73c55a37aaec08cac6030249bfbd079caf95717f17568f730f106d6373926fcc147fa8b7b76b0f911511aac035b5a79b6dd49f08e6fef744e928733b3d143cd946f8598426d101b559e76024b400af6c82cfddb7a8315ea20049a80506ea4c987030c717889",
+        "exponent1": "0089be091eca1fbda97e496c2c520b395e6279448a7d43a2d604f029959e1de691f9d4fda9380ea30c848fb9ade0ae1d044dbfecfe03ab36d5af6517dfbc3812bb503862423a5d4a5dd704042339752fe4cd16a55e79cdfc89f67885b97beea08fbfba7e5d84ae14cc12aaccb3ed394dff529c685bdd984a2aa15cd2f55f4cc6a9",
+        "exponent2": "0dec8f98dce89182bf1f44c07b552a4dcae88e362c2c9caf6317a02afddb060780ae79b600aa18c1455625a0dd693b401b22a5e75064f0dcf1edbcabdc169a22761995ddbcbfb6fac46847186dd0d4ba64c1a318da45b3144b06be7d214c81bfe644e683bff6c8bbde50351bb85565e1f40cf2c902e6c37257fee31720a77b69",
+        "coefficient": "00e1b7b58183f44db95a767f55d82a777aff5b62f44a2b29382f823e62a45bfa87356c089816314d18274c57e4294135aabffed934518f61761c6b9d3fc47201eee298944a888c5eb004b161798a91ff3775dda795f244ccbdae5bd90e71301e1c24cdb3e4398c6a2860ca67481b362947f9fb9a5b75f5b3623d7c063fd5e8aed6"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100af1d441122c45188e3b2daef70cacd253a0e611af2d17a60e703baba696e5ef2d7ca0d53eeeedaca1c079ddd3b0b0732e15a4839cd1daac35ddacd85b368f5721eee409a7983bbe3f2eb09a23632a8d700b1235fadde1ce1f05a8013a9bc05302e08027e8102e755877b59f65625d029312ed813e3960410ed419b787cd8235e002c26f1f7bd7e03754ec0fc12087edb85dc793757324ca90611a22364bba069f084fcfe7730a98f6f6b784e65b84643443e38b317af8cf99c7e4711f7303c7c323b3ca4b6b306b76bc9f554b9713fed313713d98438efcb3cc9c6d4958ba84bd80f2989e4e059005a6585ec18c6c6c887c143d9ed962303d6c74c21771184f302030100010282010004a25021838eb7d2d90c85867aca8b1bd6302bd37aa3b84ad8c8962e8615ee55823b6117830610ec58e3be4f6cbdab45331fad33d32da7b44c6da1601a4ba1425e9092e6e39a8657a8d28410d927b8a4b3ea7c204229ba108a954285691692f9c61fab8a06e02cb206081ced0bcec55c89b2f526af306c02864331b38f0e366557a8cc24d24091cc1f770b9322efa3079e9c277d2e83880ff36dc12d77beda4dace4787e937a606faadf0978ea8ed35dee6adac9d6ab23505649c4d1d0cb4713bc7921ed24a8fc6c8f106022b31fedf242856e88723d43c70358203008f2e9f04d5b62915eb8fd1297d7e4409f4be9ecd73d29defea51781ec6d22d3378d8c3902818100ea1586f2fbdfde7f7b5bf8640a757e897716cd7e7c3426b9c3df106bf6ad36242b10021cc4c23b2e7dff3114c0f66623cfe9df6e9946099e45b1b75447da1331a5cbeb40b0191901e4fb296438fc6c9db4d2f496ec5a891ee6c3ac1ae205a8bc3621642f7f58c701236354e1dff558d327d3fe91645f531ac3374938cffaba9b02818100bf825d735ff9e5da51a9b5f413dbfc1367fa0affc08a031db2b0b73c55a37aaec08cac6030249bfbd079caf95717f17568f730f106d6373926fcc147fa8b7b76b0f911511aac035b5a79b6dd49f08e6fef744e928733b3d143cd946f8598426d101b559e76024b400af6c82cfddb7a8315ea20049a80506ea4c987030c7178890281810089be091eca1fbda97e496c2c520b395e6279448a7d43a2d604f029959e1de691f9d4fda9380ea30c848fb9ade0ae1d044dbfecfe03ab36d5af6517dfbc3812bb503862423a5d4a5dd704042339752fe4cd16a55e79cdfc89f67885b97beea08fbfba7e5d84ae14cc12aaccb3ed394dff529c685bdd984a2aa15cd2f55f4cc6a90281800dec8f98dce89182bf1f44c07b552a4dcae88e362c2c9caf6317a02afddb060780ae79b600aa18c1455625a0dd693b401b22a5e75064f0dcf1edbcabdc169a22761995ddbcbfb6fac46847186dd0d4ba64c1a318da45b3144b06be7d214c81bfe644e683bff6c8bbde50351bb85565e1f40cf2c902e6c37257fee31720a77b6902818100e1b7b58183f44db95a767f55d82a777aff5b62f44a2b29382f823e62a45bfa87356c089816314d18274c57e4294135aabffed934518f61761c6b9d3fc47201eee298944a888c5eb004b161798a91ff3775dda795f244ccbdae5bd90e71301e1c24cdb3e4398c6a2860ca67481b362947f9fb9a5b75f5b3623d7c063fd5e8aed6",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvHUQRIsRRiOOy\n2u9wys0lOg5hGvLRemDnA7q6aW5e8tfKDVPu7trKHAed3TsLBzLhWkg5zR2qw13a\nzYWzaPVyHu5AmnmDu+Py6wmiNjKo1wCxI1+t3hzh8FqAE6m8BTAuCAJ+gQLnVYd7\nWfZWJdApMS7YE+OWBBDtQZt4fNgjXgAsJvH3vX4DdU7A/BIIftuF3Hk3VzJMqQYR\noiNku6Bp8IT8/ncwqY9va3hOZbhGQ0Q+OLMXr4z5nH5HEfcwPHwyOzyktrMGt2vJ\n9VS5cT/tMTcT2YQ478s8ycbUlYuoS9gPKYnk4FkAWmWF7BjGxsiHwUPZ7ZYjA9bH\nTCF3EYTzAgMBAAECggEABKJQIYOOt9LZDIWGesqLG9YwK9N6o7hK2MiWLoYV7lWC\nO2EXgwYQ7Fjjvk9svatFMx+tM9Mtp7RMbaFgGkuhQl6QkubjmoZXqNKEENknuKSz\n6nwgQim6EIqVQoVpFpL5xh+rigbgLLIGCBztC87FXImy9SavMGwChkMxs48ONmVX\nqMwk0kCRzB93C5Mi76MHnpwnfS6DiA/zbcEtd77aTazkeH6TemBvqt8JeOqO013u\natrJ1qsjUFZJxNHQy0cTvHkh7SSo/GyPEGAisx/t8kKFbohyPUPHA1ggMAjy6fBN\nW2KRXrj9EpfX5ECfS+ns1z0p3v6lF4HsbSLTN42MOQKBgQDqFYby+9/ef3tb+GQK\ndX6JdxbNfnw0JrnD3xBr9q02JCsQAhzEwjsuff8xFMD2ZiPP6d9umUYJnkWxt1RH\n2hMxpcvrQLAZGQHk+ylkOPxsnbTS9JbsWoke5sOsGuIFqLw2IWQvf1jHASNjVOHf\n9VjTJ9P+kWRfUxrDN0k4z/q6mwKBgQC/gl1zX/nl2lGptfQT2/wTZ/oK/8CKAx2y\nsLc8VaN6rsCMrGAwJJv70HnK+VcX8XVo9zDxBtY3OSb8wUf6i3t2sPkRURqsA1ta\nebbdSfCOb+90TpKHM7PRQ82Ub4WYQm0QG1WedgJLQAr2yCz923qDFeogBJqAUG6k\nyYcDDHF4iQKBgQCJvgkeyh+9qX5JbCxSCzleYnlEin1DotYE8CmVnh3mkfnU/ak4\nDqMMhI+5reCuHQRNv+z+A6s21a9lF9+8OBK7UDhiQjpdSl3XBAQjOXUv5M0WpV55\nzfyJ9niFuXvuoI+/un5dhK4UzBKqzLPtOU3/UpxoW92YSiqhXNL1X0zGqQKBgA3s\nj5jc6JGCvx9EwHtVKk3K6I42LCycr2MXoCr92wYHgK55tgCqGMFFViWg3Wk7QBsi\npedQZPDc8e28q9wWmiJ2GZXdvL+2+sRoRxht0NS6ZMGjGNpFsxRLBr59IUyBv+ZE\n5oO/9si73lA1G7hVZeH0DPLJAubDclf+4xcgp3tpAoGBAOG3tYGD9E25WnZ/Vdgq\nd3r/W2L0SispOC+CPmKkW/qHNWwImBYxTRgnTFfkKUE1qr/+2TRRj2F2HGudP8Ry\nAe7imJRKiIxesASxYXmKkf83dd2nlfJEzL2uW9kOcTAeHCTNs+Q5jGooYMpnSBs2\nKUf5+5pbdfWzYj18Bj/V6K7W\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "rx1EESLEUYjjstrvcMrNJToOYRry0Xpg5wO6umluXvLXyg1T7u7ayhwHnd07Cwcy4VpIOc0dqsNd2s2Fs2j1ch7uQJp5g7vj8usJojYyqNcAsSNfrd4c4fBagBOpvAUwLggCfoEC51WHe1n2ViXQKTEu2BPjlgQQ7UGbeHzYI14ALCbx971-A3VOwPwSCH7bhdx5N1cyTKkGEaIjZLugafCE_P53MKmPb2t4TmW4RkNEPjizF6-M-Zx-RxH3MDx8Mjs8pLazBrdryfVUuXE_7TE3E9mEOO_LPMnG1JWLqEvYDymJ5OBZAFplhewYxsbIh8FD2e2WIwPWx0whdxGE8w",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "BKJQIYOOt9LZDIWGesqLG9YwK9N6o7hK2MiWLoYV7lWCO2EXgwYQ7Fjjvk9svatFMx-tM9Mtp7RMbaFgGkuhQl6QkubjmoZXqNKEENknuKSz6nwgQim6EIqVQoVpFpL5xh-rigbgLLIGCBztC87FXImy9SavMGwChkMxs48ONmVXqMwk0kCRzB93C5Mi76MHnpwnfS6DiA_zbcEtd77aTazkeH6TemBvqt8JeOqO013uatrJ1qsjUFZJxNHQy0cTvHkh7SSo_GyPEGAisx_t8kKFbohyPUPHA1ggMAjy6fBNW2KRXrj9EpfX5ECfS-ns1z0p3v6lF4HsbSLTN42MOQ",
+        "p": "6hWG8vvf3n97W_hkCnV-iXcWzX58NCa5w98Qa_atNiQrEAIcxMI7Ln3_MRTA9mYjz-nfbplGCZ5FsbdUR9oTMaXL60CwGRkB5PspZDj8bJ200vSW7FqJHubDrBriBai8NiFkL39YxwEjY1Th3_VY0yfT_pFkX1MawzdJOM_6ups",
+        "q": "v4Jdc1_55dpRqbX0E9v8E2f6Cv_AigMdsrC3PFWjeq7AjKxgMCSb-9B5yvlXF_F1aPcw8QbWNzkm_MFH-ot7drD5EVEarANbWnm23Unwjm_vdE6ShzOz0UPNlG-FmEJtEBtVnnYCS0AK9sgs_dt6gxXqIASagFBupMmHAwxxeIk",
+        "dp": "ib4JHsofval-SWwsUgs5XmJ5RIp9Q6LWBPAplZ4d5pH51P2pOA6jDISPua3grh0ETb_s_gOrNtWvZRffvDgSu1A4YkI6XUpd1wQEIzl1L-TNFqVeec38ifZ4hbl77qCPv7p-XYSuFMwSqsyz7TlN_1KcaFvdmEoqoVzS9V9Mxqk",
+        "dq": "DeyPmNzokYK_H0TAe1UqTcrojjYsLJyvYxegKv3bBgeArnm2AKoYwUVWJaDdaTtAGyKl51Bk8Nzx7byr3BaaInYZld28v7b6xGhHGG3Q1LpkwaMY2kWzFEsGvn0hTIG_5kTmg7_2yLveUDUbuFVl4fQM8skC5sNyV_7jFyCne2k",
+        "qi": "4be1gYP0Tbladn9V2Cp3ev9bYvRKKyk4L4I-YqRb-oc1bAiYFjFNGCdMV-QpQTWqv_7ZNFGPYXYca50_xHIB7uKYlEqIjF6wBLFheYqR_zd13aeV8kTMva5b2Q5xMB4cJM2z5DmMaihgymdIGzYpR_n7mlt19bNiPXwGP9XortY"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 45,
+          "comment": "ciphertext is a simple fraction",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "6742f1e5ba666a102747f6c90b7afe5700249cf60192b201c6c29bfff1487b0ca4100091e9e1d94df3af18021822835b40b9c20e2bf83ef174deaebc94ac9770d8b128ade611c19256d6fb62a41301898af074254c756f8a241851f3d4a052d7745f99d9e161434af4940a80610cb2fe63520bcefda74564b02c99ee9b0d88036ac39ce547cf103fee0c1666f0757734c29577fbd2f88e11058b5f3e81f82ff3f456ddc8018f7ed740979b15da66469b",
+          "ct": "46a9ee986efc30f16a6d46521865f3ebf97ee2c02d693f8f3ae746c99716ee5d10a25a8fb34fb75c735062bed816c2a2cfcc6733c9d1f1b23df893cbaa8c92dbf0e8bf93a80d8a21c1d4cd2af3da728d9aa476ae55ca700820435c02cd872d3835b4cb0f4626feecb0bbe45f35e2f80c704d9a4e1e2bc613bf06fb52f26ca5cba69c3bd96b1a3845a3fed672a52110a9e710a7710a4ffa44f1ff890c1d698882eb27b27cd8184a9f5e3d4b33a51885f23b80e97887e7099c3bea6aa76db83ac9ec6880ce784d34a4cecf841404d6295f531e6f1262ddfef28f06412670ccd2af404b76f94d98ae6c2789944b66cea2a033e2f405217624fea444666ef30c7b84",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00d932a891279753a70c0a5788da0b6c740bc78384b46c43460d9d1d7d64310f066d5d62799e115b542c05012b692c5355ca525492902c1e38ab77c96a7e7d07f651f0ab91dcc4fadf46fb5244065d58620eb6d31d736eceb027c46e4c0424d27f0f16d3e248f3bf3ca93127729f043fc1a307961188c44abe77e782e3d2a022872792425f342de097145551cce568e26f34cd0ac787baf3b7e85a768a469dfcffdb6ed2ed8cd7c433f4db4577cc10ef49a34351c8ebba3240e9a5e867374df01732156e3269f656389aee2eddfeccba60ab913bf3dc734e56b094ae1644a547af5ae4d7153a87610a51af70bd5796d6a2dd874653c5cc5cdc502d7f3358f4de79",
+        "privateExponent": "49afb0149ed3ee236c284e0e35bb4e6e085905bb8de274e85d5202613a0e92c461721f289781d7f43482f6249e27d595f36fff1542285590704bd15f79ce3d5749f156a3c3bc68483bb2a3f4441c8311b160413b6aa01b2b1432c620afff3612b931cb6ca7c75a07e076b6a5626174a7e3017dde310237416b3875e588dd9f188f418ccf49d8538d29da7291c5fdd7213d615e5f1d7f94768dca6112978dbdcac1f9b801ec1463e9fc2a49d34b9a638605751485e9f1129800f3ed7e73cf27edbbcb80f11655f10b900544862bf7bf89adbcd5bd23c3ebb744a688078934138a0fb930670ff4b6588f6034777ca1124cd01caa726c75d85963cb3500795401a9",
+        "publicExponent": "010001",
+        "prime1": "00f0d6d9aa1040e8acfa4d658d632ab8342357edf9a00537c888370e747ad9584cfa6832614396db584b289ba2585badee9d2be775c194faecf80e4109bc363d8211d4ba71b06801856aee99281860620a19f0d4943f3d7d2afe6dac6c55870087959be0d2a1f8d1e018db595620ebd8ab3d5480cd5c1aec73c970269d0c7139b3",
+        "prime2": "00e6ded3339413510f9908a1c028999e530eaa029dbb82f5519bf42aa8a8f8241b151bf95ece24b35c33ffebf973755716cdde31052fe9fb8327ea6efd1e167aea0276abbb7b996ff877428534c12a48b57988995dfc1e5b93bb3460b8c5d57a8178eef7c6eebabf00859826e1a3c4676f98893c095c8a892c07d97ff7e30a9923",
+        "exponent1": "0099846a84d40d7c035f1ddcc0ce5899c86a4b0f5f92582121cb6a44e58cb5646ad5277c0db1d6c484b88bef01020f9684465d8911efce76507d2220e502bb146407d7b0eced44aecb8bc90189a45833c63a98dff88b833779236b67803ad86e46fedfb8e4aae87f67b8908196bc2f7a12556abb1bac3d6141c142a2ea72d6edaf",
+        "exponent2": "73d142a87457406a0fbe69ce894f8f42616fde421ca834c30cf66f540ef7f4bcf559043f90308f1de92430d00220d260a94416d960510410a6bc8f93413dcbc98b14d75005505300956b7481a389bfd1f23719a131725544863c5f6d3229c6fc1e9bdb071c09e8f9ad0b482e17c6d6910037903bae05fd8c6e1fa977c499337b",
+        "coefficient": "00ce18d158822540cfe589748338a77a4bd9a57b079819f028013372359f29748b8ce340df5fc42ead637b1d5c069477eb64e64ef424c9d64aec4d0d0c71b92a5d35c0aef4e9d8a2ce0a2ea8d6deddbdf9697c054dc21c05e96e2de80c651826e6eb59a06696d2f8518ae91479f321da24c3c3b6359ca12deec16fe39f62e6714c"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100d932a891279753a70c0a5788da0b6c740bc78384b46c43460d9d1d7d64310f066d5d62799e115b542c05012b692c5355ca525492902c1e38ab77c96a7e7d07f651f0ab91dcc4fadf46fb5244065d58620eb6d31d736eceb027c46e4c0424d27f0f16d3e248f3bf3ca93127729f043fc1a307961188c44abe77e782e3d2a022872792425f342de097145551cce568e26f34cd0ac787baf3b7e85a768a469dfcffdb6ed2ed8cd7c433f4db4577cc10ef49a34351c8ebba3240e9a5e867374df01732156e3269f656389aee2eddfeccba60ab913bf3dc734e56b094ae1644a547af5ae4d7153a87610a51af70bd5796d6a2dd874653c5cc5cdc502d7f3358f4de7902030100010282010049afb0149ed3ee236c284e0e35bb4e6e085905bb8de274e85d5202613a0e92c461721f289781d7f43482f6249e27d595f36fff1542285590704bd15f79ce3d5749f156a3c3bc68483bb2a3f4441c8311b160413b6aa01b2b1432c620afff3612b931cb6ca7c75a07e076b6a5626174a7e3017dde310237416b3875e588dd9f188f418ccf49d8538d29da7291c5fdd7213d615e5f1d7f94768dca6112978dbdcac1f9b801ec1463e9fc2a49d34b9a638605751485e9f1129800f3ed7e73cf27edbbcb80f11655f10b900544862bf7bf89adbcd5bd23c3ebb744a688078934138a0fb930670ff4b6588f6034777ca1124cd01caa726c75d85963cb3500795401a902818100f0d6d9aa1040e8acfa4d658d632ab8342357edf9a00537c888370e747ad9584cfa6832614396db584b289ba2585badee9d2be775c194faecf80e4109bc363d8211d4ba71b06801856aee99281860620a19f0d4943f3d7d2afe6dac6c55870087959be0d2a1f8d1e018db595620ebd8ab3d5480cd5c1aec73c970269d0c7139b302818100e6ded3339413510f9908a1c028999e530eaa029dbb82f5519bf42aa8a8f8241b151bf95ece24b35c33ffebf973755716cdde31052fe9fb8327ea6efd1e167aea0276abbb7b996ff877428534c12a48b57988995dfc1e5b93bb3460b8c5d57a8178eef7c6eebabf00859826e1a3c4676f98893c095c8a892c07d97ff7e30a99230281810099846a84d40d7c035f1ddcc0ce5899c86a4b0f5f92582121cb6a44e58cb5646ad5277c0db1d6c484b88bef01020f9684465d8911efce76507d2220e502bb146407d7b0eced44aecb8bc90189a45833c63a98dff88b833779236b67803ad86e46fedfb8e4aae87f67b8908196bc2f7a12556abb1bac3d6141c142a2ea72d6edaf02818073d142a87457406a0fbe69ce894f8f42616fde421ca834c30cf66f540ef7f4bcf559043f90308f1de92430d00220d260a94416d960510410a6bc8f93413dcbc98b14d75005505300956b7481a389bfd1f23719a131725544863c5f6d3229c6fc1e9bdb071c09e8f9ad0b482e17c6d6910037903bae05fd8c6e1fa977c499337b02818100ce18d158822540cfe589748338a77a4bd9a57b079819f028013372359f29748b8ce340df5fc42ead637b1d5c069477eb64e64ef424c9d64aec4d0d0c71b92a5d35c0aef4e9d8a2ce0a2ea8d6deddbdf9697c054dc21c05e96e2de80c651826e6eb59a06696d2f8518ae91479f321da24c3c3b6359ca12deec16fe39f62e6714c",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDZMqiRJ5dTpwwK\nV4jaC2x0C8eDhLRsQ0YNnR19ZDEPBm1dYnmeEVtULAUBK2ksU1XKUlSSkCweOKt3\nyWp+fQf2UfCrkdzE+t9G+1JEBl1YYg620x1zbs6wJ8RuTAQk0n8PFtPiSPO/PKkx\nJ3KfBD/BoweWEYjESr5354Lj0qAihyeSQl80LeCXFFVRzOVo4m80zQrHh7rzt+ha\ndopGnfz/227S7YzXxDP020V3zBDvSaNDUcjrujJA6aXoZzdN8BcyFW4yafZWOJru\nLt3+zLpgq5E789xzTlawlK4WRKVHr1rk1xU6h2EKUa9wvVeW1qLdh0ZTxcxc3FAt\nfzNY9N55AgMBAAECggEASa+wFJ7T7iNsKE4ONbtObghZBbuN4nToXVICYToOksRh\nch8ol4HX9DSC9iSeJ9WV82//FUIoVZBwS9Ffec49V0nxVqPDvGhIO7Kj9EQcgxGx\nYEE7aqAbKxQyxiCv/zYSuTHLbKfHWgfgdralYmF0p+MBfd4xAjdBazh15YjdnxiP\nQYzPSdhTjSnacpHF/dchPWFeXx1/lHaNymESl429ysH5uAHsFGPp/CpJ00uaY4YF\ndRSF6fESmADz7X5zzyftu8uA8RZV8QuQBUSGK/e/ia281b0jw+u3RKaIB4k0E4oP\nuTBnD/S2WI9gNHd8oRJM0Byqcmx12FljyzUAeVQBqQKBgQDw1tmqEEDorPpNZY1j\nKrg0I1ft+aAFN8iINw50etlYTPpoMmFDlttYSyibolhbre6dK+d1wZT67PgOQQm8\nNj2CEdS6cbBoAYVq7pkoGGBiChnw1JQ/PX0q/m2sbFWHAIeVm+DSofjR4BjbWVYg\n69irPVSAzVwa7HPJcCadDHE5swKBgQDm3tMzlBNRD5kIocAomZ5TDqoCnbuC9VGb\n9CqoqPgkGxUb+V7OJLNcM//r+XN1VxbN3jEFL+n7gyfqbv0eFnrqAnaru3uZb/h3\nQoU0wSpItXmImV38HluTuzRguMXVeoF47vfG7rq/AIWYJuGjxGdvmIk8CVyKiSwH\n2X/34wqZIwKBgQCZhGqE1A18A18d3MDOWJnIaksPX5JYISHLakTljLVkatUnfA2x\n1sSEuIvvAQIPloRGXYkR7852UH0iIOUCuxRkB9ew7O1ErsuLyQGJpFgzxjqY3/iL\ngzd5I2tngDrYbkb+37jkquh/Z7iQgZa8L3oSVWq7G6w9YUHBQqLqctbtrwKBgHPR\nQqh0V0BqD75pzolPj0Jhb95CHKg0wwz2b1QO9/S89VkEP5Awjx3pJDDQAiDSYKlE\nFtlgUQQQpryPk0E9y8mLFNdQBVBTAJVrdIGjib/R8jcZoTFyVUSGPF9tMinG/B6b\n2wccCej5rQtILhfG1pEAN5A7rgX9jG4fqXfEmTN7AoGBAM4Y0ViCJUDP5Yl0gzin\nekvZpXsHmBnwKAEzcjWfKXSLjONA31/ELq1jex1cBpR362TmTvQkydZK7E0NDHG5\nKl01wK706diizgouqNbe3b35aXwFTcIcBeluLegMZRgm5utZoGaW0vhRiukUefMh\n2iTDw7Y1nKEt7sFv459i5nFM\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "2TKokSeXU6cMCleI2gtsdAvHg4S0bENGDZ0dfWQxDwZtXWJ5nhFbVCwFAStpLFNVylJUkpAsHjird8lqfn0H9lHwq5HcxPrfRvtSRAZdWGIOttMdc27OsCfEbkwEJNJ_DxbT4kjzvzypMSdynwQ_waMHlhGIxEq-d-eC49KgIocnkkJfNC3glxRVUczlaOJvNM0Kx4e687foWnaKRp38_9tu0u2M18Qz9NtFd8wQ70mjQ1HI67oyQOml6Gc3TfAXMhVuMmn2Vjia7i7d_sy6YKuRO_Pcc05WsJSuFkSlR69a5NcVOodhClGvcL1Xltai3YdGU8XMXNxQLX8zWPTeeQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "Sa-wFJ7T7iNsKE4ONbtObghZBbuN4nToXVICYToOksRhch8ol4HX9DSC9iSeJ9WV82__FUIoVZBwS9Ffec49V0nxVqPDvGhIO7Kj9EQcgxGxYEE7aqAbKxQyxiCv_zYSuTHLbKfHWgfgdralYmF0p-MBfd4xAjdBazh15YjdnxiPQYzPSdhTjSnacpHF_dchPWFeXx1_lHaNymESl429ysH5uAHsFGPp_CpJ00uaY4YFdRSF6fESmADz7X5zzyftu8uA8RZV8QuQBUSGK_e_ia281b0jw-u3RKaIB4k0E4oPuTBnD_S2WI9gNHd8oRJM0Byqcmx12FljyzUAeVQBqQ",
+        "p": "8NbZqhBA6Kz6TWWNYyq4NCNX7fmgBTfIiDcOdHrZWEz6aDJhQ5bbWEsom6JYW63unSvndcGU-uz4DkEJvDY9ghHUunGwaAGFau6ZKBhgYgoZ8NSUPz19Kv5trGxVhwCHlZvg0qH40eAY21lWIOvYqz1UgM1cGuxzyXAmnQxxObM",
+        "q": "5t7TM5QTUQ-ZCKHAKJmeUw6qAp27gvVRm_QqqKj4JBsVG_leziSzXDP_6_lzdVcWzd4xBS_p-4Mn6m79HhZ66gJ2q7t7mW_4d0KFNMEqSLV5iJld_B5bk7s0YLjF1XqBeO73xu66vwCFmCbho8Rnb5iJPAlcioksB9l_9-MKmSM",
+        "dp": "mYRqhNQNfANfHdzAzliZyGpLD1-SWCEhy2pE5Yy1ZGrVJ3wNsdbEhLiL7wECD5aERl2JEe_OdlB9IiDlArsUZAfXsOztRK7Li8kBiaRYM8Y6mN_4i4M3eSNrZ4A62G5G_t-45Krof2e4kIGWvC96ElVquxusPWFBwUKi6nLW7a8",
+        "dq": "c9FCqHRXQGoPvmnOiU-PQmFv3kIcqDTDDPZvVA739Lz1WQQ_kDCPHekkMNACINJgqUQW2WBRBBCmvI-TQT3LyYsU11AFUFMAlWt0gaOJv9HyNxmhMXJVRIY8X20yKcb8HpvbBxwJ6PmtC0guF8bWkQA3kDuuBf2Mbh-pd8SZM3s",
+        "qi": "zhjRWIIlQM_liXSDOKd6S9mleweYGfAoATNyNZ8pdIuM40DfX8QurWN7HVwGlHfrZOZO9CTJ1krsTQ0McbkqXTXArvTp2KLOCi6o1t7dvflpfAVNwhwF6W4t6AxlGCbm61mgZpbS-FGK6RR58yHaJMPDtjWcoS3uwW_jn2LmcUw"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 46,
+          "comment": "edge case for Montgomery reduction (32 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "a41ebd80b15cbe50842790f7f30b680aaac807afeeb4e5306dee48e6d7946ab8378fa6112ae86874f7b14233ef62ce90e3c0f0eb5551a256c0759e3b14cd70411a897150640bca5d78298a557992ae3bede97b981b6950689c74d7ad90651870d8f5657a202f6dcc2d6fd2698f03642aebc489c3ac9a68c7a2c184017f8b8ea81b80ccd7871e01c9d7b3496070c2508cb69eb71667649819e803a0c0fdca45c7c21c986baab12f986f37c3132d77b5861d87753f6147a7aa39e70029c024d5896d8add076e517ef0b40049d7fd0495a3e3b63eda",
+          "ct": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00bb11e68c71d58bf30658751bc3218e68be87dc8afa5ff98ae62c06501548985959ed95172a9d3659ee6ec34bc417cee12b878001c54bc1e085ebbfc0e8d977d35ebc250618bfe6caa1d018f2f4067c3f825016c648c188166560056be9d6a95143bdd4fea6ebaab56f397ec78c9915afe0a18be3f33085c2ae2af3a799d862ec997ff556d91b3a80bd675fd2ce4f1cebfbbeb27bec856a29d267669e2d78f0e7f5a1559853ea7cbe50c3a1051f71b74591c5ab4efb2d1eda47e21f49866e80d75e237486852d5a24b72017d9334e958424ed32f5a02db7cc2cdf743b58864a219a8667890b396c73ca9e7c72c74351dd317583f463094014cedcc12179168ccb",
+        "privateExponent": "08011d7a17bda2d45b0a8d837131016187fa5309481db3952a1aeaefd5161b1d1c6e8d6c5ef09ebfbd26a155d2cc5c64c74c3cc1bd0a05ccb034ab2ac8256dfa878c9691c469bcdbbb278d53565c7e474efe537e5817d16f124a2e8467c1a3d30c23fca9565f7eb308511c7b04f67a50146eb521d6cf6fb35d027447b767b0abd7e35804e2c491aa5fed41ac8e8819772feabec736d5bf33ac2feb3d52ae6b2b27a7833c3b8c72920b526949d0c01006b43df493bcf68fa81b7cb38c163494a34b13d15503c9c274309b12dd1c23a728203d0ce133ab23116384b6d7bddabba73f91dcf56e38ea43c2c21973d22052773a18a10c254206ab45f99a129c7809b1",
+        "publicExponent": "010001",
+        "prime1": "00ded3abd74d472347657a9d94cd09e605b6799c579843335468eb26280ff6cde836d2f68e1bf011fe5e0ed882e962d4f33e10d441d311536c30ef7f61e4791fceacdeda89092442690af53644878bf7fee88ec55ed1aace4f05abd5fca138ad03585e2231eaf63c16efdc221dd9111dfd1ab320b52b0c878ae68d01092ef77b43",
+        "prime2": "00d6eb7829ef21696440506048fa4a61be6eb8f1f525fedfc6b26442071ca324a9b5c319018777b6881fb9e506949c63648ae559c5c0f9fa79b9aef4c54659afb3cc892921eacaf95b194aae4b6b1308d399da8993082d3ff2e6fef6f5043ca9018de1f6ee37252561eda1ff85a9f3a1d039d415cc2525ae52bebafed44d051bd9",
+        "exponent1": "1a36d0ba8d8ed6e9a958997d4df9e223bde9e4a8b1730670e1bef848324898c4bede66bf252e430fa7c51b579b59533022971c417a31499d2acca231c40d33debe9ba11e0a034804cf9335852e651b11d40e27ce15e08050ef9bdd9ad0e4b805f2b970506b11f8d3c1f825d3591c186914610a7205d47d85abc5dedf53b52dbd",
+        "exponent2": "1c5645acb9c3dd0283dc5525aa229e8a9e4cb25251652e9a233146e76b26339250cddd812f1c60abc80b19a0697dc9391b7b2bfffff6b5c8d0ebb9883d435c0047ea99cac80b651f56d15af3c4b568c78594a3e907fdf75d8e8975844ebfb4c4e8b12f7eaf34ad9e20d7e839f6739215435aac591358c9884d6f9863e397d5d9",
+        "coefficient": "00cbee5c8932503cb00a93125a1f89897d88ac171932871ea7cb775a9bbb0284b6a239408a9e79d7dd81846fa9e34acc81589c8281e066eb9fa7a45680249fd4b97cc3bdfacb9bf10591f4998ac63cca7355b9b7e84127c6fe14a6a9b5b64fad3540759a210ee2c7188f9296e1bffc0a4b2fe516ac6e7aafba95f36b7e03ab31d2"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100bb11e68c71d58bf30658751bc3218e68be87dc8afa5ff98ae62c06501548985959ed95172a9d3659ee6ec34bc417cee12b878001c54bc1e085ebbfc0e8d977d35ebc250618bfe6caa1d018f2f4067c3f825016c648c188166560056be9d6a95143bdd4fea6ebaab56f397ec78c9915afe0a18be3f33085c2ae2af3a799d862ec997ff556d91b3a80bd675fd2ce4f1cebfbbeb27bec856a29d267669e2d78f0e7f5a1559853ea7cbe50c3a1051f71b74591c5ab4efb2d1eda47e21f49866e80d75e237486852d5a24b72017d9334e958424ed32f5a02db7cc2cdf743b58864a219a8667890b396c73ca9e7c72c74351dd317583f463094014cedcc12179168ccb02030100010282010008011d7a17bda2d45b0a8d837131016187fa5309481db3952a1aeaefd5161b1d1c6e8d6c5ef09ebfbd26a155d2cc5c64c74c3cc1bd0a05ccb034ab2ac8256dfa878c9691c469bcdbbb278d53565c7e474efe537e5817d16f124a2e8467c1a3d30c23fca9565f7eb308511c7b04f67a50146eb521d6cf6fb35d027447b767b0abd7e35804e2c491aa5fed41ac8e8819772feabec736d5bf33ac2feb3d52ae6b2b27a7833c3b8c72920b526949d0c01006b43df493bcf68fa81b7cb38c163494a34b13d15503c9c274309b12dd1c23a728203d0ce133ab23116384b6d7bddabba73f91dcf56e38ea43c2c21973d22052773a18a10c254206ab45f99a129c7809b102818100ded3abd74d472347657a9d94cd09e605b6799c579843335468eb26280ff6cde836d2f68e1bf011fe5e0ed882e962d4f33e10d441d311536c30ef7f61e4791fceacdeda89092442690af53644878bf7fee88ec55ed1aace4f05abd5fca138ad03585e2231eaf63c16efdc221dd9111dfd1ab320b52b0c878ae68d01092ef77b4302818100d6eb7829ef21696440506048fa4a61be6eb8f1f525fedfc6b26442071ca324a9b5c319018777b6881fb9e506949c63648ae559c5c0f9fa79b9aef4c54659afb3cc892921eacaf95b194aae4b6b1308d399da8993082d3ff2e6fef6f5043ca9018de1f6ee37252561eda1ff85a9f3a1d039d415cc2525ae52bebafed44d051bd90281801a36d0ba8d8ed6e9a958997d4df9e223bde9e4a8b1730670e1bef848324898c4bede66bf252e430fa7c51b579b59533022971c417a31499d2acca231c40d33debe9ba11e0a034804cf9335852e651b11d40e27ce15e08050ef9bdd9ad0e4b805f2b970506b11f8d3c1f825d3591c186914610a7205d47d85abc5dedf53b52dbd0281801c5645acb9c3dd0283dc5525aa229e8a9e4cb25251652e9a233146e76b26339250cddd812f1c60abc80b19a0697dc9391b7b2bfffff6b5c8d0ebb9883d435c0047ea99cac80b651f56d15af3c4b568c78594a3e907fdf75d8e8975844ebfb4c4e8b12f7eaf34ad9e20d7e839f6739215435aac591358c9884d6f9863e397d5d902818100cbee5c8932503cb00a93125a1f89897d88ac171932871ea7cb775a9bbb0284b6a239408a9e79d7dd81846fa9e34acc81589c8281e066eb9fa7a45680249fd4b97cc3bdfacb9bf10591f4998ac63cca7355b9b7e84127c6fe14a6a9b5b64fad3540759a210ee2c7188f9296e1bffc0a4b2fe516ac6e7aafba95f36b7e03ab31d2",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7EeaMcdWL8wZY\ndRvDIY5ovofcivpf+YrmLAZQFUiYWVntlRcqnTZZ7m7DS8QXzuErh4ABxUvB4IXr\nv8Do2XfTXrwlBhi/5sqh0Bjy9AZ8P4JQFsZIwYgWZWAFa+nWqVFDvdT+puuqtW85\nfseMmRWv4KGL4/MwhcKuKvOnmdhi7Jl/9VbZGzqAvWdf0s5PHOv7vrJ77IVqKdJn\nZp4tePDn9aFVmFPqfL5Qw6EFH3G3RZHFq077LR7aR+IfSYZugNdeI3SGhS1aJLcg\nF9kzTpWEJO0y9aAtt8ws33Q7WIZKIZqGZ4kLOWxzyp58csdDUd0xdYP0YwlAFM7c\nwSF5FozLAgMBAAECggEACAEdehe9otRbCo2DcTEBYYf6UwlIHbOVKhrq79UWGx0c\nbo1sXvCev70moVXSzFxkx0w8wb0KBcywNKsqyCVt+oeMlpHEabzbuyeNU1ZcfkdO\n/lN+WBfRbxJKLoRnwaPTDCP8qVZffrMIURx7BPZ6UBRutSHWz2+zXQJ0R7dnsKvX\n41gE4sSRql/tQayOiBl3L+q+xzbVvzOsL+s9Uq5rKyengzw7jHKSC1JpSdDAEAa0\nPfSTvPaPqBt8s4wWNJSjSxPRVQPJwnQwmxLdHCOnKCA9DOEzqyMRY4S2173au6c/\nkdz1bjjqQ8LCGXPSIFJ3OhihDCVCBqtF+ZoSnHgJsQKBgQDe06vXTUcjR2V6nZTN\nCeYFtnmcV5hDM1Ro6yYoD/bN6DbS9o4b8BH+Xg7Yguli1PM+ENRB0xFTbDDvf2Hk\neR/OrN7aiQkkQmkK9TZEh4v3/uiOxV7Rqs5PBavV/KE4rQNYXiIx6vY8Fu/cIh3Z\nER39GrMgtSsMh4rmjQEJLvd7QwKBgQDW63gp7yFpZEBQYEj6SmG+brjx9SX+38ay\nZEIHHKMkqbXDGQGHd7aIH7nlBpScY2SK5VnFwPn6ebmu9MVGWa+zzIkpIerK+VsZ\nSq5LaxMI05naiZMILT/y5v729QQ8qQGN4fbuNyUlYe2h/4Wp86HQOdQVzCUlrlK+\nuv7UTQUb2QKBgBo20LqNjtbpqViZfU354iO96eSosXMGcOG++EgySJjEvt5mvyUu\nQw+nxRtXm1lTMCKXHEF6MUmdKsyiMcQNM96+m6EeCgNIBM+TNYUuZRsR1A4nzhXg\ngFDvm92a0OS4BfK5cFBrEfjTwfgl01kcGGkUYQpyBdR9havF3t9TtS29AoGAHFZF\nrLnD3QKD3FUlqiKeip5MslJRZS6aIzFG52smM5JQzd2BLxxgq8gLGaBpfck5G3sr\n///2tcjQ67mIPUNcAEfqmcrIC2UfVtFa88S1aMeFlKPpB/33XY6JdYROv7TE6LEv\nfq80rZ4g1+g59nOSFUNarFkTWMmITW+YY+OX1dkCgYEAy+5ciTJQPLAKkxJaH4mJ\nfYisFxkyhx6ny3dam7sChLaiOUCKnnnX3YGEb6njSsyBWJyCgeBm65+npFaAJJ/U\nuXzDvfrLm/EFkfSZisY8ynNVubfoQSfG/hSmqbW2T601QHWaIQ7ixxiPkpbhv/wK\nSy/lFqxueq+6lfNrfgOrMdI=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "uxHmjHHVi_MGWHUbwyGOaL6H3Ir6X_mK5iwGUBVImFlZ7ZUXKp02We5uw0vEF87hK4eAAcVLweCF67_A6Nl30168JQYYv-bKodAY8vQGfD-CUBbGSMGIFmVgBWvp1qlRQ73U_qbrqrVvOX7HjJkVr-Chi-PzMIXCrirzp5nYYuyZf_VW2Rs6gL1nX9LOTxzr-76ye-yFainSZ2aeLXjw5_WhVZhT6ny-UMOhBR9xt0WRxatO-y0e2kfiH0mGboDXXiN0hoUtWiS3IBfZM06VhCTtMvWgLbfMLN90O1iGSiGahmeJCzlsc8qefHLHQ1HdMXWD9GMJQBTO3MEheRaMyw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "CAEdehe9otRbCo2DcTEBYYf6UwlIHbOVKhrq79UWGx0cbo1sXvCev70moVXSzFxkx0w8wb0KBcywNKsqyCVt-oeMlpHEabzbuyeNU1ZcfkdO_lN-WBfRbxJKLoRnwaPTDCP8qVZffrMIURx7BPZ6UBRutSHWz2-zXQJ0R7dnsKvX41gE4sSRql_tQayOiBl3L-q-xzbVvzOsL-s9Uq5rKyengzw7jHKSC1JpSdDAEAa0PfSTvPaPqBt8s4wWNJSjSxPRVQPJwnQwmxLdHCOnKCA9DOEzqyMRY4S2173au6c_kdz1bjjqQ8LCGXPSIFJ3OhihDCVCBqtF-ZoSnHgJsQ",
+        "p": "3tOr101HI0dlep2UzQnmBbZ5nFeYQzNUaOsmKA_2zeg20vaOG_AR_l4O2ILpYtTzPhDUQdMRU2ww739h5Hkfzqze2okJJEJpCvU2RIeL9_7ojsVe0arOTwWr1fyhOK0DWF4iMer2PBbv3CId2REd_RqzILUrDIeK5o0BCS73e0M",
+        "q": "1ut4Ke8haWRAUGBI-kphvm648fUl_t_GsmRCBxyjJKm1wxkBh3e2iB-55QaUnGNkiuVZxcD5-nm5rvTFRlmvs8yJKSHqyvlbGUquS2sTCNOZ2omTCC0_8ub-9vUEPKkBjeH27jclJWHtof-FqfOh0DnUFcwlJa5Svrr-1E0FG9k",
+        "dp": "GjbQuo2O1umpWJl9TfniI73p5KixcwZw4b74SDJImMS-3ma_JS5DD6fFG1ebWVMwIpccQXoxSZ0qzKIxxA0z3r6boR4KA0gEz5M1hS5lGxHUDifOFeCAUO-b3ZrQ5LgF8rlwUGsR-NPB-CXTWRwYaRRhCnIF1H2Fq8Xe31O1Lb0",
+        "dq": "HFZFrLnD3QKD3FUlqiKeip5MslJRZS6aIzFG52smM5JQzd2BLxxgq8gLGaBpfck5G3sr___2tcjQ67mIPUNcAEfqmcrIC2UfVtFa88S1aMeFlKPpB_33XY6JdYROv7TE6LEvfq80rZ4g1-g59nOSFUNarFkTWMmITW-YY-OX1dk",
+        "qi": "y-5ciTJQPLAKkxJaH4mJfYisFxkyhx6ny3dam7sChLaiOUCKnnnX3YGEb6njSsyBWJyCgeBm65-npFaAJJ_UuXzDvfrLm_EFkfSZisY8ynNVubfoQSfG_hSmqbW2T601QHWaIQ7ixxiPkpbhv_wKSy_lFqxueq-6lfNrfgOrMdI"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 47,
+          "comment": "edge case for Montgomery reduction (32 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "f530f3adef7fc80a148531103d79369d741ca40cfedfb9ae1d150eeb73a4acdf71aea6defd3c493ec032f2db51758ad4e02e2bd9d48364bc0adc0a70793727455be33abdec47cb9904c7cb0bd2bbd13a5a1071d326921faedeec73b6bf0aabfb1b8d84432615d7ceb2a943d1fc5679978ac18adab009c86cc381c18878dace1351d1de94ea458465d291ee9cf591eb98284e0d497f699e7443ba15eb851907aa01cebb864ba3a6fb1227a736cdb000fff70ad25daba26a4c4af00141015a049b9dcd4ed2c1996f",
+          "ct": "bb11e68c71d58bf30658751bc3218e68be87dc8afa5ff98ae62c06501548985959ed95172a9d3659ee6ec34bc417cee12b878001c54bc1e085ebbfc0e8d977d35ebc250618bfe6caa1d018f2f4067c3f825016c648c188166560056be9d6a95143bdd4fea6ebaab56f397ec78c9915afe0a18be3f33085c2ae2af3a798d862ec997ff556d91b3a80bd675fd2ce4f1cebfbbeb27bec856a29d267669e2d78f0e7f5a1559853ea7cbe50c3a1051f71b74591c5ab4efb2d1eda47e21f49866e80d75e237486852d5a24b72017d9334e958424ed32f5a02db7cc2cdf743b58864a219a8667890b396c73ca9e7c72c74351dd317583f463094014cedcc12279168ccb",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00b47eead880e65ddd3fd77dbc859b82cbd93d16698ce29351e506c361dfc14c7a691e7f045cc7611c0fe0914ed1fb985012e249c238f8c9591255b3d27312c8840b83a1b75b3fb65ec3ec47c066aa31359cc2bbf92648d0e010e4306b8c8d7960ff0fe522e03740e25e3ea31dc61fe980e76aeb5ca56582deff392d676181dea95345fef290c431927a5e8190d1c28548c751d048c51b35c4e4ecaaee4f6c0ab376cef1b0cc0d15a843f3aa15b0de22d02c571344a1704c445bd38dab61bd291eb6ef654fb01e2c9c3149d4e385f5e3d3f2a6ff2ac6543035e742291d02faccf83a283c0f60d2f031d2536dc08861e8c942fe109cab2dbc249a60370fe8133803",
+        "privateExponent": "249f69e443073afd64f242e369129c2fe364b732f47096a6b3bb33129d5579c08eaaaee802313c3d76e540668749aee6746670c3d54e798036ada7fe67f5e43492a7833d1269338637e7adc956ab6aafaf9e7d8878a1a6ac08115cd7bd9d8906cac9fd5a9db6e855e5fc7c995275702a050a9735e5a35ab2078420f7cc7b8ee360fe9e423eaa406b44a1d35cbca917c9cf56b342ed4ee177c3dc5eac4b23619bb0f259d44913b4bc4b91d520729ca7b5430fb81ca0ff6353b5f9e414f66e79c8937d060044d17f83d4ef250c2ead084873901baf3e3007304706831cf68c58a7fd09da66b13e7d6b18b62efb3bc981341f73d158fae35e1a48e525753275e685",
+        "publicExponent": "010001",
+        "prime1": "00fddd690268fff94f703b9b1f7969498a1f6e3ea376c7fef65c52e117044c0b09287fd43703204c584721fcaa9cd7b9494d783c5d60897dd65503a06f3ba96b533c61039bce32c41aafed27a60fcd27a3396bf13925f13ca104422c6f3c0b0aa67eb680b29c0786cc1d5410bbff60c0812b9f549e5d4ece0c941bcdf3595ced47",
+        "prime2": "00b60389bea91bff17eca1989179cfb5a60cb5c94f473990c1f9a27d54d8e922d8aea9c6a0e58608a907d695342d6321ce5b52ddc9ebe03eb1c48452f1d8ad3b3a820620af15299d223faa792d557c1b065316e51aa9ff5fcf19903cd5f157995859deb0320bdbde6ad5c996eb3e2b1ddfa3525bfd250097868516e210493b0d65",
+        "exponent1": "5d153811b82a5361bb473fc3b4a2d4621ed02f8b845c24b2747bb728d75c829763102be1d7f599c8ac9c5ba6bb47a61aa89b33971174987d6442a62ae2f765f0e92cb14409c13782898b2d84883ab313f85409e8e86ea1ca70634b23a6226e4f4a1ae4e998a871d699d25f286fa52c30b0ac053ce3fda7339982f06b101330b5",
+        "exponent2": "5044c32c681bc6a5e05f6b8f4c6f03a6d5181e4d6e15bef72c86324b86d559dec138723666c2737347d7a4393c82e957be028f790b22fbc31ded553efed576b758bc2711cf7d68a4bffb0831abef6d639ea50c28742c012eae116422ddaa4a20229208962990af47e23c62e81fa4982a1636ae06b798c93a33db619ad910c7d9",
+        "coefficient": "37f2a1d6cbd14425065ed9ffe7994d80519286b49694ce977d3bb999bc7e2ea9ed85126b3895b9dec1e7aacd930bca2009ec1879bafbb0778527c53f09d12154909ec79272bda9d57aa5db653677d95b443a1f7db99dda8bb97bf1702309af1e23e39190ed7413dce6904b8eaf5396944150e4879726aaa0991dcbcd8124d8a4"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100b47eead880e65ddd3fd77dbc859b82cbd93d16698ce29351e506c361dfc14c7a691e7f045cc7611c0fe0914ed1fb985012e249c238f8c9591255b3d27312c8840b83a1b75b3fb65ec3ec47c066aa31359cc2bbf92648d0e010e4306b8c8d7960ff0fe522e03740e25e3ea31dc61fe980e76aeb5ca56582deff392d676181dea95345fef290c431927a5e8190d1c28548c751d048c51b35c4e4ecaaee4f6c0ab376cef1b0cc0d15a843f3aa15b0de22d02c571344a1704c445bd38dab61bd291eb6ef654fb01e2c9c3149d4e385f5e3d3f2a6ff2ac6543035e742291d02faccf83a283c0f60d2f031d2536dc08861e8c942fe109cab2dbc249a60370fe8133803020301000102820100249f69e443073afd64f242e369129c2fe364b732f47096a6b3bb33129d5579c08eaaaee802313c3d76e540668749aee6746670c3d54e798036ada7fe67f5e43492a7833d1269338637e7adc956ab6aafaf9e7d8878a1a6ac08115cd7bd9d8906cac9fd5a9db6e855e5fc7c995275702a050a9735e5a35ab2078420f7cc7b8ee360fe9e423eaa406b44a1d35cbca917c9cf56b342ed4ee177c3dc5eac4b23619bb0f259d44913b4bc4b91d520729ca7b5430fb81ca0ff6353b5f9e414f66e79c8937d060044d17f83d4ef250c2ead084873901baf3e3007304706831cf68c58a7fd09da66b13e7d6b18b62efb3bc981341f73d158fae35e1a48e525753275e68502818100fddd690268fff94f703b9b1f7969498a1f6e3ea376c7fef65c52e117044c0b09287fd43703204c584721fcaa9cd7b9494d783c5d60897dd65503a06f3ba96b533c61039bce32c41aafed27a60fcd27a3396bf13925f13ca104422c6f3c0b0aa67eb680b29c0786cc1d5410bbff60c0812b9f549e5d4ece0c941bcdf3595ced4702818100b60389bea91bff17eca1989179cfb5a60cb5c94f473990c1f9a27d54d8e922d8aea9c6a0e58608a907d695342d6321ce5b52ddc9ebe03eb1c48452f1d8ad3b3a820620af15299d223faa792d557c1b065316e51aa9ff5fcf19903cd5f157995859deb0320bdbde6ad5c996eb3e2b1ddfa3525bfd250097868516e210493b0d650281805d153811b82a5361bb473fc3b4a2d4621ed02f8b845c24b2747bb728d75c829763102be1d7f599c8ac9c5ba6bb47a61aa89b33971174987d6442a62ae2f765f0e92cb14409c13782898b2d84883ab313f85409e8e86ea1ca70634b23a6226e4f4a1ae4e998a871d699d25f286fa52c30b0ac053ce3fda7339982f06b101330b50281805044c32c681bc6a5e05f6b8f4c6f03a6d5181e4d6e15bef72c86324b86d559dec138723666c2737347d7a4393c82e957be028f790b22fbc31ded553efed576b758bc2711cf7d68a4bffb0831abef6d639ea50c28742c012eae116422ddaa4a20229208962990af47e23c62e81fa4982a1636ae06b798c93a33db619ad910c7d902818037f2a1d6cbd14425065ed9ffe7994d80519286b49694ce977d3bb999bc7e2ea9ed85126b3895b9dec1e7aacd930bca2009ec1879bafbb0778527c53f09d12154909ec79272bda9d57aa5db653677d95b443a1f7db99dda8bb97bf1702309af1e23e39190ed7413dce6904b8eaf5396944150e4879726aaa0991dcbcd8124d8a4",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC0furYgOZd3T/X\nfbyFm4LL2T0WaYzik1HlBsNh38FMemkefwRcx2EcD+CRTtH7mFAS4knCOPjJWRJV\ns9JzEsiEC4Oht1s/tl7D7EfAZqoxNZzCu/kmSNDgEOQwa4yNeWD/D+Ui4DdA4l4+\nox3GH+mA52rrXKVlgt7/OS1nYYHeqVNF/vKQxDGSel6BkNHChUjHUdBIxRs1xOTs\nqu5PbAqzds7xsMwNFahD86oVsN4i0CxXE0ShcExEW9ONq2G9KR6272VPsB4snDFJ\n1OOF9ePT8qb/KsZUMDXnQikdAvrM+DooPA9g0vAx0lNtwIhh6MlC/hCcqy28JJpg\nNw/oEzgDAgMBAAECggEAJJ9p5EMHOv1k8kLjaRKcL+NktzL0cJams7szEp1VecCO\nqq7oAjE8PXblQGaHSa7mdGZww9VOeYA2raf+Z/XkNJKngz0SaTOGN+etyVaraq+v\nnn2IeKGmrAgRXNe9nYkGysn9Wp226FXl/HyZUnVwKgUKlzXlo1qyB4Qg98x7juNg\n/p5CPqpAa0Sh01y8qRfJz1azQu1O4XfD3F6sSyNhm7DyWdRJE7S8S5HVIHKcp7VD\nD7gcoP9jU7X55BT2bnnIk30GAETRf4PU7yUMLq0ISHOQG68+MAcwRwaDHPaMWKf9\nCdpmsT59axi2Lvs7yYE0H3PRWPrjXhpI5SV1MnXmhQKBgQD93WkCaP/5T3A7mx95\naUmKH24+o3bH/vZcUuEXBEwLCSh/1DcDIExYRyH8qpzXuUlNeDxdYIl91lUDoG87\nqWtTPGEDm84yxBqv7SemD80nozlr8Tkl8TyhBEIsbzwLCqZ+toCynAeGzB1UELv/\nYMCBK59Unl1OzgyUG83zWVztRwKBgQC2A4m+qRv/F+yhmJF5z7WmDLXJT0c5kMH5\non1U2Oki2K6pxqDlhgipB9aVNC1jIc5bUt3J6+A+scSEUvHYrTs6ggYgrxUpnSI/\nqnktVXwbBlMW5Rqp/1/PGZA81fFXmVhZ3rAyC9veatXJlus+Kx3fo1Jb/SUAl4aF\nFuIQSTsNZQKBgF0VOBG4KlNhu0c/w7Si1GIe0C+LhFwksnR7tyjXXIKXYxAr4df1\nmcisnFumu0emGqibM5cRdJh9ZEKmKuL3ZfDpLLFECcE3gomLLYSIOrMT+FQJ6Ohu\nocpwY0sjpiJuT0oa5OmYqHHWmdJfKG+lLDCwrAU84/2nM5mC8GsQEzC1AoGAUETD\nLGgbxqXgX2uPTG8DptUYHk1uFb73LIYyS4bVWd7BOHI2ZsJzc0fXpDk8gulXvgKP\neQsi+8Md7VU+/tV2t1i8JxHPfWikv/sIMavvbWOepQwodCwBLq4RZCLdqkogIpII\nlimQr0fiPGLoH6SYKhY2rga3mMk6M9thmtkQx9kCgYA38qHWy9FEJQZe2f/nmU2A\nUZKGtJaUzpd9O7mZvH4uqe2FEms4lbneweeqzZMLyiAJ7Bh5uvuwd4UnxT8J0SFU\nkJ7HknK9qdV6pdtlNnfZW0Q6H325ndqLuXvxcCMJrx4j45GQ7XQT3OaQS46vU5aU\nQVDkh5cmqqCZHcvNgSTYpA==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "tH7q2IDmXd0_1328hZuCy9k9FmmM4pNR5QbDYd_BTHppHn8EXMdhHA_gkU7R-5hQEuJJwjj4yVkSVbPScxLIhAuDobdbP7Zew-xHwGaqMTWcwrv5JkjQ4BDkMGuMjXlg_w_lIuA3QOJePqMdxh_pgOdq61ylZYLe_zktZ2GB3qlTRf7ykMQxknpegZDRwoVIx1HQSMUbNcTk7KruT2wKs3bO8bDMDRWoQ_OqFbDeItAsVxNEoXBMRFvTjathvSketu9lT7AeLJwxSdTjhfXj0_Km_yrGVDA150IpHQL6zPg6KDwPYNLwMdJTbcCIYejJQv4QnKstvCSaYDcP6BM4Aw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "JJ9p5EMHOv1k8kLjaRKcL-NktzL0cJams7szEp1VecCOqq7oAjE8PXblQGaHSa7mdGZww9VOeYA2raf-Z_XkNJKngz0SaTOGN-etyVaraq-vnn2IeKGmrAgRXNe9nYkGysn9Wp226FXl_HyZUnVwKgUKlzXlo1qyB4Qg98x7juNg_p5CPqpAa0Sh01y8qRfJz1azQu1O4XfD3F6sSyNhm7DyWdRJE7S8S5HVIHKcp7VDD7gcoP9jU7X55BT2bnnIk30GAETRf4PU7yUMLq0ISHOQG68-MAcwRwaDHPaMWKf9CdpmsT59axi2Lvs7yYE0H3PRWPrjXhpI5SV1MnXmhQ",
+        "p": "_d1pAmj_-U9wO5sfeWlJih9uPqN2x_72XFLhFwRMCwkof9Q3AyBMWEch_Kqc17lJTXg8XWCJfdZVA6BvO6lrUzxhA5vOMsQar-0npg_NJ6M5a_E5JfE8oQRCLG88CwqmfraAspwHhswdVBC7_2DAgSufVJ5dTs4MlBvN81lc7Uc",
+        "q": "tgOJvqkb_xfsoZiRec-1pgy1yU9HOZDB-aJ9VNjpItiuqcag5YYIqQfWlTQtYyHOW1LdyevgPrHEhFLx2K07OoIGIK8VKZ0iP6p5LVV8GwZTFuUaqf9fzxmQPNXxV5lYWd6wMgvb3mrVyZbrPisd36NSW_0lAJeGhRbiEEk7DWU",
+        "dp": "XRU4EbgqU2G7Rz_DtKLUYh7QL4uEXCSydHu3KNdcgpdjECvh1_WZyKycW6a7R6YaqJszlxF0mH1kQqYq4vdl8OkssUQJwTeCiYsthIg6sxP4VAno6G6hynBjSyOmIm5PShrk6ZiocdaZ0l8ob6UsMLCsBTzj_aczmYLwaxATMLU",
+        "dq": "UETDLGgbxqXgX2uPTG8DptUYHk1uFb73LIYyS4bVWd7BOHI2ZsJzc0fXpDk8gulXvgKPeQsi-8Md7VU-_tV2t1i8JxHPfWikv_sIMavvbWOepQwodCwBLq4RZCLdqkogIpIIlimQr0fiPGLoH6SYKhY2rga3mMk6M9thmtkQx9k",
+        "qi": "N_Kh1svRRCUGXtn_55lNgFGShrSWlM6XfTu5mbx-LqnthRJrOJW53sHnqs2TC8ogCewYebr7sHeFJ8U_CdEhVJCex5JyvanVeqXbZTZ32VtEOh99uZ3ai7l78XAjCa8eI-ORkO10E9zmkEuOr1OWlEFQ5IeXJqqgmR3LzYEk2KQ"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 48,
+          "comment": "edge case for Montgomery reduction (64 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "c0e17fbe480115f5fe7a66236adcd3477fb6d7d2ac5cfcda26afb21b3de59b36b7889c9baccd91dd7dbe7fe744cc48b301ce799ce393452c6bb24a14e5db72cd8ae761a04f3972943c3b59aed2b80246ada1965bc0bd0bd52856d7ba97fe8fa80406d9c9d9af367443df036b1549d1ca1836e676cb0f4a962273c3410d29b7805a7b150c23070da72a7e5198df322c6bcc2798e8ba706854ea2f5d5428f50c01edac19d25295fd239ff86eb8edd9fb53e634044e21079c605a9d3232a61c939e7c87c339b0481a04fe2aecbcbb15f19d2389fe3f6a2dc35fb289cc6818598dce505a11f9aceddd1a",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00d96b1ed7a5071af8c48b1a162d9a3c336bb0d8b893f54719b21e2bd8581b46de773fb906a99585b777b7aab4130e15d0fd576c7968dc940019a568c6b425f0017843472c698b25253676fb0d6d1dba59ca4fdf90173af5f28b9ea93d9a95c61500fb89131f2d93217aea06910d415b551ed8e8503254c62570e8831e1152f407cbc5ce89e991719fead2cecbe62359bde60adc480efc6b0cea5177cd5663f99aba8c8f9a670b5060c9ea5231a95d655eef14485caf68a688b242e1e6a6543af239cf65c8d4aec626fae444baecf1c70b2d3da3c8b063e09e20aa441eca372b9b13a813dacfd333c491350ed348834375febfb885ae00e16a1828484675f870e1",
+        "privateExponent": "1cb31a38270da00ed48af41f975773b8e9ef473c5e3393761de003b3a435bd8e2239a427effccfd0df19bc8bd6b41647271a0234a895ed6771fb36b07c1941ec3fbec9c7600b4114ff7287434773142544227505653ba039ab1a7f86a5403e0c89bbaa657ec91a51e212c0592761c8379d41ceb0bf64175fdbdea56833ab3a910a782711243b98a540178031227d169a0113603cad54182534471b4e9f16bf3724f15d45e98127fe348ccbeba5c9fcf9fe3b11ea71c2be3bff4b040565f8179fbcf59f13605cffeab6656dce56b2e9602da5b4b15a7882f564890006f82d0c3011a63485a7b257abccada8cb00f84d66a6cfd3d42084a44db51002319bfb5711",
+        "publicExponent": "010001",
+        "prime1": "00fb91d4d6a5bdfbd5f0a82b7e89e98534564ed60638e279c6a2a26e1b635356dd89711e4b8b5af45cd64393b692b661d763b02914d555eb9d24ba5a5fe1adbf059e00eff3a3682c353179c2d6ebe39fc3ce18d492fb34a3ffbd5fdce844633fd275bde50ee36f638827becff7cd0031c335d051337a776554a0f04e614d19b8f5",
+        "prime2": "00dd3f52a51c7266f037c13913ee859cd01e4485db2a4482e340b86e494560ff9a0fbdf48a490f09f9d0b4045593115838e208d3a0dfbfd04b0f61e7110d3991714faf7266724736e8a233d855eb0fa17dac16179707e5e52d64231e35e533c234198323778cddfcdb4050c4a70d7350b3758f7a249700a08f7666037e8790d4bd",
+        "exponent1": "00f3473ead68d0c5c64999479e721dfaabf73efbe83e807d452327b315174393c05f569df66e484201b94ed67cfb7a163a25f44876162ca5d26c9f2e2084ecf1caabd6ba354173cf348da8f34bc608750af4b6bc737b2c97e00bb1b5be83cbfaff3acfadc06d1ede00e076bd4524e1283e603f1917903a002b0c0bf7b04ed02e35",
+        "exponent2": "455bb18be34415f31e776b6e4d2b03c2d68a42b0372aed2152cbbe7f27c9c5b745521654379d08529153adbc29f39905940e92516f7351580685798b85ead32683858bc683f2c14ae276804e46f74a77fc379cc3930d45f019e14c7a36d527ff6f34062d5732cc2eeb95a6607c3df7419b0c148d5ded2b686e0482f9ea83c3bd",
+        "coefficient": "7753317cd3de74bfa41c3261c32cc32dc7aec46a543458b1c8ea846cf4fec1affcde58f3c249be9b502da5b2e92ad5f004c568f0592de3997de2d9b436de400a373cedc1ab2ef9cf96cf30876c069bf2e9a8b8b6cca6fb8eb064c7b6cc087efeb15336f7d82c8f775b98464443a2ebbe471f279a8acddce03bdc1e3d407e37d1"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100d96b1ed7a5071af8c48b1a162d9a3c336bb0d8b893f54719b21e2bd8581b46de773fb906a99585b777b7aab4130e15d0fd576c7968dc940019a568c6b425f0017843472c698b25253676fb0d6d1dba59ca4fdf90173af5f28b9ea93d9a95c61500fb89131f2d93217aea06910d415b551ed8e8503254c62570e8831e1152f407cbc5ce89e991719fead2cecbe62359bde60adc480efc6b0cea5177cd5663f99aba8c8f9a670b5060c9ea5231a95d655eef14485caf68a688b242e1e6a6543af239cf65c8d4aec626fae444baecf1c70b2d3da3c8b063e09e20aa441eca372b9b13a813dacfd333c491350ed348834375febfb885ae00e16a1828484675f870e10203010001028201001cb31a38270da00ed48af41f975773b8e9ef473c5e3393761de003b3a435bd8e2239a427effccfd0df19bc8bd6b41647271a0234a895ed6771fb36b07c1941ec3fbec9c7600b4114ff7287434773142544227505653ba039ab1a7f86a5403e0c89bbaa657ec91a51e212c0592761c8379d41ceb0bf64175fdbdea56833ab3a910a782711243b98a540178031227d169a0113603cad54182534471b4e9f16bf3724f15d45e98127fe348ccbeba5c9fcf9fe3b11ea71c2be3bff4b040565f8179fbcf59f13605cffeab6656dce56b2e9602da5b4b15a7882f564890006f82d0c3011a63485a7b257abccada8cb00f84d66a6cfd3d42084a44db51002319bfb571102818100fb91d4d6a5bdfbd5f0a82b7e89e98534564ed60638e279c6a2a26e1b635356dd89711e4b8b5af45cd64393b692b661d763b02914d555eb9d24ba5a5fe1adbf059e00eff3a3682c353179c2d6ebe39fc3ce18d492fb34a3ffbd5fdce844633fd275bde50ee36f638827becff7cd0031c335d051337a776554a0f04e614d19b8f502818100dd3f52a51c7266f037c13913ee859cd01e4485db2a4482e340b86e494560ff9a0fbdf48a490f09f9d0b4045593115838e208d3a0dfbfd04b0f61e7110d3991714faf7266724736e8a233d855eb0fa17dac16179707e5e52d64231e35e533c234198323778cddfcdb4050c4a70d7350b3758f7a249700a08f7666037e8790d4bd02818100f3473ead68d0c5c64999479e721dfaabf73efbe83e807d452327b315174393c05f569df66e484201b94ed67cfb7a163a25f44876162ca5d26c9f2e2084ecf1caabd6ba354173cf348da8f34bc608750af4b6bc737b2c97e00bb1b5be83cbfaff3acfadc06d1ede00e076bd4524e1283e603f1917903a002b0c0bf7b04ed02e35028180455bb18be34415f31e776b6e4d2b03c2d68a42b0372aed2152cbbe7f27c9c5b745521654379d08529153adbc29f39905940e92516f7351580685798b85ead32683858bc683f2c14ae276804e46f74a77fc379cc3930d45f019e14c7a36d527ff6f34062d5732cc2eeb95a6607c3df7419b0c148d5ded2b686e0482f9ea83c3bd0281807753317cd3de74bfa41c3261c32cc32dc7aec46a543458b1c8ea846cf4fec1affcde58f3c249be9b502da5b2e92ad5f004c568f0592de3997de2d9b436de400a373cedc1ab2ef9cf96cf30876c069bf2e9a8b8b6cca6fb8eb064c7b6cc087efeb15336f7d82c8f775b98464443a2ebbe471f279a8acddce03bdc1e3d407e37d1",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDZax7XpQca+MSL\nGhYtmjwza7DYuJP1RxmyHivYWBtG3nc/uQaplYW3d7eqtBMOFdD9V2x5aNyUABml\naMa0JfABeENHLGmLJSU2dvsNbR26WcpP35AXOvXyi56pPZqVxhUA+4kTHy2TIXrq\nBpENQVtVHtjoUDJUxiVw6IMeEVL0B8vFzonpkXGf6tLOy+YjWb3mCtxIDvxrDOpR\nd81WY/mauoyPmmcLUGDJ6lIxqV1lXu8USFyvaKaIskLh5qZUOvI5z2XI1K7GJvrk\nRLrs8ccLLT2jyLBj4J4gqkQeyjcrmxOoE9rP0zPEkTUO00iDQ3X+v7iFrgDhahgo\nSEZ1+HDhAgMBAAECggEAHLMaOCcNoA7UivQfl1dzuOnvRzxeM5N2HeADs6Q1vY4i\nOaQn7/zP0N8ZvIvWtBZHJxoCNKiV7Wdx+zawfBlB7D++ycdgC0EU/3KHQ0dzFCVE\nInUFZTugOasaf4alQD4MibuqZX7JGlHiEsBZJ2HIN51BzrC/ZBdf296laDOrOpEK\neCcRJDuYpUAXgDEifRaaARNgPK1UGCU0RxtOnxa/NyTxXUXpgSf+NIzL66XJ/Pn+\nOxHqccK+O/9LBAVl+BefvPWfE2Bc/+q2ZW3OVrLpYC2ltLFaeIL1ZIkABvgtDDAR\npjSFp7JXq8ytqMsA+E1mps/T1CCEpE21EAIxm/tXEQKBgQD7kdTWpb371fCoK36J\n6YU0Vk7WBjjiecaiom4bY1NW3YlxHkuLWvRc1kOTtpK2YddjsCkU1VXrnSS6Wl/h\nrb8FngDv86NoLDUxecLW6+Ofw84Y1JL7NKP/vV/c6ERjP9J1veUO429jiCe+z/fN\nADHDNdBRM3p3ZVSg8E5hTRm49QKBgQDdP1KlHHJm8DfBORPuhZzQHkSF2ypEguNA\nuG5JRWD/mg+99IpJDwn50LQEVZMRWDjiCNOg37/QSw9h5xENOZFxT69yZnJHNuii\nM9hV6w+hfawWF5cH5eUtZCMeNeUzwjQZgyN3jN3820BQxKcNc1CzdY96JJcAoI92\nZgN+h5DUvQKBgQDzRz6taNDFxkmZR55yHfqr9z776D6AfUUjJ7MVF0OTwF9WnfZu\nSEIBuU7WfPt6Fjol9Eh2Fiyl0myfLiCE7PHKq9a6NUFzzzSNqPNLxgh1CvS2vHN7\nLJfgC7G1voPL+v86z63AbR7eAOB2vUUk4Sg+YD8ZF5A6ACsMC/ewTtAuNQKBgEVb\nsYvjRBXzHndrbk0rA8LWikKwNyrtIVLLvn8nycW3RVIWVDedCFKRU628KfOZBZQO\nklFvc1FYBoV5i4Xq0yaDhYvGg/LBSuJ2gE5G90p3/Decw5MNRfAZ4Ux6NtUn/280\nBi1XMswu65WmYHw990GbDBSNXe0raG4Egvnqg8O9AoGAd1MxfNPedL+kHDJhwyzD\nLceuxGpUNFixyOqEbPT+wa/83ljzwkm+m1AtpbLpKtXwBMVo8Fkt45l94tm0Nt5A\nCjc87cGrLvnPls8wh2wGm/LpqLi2zKb7jrBkx7bMCH7+sVM299gsj3dbmEZEQ6Lr\nvkcfJ5qKzdzgO9wePUB+N9E=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "2Wse16UHGvjEixoWLZo8M2uw2LiT9UcZsh4r2FgbRt53P7kGqZWFt3e3qrQTDhXQ_VdseWjclAAZpWjGtCXwAXhDRyxpiyUlNnb7DW0dulnKT9-QFzr18oueqT2alcYVAPuJEx8tkyF66gaRDUFbVR7Y6FAyVMYlcOiDHhFS9AfLxc6J6ZFxn-rSzsvmI1m95grcSA78awzqUXfNVmP5mrqMj5pnC1BgyepSMaldZV7vFEhcr2imiLJC4eamVDryOc9lyNSuxib65ES67PHHCy09o8iwY-CeIKpEHso3K5sTqBPaz9MzxJE1DtNIg0N1_r-4ha4A4WoYKEhGdfhw4Q",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "HLMaOCcNoA7UivQfl1dzuOnvRzxeM5N2HeADs6Q1vY4iOaQn7_zP0N8ZvIvWtBZHJxoCNKiV7Wdx-zawfBlB7D--ycdgC0EU_3KHQ0dzFCVEInUFZTugOasaf4alQD4MibuqZX7JGlHiEsBZJ2HIN51BzrC_ZBdf296laDOrOpEKeCcRJDuYpUAXgDEifRaaARNgPK1UGCU0RxtOnxa_NyTxXUXpgSf-NIzL66XJ_Pn-OxHqccK-O_9LBAVl-BefvPWfE2Bc_-q2ZW3OVrLpYC2ltLFaeIL1ZIkABvgtDDARpjSFp7JXq8ytqMsA-E1mps_T1CCEpE21EAIxm_tXEQ",
+        "p": "-5HU1qW9-9XwqCt-iemFNFZO1gY44nnGoqJuG2NTVt2JcR5Li1r0XNZDk7aStmHXY7ApFNVV650kulpf4a2_BZ4A7_OjaCw1MXnC1uvjn8POGNSS-zSj_71f3OhEYz_Sdb3lDuNvY4gnvs_3zQAxwzXQUTN6d2VUoPBOYU0ZuPU",
+        "q": "3T9SpRxyZvA3wTkT7oWc0B5EhdsqRILjQLhuSUVg_5oPvfSKSQ8J-dC0BFWTEVg44gjToN-_0EsPYecRDTmRcU-vcmZyRzboojPYVesPoX2sFheXB-XlLWQjHjXlM8I0GYMjd4zd_NtAUMSnDXNQs3WPeiSXAKCPdmYDfoeQ1L0",
+        "dp": "80c-rWjQxcZJmUeech36q_c---g-gH1FIyezFRdDk8BfVp32bkhCAblO1nz7ehY6JfRIdhYspdJsny4ghOzxyqvWujVBc880jajzS8YIdQr0trxzeyyX4Auxtb6Dy_r_Os-twG0e3gDgdr1FJOEoPmA_GReQOgArDAv3sE7QLjU",
+        "dq": "RVuxi-NEFfMed2tuTSsDwtaKQrA3Ku0hUsu-fyfJxbdFUhZUN50IUpFTrbwp85kFlA6SUW9zUVgGhXmLherTJoOFi8aD8sFK4naATkb3Snf8N5zDkw1F8BnhTHo21Sf_bzQGLVcyzC7rlaZgfD33QZsMFI1d7StobgSC-eqDw70",
+        "qi": "d1MxfNPedL-kHDJhwyzDLceuxGpUNFixyOqEbPT-wa_83ljzwkm-m1AtpbLpKtXwBMVo8Fkt45l94tm0Nt5ACjc87cGrLvnPls8wh2wGm_LpqLi2zKb7jrBkx7bMCH7-sVM299gsj3dbmEZEQ6LrvkcfJ5qKzdzgO9wePUB-N9E"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 49,
+          "comment": "edge case for Montgomery reduction (64 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "e0f57a6334f97163fb65a0f924259ca5558e5149bc094b06bbdb2cfe2b5cc4e52eea015afac6a4fd124dd4a0c3c25c9f7f36fc465fda623661c963a1eb6bd48663ede99ec3bed21274",
+          "ct": "d96b1ed7a5071af8c48b1a162d9a3c336bb0d8b893f54719b21e2bd8581b46de773fb906a99585b777b7aab4130e15d0fd576c7968dc940019a568c6b425f0017843472c698b25253676fb0d6d1dba59ca4fdf90173af5f28b9ea93d9a95c61500fb89131f2d93217aea06910d415b551ed8e8503254c6256fe8831e1152f407cbc5ce89e991719fead2cecbe62359bde60adc480efc6b0cea5177cd5663f99aba8c8f9a670b5060c9ea5231a95d655eef14485caf68a688b242e1e6a6543af239cf65c8d4aec626fae444baecf1c70b2d3da3c8b063e09e20aa441eca372b9b13a813dacfd333c491350ed348834375febfb885ae00e16b1828484675f870e1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00d29c00cb279876486d2f35c357d23f3a7d2d9c69021b65acc5c227e285bb53a09ce46d08bf1a75fcb4ac97f39d301fc445d6d0e31156bebe6acab4aed4a3b6f836bb057848a475ffc9e81804e1a91a523ee17379db83ec5d1b275f58072a8cefde77b92aa05063f87aa9fd348dae7987270bbb57cb161ff41a0916fe3faf27bdef1068b137b5b114004c95211de3332293491f1b45d57590ac19d82a4033c75e68cf65b62f3630b0a7c05f830f551b569fd37364206f2caaec2bbf5ddbbbcf9cec1f4c160dad459b5a23bb383afa2df7ecce990c401605efb67dc1a87edfb45f8a154093a616e7932959f87dacd46955d59bffa80a4f4be6b1d1e61f372a8ceb",
+        "privateExponent": "3c83123f4cbb23911fbde6c69f9f0b07b51bbbcaf80e0322a71767fa4fce48f2e6e142eab66dd5e4abccc343fdafec10aab8540049e5109d09760080131c8edfb669f9e25b8cd5528f229e74189a4bb3c1d96922640dfd85aadd9f295db5be14d568b4cd288eb08a9e43e53a8a52cd1c25fddaf018abdcb6781c907cb0b394c91a41418e93c60bc9dfdb6674223f7a5d51f90e866aa2c378b8793726cc0f7770ce42b1d534df724d9205fb7679f26f5488aae8e766d6afbcdcfc8aa0ce545adb25692e72960dc9bfdc52fae19953bac45c5b16b8533f0fb03ce24c493fd84c4dbcbb1cc7115a392d5923cb165bbfb0d331cb215d88e8b48ea9803beb7532b901",
+        "publicExponent": "010001",
+        "prime1": "00eecae2177a6832e4c69f7eede3993ccddae3d85fdaff478f8bb497324066d48e18c666339fcbfc2dbc46f020424688a09a2a05e3d940e0d50afc404a5af3ed222720cd34c3bbf70d293d1fd3d7626da7c89941211bdb51418741ed0aa713a05636759e9b450790b8dce14d3a48a7978f361a5633658cf9d1a5c0ce164e512cab",
+        "prime2": "00e1c93671dc20e10609495fd6b72e4d0eead443039eb34aea428c40123fb8e3797841c559bcc9850254ae5ae7b78967315be4157419a2a31fa355bb4ff6487402bf0fe64a0c3002dc86baf319f02d7630aaa57d810450da7c255b3150cf5fcd95c0979748279d9ee9edd51641a3c5fa01896c5b1c3e3847ebe829b594e627a0c1",
+        "exponent1": "234caa8f7df0d95528677b83ff192ffbde57c02cab5b01611eeddb4bfa693912a866ebc4c5e289acd920436f015d1be561e4c46a223b8d00f156c8ca3517c9fe3a7a86db3df4135946b75a751e69d67bef1378a54450ef7a185c8e85fc9cd21eec7e06ac3d5018fcbaea3358625523fa6fad05012409eb042ad48da28e814171",
+        "exponent2": "3338250cb1461825f96756c16baeaa366f1915d6b562b0e4f191c55b1e6f7fd2e76fec280e469cd0c98afffe3ec981ca55b12918bc5403b342a74925bb95f613456a82f05b516ce4bfff9af45062cfc3fc822c355f58442813855b6b9c8f7c20b39eefe7a36d0346c7f825e36016a23f45007aaeae82aff619259516a11b6e41",
+        "coefficient": "680698b60911ffa4ff64c4e15c4dcf92f8c6b4159f98bfec2e6f75c72142276371394144abba8869458832e424ed32bfaa39746d8897e2effcc3f1dabbc90adec87fdd929a82a522adb77d239ba189d42f95ecfd5f39c5dd5e38872fe5032592bf396c847970dadc602abb627d96ef636040679d24dd69c56e966df42411c00b"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100d29c00cb279876486d2f35c357d23f3a7d2d9c69021b65acc5c227e285bb53a09ce46d08bf1a75fcb4ac97f39d301fc445d6d0e31156bebe6acab4aed4a3b6f836bb057848a475ffc9e81804e1a91a523ee17379db83ec5d1b275f58072a8cefde77b92aa05063f87aa9fd348dae7987270bbb57cb161ff41a0916fe3faf27bdef1068b137b5b114004c95211de3332293491f1b45d57590ac19d82a4033c75e68cf65b62f3630b0a7c05f830f551b569fd37364206f2caaec2bbf5ddbbbcf9cec1f4c160dad459b5a23bb383afa2df7ecce990c401605efb67dc1a87edfb45f8a154093a616e7932959f87dacd46955d59bffa80a4f4be6b1d1e61f372a8ceb0203010001028201003c83123f4cbb23911fbde6c69f9f0b07b51bbbcaf80e0322a71767fa4fce48f2e6e142eab66dd5e4abccc343fdafec10aab8540049e5109d09760080131c8edfb669f9e25b8cd5528f229e74189a4bb3c1d96922640dfd85aadd9f295db5be14d568b4cd288eb08a9e43e53a8a52cd1c25fddaf018abdcb6781c907cb0b394c91a41418e93c60bc9dfdb6674223f7a5d51f90e866aa2c378b8793726cc0f7770ce42b1d534df724d9205fb7679f26f5488aae8e766d6afbcdcfc8aa0ce545adb25692e72960dc9bfdc52fae19953bac45c5b16b8533f0fb03ce24c493fd84c4dbcbb1cc7115a392d5923cb165bbfb0d331cb215d88e8b48ea9803beb7532b90102818100eecae2177a6832e4c69f7eede3993ccddae3d85fdaff478f8bb497324066d48e18c666339fcbfc2dbc46f020424688a09a2a05e3d940e0d50afc404a5af3ed222720cd34c3bbf70d293d1fd3d7626da7c89941211bdb51418741ed0aa713a05636759e9b450790b8dce14d3a48a7978f361a5633658cf9d1a5c0ce164e512cab02818100e1c93671dc20e10609495fd6b72e4d0eead443039eb34aea428c40123fb8e3797841c559bcc9850254ae5ae7b78967315be4157419a2a31fa355bb4ff6487402bf0fe64a0c3002dc86baf319f02d7630aaa57d810450da7c255b3150cf5fcd95c0979748279d9ee9edd51641a3c5fa01896c5b1c3e3847ebe829b594e627a0c1028180234caa8f7df0d95528677b83ff192ffbde57c02cab5b01611eeddb4bfa693912a866ebc4c5e289acd920436f015d1be561e4c46a223b8d00f156c8ca3517c9fe3a7a86db3df4135946b75a751e69d67bef1378a54450ef7a185c8e85fc9cd21eec7e06ac3d5018fcbaea3358625523fa6fad05012409eb042ad48da28e8141710281803338250cb1461825f96756c16baeaa366f1915d6b562b0e4f191c55b1e6f7fd2e76fec280e469cd0c98afffe3ec981ca55b12918bc5403b342a74925bb95f613456a82f05b516ce4bfff9af45062cfc3fc822c355f58442813855b6b9c8f7c20b39eefe7a36d0346c7f825e36016a23f45007aaeae82aff619259516a11b6e41028180680698b60911ffa4ff64c4e15c4dcf92f8c6b4159f98bfec2e6f75c72142276371394144abba8869458832e424ed32bfaa39746d8897e2effcc3f1dabbc90adec87fdd929a82a522adb77d239ba189d42f95ecfd5f39c5dd5e38872fe5032592bf396c847970dadc602abb627d96ef636040679d24dd69c56e966df42411c00b",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDSnADLJ5h2SG0v\nNcNX0j86fS2caQIbZazFwifihbtToJzkbQi/GnX8tKyX850wH8RF1tDjEVa+vmrK\ntK7Uo7b4NrsFeEikdf/J6BgE4akaUj7hc3nbg+xdGydfWAcqjO/ed7kqoFBj+Hqp\n/TSNrnmHJwu7V8sWH/QaCRb+P68nve8QaLE3tbEUAEyVIR3jMyKTSR8bRdV1kKwZ\n2CpAM8deaM9lti82MLCnwF+DD1UbVp/Tc2Qgbyyq7Cu/Xdu7z5zsH0wWDa1Fm1oj\nuzg6+i337M6ZDEAWBe+2fcGoft+0X4oVQJOmFueTKVn4fazUaVXVm/+oCk9L5rHR\n5h83KozrAgMBAAECggEAPIMSP0y7I5EfvebGn58LB7Ubu8r4DgMipxdn+k/OSPLm\n4ULqtm3V5KvMw0P9r+wQqrhUAEnlEJ0JdgCAExyO37Zp+eJbjNVSjyKedBiaS7PB\n2WkiZA39hardnyldtb4U1Wi0zSiOsIqeQ+U6ilLNHCX92vAYq9y2eByQfLCzlMka\nQUGOk8YLyd/bZnQiP3pdUfkOhmqiw3i4eTcmzA93cM5CsdU033JNkgX7dnnyb1SI\nqujnZtavvNz8iqDOVFrbJWkucpYNyb/cUvrhmVO6xFxbFrhTPw+wPOJMST/YTE28\nuxzHEVo5LVkjyxZbv7DTMcshXYjotI6pgDvrdTK5AQKBgQDuyuIXemgy5Maffu3j\nmTzN2uPYX9r/R4+LtJcyQGbUjhjGZjOfy/wtvEbwIEJGiKCaKgXj2UDg1Qr8QEpa\n8+0iJyDNNMO79w0pPR/T12Jtp8iZQSEb21FBh0HtCqcToFY2dZ6bRQeQuNzhTTpI\np5ePNhpWM2WM+dGlwM4WTlEsqwKBgQDhyTZx3CDhBglJX9a3Lk0O6tRDA56zSupC\njEASP7jjeXhBxVm8yYUCVK5a57eJZzFb5BV0GaKjH6NVu0/2SHQCvw/mSgwwAtyG\nuvMZ8C12MKqlfYEEUNp8JVsxUM9fzZXAl5dIJ52e6e3VFkGjxfoBiWxbHD44R+vo\nKbWU5iegwQKBgCNMqo998NlVKGd7g/8ZL/veV8Asq1sBYR7t20v6aTkSqGbrxMXi\niazZIENvAV0b5WHkxGoiO40A8VbIyjUXyf46eobbPfQTWUa3WnUeadZ77xN4pURQ\n73oYXI6F/JzSHux+Bqw9UBj8uuozWGJVI/pvrQUBJAnrBCrUjaKOgUFxAoGAMzgl\nDLFGGCX5Z1bBa66qNm8ZFda1YrDk8ZHFWx5vf9Lnb+woDkac0MmK//4+yYHKVbEp\nGLxUA7NCp0klu5X2E0VqgvBbUWzkv/+a9FBiz8P8giw1X1hEKBOFW2ucj3wgs57v\n56NtA0bH+CXjYBaiP0UAeq6ugq/2GSWVFqEbbkECgYBoBpi2CRH/pP9kxOFcTc+S\n+Ma0FZ+Yv+wub3XHIUInY3E5QUSruohpRYgy5CTtMr+qOXRtiJfi7/zD8dq7yQre\nyH/dkpqCpSKtt30jm6GJ1C+V7P1fOcXdXjiHL+UDJZK/OWyEeXDa3GAqu2J9lu9j\nYEBnnSTdacVulm30JBHACw==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "0pwAyyeYdkhtLzXDV9I_On0tnGkCG2WsxcIn4oW7U6Cc5G0Ivxp1_LSsl_OdMB_ERdbQ4xFWvr5qyrSu1KO2-Da7BXhIpHX_yegYBOGpGlI-4XN524PsXRsnX1gHKozv3ne5KqBQY_h6qf00ja55hycLu1fLFh_0GgkW_j-vJ73vEGixN7WxFABMlSEd4zMik0kfG0XVdZCsGdgqQDPHXmjPZbYvNjCwp8Bfgw9VG1af03NkIG8squwrv13bu8-c7B9MFg2tRZtaI7s4Ovot9-zOmQxAFgXvtn3BqH7ftF-KFUCTphbnkylZ-H2s1GlV1Zv_qApPS-ax0eYfNyqM6w",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "PIMSP0y7I5EfvebGn58LB7Ubu8r4DgMipxdn-k_OSPLm4ULqtm3V5KvMw0P9r-wQqrhUAEnlEJ0JdgCAExyO37Zp-eJbjNVSjyKedBiaS7PB2WkiZA39hardnyldtb4U1Wi0zSiOsIqeQ-U6ilLNHCX92vAYq9y2eByQfLCzlMkaQUGOk8YLyd_bZnQiP3pdUfkOhmqiw3i4eTcmzA93cM5CsdU033JNkgX7dnnyb1SIqujnZtavvNz8iqDOVFrbJWkucpYNyb_cUvrhmVO6xFxbFrhTPw-wPOJMST_YTE28uxzHEVo5LVkjyxZbv7DTMcshXYjotI6pgDvrdTK5AQ",
+        "p": "7sriF3poMuTGn37t45k8zdrj2F_a_0ePi7SXMkBm1I4YxmYzn8v8LbxG8CBCRoigmioF49lA4NUK_EBKWvPtIicgzTTDu_cNKT0f09dibafImUEhG9tRQYdB7QqnE6BWNnWem0UHkLjc4U06SKeXjzYaVjNljPnRpcDOFk5RLKs",
+        "q": "4ck2cdwg4QYJSV_Wty5NDurUQwOes0rqQoxAEj-443l4QcVZvMmFAlSuWue3iWcxW-QVdBmiox-jVbtP9kh0Ar8P5koMMALchrrzGfAtdjCqpX2BBFDafCVbMVDPX82VwJeXSCednunt1RZBo8X6AYlsWxw-OEfr6Cm1lOYnoME",
+        "dp": "I0yqj33w2VUoZ3uD_xkv-95XwCyrWwFhHu3bS_ppORKoZuvExeKJrNkgQ28BXRvlYeTEaiI7jQDxVsjKNRfJ_jp6hts99BNZRrdadR5p1nvvE3ilRFDvehhcjoX8nNIe7H4GrD1QGPy66jNYYlUj-m-tBQEkCesEKtSNoo6BQXE",
+        "dq": "MzglDLFGGCX5Z1bBa66qNm8ZFda1YrDk8ZHFWx5vf9Lnb-woDkac0MmK__4-yYHKVbEpGLxUA7NCp0klu5X2E0VqgvBbUWzkv_-a9FBiz8P8giw1X1hEKBOFW2ucj3wgs57v56NtA0bH-CXjYBaiP0UAeq6ugq_2GSWVFqEbbkE",
+        "qi": "aAaYtgkR_6T_ZMThXE3PkvjGtBWfmL_sLm91xyFCJ2NxOUFEq7qIaUWIMuQk7TK_qjl0bYiX4u_8w_Hau8kK3sh_3ZKagqUirbd9I5uhidQvlez9XznF3V44hy_lAyWSvzlshHlw2txgKrtifZbvY2BAZ50k3WnFbpZt9CQRwAs"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 50,
+          "comment": "edge case for Montgomery reduction (1024 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "a3807f5d34acd39123d2ec83648225b54590b45750e13c6cacf587dac4fe9c9e32a747b6b7f073d94b07311a0e",
+          "ct": "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "009b298a64d73b644bb4f184c8cebaa01fcc9b9b1fea5e93d3463a28e73284123a1abfae36ef57edd72ab9676c66b629cf42450dbf7c6347047746ff62c22f1e0b854500cd31384f6fadcf996828d96500b6b023619e2378230553e9b9226367ab7b8a06169e1325fb9e8a73c264400855c3b10229b6a661d67e1826bb32fc6ab34e4b6712066c2546bd4e47ac2789867b5e1f29c4e597a19ba715e6f6c011181f758442263355931115f9471fa7654e5fa85b69545482cadea81362b762aa2794f7f132856dea85c65f7d6b581edc89022f4cb1f6f99d5bb4a8cffde294ed5fde28692aa610e83272406cb4697f970ef16f689425e8a5174580184bb223fbb919",
+        "privateExponent": "092837b471565e3a3094d3611580429c75d31621d94f591a8e29b709c3fbb2e6ae76f3056775314272514c5703adcb04621518b55d162fd605e31105e74f680ec67ff6c6e5597d28aa6196dc6492c5e8f79f280b660d9254c0c6fdc37111dc47accc0dc56e71535bc8f4c355acdc71917c31d95e945ab7e9f479a0e989de073ef3c0b6d392bc6d11e73fdeb886687b42d5f27c404599e0ff66d8cbdc4a4bde185be86a72ebc7622d9c7f6ac3a1fc645db4ca8bd86bf19f19e2261a72b6cfb52af68f036b2a8a1ca8a207ee655b864a193dd8d845abbac3d777171bf86eb1bc882c02f0f61259979e2bf830eae9a964c8518ed2497b96dc0ca4ff9c41bc8120bd",
+        "publicExponent": "010001",
+        "prime1": "00c8f09a8ebd6bf018e3c8d9e51cfeb755a3e63a6342032bf69b496a511aa2c1a5c8cc9612a36bf618c7eb633170a19094db19885b1dc2c03e79bf0d039f782ca4f45fda4398368f5747aa7115eda85b2032e08d26ae93b56deedc63afa58fc7bc784a27976c1501ac69d840d03e38d510a644c3e51d966af4a8eff33fe073f2c5",
+        "prime2": "00c5adc2bf614abfa80b9b921f320e659f44bffab2fa4b1111c98c344c2630a410ee70dc30899efd17a22946662173485e17f3630d61d5ff1bcde4d586243b877e6737438fb9857c3beabaa442c293aa110caeb8ad6967e5a2ea2a34267b0fbde5eac1abef98f329601599abde5150d39e9ba04a7b9c172f88af07d4828fdac245",
+        "exponent1": "008582e09f011b2bdfcdd1d17d9b235f7b66b87d891ffe6d82a0b14a13f387baf54593320fd647d0afac7e295d5b41ee880980508a821eb98f896338e97456ec0afa5889f4a9b96eca8652a86af28b0f693884dd249b90875731037cb4e363c249e6ff168955062c237bfc752c287ba88e347bb25194b43202b8111ee60d63dd25",
+        "exponent2": "009fd23e93f09b389d2ad55aac721205c361183e1e9a123af8c094e46b74acfad8dd8ecdd7484d0c9f20f272027ca4f22b70fdcc65b3660add75f7bf52b6d492557629ce2bd378c2dac68aa3e77ddd593073aa87915c992da62be0774d6d4d6ae10a8e0eeea62062a1569569c952c1207729a7ccd06780af63b8ef81b7158b6e69",
+        "coefficient": "009ff86c3dc539762069ae9d5825b04d1f45722224b0aa86d76f71a9b095afc9767c4e2d2319cf33e123807b2c160d66dfd567a8532b75edb564a70fd0ced4257d0109611a943fa06efea634736bf464e68f32c55b1b91c82f6031cbd4889ba75fa94de41dc91350e41020d8b5f81b47fb640ff12d697ecdaa2dad3faa8da7c141"
+      },
+      "privateKeyPkcs8": "308204bf020100300d06092a864886f70d0101010500048204a9308204a502010002820101009b298a64d73b644bb4f184c8cebaa01fcc9b9b1fea5e93d3463a28e73284123a1abfae36ef57edd72ab9676c66b629cf42450dbf7c6347047746ff62c22f1e0b854500cd31384f6fadcf996828d96500b6b023619e2378230553e9b9226367ab7b8a06169e1325fb9e8a73c264400855c3b10229b6a661d67e1826bb32fc6ab34e4b6712066c2546bd4e47ac2789867b5e1f29c4e597a19ba715e6f6c011181f758442263355931115f9471fa7654e5fa85b69545482cadea81362b762aa2794f7f132856dea85c65f7d6b581edc89022f4cb1f6f99d5bb4a8cffde294ed5fde28692aa610e83272406cb4697f970ef16f689425e8a5174580184bb223fbb919020301000102820100092837b471565e3a3094d3611580429c75d31621d94f591a8e29b709c3fbb2e6ae76f3056775314272514c5703adcb04621518b55d162fd605e31105e74f680ec67ff6c6e5597d28aa6196dc6492c5e8f79f280b660d9254c0c6fdc37111dc47accc0dc56e71535bc8f4c355acdc71917c31d95e945ab7e9f479a0e989de073ef3c0b6d392bc6d11e73fdeb886687b42d5f27c404599e0ff66d8cbdc4a4bde185be86a72ebc7622d9c7f6ac3a1fc645db4ca8bd86bf19f19e2261a72b6cfb52af68f036b2a8a1ca8a207ee655b864a193dd8d845abbac3d777171bf86eb1bc882c02f0f61259979e2bf830eae9a964c8518ed2497b96dc0ca4ff9c41bc8120bd02818100c8f09a8ebd6bf018e3c8d9e51cfeb755a3e63a6342032bf69b496a511aa2c1a5c8cc9612a36bf618c7eb633170a19094db19885b1dc2c03e79bf0d039f782ca4f45fda4398368f5747aa7115eda85b2032e08d26ae93b56deedc63afa58fc7bc784a27976c1501ac69d840d03e38d510a644c3e51d966af4a8eff33fe073f2c502818100c5adc2bf614abfa80b9b921f320e659f44bffab2fa4b1111c98c344c2630a410ee70dc30899efd17a22946662173485e17f3630d61d5ff1bcde4d586243b877e6737438fb9857c3beabaa442c293aa110caeb8ad6967e5a2ea2a34267b0fbde5eac1abef98f329601599abde5150d39e9ba04a7b9c172f88af07d4828fdac245028181008582e09f011b2bdfcdd1d17d9b235f7b66b87d891ffe6d82a0b14a13f387baf54593320fd647d0afac7e295d5b41ee880980508a821eb98f896338e97456ec0afa5889f4a9b96eca8652a86af28b0f693884dd249b90875731037cb4e363c249e6ff168955062c237bfc752c287ba88e347bb25194b43202b8111ee60d63dd25028181009fd23e93f09b389d2ad55aac721205c361183e1e9a123af8c094e46b74acfad8dd8ecdd7484d0c9f20f272027ca4f22b70fdcc65b3660add75f7bf52b6d492557629ce2bd378c2dac68aa3e77ddd593073aa87915c992da62be0774d6d4d6ae10a8e0eeea62062a1569569c952c1207729a7ccd06780af63b8ef81b7158b6e69028181009ff86c3dc539762069ae9d5825b04d1f45722224b0aa86d76f71a9b095afc9767c4e2d2319cf33e123807b2c160d66dfd567a8532b75edb564a70fd0ced4257d0109611a943fa06efea634736bf464e68f32c55b1b91c82f6031cbd4889ba75fa94de41dc91350e41020d8b5f81b47fb640ff12d697ecdaa2dad3faa8da7c141",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCbKYpk1ztkS7Tx\nhMjOuqAfzJubH+pek9NGOijnMoQSOhq/rjbvV+3XKrlnbGa2Kc9CRQ2/fGNHBHdG\n/2LCLx4LhUUAzTE4T2+tz5loKNllALawI2GeI3gjBVPpuSJjZ6t7igYWnhMl+56K\nc8JkQAhVw7ECKbamYdZ+GCa7Mvxqs05LZxIGbCVGvU5HrCeJhnteHynE5Zehm6cV\n5vbAERgfdYRCJjNVkxEV+Ucfp2VOX6hbaVRUgsreqBNit2KqJ5T38TKFbeqFxl99\na1ge3IkCL0yx9vmdW7Soz/3ilO1f3ihpKqYQ6DJyQGy0aX+XDvFvaJQl6KUXRYAY\nS7Ij+7kZAgMBAAECggEACSg3tHFWXjowlNNhFYBCnHXTFiHZT1kajim3CcP7suau\ndvMFZ3UxQnJRTFcDrcsEYhUYtV0WL9YF4xEF509oDsZ/9sblWX0oqmGW3GSSxej3\nnygLZg2SVMDG/cNxEdxHrMwNxW5xU1vI9MNVrNxxkXwx2V6UWrfp9Hmg6YneBz7z\nwLbTkrxtEec/3riGaHtC1fJ8QEWZ4P9m2MvcSkveGFvoanLrx2ItnH9qw6H8ZF20\nyovYa/GfGeImGnK2z7Uq9o8DayqKHKiiB+5lW4ZKGT3Y2EWrusPXdxcb+G6xvIgs\nAvD2ElmXniv4MOrpqWTIUY7SSXuW3Ayk/5xBvIEgvQKBgQDI8JqOvWvwGOPI2eUc\n/rdVo+Y6Y0IDK/abSWpRGqLBpcjMlhKja/YYx+tjMXChkJTbGYhbHcLAPnm/DQOf\neCyk9F/aQ5g2j1dHqnEV7ahbIDLgjSauk7Vt7txjr6WPx7x4SieXbBUBrGnYQNA+\nONUQpkTD5R2WavSo7/M/4HPyxQKBgQDFrcK/YUq/qAubkh8yDmWfRL/6svpLERHJ\njDRMJjCkEO5w3DCJnv0XoilGZiFzSF4X82MNYdX/G83k1YYkO4d+ZzdDj7mFfDvq\nuqRCwpOqEQyuuK1pZ+Wi6io0JnsPveXqwavvmPMpYBWZq95RUNOem6BKe5wXL4iv\nB9SCj9rCRQKBgQCFguCfARsr383R0X2bI197Zrh9iR/+bYKgsUoT84e69UWTMg/W\nR9CvrH4pXVtB7ogJgFCKgh65j4ljOOl0VuwK+liJ9Km5bsqGUqhq8osPaTiE3SSb\nkIdXMQN8tONjwknm/xaJVQYsI3v8dSwoe6iONHuyUZS0MgK4ER7mDWPdJQKBgQCf\n0j6T8Js4nSrVWqxyEgXDYRg+HpoSOvjAlORrdKz62N2OzddITQyfIPJyAnyk8itw\n/cxls2YK3XX3v1K21JJVdinOK9N4wtrGiqPnfd1ZMHOqh5FcmS2mK+B3TW1NauEK\njg7upiBioVaVaclSwSB3KafM0GeAr2O474G3FYtuaQKBgQCf+Gw9xTl2IGmunVgl\nsE0fRXIiJLCqhtdvcamwla/JdnxOLSMZzzPhI4B7LBYNZt/VZ6hTK3XttWSnD9DO\n1CV9AQlhGpQ/oG7+pjRza/Rk5o8yxVsbkcgvYDHL1Iibp1+pTeQdyRNQ5BAg2LX4\nG0f7ZA/xLWl+zaotrT+qjafBQQ==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "mymKZNc7ZEu08YTIzrqgH8ybmx_qXpPTRjoo5zKEEjoav64271ft1yq5Z2xmtinPQkUNv3xjRwR3Rv9iwi8eC4VFAM0xOE9vrc-ZaCjZZQC2sCNhniN4IwVT6bkiY2ere4oGFp4TJfueinPCZEAIVcOxAim2pmHWfhgmuzL8arNOS2cSBmwlRr1OR6wniYZ7Xh8pxOWXoZunFeb2wBEYH3WEQiYzVZMRFflHH6dlTl-oW2lUVILK3qgTYrdiqieU9_EyhW3qhcZffWtYHtyJAi9Msfb5nVu0qM_94pTtX94oaSqmEOgyckBstGl_lw7xb2iUJeilF0WAGEuyI_u5GQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "CSg3tHFWXjowlNNhFYBCnHXTFiHZT1kajim3CcP7suaudvMFZ3UxQnJRTFcDrcsEYhUYtV0WL9YF4xEF509oDsZ_9sblWX0oqmGW3GSSxej3nygLZg2SVMDG_cNxEdxHrMwNxW5xU1vI9MNVrNxxkXwx2V6UWrfp9Hmg6YneBz7zwLbTkrxtEec_3riGaHtC1fJ8QEWZ4P9m2MvcSkveGFvoanLrx2ItnH9qw6H8ZF20yovYa_GfGeImGnK2z7Uq9o8DayqKHKiiB-5lW4ZKGT3Y2EWrusPXdxcb-G6xvIgsAvD2ElmXniv4MOrpqWTIUY7SSXuW3Ayk_5xBvIEgvQ",
+        "p": "yPCajr1r8BjjyNnlHP63VaPmOmNCAyv2m0lqURqiwaXIzJYSo2v2GMfrYzFwoZCU2xmIWx3CwD55vw0Dn3gspPRf2kOYNo9XR6pxFe2oWyAy4I0mrpO1be7cY6-lj8e8eEonl2wVAaxp2EDQPjjVEKZEw-Udlmr0qO_zP-Bz8sU",
+        "q": "xa3Cv2FKv6gLm5IfMg5ln0S_-rL6SxERyYw0TCYwpBDucNwwiZ79F6IpRmYhc0heF_NjDWHV_xvN5NWGJDuHfmc3Q4-5hXw76rqkQsKTqhEMrritaWflouoqNCZ7D73l6sGr75jzKWAVmaveUVDTnpugSnucFy-IrwfUgo_awkU",
+        "dp": "hYLgnwEbK9_N0dF9myNfe2a4fYkf_m2CoLFKE_OHuvVFkzIP1kfQr6x-KV1bQe6ICYBQioIeuY-JYzjpdFbsCvpYifSpuW7KhlKoavKLD2k4hN0km5CHVzEDfLTjY8JJ5v8WiVUGLCN7_HUsKHuojjR7slGUtDICuBEe5g1j3SU",
+        "dq": "n9I-k_CbOJ0q1VqschIFw2EYPh6aEjr4wJTka3Ss-tjdjs3XSE0MnyDycgJ8pPIrcP3MZbNmCt11979SttSSVXYpzivTeMLaxoqj533dWTBzqoeRXJktpivgd01tTWrhCo4O7qYgYqFWlWnJUsEgdymnzNBngK9juO-BtxWLbmk",
+        "qi": "n_hsPcU5diBprp1YJbBNH0VyIiSwqobXb3GpsJWvyXZ8Ti0jGc8z4SOAeywWDWbf1WeoUyt17bVkpw_QztQlfQEJYRqUP6Bu_qY0c2v0ZOaPMsVbG5HIL2Axy9SIm6dfqU3kHckTUOQQINi1-BtH-2QP8S1pfs2qLa0_qo2nwUE"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 51,
+          "comment": "edge case for Montgomery reduction (1024 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "f9077aa629cac80d",
+          "ct": "9a298a64d73b644bb4f184c8cebaa01fcc9b9b1fea5e93d3463a28e73284123a1abfae36ef57edd72ab9676c66b629cf42450dbf7c6347047746ff62c22f1e0b854500cd31384f6fadcf996828d96500b6b023619e2378230553e9b9226367ab7b8a06169e1325fb9e8a73c264400855c3b10229b6a661d67e1826bb32fc6ab44e4b6712066c2546bd4e47ac2789867b5e1f29c4e597a19ba715e6f6c011181f758442263355931115f9471fa7654e5fa85b69545482cadea81362b762aa2794f7f132856dea85c65f7d6b581edc89022f4cb1f6f99d5bb4a8cffde294ed5fde28692aa610e83272406cb4697f970ef16f689425e8a5174580184bb223fbb919",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "009b867320148400d6236020943c389ace0b5c2aae805d68a1084248bb3ee3206d3e1912aeefa352bdffeaeeee5acc3db5e76b992e54220e449dd0cdd9c54653a3d54a4ae02733482605f6a75d4bd8cbb87fb4718a9914f0131feb339cc656740c9a6de79993a7b7684494e5a20c86a5ac1fa71a546dd3fd3e927d0c43ef8481c86f3aabb9212845eb40afe527bcac69212235d7c7c62b94116b5b6fb304d927b5e29b100d1f4f7112f685e88d76b497f52b99ffef9b7901e4ec980f43d7c461ac22a5788fdaf01010f516be9d0b693782a804dcd4eabb28ce390feba18158969ef49ba449517208580700e82caae1b549e1003540795aede7284fcae04d6ebe43",
+        "privateExponent": "1e6d819ca726e45b00f4cfaaf0d54a4441a8b89907783efe327575715cee66ebb898833542a13b90fcbee41c321b7f7f555591d4a4953d216396f48f44af6bb1c40b12f723f43e8b61e34dff4cd58f95fb363c789756a759b686f7c41671d7a697982515c0f3b1486f128a92d7cc882152d808a8b80c1fa1dc5b26c92bd54ae6b3a7cda30da414cda14b00e98a610114d79543c6047db9f5685422a9a0fb4c77aae8a69860986d76c00283ca44c89aa6aaff8d333e00b67222a5e1a743ee54b572c5d377ee2d3c0eab9b4664aa89688fe22ff32f226ae6b498508142625be50bc6c5c3d77590fdc6bfdfddeec801e9665cb09cffe140c1972f339dfa17c12791",
+        "publicExponent": "010001",
+        "prime1": "00da48e1987c5df633fe9f03ed9fa0cb0984d81f5b81316b8eb9362c7e60c8f61d47e81265c7c9f58acc45220ba880ba6b703760795b9d9cf230f4340d34d822c4ec9b5416e7c7196dbaf510c5d348b4e0833be706ca8c0d71eedcb8dd52e257d54218ef27c9f43c697b5d69479271c5db94c600c0a4c829b0423842cf7890d587",
+        "prime2": "00b6659acaaf96ca82b4db20c970f861a3a40851eef5a37f89cc45116a79b7ad48c106e583bd401ede1b9ce6ad14626fc7fdf24ac06afbd97dac1b3ebd4b14f68312d5aaf756f715a0519cbf5f2abf9d66ca6c73a5aee5e3e7e8d34aaadf646867267afd101750aff1f2546f77ec9e6325804744d24899e5b7d2451c0ea4018065",
+        "exponent1": "21a59650a0eb02e664db3209d0cf423cc763610203da105041b05e0f64efd53012436d828ed74ca80670a99cce6e794dd25056e89dfc9f929d8526f8da2a6ec1980f21591e850c2063ef1e94bfcab746dc33c19ac461ee389faf1a37d36cdc491d1526d825432684c3e554331a19bb7beb64d1fcdfe992b37ea1997acd84d5c5",
+        "exponent2": "2dee01ff9e1db39b1c5dbdb0dc30bfad8c65c7f40b890359b8c57fb0373c4877749bfef9a0935ff280338f66f026258dcfe5ce6b0bc5a5abdec5f1938b2f992fc273699ce51a4d28d4c44af074fc516f8bf3a95f845e4178a989635909ede7d869b938b66f9892e5b3270df6bdefd8799e06d44ebb977d603fa3c57fee4eae7d",
+        "coefficient": "7162f9069f55ef6a8ac1c31bd7a33263c02ab773a3dc0e726ffa143b3a2335cfb614bc28ad4dfa350ce605ac4be2da199244561ad6adfaf9d1833a7fd960de0b5f4e4f7995892606aa28d1da78c71b9ce67006efcce78c25e3fa711e5ac7ccf5522ce6c133a72d8fe5ea3b696e7e6d2dd794b1ed5fe496d20dfb0e80c5af57a4"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a202010002820101009b867320148400d6236020943c389ace0b5c2aae805d68a1084248bb3ee3206d3e1912aeefa352bdffeaeeee5acc3db5e76b992e54220e449dd0cdd9c54653a3d54a4ae02733482605f6a75d4bd8cbb87fb4718a9914f0131feb339cc656740c9a6de79993a7b7684494e5a20c86a5ac1fa71a546dd3fd3e927d0c43ef8481c86f3aabb9212845eb40afe527bcac69212235d7c7c62b94116b5b6fb304d927b5e29b100d1f4f7112f685e88d76b497f52b99ffef9b7901e4ec980f43d7c461ac22a5788fdaf01010f516be9d0b693782a804dcd4eabb28ce390feba18158969ef49ba449517208580700e82caae1b549e1003540795aede7284fcae04d6ebe430203010001028201001e6d819ca726e45b00f4cfaaf0d54a4441a8b89907783efe327575715cee66ebb898833542a13b90fcbee41c321b7f7f555591d4a4953d216396f48f44af6bb1c40b12f723f43e8b61e34dff4cd58f95fb363c789756a759b686f7c41671d7a697982515c0f3b1486f128a92d7cc882152d808a8b80c1fa1dc5b26c92bd54ae6b3a7cda30da414cda14b00e98a610114d79543c6047db9f5685422a9a0fb4c77aae8a69860986d76c00283ca44c89aa6aaff8d333e00b67222a5e1a743ee54b572c5d377ee2d3c0eab9b4664aa89688fe22ff32f226ae6b498508142625be50bc6c5c3d77590fdc6bfdfddeec801e9665cb09cffe140c1972f339dfa17c1279102818100da48e1987c5df633fe9f03ed9fa0cb0984d81f5b81316b8eb9362c7e60c8f61d47e81265c7c9f58acc45220ba880ba6b703760795b9d9cf230f4340d34d822c4ec9b5416e7c7196dbaf510c5d348b4e0833be706ca8c0d71eedcb8dd52e257d54218ef27c9f43c697b5d69479271c5db94c600c0a4c829b0423842cf7890d58702818100b6659acaaf96ca82b4db20c970f861a3a40851eef5a37f89cc45116a79b7ad48c106e583bd401ede1b9ce6ad14626fc7fdf24ac06afbd97dac1b3ebd4b14f68312d5aaf756f715a0519cbf5f2abf9d66ca6c73a5aee5e3e7e8d34aaadf646867267afd101750aff1f2546f77ec9e6325804744d24899e5b7d2451c0ea401806502818021a59650a0eb02e664db3209d0cf423cc763610203da105041b05e0f64efd53012436d828ed74ca80670a99cce6e794dd25056e89dfc9f929d8526f8da2a6ec1980f21591e850c2063ef1e94bfcab746dc33c19ac461ee389faf1a37d36cdc491d1526d825432684c3e554331a19bb7beb64d1fcdfe992b37ea1997acd84d5c50281802dee01ff9e1db39b1c5dbdb0dc30bfad8c65c7f40b890359b8c57fb0373c4877749bfef9a0935ff280338f66f026258dcfe5ce6b0bc5a5abdec5f1938b2f992fc273699ce51a4d28d4c44af074fc516f8bf3a95f845e4178a989635909ede7d869b938b66f9892e5b3270df6bdefd8799e06d44ebb977d603fa3c57fee4eae7d0281807162f9069f55ef6a8ac1c31bd7a33263c02ab773a3dc0e726ffa143b3a2335cfb614bc28ad4dfa350ce605ac4be2da199244561ad6adfaf9d1833a7fd960de0b5f4e4f7995892606aa28d1da78c71b9ce67006efcce78c25e3fa711e5ac7ccf5522ce6c133a72d8fe5ea3b696e7e6d2dd794b1ed5fe496d20dfb0e80c5af57a4",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCbhnMgFIQA1iNg\nIJQ8OJrOC1wqroBdaKEIQki7PuMgbT4ZEq7vo1K9/+ru7lrMPbXna5kuVCIORJ3Q\nzdnFRlOj1UpK4CczSCYF9qddS9jLuH+0cYqZFPATH+sznMZWdAyabeeZk6e3aESU\n5aIMhqWsH6caVG3T/T6SfQxD74SByG86q7khKEXrQK/lJ7ysaSEiNdfHxiuUEWtb\nb7ME2Se14psQDR9PcRL2heiNdrSX9SuZ/++beQHk7JgPQ9fEYawipXiP2vAQEPUW\nvp0LaTeCqATc1Oq7KM45D+uhgViWnvSbpElRcghYBwDoLKrhtUnhADVAeVrt5yhP\nyuBNbr5DAgMBAAECggEAHm2BnKcm5FsA9M+q8NVKREGouJkHeD7+MnV1cVzuZuu4\nmIM1QqE7kPy+5BwyG39/VVWR1KSVPSFjlvSPRK9rscQLEvcj9D6LYeNN/0zVj5X7\nNjx4l1anWbaG98QWcdeml5glFcDzsUhvEoqS18yIIVLYCKi4DB+h3FsmySvVSuaz\np82jDaQUzaFLAOmKYQEU15VDxgR9ufVoVCKpoPtMd6ropphgmG12wAKDykTImqaq\n/40zPgC2ciKl4adD7lS1csXTd+4tPA6rm0Zkqoloj+Iv8y8iaua0mFCBQmJb5QvG\nxcPXdZD9xr/f3e7IAelmXLCc/+FAwZcvM536F8EnkQKBgQDaSOGYfF32M/6fA+2f\noMsJhNgfW4Exa465Nix+YMj2HUfoEmXHyfWKzEUiC6iAumtwN2B5W52c8jD0NA00\n2CLE7JtUFufHGW269RDF00i04IM75wbKjA1x7ty43VLiV9VCGO8nyfQ8aXtdaUeS\nccXblMYAwKTIKbBCOELPeJDVhwKBgQC2ZZrKr5bKgrTbIMlw+GGjpAhR7vWjf4nM\nRRFqebetSMEG5YO9QB7eG5zmrRRib8f98krAavvZfawbPr1LFPaDEtWq91b3FaBR\nnL9fKr+dZspsc6Wu5ePn6NNKqt9kaGcmev0QF1Cv8fJUb3fsnmMlgEdE0kiZ5bfS\nRRwOpAGAZQKBgCGlllCg6wLmZNsyCdDPQjzHY2ECA9oQUEGwXg9k79UwEkNtgo7X\nTKgGcKmczm55TdJQVuid/J+SnYUm+NoqbsGYDyFZHoUMIGPvHpS/yrdG3DPBmsRh\n7jifrxo302zcSR0VJtglQyaEw+VUMxoZu3vrZNH83+mSs36hmXrNhNXFAoGALe4B\n/54ds5scXb2w3DC/rYxlx/QLiQNZuMV/sDc8SHd0m/75oJNf8oAzj2bwJiWNz+XO\nawvFpavexfGTiy+ZL8JzaZzlGk0o1MRK8HT8UW+L86lfhF5BeKmJY1kJ7efYabk4\ntm+YkuWzJw32ve/YeZ4G1E67l31gP6PFf+5Orn0CgYBxYvkGn1XvaorBwxvXozJj\nwCq3c6PcDnJv+hQ7OiM1z7YUvCitTfo1DOYFrEvi2hmSRFYa1q36+dGDOn/ZYN4L\nX05PeZWJJgaqKNHaeMcbnOZwBu/M54wl4/pxHlrHzPVSLObBM6ctj+XqO2lufm0t\n15Sx7V/kltIN+w6Axa9XpA==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "m4ZzIBSEANYjYCCUPDiazgtcKq6AXWihCEJIuz7jIG0-GRKu76NSvf_q7u5azD2152uZLlQiDkSd0M3ZxUZTo9VKSuAnM0gmBfanXUvYy7h_tHGKmRTwEx_rM5zGVnQMmm3nmZOnt2hElOWiDIalrB-nGlRt0_0-kn0MQ--EgchvOqu5IShF60Cv5Se8rGkhIjXXx8YrlBFrW2-zBNknteKbEA0fT3ES9oXojXa0l_Urmf_vm3kB5OyYD0PXxGGsIqV4j9rwEBD1Fr6dC2k3gqgE3NTquyjOOQ_roYFYlp70m6RJUXIIWAcA6Cyq4bVJ4QA1QHla7ecoT8rgTW6-Qw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "Hm2BnKcm5FsA9M-q8NVKREGouJkHeD7-MnV1cVzuZuu4mIM1QqE7kPy-5BwyG39_VVWR1KSVPSFjlvSPRK9rscQLEvcj9D6LYeNN_0zVj5X7Njx4l1anWbaG98QWcdeml5glFcDzsUhvEoqS18yIIVLYCKi4DB-h3FsmySvVSuazp82jDaQUzaFLAOmKYQEU15VDxgR9ufVoVCKpoPtMd6ropphgmG12wAKDykTImqaq_40zPgC2ciKl4adD7lS1csXTd-4tPA6rm0Zkqoloj-Iv8y8iaua0mFCBQmJb5QvGxcPXdZD9xr_f3e7IAelmXLCc_-FAwZcvM536F8EnkQ",
+        "p": "2kjhmHxd9jP-nwPtn6DLCYTYH1uBMWuOuTYsfmDI9h1H6BJlx8n1isxFIguogLprcDdgeVudnPIw9DQNNNgixOybVBbnxxltuvUQxdNItOCDO-cGyowNce7cuN1S4lfVQhjvJ8n0PGl7XWlHknHF25TGAMCkyCmwQjhCz3iQ1Yc",
+        "q": "tmWayq-WyoK02yDJcPhho6QIUe71o3-JzEURanm3rUjBBuWDvUAe3huc5q0UYm_H_fJKwGr72X2sGz69SxT2gxLVqvdW9xWgUZy_Xyq_nWbKbHOlruXj5-jTSqrfZGhnJnr9EBdQr_HyVG937J5jJYBHRNJImeW30kUcDqQBgGU",
+        "dp": "IaWWUKDrAuZk2zIJ0M9CPMdjYQID2hBQQbBeD2Tv1TASQ22CjtdMqAZwqZzObnlN0lBW6J38n5KdhSb42ipuwZgPIVkehQwgY-8elL_Kt0bcM8GaxGHuOJ-vGjfTbNxJHRUm2CVDJoTD5VQzGhm7e-tk0fzf6ZKzfqGZes2E1cU",
+        "dq": "Le4B_54ds5scXb2w3DC_rYxlx_QLiQNZuMV_sDc8SHd0m_75oJNf8oAzj2bwJiWNz-XOawvFpavexfGTiy-ZL8JzaZzlGk0o1MRK8HT8UW-L86lfhF5BeKmJY1kJ7efYabk4tm-YkuWzJw32ve_YeZ4G1E67l31gP6PFf-5Orn0",
+        "qi": "cWL5Bp9V72qKwcMb16MyY8Aqt3Oj3A5yb_oUOzojNc-2FLworU36NQzmBaxL4toZkkRWGtat-vnRgzp_2WDeC19OT3mViSYGqijR2njHG5zmcAbvzOeMJeP6cR5ax8z1UizmwTOnLY_l6jtpbn5tLdeUse1f5JbSDfsOgMWvV6Q"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 52,
+          "comment": "edge case for Montgomery reduction over Z/nZ (32 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "67d3329433843fbf8516d807417f96e34ad7be1f8a8c4d4c1ca614e4255938fa622bdab0733b117506aaf3b39ae5c468894d79fc6aa451d837612df52c73eb18df7e8272de79d8621ec3e0c1e725746fd8f4eacc39a0207f91310c35a12401d1b34cf9a6bfc1c44b8b39ff4725fcbcd95c38fe1461361106e8e11be28e0d3ff81d406963db76c073ce41e4e770f9b59f3c99a8d683c5b415e6237cca91dcc31b8c1a3008",
+          "ct": "13648644122d5be6e56d210076b9bc59deaf16fff664777a2d6348b1e0da0efc4a77fe2bfe2aeb592ee56fb3208ea0e04d2026a433bdd6ff11b89839f058832d732dda51bfcd5cced8fa7cc58a91fd435fe0aac17a6084c7619b9209d83136c19161aeaca90bd5c92d5ad0d2a99efb392f29a2dd06f0c19d204fe997800e4e7df66efb9a2bc19820e8dd3cf48f3e74f17c50316ab323055366430c21b97171ac776b14ae49fb124cd9df5ead69d267659abfa21676e62b3a0e7d3fb1c575e5c116513d1b654d09d637706d94bf3b252086771398b5934e23f7de652a9906a143eb56bb54e739e53fbb21d73a55da793c82768b3ad880d1e732b5ebce5817debe",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "0087a58e0f307fe5cbd1e24b84fe4a504aeb7f6e62e482fbb2ff0662b6289594e369f5bc246bebbede1c06be16df402c60448e99152d6e8ab2eed1b4c2b36c3b7a0d2ba4f446e1e96d901f11e3a2e53acce88ef34ee36e77c6a2200876ef4750173d47c2a925704112233f32446d36d39ff0bfbb1d6369d5e188aacad1f56eca5c6380d40b8f8847a0e3145714618177682b24c29184d6b394c4f822ee3640eab510328914b2f6f4443758381dca079cc4df508f060e53dfb4a89b847fa42df73a6c60cf0b5e819296886e0d00f0823f24381830022bc07a9eb06c78e22c77ec124d95c69b5de527da2376364ea211508dc9f2f43b24ba06dbfb6996b8e488b54d",
+        "privateExponent": "0d6caf1085c642a1d755c40f9773175b32cf5bc761c22cd2dc366f928395ba347f8a1862aa639c7232e7dfec37900c5442b4b225cc674246cf27e5f1d6fc012ee51acaaa7a51655eb882baac82b4990b2a80eb47856eab5ff72fa066d4eb83dba8eeef2efa4b8fc511c3f15fa0476ace4b6f4e3f6c554f1b9101062d9d52a7a8343312b1c7e450a2874b9d7b2d1fb7e782e607832b885191673226137453716063a593faa684f6b9ba5321befade244dd3b980f3af037409e335294b8bd647c8a0be1db253a6a1baab55fcfce963b09e27e63ee1f4010a534d1acd8185abf854051c658fa12d1e4abbb4f6193fac4654461e8bc941d5fbfb12d5bedccf4836c1",
+        "publicExponent": "010001",
+        "prime1": "00bf358cbe3a8fc1381f460a7c6140e99039d11411797e1961dbb0cd53dd921315fd21083a68f0b4bd4f745ae022b8dca801874a6448f7a4b03fc138aac856e658ed5c2b548315067ecd1eb85761432a6baa1176d28e77b90225ce2ba1818099fd265ed8910a56fc822262ff90099dc773f2eb6b522b05a009a5c764422d85f765",
+        "prime2": "00b59c3c235026d77251bba38db70a483fdfbdd6b63bfe2c67c53899fadf8e03e9b5ebdd33dd93bcb2848cf3060e5ba6756f6068f9de56d2363fffee2e7d32e323a0614bfecbea0194f75b511316213ddab70f0f613b707321e4727764b253d6629d5ec4846a937aaefecc415067c3bcdd09fde86f2fe30fde24a8ae9cfea5abc9",
+        "exponent1": "57de5ef84867298f05e825077595e3ff9062418baa3e45a1cfd896f3145e7d80dc5b62b19cea08d4fa7f6907994d44b1bc4a14e8b31382ce2fee36815d217a27a1a47a9112d005b51dc421489e7cc430c7edd0a200308a87af21e8b1069737acbb065915861fe558543f145c77ded6fab4c67502449d082786d4738169f42775",
+        "exponent2": "4ac47089c544c86c1b3419e88d13e19cd25b509b23e5c7984d3cb93fec6b8636e09ba32ce82b1b838f488c00d146702866db153cd18982efacb78bf27dbec67e7357bb36c1f2ac060d33fe13d2878af4916ad4d51de874adde6435bd32218be07b93796a5e8a2af702954aca747dc432681bad66a11b64fbfab1ab799ce8cde9",
+        "coefficient": "03d54926f770f8c6d47358e502526c309b972e70beb1f20658ec0917c1729e05c06476f25f261695694797a963db5cf00fd720fca0dff673e157b0ae5a754b48799b8ec32515069cb5168a9ddd38dc7f065f0df2920be34fb8f0ff4fea403302e4944df1aa5a2198f3ee7bd3df19c27fa70614ef8cf9ceaf240846676c716813"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a2020100028201010087a58e0f307fe5cbd1e24b84fe4a504aeb7f6e62e482fbb2ff0662b6289594e369f5bc246bebbede1c06be16df402c60448e99152d6e8ab2eed1b4c2b36c3b7a0d2ba4f446e1e96d901f11e3a2e53acce88ef34ee36e77c6a2200876ef4750173d47c2a925704112233f32446d36d39ff0bfbb1d6369d5e188aacad1f56eca5c6380d40b8f8847a0e3145714618177682b24c29184d6b394c4f822ee3640eab510328914b2f6f4443758381dca079cc4df508f060e53dfb4a89b847fa42df73a6c60cf0b5e819296886e0d00f0823f24381830022bc07a9eb06c78e22c77ec124d95c69b5de527da2376364ea211508dc9f2f43b24ba06dbfb6996b8e488b54d0203010001028201000d6caf1085c642a1d755c40f9773175b32cf5bc761c22cd2dc366f928395ba347f8a1862aa639c7232e7dfec37900c5442b4b225cc674246cf27e5f1d6fc012ee51acaaa7a51655eb882baac82b4990b2a80eb47856eab5ff72fa066d4eb83dba8eeef2efa4b8fc511c3f15fa0476ace4b6f4e3f6c554f1b9101062d9d52a7a8343312b1c7e450a2874b9d7b2d1fb7e782e607832b885191673226137453716063a593faa684f6b9ba5321befade244dd3b980f3af037409e335294b8bd647c8a0be1db253a6a1baab55fcfce963b09e27e63ee1f4010a534d1acd8185abf854051c658fa12d1e4abbb4f6193fac4654461e8bc941d5fbfb12d5bedccf4836c102818100bf358cbe3a8fc1381f460a7c6140e99039d11411797e1961dbb0cd53dd921315fd21083a68f0b4bd4f745ae022b8dca801874a6448f7a4b03fc138aac856e658ed5c2b548315067ecd1eb85761432a6baa1176d28e77b90225ce2ba1818099fd265ed8910a56fc822262ff90099dc773f2eb6b522b05a009a5c764422d85f76502818100b59c3c235026d77251bba38db70a483fdfbdd6b63bfe2c67c53899fadf8e03e9b5ebdd33dd93bcb2848cf3060e5ba6756f6068f9de56d2363fffee2e7d32e323a0614bfecbea0194f75b511316213ddab70f0f613b707321e4727764b253d6629d5ec4846a937aaefecc415067c3bcdd09fde86f2fe30fde24a8ae9cfea5abc902818057de5ef84867298f05e825077595e3ff9062418baa3e45a1cfd896f3145e7d80dc5b62b19cea08d4fa7f6907994d44b1bc4a14e8b31382ce2fee36815d217a27a1a47a9112d005b51dc421489e7cc430c7edd0a200308a87af21e8b1069737acbb065915861fe558543f145c77ded6fab4c67502449d082786d4738169f427750281804ac47089c544c86c1b3419e88d13e19cd25b509b23e5c7984d3cb93fec6b8636e09ba32ce82b1b838f488c00d146702866db153cd18982efacb78bf27dbec67e7357bb36c1f2ac060d33fe13d2878af4916ad4d51de874adde6435bd32218be07b93796a5e8a2af702954aca747dc432681bad66a11b64fbfab1ab799ce8cde902818003d54926f770f8c6d47358e502526c309b972e70beb1f20658ec0917c1729e05c06476f25f261695694797a963db5cf00fd720fca0dff673e157b0ae5a754b48799b8ec32515069cb5168a9ddd38dc7f065f0df2920be34fb8f0ff4fea403302e4944df1aa5a2198f3ee7bd3df19c27fa70614ef8cf9ceaf240846676c716813",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCHpY4PMH/ly9Hi\nS4T+SlBK639uYuSC+7L/BmK2KJWU42n1vCRr677eHAa+Ft9ALGBEjpkVLW6Ksu7R\ntMKzbDt6DSuk9Ebh6W2QHxHjouU6zOiO807jbnfGoiAIdu9HUBc9R8KpJXBBEiM/\nMkRtNtOf8L+7HWNp1eGIqsrR9W7KXGOA1AuPiEeg4xRXFGGBd2grJMKRhNazlMT4\nIu42QOq1EDKJFLL29EQ3WDgdygecxN9QjwYOU9+0qJuEf6Qt9zpsYM8LXoGSlohu\nDQDwgj8kOBgwAivAep6wbHjiLHfsEk2Vxptd5SfaI3Y2TqIRUI3J8vQ7JLoG2/tp\nlrjkiLVNAgMBAAECggEADWyvEIXGQqHXVcQPl3MXWzLPW8dhwizS3DZvkoOVujR/\nihhiqmOccjLn3+w3kAxUQrSyJcxnQkbPJ+Xx1vwBLuUayqp6UWVeuIK6rIK0mQsq\ngOtHhW6rX/cvoGbU64PbqO7vLvpLj8URw/FfoEdqzktvTj9sVU8bkQEGLZ1Sp6g0\nMxKxx+RQoodLnXstH7fnguYHgyuIUZFnMiYTdFNxYGOlk/qmhPa5ulMhvvreJE3T\nuYDzrwN0CeM1KUuL1kfIoL4dslOmobqrVfz86WOwnifmPuH0AQpTTRrNgYWr+FQF\nHGWPoS0eSru09hk/rEZURh6LyUHV+/sS1b7cz0g2wQKBgQC/NYy+Oo/BOB9GCnxh\nQOmQOdEUEXl+GWHbsM1T3ZITFf0hCDpo8LS9T3Ra4CK43KgBh0pkSPeksD/BOKrI\nVuZY7VwrVIMVBn7NHrhXYUMqa6oRdtKOd7kCJc4roYGAmf0mXtiRClb8giJi/5AJ\nncdz8utrUisFoAmlx2RCLYX3ZQKBgQC1nDwjUCbXclG7o423Ckg/373Wtjv+LGfF\nOJn6344D6bXr3TPdk7yyhIzzBg5bpnVvYGj53lbSNj//7i59MuMjoGFL/svqAZT3\nW1ETFiE92rcPD2E7cHMh5HJ3ZLJT1mKdXsSEapN6rv7MQVBnw7zdCf3oby/jD94k\nqK6c/qWryQKBgFfeXvhIZymPBeglB3WV4/+QYkGLqj5Foc/YlvMUXn2A3FtisZzq\nCNT6f2kHmU1EsbxKFOizE4LOL+42gV0heiehpHqREtAFtR3EIUiefMQwx+3QogAw\nioevIeixBpc3rLsGWRWGH+VYVD8UXHfe1vq0xnUCRJ0IJ4bUc4Fp9Cd1AoGASsRw\nicVEyGwbNBnojRPhnNJbUJsj5ceYTTy5P+xrhjbgm6Ms6Csbg49IjADRRnAoZtsV\nPNGJgu+st4vyfb7GfnNXuzbB8qwGDTP+E9KHivSRatTVHeh0rd5kNb0yIYvge5N5\nal6KKvcClUrKdH3EMmgbrWahG2T7+rGreZzozekCgYAD1Ukm93D4xtRzWOUCUmww\nm5cucL6x8gZY7AkXwXKeBcBkdvJfJhaVaUeXqWPbXPAP1yD8oN/2c+FXsK5adUtI\neZuOwyUVBpy1Foqd3TjcfwZfDfKSC+NPuPD/T+pAMwLklE3xqlohmPPue9PfGcJ/\npwYU74z5zq8kCEZnbHFoEw==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "h6WODzB_5cvR4kuE_kpQSut_bmLkgvuy_wZitiiVlONp9bwka-u-3hwGvhbfQCxgRI6ZFS1uirLu0bTCs2w7eg0rpPRG4eltkB8R46LlOszojvNO4253xqIgCHbvR1AXPUfCqSVwQRIjPzJEbTbTn_C_ux1jadXhiKrK0fVuylxjgNQLj4hHoOMUVxRhgXdoKyTCkYTWs5TE-CLuNkDqtRAyiRSy9vREN1g4HcoHnMTfUI8GDlPftKibhH-kLfc6bGDPC16BkpaIbg0A8II_JDgYMAIrwHqesGx44ix37BJNlcabXeUn2iN2Nk6iEVCNyfL0OyS6Btv7aZa45Ii1TQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "DWyvEIXGQqHXVcQPl3MXWzLPW8dhwizS3DZvkoOVujR_ihhiqmOccjLn3-w3kAxUQrSyJcxnQkbPJ-Xx1vwBLuUayqp6UWVeuIK6rIK0mQsqgOtHhW6rX_cvoGbU64PbqO7vLvpLj8URw_FfoEdqzktvTj9sVU8bkQEGLZ1Sp6g0MxKxx-RQoodLnXstH7fnguYHgyuIUZFnMiYTdFNxYGOlk_qmhPa5ulMhvvreJE3TuYDzrwN0CeM1KUuL1kfIoL4dslOmobqrVfz86WOwnifmPuH0AQpTTRrNgYWr-FQFHGWPoS0eSru09hk_rEZURh6LyUHV-_sS1b7cz0g2wQ",
+        "p": "vzWMvjqPwTgfRgp8YUDpkDnRFBF5fhlh27DNU92SExX9IQg6aPC0vU90WuAiuNyoAYdKZEj3pLA_wTiqyFbmWO1cK1SDFQZ-zR64V2FDKmuqEXbSjne5AiXOK6GBgJn9Jl7YkQpW_IIiYv-QCZ3Hc_Lra1IrBaAJpcdkQi2F92U",
+        "q": "tZw8I1Am13JRu6ONtwpIP9-91rY7_ixnxTiZ-t-OA-m1690z3ZO8soSM8wYOW6Z1b2Bo-d5W0jY__-4ufTLjI6BhS_7L6gGU91tRExYhPdq3Dw9hO3BzIeRyd2SyU9ZinV7EhGqTeq7-zEFQZ8O83Qn96G8v4w_eJKiunP6lq8k",
+        "dp": "V95e-EhnKY8F6CUHdZXj_5BiQYuqPkWhz9iW8xRefYDcW2KxnOoI1Pp_aQeZTUSxvEoU6LMTgs4v7jaBXSF6J6GkepES0AW1HcQhSJ58xDDH7dCiADCKh68h6LEGlzesuwZZFYYf5VhUPxRcd97W-rTGdQJEnQgnhtRzgWn0J3U",
+        "dq": "SsRwicVEyGwbNBnojRPhnNJbUJsj5ceYTTy5P-xrhjbgm6Ms6Csbg49IjADRRnAoZtsVPNGJgu-st4vyfb7GfnNXuzbB8qwGDTP-E9KHivSRatTVHeh0rd5kNb0yIYvge5N5al6KKvcClUrKdH3EMmgbrWahG2T7-rGreZzozek",
+        "qi": "A9VJJvdw-MbUc1jlAlJsMJuXLnC-sfIGWOwJF8FyngXAZHbyXyYWlWlHl6lj21zwD9cg_KDf9nPhV7CuWnVLSHmbjsMlFQactRaKnd043H8GXw3ykgvjT7jw_0_qQDMC5JRN8apaIZjz7nvT3xnCf6cGFO-M-c6vJAhGZ2xxaBM"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 53,
+          "comment": "edge case for Montgomery reduction over Z/nZ (32 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "5d72b875a66301022bc2cb5128ec54abf1ca18e0b5b73c3fd566890796eb7172a45abcc4d806d69ae9d85ff45b717f922c",
+          "ct": "181f37c923f2f1ddc6ad1de954439dabd8915ae9a3afd379ee5ffbebf877ecc26f83df5e945b0832d267fae35bbad4772c9f50be51490ddb7e61083da7b3b007a89e0fb996fca9de05c1d071d29fcfec33e8814ebada7fd8bf8f4c8fb92ad020923342a0232a2e7416d2d6343ff9c5a562faaac8a49aca35a3e2cbf3f6c04efd56f524e9afe4dc96a72c146b452307c9360c0187147ea2fcc2bd7a8fdfe05282944530482e678bcd506ac491b34da46fbb15ad573929c257dd190e1a84a5d26c30e8ae8501597883292f56cc0863a0186731d88ade418c87fb977cbf224b259fbd5ea2521ffb33c845f2b591bcc68294e0882c1742dcb4d5f23eb7d89ab28570",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00c89ec880ede20b8666ee0fdd856abc5316d77a5d6e5b1637dafafc3cb0458681d6169215d53f4dd1087345d1597795420b0332115b974b83390dcbb444b33d52581374c58ae567c5fa2e4df2d2ae03134fcd62765f1ce9283a842acee79543a92fa1a49190db4d2618a82efdd036b87764851eea113db934e2afd538e6af050d232910903c1389ce620004556ae5e3830168ef791ff39a0ed0ef09347f3536edd89afb9caf98c31f36c2e6111c534cd5611b99b8db1ec4aabaae878a5406153ac91836285f028990573d0de94a527d2a077f1689c208b31e6f17a8a9448aaf2e7e3c68c96eb685b8e7adc92d0621cc0049c8e3cd5c1d3fc2ef631e714f4523c5",
+        "privateExponent": "3020531606badeabe7be3d25156fd4ec93c2ae32829a2c3acaf7c191a7718e425042cad99cf5da2b867ceca73b70a1e81d6f2f5015aa362dacfe9fbac76e3e0c265fc877e9097e3af278b02f4b95fddbe09d72fcd57540836b823028c14a3fd872ba3299cee7a4daba38824955ed029475932fa6d3eafc267128e01c0dceb78591b7f4093d6a7f27f3d1f7830417bbff7b8820538d67236734735a81a776c0c144a8135c2c561b075b307abb14be767128455b28efed3f382dde259ffbfdec750bf0463a150dd4cb3afed605de5ba34765b2e9b9f6db4e5c8a7be625213aa91d986697eaa7cab1daeb3abfdab88f0847a0b68c78ba8197c8e2cd8e1901db7a63",
+        "publicExponent": "010001",
+        "prime1": "00f4ba7494ef91c4f85bf016c98142f27f9fa129cdfd9045a3f723ed4394f4aeab1b6388b01bbe87f68f01e78c53cdff2bb60ef7830a7115961f9ac798c4587c5b83d9cb0549852fa27fb0522004aa5eaeadf5efc39eecb9b47f5f4d5bc1ca6efcd2ac9f02499dbd5614251869c9575a6039facbcdab5d42880cfe5def805a5637",
+        "prime2": "00d1dc41ff09641115835f68fbbedd2d7c817b80bacb960808cb5744fdd1f56df4580eed655b51eaa134c566725be6bfa0e98facfa18208d9204f471eb5d0dee477c74aa00675f4f9261a1d6297c158034cf6e4f3743d39101c617af97efac9d8f1eda7bb81ebb802ef6521d7cd44dd45107bbd6463b0a387a463a6ed6241257e3",
+        "exponent1": "455539c82423312187b27a52364bc835fdfc83c2772ed37c037d6b2fb558a8cf931fdccebfdd77d993645fbc32d5ee8fecb14ad0163a397a6193d12e679a06094b4e7da50ed22bcfa6cb464909e9568fb87b2fa545361dda942764dc3507ebefb6a3ef1c8fcc9fa26e6ca0010068be12fafa2199300e68d5f09073fe7167a67b",
+        "exponent2": "576590028349ae27b46f5e8c40df619b115d7aadd02d2a29676d6fa8f8f06a1b3134fe3e90ba5ba9490dd06d5dc28a199c4b1e7184ecc1a886f1ba2397bc3e787ce7250948039462d4d00e1d76b48990f4b5eebd883caa8dff8e4bad4dbe285bbb30a807749d07740757093abc3bb169117c736f0a156691dd7f663b3e08799b",
+        "coefficient": "5022f0cf40913a38e06e7d73916760b21a84289e44b40b66cf615a155f3f42dba2dc36dcaed85f932fd2e48799a9e800468f6693e5da05fc63fadbcf5d1a1a102987c44b7ca35e934456327ec4cafd116371e6318b7560e2b89418d708440e9b3609bbf6b5dc0083fcc7ad301524f14a6ec1d6a20319ca958dc45a7185fe660c"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100c89ec880ede20b8666ee0fdd856abc5316d77a5d6e5b1637dafafc3cb0458681d6169215d53f4dd1087345d1597795420b0332115b974b83390dcbb444b33d52581374c58ae567c5fa2e4df2d2ae03134fcd62765f1ce9283a842acee79543a92fa1a49190db4d2618a82efdd036b87764851eea113db934e2afd538e6af050d232910903c1389ce620004556ae5e3830168ef791ff39a0ed0ef09347f3536edd89afb9caf98c31f36c2e6111c534cd5611b99b8db1ec4aabaae878a5406153ac91836285f028990573d0de94a527d2a077f1689c208b31e6f17a8a9448aaf2e7e3c68c96eb685b8e7adc92d0621cc0049c8e3cd5c1d3fc2ef631e714f4523c50203010001028201003020531606badeabe7be3d25156fd4ec93c2ae32829a2c3acaf7c191a7718e425042cad99cf5da2b867ceca73b70a1e81d6f2f5015aa362dacfe9fbac76e3e0c265fc877e9097e3af278b02f4b95fddbe09d72fcd57540836b823028c14a3fd872ba3299cee7a4daba38824955ed029475932fa6d3eafc267128e01c0dceb78591b7f4093d6a7f27f3d1f7830417bbff7b8820538d67236734735a81a776c0c144a8135c2c561b075b307abb14be767128455b28efed3f382dde259ffbfdec750bf0463a150dd4cb3afed605de5ba34765b2e9b9f6db4e5c8a7be625213aa91d986697eaa7cab1daeb3abfdab88f0847a0b68c78ba8197c8e2cd8e1901db7a6302818100f4ba7494ef91c4f85bf016c98142f27f9fa129cdfd9045a3f723ed4394f4aeab1b6388b01bbe87f68f01e78c53cdff2bb60ef7830a7115961f9ac798c4587c5b83d9cb0549852fa27fb0522004aa5eaeadf5efc39eecb9b47f5f4d5bc1ca6efcd2ac9f02499dbd5614251869c9575a6039facbcdab5d42880cfe5def805a563702818100d1dc41ff09641115835f68fbbedd2d7c817b80bacb960808cb5744fdd1f56df4580eed655b51eaa134c566725be6bfa0e98facfa18208d9204f471eb5d0dee477c74aa00675f4f9261a1d6297c158034cf6e4f3743d39101c617af97efac9d8f1eda7bb81ebb802ef6521d7cd44dd45107bbd6463b0a387a463a6ed6241257e3028180455539c82423312187b27a52364bc835fdfc83c2772ed37c037d6b2fb558a8cf931fdccebfdd77d993645fbc32d5ee8fecb14ad0163a397a6193d12e679a06094b4e7da50ed22bcfa6cb464909e9568fb87b2fa545361dda942764dc3507ebefb6a3ef1c8fcc9fa26e6ca0010068be12fafa2199300e68d5f09073fe7167a67b028180576590028349ae27b46f5e8c40df619b115d7aadd02d2a29676d6fa8f8f06a1b3134fe3e90ba5ba9490dd06d5dc28a199c4b1e7184ecc1a886f1ba2397bc3e787ce7250948039462d4d00e1d76b48990f4b5eebd883caa8dff8e4bad4dbe285bbb30a807749d07740757093abc3bb169117c736f0a156691dd7f663b3e08799b0281805022f0cf40913a38e06e7d73916760b21a84289e44b40b66cf615a155f3f42dba2dc36dcaed85f932fd2e48799a9e800468f6693e5da05fc63fadbcf5d1a1a102987c44b7ca35e934456327ec4cafd116371e6318b7560e2b89418d708440e9b3609bbf6b5dc0083fcc7ad301524f14a6ec1d6a20319ca958dc45a7185fe660c",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDInsiA7eILhmbu\nD92FarxTFtd6XW5bFjfa+vw8sEWGgdYWkhXVP03RCHNF0Vl3lUILAzIRW5dLgzkN\ny7REsz1SWBN0xYrlZ8X6Lk3y0q4DE0/NYnZfHOkoOoQqzueVQ6kvoaSRkNtNJhio\nLv3QNrh3ZIUe6hE9uTTir9U45q8FDSMpEJA8E4nOYgAEVWrl44MBaO95H/OaDtDv\nCTR/NTbt2Jr7nK+Ywx82wuYRHFNM1WEbmbjbHsSquq6HilQGFTrJGDYoXwKJkFc9\nDelKUn0qB38WicIIsx5vF6ipRIqvLn48aMlutoW4563JLQYhzABJyOPNXB0/wu9j\nHnFPRSPFAgMBAAECggEAMCBTFga63qvnvj0lFW/U7JPCrjKCmiw6yvfBkadxjkJQ\nQsrZnPXaK4Z87Kc7cKHoHW8vUBWqNi2s/p+6x24+DCZfyHfpCX468niwL0uV/dvg\nnXL81XVAg2uCMCjBSj/Ycroymc7npNq6OIJJVe0ClHWTL6bT6vwmcSjgHA3Ot4WR\nt/QJPWp/J/PR94MEF7v/e4ggU41nI2c0c1qBp3bAwUSoE1wsVhsHWzB6uxS+dnEo\nRVso7+0/OC3eJZ/7/ex1C/BGOhUN1Ms6/tYF3lujR2Wy6bn2205cinvmJSE6qR2Y\nZpfqp8qx2us6v9q4jwhHoLaMeLqBl8jizY4ZAdt6YwKBgQD0unSU75HE+FvwFsmB\nQvJ/n6Epzf2QRaP3I+1DlPSuqxtjiLAbvof2jwHnjFPN/yu2DveDCnEVlh+ax5jE\nWHxbg9nLBUmFL6J/sFIgBKperq3178Oe7Lm0f19NW8HKbvzSrJ8CSZ29VhQlGGnJ\nV1pgOfrLzatdQogM/l3vgFpWNwKBgQDR3EH/CWQRFYNfaPu+3S18gXuAusuWCAjL\nV0T90fVt9FgO7WVbUeqhNMVmclvmv6Dpj6z6GCCNkgT0cetdDe5HfHSqAGdfT5Jh\nodYpfBWANM9uTzdD05EBxhevl++snY8e2nu4HruALvZSHXzUTdRRB7vWRjsKOHpG\nOm7WJBJX4wKBgEVVOcgkIzEhh7J6UjZLyDX9/IPCdy7TfAN9ay+1WKjPkx/czr/d\nd9mTZF+8MtXuj+yxStAWOjl6YZPRLmeaBglLTn2lDtIrz6bLRkkJ6VaPuHsvpUU2\nHdqUJ2TcNQfr77aj7xyPzJ+ibmygAQBovhL6+iGZMA5o1fCQc/5xZ6Z7AoGAV2WQ\nAoNJrie0b16MQN9hmxFdeq3QLSopZ21vqPjwahsxNP4+kLpbqUkN0G1dwooZnEse\ncYTswaiG8bojl7w+eHznJQlIA5Ri1NAOHXa0iZD0te69iDyqjf+OS61NvihbuzCo\nB3SdB3QHVwk6vDuxaRF8c28KFWaR3X9mOz4IeZsCgYBQIvDPQJE6OOBufXORZ2Cy\nGoQonkS0C2bPYVoVXz9C26LcNtyu2F+TL9Lkh5mp6ABGj2aT5doF/GP6289dGhoQ\nKYfES3yjXpNEVjJ+xMr9EWNx5jGLdWDiuJQY1whEDps2Cbv2tdwAg/zHrTAVJPFK\nbsHWogMZypWNxFpxhf5mDA==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "yJ7IgO3iC4Zm7g_dhWq8UxbXel1uWxY32vr8PLBFhoHWFpIV1T9N0QhzRdFZd5VCCwMyEVuXS4M5Dcu0RLM9UlgTdMWK5WfF-i5N8tKuAxNPzWJ2XxzpKDqEKs7nlUOpL6GkkZDbTSYYqC790Da4d2SFHuoRPbk04q_VOOavBQ0jKRCQPBOJzmIABFVq5eODAWjveR_zmg7Q7wk0fzU27dia-5yvmMMfNsLmERxTTNVhG5m42x7Eqrquh4pUBhU6yRg2KF8CiZBXPQ3pSlJ9Kgd_FonCCLMebxeoqUSKry5-PGjJbraFuOetyS0GIcwAScjjzVwdP8LvYx5xT0UjxQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "MCBTFga63qvnvj0lFW_U7JPCrjKCmiw6yvfBkadxjkJQQsrZnPXaK4Z87Kc7cKHoHW8vUBWqNi2s_p-6x24-DCZfyHfpCX468niwL0uV_dvgnXL81XVAg2uCMCjBSj_Ycroymc7npNq6OIJJVe0ClHWTL6bT6vwmcSjgHA3Ot4WRt_QJPWp_J_PR94MEF7v_e4ggU41nI2c0c1qBp3bAwUSoE1wsVhsHWzB6uxS-dnEoRVso7-0_OC3eJZ_7_ex1C_BGOhUN1Ms6_tYF3lujR2Wy6bn2205cinvmJSE6qR2YZpfqp8qx2us6v9q4jwhHoLaMeLqBl8jizY4ZAdt6Yw",
+        "p": "9Lp0lO-RxPhb8BbJgULyf5-hKc39kEWj9yPtQ5T0rqsbY4iwG76H9o8B54xTzf8rtg73gwpxFZYfmseYxFh8W4PZywVJhS-if7BSIASqXq6t9e_Dnuy5tH9fTVvBym780qyfAkmdvVYUJRhpyVdaYDn6y82rXUKIDP5d74BaVjc",
+        "q": "0dxB_wlkERWDX2j7vt0tfIF7gLrLlggIy1dE_dH1bfRYDu1lW1HqoTTFZnJb5r-g6Y-s-hggjZIE9HHrXQ3uR3x0qgBnX0-SYaHWKXwVgDTPbk83Q9ORAcYXr5fvrJ2PHtp7uB67gC72Uh181E3UUQe71kY7Cjh6Rjpu1iQSV-M",
+        "dp": "RVU5yCQjMSGHsnpSNkvINf38g8J3LtN8A31rL7VYqM-TH9zOv9132ZNkX7wy1e6P7LFK0BY6OXphk9EuZ5oGCUtOfaUO0ivPpstGSQnpVo-4ey-lRTYd2pQnZNw1B-vvtqPvHI_Mn6JubKABAGi-Evr6IZkwDmjV8JBz_nFnpns",
+        "dq": "V2WQAoNJrie0b16MQN9hmxFdeq3QLSopZ21vqPjwahsxNP4-kLpbqUkN0G1dwooZnEsecYTswaiG8bojl7w-eHznJQlIA5Ri1NAOHXa0iZD0te69iDyqjf-OS61NvihbuzCoB3SdB3QHVwk6vDuxaRF8c28KFWaR3X9mOz4IeZs",
+        "qi": "UCLwz0CROjjgbn1zkWdgshqEKJ5EtAtmz2FaFV8_Qtui3Dbcrthfky_S5IeZqegARo9mk-XaBfxj-tvPXRoaECmHxEt8o16TRFYyfsTK_RFjceYxi3Vg4riUGNcIRA6bNgm79rXcAIP8x60wFSTxSm7B1qIDGcqVjcRacYX-Zgw"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 54,
+          "comment": "edge case for Montgomery reduction over Z/nZ (64 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "7259cfb45f3651d59b996115be31006e82243cb1317d23418d64a047b984f4f8345ea0b8b193b532c2769b8fa0d4aba9642446eed61b037b87f045f2992738640f3fe81236d5dc36a384d0d408c4b3273a6dad21526815c29955224ea85d3ea7e77e45738dd27411c57f7b33878dd5472cb9f19fee68fd8daf7e40e6e210135d02f1bc5a6660c23418b6499cb1749336c7074df3452a88fdb723f591a70781",
+          "ct": "b3b6ce381b69a43046647e000c1ab2bb9456c7022dd1ea19a2761d85963e56f7337d04529bc975c34880552ca51497ced06bdbd8c54bf4ba83540185273b55c81b86c0a337df5fe8ebb4b43db0ac105a78f8de8240c2b3a0fb7b8f7e7fc8a70a462618387edb8a77195f8a43ba2ef1ad3f1216598cf1b4f02f2bcdd2fbe9885cdeb74754ffba96d978e68045b1754e35ba8c54183106fb2c9f5685adb5f14d239e8c8e19b39c142b0f01e3934ae1b7315b0db5986c7d9b39bbe960faa32337342b3d02ca5148f308fcaa718001e39d0c0bfcedf9e91e2d12919bcd739c431e37ddd20abf4a35644246da2951983f1d6fa32ac259f222501c4c8640b43279bb03",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00aab3022dc93a3b87213fe5e4b3fe4b27dae14af117f1ca900681c28fd3eca157df46d43a6eb0f167426b6819fd8b4bd52ba94c6fb307b16851ac071a99839325ca5917201fd71268c6ee28312d5f770dff62a497ff7c97a6ca841b1908730c5080280e3678d2859b89728716d3bbd84eb531f7b0281e1654a93165ff5911d689a238b339ac3737673ed050cbfc08b4f64f76b0596612c9883ed21f1e43bf8600466c7683ae3039044c3162b8919389108b2d51760e366dc257559b9d63bde45a2b541be9f24993b209acff5b3a24217fd337449d69075e1bec7a65ed4faef02fdc33af4df506720177c134cbc486803d5c20c3d9688985707aa5b8007882f731",
+        "privateExponent": "1cc7cb47807cd8c20f1d58abcf9c41bc31c7980cdfca64ea952a462d5d603190e104ae6e3eb10736af886ff827db5759150039b2c096fcb6b7c47f3b212481c8169ea04b4a8b06dfd3209ef6b1ad7da386ca71316e82698855ef61a93e1735bd91ea0f0168ac281a4219a504b884dcb2e2928eee2cc96bdef0daf3155345726c21950c6fcaf576a48029c160d6c02b20a4fd7390691dc82628b71ff63bdd0f3ed59603bbaf2074b08f22587e9890dc3dd098a89ab3b6a3b9345b33d23fa71670c0ae4e4048de859d0368efb0722fc5b7d18aa6c438ff41690fb90c6ea792778ded86d668a82a06bf8d48f1273bb448b3a304083c76082f2220c0857dbe7d3ec5",
+        "publicExponent": "010001",
+        "prime1": "00f099d87fed03d2501dca1b17868c7f8e51ea523e7d2aeca56410b90d73eb1cc359511ba4a315ace0953a46099f6d78ce9389f8fa6381fee687fbd644d5bcff65ab10e0acf8bcc5d37b5c3c810cfc3bd2916ed1d766b583ef787a4314d6237d177e872e9cfb0d23f7671121906586427a79cdc14d551604a224cd63bb2d0226f5",
+        "prime2": "00b59fd9a569e3f497eb16d1fb6b5ad688326a53abd0b83f1e9e8efe2336131cd3a7ab94618eb4ba8282abf0cf78e7f2ec4a4d4a1958a5cad8436f915bb1cebbcd0993e2ea01f2743566822136546ba2fc5a239579e6ec94dd7ce677de0482500ce0e70b366c10e15857d63190f7e7375ceabaf56c3542ed7f39a9df2f713591cd",
+        "exponent1": "4ada421dc27a2ee317f179ae3f00d4ea4d17ce507c966f1b215f8682e5ee5e7b73fd24d17a9f52b2681ac2115a552f816d2b3e977f7fc0f2ad99aed6a97c6c24902ce709493549827add7e4153ede11aa87e46b071d6c4de2aa836d873aa84cf5b60e92293844a0d3d367a2fb73626d67db08293f185b11954c3c56445236745",
+        "exponent2": "00b3596246e1c5e4a68fd33d0f94f76299a38f33889ad7161d5a5dc1bf6b8a7c10d5a5ad249913068a12174ff8d05fdb9651d8f8af06c6d103b5b3da4a3dcef3cc8904ac328031b767740e54559e0f9c26adac2dd2eea1f86eaf03b6a25ab983eaf3bbb36ace53ecf29bea3b8ff7fd2ec26658b039666eecaf9175999af3a3fe91",
+        "coefficient": "00b9091513c6a91a0370ae26d3ebe4cb5410d27d4086213e1030dce0e7e3f435fba1f22b71f02649b425cccd634d35a3d49baac96f9785ae39a21d8cd88a26aa553012e8439947dc3dbb4d0215b9ac24afc9a3baff7a702674013f2000640db63106fd400cd3e230b98999af9e7f6a0d03d5fee0b9c9e2e422eff3968a1cd07ae0"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100aab3022dc93a3b87213fe5e4b3fe4b27dae14af117f1ca900681c28fd3eca157df46d43a6eb0f167426b6819fd8b4bd52ba94c6fb307b16851ac071a99839325ca5917201fd71268c6ee28312d5f770dff62a497ff7c97a6ca841b1908730c5080280e3678d2859b89728716d3bbd84eb531f7b0281e1654a93165ff5911d689a238b339ac3737673ed050cbfc08b4f64f76b0596612c9883ed21f1e43bf8600466c7683ae3039044c3162b8919389108b2d51760e366dc257559b9d63bde45a2b541be9f24993b209acff5b3a24217fd337449d69075e1bec7a65ed4faef02fdc33af4df506720177c134cbc486803d5c20c3d9688985707aa5b8007882f7310203010001028201001cc7cb47807cd8c20f1d58abcf9c41bc31c7980cdfca64ea952a462d5d603190e104ae6e3eb10736af886ff827db5759150039b2c096fcb6b7c47f3b212481c8169ea04b4a8b06dfd3209ef6b1ad7da386ca71316e82698855ef61a93e1735bd91ea0f0168ac281a4219a504b884dcb2e2928eee2cc96bdef0daf3155345726c21950c6fcaf576a48029c160d6c02b20a4fd7390691dc82628b71ff63bdd0f3ed59603bbaf2074b08f22587e9890dc3dd098a89ab3b6a3b9345b33d23fa71670c0ae4e4048de859d0368efb0722fc5b7d18aa6c438ff41690fb90c6ea792778ded86d668a82a06bf8d48f1273bb448b3a304083c76082f2220c0857dbe7d3ec502818100f099d87fed03d2501dca1b17868c7f8e51ea523e7d2aeca56410b90d73eb1cc359511ba4a315ace0953a46099f6d78ce9389f8fa6381fee687fbd644d5bcff65ab10e0acf8bcc5d37b5c3c810cfc3bd2916ed1d766b583ef787a4314d6237d177e872e9cfb0d23f7671121906586427a79cdc14d551604a224cd63bb2d0226f502818100b59fd9a569e3f497eb16d1fb6b5ad688326a53abd0b83f1e9e8efe2336131cd3a7ab94618eb4ba8282abf0cf78e7f2ec4a4d4a1958a5cad8436f915bb1cebbcd0993e2ea01f2743566822136546ba2fc5a239579e6ec94dd7ce677de0482500ce0e70b366c10e15857d63190f7e7375ceabaf56c3542ed7f39a9df2f713591cd0281804ada421dc27a2ee317f179ae3f00d4ea4d17ce507c966f1b215f8682e5ee5e7b73fd24d17a9f52b2681ac2115a552f816d2b3e977f7fc0f2ad99aed6a97c6c24902ce709493549827add7e4153ede11aa87e46b071d6c4de2aa836d873aa84cf5b60e92293844a0d3d367a2fb73626d67db08293f185b11954c3c5644523674502818100b3596246e1c5e4a68fd33d0f94f76299a38f33889ad7161d5a5dc1bf6b8a7c10d5a5ad249913068a12174ff8d05fdb9651d8f8af06c6d103b5b3da4a3dcef3cc8904ac328031b767740e54559e0f9c26adac2dd2eea1f86eaf03b6a25ab983eaf3bbb36ace53ecf29bea3b8ff7fd2ec26658b039666eecaf9175999af3a3fe9102818100b9091513c6a91a0370ae26d3ebe4cb5410d27d4086213e1030dce0e7e3f435fba1f22b71f02649b425cccd634d35a3d49baac96f9785ae39a21d8cd88a26aa553012e8439947dc3dbb4d0215b9ac24afc9a3baff7a702674013f2000640db63106fd400cd3e230b98999af9e7f6a0d03d5fee0b9c9e2e422eff3968a1cd07ae0",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCqswItyTo7hyE/\n5eSz/ksn2uFK8RfxypAGgcKP0+yhV99G1DpusPFnQmtoGf2LS9UrqUxvswexaFGs\nBxqZg5MlylkXIB/XEmjG7igxLV93Df9ipJf/fJemyoQbGQhzDFCAKA42eNKFm4ly\nhxbTu9hOtTH3sCgeFlSpMWX/WRHWiaI4szmsNzdnPtBQy/wItPZPdrBZZhLJiD7S\nHx5Dv4YARmx2g64wOQRMMWK4kZOJEIstUXYONm3CV1WbnWO95ForVBvp8kmTsgms\n/1s6JCF/0zdEnWkHXhvsemXtT67wL9wzr031BnIBd8E0y8SGgD1cIMPZaImFcHql\nuAB4gvcxAgMBAAECggEAHMfLR4B82MIPHVirz5xBvDHHmAzfymTqlSpGLV1gMZDh\nBK5uPrEHNq+Ib/gn21dZFQA5ssCW/La3xH87ISSByBaeoEtKiwbf0yCe9rGtfaOG\nynExboJpiFXvYak+FzW9keoPAWisKBpCGaUEuITcsuKSju4syWve8NrzFVNFcmwh\nlQxvyvV2pIApwWDWwCsgpP1zkGkdyCYotx/2O90PPtWWA7uvIHSwjyJYfpiQ3D3Q\nmKias7ajuTRbM9I/pxZwwK5OQEjehZ0DaO+wci/Ft9GKpsQ4/0FpD7kMbqeSd43t\nhtZoqCoGv41I8Sc7tEizowQIPHYILyIgwIV9vn0+xQKBgQDwmdh/7QPSUB3KGxeG\njH+OUepSPn0q7KVkELkNc+scw1lRG6SjFazglTpGCZ9teM6Tifj6Y4H+5of71kTV\nvP9lqxDgrPi8xdN7XDyBDPw70pFu0ddmtYPveHpDFNYjfRd+hy6c+w0j92cRIZBl\nhkJ6ec3BTVUWBKIkzWO7LQIm9QKBgQC1n9mlaeP0l+sW0ftrWtaIMmpTq9C4Px6e\njv4jNhMc06erlGGOtLqCgqvwz3jn8uxKTUoZWKXK2ENvkVuxzrvNCZPi6gHydDVm\ngiE2VGui/FojlXnm7JTdfOZ33gSCUAzg5ws2bBDhWFfWMZD35zdc6rr1bDVC7X85\nqd8vcTWRzQKBgEraQh3Cei7jF/F5rj8A1OpNF85QfJZvGyFfhoLl7l57c/0k0Xqf\nUrJoGsIRWlUvgW0rPpd/f8DyrZmu1ql8bCSQLOcJSTVJgnrdfkFT7eEaqH5GsHHW\nxN4qqDbYc6qEz1tg6SKThEoNPTZ6L7c2JtZ9sIKT8YWxGVTDxWRFI2dFAoGBALNZ\nYkbhxeSmj9M9D5T3YpmjjzOImtcWHVpdwb9rinwQ1aWtJJkTBooSF0/40F/bllHY\n+K8GxtEDtbPaSj3O88yJBKwygDG3Z3QOVFWeD5wmrawt0u6h+G6vA7aiWrmD6vO7\ns2rOU+zym+o7j/f9LsJmWLA5Zm7sr5F1mZrzo/6RAoGBALkJFRPGqRoDcK4m0+vk\ny1QQ0n1AhiE+EDDc4Ofj9DX7ofIrcfAmSbQlzM1jTTWj1JuqyW+Xha45oh2M2Iom\nqlUwEuhDmUfcPbtNAhW5rCSvyaO6/3pwJnQBPyAAZA22MQb9QAzT4jC5iZmvnn9q\nDQPV/uC5yeLkIu/zlooc0Hrg\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "qrMCLck6O4chP-Xks_5LJ9rhSvEX8cqQBoHCj9PsoVffRtQ6brDxZ0JraBn9i0vVK6lMb7MHsWhRrAcamYOTJcpZFyAf1xJoxu4oMS1fdw3_YqSX_3yXpsqEGxkIcwxQgCgONnjShZuJcocW07vYTrUx97AoHhZUqTFl_1kR1omiOLM5rDc3Zz7QUMv8CLT2T3awWWYSyYg-0h8eQ7-GAEZsdoOuMDkETDFiuJGTiRCLLVF2DjZtwldVm51jveRaK1Qb6fJJk7IJrP9bOiQhf9M3RJ1pB14b7Hpl7U-u8C_cM69N9QZyAXfBNMvEhoA9XCDD2WiJhXB6pbgAeIL3MQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "HMfLR4B82MIPHVirz5xBvDHHmAzfymTqlSpGLV1gMZDhBK5uPrEHNq-Ib_gn21dZFQA5ssCW_La3xH87ISSByBaeoEtKiwbf0yCe9rGtfaOGynExboJpiFXvYak-FzW9keoPAWisKBpCGaUEuITcsuKSju4syWve8NrzFVNFcmwhlQxvyvV2pIApwWDWwCsgpP1zkGkdyCYotx_2O90PPtWWA7uvIHSwjyJYfpiQ3D3QmKias7ajuTRbM9I_pxZwwK5OQEjehZ0DaO-wci_Ft9GKpsQ4_0FpD7kMbqeSd43thtZoqCoGv41I8Sc7tEizowQIPHYILyIgwIV9vn0-xQ",
+        "p": "8JnYf-0D0lAdyhsXhox_jlHqUj59KuylZBC5DXPrHMNZURukoxWs4JU6RgmfbXjOk4n4-mOB_uaH-9ZE1bz_ZasQ4Kz4vMXTe1w8gQz8O9KRbtHXZrWD73h6QxTWI30XfocunPsNI_dnESGQZYZCennNwU1VFgSiJM1juy0CJvU",
+        "q": "tZ_ZpWnj9JfrFtH7a1rWiDJqU6vQuD8eno7-IzYTHNOnq5RhjrS6goKr8M945_LsSk1KGVilythDb5Fbsc67zQmT4uoB8nQ1ZoIhNlRrovxaI5V55uyU3Xzmd94EglAM4OcLNmwQ4VhX1jGQ9-c3XOq69Ww1Qu1_OanfL3E1kc0",
+        "dp": "StpCHcJ6LuMX8XmuPwDU6k0XzlB8lm8bIV-GguXuXntz_STRep9SsmgawhFaVS-BbSs-l39_wPKtma7WqXxsJJAs5wlJNUmCet1-QVPt4RqofkawcdbE3iqoNthzqoTPW2DpIpOESg09NnovtzYm1n2wgpPxhbEZVMPFZEUjZ0U",
+        "dq": "s1liRuHF5KaP0z0PlPdimaOPM4ia1xYdWl3Bv2uKfBDVpa0kmRMGihIXT_jQX9uWUdj4rwbG0QO1s9pKPc7zzIkErDKAMbdndA5UVZ4PnCatrC3S7qH4bq8DtqJauYPq87uzas5T7PKb6juP9_0uwmZYsDlmbuyvkXWZmvOj_pE",
+        "qi": "uQkVE8apGgNwribT6-TLVBDSfUCGIT4QMNzg5-P0Nfuh8itx8CZJtCXMzWNNNaPUm6rJb5eFrjmiHYzYiiaqVTAS6EOZR9w9u00CFbmsJK_Jo7r_enAmdAE_IABkDbYxBv1ADNPiMLmJma-ef2oNA9X-4LnJ4uQi7_OWihzQeuA"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 55,
+          "comment": "edge case for Montgomery reduction over Z/nZ (64 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "224bcda382d96b12ef56ee0fc56b67431b6490aa2f0e8f6528424c32d6611c4c0b9753a167a633e6a74465ca068ff40f802b43726a65f1251e2a075a2cffb1510249dbbda0f1877fc014310bf4c428295d5c1fa3fcca34441d4e84b1834f40079ca09ce1a52915dcf9d5472b9aec1a862d619c310cf9680fe7cbc03bfeb9cde565ca4666625ee2cd6725327c942dbb5b836f0cef24b2e646c91924543a07b6c5925ea8820b909e2040e2d50b7edf9fe5f241",
+          "ct": "97e090014478c58f681840c5170ee90584f734f154ed9b4850df6c20ac5470fa8b44c4f985ffcb52024917c51bd12a6773caa1d1d29c6b5fbd42963dfda4473cc573188ea41b3e254de9f9dd3472e00e4f22b0246fd3452f25fc607f16ac4f07d8cea65722606642b4f3ade0115ebc1cb56f3a5c600efd07e2d7e5b90977aa6cd5fcdda7bcd8123b15f71bd8f07b8440b540067de6677efe57a25eeb5d90dd4c6262e1a3b15a6a93d0e901e205420e2169bc4e1e4f55bb36432c50b92c22798c3c5c703461b99bc06ba22ec5c0fb17db74fa4faaf889f95718ae0c1d1b83e5e6421dd1327682e25c04061cfd30a7b9b4d470d736dd0c11788afa830598d8a06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00a333f78948a0c44e8e6a58c8bafc3e4fface7889db0cccb8bd82deb8b2a616f18d0860d713b6aed9d7b3ee3c6c53f830c8ae66122528d47315075433641c1e60927a425642fe40983cd014bf22fcbc41dfea61f6ae953b1ece7ba7e1fa1daff2e291c4a40ebe1e02b67280a7417338f2a206b3098e927e4c0f13ff2d2887e2fc0ead80050d10f424c6993f32ebd6c7a96c6c820e463db1b1b58980d9f092d708e779f30a786a3b144eaf513e737eee7a699e6443aa729e8e3bae605a5ef0f391401dd33ed1e78dcf0739f3e92601ce26b0363d590ec29a75f5fa876b987deb0753119e733f4da571a62be1a2b8430d9092b15d5be7b60a4676a5dbe95eb763d7",
+        "privateExponent": "0656c2e314ac95e35d39b93816b72c6e6bd5f02d9e91f933a5bcbb0cde778005a2ce3400b695ce65ccb082ecdae24a0e0f0563168a55f32683271538a7c745d0c76fb33ae980399f10219ee4aba5b864309fc86d4deba2efb7e26aab66cd1763ee33ee38d70fc057a7a17be8c32c8806388fdd0d5e79c7290a1ee336ec4f96dbd688cdcc3b881df60deb19d00c0b63131d9161aa1aae449691b2368f2f3f9f66ca5ffd266dad6b1fb8cead28844f50203b4c8cad13247807194d7e36c4e98cac2f5f2449c0c1e19bbc417bea48b9b4ccfcd7c0d079739d0c769ba44ddad578600b77e64e149bcaf0bff433709f9daaaf6523fa7879a4f07cc2cce6c934607dad",
+        "publicExponent": "010001",
+        "prime1": "00d839bceca3100480a51f6c2ab91374bd6a5af65ce69c79251fafa3a88a1e7e96eb0f7d122118c102a825dbc5ab00f8d744aec6b8eff0c710b587f4a307e141a86ba374d31716e415eccaf8f2b8513740ee2f0bec91245f66c04beff09051660a142be2b20432b44ef31ff67b749f11abf932957b7aab3d0f0f42118d0869e71b",
+        "prime2": "00c1395917600ff8d375fd320152d9f0aa458032fdec304defc4c9e5e70c5d0c6c60677dd2a512f147b6b0483f0f35a80b172e12574e3076bc4be938f3d1ece3aaf9a7e92aceb6e1606a1ce5f785463c03695a0bf04f8c612ae69faa7d146924571ed23ee64caada26aeba1da8305a2f945cd06ea0335fc50cd57f499ef2b815f5",
+        "exponent1": "0353600483bd8b542f35fc83ebb4d0e6d8ebed3e208de78f1a9da8f6bea9196958d43428433a0e3dec3828d93178225bad42c2ebb5450ecac30004533d9bc956bdd115cae96000c2159249a1f213cdb5c1f4174adc30a307018e297299c5a6bc20f34bd95117368ec04e8d8bf88f39c65b5edbcdba6547db2370f0b42a9cf661",
+        "exponent2": "47b4005bac4a410c37bcbdd1bfed20620f688383b72235c9c43d28139582f21945ad2204093dfe4b9e7fcc4f9a554f06ce934a3b1bc8e046ffe48c3deea8f9d378d1d6b50c00d1a1f5bec39816dcf9684ab01fbe0dc70a47e14d5ef70b9bf8e05b8fa9c7ccab9a48c08e5073197e5e29b047a8c5ca4abfd5036538ecc3258d",
+        "coefficient": "7ebe762a8dcdf901a5c0ded40daf3713108ed386e517e6900f2cba046e91d34df81becebb25339f8bf4954372d0383b1299e899ae088e9bc05ca1a478a5907839f5c44c40af7ab86141af92754c0dcc8c4bed879ecd58d3a3e630ed36b9f830faa22aa3e42e08617e4cef053add9cff465f8b629ac8ca2643c1147d47ce8fb4a"
+      },
+      "privateKeyPkcs8": "308204ba020100300d06092a864886f70d0101010500048204a4308204a00201000282010100a333f78948a0c44e8e6a58c8bafc3e4fface7889db0cccb8bd82deb8b2a616f18d0860d713b6aed9d7b3ee3c6c53f830c8ae66122528d47315075433641c1e60927a425642fe40983cd014bf22fcbc41dfea61f6ae953b1ece7ba7e1fa1daff2e291c4a40ebe1e02b67280a7417338f2a206b3098e927e4c0f13ff2d2887e2fc0ead80050d10f424c6993f32ebd6c7a96c6c820e463db1b1b58980d9f092d708e779f30a786a3b144eaf513e737eee7a699e6443aa729e8e3bae605a5ef0f391401dd33ed1e78dcf0739f3e92601ce26b0363d590ec29a75f5fa876b987deb0753119e733f4da571a62be1a2b8430d9092b15d5be7b60a4676a5dbe95eb763d70203010001028201000656c2e314ac95e35d39b93816b72c6e6bd5f02d9e91f933a5bcbb0cde778005a2ce3400b695ce65ccb082ecdae24a0e0f0563168a55f32683271538a7c745d0c76fb33ae980399f10219ee4aba5b864309fc86d4deba2efb7e26aab66cd1763ee33ee38d70fc057a7a17be8c32c8806388fdd0d5e79c7290a1ee336ec4f96dbd688cdcc3b881df60deb19d00c0b63131d9161aa1aae449691b2368f2f3f9f66ca5ffd266dad6b1fb8cead28844f50203b4c8cad13247807194d7e36c4e98cac2f5f2449c0c1e19bbc417bea48b9b4ccfcd7c0d079739d0c769ba44ddad578600b77e64e149bcaf0bff433709f9daaaf6523fa7879a4f07cc2cce6c934607dad02818100d839bceca3100480a51f6c2ab91374bd6a5af65ce69c79251fafa3a88a1e7e96eb0f7d122118c102a825dbc5ab00f8d744aec6b8eff0c710b587f4a307e141a86ba374d31716e415eccaf8f2b8513740ee2f0bec91245f66c04beff09051660a142be2b20432b44ef31ff67b749f11abf932957b7aab3d0f0f42118d0869e71b02818100c1395917600ff8d375fd320152d9f0aa458032fdec304defc4c9e5e70c5d0c6c60677dd2a512f147b6b0483f0f35a80b172e12574e3076bc4be938f3d1ece3aaf9a7e92aceb6e1606a1ce5f785463c03695a0bf04f8c612ae69faa7d146924571ed23ee64caada26aeba1da8305a2f945cd06ea0335fc50cd57f499ef2b815f50281800353600483bd8b542f35fc83ebb4d0e6d8ebed3e208de78f1a9da8f6bea9196958d43428433a0e3dec3828d93178225bad42c2ebb5450ecac30004533d9bc956bdd115cae96000c2159249a1f213cdb5c1f4174adc30a307018e297299c5a6bc20f34bd95117368ec04e8d8bf88f39c65b5edbcdba6547db2370f0b42a9cf661027f47b4005bac4a410c37bcbdd1bfed20620f688383b72235c9c43d28139582f21945ad2204093dfe4b9e7fcc4f9a554f06ce934a3b1bc8e046ffe48c3deea8f9d378d1d6b50c00d1a1f5bec39816dcf9684ab01fbe0dc70a47e14d5ef70b9bf8e05b8fa9c7ccab9a48c08e5073197e5e29b047a8c5ca4abfd5036538ecc3258d0281807ebe762a8dcdf901a5c0ded40daf3713108ed386e517e6900f2cba046e91d34df81becebb25339f8bf4954372d0383b1299e899ae088e9bc05ca1a478a5907839f5c44c40af7ab86141af92754c0dcc8c4bed879ecd58d3a3e630ed36b9f830faa22aa3e42e08617e4cef053add9cff465f8b629ac8ca2643c1147d47ce8fb4a",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAQCjM/eJSKDETo5q\nWMi6/D5P+s54idsMzLi9gt64sqYW8Y0IYNcTtq7Z17PuPGxT+DDIrmYSJSjUcxUH\nVDNkHB5gknpCVkL+QJg80BS/Ivy8Qd/qYfaulTseznun4fodr/LikcSkDr4eArZy\ngKdBczjyogazCY6SfkwPE/8tKIfi/A6tgAUNEPQkxpk/MuvWx6lsbIIORj2xsbWJ\ngNnwktcI53nzCnhqOxROr1E+c37uemmeZEOqcp6OO65gWl7w85FAHdM+0eeNzwc5\n8+kmAc4msDY9WQ7CmnX1+odrmH3rB1MRnnM/TaVxpivhorhDDZCSsV1b57YKRnal\n2+let2PXAgMBAAECggEABlbC4xSsleNdObk4FrcsbmvV8C2ekfkzpby7DN53gAWi\nzjQAtpXOZcywguza4koODwVjFopV8yaDJxU4p8dF0MdvszrpgDmfECGe5KuluGQw\nn8htTeui77fiaqtmzRdj7jPuONcPwFenoXvowyyIBjiP3Q1eeccpCh7jNuxPltvW\niM3MO4gd9g3rGdAMC2MTHZFhqhquRJaRsjaPLz+fZspf/SZtrWsfuM6tKIRPUCA7\nTIytEyR4BxlNfjbE6YysL18kScDB4Zu8QXvqSLm0zPzXwNB5c50MdpukTdrVeGAL\nd+ZOFJvK8L/0M3CfnaqvZSP6eHmk8HzCzObJNGB9rQKBgQDYObzsoxAEgKUfbCq5\nE3S9alr2XOaceSUfr6Ooih5+lusPfRIhGMECqCXbxasA+NdErsa47/DHELWH9KMH\n4UGoa6N00xcW5BXsyvjyuFE3QO4vC+yRJF9mwEvv8JBRZgoUK+KyBDK0TvMf9nt0\nnxGr+TKVe3qrPQ8PQhGNCGnnGwKBgQDBOVkXYA/403X9MgFS2fCqRYAy/ewwTe/E\nyeXnDF0MbGBnfdKlEvFHtrBIPw81qAsXLhJXTjB2vEvpOPPR7OOq+afpKs624WBq\nHOX3hUY8A2laC/BPjGEq5p+qfRRpJFce0j7mTKraJq66HagwWi+UXNBuoDNfxQzV\nf0me8rgV9QKBgANTYASDvYtULzX8g+u00ObY6+0+II3njxqdqPa+qRlpWNQ0KEM6\nDj3sOCjZMXgiW61Cwuu1RQ7KwwAEUz2byVa90RXK6WAAwhWSSaHyE821wfQXStww\nowcBjilymcWmvCDzS9lRFzaOwE6Ni/iPOcZbXtvNumVH2yNw8LQqnPZhAn9HtABb\nrEpBDDe8vdG/7SBiD2iDg7ciNcnEPSgTlYLyGUWtIgQJPf5Lnn/MT5pVTwbOk0o7\nG8jgRv/kjD3uqPnTeNHWtQwA0aH1vsOYFtz5aEqwH74NxwpH4U1e9wub+OBbj6nH\nzKuaSMCOUHMZfl4psEeoxcpKv9UDZTjswyWNAoGAfr52Ko3N+QGlwN7UDa83ExCO\n04blF+aQDyy6BG6R0034G+zrslM5+L9JVDctA4OxKZ6JmuCI6bwFyhpHilkHg59c\nRMQK96uGFBr5J1TA3MjEvth57NWNOj5jDtNrn4MPqiKqPkLghhfkzvBTrdnP9GX4\ntimsjKJkPBFH1Hzo+0o=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "ozP3iUigxE6OaljIuvw-T_rOeInbDMy4vYLeuLKmFvGNCGDXE7au2dez7jxsU_gwyK5mEiUo1HMVB1QzZBweYJJ6QlZC_kCYPNAUvyL8vEHf6mH2rpU7Hs57p-H6Ha_y4pHEpA6-HgK2coCnQXM48qIGswmOkn5MDxP_LSiH4vwOrYAFDRD0JMaZPzLr1sepbGyCDkY9sbG1iYDZ8JLXCOd58wp4ajsUTq9RPnN-7nppnmRDqnKejjuuYFpe8PORQB3TPtHnjc8HOfPpJgHOJrA2PVkOwpp19fqHa5h96wdTEZ5zP02lcaYr4aK4Qw2QkrFdW-e2CkZ2pdvpXrdj1w",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "BlbC4xSsleNdObk4FrcsbmvV8C2ekfkzpby7DN53gAWizjQAtpXOZcywguza4koODwVjFopV8yaDJxU4p8dF0MdvszrpgDmfECGe5KuluGQwn8htTeui77fiaqtmzRdj7jPuONcPwFenoXvowyyIBjiP3Q1eeccpCh7jNuxPltvWiM3MO4gd9g3rGdAMC2MTHZFhqhquRJaRsjaPLz-fZspf_SZtrWsfuM6tKIRPUCA7TIytEyR4BxlNfjbE6YysL18kScDB4Zu8QXvqSLm0zPzXwNB5c50MdpukTdrVeGALd-ZOFJvK8L_0M3CfnaqvZSP6eHmk8HzCzObJNGB9rQ",
+        "p": "2Dm87KMQBIClH2wquRN0vWpa9lzmnHklH6-jqIoefpbrD30SIRjBAqgl28WrAPjXRK7GuO_wxxC1h_SjB-FBqGujdNMXFuQV7Mr48rhRN0DuLwvskSRfZsBL7_CQUWYKFCvisgQytE7zH_Z7dJ8Rq_kylXt6qz0PD0IRjQhp5xs",
+        "q": "wTlZF2AP-NN1_TIBUtnwqkWAMv3sME3vxMnl5wxdDGxgZ33SpRLxR7awSD8PNagLFy4SV04wdrxL6Tjz0ezjqvmn6SrOtuFgahzl94VGPANpWgvwT4xhKuafqn0UaSRXHtI-5kyq2iauuh2oMFovlFzQbqAzX8UM1X9JnvK4FfU",
+        "dp": "A1NgBIO9i1QvNfyD67TQ5tjr7T4gjeePGp2o9r6pGWlY1DQoQzoOPew4KNkxeCJbrULC67VFDsrDAARTPZvJVr3RFcrpYADCFZJJofITzbXB9BdK3DCjBwGOKXKZxaa8IPNL2VEXNo7ATo2L-I85xlte2826ZUfbI3DwtCqc9mE",
+        "dq": "R7QAW6xKQQw3vL3Rv-0gYg9og4O3IjXJxD0oE5WC8hlFrSIECT3-S55_zE-aVU8GzpNKOxvI4Eb_5Iw97qj503jR1rUMANGh9b7DmBbc-WhKsB--DccKR-FNXvcLm_jgW4-px8yrmkjAjlBzGX5eKbBHqMXKSr_VA2U47MMljQ",
+        "qi": "fr52Ko3N-QGlwN7UDa83ExCO04blF-aQDyy6BG6R0034G-zrslM5-L9JVDctA4OxKZ6JmuCI6bwFyhpHilkHg59cRMQK96uGFBr5J1TA3MjEvth57NWNOj5jDtNrn4MPqiKqPkLghhfkzvBTrdnP9GX4timsjKJkPBFH1Hzo-0o"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 56,
+          "comment": "edge case for Montgomery reduction over Z/nZ (2048 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "991d040b49f1338a65d2f996e4f1e651f075f143db4ed0a29ae936ecef91a85d4edebb806e50735522ef88f4bbf5ce47c12eeba0f768216b9dc304544db563e53bf41a26360440997d06ba6e46c2c7c02272e00852a95e5bce8f0223f6dd235c3c7bf8132ab4ce68ef53f82dac02f142abe7db2b5ca67d7ac3857423e5df927f2eceb0c003c087e55dcaa923181ce629e3464592711a86bf0d07c80c58416b74f35ac14b2d4747818eb8cb16b6d3b6de0a21f27d4f1271439aad21024d",
+          "ct": "8c97556b822e64cc85ff36d1cd977620da4a72e765d12f742ec57732064cf19e2215b67aadf1d38a5ac23462372be206732038945001fd1991b3e3cbc10c81a073dd54e2da890f6c9d7b8e8154be1b3dc5e2c544ba8ce09687d62b707ef8dcbff88c6c33ccf72edc71d91b9e3ad51562a82c6414efe6cf7ed938bb22381e6846da3917fb2503725977ddd4750120a21a7bf6dca949b397a8e7824f2aee231fb0d16b00ed927f2fede4e7043f1ea18430b22a4767796085ea68d3ff29f5082972746d2f4e2f465534ad87088f03a8fb699f3bc840d47953bbd4cb3a29c00fccdebff359d651bfdb6fbbbebf1ecbcc748a06738ebd3f027b646920963eeb067c33",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00ab1ae81a7c70a56c14361b6dc7c28d6821fd776d3432dc812aa8ecf1ebb7e09e2c22eccadfb83ebf0f3f8842f1fc3b942bc178457af5b7fecba5e311faedf61616220503959b56b10cea46e84d97cfa1a97fac412773df8aad7de99910b61f23e376a0343b2952ba9db09a8deadfaf0265a6672a7e8a6944ab2697b08f9cb036517f82a49d76853187d9bb8e821f4b8788cd0ad6864747556bb1ad049ff69fb4dee9f9d4fd7c3083847f8903cdafabfbef26b560ba76561e4342fc68fdd177d86b20eb9efa3bffbae8e006155b396954f6c626fa0a67294f5094f6be5b4038974aa6472df0148fbaa1a74a7c31a40723f63535bd6a06fc89b5a7b34aea6c0c87",
+        "privateExponent": "346ddab81ef05f67e62b8c2d0fdc47fb240b2838909993228b2156f56c1e9c57ab3b8a6641b61197f6c2a76ca7fc7b7f140744e4b96028a08ce348585e94e2e672a2baf995b293164e584d20ea81bd9012417a553e930d68cf6f79103b642ad792dfeb080626cbe03de87afb488080fe518a732b3cba09b68e611572f7167291b9cc3d042ee53d88aa91458dffc102e2116219a03e9aac257ea643e290995655aa81237614f8a39aafca42d55786f9d890021bf4fd0bb84c229e6dfde85007f721d1d2a1b6718a2b7ece846f7a2ac4e26c00ee8b258904e6d7ebdcd3a591333845d88bd2029d75e6e7dabba94a343ef4f32bdfff786cfcf5d505567e9de99c11",
+        "publicExponent": "010001",
+        "prime1": "00dfb7b5f673f311d1641667f48f3e2a693c067291d64182d4d0e5641d6510332fa985a77b798884577c62165f93219bc55aa3873cdd94171c122a212381bb64e36fb76b22f41c9c16eb8ddc200cabaa00be10f6d756554c74530f6ba60fdc8d3aac0e03bdfdf61afb39ee21b26af14c6a23d4a55a4059e9ae92d96aa5d515f811",
+        "prime2": "00c3cba6dd3de94d596b91331da9ffa8c1b1d573d95f1e3a57dd5062d27b9aa4da9c1c9ee61ef57e9b3715fd1725d777ddfba79bb55651adc8dbc607f15316dac14de13d14253cc5a40a738761e4b8fcf4feb7ff95672a4023961b5951ec648edec85c1589868b7f0cc02e244186d61a6aa79db87b60f21e59c4db5b50a0f19317",
+        "exponent1": "7156af1706b31449d2bd0f39750077980cd2ef6436f9c5806fbc6736052769e731a906aaa56da62e745375264271fa6ac77aa55f0e9aa20294a94754a7bafa67c707537dc7d25eb9b5e88ea6a604aa01ea48c9e55a55a8801e3c67bb1fba0acab8b3f8ed5e263a91204e26402fb1c396da4436e93c44d100a2610788b0258b21",
+        "exponent2": "00a40a701754d3aed68864f2aa9bcf731835625cd975f3e175d41a91713fd5e4e0b382d72e7e29b8955aa5b5923b46374b689898c0693dad9867699725fd335cbc2fffd2289aba3beca04502dc65c1074e4c4ae47bcc1f7df552c23f27802310005f65a735bde009e628ed7fbad6b9731080b687e5f6e763be5a4c5e49434ea2a9",
+        "coefficient": "00a741113a20de887068f2dc4a91532d9ed80b6505eab0bcae6a9b06b1048242689783f65bdbc959628cf2411ab6f13a1731fde3c60aceb25859e7e1c693ae4eb914d23211687846ce746daf43cc76d1a4ce24abe00ce99a91402c23725dd4033f29aaa2e039400e0b85a8894d275517731fbde6f82ee8e62e523d64922cbd1727"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100ab1ae81a7c70a56c14361b6dc7c28d6821fd776d3432dc812aa8ecf1ebb7e09e2c22eccadfb83ebf0f3f8842f1fc3b942bc178457af5b7fecba5e311faedf61616220503959b56b10cea46e84d97cfa1a97fac412773df8aad7de99910b61f23e376a0343b2952ba9db09a8deadfaf0265a6672a7e8a6944ab2697b08f9cb036517f82a49d76853187d9bb8e821f4b8788cd0ad6864747556bb1ad049ff69fb4dee9f9d4fd7c3083847f8903cdafabfbef26b560ba76561e4342fc68fdd177d86b20eb9efa3bffbae8e006155b396954f6c626fa0a67294f5094f6be5b4038974aa6472df0148fbaa1a74a7c31a40723f63535bd6a06fc89b5a7b34aea6c0c87020301000102820100346ddab81ef05f67e62b8c2d0fdc47fb240b2838909993228b2156f56c1e9c57ab3b8a6641b61197f6c2a76ca7fc7b7f140744e4b96028a08ce348585e94e2e672a2baf995b293164e584d20ea81bd9012417a553e930d68cf6f79103b642ad792dfeb080626cbe03de87afb488080fe518a732b3cba09b68e611572f7167291b9cc3d042ee53d88aa91458dffc102e2116219a03e9aac257ea643e290995655aa81237614f8a39aafca42d55786f9d890021bf4fd0bb84c229e6dfde85007f721d1d2a1b6718a2b7ece846f7a2ac4e26c00ee8b258904e6d7ebdcd3a591333845d88bd2029d75e6e7dabba94a343ef4f32bdfff786cfcf5d505567e9de99c1102818100dfb7b5f673f311d1641667f48f3e2a693c067291d64182d4d0e5641d6510332fa985a77b798884577c62165f93219bc55aa3873cdd94171c122a212381bb64e36fb76b22f41c9c16eb8ddc200cabaa00be10f6d756554c74530f6ba60fdc8d3aac0e03bdfdf61afb39ee21b26af14c6a23d4a55a4059e9ae92d96aa5d515f81102818100c3cba6dd3de94d596b91331da9ffa8c1b1d573d95f1e3a57dd5062d27b9aa4da9c1c9ee61ef57e9b3715fd1725d777ddfba79bb55651adc8dbc607f15316dac14de13d14253cc5a40a738761e4b8fcf4feb7ff95672a4023961b5951ec648edec85c1589868b7f0cc02e244186d61a6aa79db87b60f21e59c4db5b50a0f193170281807156af1706b31449d2bd0f39750077980cd2ef6436f9c5806fbc6736052769e731a906aaa56da62e745375264271fa6ac77aa55f0e9aa20294a94754a7bafa67c707537dc7d25eb9b5e88ea6a604aa01ea48c9e55a55a8801e3c67bb1fba0acab8b3f8ed5e263a91204e26402fb1c396da4436e93c44d100a2610788b0258b2102818100a40a701754d3aed68864f2aa9bcf731835625cd975f3e175d41a91713fd5e4e0b382d72e7e29b8955aa5b5923b46374b689898c0693dad9867699725fd335cbc2fffd2289aba3beca04502dc65c1074e4c4ae47bcc1f7df552c23f27802310005f65a735bde009e628ed7fbad6b9731080b687e5f6e763be5a4c5e49434ea2a902818100a741113a20de887068f2dc4a91532d9ed80b6505eab0bcae6a9b06b1048242689783f65bdbc959628cf2411ab6f13a1731fde3c60aceb25859e7e1c693ae4eb914d23211687846ce746daf43cc76d1a4ce24abe00ce99a91402c23725dd4033f29aaa2e039400e0b85a8894d275517731fbde6f82ee8e62e523d64922cbd1727",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCrGugafHClbBQ2\nG23Hwo1oIf13bTQy3IEqqOzx67fgniwi7MrfuD6/Dz+IQvH8O5QrwXhFevW3/sul\n4xH67fYWFiIFA5WbVrEM6kboTZfPoal/rEEnc9+KrX3pmRC2HyPjdqA0OylSup2w\nmo3q368CZaZnKn6KaUSrJpewj5ywNlF/gqSddoUxh9m7joIfS4eIzQrWhkdHVWux\nrQSf9p+03un51P18MIOEf4kDza+r++8mtWC6dlYeQ0L8aP3Rd9hrIOue+jv/uujg\nBhVbOWlU9sYm+gpnKU9QlPa+W0A4l0qmRy3wFI+6oadKfDGkByP2NTW9agb8ibWn\ns0rqbAyHAgMBAAECggEANG3auB7wX2fmK4wtD9xH+yQLKDiQmZMiiyFW9WwenFer\nO4pmQbYRl/bCp2yn/Ht/FAdE5LlgKKCM40hYXpTi5nKiuvmVspMWTlhNIOqBvZAS\nQXpVPpMNaM9veRA7ZCrXkt/rCAYmy+A96Hr7SICA/lGKcys8ugm2jmEVcvcWcpG5\nzD0ELuU9iKqRRY3/wQLiEWIZoD6arCV+pkPikJlWVaqBI3YU+KOar8pC1VeG+diQ\nAhv0/Qu4TCKebf3oUAf3IdHSobZxiit+zoRveirE4mwA7osliQTm1+vc06WRMzhF\n2IvSAp115ufau6lKND708yvf/3hs/PXVBVZ+nemcEQKBgQDft7X2c/MR0WQWZ/SP\nPippPAZykdZBgtTQ5WQdZRAzL6mFp3t5iIRXfGIWX5Mhm8Vao4c83ZQXHBIqISOB\nu2Tjb7drIvQcnBbrjdwgDKuqAL4Q9tdWVUx0Uw9rpg/cjTqsDgO9/fYa+znuIbJq\n8UxqI9SlWkBZ6a6S2Wql1RX4EQKBgQDDy6bdPelNWWuRMx2p/6jBsdVz2V8eOlfd\nUGLSe5qk2pwcnuYe9X6bNxX9FyXXd937p5u1VlGtyNvGB/FTFtrBTeE9FCU8xaQK\nc4dh5Lj89P63/5VnKkAjlhtZUexkjt7IXBWJhot/DMAuJEGG1hpqp524e2DyHlnE\n21tQoPGTFwKBgHFWrxcGsxRJ0r0POXUAd5gM0u9kNvnFgG+8ZzYFJ2nnMakGqqVt\npi50U3UmQnH6asd6pV8OmqIClKlHVKe6+mfHB1N9x9JeubXojqamBKoB6kjJ5VpV\nqIAePGe7H7oKyriz+O1eJjqRIE4mQC+xw5baRDbpPETRAKJhB4iwJYshAoGBAKQK\ncBdU067WiGTyqpvPcxg1YlzZdfPhddQakXE/1eTgs4LXLn4puJVapbWSO0Y3S2iY\nmMBpPa2YZ2mXJf0zXLwv/9Iomro77KBFAtxlwQdOTErke8wfffVSwj8ngCMQAF9l\npzW94AnmKO1/uta5cxCAtofl9udjvlpMXklDTqKpAoGBAKdBETog3ohwaPLcSpFT\nLZ7YC2UF6rC8rmqbBrEEgkJol4P2W9vJWWKM8kEatvE6FzH948YKzrJYWefhxpOu\nTrkU0jIRaHhGznRtr0PMdtGkziSr4AzpmpFALCNyXdQDPymqouA5QA4LhaiJTSdV\nF3Mfveb4LujmLlI9ZJIsvRcn\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "qxroGnxwpWwUNhttx8KNaCH9d200MtyBKqjs8eu34J4sIuzK37g-vw8_iELx_DuUK8F4RXr1t_7LpeMR-u32FhYiBQOVm1axDOpG6E2Xz6Gpf6xBJ3Pfiq196ZkQth8j43agNDspUrqdsJqN6t-vAmWmZyp-imlEqyaXsI-csDZRf4KknXaFMYfZu46CH0uHiM0K1oZHR1Vrsa0En_aftN7p-dT9fDCDhH-JA82vq_vvJrVgunZWHkNC_Gj90XfYayDrnvo7_7ro4AYVWzlpVPbGJvoKZylPUJT2vltAOJdKpkct8BSPuqGnSnwxpAcj9jU1vWoG_Im1p7NK6mwMhw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "NG3auB7wX2fmK4wtD9xH-yQLKDiQmZMiiyFW9WwenFerO4pmQbYRl_bCp2yn_Ht_FAdE5LlgKKCM40hYXpTi5nKiuvmVspMWTlhNIOqBvZASQXpVPpMNaM9veRA7ZCrXkt_rCAYmy-A96Hr7SICA_lGKcys8ugm2jmEVcvcWcpG5zD0ELuU9iKqRRY3_wQLiEWIZoD6arCV-pkPikJlWVaqBI3YU-KOar8pC1VeG-diQAhv0_Qu4TCKebf3oUAf3IdHSobZxiit-zoRveirE4mwA7osliQTm1-vc06WRMzhF2IvSAp115ufau6lKND708yvf_3hs_PXVBVZ-nemcEQ",
+        "p": "37e19nPzEdFkFmf0jz4qaTwGcpHWQYLU0OVkHWUQMy-phad7eYiEV3xiFl-TIZvFWqOHPN2UFxwSKiEjgbtk42-3ayL0HJwW643cIAyrqgC-EPbXVlVMdFMPa6YP3I06rA4Dvf32Gvs57iGyavFMaiPUpVpAWemuktlqpdUV-BE",
+        "q": "w8um3T3pTVlrkTMdqf-owbHVc9lfHjpX3VBi0nuapNqcHJ7mHvV-mzcV_Rcl13fd-6ebtVZRrcjbxgfxUxbawU3hPRQlPMWkCnOHYeS4_PT-t_-VZypAI5YbWVHsZI7eyFwViYaLfwzALiRBhtYaaqeduHtg8h5ZxNtbUKDxkxc",
+        "dp": "cVavFwazFEnSvQ85dQB3mAzS72Q2-cWAb7xnNgUnaecxqQaqpW2mLnRTdSZCcfpqx3qlXw6aogKUqUdUp7r6Z8cHU33H0l65teiOpqYEqgHqSMnlWlWogB48Z7sfugrKuLP47V4mOpEgTiZAL7HDltpENuk8RNEAomEHiLAliyE",
+        "dq": "pApwF1TTrtaIZPKqm89zGDViXNl18-F11BqRcT_V5OCzgtcufim4lVqltZI7RjdLaJiYwGk9rZhnaZcl_TNcvC__0iiaujvsoEUC3GXBB05MSuR7zB999VLCPyeAIxAAX2WnNb3gCeYo7X-61rlzEIC2h-X252O-WkxeSUNOoqk",
+        "qi": "p0EROiDeiHBo8txKkVMtntgLZQXqsLyuapsGsQSCQmiXg_Zb28lZYozyQRq28ToXMf3jxgrOslhZ5-HGk65OuRTSMhFoeEbOdG2vQ8x20aTOJKvgDOmakUAsI3Jd1AM_Kaqi4DlADguFqIlNJ1UXcx-95vgu6OYuUj1kkiy9Fyc"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 57,
+          "comment": "edge case for Montgomery reduction over Z/nZ (2048 bit)",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "5b1d0e30c1973a87ed29cf3b7b4b48ae3d2e054698a86ebfbb43c5041ce7fd5146018abcb2bda195928b4820b6ce60df34c97c650c75b4dc274b35c7dd33f97839189fddd46c960f996423fb1c30a1c94c01c8ce575903d4c1af7b805443289d653b9cfcbc1482e84fe8c19cda33f9324b1aaf3e232699017d67d281450ed445265ff1aaa52e2a74b43097e590dbab20eca6b8bbd6df182b2e963e374f32f76b700661598ff707512e0f99849c73a49f7c068122952185855f254d3473246818894740b06c0f74b0711fffa7caacd403f886b4982f71a1d940d0b3118cdcb4135bec8d46b266cd2719873751a82b46f5a924",
+          "ct": "0e3f66a0127d21df1128701a777a5338d5727bc8041c3b8c25bcaa5bfc83b0261150a5bf41658c08cc019e3ebeeabb729c3bde84ffd2023f63313b3d1ac00ab4637b36e855a0d8e368971b2ba99ad1eeb74f2db48fa9abb125ea9e7568c612c1ad48110d1008141ac34c98e8952347142470171ddb4dcd914a3dc0d0ca4f51a247758da924d5ea041c8789b26974349af3a9bfb83ecd9107414a5f17c3abe5250e6891ab465ffea8b0e2fc2b43a9c1231d8a8631ea6f4a2817edbc5e918258c7b3155396b7a1cbd19a09c9b2397945eb4b767238a8833e63e79b84e143be8a4dcedeaa51cb936c08f364b74817dd1cc6a98a2cb3223f2532f17530570e6e693e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00a1c69ad4fe9b071ba4612057ee3835b0dfa96b60627848ef5b9b2b34c19816cddbadf3821c4cc487bdc4862b373a40a055dda27c87de08264a1732b3a0a00c132e72241db89f8c7e67bb415986feeef8b6fc3499d3e91a9a2ee562de2bf0bc854a8423fd10dba078c5482500874417875d0326ab8a0c8094e050282212e1291b41b241cf5c065d2f4995897d6270f02d6d0ff5b7f067b71cb76e72f0115c7fca37263a89ab155022c8a4ce19dd2e25ea9ac51d8464fd0f587c95f06fa1f9c01b0a20890dbfea12a60fc0aba9c4ebe81c17f49390021b1cc47f26b8b0352684cf8a544d9b2ae1962b7f3cb11d722710b0bfa550e57b7ca04e1b7ff16a035cdfb1",
+        "privateExponent": "29daf49c3ef3653765a42b7614903e73f0aa28b9db403bbe91f8e788d2bdc2c8a819ad72f0577c51926b923b0422f22d8989ba4c75eaa03927da30a800dae7c4deb3715caf33b869cbf4cac79b01c25a5f1d898e7321505cabdd7562fe035f032d705acf52d93fff7f2b574777b7ca4e9f65fd4f4c7c47983d21000130d94884f7393f042c7a85169b441ad7a18ad15367d7333a87f2d8653bf160850d32e4609160d57e89b11356abe7d51256651326906e11bb18354c22a88dcc7f8f10398d6ecd4596c731c307c6184c61f64ab5a3b49b7a1c4b24cb273393187d4aed24cf0fec79484f228eda3c56ca016229cc8777871c7184ce474df84d527031e3bb71",
+        "publicExponent": "010001",
+        "prime1": "00dad1d8786696213386dbd73156d3391d5c0c5f70fb29a97801cad51c3c0cf893359391d1ebfb066f778e5f76da0b3d9bd810cc2d02b4d353b598443e1039c7a91e8f1206fd2142e6409cc8d0e8c70e0e872ac173bf5c0997363ed47a015a45ecc971fe22b5f65a2860dc87ffc723edb753688d424a2614b4721a2a91720aac2f",
+        "prime2": "00bd437af3dd1ecd829c181dfab12c41a0bf43cc1ecf5b282773c5da0050df6ae63c6efc1151ccbac1e1ede5082d1e0d83ab8122286e2c6383f39d07ba0f9bf7c173591d1a416ade762cbefea74c66dc5f2e5cc5dab786ff2ff613029535077e6a23eeea0035f2927b210473651bd60b38a6e629c00a826350b6ef9c01632eda1f",
+        "exponent1": "00a1acc64a3f51d17a26bc2bc532a7a1dd857346d94d59bcf3042fff417b45022c923b54544c0d0ef630d9aac33fdb6a4bc95aafe0d9cd0d0f1e6f408cb2a45e5720530938ccb254a1973fc0484a953857979b099021e538d8d6a5998c038fd5765c68b322a65b3cc5f4bb3c68c9944c4155893c45ac4f72a0d86568ea49de84d5",
+        "exponent2": "2aee6dab77930f26fb65751772ad094dff54cfae8576b60b0cf5ea577c00d1ecdbf488f51ccb05ea08e7bfb63515c61702064ecb41028ca857d05cfa55a4197526472694d815f7d4729df881d690d698389a0ebf68361518ba06e1e51a9c528e9d0c0ac475784ac5e75d6d179852db44c4871d1d54c4f2e65238d3f87499221d",
+        "coefficient": "23b6f130671feb076e3aa0a0df22e3dce408eed61bdd2cef363a6ae39936817734b6d5612cfff2511f3fd57b58ad0c1b4be056588c77cb2a591a8d4ee51e6fea618f6e31a3f048cba05193e37fc8f7ae51814fa4fb968871ad332847a3bf3874ddbe77a7461174d9154da0940ae4886f7b6eba0972e3229968ea78b1b7c9b458"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100a1c69ad4fe9b071ba4612057ee3835b0dfa96b60627848ef5b9b2b34c19816cddbadf3821c4cc487bdc4862b373a40a055dda27c87de08264a1732b3a0a00c132e72241db89f8c7e67bb415986feeef8b6fc3499d3e91a9a2ee562de2bf0bc854a8423fd10dba078c5482500874417875d0326ab8a0c8094e050282212e1291b41b241cf5c065d2f4995897d6270f02d6d0ff5b7f067b71cb76e72f0115c7fca37263a89ab155022c8a4ce19dd2e25ea9ac51d8464fd0f587c95f06fa1f9c01b0a20890dbfea12a60fc0aba9c4ebe81c17f49390021b1cc47f26b8b0352684cf8a544d9b2ae1962b7f3cb11d722710b0bfa550e57b7ca04e1b7ff16a035cdfb102030100010282010029daf49c3ef3653765a42b7614903e73f0aa28b9db403bbe91f8e788d2bdc2c8a819ad72f0577c51926b923b0422f22d8989ba4c75eaa03927da30a800dae7c4deb3715caf33b869cbf4cac79b01c25a5f1d898e7321505cabdd7562fe035f032d705acf52d93fff7f2b574777b7ca4e9f65fd4f4c7c47983d21000130d94884f7393f042c7a85169b441ad7a18ad15367d7333a87f2d8653bf160850d32e4609160d57e89b11356abe7d51256651326906e11bb18354c22a88dcc7f8f10398d6ecd4596c731c307c6184c61f64ab5a3b49b7a1c4b24cb273393187d4aed24cf0fec79484f228eda3c56ca016229cc8777871c7184ce474df84d527031e3bb7102818100dad1d8786696213386dbd73156d3391d5c0c5f70fb29a97801cad51c3c0cf893359391d1ebfb066f778e5f76da0b3d9bd810cc2d02b4d353b598443e1039c7a91e8f1206fd2142e6409cc8d0e8c70e0e872ac173bf5c0997363ed47a015a45ecc971fe22b5f65a2860dc87ffc723edb753688d424a2614b4721a2a91720aac2f02818100bd437af3dd1ecd829c181dfab12c41a0bf43cc1ecf5b282773c5da0050df6ae63c6efc1151ccbac1e1ede5082d1e0d83ab8122286e2c6383f39d07ba0f9bf7c173591d1a416ade762cbefea74c66dc5f2e5cc5dab786ff2ff613029535077e6a23eeea0035f2927b210473651bd60b38a6e629c00a826350b6ef9c01632eda1f02818100a1acc64a3f51d17a26bc2bc532a7a1dd857346d94d59bcf3042fff417b45022c923b54544c0d0ef630d9aac33fdb6a4bc95aafe0d9cd0d0f1e6f408cb2a45e5720530938ccb254a1973fc0484a953857979b099021e538d8d6a5998c038fd5765c68b322a65b3cc5f4bb3c68c9944c4155893c45ac4f72a0d86568ea49de84d50281802aee6dab77930f26fb65751772ad094dff54cfae8576b60b0cf5ea577c00d1ecdbf488f51ccb05ea08e7bfb63515c61702064ecb41028ca857d05cfa55a4197526472694d815f7d4729df881d690d698389a0ebf68361518ba06e1e51a9c528e9d0c0ac475784ac5e75d6d179852db44c4871d1d54c4f2e65238d3f87499221d02818023b6f130671feb076e3aa0a0df22e3dce408eed61bdd2cef363a6ae39936817734b6d5612cfff2511f3fd57b58ad0c1b4be056588c77cb2a591a8d4ee51e6fea618f6e31a3f048cba05193e37fc8f7ae51814fa4fb968871ad332847a3bf3874ddbe77a7461174d9154da0940ae4886f7b6eba0972e3229968ea78b1b7c9b458",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQChxprU/psHG6Rh\nIFfuODWw36lrYGJ4SO9bmys0wZgWzdut84IcTMSHvcSGKzc6QKBV3aJ8h94IJkoX\nMrOgoAwTLnIkHbifjH5nu0FZhv7u+Lb8NJnT6RqaLuVi3ivwvIVKhCP9ENugeMVI\nJQCHRBeHXQMmq4oMgJTgUCgiEuEpG0GyQc9cBl0vSZWJfWJw8C1tD/W38Ge3HLdu\ncvARXH/KNyY6iasVUCLIpM4Z3S4l6prFHYRk/Q9YfJXwb6H5wBsKIIkNv+oSpg/A\nq6nE6+gcF/STkAIbHMR/JriwNSaEz4pUTZsq4ZYrfzyxHXInELC/pVDle3ygTht/\n8WoDXN+xAgMBAAECggEAKdr0nD7zZTdlpCt2FJA+c/CqKLnbQDu+kfjniNK9wsio\nGa1y8Fd8UZJrkjsEIvItiYm6THXqoDkn2jCoANrnxN6zcVyvM7hpy/TKx5sBwlpf\nHYmOcyFQXKvddWL+A18DLXBaz1LZP/9/K1dHd7fKTp9l/U9MfEeYPSEAATDZSIT3\nOT8ELHqFFptEGtehitFTZ9czOofy2GU78WCFDTLkYJFg1X6JsRNWq+fVElZlEyaQ\nbhG7GDVMIqiNzH+PEDmNbs1FlscxwwfGGExh9kq1o7SbehxLJMsnM5MYfUrtJM8P\n7HlITyKO2jxWygFiKcyHd4cccYTOR034TVJwMeO7cQKBgQDa0dh4ZpYhM4bb1zFW\n0zkdXAxfcPspqXgBytUcPAz4kzWTkdHr+wZvd45fdtoLPZvYEMwtArTTU7WYRD4Q\nOcepHo8SBv0hQuZAnMjQ6McODocqwXO/XAmXNj7UegFaRezJcf4itfZaKGDch//H\nI+23U2iNQkomFLRyGiqRcgqsLwKBgQC9Q3rz3R7NgpwYHfqxLEGgv0PMHs9bKCdz\nxdoAUN9q5jxu/BFRzLrB4e3lCC0eDYOrgSIobixjg/OdB7oPm/fBc1kdGkFq3nYs\nvv6nTGbcXy5cxdq3hv8v9hMClTUHfmoj7uoANfKSeyEEc2Ub1gs4puYpwAqCY1C2\n75wBYy7aHwKBgQChrMZKP1HReia8K8Uyp6HdhXNG2U1ZvPMEL/9Be0UCLJI7VFRM\nDQ72MNmqwz/bakvJWq/g2c0NDx5vQIyypF5XIFMJOMyyVKGXP8BISpU4V5ebCZAh\n5TjY1qWZjAOP1XZcaLMipls8xfS7PGjJlExBVYk8RaxPcqDYZWjqSd6E1QKBgCru\nbat3kw8m+2V1F3KtCU3/VM+uhXa2Cwz16ld8ANHs2/SI9RzLBeoI57+2NRXGFwIG\nTstBAoyoV9Bc+lWkGXUmRyaU2BX31HKd+IHWkNaYOJoOv2g2FRi6BuHlGpxSjp0M\nCsR1eErF511tF5hS20TEhx0dVMTy5lI40/h0mSIdAoGAI7bxMGcf6wduOqCg3yLj\n3OQI7tYb3SzvNjpq45k2gXc0ttVhLP/yUR8/1XtYrQwbS+BWWIx3yypZGo1O5R5v\n6mGPbjGj8EjLoFGT43/I965RgU+k+5aIca0zKEejvzh03b53p0YRdNkVTaCUCuSI\nb3tuugly4yKZaOp4sbfJtFg=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "ocaa1P6bBxukYSBX7jg1sN-pa2BieEjvW5srNMGYFs3brfOCHEzEh73Ehis3OkCgVd2ifIfeCCZKFzKzoKAMEy5yJB24n4x-Z7tBWYb-7vi2_DSZ0-kami7lYt4r8LyFSoQj_RDboHjFSCUAh0QXh10DJquKDICU4FAoIhLhKRtBskHPXAZdL0mViX1icPAtbQ_1t_Bntxy3bnLwEVx_yjcmOomrFVAiyKTOGd0uJeqaxR2EZP0PWHyV8G-h-cAbCiCJDb_qEqYPwKupxOvoHBf0k5ACGxzEfya4sDUmhM-KVE2bKuGWK388sR1yJxCwv6VQ5Xt8oE4bf_FqA1zfsQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "Kdr0nD7zZTdlpCt2FJA-c_CqKLnbQDu-kfjniNK9wsioGa1y8Fd8UZJrkjsEIvItiYm6THXqoDkn2jCoANrnxN6zcVyvM7hpy_TKx5sBwlpfHYmOcyFQXKvddWL-A18DLXBaz1LZP_9_K1dHd7fKTp9l_U9MfEeYPSEAATDZSIT3OT8ELHqFFptEGtehitFTZ9czOofy2GU78WCFDTLkYJFg1X6JsRNWq-fVElZlEyaQbhG7GDVMIqiNzH-PEDmNbs1FlscxwwfGGExh9kq1o7SbehxLJMsnM5MYfUrtJM8P7HlITyKO2jxWygFiKcyHd4cccYTOR034TVJwMeO7cQ",
+        "p": "2tHYeGaWITOG29cxVtM5HVwMX3D7Kal4AcrVHDwM-JM1k5HR6_sGb3eOX3baCz2b2BDMLQK001O1mEQ-EDnHqR6PEgb9IULmQJzI0OjHDg6HKsFzv1wJlzY-1HoBWkXsyXH-IrX2Wihg3If_xyPtt1NojUJKJhS0choqkXIKrC8",
+        "q": "vUN6890ezYKcGB36sSxBoL9DzB7PWygnc8XaAFDfauY8bvwRUcy6weHt5QgtHg2Dq4EiKG4sY4PznQe6D5v3wXNZHRpBat52LL7-p0xm3F8uXMXat4b_L_YTApU1B35qI-7qADXyknshBHNlG9YLOKbmKcAKgmNQtu-cAWMu2h8",
+        "dp": "oazGSj9R0XomvCvFMqeh3YVzRtlNWbzzBC__QXtFAiySO1RUTA0O9jDZqsM_22pLyVqv4NnNDQ8eb0CMsqReVyBTCTjMslShlz_ASEqVOFeXmwmQIeU42NalmYwDj9V2XGizIqZbPMX0uzxoyZRMQVWJPEWsT3Kg2GVo6knehNU",
+        "dq": "Ku5tq3eTDyb7ZXUXcq0JTf9Uz66FdrYLDPXqV3wA0ezb9Ij1HMsF6gjnv7Y1FcYXAgZOy0ECjKhX0Fz6VaQZdSZHJpTYFffUcp34gdaQ1pg4mg6_aDYVGLoG4eUanFKOnQwKxHV4SsXnXW0XmFLbRMSHHR1UxPLmUjjT-HSZIh0",
+        "qi": "I7bxMGcf6wduOqCg3yLj3OQI7tYb3SzvNjpq45k2gXc0ttVhLP_yUR8_1XtYrQwbS-BWWIx3yypZGo1O5R5v6mGPbjGj8EjLoFGT43_I965RgU-k-5aIca0zKEejvzh03b53p0YRdNkVTaCUCuSIb3tuugly4yKZaOp4sbfJtFg"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 58,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "63f6d1ccf5c03442d3b1b29b4e83e02242c26183fcbede9b6d7881a819d6cb48448da49ecc0ed0172713a17f24154f47461928aed551cb10cf0f7ffd47dd728edbf6c2060a340d95e980d466302439cac9aaaff9d54622ca0a4429aa891ed3cd210999ba4f442af8ecf63ba9c1cbc4b9cc4940f6854e75f789858bd429b1a398093b4dfa0018a98bba620e37f840c6a37edce04fdb739b2b7d0c9fe5a8eaaecf14d9e6e27f131742c1129769901f512bbe6b578ccc8a6f25a7cfc7fbcf743c318f2346b1cb4709",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00cba072a38b85c7802967a8ebc88ce47f80f7a82fe75e8142ecea9ae87f585b7f7ebb3fe030d5894f6406e6223e73a3dce688db3339c8ea8e6fc63069ab51be6d337906e8a0f44734cd1965d689b5556f33bd7ee19c0405587cd73e0d97de4128f67866bef20974620f5a8086ec11c13b96faea171d98fdb9a57f7c7729f5c8a594635ec72013c33374a47176bc67ce9f6ec313a6b667e6fc22be8bd116b831455112e39e7c4e5848d9a5a60f42783150a191503b6be381cc2c2aee466aa270fc00b0512a83339c442fd833f8a2d1876be5b63248f5e586de3f8bcc07b01c0f2ea658a466c7c7bbf475ce0a441bb69f63e99eaf776a17049b6a49a543c085d001",
+        "privateExponent": "2db5664e6a711d0b9a9fc3862bf65e8b7590823f409550f84c34cc91a0965db1a4a9d54896c5b4452f3bb238a122b5b78e434dcb35af3161c85ae97eaadf965aae797e30c582982254e0dce097f86dc560ccaa78ebdbe6344b0fc904e5a09529640c3a6a25ec33e51833b552b416b734d06b22158ec60b3c7b573f0203d801922cf3b149d81226526faacfa556bd91d87b6650d2450c8906fdf633efb0f11efa8681ea2993b6052bb8213747e7aa8faae9a030608bad085ae8315022f7ba0a6fbcc480bc5ee1b3b6a50bbbb245a0a3e0533e90960fed757cf9106276086f95a7cd88986cf2259cf6eb34fce31cf86518e3f42527ebd2bc97bec689e8da806e5d",
+        "publicExponent": "010001",
+        "prime1": "00f0bd0f39bbd0d5492d57c6c43d32e9ad5a036b787a27350e8f1cdb4eb568b52cf16a4ec3c09a010021fd04b9721c59db11bc6dcd3a81012003d21501ac9781d6b472f8cc34b96c49525e0538b4f7bad64c62fd5ebe9fd336b828183f1648dde68786e9256b8c82262b94f2f47ff31f66e826bc4ba7847067c2fc44a6228beda5",
+        "prime2": "00d8891a2d2d104310741cf585903fafaa4ca0fdccb15360f40dfce6e9bd44b6ea22250d70758e85414a569d0b29686e2635a66e45360aeec1a1627f1d4957bf1ddd1f1f70eb7ff3374f429483b47f18ebf19d3c7b7f67f558c916675a46b6706525bbdcd6fb94e1aa796f706a1311b939df18677b7ea8eecb899346cf989ec22d",
+        "exponent1": "009ddd5c7e9f8af2526a49852e6a73588934ddc93bd7de9e0c4e0cbe437ef28adc4df348735579a7ee4e5b7d1d9e96b8d5cf6ba11553a804f4d98c89f9ef13eb30c0642482c49053524191261b69908a14bd42aca3d49d3a0447ff02e75bd5acaddf71b8b1b13512a3b53097a17dc610718b0adbaf40cab86b5291daf296f4eb81",
+        "exponent2": "008d5b1b52888b882c5290a11b3b2ac8239578b7968be05177a1360b0c65b958eb89b4c48c38c1fc6dbdf8c2f689669a19a986679019129400a5b926205943c608d9d43a733dd9be4dca193dd8a8d91bccd363011be1f55cae443fb2e2b52cde3cb9a0652f96f6ff468995dd3df20aecef419badda69ba208190e32b23d48f3755",
+        "coefficient": "0502a12de08187e6c1c2c8c70d474b91df724f42fc310d78f8ea5040424457fc64fbbf26ddd5f4a172b956c7604e8022c65741dcd141b2fd0c529f1eae94a9544bb16fdf544426d6217ebc13ac86d8a6dae7af7d64d6d3332653ae6fd5448f0dae43210000e2a7a80bebd420d8c8609d57759fba7a8877db4539e1abe0967483"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100cba072a38b85c7802967a8ebc88ce47f80f7a82fe75e8142ecea9ae87f585b7f7ebb3fe030d5894f6406e6223e73a3dce688db3339c8ea8e6fc63069ab51be6d337906e8a0f44734cd1965d689b5556f33bd7ee19c0405587cd73e0d97de4128f67866bef20974620f5a8086ec11c13b96faea171d98fdb9a57f7c7729f5c8a594635ec72013c33374a47176bc67ce9f6ec313a6b667e6fc22be8bd116b831455112e39e7c4e5848d9a5a60f42783150a191503b6be381cc2c2aee466aa270fc00b0512a83339c442fd833f8a2d1876be5b63248f5e586de3f8bcc07b01c0f2ea658a466c7c7bbf475ce0a441bb69f63e99eaf776a17049b6a49a543c085d0010203010001028201002db5664e6a711d0b9a9fc3862bf65e8b7590823f409550f84c34cc91a0965db1a4a9d54896c5b4452f3bb238a122b5b78e434dcb35af3161c85ae97eaadf965aae797e30c582982254e0dce097f86dc560ccaa78ebdbe6344b0fc904e5a09529640c3a6a25ec33e51833b552b416b734d06b22158ec60b3c7b573f0203d801922cf3b149d81226526faacfa556bd91d87b6650d2450c8906fdf633efb0f11efa8681ea2993b6052bb8213747e7aa8faae9a030608bad085ae8315022f7ba0a6fbcc480bc5ee1b3b6a50bbbb245a0a3e0533e90960fed757cf9106276086f95a7cd88986cf2259cf6eb34fce31cf86518e3f42527ebd2bc97bec689e8da806e5d02818100f0bd0f39bbd0d5492d57c6c43d32e9ad5a036b787a27350e8f1cdb4eb568b52cf16a4ec3c09a010021fd04b9721c59db11bc6dcd3a81012003d21501ac9781d6b472f8cc34b96c49525e0538b4f7bad64c62fd5ebe9fd336b828183f1648dde68786e9256b8c82262b94f2f47ff31f66e826bc4ba7847067c2fc44a6228beda502818100d8891a2d2d104310741cf585903fafaa4ca0fdccb15360f40dfce6e9bd44b6ea22250d70758e85414a569d0b29686e2635a66e45360aeec1a1627f1d4957bf1ddd1f1f70eb7ff3374f429483b47f18ebf19d3c7b7f67f558c916675a46b6706525bbdcd6fb94e1aa796f706a1311b939df18677b7ea8eecb899346cf989ec22d028181009ddd5c7e9f8af2526a49852e6a73588934ddc93bd7de9e0c4e0cbe437ef28adc4df348735579a7ee4e5b7d1d9e96b8d5cf6ba11553a804f4d98c89f9ef13eb30c0642482c49053524191261b69908a14bd42aca3d49d3a0447ff02e75bd5acaddf71b8b1b13512a3b53097a17dc610718b0adbaf40cab86b5291daf296f4eb81028181008d5b1b52888b882c5290a11b3b2ac8239578b7968be05177a1360b0c65b958eb89b4c48c38c1fc6dbdf8c2f689669a19a986679019129400a5b926205943c608d9d43a733dd9be4dca193dd8a8d91bccd363011be1f55cae443fb2e2b52cde3cb9a0652f96f6ff468995dd3df20aecef419badda69ba208190e32b23d48f37550281800502a12de08187e6c1c2c8c70d474b91df724f42fc310d78f8ea5040424457fc64fbbf26ddd5f4a172b956c7604e8022c65741dcd141b2fd0c529f1eae94a9544bb16fdf544426d6217ebc13ac86d8a6dae7af7d64d6d3332653ae6fd5448f0dae43210000e2a7a80bebd420d8c8609d57759fba7a8877db4539e1abe0967483",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDLoHKji4XHgCln\nqOvIjOR/gPeoL+degULs6prof1hbf367P+Aw1YlPZAbmIj5zo9zmiNszOcjqjm/G\nMGmrUb5tM3kG6KD0RzTNGWXWibVVbzO9fuGcBAVYfNc+DZfeQSj2eGa+8gl0Yg9a\ngIbsEcE7lvrqFx2Y/bmlf3x3KfXIpZRjXscgE8MzdKRxdrxnzp9uwxOmtmfm/CK+\ni9EWuDFFURLjnnxOWEjZpaYPQngxUKGRUDtr44HMLCruRmqicPwAsFEqgzOcRC/Y\nM/ii0Ydr5bYySPXlht4/i8wHsBwPLqZYpGbHx7v0dc4KRBu2n2Ppnq93ahcEm2pJ\npUPAhdABAgMBAAECggEALbVmTmpxHQuan8OGK/Zei3WQgj9AlVD4TDTMkaCWXbGk\nqdVIlsW0RS87sjihIrW3jkNNyzWvMWHIWul+qt+WWq55fjDFgpgiVODc4Jf4bcVg\nzKp469vmNEsPyQTloJUpZAw6aiXsM+UYM7VStBa3NNBrIhWOxgs8e1c/AgPYAZIs\n87FJ2BImUm+qz6VWvZHYe2ZQ0kUMiQb99jPvsPEe+oaB6imTtgUruCE3R+eqj6rp\noDBgi60IWugxUCL3ugpvvMSAvF7hs7alC7uyRaCj4FM+kJYP7XV8+RBidghvlafN\niJhs8iWc9us0/OMc+GUY4/QlJ+vSvJe+xono2oBuXQKBgQDwvQ85u9DVSS1XxsQ9\nMumtWgNreHonNQ6PHNtOtWi1LPFqTsPAmgEAIf0EuXIcWdsRvG3NOoEBIAPSFQGs\nl4HWtHL4zDS5bElSXgU4tPe61kxi/V6+n9M2uCgYPxZI3eaHhukla4yCJiuU8vR/\n8x9m6Ca8S6eEcGfC/ESmIovtpQKBgQDYiRotLRBDEHQc9YWQP6+qTKD9zLFTYPQN\n/ObpvUS26iIlDXB1joVBSladCylobiY1pm5FNgruwaFifx1JV78d3R8fcOt/8zdP\nQpSDtH8Y6/GdPHt/Z/VYyRZnWka2cGUlu9zW+5ThqnlvcGoTEbk53xhne36o7suJ\nk0bPmJ7CLQKBgQCd3Vx+n4ryUmpJhS5qc1iJNN3JO9fengxODL5DfvKK3E3zSHNV\neafuTlt9HZ6WuNXPa6EVU6gE9NmMifnvE+swwGQkgsSQU1JBkSYbaZCKFL1CrKPU\nnToER/8C51vVrK3fcbixsTUSo7Uwl6F9xhBxiwrbr0DKuGtSkdrylvTrgQKBgQCN\nWxtSiIuILFKQoRs7KsgjlXi3lovgUXehNgsMZblY64m0xIw4wfxtvfjC9olmmhmp\nhmeQGRKUAKW5JiBZQ8YI2dQ6cz3Zvk3KGT3YqNkbzNNjARvh9VyuRD+y4rUs3jy5\noGUvlvb/RomV3T3yCuzvQZut2mm6IIGQ4ysj1I83VQKBgAUCoS3ggYfmwcLIxw1H\nS5Hfck9C/DENePjqUEBCRFf8ZPu/Jt3V9KFyuVbHYE6AIsZXQdzRQbL9DFKfHq6U\nqVRLsW/fVEQm1iF+vBOshtim2uevfWTW0zMmU65v1USPDa5DIQAA4qeoC+vUINjI\nYJ1XdZ+6eoh320U54avglnSD\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "y6Byo4uFx4ApZ6jryIzkf4D3qC_nXoFC7Oqa6H9YW39-uz_gMNWJT2QG5iI-c6Pc5ojbMznI6o5vxjBpq1G-bTN5Buig9Ec0zRll1om1VW8zvX7hnAQFWHzXPg2X3kEo9nhmvvIJdGIPWoCG7BHBO5b66hcdmP25pX98dyn1yKWUY17HIBPDM3SkcXa8Z86fbsMTprZn5vwivovRFrgxRVES4558TlhI2aWmD0J4MVChkVA7a-OBzCwq7kZqonD8ALBRKoMznEQv2DP4otGHa-W2Mkj15YbeP4vMB7AcDy6mWKRmx8e79HXOCkQbtp9j6Z6vd2oXBJtqSaVDwIXQAQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "LbVmTmpxHQuan8OGK_Zei3WQgj9AlVD4TDTMkaCWXbGkqdVIlsW0RS87sjihIrW3jkNNyzWvMWHIWul-qt-WWq55fjDFgpgiVODc4Jf4bcVgzKp469vmNEsPyQTloJUpZAw6aiXsM-UYM7VStBa3NNBrIhWOxgs8e1c_AgPYAZIs87FJ2BImUm-qz6VWvZHYe2ZQ0kUMiQb99jPvsPEe-oaB6imTtgUruCE3R-eqj6rpoDBgi60IWugxUCL3ugpvvMSAvF7hs7alC7uyRaCj4FM-kJYP7XV8-RBidghvlafNiJhs8iWc9us0_OMc-GUY4_QlJ-vSvJe-xono2oBuXQ",
+        "p": "8L0PObvQ1UktV8bEPTLprVoDa3h6JzUOjxzbTrVotSzxak7DwJoBACH9BLlyHFnbEbxtzTqBASAD0hUBrJeB1rRy-Mw0uWxJUl4FOLT3utZMYv1evp_TNrgoGD8WSN3mh4bpJWuMgiYrlPL0f_MfZugmvEunhHBnwvxEpiKL7aU",
+        "q": "2IkaLS0QQxB0HPWFkD-vqkyg_cyxU2D0Dfzm6b1EtuoiJQ1wdY6FQUpWnQspaG4mNaZuRTYK7sGhYn8dSVe_Hd0fH3Drf_M3T0KUg7R_GOvxnTx7f2f1WMkWZ1pGtnBlJbvc1vuU4ap5b3BqExG5Od8YZ3t-qO7LiZNGz5iewi0",
+        "dp": "nd1cfp-K8lJqSYUuanNYiTTdyTvX3p4MTgy-Q37yitxN80hzVXmn7k5bfR2elrjVz2uhFVOoBPTZjIn57xPrMMBkJILEkFNSQZEmG2mQihS9Qqyj1J06BEf_Audb1ayt33G4sbE1EqO1MJehfcYQcYsK269AyrhrUpHa8pb064E",
+        "dq": "jVsbUoiLiCxSkKEbOyrII5V4t5aL4FF3oTYLDGW5WOuJtMSMOMH8bb34wvaJZpoZqYZnkBkSlACluSYgWUPGCNnUOnM92b5Nyhk92KjZG8zTYwEb4fVcrkQ_suK1LN48uaBlL5b2_0aJld098grs70GbrdppuiCBkOMrI9SPN1U",
+        "qi": "BQKhLeCBh-bBwsjHDUdLkd9yT0L8MQ14-OpQQEJEV_xk-78m3dX0oXK5VsdgToAixldB3NFBsv0MUp8erpSpVEuxb99URCbWIX68E6yG2Kba5699ZNbTMyZTrm_VRI8NrkMhAADip6gL69Qg2MhgnVd1n7p6iHfbRTnhq-CWdIM"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 59,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "ca095311d2c3cba494ca686bf451a3ee1ff4ecff1fe7738001c9d8f494e2375efbf0b03e832bcbd1d8d1a319d262c844fc1aedaaae7c06bc654e4af0412265aa0dd1cf46652460d43b14436ba8cc7c72870fcb92554e1c2c468fdcc2e31769437b57d47a348c6af331ac9e0132d41607ee95300330537fbd74e25e661ddc9989d201155f388a93cf8ffa7d44b33a4c1baf7a1b056ca80eef22a14d1f1c4460d6136ae6601fb19afed2b78f333047e8bdaace0a6c61b056c23a360829e632d1e847f9f57aac7322e27d6fd1a77c941743605405c037ebcc8ad0b68b034f954af5fb47943f5580abc20d59b6d419",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00970c802f8bc69e2e7e9f5c38834600446ef0d5f037311c6b143ed35258f9523bdc9b8bd753b68e842e7399769d9d428b8ce68f0ab97427205896b66b4d26b45c99b3dc5d0268ce20e33270121f50ebe23bd24c8e378b31fc30fd079f1918fc54d9e57229db62eb454ca45eba505bc4166f80d24784e58b14bac6b3435c4fc6eae8a14d67a06eda445ec46e9826d3f75da0a63f4a295c8478cccc9d19177d74f57a5ee66d9a1004bddf546eea046a9c9eb78e3b1bae5fe7f8240703bca97d7224c7f2f9ad549d87f5a9b64957ab85e92ca22cd6543f36595412bf535f258b2233dae92da91cffa8a0a2215bfbbef75d078cc516e388db733da5cd656f93b0eb59",
+        "privateExponent": "0315872201647c2b169c861f64c5c7805e3406683dd63fbe6b76c76d8f61c2d534514c3b08ab69f046bb074381df19c25bed82b6ed37b30b50e7bde085be2031625586eeb2bb8556ec50a5b3670689d470148089e8562c1e7a391660601caf9d4368310b2bfeb26f532be97fbc1f8d8ac83acd00571531406a7a5f6365157f6a192f4e4cd052bb3f3b08269f28f8f2acbfcacf8707c367c786bce8ebda4a8b5083fcd907e91ceb1962524ed0c13b10729950f3689f6713e50d0a89df0aac7ba82af33892f004d76c7bd051b3ffedc3941b32b71d2fb5fb1b68cc8b817b6679af74669bbf264a487281eb8624a8bbeb3145b16a53626f41ad797ebc9b42a52fa1",
+        "publicExponent": "010001",
+        "prime1": "00c6796d5db4801718b6407a1685751c5d7261b8ea32155320a956c130f17116f81fd01284062a5f1b114901fead4a38d12130356805ac921fc538307379fc1399638a6b9f06a88d1cb6b88580bd42a411d96b6e785cda570b4dec2a651a9841dd94f5121a4fe7c7fc028f554d0ced4c87f7a1eeb3b723a2e82f41841cff4e9261",
+        "prime2": "00c2d427a9927c45b982cd3f08eb077201126577138d7e9e0bf80b6f55a884ebee9cd9945f041c52618efe8eb2a7ba4440cd7acbb236607ceb89ab2faca8d10f377512e9ffbf3b772fa9f8b745820c8d9ceb5e8e98378e9f3ab391506e051f3253e9c6d583138258659c7abee19baa2ee169b8aa01b5ffa15289538b0a8cd66bf9",
+        "exponent1": "3fea40b70976aa7971cfa7c172eef8d87b0a4f5354179bf28bb5fd76f679d5ccc7e9e8dc8d63bdc6e8b51b2859c3ea3226bef0a3f417d3e2d94f34032c086a835e13e87e88d564c4176faac67fac634bc039a194af4a3cf7cdfb3cd7dc4da6006684d97491c0f19d0d71fd2558015f40f61536dab72289c6bdd91a6380305c61",
+        "exponent2": "5d440c7c9bb84bf4838e5787a0635f0aee508e5158e1ed2cd3a03dbae6c242e36648ae43520770d46d0ca529172c0ef26aab4709d80816a4f6b17150193c83294c2d32c1903d1a5041f0e3632ddf6e87591159f7ba58d716d5d1518c697d46ad6ef31550fb2ce1be3acb73c732aaa4689a20a199d2133e99f14d81f919f4a799",
+        "coefficient": "3dcc0287c0343f8fcb35c8a2f88b605e650be24d42d8d65a95241a51838eb63b4e76ce15feb538bcd2db0e9cc4f85fd9ece0414b9162024ec2d06e8472f67e97745fc69492ca049cbd4166822d810244ca28b2451ab29d2cf24836368770ebb7bd591125cb48b5307c590ff270783378b17402af4bdd356840aa6c51d84c3362"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100970c802f8bc69e2e7e9f5c38834600446ef0d5f037311c6b143ed35258f9523bdc9b8bd753b68e842e7399769d9d428b8ce68f0ab97427205896b66b4d26b45c99b3dc5d0268ce20e33270121f50ebe23bd24c8e378b31fc30fd079f1918fc54d9e57229db62eb454ca45eba505bc4166f80d24784e58b14bac6b3435c4fc6eae8a14d67a06eda445ec46e9826d3f75da0a63f4a295c8478cccc9d19177d74f57a5ee66d9a1004bddf546eea046a9c9eb78e3b1bae5fe7f8240703bca97d7224c7f2f9ad549d87f5a9b64957ab85e92ca22cd6543f36595412bf535f258b2233dae92da91cffa8a0a2215bfbbef75d078cc516e388db733da5cd656f93b0eb590203010001028201000315872201647c2b169c861f64c5c7805e3406683dd63fbe6b76c76d8f61c2d534514c3b08ab69f046bb074381df19c25bed82b6ed37b30b50e7bde085be2031625586eeb2bb8556ec50a5b3670689d470148089e8562c1e7a391660601caf9d4368310b2bfeb26f532be97fbc1f8d8ac83acd00571531406a7a5f6365157f6a192f4e4cd052bb3f3b08269f28f8f2acbfcacf8707c367c786bce8ebda4a8b5083fcd907e91ceb1962524ed0c13b10729950f3689f6713e50d0a89df0aac7ba82af33892f004d76c7bd051b3ffedc3941b32b71d2fb5fb1b68cc8b817b6679af74669bbf264a487281eb8624a8bbeb3145b16a53626f41ad797ebc9b42a52fa102818100c6796d5db4801718b6407a1685751c5d7261b8ea32155320a956c130f17116f81fd01284062a5f1b114901fead4a38d12130356805ac921fc538307379fc1399638a6b9f06a88d1cb6b88580bd42a411d96b6e785cda570b4dec2a651a9841dd94f5121a4fe7c7fc028f554d0ced4c87f7a1eeb3b723a2e82f41841cff4e926102818100c2d427a9927c45b982cd3f08eb077201126577138d7e9e0bf80b6f55a884ebee9cd9945f041c52618efe8eb2a7ba4440cd7acbb236607ceb89ab2faca8d10f377512e9ffbf3b772fa9f8b745820c8d9ceb5e8e98378e9f3ab391506e051f3253e9c6d583138258659c7abee19baa2ee169b8aa01b5ffa15289538b0a8cd66bf90281803fea40b70976aa7971cfa7c172eef8d87b0a4f5354179bf28bb5fd76f679d5ccc7e9e8dc8d63bdc6e8b51b2859c3ea3226bef0a3f417d3e2d94f34032c086a835e13e87e88d564c4176faac67fac634bc039a194af4a3cf7cdfb3cd7dc4da6006684d97491c0f19d0d71fd2558015f40f61536dab72289c6bdd91a6380305c610281805d440c7c9bb84bf4838e5787a0635f0aee508e5158e1ed2cd3a03dbae6c242e36648ae43520770d46d0ca529172c0ef26aab4709d80816a4f6b17150193c83294c2d32c1903d1a5041f0e3632ddf6e87591159f7ba58d716d5d1518c697d46ad6ef31550fb2ce1be3acb73c732aaa4689a20a199d2133e99f14d81f919f4a7990281803dcc0287c0343f8fcb35c8a2f88b605e650be24d42d8d65a95241a51838eb63b4e76ce15feb538bcd2db0e9cc4f85fd9ece0414b9162024ec2d06e8472f67e97745fc69492ca049cbd4166822d810244ca28b2451ab29d2cf24836368770ebb7bd591125cb48b5307c590ff270783378b17402af4bdd356840aa6c51d84c3362",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCXDIAvi8aeLn6f\nXDiDRgBEbvDV8DcxHGsUPtNSWPlSO9ybi9dTto6ELnOZdp2dQouM5o8KuXQnIFiW\ntmtNJrRcmbPcXQJoziDjMnASH1Dr4jvSTI43izH8MP0HnxkY/FTZ5XIp22LrRUyk\nXrpQW8QWb4DSR4TlixS6xrNDXE/G6uihTWegbtpEXsRumCbT912gpj9KKVyEeMzM\nnRkXfXT1el7mbZoQBL3fVG7qBGqcnreOOxuuX+f4JAcDvKl9ciTH8vmtVJ2H9am2\nSVerheksoizWVD82WVQSv1NfJYsiM9rpLakc/6igoiFb+773XQeMxRbjiNtzPaXN\nZW+TsOtZAgMBAAECggEAAxWHIgFkfCsWnIYfZMXHgF40Bmg91j++a3bHbY9hwtU0\nUUw7CKtp8Ea7B0OB3xnCW+2Ctu03swtQ573ghb4gMWJVhu6yu4VW7FCls2cGidRw\nFICJ6FYsHno5FmBgHK+dQ2gxCyv+sm9TK+l/vB+Nisg6zQBXFTFAanpfY2UVf2oZ\nL05M0FK7PzsIJp8o+PKsv8rPhwfDZ8eGvOjr2kqLUIP82QfpHOsZYlJO0ME7EHKZ\nUPNon2cT5Q0Kid8KrHuoKvM4kvAE12x70FGz/+3DlBsytx0vtfsbaMyLgXtmea90\nZpu/JkpIcoHrhiSou+sxRbFqU2JvQa15frybQqUvoQKBgQDGeW1dtIAXGLZAehaF\ndRxdcmG46jIVUyCpVsEw8XEW+B/QEoQGKl8bEUkB/q1KONEhMDVoBaySH8U4MHN5\n/BOZY4prnwaojRy2uIWAvUKkEdlrbnhc2lcLTewqZRqYQd2U9RIaT+fH/AKPVU0M\n7UyH96Hus7cjougvQYQc/06SYQKBgQDC1CepknxFuYLNPwjrB3IBEmV3E41+ngv4\nC29VqITr7pzZlF8EHFJhjv6Osqe6REDNesuyNmB864mrL6yo0Q83dRLp/787dy+p\n+LdFggyNnOtejpg3jp86s5FQbgUfMlPpxtWDE4JYZZx6vuGbqi7habiqAbX/oVKJ\nU4sKjNZr+QKBgD/qQLcJdqp5cc+nwXLu+Nh7Ck9TVBeb8ou1/Xb2edXMx+no3I1j\nvcbotRsoWcPqMia+8KP0F9Pi2U80AywIaoNeE+h+iNVkxBdvqsZ/rGNLwDmhlK9K\nPPfN+zzX3E2mAGaE2XSRwPGdDXH9JVgBX0D2FTbatyKJxr3ZGmOAMFxhAoGAXUQM\nfJu4S/SDjleHoGNfCu5QjlFY4e0s06A9uubCQuNmSK5DUgdw1G0MpSkXLA7yaqtH\nCdgIFqT2sXFQGTyDKUwtMsGQPRpQQfDjYy3fbodZEVn3uljXFtXRUYxpfUatbvMV\nUPss4b46y3PHMqqkaJogoZnSEz6Z8U2B+Rn0p5kCgYA9zAKHwDQ/j8s1yKL4i2Be\nZQviTULY1lqVJBpRg462O052zhX+tTi80tsOnMT4X9ns4EFLkWICTsLQboRy9n6X\ndF/GlJLKBJy9QWaCLYECRMooskUasp0s8kg2Nodw67e9WREly0i1MHxZD/JweDN4\nsXQCr0vdNWhAqmxR2EwzYg==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "lwyAL4vGni5-n1w4g0YARG7w1fA3MRxrFD7TUlj5Ujvcm4vXU7aOhC5zmXadnUKLjOaPCrl0JyBYlrZrTSa0XJmz3F0CaM4g4zJwEh9Q6-I70kyON4sx_DD9B58ZGPxU2eVyKdti60VMpF66UFvEFm-A0keE5YsUusazQ1xPxurooU1noG7aRF7Ebpgm0_ddoKY_SilchHjMzJ0ZF3109Xpe5m2aEAS931Ru6gRqnJ63jjsbrl_n-CQHA7ypfXIkx_L5rVSdh_WptklXq4XpLKIs1lQ_NllUEr9TXyWLIjPa6S2pHP-ooKIhW_u-910HjMUW44jbcz2lzWVvk7DrWQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "AxWHIgFkfCsWnIYfZMXHgF40Bmg91j--a3bHbY9hwtU0UUw7CKtp8Ea7B0OB3xnCW-2Ctu03swtQ573ghb4gMWJVhu6yu4VW7FCls2cGidRwFICJ6FYsHno5FmBgHK-dQ2gxCyv-sm9TK-l_vB-Nisg6zQBXFTFAanpfY2UVf2oZL05M0FK7PzsIJp8o-PKsv8rPhwfDZ8eGvOjr2kqLUIP82QfpHOsZYlJO0ME7EHKZUPNon2cT5Q0Kid8KrHuoKvM4kvAE12x70FGz_-3DlBsytx0vtfsbaMyLgXtmea90Zpu_JkpIcoHrhiSou-sxRbFqU2JvQa15frybQqUvoQ",
+        "p": "xnltXbSAFxi2QHoWhXUcXXJhuOoyFVMgqVbBMPFxFvgf0BKEBipfGxFJAf6tSjjRITA1aAWskh_FODBzefwTmWOKa58GqI0ctriFgL1CpBHZa254XNpXC03sKmUamEHdlPUSGk_nx_wCj1VNDO1Mh_eh7rO3I6LoL0GEHP9OkmE",
+        "q": "wtQnqZJ8RbmCzT8I6wdyARJldxONfp4L-AtvVaiE6-6c2ZRfBBxSYY7-jrKnukRAzXrLsjZgfOuJqy-sqNEPN3US6f-_O3cvqfi3RYIMjZzrXo6YN46fOrORUG4FHzJT6cbVgxOCWGWcer7hm6ou4Wm4qgG1_6FSiVOLCozWa_k",
+        "dp": "P-pAtwl2qnlxz6fBcu742HsKT1NUF5vyi7X9dvZ51czH6ejcjWO9xui1GyhZw-oyJr7wo_QX0-LZTzQDLAhqg14T6H6I1WTEF2-qxn-sY0vAOaGUr0o89837PNfcTaYAZoTZdJHA8Z0Ncf0lWAFfQPYVNtq3IonGvdkaY4AwXGE",
+        "dq": "XUQMfJu4S_SDjleHoGNfCu5QjlFY4e0s06A9uubCQuNmSK5DUgdw1G0MpSkXLA7yaqtHCdgIFqT2sXFQGTyDKUwtMsGQPRpQQfDjYy3fbodZEVn3uljXFtXRUYxpfUatbvMVUPss4b46y3PHMqqkaJogoZnSEz6Z8U2B-Rn0p5k",
+        "qi": "PcwCh8A0P4_LNcii-ItgXmUL4k1C2NZalSQaUYOOtjtOds4V_rU4vNLbDpzE-F_Z7OBBS5FiAk7C0G6EcvZ-l3RfxpSSygScvUFmgi2BAkTKKLJFGrKdLPJINjaHcOu3vVkRJctItTB8WQ_ycHgzeLF0Aq9L3TVoQKpsUdhMM2I"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 60,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "575b819ff5b00428d51e8ce5df4a02d588ce49f9540cb6f27a53f0f27b2741d2ba97d9192fb67c90f564a48965",
+          "ct": "970c802f8bc69e2e7e9f5c38834600446ef0d5f037311c6b143ed35258f9523bdc9b8bd753b68e842e7399769d9d428b8ce68f0ab97427205896b66b4d26b45c99b3dc5d0268ce20e33270121f50ebe23bd24c8e378b31fc30fd079f1918fc54d9e57229db62eb454ca45eba505bc4166f80d24784e58b14bac6b3435c4fc6ea68a14d67a06eda445ec46e9826d3f75da0a63f4a295c8478cccc9d19177d74f57a5ee66d9a1004bddf546eea046a9c9eb78e3b1bae5fe7f8240703bca97d7224c7f2f9ad549d87f5a9b64957ab85e92ca22cd6543f36595412bf535f258b2233dae92da91cffa8a0a2215bfbbef75d078cc516e388db733da5cd656f93b0eb58",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00b5b356e62591aa12b607c9541e081020a8e48752f9e1bc50989494ad5c5a22079a00b607d8f5ba364475515ca5c9c204b8f294c0a42fa3265f9a3337f3331cc52db473dd4644f9ccbdbf3742f3dde513b3d6df9cea6e94e2e2295147ce03685d42515c2e1a869529d41a51c06cd0c608932adc5b5ce790b4e8f9c72a34d0e5b216c01253c22ebe6eb71917812ec899df666b94e0a2290e75197063ea55e3390e2a7ddcf9c47e2543030f69195a3379d4739090dfcd07295bfc9a8e2891ee9ef286623cb9963c056d934749fd2bcd73e47b816595d54bc2635fea68098f7807687996c1826023459bb4211ff1e98ac140823a36b70345b6c4c6bfdf7aadc5d34f",
+        "privateExponent": "0241a274e5fd62b279932fd87644b53e5219a2b79a5ff2522605d406d4adf277c06cf58828724671037949dabb7fd6c97ab6007a3adb5ea5b17f441551ffcdea89a91887daa63c730d80c6e7d818383585d9ee500c05b8319aaa893b496039a3a65af7fe3b6c568c9808a400684050cb11ebf0da1c25174bc378865ad9f97adb63e04419119e0d15b4c846bfa6aeab1ff9c84f0a91699ba30a7f802f8c2784575826a86fe8cc0e62e33618049eb612f55d2680ded0fdc01cbd9e3ed1a1489fb81f7eba189c6a6a466b8cfc519e7c3aa054ec61c1464682fc8057957e8c30877d640b7a72057ce86e6603923de621a0e1ca0138cf68efc016a6bad720d6df69a1",
+        "publicExponent": "010001",
+        "prime1": "00f445d8afa1f24d7e26811bff63736f8dff4cd25d52432ebe8d58b5e31bfe4fb41d6125a03939a97f1a5dc12215588aad9b3c7b8eba85697b348a7a6912ef0afb6566362bbdde146fa0404a039f668bc5d897d0991d12b5942527aabced875b6aadb65d96fc2550181359a70fadecd40745833dce8a571b092f6b7bcc853621b1",
+        "prime2": "00be6c781cf766ccb1ca7c9ee8600b928c2d6dd362993f8ddbadf111e876e0e52c381ea344c1e310f7bf17c1d221bd896258f267160e4707565426214db5980594878eb7bb9983b57f6419f15cdb5d6a7959cc09eb46adb988bdffa22898a9104fd7675a0a29648512f4206e0a7bbe7e412a4e17d4cad3f56837091cc706eb84ff",
+        "exponent1": "252edca51f89bab2113a6600a22ad8384d3c6c69383471d11fc2f92cf0fded3405a4dc0d5fa89f5c71af03cf2460adfb6f3dedb0f4438aa2ee8485cda8cc2a67ca2f9cdf5baf8a7cd36ff5d447575cbf6910f2f7dbad1566cfa112246023d28e9292c7fc4bb58253a7de65c7c539dfac9bb036a051fea066ed88f6f752efc281",
+        "exponent2": "797ad7519b5f207cd7b192eaa9c318358711c645e38010eeb153d659d7e4f72eb38a901be0190c8d1082866a988dc2e453dc287980983d8d0c57daed2949175e3ef0843410e65e562bb5052e78df6a7a8a17c9c827a9d26ff2cdef5438b7ba294540b0c744cad4be57b18ca1f179802ff05e2b83dbf5465cbaa77c8d57d3ce5f",
+        "coefficient": "0088e5157aaa70e37b656f77c266986cfc2dbdfb3f72f2b9f6ae1c2814c9c8085c5390735a1b4076423af07a7c0462051ffd0c47051e13b42c69f67910d295f2faee7ecfdaf01ead40a8cce361ae88820101a3717e70e424a6e4bea9ecda1b7d2fc58977e84c40f7afc806016a3ec806a3077e7ae4f31ef34d09d3f99143e894b2"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100b5b356e62591aa12b607c9541e081020a8e48752f9e1bc50989494ad5c5a22079a00b607d8f5ba364475515ca5c9c204b8f294c0a42fa3265f9a3337f3331cc52db473dd4644f9ccbdbf3742f3dde513b3d6df9cea6e94e2e2295147ce03685d42515c2e1a869529d41a51c06cd0c608932adc5b5ce790b4e8f9c72a34d0e5b216c01253c22ebe6eb71917812ec899df666b94e0a2290e75197063ea55e3390e2a7ddcf9c47e2543030f69195a3379d4739090dfcd07295bfc9a8e2891ee9ef286623cb9963c056d934749fd2bcd73e47b816595d54bc2635fea68098f7807687996c1826023459bb4211ff1e98ac140823a36b70345b6c4c6bfdf7aadc5d34f0203010001028201000241a274e5fd62b279932fd87644b53e5219a2b79a5ff2522605d406d4adf277c06cf58828724671037949dabb7fd6c97ab6007a3adb5ea5b17f441551ffcdea89a91887daa63c730d80c6e7d818383585d9ee500c05b8319aaa893b496039a3a65af7fe3b6c568c9808a400684050cb11ebf0da1c25174bc378865ad9f97adb63e04419119e0d15b4c846bfa6aeab1ff9c84f0a91699ba30a7f802f8c2784575826a86fe8cc0e62e33618049eb612f55d2680ded0fdc01cbd9e3ed1a1489fb81f7eba189c6a6a466b8cfc519e7c3aa054ec61c1464682fc8057957e8c30877d640b7a72057ce86e6603923de621a0e1ca0138cf68efc016a6bad720d6df69a102818100f445d8afa1f24d7e26811bff63736f8dff4cd25d52432ebe8d58b5e31bfe4fb41d6125a03939a97f1a5dc12215588aad9b3c7b8eba85697b348a7a6912ef0afb6566362bbdde146fa0404a039f668bc5d897d0991d12b5942527aabced875b6aadb65d96fc2550181359a70fadecd40745833dce8a571b092f6b7bcc853621b102818100be6c781cf766ccb1ca7c9ee8600b928c2d6dd362993f8ddbadf111e876e0e52c381ea344c1e310f7bf17c1d221bd896258f267160e4707565426214db5980594878eb7bb9983b57f6419f15cdb5d6a7959cc09eb46adb988bdffa22898a9104fd7675a0a29648512f4206e0a7bbe7e412a4e17d4cad3f56837091cc706eb84ff028180252edca51f89bab2113a6600a22ad8384d3c6c69383471d11fc2f92cf0fded3405a4dc0d5fa89f5c71af03cf2460adfb6f3dedb0f4438aa2ee8485cda8cc2a67ca2f9cdf5baf8a7cd36ff5d447575cbf6910f2f7dbad1566cfa112246023d28e9292c7fc4bb58253a7de65c7c539dfac9bb036a051fea066ed88f6f752efc281028180797ad7519b5f207cd7b192eaa9c318358711c645e38010eeb153d659d7e4f72eb38a901be0190c8d1082866a988dc2e453dc287980983d8d0c57daed2949175e3ef0843410e65e562bb5052e78df6a7a8a17c9c827a9d26ff2cdef5438b7ba294540b0c744cad4be57b18ca1f179802ff05e2b83dbf5465cbaa77c8d57d3ce5f0281810088e5157aaa70e37b656f77c266986cfc2dbdfb3f72f2b9f6ae1c2814c9c8085c5390735a1b4076423af07a7c0462051ffd0c47051e13b42c69f67910d295f2faee7ecfdaf01ead40a8cce361ae88820101a3717e70e424a6e4bea9ecda1b7d2fc58977e84c40f7afc806016a3ec806a3077e7ae4f31ef34d09d3f99143e894b2",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC1s1bmJZGqErYH\nyVQeCBAgqOSHUvnhvFCYlJStXFoiB5oAtgfY9bo2RHVRXKXJwgS48pTApC+jJl+a\nMzfzMxzFLbRz3UZE+cy9vzdC893lE7PW35zqbpTi4ilRR84DaF1CUVwuGoaVKdQa\nUcBs0MYIkyrcW1znkLTo+ccqNNDlshbAElPCLr5utxkXgS7Imd9ma5TgoikOdRlw\nY+pV4zkOKn3c+cR+JUMDD2kZWjN51HOQkN/NBylb/JqOKJHunvKGYjy5ljwFbZNH\nSf0rzXPke4FlldVLwmNf6mgJj3gHaHmWwYJgI0WbtCEf8emKwUCCOja3A0W2xMa/\n33qtxdNPAgMBAAECggEAAkGidOX9YrJ5ky/YdkS1PlIZoreaX/JSJgXUBtSt8nfA\nbPWIKHJGcQN5Sdq7f9bJerYAejrbXqWxf0QVUf/N6ompGIfapjxzDYDG59gYODWF\n2e5QDAW4MZqqiTtJYDmjplr3/jtsVoyYCKQAaEBQyxHr8NocJRdLw3iGWtn5ettj\n4EQZEZ4NFbTIRr+mrqsf+chPCpFpm6MKf4AvjCeEV1gmqG/ozA5i4zYYBJ62EvVd\nJoDe0P3AHL2ePtGhSJ+4H366GJxqakZrjPxRnnw6oFTsYcFGRoL8gFeVfowwh31k\nC3pyBXzobmYDkj3mIaDhygE4z2jvwBamutcg1t9poQKBgQD0RdivofJNfiaBG/9j\nc2+N/0zSXVJDLr6NWLXjG/5PtB1hJaA5Oal/Gl3BIhVYiq2bPHuOuoVpezSKemkS\n7wr7ZWY2K73eFG+gQEoDn2aLxdiX0JkdErWUJSeqvO2HW2qttl2W/CVQGBNZpw+t\n7NQHRYM9zopXGwkva3vMhTYhsQKBgQC+bHgc92bMscp8nuhgC5KMLW3TYpk/jdut\n8RHoduDlLDgeo0TB4xD3vxfB0iG9iWJY8mcWDkcHVlQmIU21mAWUh463u5mDtX9k\nGfFc211qeVnMCetGrbmIvf+iKJipEE/XZ1oKKWSFEvQgbgp7vn5BKk4X1MrT9Wg3\nCRzHBuuE/wKBgCUu3KUfibqyETpmAKIq2DhNPGxpODRx0R/C+Szw/e00BaTcDV+o\nn1xxrwPPJGCt+2897bD0Q4qi7oSFzajMKmfKL5zfW6+KfNNv9dRHV1y/aRDy99ut\nFWbPoRIkYCPSjpKSx/xLtYJTp95lx8U536ybsDagUf6gZu2I9vdS78KBAoGAeXrX\nUZtfIHzXsZLqqcMYNYcRxkXjgBDusVPWWdfk9y6zipAb4BkMjRCChmqYjcLkU9wo\neYCYPY0MV9rtKUkXXj7whDQQ5l5WK7UFLnjfanqKF8nIJ6nSb/LN71Q4t7opRUCw\nx0TK1L5XsYyh8XmAL/BeK4Pb9UZcuqd8jVfTzl8CgYEAiOUVeqpw43tlb3fCZphs\n/C29+z9y8rn2rhwoFMnICFxTkHNaG0B2QjrwenwEYgUf/QxHBR4TtCxp9nkQ0pXy\n+u5+z9rwHq1AqMzjYa6IggEBo3F+cOQkpuS+qezaG30vxYl36ExA96/IBgFqPsgG\nowd+euTzHvNNCdP5kUPolLI=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "tbNW5iWRqhK2B8lUHggQIKjkh1L54bxQmJSUrVxaIgeaALYH2PW6NkR1UVylycIEuPKUwKQvoyZfmjM38zMcxS20c91GRPnMvb83QvPd5ROz1t-c6m6U4uIpUUfOA2hdQlFcLhqGlSnUGlHAbNDGCJMq3Ftc55C06PnHKjTQ5bIWwBJTwi6-brcZF4EuyJnfZmuU4KIpDnUZcGPqVeM5Dip93PnEfiVDAw9pGVozedRzkJDfzQcpW_yajiiR7p7yhmI8uZY8BW2TR0n9K81z5HuBZZXVS8JjX-poCY94B2h5lsGCYCNFm7QhH_HpisFAgjo2twNFtsTGv996rcXTTw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "AkGidOX9YrJ5ky_YdkS1PlIZoreaX_JSJgXUBtSt8nfAbPWIKHJGcQN5Sdq7f9bJerYAejrbXqWxf0QVUf_N6ompGIfapjxzDYDG59gYODWF2e5QDAW4MZqqiTtJYDmjplr3_jtsVoyYCKQAaEBQyxHr8NocJRdLw3iGWtn5ettj4EQZEZ4NFbTIRr-mrqsf-chPCpFpm6MKf4AvjCeEV1gmqG_ozA5i4zYYBJ62EvVdJoDe0P3AHL2ePtGhSJ-4H366GJxqakZrjPxRnnw6oFTsYcFGRoL8gFeVfowwh31kC3pyBXzobmYDkj3mIaDhygE4z2jvwBamutcg1t9poQ",
+        "p": "9EXYr6HyTX4mgRv_Y3Nvjf9M0l1SQy6-jVi14xv-T7QdYSWgOTmpfxpdwSIVWIqtmzx7jrqFaXs0inppEu8K-2VmNiu93hRvoEBKA59mi8XYl9CZHRK1lCUnqrzth1tqrbZdlvwlUBgTWacPrezUB0WDPc6KVxsJL2t7zIU2IbE",
+        "q": "vmx4HPdmzLHKfJ7oYAuSjC1t02KZP43brfER6Hbg5Sw4HqNEweMQ978XwdIhvYliWPJnFg5HB1ZUJiFNtZgFlIeOt7uZg7V_ZBnxXNtdanlZzAnrRq25iL3_oiiYqRBP12daCilkhRL0IG4Ke75-QSpOF9TK0_VoNwkcxwbrhP8",
+        "dp": "JS7cpR-JurIROmYAoirYOE08bGk4NHHRH8L5LPD97TQFpNwNX6ifXHGvA88kYK37bz3tsPRDiqLuhIXNqMwqZ8ovnN9br4p802_11EdXXL9pEPL3260VZs-hEiRgI9KOkpLH_Eu1glOn3mXHxTnfrJuwNqBR_qBm7Yj291LvwoE",
+        "dq": "eXrXUZtfIHzXsZLqqcMYNYcRxkXjgBDusVPWWdfk9y6zipAb4BkMjRCChmqYjcLkU9woeYCYPY0MV9rtKUkXXj7whDQQ5l5WK7UFLnjfanqKF8nIJ6nSb_LN71Q4t7opRUCwx0TK1L5XsYyh8XmAL_BeK4Pb9UZcuqd8jVfTzl8",
+        "qi": "iOUVeqpw43tlb3fCZphs_C29-z9y8rn2rhwoFMnICFxTkHNaG0B2QjrwenwEYgUf_QxHBR4TtCxp9nkQ0pXy-u5-z9rwHq1AqMzjYa6IggEBo3F-cOQkpuS-qezaG30vxYl36ExA96_IBgFqPsgGowd-euTzHvNNCdP5kUPolLI"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 61,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "1f7926bf036e2dc744b3591cdc9575b7f1e6cab9a3766de85b56b9e975f13046b41ca9df17fbf93ef4f260f8bd263182dd4a4fd87edd9716d63b99e9ad30212e9f506c345838e34b3d784d1785bebd59c52e24f7748361c670c29999f4766f84702f3997550989ec36ced0eca73bfe167c8b1913abc69f537d7171dc84b268198681228c71e6a6b9d402de2302e4704392a4e946ac0c6a6e29184659ee",
+          "ct": "b5b356e62591aa12b607c9541e081020a8e48752f9e1bc50989494ad5c5a22079a00b607d8f5ba364475515ca5c9c204b8f294c0a42fa3265f9a3337f3331cc52db473dd4644f9ccbdbf3742f3dde513b3d6df9cea6e94e2e2295147ce03685d42515c2e1a869529d41a51c06cd0c608932adc5b5ce790b4e8f9c72a34d0e5b215c01253c22ebe6eb71917812ec899df666b94e0a2290e75197063ea55e3390e2a7ddcf9c47e2543030f69195a3379d4739090dfcd07295bfc9a8e2891ee9ef286623cb9963c056d934749fd2bcd73e47b816595d54bc2635fea68098f7807687996c1826023459bb4211ff1e98ac140823a36b70345b6c4c6bfdf7aadc5d350",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00e1553db85d0a89d51fbc963fb8be566b0b8c72e8174e7f9f969c0d892fd259ae5aa44c0cf97702372724c7edadbee4cd581890f67824dd65fe7d67ac12e9db1da108eed274352d4597bab6e3624421769d2d634d203f878abf1a7de27f650e3ef551cbffc5469b4d23e608a1ed57a36c0dba443ba2957f58a0aad0530c20b515295b1f4e3ae9df2ccc69d025bc23283039d1e42f015b24ae919aab8e812f03a6f3cd3013cbf00d35edb489ccec7e68105cd6ffb2b85623c1238a6ceb04b73c7e2df0402376d71ac3e03278eb2a7a5895f81b7f3dec62e9fd95efe22ec152d0c673d7004d244e87bdc787ba632fee75d805e29229e111fc083b0484b0480ba63f",
+        "privateExponent": "4ca464a8d7a4a4fb039f6e6f6014056ac573d105961fd212e2f4533a4d34bbe22cdc632daa904b059d5fca4cd262f289d1a4117273acfe4d19c167c8c46a1c683884c44e7ace3786cb33ebceed7684f74640d0dcc3d237f4fe4931761fa4acb2c7583a0dd5f8cd0bf0e0e620c58ca07e393118d23bdba383eeaa0acfa4795f7d9ea26c83305a6fc8a808058414cc0cea5f9cc97fd394cab0756c55823b86adfde6c46a6dfbf52da24a3323bd86cf35916450d9b4ba03be365f6ba3ff91fb6a4c235a229d49a572d23afa2e3268b164a94810741f40dcaf3a628563368f567eb624018d4a110c981ab6d2da5fd7f3c30b0cbe22120ac63c0a73e09affae95ef91",
+        "publicExponent": "010001",
+        "prime1": "00f95c944ccde828d364543764b0f05ea6044bc2d3c5918dd1b6b8bc3623f95810a5406215fe4202cdf924978a908c47c2390ea20f375f10ba3dbe43d8dd40dafc301dad1b10a8b7f17ea97f7f7009dcf2bfb3a1b8cf7f5569b064a21dba9c959ec2b71c2cc057e91a21702bfba954f2ca269e8cd030c0f4f4803ad0becfc58e09",
+        "prime2": "00e754e7875edcb5332189ff31b9c2b6b93579e5e7e1fbc013da4f8b1a32c68d5d6774c6e3b1dfc5e55b22f2b30fb12a70692560cd40c2fa6d087afbc617c36a582e3ce5d7a506f45b443bc6170b0d11c711045f92c49ec3b5899a1d3c191bfb97bfbc8051caefd7935d5abcf161a5af7d5d9d971edb0c07f9f88fe72eff2fa407",
+        "exponent1": "008c8d8e59ac460b9cfb942c94e8d6d3c2a7f13c23b9dccd1f43eae4cb6f83800c01d94470391c64104d3a3ee0af9122716b4fc030eb78fe28bbdc9ec9820ca862358cc4a1d8c600c872287fe108f9c63c5da996a260f2d8e5f5b3035dd66da4381470b9c4cfb5bd82290edcfbc0fa4ccf7ced2959bfe14330fd86295b2429aa61",
+        "exponent2": "772074fe742e6a2d838701e0c48d6df560817e90740265be937cc4e05fe779a2f104e4eb1a8d66e69e9117b4784f3ed09685061d8ccd1b930c7bf0ade94cdbb5bf51e2f6b2e82aebd8ee832b18a8c94fdf0686851935bd08fe6c5bc3b8167df07e6f7f111fd575095158c9d5eff817b0128675ed10d6584134ec3e1c28938aff",
+        "coefficient": "00a957119ae91810c9e2e92d8cefe0aeed8a7dc65d777d55948d6c09794b7d096a91789730d286370db6a761f048e1bb9a294b07f8a652b93abdca388c561c2acbb1e65ef93c8a230ff2cbde5e690ad7a04abcca80d253272e3687b99d17160c31ab73c6524e815004ab78ab8fad16d089952bf55889b2f75d473112823e4237ce"
+      },
+      "privateKeyPkcs8": "308204be020100300d06092a864886f70d0101010500048204a8308204a40201000282010100e1553db85d0a89d51fbc963fb8be566b0b8c72e8174e7f9f969c0d892fd259ae5aa44c0cf97702372724c7edadbee4cd581890f67824dd65fe7d67ac12e9db1da108eed274352d4597bab6e3624421769d2d634d203f878abf1a7de27f650e3ef551cbffc5469b4d23e608a1ed57a36c0dba443ba2957f58a0aad0530c20b515295b1f4e3ae9df2ccc69d025bc23283039d1e42f015b24ae919aab8e812f03a6f3cd3013cbf00d35edb489ccec7e68105cd6ffb2b85623c1238a6ceb04b73c7e2df0402376d71ac3e03278eb2a7a5895f81b7f3dec62e9fd95efe22ec152d0c673d7004d244e87bdc787ba632fee75d805e29229e111fc083b0484b0480ba63f0203010001028201004ca464a8d7a4a4fb039f6e6f6014056ac573d105961fd212e2f4533a4d34bbe22cdc632daa904b059d5fca4cd262f289d1a4117273acfe4d19c167c8c46a1c683884c44e7ace3786cb33ebceed7684f74640d0dcc3d237f4fe4931761fa4acb2c7583a0dd5f8cd0bf0e0e620c58ca07e393118d23bdba383eeaa0acfa4795f7d9ea26c83305a6fc8a808058414cc0cea5f9cc97fd394cab0756c55823b86adfde6c46a6dfbf52da24a3323bd86cf35916450d9b4ba03be365f6ba3ff91fb6a4c235a229d49a572d23afa2e3268b164a94810741f40dcaf3a628563368f567eb624018d4a110c981ab6d2da5fd7f3c30b0cbe22120ac63c0a73e09affae95ef9102818100f95c944ccde828d364543764b0f05ea6044bc2d3c5918dd1b6b8bc3623f95810a5406215fe4202cdf924978a908c47c2390ea20f375f10ba3dbe43d8dd40dafc301dad1b10a8b7f17ea97f7f7009dcf2bfb3a1b8cf7f5569b064a21dba9c959ec2b71c2cc057e91a21702bfba954f2ca269e8cd030c0f4f4803ad0becfc58e0902818100e754e7875edcb5332189ff31b9c2b6b93579e5e7e1fbc013da4f8b1a32c68d5d6774c6e3b1dfc5e55b22f2b30fb12a70692560cd40c2fa6d087afbc617c36a582e3ce5d7a506f45b443bc6170b0d11c711045f92c49ec3b5899a1d3c191bfb97bfbc8051caefd7935d5abcf161a5af7d5d9d971edb0c07f9f88fe72eff2fa407028181008c8d8e59ac460b9cfb942c94e8d6d3c2a7f13c23b9dccd1f43eae4cb6f83800c01d94470391c64104d3a3ee0af9122716b4fc030eb78fe28bbdc9ec9820ca862358cc4a1d8c600c872287fe108f9c63c5da996a260f2d8e5f5b3035dd66da4381470b9c4cfb5bd82290edcfbc0fa4ccf7ced2959bfe14330fd86295b2429aa61028180772074fe742e6a2d838701e0c48d6df560817e90740265be937cc4e05fe779a2f104e4eb1a8d66e69e9117b4784f3ed09685061d8ccd1b930c7bf0ade94cdbb5bf51e2f6b2e82aebd8ee832b18a8c94fdf0686851935bd08fe6c5bc3b8167df07e6f7f111fd575095158c9d5eff817b0128675ed10d6584134ec3e1c28938aff02818100a957119ae91810c9e2e92d8cefe0aeed8a7dc65d777d55948d6c09794b7d096a91789730d286370db6a761f048e1bb9a294b07f8a652b93abdca388c561c2acbb1e65ef93c8a230ff2cbde5e690ad7a04abcca80d253272e3687b99d17160c31ab73c6524e815004ab78ab8fad16d089952bf55889b2f75d473112823e4237ce",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDhVT24XQqJ1R+8\nlj+4vlZrC4xy6BdOf5+WnA2JL9JZrlqkTAz5dwI3JyTH7a2+5M1YGJD2eCTdZf59\nZ6wS6dsdoQju0nQ1LUWXurbjYkQhdp0tY00gP4eKvxp94n9lDj71Ucv/xUabTSPm\nCKHtV6NsDbpEO6KVf1igqtBTDCC1FSlbH0466d8szGnQJbwjKDA50eQvAVskrpGa\nq46BLwOm880wE8vwDTXttInM7H5oEFzW/7K4ViPBI4ps6wS3PH4t8EAjdtcaw+Ay\neOsqeliV+Bt/Pexi6f2V7+IuwVLQxnPXAE0kToe9x4e6Yy/uddgF4pIp4RH8CDsE\nhLBIC6Y/AgMBAAECggEATKRkqNekpPsDn25vYBQFasVz0QWWH9IS4vRTOk00u+Is\n3GMtqpBLBZ1fykzSYvKJ0aQRcnOs/k0ZwWfIxGocaDiExE56zjeGyzPrzu12hPdG\nQNDcw9I39P5JMXYfpKyyx1g6DdX4zQvw4OYgxYygfjkxGNI726OD7qoKz6R5X32e\nomyDMFpvyKgIBYQUzAzqX5zJf9OUyrB1bFWCO4at/ebEam379S2iSjMjvYbPNZFk\nUNm0ugO+Nl9ro/+R+2pMI1oinUmlctI6+i4yaLFkqUgQdB9A3K86YoVjNo9WfrYk\nAY1KEQyYGrbS2l/X88MLDL4iEgrGPApz4Jr/rpXvkQKBgQD5XJRMzego02RUN2Sw\n8F6mBEvC08WRjdG2uLw2I/lYEKVAYhX+QgLN+SSXipCMR8I5DqIPN18Quj2+Q9jd\nQNr8MB2tGxCot/F+qX9/cAnc8r+zobjPf1VpsGSiHbqclZ7CtxwswFfpGiFwK/up\nVPLKJp6M0DDA9PSAOtC+z8WOCQKBgQDnVOeHXty1MyGJ/zG5wra5NXnl5+H7wBPa\nT4saMsaNXWd0xuOx38XlWyLysw+xKnBpJWDNQML6bQh6+8YXw2pYLjzl16UG9FtE\nO8YXCw0RxxEEX5LEnsO1iZodPBkb+5e/vIBRyu/Xk11avPFhpa99XZ2XHtsMB/n4\nj+cu/y+kBwKBgQCMjY5ZrEYLnPuULJTo1tPCp/E8I7nczR9D6uTLb4OADAHZRHA5\nHGQQTTo+4K+RInFrT8Aw63j+KLvcnsmCDKhiNYzEodjGAMhyKH/hCPnGPF2plqJg\n8tjl9bMDXdZtpDgUcLnEz7W9gikO3PvA+kzPfO0pWb/hQzD9hilbJCmqYQKBgHcg\ndP50Lmotg4cB4MSNbfVggX6QdAJlvpN8xOBf53mi8QTk6xqNZuaekRe0eE8+0JaF\nBh2MzRuTDHvwrelM27W/UeL2sugq69jugysYqMlP3waGhRk1vQj+bFvDuBZ98H5v\nfxEf1XUJUVjJ1e/4F7AShnXtENZYQTTsPhwok4r/AoGBAKlXEZrpGBDJ4uktjO/g\nru2KfcZdd31VlI1sCXlLfQlqkXiXMNKGNw22p2HwSOG7milLB/imUrk6vco4jFYc\nKsux5l75PIojD/LL3l5pCtegSrzKgNJTJy42h7mdFxYMMatzxlJOgVAEq3irj60W\n0ImVK/VYibL3XUcxEoI+QjfO\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "4VU9uF0KidUfvJY_uL5WawuMcugXTn-flpwNiS_SWa5apEwM-XcCNyckx-2tvuTNWBiQ9ngk3WX-fWesEunbHaEI7tJ0NS1Fl7q242JEIXadLWNNID-Hir8afeJ_ZQ4-9VHL_8VGm00j5gih7VejbA26RDuilX9YoKrQUwwgtRUpWx9OOunfLMxp0CW8IygwOdHkLwFbJK6RmquOgS8DpvPNMBPL8A017bSJzOx-aBBc1v-yuFYjwSOKbOsEtzx-LfBAI3bXGsPgMnjrKnpYlfgbfz3sYun9le_iLsFS0MZz1wBNJE6HvceHumMv7nXYBeKSKeER_Ag7BISwSAumPw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "TKRkqNekpPsDn25vYBQFasVz0QWWH9IS4vRTOk00u-Is3GMtqpBLBZ1fykzSYvKJ0aQRcnOs_k0ZwWfIxGocaDiExE56zjeGyzPrzu12hPdGQNDcw9I39P5JMXYfpKyyx1g6DdX4zQvw4OYgxYygfjkxGNI726OD7qoKz6R5X32eomyDMFpvyKgIBYQUzAzqX5zJf9OUyrB1bFWCO4at_ebEam379S2iSjMjvYbPNZFkUNm0ugO-Nl9ro_-R-2pMI1oinUmlctI6-i4yaLFkqUgQdB9A3K86YoVjNo9WfrYkAY1KEQyYGrbS2l_X88MLDL4iEgrGPApz4Jr_rpXvkQ",
+        "p": "-VyUTM3oKNNkVDdksPBepgRLwtPFkY3Rtri8NiP5WBClQGIV_kICzfkkl4qQjEfCOQ6iDzdfELo9vkPY3UDa_DAdrRsQqLfxfql_f3AJ3PK_s6G4z39VabBkoh26nJWewrccLMBX6RohcCv7qVTyyiaejNAwwPT0gDrQvs_Fjgk",
+        "q": "51Tnh17ctTMhif8xucK2uTV55efh-8AT2k-LGjLGjV1ndMbjsd_F5Vsi8rMPsSpwaSVgzUDC-m0IevvGF8NqWC485delBvRbRDvGFwsNEccRBF-SxJ7DtYmaHTwZG_uXv7yAUcrv15NdWrzxYaWvfV2dlx7bDAf5-I_nLv8vpAc",
+        "dp": "jI2OWaxGC5z7lCyU6NbTwqfxPCO53M0fQ-rky2-DgAwB2URwORxkEE06PuCvkSJxa0_AMOt4_ii73J7JggyoYjWMxKHYxgDIcih_4Qj5xjxdqZaiYPLY5fWzA13WbaQ4FHC5xM-1vYIpDtz7wPpMz3ztKVm_4UMw_YYpWyQpqmE",
+        "dq": "dyB0_nQuai2DhwHgxI1t9WCBfpB0AmW-k3zE4F_neaLxBOTrGo1m5p6RF7R4Tz7QloUGHYzNG5MMe_Ct6Uzbtb9R4vay6Crr2O6DKxioyU_fBoaFGTW9CP5sW8O4Fn3wfm9_ER_VdQlRWMnV7_gXsBKGde0Q1lhBNOw-HCiTiv8",
+        "qi": "qVcRmukYEMni6S2M7-Cu7Yp9xl13fVWUjWwJeUt9CWqReJcw0oY3DbanYfBI4buaKUsH-KZSuTq9yjiMVhwqy7HmXvk8iiMP8sveXmkK16BKvMqA0lMnLjaHuZ0XFgwxq3PGUk6BUASreKuPrRbQiZUr9ViJsvddRzESgj5CN84"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 62,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "d59187caba5dbdbc43e6523e1163ee57187cf0999abd64e0de5d238118677b17855f588352f2208b2a92b1c296ddfa9e2bc2b271404034ef96b04122d55d3509f1f9f75658c13172caef5c1ead5d33245c1c1ead84ebfd6f7bf321c0c513c1a2e248ba9805fd3d59d84146032887ae0b0da75d65846aff104366c1e3501d09f3edacc6ce9e41f60f489bd7b0afeecc080110daf9372e18a2e26bf870d640d27cbbc92855a2ca16bbc08c7e0845cd10c964",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "009c674c8eb6b1119cadf24265cc7751bbb162a63083dfa58726df27b77b10bf030210affd810d785284374647cb89e5e78d04e7f07d24bdaf8aaf9c4aed1e176613d77f99d3e86dc97878c2eada2f6ac55c73aa7211606291736a0ba33ebeb48cbc89ee36e18d963e6250c3f9b1a29f4cd7668761cf72bfcdeb31ea58bcff31ab2d09a3502e1063e77a19cf0ef31c14a386536abb62306c41b386d4d7559b486f14c66f81cd9268b25987450b1b64209a9bfbbad7a2d5b6ccada0f5ee97687de9976980c33a4e7cd4cd1fb2f2b2fc59fcf68843f3cba885fefe4c244f8f19602947688dc697bae5f53734178b2c82497f83c60331542a5dd557010ecc3847acf9",
+        "privateExponent": "0124247cf84b16f81bfea8ad615ec1986079b0ae83fbedf713c1fea6022fbdb43a3397ecc969b848d515717cc48ba6b444426e3c406126dfc7e1ad0a14888db6145d433040c975eb6f44c76b7c19aae5962e7e8c32b6281940e60ae9889fddd0c7cd5cde4ffb839d0bc81cdc2fa019070106f6206f2798a6386450a1d76e6c0a831350bd8578753a7aa80a568a7ada7445e713dad4ea9e93235ea410704d596b5c67b99e693097c84e89bd0c97ad4300a46148119dad44e317207567bce812f149194e6ebef5921eca6c292a2f2141b5d0d0fe86dbcc8a75245b0d1cad40eeb4345a07fc04a702fd78cbd22ce37606525e0c73aded1ea2460d1e3e67e9a49dd1",
+        "publicExponent": "010001",
+        "prime1": "00d4a180a199b63e0657e4c03928e70b55d7defae203566eda84c584ffede87dfb0f5bba31d0fe6a46b4e0eddbcd80291c2fb550d5500e65aa198f32efb4d2e61a7acb82f41536931b9581bd4e96f7d10040bb240b06c77dd24a7b0a041e943b66248b2448adf068e297a5bc66f6dc986e0375888e16c659b75173fa115793b7e9",
+        "prime2": "00bc4de42bf505e84cb3385505a2fa55ee0d0691f6bda9ed283a9daacb4b13631f6601cae8ee1e107ac4c8521646fb37cad6654fad88c60bf2c137d06882b8d18caa6f2379089add3474f20e01129914992ea06050540d04b5050e723830f86d0b898f22faa746bcd21ddfb8e2e8cb7de19ad52a55070b0dd4eea8fb4798893291",
+        "exponent1": "3788266c0e150685e996988d551d625c7d10833d5bd9cb01cf03370510415405a9b12f23ab8d867c08e965b5ae29f692a1f31cb5593f29560f6ed2c2bfdb04b58db470f30647468c41b3ac9945dc5afd51ea8e334305feda591161404a2c34872cac1a41d10ba498e93a23c6505ab484a6ea9f4b5caf58e703a2e2807cfadb61",
+        "exponent2": "3b7b675e335220654a1fbb4bc285cd6b1b163e397104227418c00159a26787623db8c73df929ea0ebde68177a4086b4159a43b1d181d675cd1882dff357be845c4f8c27dd32808442fc4de839c3a5af560732cb97333818f24ffc138dacf3eb2ec4b18c390df9979ce1203b739ce3dff6c07760dd1e1be06cb34f9db4de5d8e1",
+        "coefficient": "00a08e8c751bf67cb72e99179e91f17ae2250fcae4002189c11a19d47d9ec70c864cf45bdf52a87f48fd68d21bc8a67386eb1888b9e714bdebe429d27e455c818b06552d34e2f89136646acfad68cbaa7edc878306349c6626885df770eac14a67312af3037a60a9856dbffe0545b2411bfbc21c45b91c076442527d67f6ead5c6"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a302010002820101009c674c8eb6b1119cadf24265cc7751bbb162a63083dfa58726df27b77b10bf030210affd810d785284374647cb89e5e78d04e7f07d24bdaf8aaf9c4aed1e176613d77f99d3e86dc97878c2eada2f6ac55c73aa7211606291736a0ba33ebeb48cbc89ee36e18d963e6250c3f9b1a29f4cd7668761cf72bfcdeb31ea58bcff31ab2d09a3502e1063e77a19cf0ef31c14a386536abb62306c41b386d4d7559b486f14c66f81cd9268b25987450b1b64209a9bfbbad7a2d5b6ccada0f5ee97687de9976980c33a4e7cd4cd1fb2f2b2fc59fcf68843f3cba885fefe4c244f8f19602947688dc697bae5f53734178b2c82497f83c60331542a5dd557010ecc3847acf90203010001028201000124247cf84b16f81bfea8ad615ec1986079b0ae83fbedf713c1fea6022fbdb43a3397ecc969b848d515717cc48ba6b444426e3c406126dfc7e1ad0a14888db6145d433040c975eb6f44c76b7c19aae5962e7e8c32b6281940e60ae9889fddd0c7cd5cde4ffb839d0bc81cdc2fa019070106f6206f2798a6386450a1d76e6c0a831350bd8578753a7aa80a568a7ada7445e713dad4ea9e93235ea410704d596b5c67b99e693097c84e89bd0c97ad4300a46148119dad44e317207567bce812f149194e6ebef5921eca6c292a2f2141b5d0d0fe86dbcc8a75245b0d1cad40eeb4345a07fc04a702fd78cbd22ce37606525e0c73aded1ea2460d1e3e67e9a49dd102818100d4a180a199b63e0657e4c03928e70b55d7defae203566eda84c584ffede87dfb0f5bba31d0fe6a46b4e0eddbcd80291c2fb550d5500e65aa198f32efb4d2e61a7acb82f41536931b9581bd4e96f7d10040bb240b06c77dd24a7b0a041e943b66248b2448adf068e297a5bc66f6dc986e0375888e16c659b75173fa115793b7e902818100bc4de42bf505e84cb3385505a2fa55ee0d0691f6bda9ed283a9daacb4b13631f6601cae8ee1e107ac4c8521646fb37cad6654fad88c60bf2c137d06882b8d18caa6f2379089add3474f20e01129914992ea06050540d04b5050e723830f86d0b898f22faa746bcd21ddfb8e2e8cb7de19ad52a55070b0dd4eea8fb47988932910281803788266c0e150685e996988d551d625c7d10833d5bd9cb01cf03370510415405a9b12f23ab8d867c08e965b5ae29f692a1f31cb5593f29560f6ed2c2bfdb04b58db470f30647468c41b3ac9945dc5afd51ea8e334305feda591161404a2c34872cac1a41d10ba498e93a23c6505ab484a6ea9f4b5caf58e703a2e2807cfadb610281803b7b675e335220654a1fbb4bc285cd6b1b163e397104227418c00159a26787623db8c73df929ea0ebde68177a4086b4159a43b1d181d675cd1882dff357be845c4f8c27dd32808442fc4de839c3a5af560732cb97333818f24ffc138dacf3eb2ec4b18c390df9979ce1203b739ce3dff6c07760dd1e1be06cb34f9db4de5d8e102818100a08e8c751bf67cb72e99179e91f17ae2250fcae4002189c11a19d47d9ec70c864cf45bdf52a87f48fd68d21bc8a67386eb1888b9e714bdebe429d27e455c818b06552d34e2f89136646acfad68cbaa7edc878306349c6626885df770eac14a67312af3037a60a9856dbffe0545b2411bfbc21c45b91c076442527d67f6ead5c6",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCcZ0yOtrERnK3y\nQmXMd1G7sWKmMIPfpYcm3ye3exC/AwIQr/2BDXhShDdGR8uJ5eeNBOfwfSS9r4qv\nnErtHhdmE9d/mdPobcl4eMLq2i9qxVxzqnIRYGKRc2oLoz6+tIy8ie424Y2WPmJQ\nw/mxop9M12aHYc9yv83rMepYvP8xqy0Jo1AuEGPnehnPDvMcFKOGU2q7YjBsQbOG\n1NdVm0hvFMZvgc2SaLJZh0ULG2Qgmpv7utei1bbMraD17pdofemXaYDDOk581M0f\nsvKy/Fn89ohD88uohf7+TCRPjxlgKUdojcaXuuX1NzQXiyyCSX+DxgMxVCpd1VcB\nDsw4R6z5AgMBAAECggEAASQkfPhLFvgb/qitYV7BmGB5sK6D++33E8H+pgIvvbQ6\nM5fsyWm4SNUVcXzEi6a0REJuPEBhJt/H4a0KFIiNthRdQzBAyXXrb0THa3wZquWW\nLn6MMrYoGUDmCumIn93Qx81c3k/7g50LyBzcL6AZBwEG9iBvJ5imOGRQoddubAqD\nE1C9hXh1OnqoClaKetp0RecT2tTqnpMjXqQQcE1Za1xnuZ5pMJfITom9DJetQwCk\nYUgRna1E4xcgdWe86BLxSRlObr71kh7KbCkqLyFBtdDQ/obbzIp1JFsNHK1A7rQ0\nWgf8BKcC/XjL0izjdgZSXgxzre0eokYNHj5n6aSd0QKBgQDUoYChmbY+BlfkwDko\n5wtV19764gNWbtqExYT/7eh9+w9bujHQ/mpGtODt282AKRwvtVDVUA5lqhmPMu+0\n0uYaesuC9BU2kxuVgb1OlvfRAEC7JAsGx33SSnsKBB6UO2YkiyRIrfBo4pelvGb2\n3JhuA3WIjhbGWbdRc/oRV5O36QKBgQC8TeQr9QXoTLM4VQWi+lXuDQaR9r2p7Sg6\nnarLSxNjH2YByujuHhB6xMhSFkb7N8rWZU+tiMYL8sE30GiCuNGMqm8jeQia3TR0\n8g4BEpkUmS6gYFBUDQS1BQ5yODD4bQuJjyL6p0a80h3fuOLoy33hmtUqVQcLDdTu\nqPtHmIkykQKBgDeIJmwOFQaF6ZaYjVUdYlx9EIM9W9nLAc8DNwUQQVQFqbEvI6uN\nhnwI6WW1rin2kqHzHLVZPylWD27Swr/bBLWNtHDzBkdGjEGzrJlF3Fr9UeqOM0MF\n/tpZEWFASiw0hyysGkHRC6SY6TojxlBatISm6p9LXK9Y5wOi4oB8+tthAoGAO3tn\nXjNSIGVKH7tLwoXNaxsWPjlxBCJ0GMABWaJnh2I9uMc9+SnqDr3mgXekCGtBWaQ7\nHRgdZ1zRiC3/NXvoRcT4wn3TKAhEL8Teg5w6WvVgcyy5czOBjyT/wTjazz6y7EsY\nw5DfmXnOEgO3Oc49/2wHdg3R4b4GyzT5203l2OECgYEAoI6MdRv2fLcumReekfF6\n4iUPyuQAIYnBGhnUfZ7HDIZM9FvfUqh/SP1o0hvIpnOG6xiIuecUvevkKdJ+RVyB\niwZVLTTi+JE2ZGrPrWjLqn7ch4MGNJxmJohd93DqwUpnMSrzA3pgqYVtv/4FRbJB\nG/vCHEW5HAdkQlJ9Z/bq1cY=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "nGdMjraxEZyt8kJlzHdRu7FipjCD36WHJt8nt3sQvwMCEK_9gQ14UoQ3RkfLieXnjQTn8H0kva-Kr5xK7R4XZhPXf5nT6G3JeHjC6tovasVcc6pyEWBikXNqC6M-vrSMvInuNuGNlj5iUMP5saKfTNdmh2HPcr_N6zHqWLz_MastCaNQLhBj53oZzw7zHBSjhlNqu2IwbEGzhtTXVZtIbxTGb4HNkmiyWYdFCxtkIJqb-7rXotW2zK2g9e6XaH3pl2mAwzpOfNTNH7LysvxZ_PaIQ_PLqIX-_kwkT48ZYClHaI3Gl7rl9Tc0F4ssgkl_g8YDMVQqXdVXAQ7MOEes-Q",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "ASQkfPhLFvgb_qitYV7BmGB5sK6D--33E8H-pgIvvbQ6M5fsyWm4SNUVcXzEi6a0REJuPEBhJt_H4a0KFIiNthRdQzBAyXXrb0THa3wZquWWLn6MMrYoGUDmCumIn93Qx81c3k_7g50LyBzcL6AZBwEG9iBvJ5imOGRQoddubAqDE1C9hXh1OnqoClaKetp0RecT2tTqnpMjXqQQcE1Za1xnuZ5pMJfITom9DJetQwCkYUgRna1E4xcgdWe86BLxSRlObr71kh7KbCkqLyFBtdDQ_obbzIp1JFsNHK1A7rQ0Wgf8BKcC_XjL0izjdgZSXgxzre0eokYNHj5n6aSd0Q",
+        "p": "1KGAoZm2PgZX5MA5KOcLVdfe-uIDVm7ahMWE_-3offsPW7ox0P5qRrTg7dvNgCkcL7VQ1VAOZaoZjzLvtNLmGnrLgvQVNpMblYG9Tpb30QBAuyQLBsd90kp7CgQelDtmJIskSK3waOKXpbxm9tyYbgN1iI4Wxlm3UXP6EVeTt-k",
+        "q": "vE3kK_UF6EyzOFUFovpV7g0Gkfa9qe0oOp2qy0sTYx9mAcro7h4QesTIUhZG-zfK1mVPrYjGC_LBN9BogrjRjKpvI3kImt00dPIOARKZFJkuoGBQVA0EtQUOcjgw-G0LiY8i-qdGvNId37ji6Mt94ZrVKlUHCw3U7qj7R5iJMpE",
+        "dp": "N4gmbA4VBoXplpiNVR1iXH0Qgz1b2csBzwM3BRBBVAWpsS8jq42GfAjpZbWuKfaSofMctVk_KVYPbtLCv9sEtY20cPMGR0aMQbOsmUXcWv1R6o4zQwX-2lkRYUBKLDSHLKwaQdELpJjpOiPGUFq0hKbqn0tcr1jnA6LigHz622E",
+        "dq": "O3tnXjNSIGVKH7tLwoXNaxsWPjlxBCJ0GMABWaJnh2I9uMc9-SnqDr3mgXekCGtBWaQ7HRgdZ1zRiC3_NXvoRcT4wn3TKAhEL8Teg5w6WvVgcyy5czOBjyT_wTjazz6y7EsYw5DfmXnOEgO3Oc49_2wHdg3R4b4GyzT5203l2OE",
+        "qi": "oI6MdRv2fLcumReekfF64iUPyuQAIYnBGhnUfZ7HDIZM9FvfUqh_SP1o0hvIpnOG6xiIuecUvevkKdJ-RVyBiwZVLTTi-JE2ZGrPrWjLqn7ch4MGNJxmJohd93DqwUpnMSrzA3pgqYVtv_4FRbJBG_vCHEW5HAdkQlJ9Z_bq1cY"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 63,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "69fc21cfdfdaf947da0c6ca5c9d78967fac976579659c93a8991e93d12120b10bc6342cc128912af3093696afb4937dacb30bca328b5aea273a2d512c5b98fdc050c213b87d23ce11957b08d74d3ac5a89234d9022f1a132e0b4d6afc411082569ede3f1d71d94886159d7eb8eb8",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00cf0ccf73f02736be83c4a6a2039ac3a36d7d1883db608b4055c00ae37f672d420f1eefead15d06b6c639d462ad3297b4213cede8a129570447d5f09dfbf985d54af8599e431247fd759acaf1ce51da4553f343fcb0649b5ee2c294cfe9c2a571757cab5fb4d2a513bba3064b471a134f1bb87fd786fcb42c18d565c54693cc5541e4d26fce244f2210c1454da32d7a061ccaa8faab3f1c8d5cc922a099b3fe75b081213cb917d210e2ac2a24ab56a08400e0cdb18a1c8c71a37f546faf83cdc261fd82c2e47a6879124072b90b7519e53823d4dcf422459103abb2966f9564e55a05c21fc3b43658952f9627422459cdd3214f3ae257558ded08783b17cec529",
+        "privateExponent": "01482945a4bc3d6ac70a91e48964ad26e71fe1e5b9173b2d7a0a6f16d2fc5acba0a7d6a0ebcc6964facbb35cac0956e69ad91378fffc6f493bbf9f967ecf9fec3ee3543cb65a17df8219a3fd84c33d7875e958e7a8d8ea9c570790dfcba8f498c3fb325d6c936c49b7bcede64be9a5aa74f7bab4e5254de143031936f435a88b70bab7bb73f54402f21cf06b4a64f83ae490316aee28c6d099d74930b0616f56c0786f95133896e059363f94c7c459eb1eabf50f43b2edff2b04f0344b4b3932caa3fcc18b47aa1bfbbeb3d70f34feb97e44fd23b51c22e87105b8d74c821a0fb09fc120a181c0fe09f67f4fea76d53bda8b99602d82700694cd332f6499f68d",
+        "publicExponent": "010001",
+        "prime1": "00f3f8c1d23e61b0213a323ddfea2df12b78b8c06ed636eed2b436e1f7c10e6f916bad4a67871a411289467aac9ac771393cb1019b988f345c52087a4e2b4b206e64ffe60dddd2702f1e9fca4f7bcf9f6c3be30adb848fbb1426b8366914ebbec32799f65052255034ac85bb16f4316847df2d35c5c4a009c40bb56cfb66b47465",
+        "prime2": "00d9420dab2a0ae1bf9db09b143f89a13b4dbc6de900e8a5ffa5a5518d838cf89cc74fc8a1447fcac34d30d15d07cd0e807f0d1b99cd77741917fb8598ebd73405b25d6bca4c15a9f5d07e60522fde4e283ae25d5c9b0c243a58097f00cf9aef9c52a236828b069e584de7abcc767cad43d838ebb2b447203e14915b517e169775",
+        "exponent1": "6bf8cf6e88851b39d9539ae699f13326960acdbf3fb69803501669f307d1a7b6a7fccd4cfc11b672c9a6136c8823740c6cbbb9866f02119e39ffde80f1d011ce498ca6f7c40ff9ee20937f29a615c0ec59a4a58d7921531e1bf4b2bfd6ae6e8257e85f863494a6e668e3d664d635777d375bfecc43b4c01daf40dfb67341b1b1",
+        "exponent2": "00b7b68d4c61bed5ea6c73bc8f40b326edb8ec4f9caa3210bcbedbaebc95b30d3fb5a297ab16fb61000933f0b6543467c0ecaeaeda3dce7714091d9d791464e40eb5271e50f0499970cd9f2fe00fae5234dea6300070f3b166ccaf2b000a8d9f7476c3c88856fb7fc6780a2152421767846940a8be72877a92445e2df419450d49",
+        "coefficient": "5c6e8fc9deeb3afedc1cb2b2c377c9c2a56837a7e15152a587f932655b846e14526b13515a3a78e2ae3420e1508cd494a4a6070e83b1fae8249c01d2e41f926acd9c980569caf6b0bff559715feff770510972392c4bb88ac72d1a5af09abe2d5b568997357ea2073da38bee8b2e078f746512ca09bae177f226c1724e516ada"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100cf0ccf73f02736be83c4a6a2039ac3a36d7d1883db608b4055c00ae37f672d420f1eefead15d06b6c639d462ad3297b4213cede8a129570447d5f09dfbf985d54af8599e431247fd759acaf1ce51da4553f343fcb0649b5ee2c294cfe9c2a571757cab5fb4d2a513bba3064b471a134f1bb87fd786fcb42c18d565c54693cc5541e4d26fce244f2210c1454da32d7a061ccaa8faab3f1c8d5cc922a099b3fe75b081213cb917d210e2ac2a24ab56a08400e0cdb18a1c8c71a37f546faf83cdc261fd82c2e47a6879124072b90b7519e53823d4dcf422459103abb2966f9564e55a05c21fc3b43658952f9627422459cdd3214f3ae257558ded08783b17cec52902030100010282010001482945a4bc3d6ac70a91e48964ad26e71fe1e5b9173b2d7a0a6f16d2fc5acba0a7d6a0ebcc6964facbb35cac0956e69ad91378fffc6f493bbf9f967ecf9fec3ee3543cb65a17df8219a3fd84c33d7875e958e7a8d8ea9c570790dfcba8f498c3fb325d6c936c49b7bcede64be9a5aa74f7bab4e5254de143031936f435a88b70bab7bb73f54402f21cf06b4a64f83ae490316aee28c6d099d74930b0616f56c0786f95133896e059363f94c7c459eb1eabf50f43b2edff2b04f0344b4b3932caa3fcc18b47aa1bfbbeb3d70f34feb97e44fd23b51c22e87105b8d74c821a0fb09fc120a181c0fe09f67f4fea76d53bda8b99602d82700694cd332f6499f68d02818100f3f8c1d23e61b0213a323ddfea2df12b78b8c06ed636eed2b436e1f7c10e6f916bad4a67871a411289467aac9ac771393cb1019b988f345c52087a4e2b4b206e64ffe60dddd2702f1e9fca4f7bcf9f6c3be30adb848fbb1426b8366914ebbec32799f65052255034ac85bb16f4316847df2d35c5c4a009c40bb56cfb66b4746502818100d9420dab2a0ae1bf9db09b143f89a13b4dbc6de900e8a5ffa5a5518d838cf89cc74fc8a1447fcac34d30d15d07cd0e807f0d1b99cd77741917fb8598ebd73405b25d6bca4c15a9f5d07e60522fde4e283ae25d5c9b0c243a58097f00cf9aef9c52a236828b069e584de7abcc767cad43d838ebb2b447203e14915b517e1697750281806bf8cf6e88851b39d9539ae699f13326960acdbf3fb69803501669f307d1a7b6a7fccd4cfc11b672c9a6136c8823740c6cbbb9866f02119e39ffde80f1d011ce498ca6f7c40ff9ee20937f29a615c0ec59a4a58d7921531e1bf4b2bfd6ae6e8257e85f863494a6e668e3d664d635777d375bfecc43b4c01daf40dfb67341b1b102818100b7b68d4c61bed5ea6c73bc8f40b326edb8ec4f9caa3210bcbedbaebc95b30d3fb5a297ab16fb61000933f0b6543467c0ecaeaeda3dce7714091d9d791464e40eb5271e50f0499970cd9f2fe00fae5234dea6300070f3b166ccaf2b000a8d9f7476c3c88856fb7fc6780a2152421767846940a8be72877a92445e2df419450d490281805c6e8fc9deeb3afedc1cb2b2c377c9c2a56837a7e15152a587f932655b846e14526b13515a3a78e2ae3420e1508cd494a4a6070e83b1fae8249c01d2e41f926acd9c980569caf6b0bff559715feff770510972392c4bb88ac72d1a5af09abe2d5b568997357ea2073da38bee8b2e078f746512ca09bae177f226c1724e516ada",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDPDM9z8Cc2voPE\npqIDmsOjbX0Yg9tgi0BVwArjf2ctQg8e7+rRXQa2xjnUYq0yl7QhPO3ooSlXBEfV\n8J37+YXVSvhZnkMSR/11msrxzlHaRVPzQ/ywZJte4sKUz+nCpXF1fKtftNKlE7uj\nBktHGhNPG7h/14b8tCwY1WXFRpPMVUHk0m/OJE8iEMFFTaMtegYcyqj6qz8cjVzJ\nIqCZs/51sIEhPLkX0hDirCokq1aghADgzbGKHIxxo39Ub6+DzcJh/YLC5HpoeRJA\ncrkLdRnlOCPU3PQiRZEDq7KWb5Vk5VoFwh/DtDZYlS+WJ0IkWc3TIU864ldVje0I\neDsXzsUpAgMBAAECggEAAUgpRaS8PWrHCpHkiWStJucf4eW5FzstegpvFtL8Wsug\np9ag68xpZPrLs1ysCVbmmtkTeP/8b0k7v5+Wfs+f7D7jVDy2Whffghmj/YTDPXh1\n6VjnqNjqnFcHkN/LqPSYw/syXWyTbEm3vO3mS+mlqnT3urTlJU3hQwMZNvQ1qItw\nure7c/VEAvIc8GtKZPg65JAxau4oxtCZ10kwsGFvVsB4b5UTOJbgWTY/lMfEWese\nq/UPQ7Lt/ysE8DRLSzkyyqP8wYtHqhv7vrPXDzT+uX5E/SO1HCLocQW410yCGg+w\nn8EgoYHA/gn2f0/qdtU72ouZYC2CcAaUzTMvZJn2jQKBgQDz+MHSPmGwIToyPd/q\nLfEreLjAbtY27tK0NuH3wQ5vkWutSmeHGkESiUZ6rJrHcTk8sQGbmI80XFIIek4r\nSyBuZP/mDd3ScC8en8pPe8+fbDvjCtuEj7sUJrg2aRTrvsMnmfZQUiVQNKyFuxb0\nMWhH3y01xcSgCcQLtWz7ZrR0ZQKBgQDZQg2rKgrhv52wmxQ/iaE7Tbxt6QDopf+l\npVGNg4z4nMdPyKFEf8rDTTDRXQfNDoB/DRuZzXd0GRf7hZjr1zQFsl1rykwVqfXQ\nfmBSL95OKDriXVybDCQ6WAl/AM+a75xSojaCiwaeWE3nq8x2fK1D2DjrsrRHID4U\nkVtRfhaXdQKBgGv4z26IhRs52VOa5pnxMyaWCs2/P7aYA1AWafMH0ae2p/zNTPwR\ntnLJphNsiCN0DGy7uYZvAhGeOf/egPHQEc5JjKb3xA/57iCTfymmFcDsWaSljXkh\nUx4b9LK/1q5uglfoX4Y0lKbmaOPWZNY1d303W/7MQ7TAHa9A37ZzQbGxAoGBALe2\njUxhvtXqbHO8j0CzJu247E+cqjIQvL7brryVsw0/taKXqxb7YQAJM/C2VDRnwOyu\nrto9zncUCR2deRRk5A61Jx5Q8EmZcM2fL+APrlI03qYwAHDzsWbMrysACo2fdHbD\nyIhW+3/GeAohUkIXZ4RpQKi+cod6kkReLfQZRQ1JAoGAXG6Pyd7rOv7cHLKyw3fJ\nwqVoN6fhUVKlh/kyZVuEbhRSaxNRWjp44q40IOFQjNSUpKYHDoOx+ugknAHS5B+S\nas2cmAVpyvawv/VZcV/v93BRCXI5LEu4isctGlrwmr4tW1aJlzV+ogc9o4vuiy4H\nj3RlEsoJuuF38ibBck5Rato=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "zwzPc_AnNr6DxKaiA5rDo219GIPbYItAVcAK439nLUIPHu_q0V0GtsY51GKtMpe0ITzt6KEpVwRH1fCd-_mF1Ur4WZ5DEkf9dZrK8c5R2kVT80P8sGSbXuLClM_pwqVxdXyrX7TSpRO7owZLRxoTTxu4f9eG_LQsGNVlxUaTzFVB5NJvziRPIhDBRU2jLXoGHMqo-qs_HI1cySKgmbP-dbCBITy5F9IQ4qwqJKtWoIQA4M2xihyMcaN_VG-vg83CYf2CwuR6aHkSQHK5C3UZ5Tgj1Nz0IkWRA6uylm-VZOVaBcIfw7Q2WJUvlidCJFnN0yFPOuJXVY3tCHg7F87FKQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "AUgpRaS8PWrHCpHkiWStJucf4eW5FzstegpvFtL8Wsugp9ag68xpZPrLs1ysCVbmmtkTeP_8b0k7v5-Wfs-f7D7jVDy2Whffghmj_YTDPXh16VjnqNjqnFcHkN_LqPSYw_syXWyTbEm3vO3mS-mlqnT3urTlJU3hQwMZNvQ1qItwure7c_VEAvIc8GtKZPg65JAxau4oxtCZ10kwsGFvVsB4b5UTOJbgWTY_lMfEWeseq_UPQ7Lt_ysE8DRLSzkyyqP8wYtHqhv7vrPXDzT-uX5E_SO1HCLocQW410yCGg-wn8EgoYHA_gn2f0_qdtU72ouZYC2CcAaUzTMvZJn2jQ",
+        "p": "8_jB0j5hsCE6Mj3f6i3xK3i4wG7WNu7StDbh98EOb5FrrUpnhxpBEolGeqyax3E5PLEBm5iPNFxSCHpOK0sgbmT_5g3d0nAvHp_KT3vPn2w74wrbhI-7FCa4NmkU677DJ5n2UFIlUDSshbsW9DFoR98tNcXEoAnEC7Vs-2a0dGU",
+        "q": "2UINqyoK4b-dsJsUP4mhO028bekA6KX_paVRjYOM-JzHT8ihRH_Kw00w0V0HzQ6Afw0bmc13dBkX-4WY69c0BbJda8pMFan10H5gUi_eTig64l1cmwwkOlgJfwDPmu-cUqI2gosGnlhN56vMdnytQ9g467K0RyA-FJFbUX4Wl3U",
+        "dp": "a_jPboiFGznZU5rmmfEzJpYKzb8_tpgDUBZp8wfRp7an_M1M_BG2csmmE2yII3QMbLu5hm8CEZ45_96A8dARzkmMpvfED_nuIJN_KaYVwOxZpKWNeSFTHhv0sr_Wrm6CV-hfhjSUpuZo49Zk1jV3fTdb_sxDtMAdr0DftnNBsbE",
+        "dq": "t7aNTGG-1epsc7yPQLMm7bjsT5yqMhC8vtuuvJWzDT-1operFvthAAkz8LZUNGfA7K6u2j3OdxQJHZ15FGTkDrUnHlDwSZlwzZ8v4A-uUjTepjAAcPOxZsyvKwAKjZ90dsPIiFb7f8Z4CiFSQhdnhGlAqL5yh3qSRF4t9BlFDUk",
+        "qi": "XG6Pyd7rOv7cHLKyw3fJwqVoN6fhUVKlh_kyZVuEbhRSaxNRWjp44q40IOFQjNSUpKYHDoOx-ugknAHS5B-Sas2cmAVpyvawv_VZcV_v93BRCXI5LEu4isctGlrwmr4tW1aJlzV-ogc9o4vuiy4Hj3RlEsoJuuF38ibBck5Rato"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 64,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "8923733a345f80b10575ce05c18cb8543de89cbf37886f51c6b9369ecc01b880587e9c41f1848b2539a6919752d07429f3b012e9ac62e5d192cb980489ec54ee54a432a1f6adc583477b404d816e499666b4c91d2fc4e7d1844631997afdd05f190c433a6bffe334de4476284e8e6b30f4fd6da692",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00bf00ce8851532bb7cb0574acfa4f8992e37ececd04364f3d920a4bbf8b17523d967854dd28291c9adb51760356f24b8694995cad1f91fdd3c738b307b36f27f95d185fc331f5d614a4238f3f2157c1ae3a91bf6c5ac632259f2eff08f7bcffbfa6351bffaeb91ceedca6779b5c82e07b4ea2791196ced821793332ea313dfaa64064eb5e8f71de0ad1cdf680fec6a5617fcf970cc4eeac5ff017009400944997e8c36b1ab87a08545b027480815b78fd04ee3bd8daa31460246e9e258b31243ddae72fa770ac0fff907a6e99622b7b936529137a5b96b43562037459e5dff9abb3bfa7b4fb9d57a9345d86a72ea636fda36ee36eb913677c494bab01042b982d",
+        "privateExponent": "031bb5c0b52617d78957c0e2d1bdfa9ca7d417f471259b1b82e564ff2c79c82e556506e8846f4ad6604c4e91d657e20fc21a4ece486dbd46357f4036975e6f359924bce635c96cdef01ede05667b019d5eb9a1765771d33e167d92cbe8102ccf471aa5267f86e6a82272190f2fadb78e7a249db8c20e02a964ca070195a48f101f4f61ec378950df5b477c645186501cc9e97964022c103373f7181546131488c85a27268ffd923a7222998daa45e3d48250ddf77e9233e1c860bcdf188053481996e99fb010859a8de9a0570a96e3bdd3015eddccd65f0209bc7de96fe5e3338fd3d452c6f0da8afbbd43ffe65c9d6f86a492e281c88fb194a702924f6b2937",
+        "publicExponent": "010001",
+        "prime1": "00f487bed27b53cd84bbc984a233cf087da6e714181b5a016435751d7f7b1ebba10e7fbcf43028f022d8858b660a687e683c52e7139b9ea72ab6a95160abe03772fda4116f62808d9d61c25be94f1924f31f17abb34321c49232137912f1d9a4f0a633b292fb2ec7c0878e060be161b4a6571e12f5e95a9d490c15009d9ffd26d7",
+        "prime2": "00c7f652730125870f9750bc5430f39e8bbf66b2d8ec4b3f33dba050b06349f62c68808773e923cb7f508c9677855691d43d0e004f7fa8fbcb63cde1a1db7e958e869b0a644c0c9fc512f38aaa92116b37cc527c7ffeda076c47b1a8004ecd0ee4551a9fa7662d27e44960114f3e42ff5de15ae3a7d18177792081dd144d250c9b",
+        "exponent1": "0d5b8cf4fa7fad6e5ec3b75714f56e454ee4b898488636253f365292302b919c4eaa73abf32589589df34d96196373e445c7519024a41a059f4cc8813b62582513edee75e32f9a8cca564fa703072099974d37b7e726e512076240eee3ff3b9f59b4e1405e304401246681b60c6dc5ec803dc8535e97f09798ed5cc73f8218a9",
+        "exponent2": "22527c6a730aeef8d51f2d8441f6bf02fbb2740659e0bc937922365760638496b0c546fab54cc8942cce44d175189be55329811224366c29c812c1a4d7990db0ae18149b8c962a22589366fcca1fa548a9908b00294d6132cbc789afabd6f4b46a8b2c563e6a87cb5e70d7e7c3271ad0116b596227cad227ff556b0e1e03bafb",
+        "coefficient": "0a6cea1e04c32597597bd18db5f5c781a73eceaa330830e031eb535c6ce08ef3db4bc37e5b382fe34342ba6f242dcf632d189603cfa41d81a10b7f94a4ac1d9e62d40cecdc342c95ef3deaddf147b175673cef2fda9035809a94c52eabb52c348e13fb91025b8b6e3ce721809a6dec9cc510a529e0bff8cf8ce4ea78b5073326"
+      },
+      "privateKeyPkcs8": "308204bc020100300d06092a864886f70d0101010500048204a6308204a20201000282010100bf00ce8851532bb7cb0574acfa4f8992e37ececd04364f3d920a4bbf8b17523d967854dd28291c9adb51760356f24b8694995cad1f91fdd3c738b307b36f27f95d185fc331f5d614a4238f3f2157c1ae3a91bf6c5ac632259f2eff08f7bcffbfa6351bffaeb91ceedca6779b5c82e07b4ea2791196ced821793332ea313dfaa64064eb5e8f71de0ad1cdf680fec6a5617fcf970cc4eeac5ff017009400944997e8c36b1ab87a08545b027480815b78fd04ee3bd8daa31460246e9e258b31243ddae72fa770ac0fff907a6e99622b7b936529137a5b96b43562037459e5dff9abb3bfa7b4fb9d57a9345d86a72ea636fda36ee36eb913677c494bab01042b982d020301000102820100031bb5c0b52617d78957c0e2d1bdfa9ca7d417f471259b1b82e564ff2c79c82e556506e8846f4ad6604c4e91d657e20fc21a4ece486dbd46357f4036975e6f359924bce635c96cdef01ede05667b019d5eb9a1765771d33e167d92cbe8102ccf471aa5267f86e6a82272190f2fadb78e7a249db8c20e02a964ca070195a48f101f4f61ec378950df5b477c645186501cc9e97964022c103373f7181546131488c85a27268ffd923a7222998daa45e3d48250ddf77e9233e1c860bcdf188053481996e99fb010859a8de9a0570a96e3bdd3015eddccd65f0209bc7de96fe5e3338fd3d452c6f0da8afbbd43ffe65c9d6f86a492e281c88fb194a702924f6b293702818100f487bed27b53cd84bbc984a233cf087da6e714181b5a016435751d7f7b1ebba10e7fbcf43028f022d8858b660a687e683c52e7139b9ea72ab6a95160abe03772fda4116f62808d9d61c25be94f1924f31f17abb34321c49232137912f1d9a4f0a633b292fb2ec7c0878e060be161b4a6571e12f5e95a9d490c15009d9ffd26d702818100c7f652730125870f9750bc5430f39e8bbf66b2d8ec4b3f33dba050b06349f62c68808773e923cb7f508c9677855691d43d0e004f7fa8fbcb63cde1a1db7e958e869b0a644c0c9fc512f38aaa92116b37cc527c7ffeda076c47b1a8004ecd0ee4551a9fa7662d27e44960114f3e42ff5de15ae3a7d18177792081dd144d250c9b0281800d5b8cf4fa7fad6e5ec3b75714f56e454ee4b898488636253f365292302b919c4eaa73abf32589589df34d96196373e445c7519024a41a059f4cc8813b62582513edee75e32f9a8cca564fa703072099974d37b7e726e512076240eee3ff3b9f59b4e1405e304401246681b60c6dc5ec803dc8535e97f09798ed5cc73f8218a902818022527c6a730aeef8d51f2d8441f6bf02fbb2740659e0bc937922365760638496b0c546fab54cc8942cce44d175189be55329811224366c29c812c1a4d7990db0ae18149b8c962a22589366fcca1fa548a9908b00294d6132cbc789afabd6f4b46a8b2c563e6a87cb5e70d7e7c3271ad0116b596227cad227ff556b0e1e03bafb0281800a6cea1e04c32597597bd18db5f5c781a73eceaa330830e031eb535c6ce08ef3db4bc37e5b382fe34342ba6f242dcf632d189603cfa41d81a10b7f94a4ac1d9e62d40cecdc342c95ef3deaddf147b175673cef2fda9035809a94c52eabb52c348e13fb91025b8b6e3ce721809a6dec9cc510a529e0bff8cf8ce4ea78b5073326",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC/AM6IUVMrt8sF\ndKz6T4mS437OzQQ2Tz2SCku/ixdSPZZ4VN0oKRya21F2A1byS4aUmVytH5H908c4\nswezbyf5XRhfwzH11hSkI48/IVfBrjqRv2xaxjIlny7/CPe8/7+mNRv/rrkc7tym\nd5tcguB7TqJ5EZbO2CF5MzLqMT36pkBk616Pcd4K0c32gP7GpWF/z5cMxO6sX/AX\nAJQAlEmX6MNrGrh6CFRbAnSAgVt4/QTuO9jaoxRgJG6eJYsxJD3a5y+ncKwP/5B6\nbpliK3uTZSkTeluWtDViA3RZ5d/5q7O/p7T7nVepNF2Gpy6mNv2jbuNuuRNnfElL\nqwEEK5gtAgMBAAECggEAAxu1wLUmF9eJV8Di0b36nKfUF/RxJZsbguVk/yx5yC5V\nZQbohG9K1mBMTpHWV+IPwhpOzkhtvUY1f0A2l15vNZkkvOY1yWze8B7eBWZ7AZ1e\nuaF2V3HTPhZ9ksvoECzPRxqlJn+G5qgichkPL623jnoknbjCDgKpZMoHAZWkjxAf\nT2HsN4lQ31tHfGRRhlAcyel5ZAIsEDNz9xgVRhMUiMhaJyaP/ZI6ciKZjapF49SC\nUN33fpIz4chgvN8YgFNIGZbpn7AQhZqN6aBXCpbjvdMBXt3M1l8CCbx96W/l4zOP\n09RSxvDaivu9Q//mXJ1vhqSS4oHIj7GUpwKST2spNwKBgQD0h77Se1PNhLvJhKIz\nzwh9pucUGBtaAWQ1dR1/ex67oQ5/vPQwKPAi2IWLZgpofmg8UucTm56nKrapUWCr\n4Ddy/aQRb2KAjZ1hwlvpTxkk8x8Xq7NDIcSSMhN5EvHZpPCmM7KS+y7HwIeOBgvh\nYbSmVx4S9elanUkMFQCdn/0m1wKBgQDH9lJzASWHD5dQvFQw856Lv2ay2OxLPzPb\noFCwY0n2LGiAh3PpI8t/UIyWd4VWkdQ9DgBPf6j7y2PN4aHbfpWOhpsKZEwMn8US\n84qqkhFrN8xSfH/+2gdsR7GoAE7NDuRVGp+nZi0n5ElgEU8+Qv9d4Vrjp9GBd3kg\ngd0UTSUMmwKBgA1bjPT6f61uXsO3VxT1bkVO5LiYSIY2JT82UpIwK5GcTqpzq/Ml\niVid802WGWNz5EXHUZAkpBoFn0zIgTtiWCUT7e514y+ajMpWT6cDByCZl003t+cm\n5RIHYkDu4/87n1m04UBeMEQBJGaBtgxtxeyAPchTXpfwl5jtXMc/ghipAoGAIlJ8\nanMK7vjVHy2EQfa/AvuydAZZ4LyTeSI2V2BjhJawxUb6tUzIlCzORNF1GJvlUymB\nEiQ2bCnIEsGk15kNsK4YFJuMlioiWJNm/MofpUipkIsAKU1hMsvHia+r1vS0aoss\nVj5qh8tecNfnwyca0BFrWWInytIn/1VrDh4DuvsCgYAKbOoeBMMll1l70Y219ceB\npz7OqjMIMOAx61NcbOCO89tLw35bOC/jQ0K6byQtz2MtGJYDz6QdgaELf5SkrB2e\nYtQM7Nw0LJXvPerd8UexdWc87y/akDWAmpTFLqu1LDSOE/uRAluLbjznIYCabeyc\nxRClKeC/+M+M5Op4tQczJg==\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "vwDOiFFTK7fLBXSs-k-JkuN-zs0ENk89kgpLv4sXUj2WeFTdKCkcmttRdgNW8kuGlJlcrR-R_dPHOLMHs28n-V0YX8Mx9dYUpCOPPyFXwa46kb9sWsYyJZ8u_wj3vP-_pjUb_665HO7cpnebXILge06ieRGWztgheTMy6jE9-qZAZOtej3HeCtHN9oD-xqVhf8-XDMTurF_wFwCUAJRJl-jDaxq4eghUWwJ0gIFbeP0E7jvY2qMUYCRuniWLMSQ92ucvp3CsD_-Qem6ZYit7k2UpE3pblrQ1YgN0WeXf-auzv6e0-51XqTRdhqcupjb9o27jbrkTZ3xJS6sBBCuYLQ",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "Axu1wLUmF9eJV8Di0b36nKfUF_RxJZsbguVk_yx5yC5VZQbohG9K1mBMTpHWV-IPwhpOzkhtvUY1f0A2l15vNZkkvOY1yWze8B7eBWZ7AZ1euaF2V3HTPhZ9ksvoECzPRxqlJn-G5qgichkPL623jnoknbjCDgKpZMoHAZWkjxAfT2HsN4lQ31tHfGRRhlAcyel5ZAIsEDNz9xgVRhMUiMhaJyaP_ZI6ciKZjapF49SCUN33fpIz4chgvN8YgFNIGZbpn7AQhZqN6aBXCpbjvdMBXt3M1l8CCbx96W_l4zOP09RSxvDaivu9Q__mXJ1vhqSS4oHIj7GUpwKST2spNw",
+        "p": "9Ie-0ntTzYS7yYSiM88IfabnFBgbWgFkNXUdf3seu6EOf7z0MCjwItiFi2YKaH5oPFLnE5uepyq2qVFgq-A3cv2kEW9igI2dYcJb6U8ZJPMfF6uzQyHEkjITeRLx2aTwpjOykvsux8CHjgYL4WG0plceEvXpWp1JDBUAnZ_9Jtc",
+        "q": "x_ZScwElhw-XULxUMPOei79mstjsSz8z26BQsGNJ9ixogIdz6SPLf1CMlneFVpHUPQ4AT3-o-8tjzeGh236VjoabCmRMDJ_FEvOKqpIRazfMUnx__toHbEexqABOzQ7kVRqfp2YtJ-RJYBFPPkL_XeFa46fRgXd5IIHdFE0lDJs",
+        "dp": "DVuM9Pp_rW5ew7dXFPVuRU7kuJhIhjYlPzZSkjArkZxOqnOr8yWJWJ3zTZYZY3PkRcdRkCSkGgWfTMiBO2JYJRPt7nXjL5qMylZPpwMHIJmXTTe35yblEgdiQO7j_zufWbThQF4wRAEkZoG2DG3F7IA9yFNel_CXmO1cxz-CGKk",
+        "dq": "IlJ8anMK7vjVHy2EQfa_AvuydAZZ4LyTeSI2V2BjhJawxUb6tUzIlCzORNF1GJvlUymBEiQ2bCnIEsGk15kNsK4YFJuMlioiWJNm_MofpUipkIsAKU1hMsvHia-r1vS0aossVj5qh8tecNfnwyca0BFrWWInytIn_1VrDh4Duvs",
+        "qi": "CmzqHgTDJZdZe9GNtfXHgac-zqozCDDgMetTXGzgjvPbS8N-Wzgv40NCum8kLc9jLRiWA8-kHYGhC3-UpKwdnmLUDOzcNCyV7z3q3fFHsXVnPO8v2pA1gJqUxS6rtSw0jhP7kQJbi2485yGAmm3snMUQpSngv_jPjOTqeLUHMyY"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 65,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "4947c8c3306ed0cc1841318746a17078557b686f0dc45c6289e02ef4c595b5d0c2c92d7cab1e93ce0e1470a2a5e116e4a49de188c149bcebebfe669ba256d64fadab70fd7e36734eaf10b90f7b4a5004c04ada14a0ef75c0f25a3094010d2b43d5c023",
+          "ct": "bf00ce8851532bb7cb0574acfa4f8992e37ececd04364f3d920a4bbf8b17523d967854dd28291c9adb51760356f24b8694995cad1f91fdd3c738b307b36f27f95d185fc331f5d614a4238f3f2157c1ae3a91bf6c5ac632259f2eff08f7bcffbfa6351bffaeb91ceedca6779b5c82e07b4ea2791196ced821793332ea313dfaa5c064eb5e8f71de0ad1cdf680fec6a5617fcf970cc4eeac5ff017009400944997e8c36b1ab87a08545b027480815b78fd04ee3bd8daa31460246e9e258b31243ddae72fa770ac0fff907a6e99622b7b936529137a5b96b43562037459e5dff9abb3bfa7b4fb9d57a9345d86a72ea636fda36ee36eb913677c494bab01042b982c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00cc890f82986e18c35e18a2ea354bd2c7e88dca9f0e1981497b31342b893992a49f36380fbe9829995e9aec1b3ec88dfbcbfb11bd2a00140f8f6647c5e3bdda527799ef0571f45427f10d2463ee096fda48c41085d3a90bf7072d06fb7a3d2286cd10255a82a52452ea3e61e2d8e35eff9f6b831b48f09b522df104f48ac58f76cd241b9fddc042e7683774117808681693536600e1cd3035dcf6ec30a6bdf659b15e0417c3bfc4c9a591f2f858081df1243477d41812a6ac74bc4fbb6485b18aaf6a00c32593751a527723b4802d318038698de9063818044cca1b035b8800193fed71d3c38ed3296fddb336552b68d380d1214b13a1c86e6f687bd37e5fd22b",
+        "privateExponent": "2137ab3caeebc67ac827e1217f595a989bd49751209594d12dc02e74599b6f8cebcc7eeb53ad5ba82c5ca5b6c10a0a4117fe2501df35d70c35e24b0ac0f35ee720c46fb4a72ea292400c3dda3ad8ee80f96b5a3199cfed0107f9d095fbe2bcde3ea47e24866e328982c071de4912182614aa7dc6eb20246182d38f55f5c9a304427083792773ea0c881f01d340804b626c4d0cfd36ac759e65c6692cb59ff0cf5952d8d97770e601fb8696f746e232f1083be375ab4360a7c9b25e7210b3b83e498dfedd32b900f795907f3dfd15edb52d8e4d69b964f4196433a0d8fea8ca875b682970a56836b7708252ef145b6dcb8a52a6306fd19651bc75701c9bcab7c1",
+        "publicExponent": "010001",
+        "prime1": "00ea90923ad1a16d8f5704bdfd34a7f059941112c391f656b750f6c9ca1d916397ebcc33f48c300a9d001071caf00d33f80cf0ae3efd899c6443e6cdb9214d9dfb209e088163e75dd7582d3639df75d9cf113eb42bc61f7e90ebd9a619deb41c76d5728f3134d4564142e166f46313f1a7492f23d207fc2d8fa15cc7a01f242141",
+        "prime2": "00df39faf40d3cbaf2aed2d0f69c67b2bbb19e7c81bc90306918471d1e406cac8ed9969e8bdc80be72502176d68ea1f6016ecaf4d3b4ce24ea76762325fd1680345e5c5b77ba4888b9d7d4fd85af16e20cc922b8bd2bbb49f6373236ddc939063ae276d2fb4a3812de74047a1d9259fd877e2329920f4424585bb27afdc61eec6b",
+        "exponent1": "00cc97db2438b2d00825c37a1fbfecf7a47a94c5c415ad4307d433dde05017ff4184a7716dcd551dfcc11096e086af4d73ff7d72ce7880ae0b7a7a775811e74c73bd887a2cb9c215c4fe21395a13420d0022af89a160c719b33834783fba53693c7182e1c8eea682b19baf5508b6deaf79d548abbac7c23acf3bd4dc3e1acb7dc1",
+        "exponent2": "54bbe08bb55ea1242fc26c79c02308d0807ac58e45b281fdd2ae63da30e04f9c25f22b9ab187d942f131d2b75d0b13a3b597aad995df4e5a05bf9056023d014b5faa353a3c66fe27754b2f3508a26a0a2a6b58aece23d8ce7263483a66009461d3c7010d4c3dfec39c4c7ac230e4a1fd459f394f6d261399caacf44cd260b8a3",
+        "coefficient": "4f8c1d61e059c9920e68544adc7e028f8f05933b4f49cec1614999d120450198bef26bdde1099bffc5316baef331c2b3d854e42a2f18858735641952104847cbbce742c8a6b9238143af4b27cb8ca4ef931f5509f2bca875397edfabdd2263e0867303dbdfbfac683a10c42d76184f320c469ab0f680a83797684b61026b93df"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100cc890f82986e18c35e18a2ea354bd2c7e88dca9f0e1981497b31342b893992a49f36380fbe9829995e9aec1b3ec88dfbcbfb11bd2a00140f8f6647c5e3bdda527799ef0571f45427f10d2463ee096fda48c41085d3a90bf7072d06fb7a3d2286cd10255a82a52452ea3e61e2d8e35eff9f6b831b48f09b522df104f48ac58f76cd241b9fddc042e7683774117808681693536600e1cd3035dcf6ec30a6bdf659b15e0417c3bfc4c9a591f2f858081df1243477d41812a6ac74bc4fbb6485b18aaf6a00c32593751a527723b4802d318038698de9063818044cca1b035b8800193fed71d3c38ed3296fddb336552b68d380d1214b13a1c86e6f687bd37e5fd22b0203010001028201002137ab3caeebc67ac827e1217f595a989bd49751209594d12dc02e74599b6f8cebcc7eeb53ad5ba82c5ca5b6c10a0a4117fe2501df35d70c35e24b0ac0f35ee720c46fb4a72ea292400c3dda3ad8ee80f96b5a3199cfed0107f9d095fbe2bcde3ea47e24866e328982c071de4912182614aa7dc6eb20246182d38f55f5c9a304427083792773ea0c881f01d340804b626c4d0cfd36ac759e65c6692cb59ff0cf5952d8d97770e601fb8696f746e232f1083be375ab4360a7c9b25e7210b3b83e498dfedd32b900f795907f3dfd15edb52d8e4d69b964f4196433a0d8fea8ca875b682970a56836b7708252ef145b6dcb8a52a6306fd19651bc75701c9bcab7c102818100ea90923ad1a16d8f5704bdfd34a7f059941112c391f656b750f6c9ca1d916397ebcc33f48c300a9d001071caf00d33f80cf0ae3efd899c6443e6cdb9214d9dfb209e088163e75dd7582d3639df75d9cf113eb42bc61f7e90ebd9a619deb41c76d5728f3134d4564142e166f46313f1a7492f23d207fc2d8fa15cc7a01f24214102818100df39faf40d3cbaf2aed2d0f69c67b2bbb19e7c81bc90306918471d1e406cac8ed9969e8bdc80be72502176d68ea1f6016ecaf4d3b4ce24ea76762325fd1680345e5c5b77ba4888b9d7d4fd85af16e20cc922b8bd2bbb49f6373236ddc939063ae276d2fb4a3812de74047a1d9259fd877e2329920f4424585bb27afdc61eec6b02818100cc97db2438b2d00825c37a1fbfecf7a47a94c5c415ad4307d433dde05017ff4184a7716dcd551dfcc11096e086af4d73ff7d72ce7880ae0b7a7a775811e74c73bd887a2cb9c215c4fe21395a13420d0022af89a160c719b33834783fba53693c7182e1c8eea682b19baf5508b6deaf79d548abbac7c23acf3bd4dc3e1acb7dc102818054bbe08bb55ea1242fc26c79c02308d0807ac58e45b281fdd2ae63da30e04f9c25f22b9ab187d942f131d2b75d0b13a3b597aad995df4e5a05bf9056023d014b5faa353a3c66fe27754b2f3508a26a0a2a6b58aece23d8ce7263483a66009461d3c7010d4c3dfec39c4c7ac230e4a1fd459f394f6d261399caacf44cd260b8a30281804f8c1d61e059c9920e68544adc7e028f8f05933b4f49cec1614999d120450198bef26bdde1099bffc5316baef331c2b3d854e42a2f18858735641952104847cbbce742c8a6b9238143af4b27cb8ca4ef931f5509f2bca875397edfabdd2263e0867303dbdfbfac683a10c42d76184f320c469ab0f680a83797684b61026b93df",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDMiQ+CmG4Yw14Y\nouo1S9LH6I3Knw4ZgUl7MTQriTmSpJ82OA++mCmZXprsGz7IjfvL+xG9KgAUD49m\nR8XjvdpSd5nvBXH0VCfxDSRj7glv2kjEEIXTqQv3By0G+3o9IobNECVagqUkUuo+\nYeLY417/n2uDG0jwm1It8QT0isWPds0kG5/dwELnaDd0EXgIaBaTU2YA4c0wNdz2\n7DCmvfZZsV4EF8O/xMmlkfL4WAgd8SQ0d9QYEqasdLxPu2SFsYqvagDDJZN1GlJ3\nI7SALTGAOGmN6QY4GARMyhsDW4gAGT/tcdPDjtMpb92zNlUraNOA0SFLE6HIbm9o\ne9N+X9IrAgMBAAECggEAITerPK7rxnrIJ+Ehf1lamJvUl1EglZTRLcAudFmbb4zr\nzH7rU61bqCxcpbbBCgpBF/4lAd811ww14ksKwPNe5yDEb7SnLqKSQAw92jrY7oD5\na1oxmc/tAQf50JX74rzePqR+JIZuMomCwHHeSRIYJhSqfcbrICRhgtOPVfXJowRC\ncIN5J3PqDIgfAdNAgEtibE0M/TasdZ5lxmkstZ/wz1lS2Nl3cOYB+4aW90biMvEI\nO+N1q0Ngp8myXnIQs7g+SY3+3TK5APeVkH89/RXttS2OTWm5ZPQZZDOg2P6oyodb\naClwpWg2t3CCUu8UW23LilKmMG/RllG8dXAcm8q3wQKBgQDqkJI60aFtj1cEvf00\np/BZlBESw5H2VrdQ9snKHZFjl+vMM/SMMAqdABBxyvANM/gM8K4+/YmcZEPmzbkh\nTZ37IJ4IgWPnXddYLTY533XZzxE+tCvGH36Q69mmGd60HHbVco8xNNRWQULhZvRj\nE/GnSS8j0gf8LY+hXMegHyQhQQKBgQDfOfr0DTy68q7S0PacZ7K7sZ58gbyQMGkY\nRx0eQGysjtmWnovcgL5yUCF21o6h9gFuyvTTtM4k6nZ2IyX9FoA0Xlxbd7pIiLnX\n1P2FrxbiDMkiuL0ru0n2NzI23ck5BjridtL7SjgS3nQEeh2SWf2HfiMpkg9EJFhb\nsnr9xh7sawKBgQDMl9skOLLQCCXDeh+/7PekepTFxBWtQwfUM93gUBf/QYSncW3N\nVR38wRCW4IavTXP/fXLOeICuC3p6d1gR50xzvYh6LLnCFcT+ITlaE0INACKviaFg\nxxmzODR4P7pTaTxxguHI7qaCsZuvVQi23q951UirusfCOs871Nw+Gst9wQKBgFS7\n4Iu1XqEkL8JsecAjCNCAesWORbKB/dKuY9ow4E+cJfIrmrGH2ULxMdK3XQsTo7WX\nqtmV305aBb+QVgI9AUtfqjU6PGb+J3VLLzUIomoKKmtYrs4j2M5yY0g6ZgCUYdPH\nAQ1MPf7DnEx6wjDkof1FnzlPbSYTmcqs9EzSYLijAoGAT4wdYeBZyZIOaFRK3H4C\nj48FkztPSc7BYUmZ0SBFAZi+8mvd4Qmb/8Uxa67zMcKz2FTkKi8YhYc1ZBlSEEhH\ny7znQsimuSOBQ69LJ8uMpO+TH1UJ8ryodTl+36vdImPghnMD29+/rGg6EMQtdhhP\nMgxGmrD2gKg3l2hLYQJrk98=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "zIkPgphuGMNeGKLqNUvSx-iNyp8OGYFJezE0K4k5kqSfNjgPvpgpmV6a7Bs-yI37y_sRvSoAFA-PZkfF473aUneZ7wVx9FQn8Q0kY-4Jb9pIxBCF06kL9wctBvt6PSKGzRAlWoKlJFLqPmHi2ONe_59rgxtI8JtSLfEE9IrFj3bNJBuf3cBC52g3dBF4CGgWk1NmAOHNMDXc9uwwpr32WbFeBBfDv8TJpZHy-FgIHfEkNHfUGBKmrHS8T7tkhbGKr2oAwyWTdRpSdyO0gC0xgDhpjekGOBgETMobA1uIABk_7XHTw47TKW_dszZVK2jTgNEhSxOhyG5vaHvTfl_SKw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "ITerPK7rxnrIJ-Ehf1lamJvUl1EglZTRLcAudFmbb4zrzH7rU61bqCxcpbbBCgpBF_4lAd811ww14ksKwPNe5yDEb7SnLqKSQAw92jrY7oD5a1oxmc_tAQf50JX74rzePqR-JIZuMomCwHHeSRIYJhSqfcbrICRhgtOPVfXJowRCcIN5J3PqDIgfAdNAgEtibE0M_TasdZ5lxmkstZ_wz1lS2Nl3cOYB-4aW90biMvEIO-N1q0Ngp8myXnIQs7g-SY3-3TK5APeVkH89_RXttS2OTWm5ZPQZZDOg2P6oyodbaClwpWg2t3CCUu8UW23LilKmMG_RllG8dXAcm8q3wQ",
+        "p": "6pCSOtGhbY9XBL39NKfwWZQREsOR9la3UPbJyh2RY5frzDP0jDAKnQAQccrwDTP4DPCuPv2JnGRD5s25IU2d-yCeCIFj513XWC02Od912c8RPrQrxh9-kOvZphnetBx21XKPMTTUVkFC4Wb0YxPxp0kvI9IH_C2PoVzHoB8kIUE",
+        "q": "3zn69A08uvKu0tD2nGeyu7GefIG8kDBpGEcdHkBsrI7Zlp6L3IC-clAhdtaOofYBbsr007TOJOp2diMl_RaANF5cW3e6SIi519T9ha8W4gzJIri9K7tJ9jcyNt3JOQY64nbS-0o4Et50BHodkln9h34jKZIPRCRYW7J6_cYe7Gs",
+        "dp": "zJfbJDiy0Aglw3ofv-z3pHqUxcQVrUMH1DPd4FAX_0GEp3FtzVUd_MEQluCGr01z_31yzniArgt6endYEedMc72Ieiy5whXE_iE5WhNCDQAir4mhYMcZszg0eD-6U2k8cYLhyO6mgrGbr1UItt6vedVIq7rHwjrPO9TcPhrLfcE",
+        "dq": "VLvgi7VeoSQvwmx5wCMI0IB6xY5FsoH90q5j2jDgT5wl8iuasYfZQvEx0rddCxOjtZeq2ZXfTloFv5BWAj0BS1-qNTo8Zv4ndUsvNQiiagoqa1iuziPYznJjSDpmAJRh08cBDUw9_sOcTHrCMOSh_UWfOU9tJhOZyqz0TNJguKM",
+        "qi": "T4wdYeBZyZIOaFRK3H4Cj48FkztPSc7BYUmZ0SBFAZi-8mvd4Qmb_8Uxa67zMcKz2FTkKi8YhYc1ZBlSEEhHy7znQsimuSOBQ69LJ8uMpO-TH1UJ8ryodTl-36vdImPghnMD29-_rGg6EMQtdhhPMgxGmrD2gKg3l2hLYQJrk98"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 66,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "841ee52c94cac3dda367429494b2a07274e19f7f9567bceae1a940df892b8e44c7c86bdcc6ea7232774ee2195b19bfe932a88c12401c06fe0b865583d989ed3236fdb18264499a36b6ae6ba1bfc68b8220a0e3fa2f8221bb3e72e267115469c8648b5ec81d04393f8357daea9b849b95d2707a3b13e4e27a5be8e75e803f41b081c7accae863211f5357a4c81c",
+          "ct": "cc890f82986e18c35e18a2ea354bd2c7e88dca9f0e1981497b31342b893992a49f36380fbe9829995e9aec1b3ec88dfbcbfb11bd2a00140f8f6647c5e3bdda527799ef0571f45427f10d2463ee096fda48c41085d3a90bf7072d06fb7a3d2286cd10255a82a52452ea3e61e2d8e35eff9f6b831b48f09b522df104f48ac58f76cc241b9fddc042e7683774117808681693536600e1cd3035dcf6ec30a6bdf659b15e0417c3bfc4c9a591f2f858081df1243477d41812a6ac74bc4fbb6485b18aaf6a00c32593751a527723b4802d318038698de9063818044cca1b035b8800193fed71d3c38ed3296fddb336552b68d380d1214b13a1c86e6f687bd37e5fd22c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "RsaesPkcs1Decrypt",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "privateKey": {
+        "modulus": "00b519563f7b707c6e9b89342aa5314536c521dd78877a3307b372f617622cb06c84626ca4e09e92cb869acaa07b04e18ae51a2935eb0d4cd29ddb96e5fea661c6f038859e31a96bcebefa32cd77dcbb2817c20774ce6badb1795c8b1e73a555921e6cf2726663576d9075af06dd89795bdf10b3f1973cdfbe81fd0f09d9b7aca821e3f403bbf517982d39f1a3411814a24f72d02f96a545cd0e0297ed88f3603cecc340adb01e2b35f9b7d8c2e4fa04e22122e5931cec5a12a3e0b93ca623a7d1a337c2bf6faf6ac17c0480a2b7e922dd99ee44297c5c085f044a92865429696387768e1ac55b0acd5bf312fe10279d3e7277f11c46ebf161feba67aeb49b103f",
+        "privateExponent": "172e8e47a3b5a8a555fbf06011c8fbfb00ad64416a0233fc6535aeed1bb041c88502690ae005472038c8f6c2d28c88e733e02f41f6269132181544673390e3ccf3477649e39734342bbbdba5f3ea7450b3b32ed6291847e1d879b15b42b82425dcb185dad6b81a631838b5a0c8da060818714b14d40f184b0ad909c44688ddad1412f62d21b6d59bdcc755326bef192ab0f80fd993f23ab173acbb0d637c504b19e332d3911b59ff3b9b7e8e1e05fe6f06b82444fe08eec7d829942c1eddde1e7e1402128dfd95adfabd281f180fd51cfbb72de7643148df16bfdde797b1d3856e8ab0b199b7370dea76cab5d7d1645471d9a90f035127f4501ad9b8e0fb4339",
+        "publicExponent": "010001",
+        "prime1": "00e9cffe9f3b702d03ee7c25703f1314b2647963de2da16f2c7966d3ebc18fea929f28cb7a55f576d9c3a5a2513087a439d74cae037a965a31832b87188d3ce71a2000f54b983956c8e6827e854d21b4c37eb3948f6801895319b1cf51e020dbb7883bf15164f1499696feda88eb0b6d75877deec33da2390e9976d698a6d9b0c9",
+        "prime2": "00c648c5f9422c0127928e7a9cfe9b345185d53e06d8bbb35201cae7bdfa2ceb7a6b31bcb88f4617c995feb2b71ec8f4e1854fc17639c970bcdf37fc46654305a690b8e6a6bea726e8b7ea40edb886532d7944a2ad2763cbe612cc170d7ca95fb90ba90a806190252dcac94a3e79ba45e4abde0391769c1e750834f5cd00e384c7",
+        "exponent1": "00cb766a369a7ca54f948a87f1c391912323f7d68612e33661574bba02a02fe28ab0e1c91fae09aae11935dba81739121a1b56e8deb220806031ab0126c65147321ec376b1cfc7a5d3b173c131b2cb3008270b92adb06e15d830b5e09979165edcb93aa0669a16b658cb10ff8ec22af197a2ce5da59ccebc240e3bb1c6a8fb2ab1",
+        "exponent2": "51a7f48792bda678127dc476d4cf3bbb7adef75d40720405f8a103d093af5e061b10ef841dd4a2c52c95282a0b6e7c924721322daadc8f25e8d3187c310569d54f7225e2734f48d1bbb3a7ab7e3b2b13e605e2ec65f54e29e081d5d8830709599e38ae0f729e370165aa817dbb097ff10cea3013fe818a756dbcc9a0f405be4f",
+        "coefficient": "6011e90bcbdc97ec1d0d43992f8830d4bda5922997eec843a9ed14f80f83d0a0afad3cc320108cae02e4010403b31650c26af431563f0821858c5da0095a9813c45c11bbf2a43bfc36ebd036cd4548f406a933235a5ea71aabe29ca536c5d8a37fd1310b43f0e1bcec13bba1d6a9968c718bf974f5b73ccbd808d1248c8f5cae"
+      },
+      "privateKeyPkcs8": "308204bd020100300d06092a864886f70d0101010500048204a7308204a30201000282010100b519563f7b707c6e9b89342aa5314536c521dd78877a3307b372f617622cb06c84626ca4e09e92cb869acaa07b04e18ae51a2935eb0d4cd29ddb96e5fea661c6f038859e31a96bcebefa32cd77dcbb2817c20774ce6badb1795c8b1e73a555921e6cf2726663576d9075af06dd89795bdf10b3f1973cdfbe81fd0f09d9b7aca821e3f403bbf517982d39f1a3411814a24f72d02f96a545cd0e0297ed88f3603cecc340adb01e2b35f9b7d8c2e4fa04e22122e5931cec5a12a3e0b93ca623a7d1a337c2bf6faf6ac17c0480a2b7e922dd99ee44297c5c085f044a92865429696387768e1ac55b0acd5bf312fe10279d3e7277f11c46ebf161feba67aeb49b103f020301000102820100172e8e47a3b5a8a555fbf06011c8fbfb00ad64416a0233fc6535aeed1bb041c88502690ae005472038c8f6c2d28c88e733e02f41f6269132181544673390e3ccf3477649e39734342bbbdba5f3ea7450b3b32ed6291847e1d879b15b42b82425dcb185dad6b81a631838b5a0c8da060818714b14d40f184b0ad909c44688ddad1412f62d21b6d59bdcc755326bef192ab0f80fd993f23ab173acbb0d637c504b19e332d3911b59ff3b9b7e8e1e05fe6f06b82444fe08eec7d829942c1eddde1e7e1402128dfd95adfabd281f180fd51cfbb72de7643148df16bfdde797b1d3856e8ab0b199b7370dea76cab5d7d1645471d9a90f035127f4501ad9b8e0fb433902818100e9cffe9f3b702d03ee7c25703f1314b2647963de2da16f2c7966d3ebc18fea929f28cb7a55f576d9c3a5a2513087a439d74cae037a965a31832b87188d3ce71a2000f54b983956c8e6827e854d21b4c37eb3948f6801895319b1cf51e020dbb7883bf15164f1499696feda88eb0b6d75877deec33da2390e9976d698a6d9b0c902818100c648c5f9422c0127928e7a9cfe9b345185d53e06d8bbb35201cae7bdfa2ceb7a6b31bcb88f4617c995feb2b71ec8f4e1854fc17639c970bcdf37fc46654305a690b8e6a6bea726e8b7ea40edb886532d7944a2ad2763cbe612cc170d7ca95fb90ba90a806190252dcac94a3e79ba45e4abde0391769c1e750834f5cd00e384c702818100cb766a369a7ca54f948a87f1c391912323f7d68612e33661574bba02a02fe28ab0e1c91fae09aae11935dba81739121a1b56e8deb220806031ab0126c65147321ec376b1cfc7a5d3b173c131b2cb3008270b92adb06e15d830b5e09979165edcb93aa0669a16b658cb10ff8ec22af197a2ce5da59ccebc240e3bb1c6a8fb2ab102818051a7f48792bda678127dc476d4cf3bbb7adef75d40720405f8a103d093af5e061b10ef841dd4a2c52c95282a0b6e7c924721322daadc8f25e8d3187c310569d54f7225e2734f48d1bbb3a7ab7e3b2b13e605e2ec65f54e29e081d5d8830709599e38ae0f729e370165aa817dbb097ff10cea3013fe818a756dbcc9a0f405be4f0281806011e90bcbdc97ec1d0d43992f8830d4bda5922997eec843a9ed14f80f83d0a0afad3cc320108cae02e4010403b31650c26af431563f0821858c5da0095a9813c45c11bbf2a43bfc36ebd036cd4548f406a933235a5ea71aabe29ca536c5d8a37fd1310b43f0e1bcec13bba1d6a9968c718bf974f5b73ccbd808d1248c8f5cae",
+      "privateKeyPem": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC1GVY/e3B8bpuJ\nNCqlMUU2xSHdeId6MwezcvYXYiywbIRibKTgnpLLhprKoHsE4YrlGik16w1M0p3b\nluX+pmHG8DiFnjGpa86++jLNd9y7KBfCB3TOa62xeVyLHnOlVZIebPJyZmNXbZB1\nrwbdiXlb3xCz8Zc8376B/Q8J2besqCHj9AO79ReYLTnxo0EYFKJPctAvlqVFzQ4C\nl+2I82A87MNArbAeKzX5t9jC5PoE4iEi5ZMc7FoSo+C5PKYjp9GjN8K/b69qwXwE\ngKK36SLdme5EKXxcCF8ESpKGVClpY4d2jhrFWwrNW/MS/hAnnT5yd/EcRuvxYf66\nZ660mxA/AgMBAAECggEAFy6OR6O1qKVV+/BgEcj7+wCtZEFqAjP8ZTWu7RuwQciF\nAmkK4AVHIDjI9sLSjIjnM+AvQfYmkTIYFURnM5DjzPNHdknjlzQ0K7vbpfPqdFCz\nsy7WKRhH4dh5sVtCuCQl3LGF2ta4GmMYOLWgyNoGCBhxSxTUDxhLCtkJxEaI3a0U\nEvYtIbbVm9zHVTJr7xkqsPgP2ZPyOrFzrLsNY3xQSxnjMtORG1n/O5t+jh4F/m8G\nuCRE/gjux9gplCwe3d4efhQCEo39la36vSgfGA/VHPu3LedkMUjfFr/d55ex04Vu\nirCxmbc3Dep2yrXX0WRUcdmpDwNRJ/RQGtm44PtDOQKBgQDpz/6fO3AtA+58JXA/\nExSyZHlj3i2hbyx5ZtPrwY/qkp8oy3pV9XbZw6WiUTCHpDnXTK4DepZaMYMrhxiN\nPOcaIAD1S5g5Vsjmgn6FTSG0w36zlI9oAYlTGbHPUeAg27eIO/FRZPFJlpb+2ojr\nC211h33uwz2iOQ6ZdtaYptmwyQKBgQDGSMX5QiwBJ5KOepz+mzRRhdU+Bti7s1IB\nyue9+izremsxvLiPRhfJlf6ytx7I9OGFT8F2OclwvN83/EZlQwWmkLjmpr6nJui3\n6kDtuIZTLXlEoq0nY8vmEswXDXypX7kLqQqAYZAlLcrJSj55ukXkq94DkXacHnUI\nNPXNAOOExwKBgQDLdmo2mnylT5SKh/HDkZEjI/fWhhLjNmFXS7oCoC/iirDhyR+u\nCarhGTXbqBc5EhobVujesiCAYDGrASbGUUcyHsN2sc/HpdOxc8ExssswCCcLkq2w\nbhXYMLXgmXkWXty5OqBmmha2WMsQ/47CKvGXos5dpZzOvCQOO7HGqPsqsQKBgFGn\n9IeSvaZ4En3EdtTPO7t63vddQHIEBfihA9CTr14GGxDvhB3UosUslSgqC258kkch\nMi2q3I8l6NMYfDEFadVPciXic09I0buzp6t+OysT5gXi7GX1TinggdXYgwcJWZ44\nrg9ynjcBZaqBfbsJf/EM6jAT/oGKdW28yaD0Bb5PAoGAYBHpC8vcl+wdDUOZL4gw\n1L2lkimX7shDqe0U+A+D0KCvrTzDIBCMrgLkAQQDsxZQwmr0MVY/CCGFjF2gCVqY\nE8RcEbvypDv8NuvQNs1FSPQGqTMjWl6nGqvinKU2xdijf9ExC0Pw4bzsE7uh1qmW\njHGL+XT1tzzL2AjRJIyPXK4=\n-----END PRIVATE KEY-----\n",
+      "privateKeyJwk": {
+        "kty": "RSA",
+        "alg": "RSA1_5",
+        "n": "tRlWP3twfG6biTQqpTFFNsUh3XiHejMHs3L2F2IssGyEYmyk4J6Sy4aayqB7BOGK5RopNesNTNKd25bl_qZhxvA4hZ4xqWvOvvoyzXfcuygXwgd0zmutsXlcix5zpVWSHmzycmZjV22Qda8G3Yl5W98Qs_GXPN--gf0PCdm3rKgh4_QDu_UXmC058aNBGBSiT3LQL5alRc0OApftiPNgPOzDQK2wHis1-bfYwuT6BOIhIuWTHOxaEqPguTymI6fRozfCv2-vasF8BICit-ki3ZnuRCl8XAhfBEqShlQpaWOHdo4axVsKzVvzEv4QJ50-cnfxHEbr8WH-umeutJsQPw",
+        "e": "AQAB",
+        "kid": "none",
+        "d": "Fy6OR6O1qKVV-_BgEcj7-wCtZEFqAjP8ZTWu7RuwQciFAmkK4AVHIDjI9sLSjIjnM-AvQfYmkTIYFURnM5DjzPNHdknjlzQ0K7vbpfPqdFCzsy7WKRhH4dh5sVtCuCQl3LGF2ta4GmMYOLWgyNoGCBhxSxTUDxhLCtkJxEaI3a0UEvYtIbbVm9zHVTJr7xkqsPgP2ZPyOrFzrLsNY3xQSxnjMtORG1n_O5t-jh4F_m8GuCRE_gjux9gplCwe3d4efhQCEo39la36vSgfGA_VHPu3LedkMUjfFr_d55ex04VuirCxmbc3Dep2yrXX0WRUcdmpDwNRJ_RQGtm44PtDOQ",
+        "p": "6c_-nztwLQPufCVwPxMUsmR5Y94toW8seWbT68GP6pKfKMt6VfV22cOlolEwh6Q510yuA3qWWjGDK4cYjTznGiAA9UuYOVbI5oJ-hU0htMN-s5SPaAGJUxmxz1HgINu3iDvxUWTxSZaW_tqI6wttdYd97sM9ojkOmXbWmKbZsMk",
+        "q": "xkjF-UIsASeSjnqc_ps0UYXVPgbYu7NSAcrnvfos63prMby4j0YXyZX-srceyPThhU_BdjnJcLzfN_xGZUMFppC45qa-pybot-pA7biGUy15RKKtJ2PL5hLMFw18qV-5C6kKgGGQJS3KyUo-ebpF5KveA5F2nB51CDT1zQDjhMc",
+        "dp": "y3ZqNpp8pU-Uiofxw5GRIyP31oYS4zZhV0u6AqAv4oqw4ckfrgmq4Rk126gXORIaG1bo3rIggGAxqwEmxlFHMh7DdrHPx6XTsXPBMbLLMAgnC5KtsG4V2DC14Jl5Fl7cuTqgZpoWtljLEP-Owirxl6LOXaWczrwkDjuxxqj7KrE",
+        "dq": "Uaf0h5K9pngSfcR21M87u3re911AcgQF-KED0JOvXgYbEO-EHdSixSyVKCoLbnySRyEyLarcjyXo0xh8MQVp1U9yJeJzT0jRu7Onq347KxPmBeLsZfVOKeCB1diDBwlZnjiuD3KeNwFlqoF9uwl_8QzqMBP-gYp1bbzJoPQFvk8",
+        "qi": "YBHpC8vcl-wdDUOZL4gw1L2lkimX7shDqe0U-A-D0KCvrTzDIBCMrgLkAQQDsxZQwmr0MVY_CCGFjF2gCVqYE8RcEbvypDv8NuvQNs1FSPQGqTMjWl6nGqvinKU2xdijf9ExC0Pw4bzsE7uh1qmWjHGL-XT1tzzL2AjRJIyPXK4"
+      },
+      "keySize": 2048,
+      "tests": [
+        {
+          "tcId": 67,
+          "comment": "edge case for montgomery reduction with special primes",
+          "flags": [
+            "SpecialCase"
+          ],
+          "msg": "a3b94a63d4937de4bf024bce52957cd9af5efb3b0defef908d5f2ce35941b10168128951a1c5093dcdcebaa0622fdfc1e481daac4ce5675ed6690cec5f8ef20305185ed5b61db798e7a13626831fa9",
+          "ct": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "valid"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Wave 4: the RSA *decryption* side. RSAES-PKCS#1 v1.5 (67 Bleichenbacher-shaped cases) and RSA-OAEP (37 Manger-shaped cases), driven with the vectors' private keys — each case a full private-key modexp, so they get their own CI suite slot.

## One accepted-invalid found and fixed

**rsa_oaep tcId 27, "added n to c"** — the ciphertext-side twin of 0.535.0's unreduced-signature fix: `c + n` is a distinct byte string with the same residue, invisible after `raw_decrypt`'s mod-n reduction. RFC 8017 §7.1.2/§7.2.2 step 1 requires exactly k octets with c < n. The range gate now guards `decrypt_oaep` **and** `decrypt_pkcs1` (same latent hole), completing the set: every RSA entry point — sign-verify v1.5/PSS, decrypt v1.5/OAEP — now rejects unreduced inputs.

## Clean on import

RSAES v1.5: 67/67 (all Bleichenbacher padding mangles rejected uniformly). OAEP: 29/29 expressible; the 8 labelled cases are **counted-skipped** — `decrypt_oaep` has no label parameter (API gap noted for #739).

## Verified

Post-fix: oaep 0 failed, rsaes 0 failed, `crypto_rsa_oaep_pss` KATs green, `fmt_gate` canonical.

Program tally: **13 families, ~3,800 adversarial cases, 10 forgery/malleability classes fixed** across four waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)