### PR TITLE
docs(changelog): restore the [current] section the audit merge folded away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
-## [0.538.0]
+## [current]
 
 ### Added
 
@@ -144,6 +144,8 @@ version number before tagging the release.
   went too: it had been broken since a source file it lists was removed, and
   the tests it compiled now run in `make test`.
 
+## [0.538.0]
+
 ### Added
 - `std.os.testing` + `std.http.client.httptest` (stage 2 of the aeocha
   tease-out): the process-shape matchers (`expect_exit`,
@@ -201,6 +203,7 @@ version number before tagging the release.
   the registry when the exact lookup misses. Surfaced by `std.spec`, the
   first stdlib module to use a top-level mutable `var`; no working module
   changes its generated C. (`compiler/aether_module.c`.)
+
 ## [0.537.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,6 @@ version number before tagging the release.
   `std.os.testing` + `std.http.client.httptest` are the replacements,
   and the env-file report transport replaces the old IPC-pipe
   convention for spec children.
-
-## [0.538.0]
-
-### Added
-
 - **`make check-standalone`: a compile gate for every C source with its own
   `main()`.** The runtime examples, micro-benchmarks and demos are linked by no
   target, so nothing noticed when they stopped compiling: three carried include


### PR DESCRIPTION
The Release workflow has been failing on main since #1568 merged:

```
No '## [current]' section in CHANGELOG.md, so 0.539.0
would ship with nothing recorded.
```

The audit branch carried its entry under `## [current]`. main had meanwhile cut 0.538.0, which renames that heading to the version. The textual merge kept both bodies under the single surviving heading, so the audit entry landed inside an already-tagged section and the file was left with no `[current]` at all.

This moves the audit entry back under `## [current]`. `## [0.538.0]` is now byte-identical to the section tagged as `v0.538.0` (verified by diffing against `git show v0.538.0:CHANGELOG.md`), so nothing that shipped in that release changes.

No code changes.