### PR TITLE
fix(modules): a closure parameter must shadow a same-named module function (#1606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+- Module namespacing: a **closure parameter** now shadows a same-named
+  module-level function or const (#1606). `rename_intra_module_refs`
+  skips its `<ns>_<name>` rewrite for locally-bound names, but
+  `collect_local_names` recognised only `AST_PATTERN_VARIABLE` /
+  `AST_VARIABLE_DECLARATION` / `AST_CONST_DECLARATION` — a closure
+  parameter is an `AST_CLOSURE_PARAM`, and closures established no scope
+  of their own. So inside a module defining `item()`, the closure
+  `|item: ptr| { f(item) }` had its `item` rewritten to `<ns>_item`,
+  passing **the address of the function** where the parameter's value
+  belonged. The C compiled and type-checked cleanly, and the callee then
+  read a function pointer as data.
+  Found via aether-ui, where it segfaulted `table_demo` at startup inside
+  `aether_string_data`; verified A/B on the reporting commit (`e6feacc`):
+  SIGSEGV with the unfixed compiler, runs clean with the fix, from an
+  identical source tree. Reduced to a 16-line fixture that printed the
+  raw machine code of the shadowed function instead of its data.
+  Closures now establish a scope that EXTENDS the enclosing one, so a
+  closure can still read enclosing locals and still resolve non-shadowed
+  module functions and consts normally.
+
 ## [0.543.0]
 
 ### Fixed

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -1628,8 +1628,16 @@ static int name_in_list(const char* name, const char** list, int count) {
 // Recursively walks blocks to find all AST_VARIABLE_DECLARATION and AST_CONST_DECLARATION names.
 static void collect_local_names(ASTNode* node, const char** names, int* count, int max) {
     if (!node || *count >= max) return;
+    /* #1606: AST_CLOSURE_PARAM belongs here alongside AST_PATTERN_VARIABLE.
+       A closure parameter binds a name exactly as a function parameter does,
+       so it must shadow a same-named module function or const. Without it,
+       `|item: ptr| { f(item) }` inside a module that also defines `item()`
+       had its `item` rewritten to `<ns>_item` — the ADDRESS OF THE FUNCTION
+       passed where the parameter's value belonged. That compiled, and the
+       callee then read a function pointer as data. */
     if ((node->type == AST_PATTERN_VARIABLE || node->type == AST_VARIABLE_DECLARATION ||
-         node->type == AST_CONST_DECLARATION) && node->value) {
+         node->type == AST_CONST_DECLARATION || node->type == AST_CLOSURE_PARAM) &&
+        node->value) {
         if (!name_in_list(node->value, names, *count)) {
             names[(*count)++] = node->value;
         }
@@ -1736,6 +1744,45 @@ static void rename_intra_module_refs(ASTNode* node, const char* prefix,
                 }
             }
         }
+    }
+
+    /* #1606: a closure introduces its own scope, so its parameters (and the
+       locals in its body) shadow module functions/consts for the whole body.
+       Previously only AST_FUNCTION_DEFINITION established a scope, so a
+       closure parameter never made it into local_names and a same-named
+       module function won the rename — silently substituting the function's
+       address for the parameter's value in argument position.
+
+       The enclosing scope's names stay in effect (a closure can read them),
+       so this EXTENDS local_names rather than replacing it: parameters and
+       body-locals of the closure are appended to whatever the enclosing
+       function already contributed. */
+    if (node->type == AST_CLOSURE) {
+        const char* clo_locals[128];
+        int clo_local_count = 0;
+        /* The closure's OWN bindings go in first. The list is capped, and if
+           a large enclosing scope filled it the parameters would be the names
+           dropped — which is precisely the bug this branch exists to prevent.
+           Enclosing names are appended after, and merely losing one of those
+           costs a missed rename-suppression, not a wrong symbol. */
+        collect_local_names(node, clo_locals, &clo_local_count, 128);
+        for (int i = 0; i < local_count && clo_local_count < 128; i++) {
+            if (!name_in_list(local_names[i], clo_locals, clo_local_count)) {
+                clo_locals[clo_local_count++] = local_names[i];
+            }
+        }
+        int kept_c = 0;
+        for (int i = 0; i < clo_local_count; i++) {
+            if (!name_is_module_global_var(prefix, clo_locals[i])) {
+                clo_locals[kept_c++] = clo_locals[i];
+            }
+        }
+        clo_local_count = kept_c;
+        for (int i = 0; i < node->child_count; i++) {
+            rename_intra_module_refs(node->children[i], prefix, func_names, func_count,
+                                     const_names, const_count, clo_locals, clo_local_count);
+        }
+        return;
     }
 
     // When entering a function definition, collect its local names for shadowing checks.

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -37,6 +37,7 @@ tests/integration/caller_info/
 tests/integration/cas_roundtrip/
 tests/integration/circular_import_diag/
 tests/integration/closure_actor_state_reject/
+tests/integration/closure_param_shadows_module_fn/
 tests/integration/closure_builder_ctx_inject_no_uaf/
 tests/integration/closure_extern_retains_no_uaf/
 tests/integration/closure_qualified_ctx_inject_no_uaf/

--- a/tests/integration/closure_param_shadows_module_fn/lib/uix/module.ae
+++ b/tests/integration/closure_param_shadows_module_fn/lib/uix/module.ae
@@ -1,0 +1,21 @@
+// #1606 fixture. This module defines a function `item` AND a closure whose
+// PARAMETER is named `item`. The closure passes that parameter onward as an
+// argument — the shape that used to emit the module function's ADDRESS
+// (`uix_item`) in place of the parameter's value.
+exports(item, invoke_cell, drive)
+
+// The colliding module-level function.
+item(_ctx: ptr, label: string) { println("GLOBAL item(${label})") }
+
+invoke_cell(cb: fn, it: ptr, c: int) -> string { return call(cb, it, c) }
+
+each_row(f: fn, r: ptr) { call(f, r, 0, 0) }
+
+// The closure's `item` must win over the module's `item` throughout the body.
+drive(cell: fn, rows: ptr) {
+    each_row(| item: ptr, i: int, row: int | {
+            // Argument position: the bug lived here.
+            s = invoke_cell(cell, item, 0)
+            println("cell -> ${s}")
+        }, rows)
+}

--- a/tests/integration/closure_param_shadows_module_fn/probe.ae
+++ b/tests/integration/closure_param_shadows_module_fn/probe.ae
@@ -1,0 +1,12 @@
+// #1606: a closure parameter must shadow a same-named module function.
+//
+// Before the fix this printed the raw machine code of `uix_item` — the
+// function's address was passed where the row pointer belonged, then read
+// as a string. In aether-ui the same defect segfaulted table_demo at
+// startup inside aether_string_data.
+import uix
+
+main() {
+    s = "REAL-ROW"
+    uix.drive(| item: ptr, c: int | { return item }, s)
+}

--- a/tests/integration/closure_param_shadows_module_fn/test_closure_param_shadows_module_fn.sh
+++ b/tests/integration/closure_param_shadows_module_fn/test_closure_param_shadows_module_fn.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# #1606: a CLOSURE PARAMETER must shadow a same-named module-level function.
+#
+# The module namespacing pass (rename_intra_module_refs) rewrites bare
+# references to module functions into their `<ns>_<name>` spelling so the
+# emitted C resolves. It skipped that rewrite for names shadowed by a local
+# binding — but `collect_local_names` only knew about AST_PATTERN_VARIABLE /
+# AST_VARIABLE_DECLARATION / AST_CONST_DECLARATION, and a closure parameter is
+# an AST_CLOSURE_PARAM. Closures also established no scope of their own.
+#
+# So in a module defining `item()`, a closure `|item: ptr| { f(item) }` had its
+# `item` rewritten to `<ns>_item`: the ADDRESS OF THE FUNCTION passed where the
+# parameter's value belonged. It compiled cleanly, type-checked cleanly, and the
+# callee then read a function pointer as data.
+#
+# Two properties are pinned here, and the first is the load-bearing one:
+#
+#   1. the value survives — printing it yields the string that was passed in,
+#      not the bytes of a function body,
+#   2. the emitted C names the PARAMETER (`item`) in argument position, not the
+#      prefixed module function (`uix_item`).
+#
+# (2) is what makes a regression legible: without it a future breakage shows up
+# only as garbage output, which is exactly how this bug hid for so long. In
+# aether-ui the same defect segfaulted table_demo at startup inside
+# aether_string_data — verified A/B on commit e6feacc: SIGSEGV with the unfixed
+# compiler, runs clean with the fix.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+AETHERC="$ROOT/build/aetherc"
+[ -n "${EXE_EXT:-}" ] && { AE="$AE$EXE_EXT"; AETHERC="$AETHERC$EXE_EXT"; }
+
+[ -x "$AE" ] || { echo "  [SKIP] closure_param_shadows_module_fn: ae not built"; exit 0; }
+
+cd "$ROOT" || exit 1
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+    echo "  [FAIL] closure_param_shadows_module_fn: $1"
+    [ -n "$2" ] && [ -f "$2" ] && sed 's/^/        /' "$2" | head -12
+    exit 1
+}
+
+# ---- Property 1: the parameter's VALUE reaches the callee -----------------
+AETHER_LIB_DIR="$SCRIPT_DIR/lib" "$AE" run "$SCRIPT_DIR/probe.ae" \
+    >"$TMP/out.log" 2>&1 || fail "probe did not run" "$TMP/out.log"
+
+grep -q "cell -> REAL-ROW" "$TMP/out.log" \
+    || fail "closure parameter did not survive; the module function shadowed it" "$TMP/out.log"
+
+# The failure mode was printing a function body's bytes. Catch any recurrence
+# even if the marker string somehow appeared too.
+if grep -qE "cell -> .*[^R][^E][^A][^L]" "$TMP/out.log" && ! grep -q "cell -> REAL-ROW" "$TMP/out.log"; then
+    fail "unexpected cell payload — function bytes leaking again?" "$TMP/out.log"
+fi
+
+# ---- Property 2: the emitted C names the parameter, not the module fn -----
+AETHER_LIB_DIR="$SCRIPT_DIR/lib" "$AETHERC" "$SCRIPT_DIR/probe.ae" "$TMP/probe.c" \
+    >"$TMP/gen.log" 2>&1 || fail "aetherc failed" "$TMP/gen.log"
+
+# The call must pass `item` (the closure's own parameter).
+grep -q "uix_invoke_cell(cell, item," "$TMP/probe.c" \
+    || fail "emitted C does not pass the closure parameter in argument position" "$TMP/probe.c"
+
+# And must NOT pass the prefixed module function's address.
+if grep -q "uix_invoke_cell(cell, uix_item," "$TMP/probe.c"; then
+    fail "emitted C passes the module function uix_item instead of the parameter (#1606 regression)"
+fi
+
+# The module function itself must still be prefixed where it IS meant — the fix
+# must not have disabled intra-module renaming wholesale.
+grep -q "uix_item" "$TMP/probe.c" \
+    || fail "module function lost its namespace prefix entirely — rename pass over-suppressed"
+
+echo "  [PASS] closure_param_shadows_module_fn: closure param wins over same-named module fn (#1606)"
+exit 0


### PR DESCRIPTION
Closes #1606.

The report asked for a **diagnostic**. It turned out to be a codegen bug: correct source compiled into wrong code, so this fixes the resolution instead.

## Root cause

`rename_intra_module_refs` (compiler/aether_module.c) rewrites bare references to module functions/consts into `<ns>_<name>`, skipping names shadowed by a local binding. But `collect_local_names` recognised only `AST_PATTERN_VARIABLE` / `AST_VARIABLE_DECLARATION` / `AST_CONST_DECLARATION` — a closure parameter is an **`AST_CLOSURE_PARAM`**, a node type that appeared **nowhere** in that file. Closures also established no scope of their own; only `AST_FUNCTION_DEFINITION` did.

So in a module defining `item()`:

```aether
|item: ptr, i: int| { f(item) }     // `item` here is the PARAMETER
```

emitted

```c
uix_invoke_cell(cell, uix_item, 0);   // the FUNCTION's address, not the parameter
```

The callee then read a function pointer as data. In aether-ui that was a `Person*` cast and a segfault inside `aether_string_data`.

This also explains the reporter's puzzle that the generated C was "byte-identical apart from one name": `sed 's/ui_item/ui_zzz_item/g'` rewrites both the definition *and* the wrongly-substituted argument, so the normalisation hid the very difference it was testing for.

## The fix

- `collect_local_names` learns `AST_CLOSURE_PARAM`.
- `AST_CLOSURE` establishes a scope that **extends** the enclosing one — a closure still reads enclosing locals and still resolves non-shadowed module functions/consts normally.
- The closure's own bindings are collected **first**. The list is capped at 128; had a large enclosing scope filled it, the parameters would be precisely the names dropped, reintroducing the bug. Losing an enclosing name instead costs a missed rename-suppression, not a wrong symbol.

## Verification

**A/B on the reporting application** — aether-ui at the crashing commit `e6feacc`, identical source and build script, only the compiler differing:

| compiler | result |
|---|---|
| unfixed | **exit 139 — SIGSEGV** |
| fixed | exit 124 (still running when the timeout killed it) |

Both crash sites now emit `item` instead of `ui_item`.

**Reduced to a 16-line fixture** (no UI, no GTK) that on the unfixed compiler prints the raw machine code of the shadowed function instead of the string passed in.

**Regression test** `tests/integration/closure_param_shadows_module_fn/` pins both halves — the parameter's value survives the call, *and* the emitted C names the parameter rather than the prefixed function. It also asserts the module function is **still** prefixed where it should be, so the fix cannot silently regress into suppressing renames wholesale. Verified to fail on the unfixed compiler.

Also checked by hand: non-shadowed module functions and consts still resolve inside closures (`helper(5)*2 + CONST_X` → 17), and nested closures scope correctly (inner shadow wins, outer unaffected).

**Suite:** 390 unit tests pass; full `.ae` sweep **1005 passed / 8 failed**, all 8 pre-existing and none closure- or module-related — `http_server_h2` (documented in `asks/`), `windows_crt_symbols` and `contrib_vulkan_portability` (#1605), `wycheproof` (verified identical on the unfixed compiler — a local sandbox SIGKILL), plus `http_server_keepalive` which passes standalone. `fmt_gate` flagged my new fixtures; formatted and green.

## On the original ask

A diagnostic is still worth having, but as a follow-up rather than the fix — correct source should not compile into wrong code in the first place. Worth noting the sibling case *is* already diagnosed, misleadingly: when a closure body **calls** the shadowed name, the typechecker reports `error[E0301]: Undefined function 'item'`, though the function is defined and the parameter has merely made it unreachable. That message deserves rewording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)