### PR TITLE
feat: optional why-message on fluent matchers (#1576); ae add from release artifacts (#1360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ version number before tagging the release.
 ## [current]
 
 ### Added
+- std.spec's fluent value-comparison matchers take an optional trailing
+  intent message (#1576): `to_equal`, `to_be_gt`, `to_be_lt`,
+  `to_be_truthy`, `to_be_falsy`, `to_equal_str`, `to_contain` and
+  `to_start_with` now accept `msg` and render `"<msg> — <generated
+  text>"` on failure. The generated text says what the values were; the
+  message says why the check matters, which is what a failing-CI
+  triager needs. The issue weighed a breaking required-`msg` sweep
+  against parallel `*_because` variants — neither is necessary: Aether's
+  default arguments resolve through UFCS method-call chaining, so the
+  parameter is optional, existing chains are untouched (their wording is
+  byte-identical), and one chain can annotate only the links that need
+  it. `not_()` negation carries the message too.
+- `to_equal_str` now reports through the caret-aligned diff (the
+  `assert_str_eq_diff` form) once either string reaches 24 characters,
+  where a quoted pair stops being legible and the index + caret is what
+  actually locates the differing byte. Shorter strings keep the compact
+  form.
+- `ae add` installs from a published release artifact instead of always
+  git-cloning (#1360). With `@version` it looks for
+  `<repo>-<tag>-<os>-<arch>.tar.gz` (then `.zip`) under the package's
+  `releases/download/<tag>/`, the layout Aether's own releases use, and
+  falls back to the clone when nothing matches — so a package that
+  publishes no artifacts behaves exactly as before. `--source` forces
+  the clone. A sibling `<asset>.sha256` is verified when published: a
+  MISMATCH is fatal, installs nothing, and deliberately does NOT fall
+  back to git (which would defeat the verification); a missing checksum
+  installs with a warning. `AE_RELEASE_BASE_URL` repoints the origin at
+  an internal mirror. The consuming half already existed — the
+  binary-import prepass reads a `--emit=lib` artifact's catalog and
+  synthesizes its interface — so this closes the fetch gap only.
+
+## [current]
+
+### Added
 - `WINDOWS=1` cross-build knob: build the `ae`/`aetherc` toolchain FOR
   Windows from a Linux host with `zig cc -target x86_64-windows-gnu`
   (#1592). Companion to `FREEBSD=1`, and simpler — zig bundles the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,7 +167,28 @@ ae add github.com/user/repo          # latest from GitHub
 ae add github.com/user/repo@v1.0.0   # specific version
 ae add gitlab.com/user/repo           # GitLab
 ae add codeberg.org/user/repo         # Codeberg
+ae add github.com/user/repo@v1.0.0 --source   # force the git clone
 ```
+
+With `@version`, `ae add` prefers a **published release artifact** when the
+package ships one for your platform, and falls back to cloning otherwise.
+The asset is expected at the same layout Aether's own releases use:
+
+```
+https://<package>/releases/download/<tag>/<repo>-<tag>-<os>-<arch>.tar.gz
+```
+
+(`.zip` is tried too; `<os>-<arch>` is `linux-x86_64`, `macos-arm64`, and
+so on.) A sibling `<asset>.sha256` is verified when present — a
+**mismatch is fatal and installs nothing**, and there is no silent
+fall-back to git, which would defeat the check. An artifact with no
+published checksum installs with a warning.
+
+Prebuilt `--emit=lib` artifacts are directly importable: the binary-import
+prepass reads the artifact's catalog and synthesizes the interface, so a
+released library needs no toolchain to consume. Set
+`AE_RELEASE_BASE_URL` to point at an internal mirror serving the same
+layout.
 
 ## Error Handling
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -127,6 +127,37 @@ Available matchers: `to_equal`, `to_be_gt`, `to_be_lt`, `to_be_truthy`,
 `to_be_falsy` (int); `to_equal_str`, `to_contain`, `to_start_with`
 (string); `satisfies`, `satisfies_str` (both).
 
+#### Saying *why* a check matters
+
+Every value-comparison matcher takes an optional trailing message. The
+generated text tells you *what* the values were; the message tells a
+failing-CI triager *why* the check exists, which is the part the values
+cannot convey:
+
+```aether
+spec.expect_str(egress_fqdn_csv("python_vm"))
+    .to_equal_str(want, "a node's egress set is exactly its declared whitelist")
+spec.expect_int(n).to_be_gt(0, "a derived attempt budget is never zero")
+```
+
+```
+FAIL: a node's egress set is exactly its declared whitelist — strings differ at index 14
+        expected: "api.github.com, api.anthropic.com"
+        actual:   "api.github.com"
+                                 ^
+```
+
+The message is optional, so existing chains are unaffected and a single
+chain can annotate only the links that need it
+(`.to_be_gt(0).to_equal(7, "why")`). Omit it and the wording is exactly
+what it always was.
+
+`to_equal_str` switches to the caret-aligned diff (the same form
+`assert_str_eq_diff` uses) once either string is long enough that
+eyeballing a quoted pair stops working — on a long whitelist the index
+and caret are what actually locate the differing byte. Short strings
+keep the compact `expected 'x', got 'y'` form.
+
 ### Extending the fluent chain
 
 `IntSubject` and `StrSubject` are exported. A free function whose first

--- a/std/spec/module.ae
+++ b/std/spec/module.ae
@@ -584,71 +584,113 @@ not_(s: IntSubject) -> IntSubject {
     return IntSubject { value: s.value, negated: 1 }
 }
 
+// _why(msg) — render an optional intent message as a failure-text
+// prefix. Every value-comparison matcher takes a trailing
+// `msg: string = ""` (#1576): the auto-generated text says WHAT the
+// values were, the message says WHY the check matters, which is the
+// part a CI triager actually needs ("peer egress -> internal net" beats
+// "expected 'internal', got 'shared'"). Default-empty, so it is purely
+// additive — existing chains keep their exact wording, and a chain can
+// mix annotated and bare links freely.
+//
+// Optional rather than required (the issue offered required-sweep vs
+// parallel *_because variants): Aether's default arguments resolve
+// correctly through UFCS method-call chaining, so neither the breaking
+// sweep nor the doubled matcher surface is necessary.
+_why(msg: string) -> string {
+    if string.equals(msg, "") == 1 { return "" }
+    return "${msg} — "
+}
+
 // _verdict_int(ok) — shared verdict: given whether the positive
 // predicate held, report against the ambient fw honouring the negated
 // flag.
-_verdict_int(s: IntSubject, ok: int, what: string) {
+_verdict_int(s: IntSubject, ok: int, what: string, msg: string) {
+    w = _why(msg)
     if s.negated == 0 {
-        if ok == 0 { fail("expected ${what}") }
+        if ok == 0 { fail("${w}expected ${what}") }
     } else {
-        if ok == 1 { fail("expected NOT ${what}") }
+        if ok == 1 { fail("${w}expected NOT ${what}") }
     }
 }
 
-to_equal(s: IntSubject, want: int) -> IntSubject {
+to_equal(s: IntSubject, want: int, msg: string = "") -> IntSubject {
     ok = 0
     if s.value == want { ok = 1 }
-    _verdict_int(s, ok, "${want}, got ${s.value}")
+    _verdict_int(s, ok, "${want}, got ${s.value}", msg)
     return s
 }
 
-to_be_gt(s: IntSubject, bound: int) -> IntSubject {
+to_be_gt(s: IntSubject, bound: int, msg: string = "") -> IntSubject {
     ok = 0
     if s.value > bound { ok = 1 }
-    _verdict_int(s, ok, "> ${bound}, got ${s.value}")
+    _verdict_int(s, ok, "> ${bound}, got ${s.value}", msg)
     return s
 }
 
-to_be_lt(s: IntSubject, bound: int) -> IntSubject {
+to_be_lt(s: IntSubject, bound: int, msg: string = "") -> IntSubject {
     ok = 0
     if s.value < bound { ok = 1 }
-    _verdict_int(s, ok, "< ${bound}, got ${s.value}")
+    _verdict_int(s, ok, "< ${bound}, got ${s.value}", msg)
     return s
 }
 
-to_be_truthy(s: IntSubject) -> IntSubject {
+to_be_truthy(s: IntSubject, msg: string = "") -> IntSubject {
     ok = 0
     if s.value != 0 { ok = 1 }
-    _verdict_int(s, ok, "truthy, got ${s.value}")
+    _verdict_int(s, ok, "truthy, got ${s.value}", msg)
     return s
 }
 
-to_be_falsy(s: IntSubject) -> IntSubject {
+to_be_falsy(s: IntSubject, msg: string = "") -> IntSubject {
     ok = 0
     if s.value == 0 { ok = 1 }
-    _verdict_int(s, ok, "falsy, got ${s.value}")
+    _verdict_int(s, ok, "falsy, got ${s.value}", msg)
     return s
 }
 
 // String subject matchers. negated is honoured but there's no string
 // not_() yet — add one if a downstream test needs `.not_().to_contain`.
-to_equal_str(s: StrSubject, want: string) -> StrSubject {
+//
+// to_equal_str reports through the CARET-ALIGNED diff once either side
+// is long enough that eyeballing two quoted strings stops working
+// (#1576): on a 40-character egress whitelist the index + caret is what
+// actually locates the differing byte, so the fluent matcher should not
+// be strictly worse than assert_str_eq_diff for the same comparison.
+// Short strings keep the compact one-line form — a diff block for
+// `expected 'a', got 'b'` is noise.
+//
+// The caret's column is computed from the rendered "expected: " line,
+// so it stays aligned whether or not a `msg` prefix is present (the
+// prefix sits on its own leading line rather than shifting the block).
+const _STR_DIFF_MIN = 24
+
+to_equal_str(s: StrSubject, want: string, msg: string = "") -> StrSubject {
     if string.equals(s.value, want) == 0 {
-        fail("expected '${want}', got '${s.value}'")
+        w = _why(msg)
+        longest = string.length(want)
+        if string.length(s.value) > longest { longest = string.length(s.value) }
+        if longest >= _STR_DIFF_MIN {
+            d = _first_diff(s.value, want)
+            caret = string.pad_start("^", 19 + d + 1, 32)
+            fail("${w}strings differ at index ${d}\n        expected: \"${want}\"\n        actual:   \"${s.value}\"\n${caret}")
+        } else {
+            fail("${w}expected '${want}', got '${s.value}'")
+        }
     }
     return s
 }
 
-to_contain(s: StrSubject, needle: string) -> StrSubject {
+to_contain(s: StrSubject, needle: string, msg: string = "") -> StrSubject {
     if string.contains(s.value, needle) == 0 {
-        fail("'${s.value}' does not contain '${needle}'")
+        fail("${_why(msg)}'${s.value}' does not contain '${needle}'")
     }
     return s
 }
 
-to_start_with(s: StrSubject, prefix: string) -> StrSubject {
+to_start_with(s: StrSubject, prefix: string, msg: string = "") -> StrSubject {
     if string.starts_with(s.value, prefix) == 0 {
-        fail("'${s.value}' does not start with '${prefix}'")
+        fail("${_why(msg)}'${s.value}' does not start with '${prefix}'")
     }
     return s
 }
@@ -663,7 +705,7 @@ to_start_with(s: StrSubject, prefix: string) -> StrSubject {
 satisfies(s: IntSubject, pred: fn, msg: string) -> IntSubject {
     ok = 0
     if call(pred, s.value) == 1 { ok = 1 }
-    _verdict_int(s, ok, "to satisfy '${msg}', got ${s.value}")
+    _verdict_int(s, ok, "to satisfy '${msg}', got ${s.value}", "")
     return s
 }
 

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -10,6 +10,7 @@
 /custom_lib_dir/
 /lib/
 tests/integration/ae_inspect/
+tests/integration/ae_add_release_artifact/
 tests/integration/ae_run_cflags/
 tests/integration/aether_string_ffi_unwrap/
 tests/integration/aether_string_to_c_extern/
@@ -158,6 +159,7 @@ tests/integration/selective_import_shadow/
 tests/integration/source_location/
 tests/integration/source_location_default_capture/
 tests/integration/spec_format_reporting/
+tests/integration/spec_why_message/
 tests/integration/sqlite_prepared/
 tests/integration/sqlite_roundtrip/
 tests/integration/std_dl/

--- a/tests/integration/ae_add_release_artifact/test_ae_add_release_artifact.sh
+++ b/tests/integration/ae_add_release_artifact/test_ae_add_release_artifact.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# #1360: `ae add` installs from a published release artifact when one
+# matches the host, instead of always git-cloning.
+#
+# Hermetic by construction: a python http.server on a loopback port
+# serves a fake forge whose layout mirrors a real one
+# (<pkg>/releases/download/<tag>/<repo>-<tag>-<os>-<arch>.tar.gz), and
+# AE_RELEASE_BASE_URL points `ae add` at it. Nothing here touches the
+# public internet or a real package host.
+#
+# Pinned properties:
+#   1. a matching artifact is downloaded, checksum-verified, unpacked
+#      into ~/.aether/packages/<pkg>/, and recorded in aether.toml,
+#   2. a MISMATCHED checksum is fatal — nothing is installed, exit 1
+#      (the security-critical case; a released binary must be verified
+#      in a way a git tag need not be),
+#   3. an artifact with no published .sha256 installs but WARNS,
+#   4. --source skips the artifact path entirely (falls to git),
+#   5. no matching artifact falls back to git rather than failing.
+#
+# HOME is redirected to a scratch dir so the real package cache is never
+# touched.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -n "${EXE_EXT:-}" ] && AE="$AE$EXE_EXT"
+
+[ -x "$AE" ] || { echo "  [SKIP] ae_add_release_artifact: ae not built"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "  [SKIP] ae_add_release_artifact: python3 needed to serve fixtures"; exit 0; }
+command -v tar >/dev/null 2>&1 || { echo "  [SKIP] ae_add_release_artifact: tar needed"; exit 0; }
+if command -v sha256sum >/dev/null 2>&1; then SHA="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then SHA="shasum -a 256"
+else echo "  [SKIP] ae_add_release_artifact: no sha256 tool"; exit 0; fi
+
+# The artifact path is per-host-triple; on a host we publish no assets
+# for, ae_host_triple() returns NULL and everything correctly falls back
+# to git — nothing to assert here.
+case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64|Linux-aarch64|Linux-arm64|Darwin-arm64|Darwin-x86_64) ;;
+    *) echo "  [SKIP] ae_add_release_artifact: no release triple for this host"; exit 0 ;;
+esac
+
+TMP="$(mktemp -d)"
+PORT=""
+SRV_PID=""
+cleanup() {
+    [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+    rm -rf "$TMP"
+    return 0
+}
+trap cleanup EXIT
+
+fail() {
+    echo "  [FAIL] ae_add_release_artifact: $1"
+    [ -n "$2" ] && [ -f "$2" ] && sed 's/^/        /' "$2"
+    exit 1
+}
+
+# ---- host triple, spelled as the release convention does ------------------
+case "$(uname -s)" in
+    Linux)  OS_PART="linux" ;;
+    Darwin) OS_PART="macos" ;;
+esac
+case "$(uname -m)" in
+    x86_64)          ARCH_PART="x86_64" ;;
+    aarch64|arm64)   ARCH_PART="arm64" ;;
+esac
+TRIPLE="$OS_PART-$ARCH_PART"
+
+# ---- fake forge ----------------------------------------------------------
+FORGE="$TMP/forge"
+PKG="fake.host/user/repo"
+mk_release() {   # $1 = tag, $2 = "sum" | "nosum"
+    d="$FORGE/$PKG/releases/download/$1"
+    mkdir -p "$d/payload"
+    printf 'greet() -> string { return "hi" }\n' > "$d/payload/module.ae"
+    ( cd "$d" && tar -czf "repo-$1-$TRIPLE.tar.gz" -C payload . )
+    rm -rf "$d/payload"
+    if [ "$2" = "sum" ]; then
+        ( cd "$d" && $SHA "repo-$1-$TRIPLE.tar.gz" | awk -v n="repo-$1-$TRIPLE.tar.gz" '{print $1"  "n}' \
+            > "repo-$1-$TRIPLE.tar.gz.sha256" )
+    elif [ "$2" = "badsum" ]; then
+        ( cd "$d" && echo "0000000000000000000000000000000000000000000000000000000000000000  repo-$1-$TRIPLE.tar.gz" \
+            > "repo-$1-$TRIPLE.tar.gz.sha256" )
+    fi
+}
+mk_release v1.0.0 sum
+mk_release v2.0.0 badsum
+mk_release v3.0.0 nosum
+
+# ---- serve it on a free loopback port ------------------------------------
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+( cd "$FORGE" && exec python3 -m http.server "$PORT" --bind 127.0.0.1 >/dev/null 2>&1 ) &
+SRV_PID=$!
+
+# Wait for readiness rather than sleeping a guessed interval.
+ready=0
+i=0
+while [ "$i" -lt 50 ]; do
+    if curl -fsS -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null; then ready=1; break; fi
+    i=$((i + 1))
+    sleep 0.1
+done
+[ "$ready" = "1" ] || { echo "  [SKIP] ae_add_release_artifact: fixture server did not start"; exit 0; }
+
+BASE="http://127.0.0.1:$PORT"
+
+# ---- each case runs in its own project + its own fake HOME ---------------
+new_proj() {
+    p="$TMP/proj_$1"
+    mkdir -p "$p/home"
+    printf '[package]\nname = "t"\nversion = "0.1.0"\n\n[dependencies]\n' > "$p/aether.toml"
+    echo "$p"
+}
+
+# ---- Property 1: artifact installed + verified + recorded ----------------
+P="$(new_proj ok)"
+( cd "$P" && HOME="$P/home" AE_RELEASE_BASE_URL="$BASE" "$AE" add "$PKG@v1.0.0" ) \
+    >"$TMP/ok.log" 2>&1 || fail "install from artifact exited non-zero" "$TMP/ok.log"
+
+grep -q "Found release artifact repo-v1.0.0-$TRIPLE.tar.gz" "$TMP/ok.log" \
+    || fail "did not report finding the release artifact" "$TMP/ok.log"
+grep -q "Checksum verified" "$TMP/ok.log" \
+    || fail "did not verify the published checksum" "$TMP/ok.log"
+[ -f "$P/home/.aether/packages/$PKG/module.ae" ] \
+    || fail "artifact contents not unpacked into the package dir" "$TMP/ok.log"
+grep -q "$PKG" "$P/aether.toml" \
+    || fail "dependency not recorded in aether.toml"
+# It must NOT have fallen through to git.
+grep -qi "Downloading\.\.\." "$TMP/ok.log" \
+    && fail "took the git path despite a matching artifact" "$TMP/ok.log"
+
+# ---- Property 2: checksum mismatch is fatal ------------------------------
+P="$(new_proj bad)"
+( cd "$P" && HOME="$P/home" AE_RELEASE_BASE_URL="$BASE" "$AE" add "$PKG@v2.0.0" ) \
+    >"$TMP/bad.log" 2>&1 && bad_rc=0 || bad_rc=$?
+
+[ "$bad_rc" -ne 0 ] || fail "a MISMATCHED checksum exited 0 — must be fatal" "$TMP/bad.log"
+grep -qi "checksum MISMATCH" "$TMP/bad.log" \
+    || fail "no checksum-mismatch diagnostic" "$TMP/bad.log"
+[ ! -e "$P/home/.aether/packages/$PKG/module.ae" ] \
+    || fail "installed a tampered artifact" "$TMP/bad.log"
+# A mismatch must NOT silently fall back to cloning — that would defeat
+# the verification entirely.
+grep -qi "Downloading\.\.\." "$TMP/bad.log" \
+    && fail "fell back to git after a checksum mismatch" "$TMP/bad.log"
+
+# ---- Property 3: no published checksum installs, but warns ---------------
+P="$(new_proj nosum)"
+( cd "$P" && HOME="$P/home" AE_RELEASE_BASE_URL="$BASE" "$AE" add "$PKG@v3.0.0" ) \
+    >"$TMP/nosum.log" 2>&1 || fail "unsigned artifact install exited non-zero" "$TMP/nosum.log"
+grep -qi "publishes no .sha256" "$TMP/nosum.log" \
+    || fail "no warning for an artifact without a published checksum" "$TMP/nosum.log"
+[ -f "$P/home/.aether/packages/$PKG/module.ae" ] \
+    || fail "unsigned artifact was not installed" "$TMP/nosum.log"
+
+# ---- Property 4: --source skips the artifact path ------------------------
+# fake.host does not resolve, so git fails — that failure IS the proof the
+# artifact path was skipped.
+P="$(new_proj src)"
+( cd "$P" && HOME="$P/home" AE_RELEASE_BASE_URL="$BASE" "$AE" add "$PKG@v1.0.0" --source ) \
+    >"$TMP/src.log" 2>&1
+grep -q "Found release artifact" "$TMP/src.log" \
+    && fail "--source still used the release artifact" "$TMP/src.log"
+grep -qi "Downloading\.\.\." "$TMP/src.log" \
+    || fail "--source did not take the git path" "$TMP/src.log"
+
+# ---- Property 5: no matching artifact falls back to git ------------------
+P="$(new_proj none)"
+( cd "$P" && HOME="$P/home" AE_RELEASE_BASE_URL="$BASE" "$AE" add "$PKG@v9.9.9" ) \
+    >"$TMP/none.log" 2>&1
+grep -q "Found release artifact" "$TMP/none.log" \
+    && fail "claimed to find an artifact for an unpublished tag" "$TMP/none.log"
+grep -qi "Downloading\.\.\." "$TMP/none.log" \
+    || fail "did not fall back to git when no artifact matched" "$TMP/none.log"
+
+echo "  [PASS] ae_add_release_artifact: artifact install + checksum gate + --source/no-asset fallbacks"
+exit 0

--- a/tests/integration/spec_why_message/probe.ae
+++ b/tests/integration/spec_why_message/probe.ae
@@ -1,0 +1,35 @@
+// Fixture for the #1576 why-message format test. Every assertion here
+// FAILS on purpose: the harness reads the failure text, which is the
+// only way to pin formatting (a passing suite prints none).
+//
+// Deliberately avoids the em-dash in any message so the harness can
+// grep for the separator the matchers insert.
+import std.spec
+
+main() {
+    fw = spec.init()
+    spec.describe(fw, "why") {
+        spec.it("int bare") callback {
+            spec.expect_int(5).to_equal(4)
+        }
+        spec.it("int annotated") callback {
+            spec.expect_int(5).to_equal(4, "budget is never zero")
+        }
+        spec.it("short str bare") callback {
+            spec.expect_str("abc").to_equal_str("abd")
+        }
+        spec.it("short str annotated") callback {
+            spec.expect_str("abc").to_equal_str("abd", "name is exact")
+        }
+        spec.it("long str annotated uses caret diff") callback {
+            spec.expect_str("api.github.com").to_equal_str("api.github.com, api.anthropic.com", "egress set is the whitelist")
+        }
+        spec.it("contains annotated") callback {
+            spec.expect_str("shared").to_contain("internal", "peer egress to internal net")
+        }
+        spec.it("negated annotated") callback {
+            spec.expect_int(4).not_().to_equal(4, "must differ from the default")
+        }
+    }
+    spec.run_summary(fw)
+}

--- a/tests/integration/spec_why_message/test_spec_why_message.sh
+++ b/tests/integration/spec_why_message/test_spec_why_message.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# #1576: std.spec's fluent value-comparison matchers take an optional
+# trailing intent message ("why this check matters"), which prefixes the
+# auto-generated failure text.
+#
+# This has to be an integration test rather than a spec: the thing under
+# test is FAILURE TEXT, and a passing suite emits none. probe.ae fails
+# every assertion on purpose; we read what it printed.
+#
+# Pinned properties:
+#   1. a bare matcher's wording is UNCHANGED (the feature is additive —
+#      this is the regression guard for ~810 existing downstream call
+#      sites that pass no message),
+#   2. an annotated matcher prefixes "<msg> — ",
+#   3. to_equal_str switches to the caret-aligned diff once a string is
+#      long enough for a quoted pair to stop being legible, and the
+#      caret still lands on the first differing byte,
+#   4. the message survives not_() negation,
+#   5. the probe exits non-zero (the assertions really did fail — a
+#      green probe would make every grep above vacuous).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -n "${EXE_EXT:-}" ] && AE="$AE$EXE_EXT"
+
+[ -x "$AE" ] || { echo "  [SKIP] spec_why_message: ae not built"; exit 0; }
+
+cd "$ROOT" || exit 1
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+    echo "  [FAIL] spec_why_message: $1"
+    [ -f "$TMP/out.log" ] && sed 's/^/        /' "$TMP/out.log"
+    exit 1
+}
+
+# The probe fails by design, so don't let `set -e` kill us on its exit.
+AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/probe.ae" >"$TMP/out.log" 2>&1 && probe_rc=0 || probe_rc=$?
+
+# Property 5 first: a probe that passed would make every check vacuous.
+[ "$probe_rc" -ne 0 ] || fail "probe exited 0 — its assertions were supposed to fail"
+
+# Strip ANSI colour so greps match the raw text.
+sed 's/\x1b\[[0-9;]*m//g' "$TMP/out.log" > "$TMP/plain.log"
+
+# Property 1: bare matchers keep their exact previous wording.
+grep -q "FAIL: expected 4, got 5" "$TMP/plain.log" \
+    || fail "bare int matcher's wording changed (should be 'expected 4, got 5')"
+grep -q "FAIL: expected 'abd', got 'abc'" "$TMP/plain.log" \
+    || fail "bare short-string matcher's wording changed"
+
+# Property 2: annotated matchers prefix the message.
+grep -q "budget is never zero — expected 4, got 5" "$TMP/plain.log" \
+    || fail "int matcher did not prefix its intent message"
+grep -q "name is exact — expected 'abd', got 'abc'" "$TMP/plain.log" \
+    || fail "short-string matcher did not prefix its intent message"
+grep -q "peer egress to internal net — 'shared' does not contain 'internal'" "$TMP/plain.log" \
+    || fail "to_contain did not prefix its intent message"
+
+# Property 3: long strings get the caret-aligned diff, message included.
+# The two strings share "api.github.com" and diverge at index 14.
+grep -q "egress set is the whitelist — strings differ at index 14" "$TMP/plain.log" \
+    || fail "long to_equal_str did not use the caret diff form with its message"
+grep -q 'expected: "api.github.com, api.anthropic.com"' "$TMP/plain.log" \
+    || fail "caret diff missing the expected line"
+# The caret line is spaces then a single ^; check it is present and that
+# the ^ sits at the column the diff index implies (19 + d + 1 = 34).
+caret_col=$(grep -n '^ *\^ *$' "$TMP/plain.log" | head -1 | cut -d: -f1)
+[ -n "$caret_col" ] || fail "no caret line in the diff output"
+caret_pos=$(grep '^ *\^ *$' "$TMP/plain.log" | head -1 | awk '{ print index($0, "^") }')
+[ "$caret_pos" = "34" ] \
+    || fail "caret at column $caret_pos, expected 34 (19 + index 14 + 1)"
+
+# Property 4: negation keeps the message.
+grep -q "must differ from the default — expected NOT 4" "$TMP/plain.log" \
+    || fail "not_() dropped the intent message"
+
+echo "  [PASS] spec_why_message: optional intent message on fluent matchers (bare wording unchanged, caret diff aligned)"
+exit 0

--- a/tests/regression/test_spec_module.ae
+++ b/tests/regression/test_spec_module.ae
@@ -71,6 +71,25 @@ main() {
                 spec.expect_str("aether").to_start_with("ae").to_contain("the")
                 spec.expect_str(built_label("run")).to_equal_str("run-ok")
             }
+            // #1576: every value-comparison matcher takes an optional
+            // trailing intent message. These all PASS — the point is
+            // that the extra argument parses, type-checks and threads
+            // through UFCS chaining; the failure-text formatting is
+            // pinned by tests/integration/spec_why_message/, which can
+            // observe output a green suite cannot.
+            spec.it("optional why-message on every matcher") callback {
+                spec.expect_int(7).to_equal(7, "int equality carries intent")
+                spec.expect_int(7).to_be_gt(0, "budget is never zero")
+                spec.expect_int(7).to_be_lt(10, "budget is bounded")
+                spec.expect_int(1).to_be_truthy("flag is set")
+                spec.expect_int(0).to_be_falsy("flag is clear")
+                spec.expect_str("aether").to_equal_str("aether", "name is exact")
+                spec.expect_str("aether").to_contain("eth", "substring rule")
+                spec.expect_str("aether").to_start_with("ae", "prefix rule")
+                // Mixed annotated / bare links in ONE chain — the
+                // default-argument path has to survive chaining.
+                spec.expect_int(5).to_be_gt(0).to_equal(5, "why").to_be_lt(9)
+            }
         }
 
         spec.describe("collection matchers") {

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5996,14 +5996,206 @@ static int cmd_test(int argc, char** argv) {
     return (failed > 0) ? 1 : 0;
 }
 
+/* --- `ae add` release-artifact support (#1360) ------------------------
+ *
+ * `ae add` historically only ever git-cloned. The CONSUMING half of
+ * binary packages was already built — prepare_binary_imports() reads a
+ * `--emit=lib` artifact's aether_lib_meta() catalog and synthesizes an
+ * Aether interface stub — so only the fetch was missing.
+ *
+ * Asset naming follows the convention Aether's own releases use:
+ *   <repo>-<version>-<os>-<arch>.tar.gz
+ * e.g. mylib-v1.2.0-linux-x86_64.tar.gz. We try the tarball, then the
+ * zip, and fall back to the git clone when neither is present — so a
+ * package that publishes no artifacts behaves exactly as before.
+ */
+
+/* Host triple as the release convention spells it ("linux-x86_64",
+ * "macos-arm64"). Returns NULL when the host is one we do not publish
+ * artifacts for, which forces the git-clone path. */
+static const char* ae_host_triple(void) {
+#if defined(__linux__)
+#  if defined(__x86_64__)
+    return "linux-x86_64";
+#  elif defined(__aarch64__)
+    return "linux-arm64";
+#  else
+    return NULL;
+#  endif
+#elif defined(__APPLE__)
+#  if defined(__aarch64__)
+    return "macos-arm64";
+#  elif defined(__x86_64__)
+    return "macos-x86_64";
+#  else
+    return NULL;
+#  endif
+#elif defined(_WIN32)
+#  if defined(__x86_64__) || defined(_M_X64)
+    return "windows-x86_64";
+#  else
+    return NULL;
+#  endif
+#else
+    return NULL;
+#endif
+}
+
+/* Last path component of "github.com/user/repo" -> "repo". */
+static const char* ae_pkg_basename(const char* package) {
+    const char* slash = strrchr(package, '/');
+    return slash ? slash + 1 : package;
+}
+
+/* Verify a downloaded artifact against a `<asset>.sha256` sibling, when
+ * the publisher provides one. A released binary deserves verification a
+ * git tag does not need (#1360).
+ *
+ * Returns  1  verified,
+ *          0  no checksum published (caller decides — we warn, matching
+ *             the git path's own trust level rather than refusing),
+ *         -1  checksum published but MISMATCHED — always fatal.
+ */
+static int ae_verify_sha256(const char* archive, const char* url_base,
+                            const char* asset, const char* tmp_dir) {
+    char sum_url[2048], sum_path[1024], cmd[4096];
+    snprintf(sum_url, sizeof(sum_url), "%s/%s.sha256", url_base, asset);
+    snprintf(sum_path, sizeof(sum_path), "%s/%s.sha256", tmp_dir, asset);
+    if (ae_download(sum_url, sum_path) != 0 || !path_exists(sum_path)) {
+        return 0;   /* publisher shipped no checksum */
+    }
+    /* Read the published hex. Both sha256sum and shasum print
+     * "<hex>  <name>", so take the first whitespace-delimited field and
+     * ignore whatever path the publisher hashed. */
+    char want_hex[128] = {0};
+    FILE* sf = fopen(sum_path, "r");
+    if (!sf) { remove(sum_path); return 0; }
+    if (fscanf(sf, "%127s", want_hex) != 1) { fclose(sf); remove(sum_path); return 0; }
+    fclose(sf);
+    remove(sum_path);
+
+    /* Hash the artifact. run_cmd* exec a tokenized argv rather than a
+     * shell, so pipelines and $(...) are not available here — write the
+     * digest to a file and read it back. */
+    char got_path[1024];
+    snprintf(got_path, sizeof(got_path), "%s/.ae_sha256.out", tmp_dir);
+    remove(got_path);
+
+    const char* hashers[2] = { "sha256sum", "shasum -a 256" };
+    int hashed = 0;
+    for (int h = 0; h < 2 && !hashed; h++) {
+        snprintf(cmd, sizeof(cmd), "%s \"%s\" > \"%s\" 2>/dev/null",
+                 hashers[h], archive, got_path);
+        /* This one DOES need a shell (redirection), so go through
+         * system() rather than the tokenizing runner. */
+        if (system(cmd) == 0 && path_exists(got_path)) hashed = 1;
+    }
+    if (!hashed) {
+        fprintf(stderr, "Warning: no sha256sum/shasum available; skipping checksum verification.\n");
+        remove(got_path);
+        return 0;
+    }
+
+    char got_hex[128] = {0};
+    FILE* gf = fopen(got_path, "r");
+    if (!gf) { remove(got_path); return 0; }
+    int ok_read = (fscanf(gf, "%127s", got_hex) == 1);
+    fclose(gf);
+    remove(got_path);
+    if (!ok_read) return 0;
+
+    return (strcasecmp(want_hex, got_hex) == 0) ? 1 : -1;
+}
+
+/* Try to install <package>@<version> from a published release asset.
+ * Returns 1 when the package was installed from an artifact, 0 when no
+ * matching artifact exists (caller falls back to git). */
+static int ae_try_release_asset(const char* package, const char* version,
+                                const char* pkg_dir) {
+    const char* triple = ae_host_triple();
+    if (!triple) return 0;              /* unpublished host → clone */
+    if (!version) return 0;             /* artifacts are per-tag */
+
+    const char* repo = ae_pkg_basename(package);
+
+    /* Normalise to the tag spelling releases use (v-prefixed). */
+    char tag[128];
+    if (version[0] == 'v') snprintf(tag, sizeof(tag), "%s", version);
+    else                   snprintf(tag, sizeof(tag), "v%s", version);
+
+    /* AE_RELEASE_BASE_URL overrides the forge origin: it replaces the
+     * "https://<package>" prefix, so an internal mirror or an air-gapped
+     * file:// tree can serve the same asset layout. It is also what makes
+     * this path testable without reaching the public internet. */
+    char url_base[1536];
+    const char* origin = getenv("AE_RELEASE_BASE_URL");
+    if (origin && *origin) {
+        snprintf(url_base, sizeof(url_base),
+                 "%s/%s/releases/download/%s", origin, package, tag);
+    } else {
+        snprintf(url_base, sizeof(url_base),
+                 "https://%s/releases/download/%s", package, tag);
+    }
+
+    char tmp_dir[1024];
+    snprintf(tmp_dir, sizeof(tmp_dir), "%s/.aether/tmp", get_home_dir());
+    mkdirs(tmp_dir);
+
+    /* tar.gz first (the POSIX default), then zip (what the Windows
+     * releases publish). */
+    const char* exts[2] = { "tar.gz", "zip" };
+    for (int i = 0; i < 2; i++) {
+        char asset[512], url[2048], archive[1024];
+        snprintf(asset, sizeof(asset), "%s-%s-%s.%s", repo, tag, triple, exts[i]);
+        snprintf(url, sizeof(url), "%s/%s", url_base, asset);
+        snprintf(archive, sizeof(archive), "%s/%s", tmp_dir, asset);
+
+        if (ae_download(url, archive) != 0 || !path_exists(archive)) {
+            continue;                   /* no such asset — try the next */
+        }
+        printf("Found release artifact %s\n", asset);
+
+        int v = ae_verify_sha256(archive, url_base, asset, tmp_dir);
+        if (v < 0) {
+            fprintf(stderr, "Error: checksum MISMATCH for %s — refusing to install.\n", asset);
+            remove(archive);
+            return -1;                  /* fatal: do NOT fall back */
+        }
+        if (v == 0) {
+            fprintf(stderr, "Warning: %s publishes no .sha256 — installing unverified.\n", asset);
+        } else {
+            printf("Checksum verified.\n");
+        }
+
+        mkdirs(pkg_dir);
+        if (ae_extract(archive, pkg_dir) != 0) {
+            fprintf(stderr, "Error: could not unpack %s.\n", asset);
+            remove(archive);
+            return -1;
+        }
+        remove(archive);
+        printf("Installed %s@%s from release artifact.\n", package, tag);
+        return 1;
+    }
+    return 0;                            /* nothing published for us */
+}
+
 static int cmd_add(int argc, char** argv) {
     if (argc < 1 || argv[0][0] == '-') {
-        fprintf(stderr, "Usage: ae add <host>/<user>/<repo>[@version]\n");
+        fprintf(stderr, "Usage: ae add <host>/<user>/<repo>[@version] [--source]\n");
         fprintf(stderr, "Examples:\n");
         fprintf(stderr, "  ae add github.com/user/repo\n");
         fprintf(stderr, "  ae add github.com/user/repo@v1.2.0\n");
         fprintf(stderr, "  ae add gitlab.com/user/repo\n");
+        fprintf(stderr, "\nWith @version, a matching release artifact is preferred when the\n");
+        fprintf(stderr, "package publishes one; --source forces the git clone.\n");
         return 1;
+    }
+
+    /* --source forces the historical git-clone path (#1360). */
+    bool force_source = false;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--source") == 0) force_source = true;
     }
 
     // Parse package@version
@@ -6053,6 +6245,15 @@ static int cmd_add(int argc, char** argv) {
     snprintf(pkg_dir, sizeof(pkg_dir), "%.511s/%.511s", cache_dir, package);
 
     if (!dir_exists(pkg_dir)) {
+        /* Prefer a published release artifact when one matches this host
+         * (#1360): faster than a clone, needs no toolchain to consume,
+         * and pins against an immutable asset rather than a movable tag.
+         * Falls back to the clone when nothing is published. */
+        if (!force_source) {
+            int r = ae_try_release_asset(package, version, pkg_dir);
+            if (r < 0) return 1;        /* checksum mismatch — already reported */
+            if (r > 0) goto write_toml; /* installed from artifact */
+        }
         printf("Downloading...\n");
         char parent[1024];
         strncpy(parent, pkg_dir, sizeof(parent) - 1);
@@ -6094,6 +6295,7 @@ static int cmd_add(int argc, char** argv) {
         }
     }
 
+write_toml:
     // Add to aether.toml
     FILE* f = fopen("aether.toml", "r");
     if (!f) {

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -73,6 +73,12 @@ void build_gcc_cmd(char* cmd, size_t size,
 
 /* ae_version.c — version manager (list/install/switch releases). */
 int cmd_version(int argc, char** argv);
+/* Download a URL to a path / unpack an archive into a directory. Both
+ * shell out to whatever the platform has (curl or wget; tar or
+ * Expand-Archive) and return 0 on success. Shared with `ae add`'s
+ * release-artifact path (#1360). */
+int ae_download(const char* url, const char* dest);
+int ae_extract(const char* archive, const char* dest_dir);
 int cmd_version_use(const char* version);
 int cmd_install(int argc, char** argv);
 int cmd_upgrade(void);

--- a/tools/ae_version.c
+++ b/tools/ae_version.c
@@ -66,7 +66,7 @@
 
 // Download url → dest file. Uses curl/wget on POSIX, PowerShell on Windows.
 // Creates parent directories of dest if they don't exist.
-static int ae_download(const char* url, const char* dest) {
+int ae_download(const char* url, const char* dest) {
     // Ensure parent directory exists (e.g. ~/.aether/ for releases.json)
     {
         char parent[1024];
@@ -106,7 +106,7 @@ static int ae_download(const char* url, const char* dest) {
 }
 
 // Extract archive → dest_dir.
-static int ae_extract(const char* archive, const char* dest_dir) {
+int ae_extract(const char* archive, const char* dest_dir) {
 #ifdef _WIN32
     char tmp[64];
     snprintf(tmp, sizeof(tmp), "ae_ex_%u.ps1", (unsigned)GetCurrentProcessId());


### PR DESCRIPTION
Closes #1576, closes #1360 — two independent features in one PR to conserve Actions minutes.

---

## #1576 — optional intent message on the fluent matchers

`to_equal`, `to_be_gt`, `to_be_lt`, `to_be_truthy`, `to_be_falsy`, `to_equal_str`, `to_contain` and `to_start_with` take a trailing `msg` and render `"<msg> — <generated text>"`:

```
FAIL: a node's egress set is exactly its declared whitelist — strings differ at index 14
        expected: "api.github.com, api.anthropic.com"
        actual:   "api.github.com"
                                 ^
```

**The (a)-vs-(b) choice turned out to be a false dilemma.** The issue offered a breaking required-`msg` sweep versus parallel `*_because` variants, and @paul-hammant's comment argued (a) with a strong case (810 live aeo call sites, aeo volunteering to sweep). Both rest on "Aether is fixed-arity (no overloading), so this is a signature change" — but Aether *does* have default arguments, and I verified they resolve correctly through UFCS method-call chaining before relying on it:

```aether
_ = mk(7).to_be_gt(0).to_equal(7, "why this matters").to_be_gt(1, "another")
```

So the parameter is **optional**: no breaking sweep, no doubled matcher surface, no worse-but-shorter default. Existing chains keep byte-identical wording (pinned by a test), and a single chain can annotate only the links that need it. aeo can adopt messages incrementally on its 810 sites rather than in one atomic change — and nothing forces a message onto checks whose values genuinely are self-explanatory.

**The diff-form request is honoured.** Per the comment's nit, `to_equal_str` now reports through the caret-aligned diff (the `assert_str_eq_diff` form) once either string reaches 24 characters — where eyeballing a quoted pair stops working and the index + caret is what actually finds the byte. Short strings keep the compact `expected 'x', got 'y'`. `not_()` negation carries the message too.

## #1360 — `ae add` installs from release artifacts

```bash
ae add github.com/user/repo@v1.2.0            # prefers a matching release asset
ae add github.com/user/repo@v1.2.0 --source   # forces the clone
```

Looks for `<repo>-<tag>-<os>-<arch>.tar.gz` (then `.zip`) under `releases/download/<tag>/` — the layout Aether's own releases use — and **falls back to the git clone when nothing matches**, so a package publishing no artifacts behaves exactly as before.

On the points the issue left to decide:
- **Checksum**: a sibling `<asset>.sha256` is verified when published. A **mismatch is fatal** — nothing installs, exit 1, and deliberately **no fall-back to git**, since silently cloning after a failed verification would defeat the check. No published checksum installs with a warning (matching the git path's own trust level rather than refusing outright).
- **Windows**: the fetch itself is cross-platform (`ae_download`/`ae_extract` already handle both); only *consuming* a binary import stays POSIX-gated, unchanged by this PR.
- **Mirrors**: `AE_RELEASE_BASE_URL` repoints the origin, which is also what makes the path testable without the public internet.

`ae_download`/`ae_extract` are promoted from `ae_version.c` statics to shared helpers rather than duplicated.

Two defects found by *testing* rather than reading, worth flagging since both would have shipped silently:
1. `run_cmd*` exec a **tokenized argv, not a shell**, so my first checksum implementation's `$(...)`/`&&` never executed — every verification "passed" as a mismatch. Rewritten in plain C (also removes the shell-quoting risk).
2. The `https://` origin was hardcoded, making the whole artifact path untestable offline.

## Tests

- **`tests/integration/spec_why_message/`** pins the *failure text*, which a passing suite cannot observe: bare wording unchanged (the regression guard for ~810 downstream message-less call sites), message prefixed, caret column asserted at 34 for a divergence at index 14, and the message surviving `not_()`.
- **`tests/integration/ae_add_release_artifact/`** serves a fake forge over loopback with a redirected `HOME` — hermetic, no network. Five properties: install+verify, fatal mismatch *and no git fall-back*, unsigned-warns-but-installs, `--source` skips, no-asset falls back. **Verified to fail** when the checksum gate is sabotaged.
- `test_spec_module` gains a matcher-coverage `it()` — 11 passing, still valgrind-clean at **0 bytes**.
- `spec_format_reporting`, `std_testing_arms` pass; fmt gate clean.

Docs: `docs/testing.md` gains a "Saying *why* a check matters" section; `docs/getting-started.md` documents the artifact layout, the checksum policy and `--source`.

@paul-hammant — worth relaying to aeo that the sweep they volunteered for isn't needed: they can add messages where they help, at their own pace, and their existing 810 sites keep working untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)