### PR TITLE
fix(contrib): probe_ruby falls back to rbconfig when there is no ruby.pc

### DIFF
--- a/tests/scripts/contrib_build.sh
+++ b/tests/scripts/contrib_build.sh
@@ -190,12 +190,34 @@ probe_python() {
 }
 
 probe_ruby() {
-    for v in ruby-3.2 ruby-3.1 ruby-3.0 ruby; do
+    # pkg-config first, when the distro ships a .pc.
+    for v in ruby-3.4 ruby-3.3 ruby-3.2 ruby-3.1 ruby-3.0 ruby; do
         if pkg-config --exists "$v" 2>/dev/null; then
             pkg-config --cflags-only-I "$v"
             return 0
         fi
     done
+    # Fall back to asking RUBY ITSELF. Several distributions (CachyOS/Arch
+    # among them) install the headers with NO ruby.pc at all, so every
+    # pkg-config branch above fails and the bridge silently never builds —
+    # observed on the nightly box, where ruby 3.4.10 was installed and
+    # `contrib-host-check` still reported "libaether_host_ruby.a
+    # unavailable". A hardcoded version list also ages badly: this one
+    # stopped at 3.2 while the box had 3.4.
+    #
+    # rubyhdrdir + rubyarchhdrdir are what ruby's own extension builds use,
+    # so they are correct wherever ruby runs. Same principle as the soname
+    # probes in the [3/3] spec phase: ask the runtime, do not guess at the
+    # packaging.
+    if command -v ruby >/dev/null 2>&1; then
+        rb_inc="$(ruby -rrbconfig -e 'print RbConfig::CONFIG["rubyhdrdir"]' 2>/dev/null)"
+        rb_arch="$(ruby -rrbconfig -e 'print RbConfig::CONFIG["rubyarchhdrdir"]' 2>/dev/null)"
+        if [ -n "$rb_inc" ] && [ -f "$rb_inc/ruby.h" ]; then
+            printf -- '-I%s' "$rb_inc"
+            [ -n "$rb_arch" ] && printf -- ' -I%s' "$rb_arch"
+            return 0
+        fi
+    fi
     return 1
 }
 


### PR DESCRIPTION
Found by running the nightly on the CachyOS box after today's merges — see the run notes below, since the nightly itself was otherwise ALL GREEN.

## The symptom

`make contrib-host-check`'s `[3/3]` phase reported:

```
  --- duktape ---   5 passing
  --- lua ---       5 passing
  --- perl ---      5 passing
  --- python ---    5 passing
  --- ruby ---      SKIP: libaether_host_ruby.a unavailable (bridge deps not installed)
```

on a machine with **ruby 3.4.10 and its headers installed**. The skip was honest — it named the reason and didn't pretend to pass — but the dependency was present, so it should have run.

## The cause

`probe_ruby()` tried `pkg-config` for `ruby-3.2`, `ruby-3.1`, `ruby-3.0`, `ruby`, and nothing else. CachyOS (Arch) ships the headers with **no `ruby.pc` at all**, so every branch failed. The hardcoded list had also aged badly: it stopped at 3.2 while the box had 3.4.

## The fix

Ask **Ruby itself** via `rbconfig`'s `rubyhdrdir`/`rubyarchhdrdir` — the same paths Ruby's own extension builds use, so they're correct wherever Ruby runs. `pkg-config` is still tried first (with 3.4/3.3 added), so distributions shipping a `.pc` are unaffected.

Same principle as the soname probes in #1613: **ask the runtime, don't guess at the packaging**. This is now the fourth instance of that pattern in a week — alongside the Vulkan headers on this same box, `ae --version` reporting the pin (#1602), and the MinGW cross-compile include probe (#1605).

## Verified on both boxes

| box | before | after |
|---|---|---|
| Debian (has `ruby.pc`) | pkg-config path, veneer builds | **unchanged** — still pkg-config, still builds |
| CachyOS (no `.pc`) | probe fails, bridge skipped | yields working `-I` flags, compiles a `ruby.h` probe, **veneer builds** (12,218 bytes) |

## One thing this does NOT fix

The Ruby **spec** still doesn't pass on CachyOS: with the veneer now built, ruby 3.4 segfaults inside libruby partway through it (`[BUG] Segmentation fault at 0x0000000000000010`), after the first spec passes. Two consecutive `ruby_run` calls in isolation are fine, so it needs more of the spec's context to reproduce.

That's a **separate defect** and I'm filing it apart rather than bundling it here. This PR fixes the bridge being *invisible*; it does not claim the bridge works on Ruby 3.4. Worth knowing before anyone reads a future green `[3/3]` as proof of 3.4 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)