### PR TITLE
feat(spec): skip verbs (#1610); co-locate the ruby bridge spec in Aether

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+- `std.spec` gained skip verbs (#1610): `it_when(cond, desc, reason)` for
+  dependency gating, `skip_it(desc, reason)` for a permanent exclusion, and
+  `skip_all_if(fw, cond, reason)` for a file-level bail-out. A skipped test
+  does not run its body, counts in neither passed nor failed, and prints a
+  distinct `⊘` line carrying its reason plus an `N skipped` summary.
+  Until now a spec whose subject might be absent from the host — a
+  host-language bridge, a driver, a system library — had to fail (presenting
+  a *provisioning* gap as a code defect), pass dishonestly, or bail out
+  before `spec.init()` where the framework could not see it. The dishonest
+  option is the one that bites: a box that skips everything looked exactly
+  like a box that passes everything, which is how nine silently-skipping
+  contrib/vulkan tests and `ruby SKIP (no demo)` went unnoticed on the
+  nightly.
+- The aeocha-v1 structured report carries `skipped=N`, and skipped tests
+  emit rows with a `SKIP` status and their reason as the message. This is
+  **additive** — docs/testing.md's contract already permits new keys and
+  requires consumers to ignore unknown ones, so there is no `version=` bump.
+  `total` deliberately remains `passed + failed`: folding skips in would
+  *repurpose* an existing key, which the contract forbids.
+- `contrib/host/ruby/test_host_ruby.ae` — the first **co-located** contrib
+  test, written in Aether against `std.spec` rather than as a shell harness.
+  It drives the bridge through `import contrib.host.ruby`, the path a real
+  user takes, so it covers the module declarations and contrib-link plumbing
+  as well as the C shim. Covers evaluation, that the interpreter genuinely
+  runs (Ruby computes a value and a second eval asserts on it Ruby-side),
+  exceptions *and* syntax errors propagating as failures rather than being
+  swallowed, and init idempotence while the VM is live. Uses `it_when`, so a
+  box without Ruby reports skipped rather than failed.
+- `make contrib-host-check` gained a `[3/3]` phase that auto-discovers
+  `contrib/host/*/test_*.ae` and runs them, performing the bridge's
+  documented `LIBRUBY_SO` probe first. A bridge that adds a co-located spec
+  is picked up with no Makefile change.
+
+### Fixed
+- Documented two `contrib.host.ruby` behaviours that cost real debugging
+  time (contrib/host/ruby/README.md): **Ruby's `puts` output is buffered and
+  silently vanishes** unless `ruby_finalize_host()` runs or the script sets
+  `$stdout.sync = true` — the script *did* execute, only the output was
+  lost; and **`ruby_finalize_host()` is terminal** — CRuby's
+  `ruby_finalize()` destroys the VM permanently, yet a post-finalize
+  `ruby_init_host()` still returns 0 and the next `ruby_run()` segfaults
+  inside libruby. Call it once at shutdown, or not at all.
+
 ## [0.544.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -2609,8 +2609,25 @@ contrib-host-check: compiler ae stdlib
 	echo "  $$pass passed, $$fail failed (stub mode)"; \
 	if [ "$$fail" -gt 0 ]; then exit 1; fi
 	@echo ""
-	@echo "[2/2] Link + run — demos for bridges with dev libs available..."
+	@echo "[2/3] Link + run — demos for bridges with dev libs available..."
 	@bash tests/scripts/contrib_host_demos.sh || exit 1
+	@echo ""
+	@echo "[3/3] Co-located bridge specs (contrib/host/*/test_*.ae)..."
+	@rc=0; found=0; \
+	for t in $$(find contrib/host -maxdepth 2 -name 'test_*.ae' 2>/dev/null | sort); do \
+	  found=$$((found + 1)); \
+	  lang=$$(basename $$(dirname "$$t")); \
+	  echo "  --- $$lang ---"; \
+	  if [ "$$lang" = "ruby" ] && command -v ruby >/dev/null 2>&1; then \
+	    AETHER_RUBY_SONAME="$$(ruby -rrbconfig -e 'print RbConfig::CONFIG["LIBRUBY_SO"]' 2>/dev/null)"; \
+	    export AETHER_RUBY_SONAME; \
+	  fi; \
+	  out="$$(./build/ae$(EXE_EXT) run "$$t" 2>&1)"; trc=$$?; \
+	  echo "$$out" | sed 's/^/  /'; \
+	  if [ "$$trc" -ne 0 ]; then rc=1; fi; \
+	done; \
+	if [ "$$found" -eq 0 ]; then echo "  (none yet)"; fi; \
+	exit $$rc
 	@echo ""
 	@echo "==================================="
 	@echo "  contrib/host check PASSED"

--- a/Makefile
+++ b/Makefile
@@ -2622,6 +2622,13 @@ contrib-host-check: compiler ae stdlib
 	    AETHER_RUBY_SONAME="$$(ruby -rrbconfig -e 'print RbConfig::CONFIG["LIBRUBY_SO"]' 2>/dev/null)"; \
 	    export AETHER_RUBY_SONAME; \
 	  fi; \
+	  if [ ! -f "build/contrib/libaether_host_$$lang.a" ]; then \
+	    MODULES="$$lang" bash tests/scripts/contrib_build.sh >/dev/null 2>&1 || true; \
+	  fi; \
+	  if [ ! -f "build/contrib/libaether_host_$$lang.a" ]; then \
+	    echo "    SKIP: libaether_host_$$lang.a unavailable (bridge deps not installed)"; \
+	    continue; \
+	  fi; \
 	  out="$$(./build/ae$(EXE_EXT) run "$$t" 2>&1)"; trc=$$?; \
 	  echo "$$out" | sed 's/^/  /'; \
 	  if [ "$$trc" -ne 0 ]; then rc=1; fi; \

--- a/contrib/host/ruby/README.md
+++ b/contrib/host/ruby/README.md
@@ -128,10 +128,78 @@ main() {
   immediately after `#include <ruby.h>` — the bridge uses libc
   snprintf for plain string assembly, not Ruby's format extensions.
 
+## Ruby stdout is buffered — `puts` output can vanish
+
+libruby buffers `$stdout`, and **nothing flushes it when an Aether program
+exits**. So this prints `done` and nothing else:
+
+```aether
+import contrib.host.ruby
+
+main() {
+    _ = ruby.ruby_init_host()
+    _ = ruby.ruby_run("puts 'hello from ruby'")   // never appears!
+    println("done")
+}
+```
+
+The script *did* run — only the buffered output is lost. Confirmed by having
+Ruby write a file instead: the file appears with the right contents while the
+`puts` does not.
+
+Two ways to get the output:
+
+```aether
+// 1. Finalize before exit — flushes as part of VM teardown.
+ruby.ruby_finalize_host()
+
+// 2. Or make Ruby's stdout unbuffered, if you need output as it happens.
+_ = ruby.ruby_run("$stdout.sync = true")
+```
+
+This is why [`test_host_ruby.ae`](test_host_ruby.ae) asserts on **return
+codes and Ruby-side state**, never on the bridge's stdout — a test that
+grepped for `puts` output would be asserting on flush timing rather than on
+the bridge.
+
+## Lifecycle: finalize is terminal
+
+`ruby_init_host()` is idempotent while the VM is live — call it defensively
+before an eval and it is a no-op. But `ruby_finalize_host()` calls CRuby's
+`ruby_finalize()`, which tears the VM down **permanently**: `ruby_init()`
+cannot be called again in the same process.
+
+The bridge does not currently enforce that. A post-finalize
+`ruby_init_host()` returns **0**, and the next `ruby_run()` segfaults inside
+libruby:
+
+```
+eval:1: [BUG] Segmentation fault at 0x0000000000000000
+c:0003 p:---- s:0011 e:000010 CFUNC  :puts
+```
+
+So: **call `ruby_finalize_host()` once, at shutdown, or not at all.** A
+long-running host that wants to reset script state should do it in Ruby
+rather than by cycling the VM. `test_host_ruby.ae` pins the supported
+lifecycle and deliberately does not exercise the unsupported one, leaving a
+baseline for a future fix.
+
 ## Testing
 
-Three tests exercise the Ruby host; all SKIP cleanly when Ruby isn't
+Four tests exercise the Ruby host; all SKIP cleanly when Ruby isn't
 installed, so they no-op on hosts without it.
+
+- **Embedding lifecycle (co-located)** — [`test_host_ruby.ae`](test_host_ruby.ae),
+  next to the bridge, written in Aether against `std.spec`. Drives the
+  bridge through `import contrib.host.ruby` — the path a real user takes, so
+  it covers the module declarations and contrib-link plumbing as well as the
+  C shim. Covers evaluation, that the interpreter *really* runs (Ruby
+  computes a value and a second eval asserts on it Ruby-side), exceptions and
+  syntax errors propagating as failures rather than being swallowed, and init
+  idempotence while the VM is live. Uses `spec.it_when` (#1610) so a box
+  without Ruby reports **skipped**, not passed and not failed. Run by
+  `make contrib-host-check`'s `[3/3]` phase, which performs the `LIBRUBY_SO`
+  probe first.
 
 - **Namespace / FFI SDK** —
   [`tests/integration/namespace_ruby/`](../../../tests/integration/namespace_ruby/).

--- a/contrib/host/ruby/test_host_ruby.ae
+++ b/contrib/host/ruby/test_host_ruby.ae
@@ -1,0 +1,93 @@
+// Integration tests for contrib.host.ruby — CO-LOCATED with the bridge they
+// exercise rather than under tests/integration/ (the direction argued in
+// #1584), and written in Aether against std.spec rather than as a shell
+// harness wrapping a C heredoc.
+//
+// Writing it in Aether is not just brevity. This drives the bridge through
+// `import contrib.host.ruby` — the path a REAL USER takes — so it covers the
+// module declarations and the contrib-link plumbing as well as the C shim.
+// A C harness tests aether_host_ruby.c directly and would pass even if
+// module.ae's extern declarations had drifted from it.
+//
+// SKIPPING: the bridge dlopens libruby at runtime, so a box without Ruby
+// cannot run these. That is a provisioning gap, not a code defect, so the
+// tests skip rather than fail (#1610's it_when). The probe is
+// ruby_init_host() itself: it returns non-zero when libruby cannot be
+// dlopened, which is exactly the condition that matters.
+//
+// SONAME: the bridge tries $AETHER_RUBY_SONAME then a bare "libruby.so".
+// Debian ships that unversioned symlink; Fedora/Bazzite do not, and there
+// the caller must pass the exact soname from
+//   ruby -rrbconfig -e 'print RbConfig::CONFIG["LIBRUBY_SO"]'
+// The Makefile's contrib-host-check phase performs that probe and exports
+// the variable before running this file.
+//
+// STDOUT: Ruby's own `puts` output is buffered by libruby and is NOT flushed
+// when an Aether program exits — it appears only after ruby_finalize_host()
+// (or with `$stdout.sync = true`). These tests therefore assert on RETURN
+// CODES and on state observed back through Ruby, never on the bridge's
+// stdout. See the README's "Ruby stdout is buffered" section.
+
+import contrib.host.ruby
+import std.spec
+
+main() {
+    fw = spec.init()
+
+    // The dependency probe. Non-zero means libruby could not be dlopened.
+    have_ruby = 0
+    if ruby.ruby_init_host() == 0 { have_ruby = 1 }
+    reason = "libruby not loadable (set AETHER_RUBY_SONAME)"
+
+    spec.describe(fw, "contrib.host.ruby") {
+        spec.it_when(have_ruby, "evaluates a script and reports success", reason) callback {
+            spec.assert_eq(ruby.ruby_run("$aether_probe = 1"), 0,
+                "a valid script returns 0")
+        }
+
+        // A bridge that dlopens libruby and resolves its symbols but never
+        // actually evaluates would satisfy the return-code check above. This
+        // one can only pass if the interpreter really ran: Ruby computes a
+        // value, and a second eval asserts on it Ruby-side, raising when the
+        // arithmetic did not happen.
+        spec.it_when(have_ruby, "really executes — Ruby-side state persists", reason) callback {
+            spec.assert_eq(ruby.ruby_run("$aether_sum = (2 + 3) * 7"), 0,
+                "computation evaluates")
+            spec.assert_eq(ruby.ruby_run("raise 'wrong' unless $aether_sum == 35"), 0,
+                "Ruby sees 35 — the interpreter genuinely ran")
+        }
+
+        // A bridge that swallows script errors is worse than one that cannot
+        // run at all: the caller believes the script worked. Asserted
+        // negatively so the bridge may change its error code freely.
+        spec.it_when(have_ruby, "propagates a raised exception as failure", reason) callback {
+            spec.assert_not_eq(ruby.ruby_run("raise 'deliberate'"), 0,
+                "a raising script must NOT report success")
+        }
+
+        // A syntax error is a different path through rb_eval_string_protect
+        // than a raise, and must also be reported.
+        spec.it_when(have_ruby, "reports a syntax error as failure", reason) callback {
+            spec.assert_not_eq(ruby.ruby_run("def ("), 0,
+                "unparseable code must NOT report success")
+        }
+
+        // A host that defensively calls init before each eval must not pay
+        // for it or crash: while the VM is live, init is a no-op.
+        spec.it_when(have_ruby, "init is idempotent while the VM is live", reason) callback {
+            spec.assert_eq(ruby.ruby_init_host(), 0, "second init returns 0")
+            spec.assert_eq(ruby.ruby_run("$aether_probe = 2"), 0,
+                "the VM still evaluates afterwards")
+        }
+    }
+
+    spec.run_summary(fw)
+
+    // Finalize ONCE, after the suite. Deliberately not followed by another
+    // init: CRuby's ruby_finalize() tears the VM down permanently, and the
+    // bridge currently returns 0 from a post-finalize ruby_init_host() and
+    // then segfaults on the next eval. That unsupported path is documented
+    // in the README and left untested on purpose, so a future fix has a
+    // baseline to change rather than a test to fight.
+    if have_ruby == 1 { ruby.ruby_finalize_host() }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -218,6 +218,47 @@ spec.expect_elapsed_under(os.now_monotonic_ns() - t0, 50ms, "fast path")
 Use monotonic-clock deltas (not wall-clock) — only the delta is
 meaningful and a wall jump would corrupt it.
 
+### Skipping a test whose dependency may be absent
+
+A spec whose subject may not exist on the host — a host-language bridge, a
+driver, a daemon, a system library — needs a third outcome besides pass and
+fail. Failing presents a *provisioning* gap as a code defect (and gets the
+test deleted from the sweep); passing silently is worse, because a box that
+skips everything then looks exactly like a box that passes everything.
+
+```aether
+have_ruby = 0
+if ruby.ruby_init_host() == 0 { have_ruby = 1 }
+
+spec.describe(fw, "contrib.host.ruby") {
+    spec.it_when(have_ruby, "evaluates a script", "libruby not loadable") callback {
+        spec.assert_eq(ruby.ruby_run("$x = 1"), 0, "eval")
+    }
+}
+```
+
+```
+contrib.host.ruby
+  ⊘ evaluates a script  (skipped: libruby not loadable)
+
+  0 passing
+  5 skipped
+```
+
+Exit status is 0 — a skip is not a failure — but the count is on stdout and
+`skipped=N` is in the structured report, so a degraded box is visible rather
+than quietly green.
+
+| verb | use for |
+|---|---|
+| `it_when(cond, desc, reason)` | dependency gating — the common case. `cond` is a plain int the caller computes, keeping the probe visible at the call site. |
+| `skip_it(desc, reason)` | a **permanent** exclusion (known-broken path, unsupported platform) where the body is kept for the day it is re-enabled. |
+| `skip_all_if(fw, cond, reason)` | file-level bail-out; returns 1 when the caller should `return`. The condition is evaluated eagerly, so guard an expensive probe yourself. |
+
+Prefer `it_when` for anything that is really a missing dependency:
+an unconditional `skip_it` hides *why* it is skipped, which is the
+information a provisioning fix needs.
+
 ## Structured reporting
 
 By default `ae test` prints human progress and a `PASS`/`FAIL` line per
@@ -339,6 +380,7 @@ version=1
 total=<N>
 passed=<N>
 failed=<N>
+skipped=<N>
 errored=<N>
 duration_ms=<N>
 duration_ns=<N>
@@ -346,6 +388,13 @@ duration_ns=<N>
 <STATUS>\t<index>\t"<name>"\t<duration_ns>[\t<message>]
 ...
 ```
+
+`skipped=` was **added** under `version=1` (#1610), which the additive rule
+below permits — no version bump, and a consumer that does not know the key
+ignores it. Note `total` deliberately remains `passed + failed`: folding
+skips into it would *repurpose* an existing key, which the rules forbid.
+Rows for skipped tests carry `SKIP` as their `<STATUS>` and a duration of
+`0`, with the skip reason in the optional `<message>` field.
 
 The rules a consumer may rely on, and an editor must preserve:
 

--- a/std/spec/module.ae
+++ b/std/spec/module.ae
@@ -69,6 +69,11 @@ import std.file
 exports(
     init,
     describe, it, it_within,
+    // Skip verbs (#1610). A dependency-gated test must be able to say
+    // "not run here" without either failing (a provisioning gap is not a
+    // code defect) or passing silently (which is how three separate
+    // silently-degraded boxes went unnoticed).
+    it_when, skip_it, skip_all_if,
     before_each, after_each,
     fail, assert_true, assert_false,
     assert_eq, assert_str_eq, assert_str_eq_diff, assert_not_eq, assert_gt,
@@ -121,6 +126,7 @@ init() -> ptr {
     fw = map.new()
     map.put_raw(fw, "passed", ref(0))
     map.put_raw(fw, "failed", ref(0))
+    map.put_raw(fw, "skipped", ref(0))
     map.put_raw(fw, "depth", ref(0))
     // Per-it() telemetry (for the structured report path).
     // "current_it" stores the in-flight it-record map directly (or null
@@ -265,6 +271,108 @@ it(_ctx: ptr, description: string, test_fn: fn) {
     rec, old_failed, t0 = _it_begin(_ctx, description)
     call(test_fn)
     _it_end(_ctx, description, rec, old_failed, t0, 0)
+}
+
+// ---------------------------------------------------------------------------
+// Skip verbs (#1610)
+//
+// A test whose subject may be absent from the host — a host-language
+// bridge, a driver, a daemon, a system library — needs a third outcome
+// besides pass and fail. Failing presents a PROVISIONING gap as a code
+// defect (and gets the test deleted from the sweep); passing silently is
+// worse, and is exactly how nine contrib/vulkan tests, a mis-scoped
+// cross-compile probe, and `ruby SKIP (no demo)` all went unnoticed on a
+// live box. A skip that reports as a pass is worse than no skip at all.
+//
+// A skipped it() does NOT run its body, counts in neither passed nor
+// failed, and is reported distinctly (⊘) with its reason.
+// ---------------------------------------------------------------------------
+
+// Record a skip: print the line, bump the counter, and stamp a record so
+// the structured report carries it. Mirrors _it_end's bookkeeping minus
+// the timing and the hooks — a body that never ran has no duration, and
+// before/after hooks exist to set up a body that is not going to run.
+_record_skip(_ctx: ptr, description: string, reason: string) {
+    fw = _fw_of(_ctx)
+    skipped_ref = map.get_raw(fw, "skipped")
+    depth_ref = map.get_raw(fw, "depth")
+    its_list = map.get_raw(fw, "its")
+
+    d = ref_get(depth_ref)
+    for (i = 0; i < d; i ++) { print("  ") }
+    if string.equals(reason, "") == 1 {
+        print("\x1b[33m  ⊘\x1b[0m ${description}\n")
+    } else {
+        print("\x1b[33m  ⊘\x1b[0m ${description}  \x1b[33m(skipped: ${reason})\x1b[0m\n")
+    }
+    ref_set(skipped_ref, ref_get(skipped_ref) + 1)
+
+    rec = map.new()
+    map.put_raw(rec, "name", description)
+    map.put_raw(rec, "status", "SKIP")
+    map.put_raw(rec, "duration_ns_str", "0")
+    if string.equals(reason, "") == 0 { map.put_raw(rec, "message", reason) }
+    list.add(its_list, rec)
+}
+
+// it_when(cond, description, reason, test_fn) — run the body only when
+// `cond` is non-zero; otherwise report a skip carrying `reason`.
+//
+// The condition is a plain int the caller computes, so the probe stays
+// visible at the call site rather than hidden behind a predicate:
+//
+//     have_ruby = ruby.ruby_init_host() == 0
+//     spec.it_when(have_ruby, "evaluates", "libruby not loadable") callback {
+//         ...
+//     }
+//
+// `reason` is REQUIRED even on the true path, where it is unused: Aether
+// cannot give it a default because a defaulted parameter may not precede a
+// non-defaulted one, and the trailing-block `callback` always occupies the
+// last slot. Pass "" when the condition is a constant true.
+//
+// test_fn is CALLED here rather than forwarded, for the closure-env
+// reason documented on it().
+it_when(_ctx: ptr, cond: int, description: string, reason: string, test_fn: fn) {
+    if cond == 0 {
+        _record_skip(_ctx, description, reason)
+        return
+    }
+    rec, old_failed, t0 = _it_begin(_ctx, description)
+    call(test_fn)
+    _it_end(_ctx, description, rec, old_failed, t0, 0)
+}
+
+// skip_it(description, reason, test_fn) — an it() that never runs.
+// For a PERMANENT exclusion (a known-broken path, an unsupported
+// platform) where the body is kept for the day it is re-enabled. Use
+// it_when for dependency gating; an unconditional skip that is really a
+// missing dependency hides the provisioning gap.
+skip_it(_ctx: ptr, description: string, reason: string, test_fn: fn) {
+    // test_fn is deliberately unused — the body does not run. It stays in
+    // the signature so re-enabling is a one-word edit (skip_it -> it).
+    _ = test_fn
+    _record_skip(_ctx, description, reason)
+}
+
+// skip_all_if(fw, cond, reason) — file-level bail-out. Returns 1 when the
+// caller should stop (and has already printed the notice), 0 to proceed:
+//
+//     if spec.skip_all_if(fw, have_ruby == 0, "libruby not loadable") == 1 {
+//         return
+//     }
+//
+// NB `cond` is evaluated eagerly by the caller, so an expensive probe
+// still runs. When the probe IS the dependency check that is exactly
+// right; when it is costly, guard the probe itself.
+skip_all_if(fw: ptr, cond: int, reason: string) -> int {
+    if cond == 0 { return 0 }
+    if string.equals(reason, "") == 1 {
+        println("\x1b[33m  ⊘ suite skipped\x1b[0m")
+    } else {
+        println("\x1b[33m  ⊘ suite skipped: ${reason}\x1b[0m")
+    }
+    return 1
 }
 
 // it_within(_ctx, description, budget, test_fn) — an it() that also
@@ -855,9 +963,11 @@ fn _teardown(fw: ptr) {
 run_summary(fw: ptr) {
     passed_ref = map.get_raw(fw, "passed")
     failed_ref = map.get_raw(fw, "failed")
+    skipped_ref = map.get_raw(fw, "skipped")
     depth_ref = map.get_raw(fw, "depth")
     passed = ref_get(passed_ref)
     failed = ref_get(failed_ref)
+    skipped = ref_get(skipped_ref)
 
     println("")
     if failed == 0 {
@@ -866,6 +976,13 @@ run_summary(fw: ptr) {
         println("\x1b[32m  ${passed} passing\x1b[0m")
         println("\x1b[31m  ${failed} failing\x1b[0m")
     }
+    // Skips are ALWAYS reported when non-zero (#1610): a run that skipped
+    // everything must not look like a run that passed everything. This is
+    // the line that distinguishes "green because it ran" from "green
+    // because it did not".
+    if skipped > 0 {
+        println("\x1b[33m  ${skipped} skipped\x1b[0m")
+    }
     println("")
 
     // Structured report — opt-in, off by default. Emitted only when the
@@ -873,10 +990,11 @@ run_summary(fw: ptr) {
     // (AE_SPEC_REPORT). `ae test --format=<fmt>` sets both per child and
     // aggregates; a plain `ae run foo.ae` from a terminal sets neither,
     // so this block is skipped and human output is the only output.
-    _emit_report(fw, passed, failed)
+    _emit_report(fw, passed, failed, skipped)
 
     ref_free(passed_ref)
     ref_free(failed_ref)
+    ref_free(skipped_ref)
     ref_free(depth_ref)
     _teardown(fw)
 
@@ -893,7 +1011,7 @@ run_summary(fw: ptr) {
 // An unrecognised or empty format is a no-op (human output already
 // printed). Writing to a file (not a pipe) means no 64K pipe-buffer
 // deadlock, so the report is emitted in full.
-_emit_report(fw: ptr, passed: int, failed: int) {
+_emit_report(fw: ptr, passed: int, failed: int, skipped: int) {
     // os.getenv returns a null pointer (== 0) for an unset variable, so
     // null-check BEFORE any string.* call (which would deref it). An
     // empty value counts as "not set" too.
@@ -909,10 +1027,10 @@ _emit_report(fw: ptr, passed: int, failed: int) {
         report = _format_tap(fw)
     } else {
         if string.equals(fmt, "aeocha") == 1 {
-            report = _format_aeocha_v1(fw, passed, failed)
+            report = _format_aeocha_v1(fw, passed, failed, skipped)
         } else {
             if string.equals(fmt, "aeocha-v1") == 1 {
-                report = _format_aeocha_v1(fw, passed, failed)
+                report = _format_aeocha_v1(fw, passed, failed, skipped)
             } else {
                 // Unknown format — nothing to write.
                 return
@@ -1019,7 +1137,7 @@ _tap_yaml_scalar(s: string) -> string {
 // parse it. Do not rename/remove header keys, change the `---`
 // separator, or reshape rows within version=1 — an incompatible change
 // MUST bump the leading `version=` line. Additive header keys are fine.
-_format_aeocha_v1(fw: ptr, passed: int, failed: int) -> string {
+_format_aeocha_v1(fw: ptr, passed: int, failed: int, skipped: int) -> string {
     its = map.get_raw(fw, "its")
     n = list.size(its)
     t_start_str = map.get_raw(fw, "t_start_ns_str")
@@ -1029,8 +1147,13 @@ _format_aeocha_v1(fw: ptr, passed: int, failed: int) -> string {
     total_duration_ns = os.now_monotonic_ns() - t_start_ns
     total_duration_ms = total_duration_ns / 1000000
 
+    // `total` stays passed+failed DELIBERATELY. docs/testing.md's contract
+    // permits ADDING keys (consumers ignore unknown ones) but forbids
+    // repurposing existing ones, and folding skips into `total` would
+    // silently change what every current consumer already parses.
+    // `skipped` rides alongside as a new key — additive, no version bump.
     total = passed + failed
-    header = "version=1\ntotal=${total}\npassed=${passed}\nfailed=${failed}\nerrored=0\nduration_ms=${total_duration_ms}\nduration_ns=${total_duration_ns}\n---\n"
+    header = "version=1\ntotal=${total}\npassed=${passed}\nfailed=${failed}\nskipped=${skipped}\nerrored=0\nduration_ms=${total_duration_ms}\nduration_ns=${total_duration_ns}\n---\n"
 
     rows = _build_rows(its, n)
     return string.concat(header, rows)

--- a/tests/regression/test_spec_module.ae
+++ b/tests/regression/test_spec_module.ae
@@ -77,6 +77,20 @@ main() {
             // through UFCS chaining; the failure-text formatting is
             // pinned by tests/integration/spec_why_message/, which can
             // observe output a green suite cannot.
+            // #1610: skip verbs. it_when(0,...) and skip_it must NOT run
+            // their bodies — each body below asserts something FALSE, so a
+            // verb that ran it would turn this suite red. That is the whole
+            // check: a skip that silently runs (or silently passes) is the
+            // failure mode the feature exists to prevent.
+            spec.it_when(0, "it_when(false) does not run its body", "deliberate") callback {
+                spec.assert_eq(0, 1, "MUST NOT RUN")
+            }
+            spec.skip_it("skip_it never runs its body", "deliberate") callback {
+                spec.assert_eq(0, 1, "MUST NOT RUN")
+            }
+            spec.it_when(1, "it_when(true) runs normally", "") callback {
+                spec.assert_eq(3, 3, "three")
+            }
             spec.it("optional why-message on every matcher") callback {
                 spec.expect_int(7).to_equal(7, "int equality carries intent")
                 spec.expect_int(7).to_be_gt(0, "budget is never zero")


### PR DESCRIPTION
Closes #1610. Supersedes #1608 (same goal, rewritten in Aether per review — please close that one in favour of this).

Three related changes.

## 1. `std.spec` skip verbs — #1610

```aether
have_ruby = 0
if ruby.ruby_init_host() == 0 { have_ruby = 1 }

spec.it_when(have_ruby, "evaluates a script", "libruby not loadable") callback {
    spec.assert_eq(ruby.ruby_run("$x = 1"), 0, "eval")
}
```

```
contrib.host.ruby
  ⊘ evaluates a script  (skipped: libruby not loadable)

  0 passing
  5 skipped
```

| verb | for |
|---|---|
| `it_when(cond, desc, reason)` | dependency gating — the common case |
| `skip_it(desc, reason)` | a **permanent** exclusion, body kept for re-enabling |
| `skip_all_if(fw, cond, reason)` | file-level bail-out |

Skipped bodies do not run, count in neither passed nor failed, and print a distinct `⊘` line. Exit status stays 0 — a skip is not a failure — but the count is on stdout and in the report, so a degraded box is **visible rather than quietly green**. That is the whole point: a box that skips everything used to look exactly like a box that passes everything, which is how nine silently-skipping `contrib/vulkan` tests and `ruby SKIP (no demo)` went unnoticed on the nightly.

**Report contract.** `skipped=N` is added to the aeocha-v1 header and skipped tests emit `SKIP` rows. This is **additive** — `docs/testing.md` already states new keys may be added and consumers must ignore unknown ones — so **no `version=` bump**. `total` deliberately stays `passed + failed`, because folding skips in would *repurpose* an existing key, the one thing the contract forbids.

**One design note discovered by trying it:** `reason` is required even on the true path. Aether cannot default it — a defaulted parameter may not precede a non-defaulted one, and the trailing-block `callback` always occupies the last slot. The compiler rejects the *call site*, not the declaration, so this is documented in the source rather than left as a trap.

## 2. `contrib/host/ruby/test_host_ruby.ae` — co-located, in Aether

You asked why this wasn't an `.ae` test. It should have been; my original justification ("matching `host_lua_bidirectional`") was convention-following, not a reason. Rewritten:

| | shell + C heredoc (#1608) | `.ae` + std.spec (this) |
|---|---|---|
| size | ~150 lines | ~20 lines of spec |
| tests the surface users use | ✗ the raw C ABI | ✓ `import contrib.host.ruby` |
| dogfoods our framework | ✗ | ✓ |
| header/soname/link plumbing | hand-rolled | `ae` handles it |

That second row is the substantive one: a C harness would still pass if `module.ae`'s extern declarations had drifted from the C shim. Going through the import covers the module declarations and contrib-link plumbing too.

Five specs: evaluation; that the interpreter **genuinely runs** (Ruby computes a value and a second eval asserts on it Ruby-side — a bridge that loads libruby but never evaluates would satisfy a return-code check alone); exceptions **and** syntax errors propagating as failures rather than being swallowed; and init idempotence while the VM is live. Verified both ways — **5 passing** with Ruby present, **0 passing / 5 skipped / exit 0** with a bogus soname.

`make contrib-host-check` gains a `[3/3]` phase auto-discovering `contrib/host/*/test_*.ae`, performing the documented `LIBRUBY_SO` probe first, so the next bridge to add a spec needs no Makefile change.

**A bug I caught in my own wiring:** the first version piped `ae run` through `sed`, which swallowed the exit code — a deliberately failing test gave `make rc=0`, making the gate pure decoration. Now output is captured then printed; re-verified `rc=2` on failure and `rc=0` on success.

## 3. Two bridge behaviours documented (not fixed)

- **Ruby's `puts` output is buffered and silently vanishes** unless `ruby_finalize_host()` runs or the script sets `$stdout.sync = true`. The script *did* execute — confirmed by having Ruby write a file instead, which appeared with correct contents while the `puts` did not. This is why the spec asserts on return codes and Ruby-side state, never on the bridge's stdout.
- **`ruby_finalize_host()` is terminal.** CRuby's `ruby_finalize()` destroys the VM permanently, yet a post-finalize `ruby_init_host()` returns **0** and the next `ruby_run()` segfaults inside libruby. Documented as "call it once at shutdown, or not at all". I deliberately did **not** change the bridge: whether post-finalize init should return non-zero, or finalize become a no-op, is a design call for whoever owns it. The spec pins the supported lifecycle and leaves the unsupported path untested, so a future fix has a baseline to change rather than a test to fight.

## Verification

`test_spec_module` **12 passing, 2 skipped** — the two new skip cases assert something *false* in their bodies, so a verb that wrongly ran one would turn the suite red. `spec_format_reporting`, `std_testing_arms`, `spec_why_message` all pass; fmt gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)