### PR TITLE
fix(ae): forward SIGTERM/SIGINT/SIGHUP from `ae run` to the program it launched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **`ae run` now forwards `SIGTERM`/`SIGINT`/`SIGHUP` to the program it
+  launched.** `ae run prog.ae & ; kill $!` killed only the wrapper and
+  orphaned the program, which kept whatever socket it had bound: `ae run`
+  builds and then *spawns* the binary (it cannot `exec` it — it still has
+  to evict a crashed binary from the cache and delete a non-cached temp
+  exe), so the wrapper was always a separate process.
+  Ephemeral CI cannot catch this, because the runner is discarded with its
+  orphans. On a persistent box the orphan squats its port and the next run
+  of the same test fails to bind, so a green run poisons the one after it
+  with no code change in between. 25 integration tests background `ae run`
+  and kill `$!`, so this is fixed once in the driver rather than 25 times
+  in the tests.
+  Scoped to the program run: build steps keep the plain path, handlers are
+  installed only while the child is alive and the previous dispositions
+  restored after, and `waitpid` resumes on `EINTR` (abandoning it there
+  would orphan the child — the bug itself). Windows is unchanged; the
+  report is POSIX-specific.
+  Regression test in `tests/integration/ae_run_signal_forwarding/`,
+  verified to FAIL against an `ae` built without the fix.
+
 ### Changed
 
 - `contrib/host/aether` and `contrib/host/factor` gain co-located specs,

--- a/tests/integration/ae_run_signal_forwarding/test_ae_run_signal_forwarding.sh
+++ b/tests/integration/ae_run_signal_forwarding/test_ae_run_signal_forwarding.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# `ae run <prog>.ae &` + `kill $!` must not orphan the program.
+#
+# ae run BUILDS then SPAWNS the binary and waits — it does not exec it,
+# because it still has cleanup to do afterwards (evict a crashed binary
+# from the cache, delete a non-cached temp exe). So killing the wrapper
+# used to leave the child running, holding whatever socket it had bound.
+#
+# Ephemeral CI cannot catch this: the runner is discarded. On a persistent
+# box the orphan squats the port and the NEXT run of the same test fails
+# to bind — a green run poisoning the one after it with no code change in
+# between. That is how it was found (aeci's proxtek VM, 2026-08-16).
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if [ ! -x "$AE" ]; then
+    echo "  [SKIP] ae_run_signal_forwarding: $AE not built"
+    exit 0
+fi
+case "$(uname -s 2>/dev/null)" in
+    Linux|Darwin) ;;
+    *) echo "  [SKIP] ae_run_signal_forwarding: POSIX-only (kill \$! semantics)"; exit 0 ;;
+esac
+if ! command -v pgrep >/dev/null 2>&1; then
+    echo "  [SKIP] ae_run_signal_forwarding: pgrep not available"
+    exit 0
+fi
+
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+cat > "$TMPDIR_T/longrun.ae" <<'EOF'
+extern sleep(ms: int)
+main() {
+    println("UP")
+    i = 0
+    while i < 120 { sleep(1000); i = i + 1 }
+}
+EOF
+
+AETHER_HOME="$ROOT" "$AE" run "$TMPDIR_T/longrun.ae" > "$TMPDIR_T/out.log" 2>&1 &
+WRAPPER=$!
+
+# Wait for the program itself to be up, not merely for ae to have started:
+# the build has to finish first.
+CHILD=""
+for _ in $(seq 1 60); do
+    sleep 0.5
+    CHILD="$(pgrep -P "$WRAPPER" 2>/dev/null | head -1)"
+    [ -n "$CHILD" ] && break
+done
+
+if [ -z "$CHILD" ]; then
+    # Nothing to assert against — the program never got far enough. Do not
+    # fail: on a loaded or restricted box this is environmental.
+    kill "$WRAPPER" 2>/dev/null
+    echo "  [SKIP] ae_run_signal_forwarding: child never observed"
+    exit 0
+fi
+
+kill "$WRAPPER" 2>/dev/null
+sleep 2
+
+if kill -0 "$CHILD" 2>/dev/null; then
+    kill -9 "$CHILD" 2>/dev/null
+    echo "  [FAIL] ae_run_signal_forwarding: child $CHILD survived the wrapper (orphaned)"
+    exit 1
+fi
+
+echo "  [PASS] ae_run_signal_forwarding: killing ae run also terminated the program"
+exit 0

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <ctype.h>
 #include <limits.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <time.h>     // gc_stale_cache_tmp age gate (#1032)
 
@@ -42,6 +43,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/wait.h>
+#include <signal.h>
 #include <spawn.h>
 #include <libgen.h>
 #include <dirent.h>
@@ -578,6 +580,97 @@ int run_cmd_show_warnings(const char* cmd) {
     return posix_run(cmd, 2);
 #else
     return win_run(cmd, 2);
+#endif
+}
+
+#ifndef _WIN32
+/* The pid of the program `ae run` launched, for the signal forwarder.
+ * volatile sig_atomic_t because the handler reads it. 0 = nothing running. */
+static volatile sig_atomic_t g_child_pid = 0;
+
+/* Forward a terminating signal to the child, then re-raise it so `ae`
+ * dies of the same signal it was sent (correct $? for the shell).
+ *
+ * WHY THIS EXISTS: `ae run` builds, then SPAWNS the built binary and
+ * waits — it does not exec it, because it still has work to do afterwards
+ * (evict a crashed binary from the cache, delete a non-cached temp exe).
+ * That means `ae run server.ae & ; kill $!` killed only the wrapper and
+ * ORPHANED the server, which kept its listening socket. On an ephemeral
+ * CI runner nobody notices; on a persistent box the orphan squats the
+ * port and the NEXT run of the same test fails to bind — a green run
+ * poisoning the one after it, with no code change in between.
+ *
+ * Forwarding rather than exec'ing keeps the post-run cleanup intact. */
+static void forward_signal_to_child(int sig) {
+    if (g_child_pid > 0) kill((pid_t)g_child_pid, sig);
+    /* Restore the default and re-raise so we report death-by-signal
+     * rather than exiting 0 out of a handler. */
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+#endif
+
+/* Run the just-built program, forwarding termination signals to it.
+ * Used ONLY for the program `ae run` launches — build steps (aetherc,
+ * gcc) keep the plain run_cmd path, where forwarding would be wrong. */
+int run_cmd_forwarding(const char* cmd) {
+#ifdef _WIN32
+    /* Windows has no SIGTERM-to-child model that matches this; the
+     * orphaning report is POSIX-specific (kill $! in a shell test). */
+    return win_run(cmd, 0);
+#else
+    if (tc.verbose) fprintf(stderr, "[cmd] %s\n", cmd);
+    char buf[AE_CMD_BUF];
+    strncpy(buf, cmd, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    char* toks[512];
+    int n = 0;
+    for (char* p = buf; *p && n < 511; ) {
+        while (*p == ' ') p++;
+        if (!*p) break;
+        if (*p == '"') {
+            p++;
+            toks[n++] = p;
+            while (*p && *p != '"') p++;
+            if (*p) *p++ = '\0';
+        } else {
+            toks[n++] = p;
+            while (*p && *p != ' ') p++;
+            if (*p) *p++ = '\0';
+        }
+    }
+    toks[n] = NULL;
+    if (n == 0) return 0;
+
+    pid_t pid;
+    if (posix_spawnp(&pid, toks[0], NULL, NULL, toks, environ) != 0) return -1;
+    g_child_pid = (sig_atomic_t)pid;
+
+    /* Install forwarders only while the child is alive, and keep the
+     * previous dispositions so `ae` is unchanged for every other path. */
+    struct sigaction sa;
+    struct sigaction old_term, old_int, old_hup;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = forward_signal_to_child;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGTERM, &sa, &old_term);
+    sigaction(SIGINT,  &sa, &old_int);
+    sigaction(SIGHUP,  &sa, &old_hup);
+
+    int status = 0;
+    /* EINTR: a forwarded signal interrupts waitpid; resume rather than
+     * abandoning the child (which would orphan it — the very bug). */
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) { }
+
+    sigaction(SIGTERM, &old_term, NULL);
+    sigaction(SIGINT,  &old_int,  NULL);
+    sigaction(SIGHUP,  &old_hup,  NULL);
+    g_child_pid = 0;
+
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    if (WIFSIGNALED(status)) return -WTERMSIG(status);
+    return -1;
 #endif
 }
 
@@ -3170,7 +3263,7 @@ static int cmd_run(int argc, char** argv) {
             off += (size_t)w;
         }
     }
-    int rc = run_cmd(cmd);
+    int rc = run_cmd_forwarding(cmd);
 
     if (rc < 0) {
         fprintf(stderr, "Program crashed (signal %d", -rc);


### PR DESCRIPTION
Takes on `asks/ae-run-orphans-backgrounded-server-child.md`.

`ae run prog.ae & ; kill $!` killed only the wrapper and **orphaned the
program**, which kept whatever socket it had bound.

## Root cause — confirmed in the source

`ae run` builds, then `posix_spawnp`s the binary and `waitpid`s. It does
not `exec` it, because it still has work to do afterwards: evict a crashed
binary from the cache, delete a non-cached temp exe. So the wrapper is
always a separate process, and a signal sent to it never reached the
child.

(The ask wondered whether exec was ever the model, given the
`AE_TEST_RUNNER` changelog wording. It wasn't — `posix_run` has always
been spawn+wait. The wrapper simply never forwarded death to its child.)

## Why it only shows up on a persistent box

Ephemeral CI structurally cannot catch this: the runner is discarded with
its orphans. On a long-lived box the orphan squats its port and the **next**
run of the same test fails to bind — a green run poisoning the one after
it, with no code change in between.

This box had one too, found while investigating:

```
LISTEN 127.0.0.1:18293  users:(("6d9eed689398f63",pid=31500,fd=15))
```

Same hash-named-binary shape as the reported `cd50997528bcde3` /
`613908e2da08364`.

## Scope — one fix, not 25

**25 integration tests** background `ae run` and kill `$!`
(`http_client_forward_proxy` is just the one whose port collision surfaces
first). Fixing the driver fixes all of them, current and future, and
matches what any shell user expects `kill $!` to do.

## Forwarding rather than exec

The ask offers exec as the preferred option and it would also work — but it
would skip the post-run cleanup above. A handler that forwards the signal
and then re-raises it keeps that cleanup **and** still gives the shell the
right `$?`.

Deliberately narrow:
- Applies **only** to the program run. Build steps (aetherc, gcc) keep the
  plain `run_cmd` path, where forwarding would be wrong.
- Handlers are installed only while the child is alive, and the previous
  dispositions are restored afterwards — every other path through `ae` is
  byte-for-byte unchanged.
- `waitpid` resumes on `EINTR`. Abandoning the wait there would orphan the
  child, which is the bug itself.
- Windows keeps `win_run`: the report is POSIX-specific (`kill $!` in a
  shell test) and there is no matching SIGTERM-to-child model there.

## Verified

**A/B on the exact logic**, in a standalone harness replicating
`run_cmd_forwarding`:

| | child after `kill` on the wrapper |
|---|---|
| without forwarding | **SURVIVED** (orphaned) |
| with forwarding | died — reported `CHILD-GOT-SIGTERM` |

**The regression test was checked both ways.** `tests/integration/ae_run_signal_forwarding/`
fails (`child NNNN survived the wrapper (orphaned)`) against an `ae` built
without the fix, and passes with it — so it actually detects the bug
rather than merely passing.

**Normal behaviour re-checked:** exit 0 and exit 7 propagate; an aborting
program still prints `Program crashed (signal 6: aborted)`, so the
crashed-binary cache-eviction path still runs.

The test skips rather than fails where it cannot observe a child (no
`pgrep`, non-POSIX, or the program never got far enough), so it will not
add flake on constrained runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)