### PR TITLE
test(host/ruby): co-locate an embedding-lifecycle test with the bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+- `contrib/host/ruby/test_host_ruby.sh` — the first **co-located** contrib
+  test, sitting next to the bridge it exercises rather than under
+  `tests/integration/` (the direction argued in #1584). Drives
+  `ruby_init_host` / `ruby_run` / `ruby_finalize_host` directly: evaluation,
+  Ruby-side computation reaching stdout, a raised exception propagating as a
+  non-zero return rather than being swallowed, and init idempotence while the
+  VM is live. Performs the bridge's own documented `LIBRUBY_SO` probe so it
+  works on both Debian-style and Fedora-style packagings, and SKIPs cleanly
+  without Ruby.
+  Ruby was not uncovered before this — `namespace_ruby` and the shared-map
+  test both drive it from outside — but nothing exercised the embedding
+  lifecycle directly, which is how the finalize defect below went unnoticed.
+- `make contrib-host-check` gained a third phase that auto-discovers
+  `contrib/host/*/test_*.sh` and runs them, so a bridge that adds a
+  co-located test is picked up with no Makefile change. Verified that a
+  failing co-located test fails the target.
+
+### Fixed
+- Documented that `ruby_finalize_host()` is **terminal**
+  (contrib/host/ruby/README.md). CRuby's `ruby_finalize()` tears the VM down
+  permanently, but the bridge's post-finalize `ruby_init_host()` still
+  returns 0 and the next `ruby_run()` segfaults inside libruby. Call it once
+  at shutdown, or not at all. The new test pins the supported lifecycle and
+  deliberately does not exercise the unsupported one, so a future fix has a
+  baseline to change.
+
 ## [0.543.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -2609,8 +2609,17 @@ contrib-host-check: compiler ae stdlib
 	echo "  $$pass passed, $$fail failed (stub mode)"; \
 	if [ "$$fail" -gt 0 ]; then exit 1; fi
 	@echo ""
-	@echo "[2/2] Link + run — demos for bridges with dev libs available..."
+	@echo "[2/3] Link + run — demos for bridges with dev libs available..."
 	@bash tests/scripts/contrib_host_demos.sh || exit 1
+	@echo ""
+	@echo "[3/3] Co-located bridge tests (contrib/host/*/test_*.sh)..."
+	@rc=0; found=0; \
+	for t in $$(find contrib/host -maxdepth 2 -name 'test_*.sh' 2>/dev/null | sort); do \
+	  found=$$((found + 1)); \
+	  bash "$$t" || rc=1; \
+	done; \
+	if [ "$$found" -eq 0 ]; then echo "  (none yet)"; fi; \
+	exit $$rc
 	@echo ""
 	@echo "==================================="
 	@echo "  contrib/host check PASSED"

--- a/contrib/host/ruby/README.md
+++ b/contrib/host/ruby/README.md
@@ -128,10 +128,40 @@ main() {
   immediately after `#include <ruby.h>` — the bridge uses libc
   snprintf for plain string assembly, not Ruby's format extensions.
 
+## Lifecycle: finalize is terminal
+
+`ruby_init_host()` is idempotent while the VM is live — call it defensively
+before an eval and it is a no-op. But `ruby_finalize_host()` calls CRuby's
+`ruby_finalize()`, which tears the VM down **permanently**: `ruby_init()`
+cannot be called again in the same process.
+
+The bridge does not currently enforce that. A post-finalize
+`ruby_init_host()` returns **0**, and the next `ruby_run()` segfaults inside
+libruby:
+
+```
+eval:1: [BUG] Segmentation fault at 0x0000000000000000
+c:0003 p:---- s:0011 e:000010 CFUNC  :puts
+```
+
+So: **call `ruby_finalize_host()` once, at shutdown, or not at all.** A
+long-running host that wants to reset script state should do it in Ruby
+rather than by cycling the VM. See the note in
+[`test_host_ruby.sh`](test_host_ruby.sh), which pins the supported lifecycle
+and deliberately does not exercise the unsupported one.
+
 ## Testing
 
-Three tests exercise the Ruby host; all SKIP cleanly when Ruby isn't
+Four tests exercise the Ruby host; all SKIP cleanly when Ruby isn't
 installed, so they no-op on hosts without it.
+
+- **Embedding lifecycle (co-located)** — [`test_host_ruby.sh`](test_host_ruby.sh),
+  next to the bridge it tests. Drives `ruby_init_host` / `ruby_run` /
+  `ruby_finalize_host` directly from C: evaluation, Ruby-side computation
+  reaching stdout, a raised exception propagating as a non-zero return
+  (rather than being swallowed), and init idempotence while the VM is live.
+  Performs the bridge's own documented `LIBRUBY_SO` probe, so it works on
+  both Debian-style (unversioned symlink) and Fedora-style packagings.
 
 - **Namespace / FFI SDK** —
   [`tests/integration/namespace_ruby/`](../../../tests/integration/namespace_ruby/).

--- a/contrib/host/ruby/test_host_ruby.sh
+++ b/contrib/host/ruby/test_host_ruby.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+# Integration tests for contrib.host.ruby, CO-LOCATED with the bridge they
+# test rather than in tests/integration/host_ruby/ (the convention the other
+# bridges follow). Co-location is the direction argued in issue #1584: the
+# test sits next to the code it describes, and a change to the bridge and its
+# test is one diff in one directory.
+#
+# WHY THIS EXISTS: the bridge's OWN embedding lifecycle had no direct test.
+# Ruby is not uncovered — tests/integration/namespace_ruby/ exercises the
+# generated FFI SDK over Fiddle, and tests/sandbox/test_shared_map_all.sh
+# covers ruby_run_sandboxed_with_map — but both drive Ruby from the OUTSIDE.
+# Nothing exercised ruby_init_host / ruby_run / ruby_finalize_host directly,
+# which is why the post-finalize re-init crash below went unnoticed.
+#
+# It is also the piece the NIGHTLY misses: contrib_check.sh has no host/*
+# entries at all, and contrib_host_demos.sh reports `ruby SKIP (no demo)`,
+# so on that box the bridge got a 7ms `ae check` of module.ae and a
+# `-fsyntax-only` of the C shim, and nothing executed.
+#
+# LOADING MODEL: the bridge dlopens libruby rather than linking it, so the
+# soname must be resolved at runtime. Debian ships an unversioned
+# libruby.so symlink; Fedora/Bazzite do not, which is why the bridge
+# documents `ruby -rrbconfig -e 'print RbConfig::CONFIG["LIBRUBY_SO"]'` as
+# the orchestrator's probe. This script performs exactly that probe and
+# exports AETHER_RUBY_SONAME, so it works on both packagings.
+#
+# Driven from C rather than through `ae build`: it exercises the same surface
+# module.ae declares, without depending on contrib-link plumbing — matching
+# tests/integration/host_lua_bidirectional/.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT) echo "  [SKIP] host_ruby on Windows"; exit 0 ;;
+esac
+
+fail() {
+    echo "  [FAIL] host_ruby: $1"
+    [ -n "${2:-}" ] && [ -f "$2" ] && sed 's/^/        /' "$2" | head -12
+    exit 1
+}
+
+# ---- dependency probes: SKIP (not FAIL) when ruby isn't provisioned -------
+command -v ruby >/dev/null 2>&1 || { echo "  [SKIP] host_ruby: no ruby runtime"; exit 0; }
+
+RUBY_CFLAGS=""
+if pkg-config --exists ruby 2>/dev/null; then
+    RUBY_CFLAGS="$(pkg-config --cflags ruby)"
+else
+    # Debian/Ubuntu without the .pc: headers live in a versioned dir.
+    for d in /usr/include/ruby-*; do
+        [ -f "$d/ruby.h" ] && { RUBY_CFLAGS="-I$d"; break; }
+    done
+fi
+[ -n "$RUBY_CFLAGS" ] || { echo "  [SKIP] host_ruby: no ruby dev headers"; exit 0; }
+
+# The bridge's own documented soname probe.
+RUBY_SONAME="$(ruby -rrbconfig -e 'print RbConfig::CONFIG["LIBRUBY_SO"]' 2>/dev/null)"
+[ -n "$RUBY_SONAME" ] || { echo "  [SKIP] host_ruby: could not probe LIBRUBY_SO"; exit 0; }
+export AETHER_RUBY_SONAME="$RUBY_SONAME"
+
+[ -f "$ROOT/build/libaether.a" ] || { echo "  [SKIP] host_ruby: libaether.a not built"; exit 0; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- build the harness ----------------------------------------------------
+# ruby.h's own headers are noisy under -Wall -Wextra; this test is about the
+# bridge's behaviour, not Ruby's header hygiene.
+if ! gcc -o "$TMP/t" \
+    "$SCRIPT_DIR/aether_host_ruby.c" \
+    "$ROOT/runtime/aether_sandbox.c" \
+    "$ROOT/runtime/aether_shared_map.c" \
+    $RUBY_CFLAGS -I"$ROOT" -I"$ROOT/runtime" \
+    -DAETHER_HAS_RUBY -DAETHER_HAS_SANDBOX \
+    -L"$ROOT/build" -laether -ldl -lm -lrt -lpthread \
+    -Wno-discarded-qualifiers \
+    -xc - 2>"$TMP/cc.log" << 'CEOF'
+#include <stdio.h>
+#include <string.h>
+#include "contrib/host/ruby/aether_host_ruby.h"
+
+/* The bridge links against libaether; these are the symbols an `ae`-built
+   program would normally supply. */
+void aether_args_init(int a, char** v){ (void)a; (void)v; }
+void* _aether_ctx_stack[64];
+int _aether_ctx_depth = 0;
+
+int main(void) {
+    if (ruby_init_host() != 0) { printf("FAIL init_host\n"); return 1; }
+
+    /* 1. Plain evaluation. */
+    if (ruby_run("puts 'RB-HELLO'") != 0) { printf("FAIL run\n"); return 1; }
+
+    /* 2. Ruby-side computation reaching stdout — proves the interpreter is
+          really executing, not just loading. */
+    if (ruby_run("puts (2 + 3) * 7") != 0) { printf("FAIL run-arith\n"); return 1; }
+
+    /* 3. A raised exception must be reported as failure, not silently
+          swallowed. A bridge that returns 0 for broken script code is worse
+          than one that cannot run at all: the caller believes it worked. */
+    int bad = ruby_run("raise 'deliberate'");
+    printf("EXC-RC=%d\n", bad);
+
+    /* 4. Repeated init is a no-op while the VM is live — a host that calls
+          init defensively before each eval must not pay for it or crash. */
+    if (ruby_init_host() != 0) { printf("FAIL reinit-live\n"); return 1; }
+    if (ruby_run("puts 'RB-STILL-LIVE'") != 0) { printf("FAIL run-after-reinit\n"); return 1; }
+
+    /* 5. Finalize once, at the end. NOT followed by another init: CRuby's
+          ruby_finalize() tears the VM down permanently and ruby_init()
+          cannot be called again in the same process. The bridge currently
+          returns 0 from a post-finalize ruby_init_host() and then segfaults
+          on the next eval — see the note in README.md. This test
+          deliberately does NOT exercise that path; it pins the supported
+          lifecycle so a future fix has a baseline to change. */
+    ruby_finalize_host();
+
+    printf("DONE\n");
+    return 0;
+}
+CEOF
+then
+    fail "harness did not compile" "$TMP/cc.log"
+fi
+
+# ---- run ------------------------------------------------------------------
+if ! "$TMP/t" > "$TMP/out.log" 2>&1; then
+    fail "harness exited non-zero" "$TMP/out.log"
+fi
+
+grep -q "RB-HELLO" "$TMP/out.log" \
+    || fail "ruby_run did not execute the script" "$TMP/out.log"
+grep -q "^35$" "$TMP/out.log" \
+    || fail "ruby-side arithmetic did not reach stdout (interpreter not really running?)" "$TMP/out.log"
+grep -q "RB-STILL-LIVE" "$TMP/out.log" \
+    || fail "a repeated init while the VM is live broke the embedding" "$TMP/out.log"
+grep -q "DONE" "$TMP/out.log" \
+    || fail "harness did not reach the end" "$TMP/out.log"
+
+# A raised Ruby exception must NOT be reported as success.
+if grep -q "^EXC-RC=0$" "$TMP/out.log"; then
+    fail "a raising script returned rc=0 — failures are being swallowed" "$TMP/out.log"
+fi
+
+echo "  [PASS] host_ruby: eval, compute, exception-propagates, idempotent init"
+exit 0


### PR DESCRIPTION
Co-locates a real integration test with `contrib/host/ruby/` rather than putting it under `tests/integration/host_ruby/` — the direction argued in #1584. A change to the bridge and its test is now one diff in one directory.

## What prompted it

You noticed the nightly reports `ae check` of `host/ruby` in **7ms** and asked for the same set to have their tests run. Digging in:

| layer | covers ruby? |
|---|---|
| nightly `contrib_ae_check` sweep | ✅ `ae check module.ae` — type-check only (the 7ms) |
| `make contrib-host-check` [1/2] | ✅ `cc -fsyntax-only` on the C shim |
| `make contrib-host-check` [2/2] demos | ❌ `ruby SKIP (no demo)` |
| `contrib_check.sh` (build **and run**) | ❌ **no `host/*` entries at all** |

**Correction to something I said mid-investigation:** Ruby is *not* uncovered. `tests/integration/namespace_ruby/` exercises the generated FFI SDK over Fiddle (verified passing here), and `tests/sandbox/test_shared_map_all.sh` covers `ruby_run_sandboxed_with_map`. But both drive Ruby from the **outside**. Nothing exercised `ruby_init_host` / `ruby_run` / `ruby_finalize_host` directly — which is exactly how the defect below stayed hidden.

## What the test covers

- evaluation reaches the interpreter;
- **Ruby-side computation reaches stdout** (`(2+3)*7` → `35`) — a bridge that loads libruby but never executes would pass a weaker check;
- a **raised exception propagates as non-zero**, rather than being swallowed (a bridge returning 0 for broken script code is worse than one that cannot run: the caller believes it worked);
- **init is idempotent** while the VM is live.

It performs the bridge's own documented `LIBRUBY_SO` probe (`ruby -rrbconfig -e 'print RbConfig::CONFIG["LIBRUBY_SO"]'`), so it works on Debian-style packaging (unversioned `libruby.so` symlink) and Fedora/Bazzite-style (no symlink) alike, and SKIPs cleanly wherever Ruby is absent.

## What it found

**`ruby_finalize_host()` is terminal, and the bridge doesn't say so.** CRuby's `ruby_finalize()` tears the VM down permanently — `ruby_init()` cannot be called again in the same process. But the bridge's post-finalize `ruby_init_host()` returns **0**, and the next `ruby_run()` segfaults inside libruby:

```
eval:1: [BUG] Segmentation fault at 0x0000000000000000
c:0003 p:---- s:0011 e:000010 CFUNC  :puts
```

Reporting success and then crashing is worse than refusing outright. I've documented the supported lifecycle in `README.md` ("call it once at shutdown, or not at all") and the test **deliberately does not exercise the unsupported path** — it pins the supported one so a future fix has a baseline to change. I did not change the bridge's behaviour here: that's a separate decision (make post-finalize init return non-zero? make finalize a no-op?) and belongs to whoever owns the bridge.

## Wiring

`make contrib-host-check` gains a `[3/3]` phase that **auto-discovers** `contrib/host/*/test_*.sh`, so the next bridge to add a co-located test is picked up with no Makefile change:

```
[3/3] Co-located bridge tests (contrib/host/*/test_*.sh)...
  [PASS] host_ruby: eval, compute, exception-propagates, idempotent init
```

Verified the wiring actually gates: with a deliberately failing test in place, `make contrib-host-check` exits **2** rather than printing and passing.

Since the nightly already runs `make contrib-host-check` as a recorded step, this reaches the cachyos box with no change to the nightly script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)