### PR TITLE
The three aeb-line asks: multi-TU link pin (macOS), aeocha-v1 report contract, aeocha homing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+- Regression pin for the multi-TU link model (aeb's orchestrator shape,
+  from the aeb-line asks): four modules compiled to separate objects
+  link with NO -Wl,--allow-multiple-definition and run — imported
+  functions are cloned per-TU as `static` (landed with the #1568 audit),
+  a module's own functions stay external. Guards the macOS/ld64 story:
+  downstream multi-TU tools need no GNU-only dedup flags.
+- The `AE_SPEC_REPORT` aeocha-v1 test-report format is now a documented,
+  versioned CONTRACT (docs/testing.md): header keys, `---` separator,
+  row shape, and the incompatible-change-bumps-`version=` rule —
+  `_format_aeocha_v1` carries a producer-side pointer. Downstream
+  parsers (aeb's driver_test reporting) may depend on it deliberately.
+- docs/testing.md states `contrib.aeocha`'s retirement explicitly:
+  nothing in std/contrib references it (verified), `std.spec` +
+  `std.os.testing` + `std.http.client.httptest` are the replacements,
+  and the env-file report transport replaces the old IPC-pipe
+  convention for spec children.
+
 ## [0.538.0]
 
 ### Added

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -294,3 +294,54 @@ retains its own copies (and the mutation-testing facility) for
 standalone use. See `tests/integration/std_testing_arms/probe.ae` for
 an end-to-end example driving both arms against real subprocesses and
 an in-process fixture server.
+
+## Test report format (aeocha-v1) — a stable, versioned contract
+
+`std.spec`'s `run_summary` writes a machine-readable report to the path
+in `AE_SPEC_REPORT` when `AE_SPEC_FORMAT=aeocha` (or `aeocha-v1`) is
+set; `ae test --format=aeocha-v1` arranges both per child. Downstream
+tools (aeb's `aether.driver_test` reporting among them) parse this file,
+so its shape is a **contract, not an implementation detail**:
+
+```
+version=1
+total=<N>
+passed=<N>
+failed=<N>
+errored=<N>
+duration_ms=<N>
+duration_ns=<N>
+---
+<STATUS>\t<index>\t"<name>"\t<duration_ns>[\t<message>]
+...
+```
+
+The rules a consumer may rely on, and an editor must preserve:
+
+1. The header is `key=value` lines, one per line, starting with
+   `version=`. Within `version=1` the keys above keep their names and
+   meanings. **New keys may be added** (consumers must ignore unknown
+   keys); existing keys are never renamed, repurposed, or removed.
+2. The header ends at the first `---` line (`\n---\n`); rows follow.
+3. Each row is tab-separated: STATUS (`PASS`/`FAIL`), a 1-based index,
+   the double-quoted test name, a duration (nanoseconds today — treat
+   the unit as unspecified within v1 and do not compute from it), and —
+   only when present — a trailing message field.
+4. **Any change that breaks rules 1–3 bumps the leading `version=`**
+   so a pinned consumer detects v2 instead of misparsing v1.
+
+`_format_aeocha_v1` in `std/spec/module.ae` is the single producer;
+it carries a pointer back to this section.
+
+## `contrib.aeocha` is retired
+
+The aeocha framework was absorbed into the stdlib: `import std.spec`
+(core + fluent + collections + timing), `import std.os.testing`
+(process matchers), `import std.http.client.httptest` (HTTP matchers,
+`within`/`without`/`eventually`). No std or contrib module references
+`contrib.aeocha`, and nothing in a test's closure requires the aeocha
+repo or its old IPC-pipe report convention — the env-file transport
+above replaces it. Downstreams still importing `contrib.aeocha` from
+pre-spinout snapshots should migrate to the modules above; the
+standalone aeocha repo remains only as a thin compatibility facade
+plus its aeb IPC reporter and mutation-testing tool.

--- a/std/spec/module.ae
+++ b/std/spec/module.ae
@@ -959,6 +959,12 @@ _tap_yaml_scalar(s: string) -> string {
 // 0; v1 row consumers match STATUS/index/"name"/message and ignore the
 // duration value, so this stays wire-compatible. errored is always 0 —
 // spec categorises everything as PASS or FAIL today.
+//
+// CONTRACT: this format is documented in docs/testing.md ("Test report
+// format (aeocha-v1)") and external tools (aeb's driver_test reporting)
+// parse it. Do not rename/remove header keys, change the `---`
+// separator, or reshape rows within version=1 — an incompatible change
+// MUST bump the leading `version=` line. Additive header keys are fine.
 _format_aeocha_v1(fw: ptr, passed: int, failed: int) -> string {
     its = map.get_raw(fw, "its")
     n = list.size(its)

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -134,6 +134,7 @@ tests/integration/module_name_local_shadow/
 tests/integration/module_reexport/
 tests/integration/module_token_cap/
 tests/integration/module_var_cross_import/
+tests/integration/multi_tu_import_link/
 tests/integration/namespace_
 tests/integration/optional_reject/
 tests/integration/or_block_reject/

--- a/tests/integration/multi_tu_import_link/a/module.ae
+++ b/tests/integration/multi_tu_import_link/a/module.ae
@@ -1,0 +1,3 @@
+import helper(shared)
+
+a_val() { return shared() + 1 }

--- a/tests/integration/multi_tu_import_link/b/module.ae
+++ b/tests/integration/multi_tu_import_link/b/module.ae
@@ -1,0 +1,3 @@
+import helper(shared)
+
+b_val() { return shared() + 2 }

--- a/tests/integration/multi_tu_import_link/helper/module.ae
+++ b/tests/integration/multi_tu_import_link/helper/module.ae
@@ -1,0 +1,1 @@
+shared() { return 41 }

--- a/tests/integration/multi_tu_import_link/main.ae
+++ b/tests/integration/multi_tu_import_link/main.ae
@@ -1,0 +1,5 @@
+import a(a_val)
+import b(b_val)
+import std.io
+
+main() { println("${a_val()} ${b_val()}") }

--- a/tests/integration/multi_tu_import_link/test_multi_tu_import_link.sh
+++ b/tests/integration/multi_tu_import_link/test_multi_tu_import_link.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Regression for the aeb-line ask "imported-module fns not static break
+# macOS link": a multi-TU program — each module compiled to its own
+# object, all linked together — must link with NO
+# -Wl,--allow-multiple-definition (GNU-only; Apple ld64 rejects it) and
+# no -multiply_defined (removed in Xcode 15). The root fix (#1568):
+# imported-module functions are cloned per-TU as `static`, so N TUs
+# importing one module produce zero duplicate external symbols; a
+# module's OWN functions stay external (the unit of inter-TU linking).
+#
+# This is exactly aeb's orchestrator shape (one .c/.o per build node,
+# one final link), which could not link on macOS at all before the fix.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$ROOT" || exit 1
+
+AE="$ROOT/build/ae"
+AETHERC="$ROOT/build/aetherc"
+[ -n "${EXE_EXT:-}" ] && { AE="$AE$EXE_EXT"; AETHERC="$AETHERC$EXE_EXT"; }
+[ -x "$AETHERC" ] || { echo "  [SKIP] multi_tu_import_link: aetherc missing (run make)"; exit 0; }
+
+CC="${CC:-cc}"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "  [FAIL] multi_tu_import_link: $1"; shift; for f in "$@"; do [ -f "$f" ] && sed 's/^/        /' "$f" | tail -8; done; exit 1; }
+
+# One TU per module + the driver, aeb-style.
+for m in helper/module a/module b/module main; do
+    out="$TMP/$(echo "$m" | tr '/' '_').c"
+    ( cd "$SCRIPT_DIR" && "$AETHERC" "$m.ae" "$out" ) >"$TMP/cc.log" 2>&1 \
+        || fail "aetherc failed on $m.ae" "$TMP/cc.log"
+done
+
+CFLAGS_ALL=$("$AE" cflags --cflags 2>/dev/null)
+LIBS_ALL=$("$AE" cflags --libs 2>/dev/null)
+for c in "$TMP"/*.c; do
+    $CC -c "$c" -o "${c%.c}.o" $CFLAGS_ALL 2>"$TMP/gcc.log" \
+        || fail "TU compile failed: $c" "$TMP/gcc.log"
+done
+
+# The load-bearing step: link every object with NO duplicate-symbol
+# escape hatch of any kind.
+if ! $CC "$TMP"/*.o -o "$TMP/repro" $LIBS_ALL 2>"$TMP/link.log"; then
+    if grep -qiE "duplicate symbol|multiple definition" "$TMP/link.log"; then
+        fail "duplicate symbols across TUs (imported clones not static?)" "$TMP/link.log"
+    fi
+    fail "link failed" "$TMP/link.log"
+fi
+
+out=$("$TMP/repro" 2>&1)
+[ "$out" = "42 43" ] || fail "wrong output: '$out'"
+
+# Belt: the imported clone really is local, the module's own fn external.
+if command -v nm >/dev/null 2>&1; then
+    a_o=$(ls "$TMP"/a_module.o)
+    nm "$a_o" | grep -qE " T _?a_val" || fail "a_val lost external linkage (inter-TU calls would break)"
+    if nm "$a_o" | grep -qE " T _?helper_shared"; then
+        fail "imported clone helper_shared is EXTERNAL in a's TU (dup-symbol regression)"
+    fi
+fi
+
+echo "  [PASS] multi_tu_import_link: 4 TUs, no dedup flags, runs (42 43)"


### PR DESCRIPTION
One PR for the three 2026-08-15 aeb-line asks, as agreed.

## 1. `asks/imported-module-fns-not-static-break-macos-link.md` — already fixed; now pinned

The root-cause fix landed with the #1568 audit (imported-module functions clone per-TU as `static AETHER_MAYBE_UNUSED`; a module's own functions stay external — `docs/emit-lib.md` documents the model). Verified with the ask's exact repro: four modules → four objects → one link, **zero** `--allow-multiple-definition` / `-multiply_defined`, correct output, correct `nm` linkage.

This PR adds the **pin**: `tests/integration/multi_tu_import_link/` runs that exact aeb-orchestrator shape in CI on every platform — the link must succeed with no dedup flags, the binary must run, and `nm` must show the imported clone local + the module's own fn external. That makes the macOS/ld64 guarantee durable rather than incidental.

**For aeb**: from the next release, drop `-Wl,--allow-multiple-definition` from `tools/aeb-link.ae` and the macOS platform-gate entirely (the ask's acceptance).

## 2. `asks/spec-report-format-stable-versioned-contract.md` — contract committed

`docs/testing.md` gains "Test report format (aeocha-v1) — a stable, versioned contract": header keys, the `\n---\n` separator, the row shape, unknown-header-keys-are-additive, and the **incompatible-change-bumps-`version=`** rule. `_format_aeocha_v1` carries a producer-side pointer so an editor meets the contract before touching the format.

One correction to the ask while writing it down: the per-row duration is **nanoseconds**, not ms — the contract states the unit as unspecified-within-v1 (consumers, aeb included, already ignore the value), keeping it wire-compatible.

## 3. `asks/home-the-ipc-report-channel-away-from-sunsetting-aeocha.md` — verified + documented

- Verified: **zero** `contrib.aeocha` references across `std/`, `contrib/`, `docs/` — a clean `ae` install resolves everything a `std.spec`-based `driver_test` needs with no aeocha in the closure.
- Documented (`docs/testing.md`): `contrib.aeocha` is retired; the replacements are `std.spec` / `std.os.testing` / `std.http.client.httptest`; the env-file report transport (`AE_SPEC_REPORT`) replaces the old IPC-pipe convention for spec children. Downstreams migrate deliberately, per the ask's acceptance.

Gates: multi-TU test green post-rebase on #1579's merge, fmt canonical, spec regression + format-reporting tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)