### PR TITLE
fix: schema_api member routes (#1625) and actor ask inside closures (#1626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ version number before tagging the release.
 
 ### Fixed
 
+- **Actors are usable from inside closures (#1626).** Two codegen gaps hit
+  any actor used from a closure or trailing block — e.g. a `std.spec` `it`
+  block. `a ? Msg {}` lowered to nothing, because closure BODIES were
+  emitted before the message types had been registered, so the ask could
+  not resolve the message and emitted an error comment where the
+  expression belonged. And a captured actor handle got an env slot typed
+  with the bare actor name before that name was typedef'd, so it read as
+  an implicit `int`. Closure declarations now emit early (other code
+  references them) while bodies emit after the message definitions, and
+  each actor gets a forward `typedef struct X X;`. Actor specs no longer
+  need the hoist-the-exchange-into-a-helper workaround.
+- **`tinyweb.schema_api` member routes now match (#1625).**
+  `show`/`update`/`destroy` were registered as the regex `"/(\w+)"`, but
+  the tinyweb router does not do regex — it supports exact segments,
+  Express-style `:param`, and `*`. Every real member request 404'd, and
+  had since they were written; `update` is the costly one, being the other
+  validated verb. They now use `/:id`.
+  The auto-mounted `GET {prefix}/schema` also had to move. The router
+  matches in REVERSE registration order (tinyweb walks its list forward
+  while `http_server_add_route` prepends), so `json_api()`'s own route was
+  tried *after* everything the user declared and `show()` answered
+  `/schema` with `"schema"` as the id. Each leaf builder now mounts
+  `/schema` after registering its own route.
+
+
+### Fixed
+
 - **`ae run` now forwards `SIGTERM`/`SIGINT`/`SIGHUP` to the program it
   launched.** `ae run prog.ae & ; kill $!` killed only the wrapper and
   orphaned the program, which kept whatever socket it had bound: `ae run`

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -5471,6 +5471,22 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
         fprintf(gen->output, ");\n");
     }
 
+    /* Forward typedef for each actor, so the BARE name is usable before the
+     * actor's own `typedef struct X { ... } X;` is emitted.
+     *
+     * A closure that captures an actor handle gets an env slot typed from
+     * lookup_var_c_type, which yields the bare "X" — but the closure env
+     * typedef is emitted well before the actor struct, so the slot read as
+     * an implicit int and the C compiler reported "initialization of 'X *'
+     * from incompatible pointer type 'int *'". C allows repeating a
+     * typedef with the same definition, so the later full definition is
+     * unaffected. (#1626) */
+    for (int i = 0; i < program->child_count; i++) {
+        ASTNode* child = program->children[i];
+        if (!child || child->type != AST_ACTOR_DEFINITION || !child->value) continue;
+        fprintf(gen->output, "typedef struct %s %s;\n", child->value, child->value);
+    }
+
     // Forward declarations for actor spawn functions (actors can spawn other actors
     // from within receive handlers, which appear before the spawn function definition)
     for (int i = 0; i < program->child_count; i++) {
@@ -5539,8 +5555,8 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     emit_bare_fn_adapter_decls(gen);
 
     if (gen->closure_count > 0) {
-        print_line(gen, "// Closure definitions");
-        emit_closure_definitions(gen);
+        print_line(gen, "// Closure declarations");
+        emit_closure_declarations(gen);
     }
 
     emit_bare_fn_adapters(gen);
@@ -5896,6 +5912,15 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
             default:
                 break;
         }
+    }
+
+    /* Closure BODIES, after the loop above has emitted the message
+     * definitions (and so registered them with gen->message_registry).
+     * A body containing `a ? Msg {}` needs that registry populated; the
+     * forward declarations went out early, before this loop. (#1626) */
+    if (gen->closure_count > 0) {
+        print_line(gen, "// Closure definitions");
+        emit_closure_definitions(gen);
     }
 
     // --emit=lib / --emit=both: append aether_<name> alias stubs that form

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1754,8 +1754,9 @@ static void emit_closure_env_typedef(CodeGenerator* gen, int ci) {
  * definitions. A closure body containing `a ? Msg {}` lowers through the
  * codegen message registry, which is not populated until the
  * AST_MESSAGE_DEFINITION arm runs — so emitting bodies before that arm
- * produced `int r = /* ERROR: unknown message type Msg *\/;` and the C
- * compiler stopped at "expected expression before ';'". The declarations
+ * produced an "unknown message type" error comment where the expression
+ * belonged, and the C compiler stopped at "expected expression before
+ * ';'". The declarations
  * have no such dependency, so they stay early (other emitted code
  * references them) while the bodies move after the messages. (#1626) */
 void emit_closure_declarations(CodeGenerator* gen) {

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1748,8 +1748,17 @@ static void emit_closure_env_typedef(CodeGenerator* gen, int ci) {
 // (e.g. when an inline `|a,b| { ... }` lambda is passed as an argument
 // inside the outer closure's body). Pass 2 emits bodies + MSVC
 // constructor helpers.
-void emit_closure_definitions(CodeGenerator* gen) {
-    // Pass 1: forward declarations.
+/* Pass 1 only: env typedefs + forward declarations.
+ *
+ * Split out from the bodies so the two halves can straddle the message
+ * definitions. A closure body containing `a ? Msg {}` lowers through the
+ * codegen message registry, which is not populated until the
+ * AST_MESSAGE_DEFINITION arm runs — so emitting bodies before that arm
+ * produced `int r = /* ERROR: unknown message type Msg *\/;` and the C
+ * compiler stopped at "expected expression before ';'". The declarations
+ * have no such dependency, so they stay early (other emitted code
+ * references them) while the bodies move after the messages. (#1626) */
+void emit_closure_declarations(CodeGenerator* gen) {
     for (int ci = 0; ci < gen->closure_count; ci++) {
         emit_closure_env_typedef(gen, ci);
         const char* ret_type = resolve_closure_return_type(gen, ci);
@@ -1757,7 +1766,9 @@ void emit_closure_definitions(CodeGenerator* gen) {
         fprintf(gen->output, ";\n");
     }
     if (gen->closure_count > 0) fprintf(gen->output, "\n");
+}
 
+void emit_closure_definitions(CodeGenerator* gen) {
     // Pass 2: bodies and constructors.
     for (int ci = 0; ci < gen->closure_count; ci++) {
         int id = gen->closures[ci].id;

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1770,6 +1770,20 @@ void emit_closure_declarations(CodeGenerator* gen) {
 }
 
 void emit_closure_definitions(CodeGenerator* gen) {
+    /* A closure body is not a continuation of whatever function was
+     * emitted last, so it must not inherit that function's return type.
+     * gen->current_func_return_type feeds the `_builder_ret` type in
+     * return lowering; leaving a stale value there made a closure that
+     * `return 0`s emit `_tuple_int_string _builder_ret = 0;` when the
+     * previously-emitted function happened to return a tuple.
+     *
+     * This was latent while bodies were emitted before the top-level
+     * function loop (the field was still NULL then). Moving them after
+     * the message definitions for #1626 exposed it, so it is saved and
+     * cleared here rather than relying on emission position. */
+    Type* saved_ret = gen->current_func_return_type;
+    gen->current_func_return_type = NULL;
+
     // Pass 2: bodies and constructors.
     for (int ci = 0; ci < gen->closure_count; ci++) {
         int id = gen->closures[ci].id;
@@ -2019,6 +2033,8 @@ void emit_closure_definitions(CodeGenerator* gen) {
             fprintf(gen->output, "#endif\n\n");
         }
     }
+
+    gen->current_func_return_type = saved_ret;
 }
 
 // Look up a message field definition by name. Returns NULL if missing.

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -367,6 +367,7 @@ void generate_main_function(CodeGenerator* gen, ASTNode* main);
 
 /* Closure support (codegen_expr.c) */
 void discover_closures(CodeGenerator* gen, ASTNode* node);
+void emit_closure_declarations(CodeGenerator* gen);
 void emit_closure_definitions(CodeGenerator* gen);
 /* L4 validation: reject closures inside actor handlers that write to
    actor state fields. Run after discover_closures, before codegen.

--- a/contrib/tinyweb/schema_api/module.ae
+++ b/contrib/tinyweb/schema_api/module.ae
@@ -56,6 +56,7 @@ struct ApiGroup {
     ctx: ptr // the underlying tinyweb path/context map
     resource: ptr // *std.schema.Schema (opaque ptr here)
     prefix: string
+    schema_mounted: int // guards the lazy GET {prefix}/schema mount
 }
 
 // An ApiGroup carries the mount prefix + resource, so a list of the groups
@@ -74,6 +75,7 @@ json_api(_ctx: ptr, prefix: string, resource: ptr) -> ptr {
     g.ctx = grp_ctx
     g.resource = resource
     g.prefix = prefix
+    g.schema_mounted = 0
 
     // Mount the validating filter for all write methods on this path subtree.
     // The filter closure captures `resource`; on failure it writes the response
@@ -88,19 +90,44 @@ json_api(_ctx: ptr, prefix: string, resource: ptr) -> ptr {
         return validate_body(res, req, resource)
     }
 
-    // Auto-mount GET {prefix}/schema — the resource's own draft-07 JSON Schema
-    // (std.schema.to_json_schema). "A declarative resource is a projectable
-    // artifact": the same declaration that validates requests also serves its
-    // contract. Registered before the user's show() route so /schema isn't
-    // swallowed by a GET /(\w+) id matcher.
-    end_point(grp_ctx, GET, "/schema") | req: ptr, res: ptr, ctx: ptr | {
+    // GET {prefix}/schema is NOT mounted here — see mount_schema_route().
+
+    return g
+}
+
+// Auto-mount GET {prefix}/schema — the resource's own draft-07 JSON Schema
+// (std.schema.to_json_schema). "A declarative resource is a projectable
+// artifact": the same declaration that validates requests also serves its
+// contract.
+//
+// ORDERING IS WHY THIS IS NOT IN json_api(). The router matches routes in
+// REVERSE registration order: tinyweb walks its route list forward, but
+// http_server_add_route PREPENDS each one
+// (`route->next = server->routes; server->routes = route`), so the
+// LAST route registered is the FIRST one tried.
+//
+// json_api()'s body runs BEFORE its trailing block, so anything it
+// registers is tried AFTER everything the user declares — the opposite of
+// what a literal reading suggests. Mounting /schema there put it behind
+// the user's show() route, so `GET {prefix}/schema` was answered by
+// show() with "schema" as the id.
+//
+// Every leaf builder therefore calls this AFTER registering its own
+// route. create()/index() cover a resource that declares no member verb;
+// show()/update()/destroy() re-mount it after theirs, and because a later
+// registration is tried earlier, that last mount is the one that wins
+// over `/:id`. Re-mounting is deliberate — the duplicate route is
+// unreachable and costs one list node, which is the cheap way to get the
+// ordering right without knowing what the user will declare next.
+fn mount_schema_route(g: *ApiGroup) {
+    g.schema_mounted = 1
+    resource = g.resource
+    end_point(g.ctx, GET, "/schema") | req: ptr, res: ptr, ctx: ptr | {
         js = schema.to_json_schema(resource)
         response_set_header(res, "Content-Type", "application/schema+json")
         response_json(res, js)
         string.string_free(js)
     }
-
-    return g
 }
 
 // Parse the request body as JSON, coerce it into a schema-input map, and run
@@ -249,30 +276,41 @@ fn write_validation_errors(res: ptr, errors: ptr) {
 create(_ctx: ptr, handler: fn) {
     g = _ctx as *ApiGroup
     end_point(g.ctx, POST, "/", handler)
+    // Covers a resource that declares no member verb at all. If a member
+    // verb IS declared later it re-mounts /schema after its own route, and
+    // that later registration is the one that wins — see
+    // mount_schema_route().
+    mount_schema_route(g)
 }
 
 // index -> GET {prefix}/  (list; not validated — no body)
 index(_ctx: ptr, handler: fn) {
     g = _ctx as *ApiGroup
     end_point(g.ctx, GET, "/", handler)
+    mount_schema_route(g)
 }
 
-// show -> GET {prefix}/(\w+)
+// show -> GET {prefix}/:id
 show(_ctx: ptr, handler: fn) {
     g = _ctx as *ApiGroup
-    end_point(g.ctx, GET, "/(\\w+)", handler)
+    end_point(g.ctx, GET, "/:id", handler)
+    // Registered AFTER the member route so it outranks it — see
+    // mount_schema_route()'s note on reverse match order.
+    mount_schema_route(g)
 }
 
-// update -> PUT {prefix}/(\w+)  (validated)
+// update -> PUT {prefix}/:id  (validated)
 update(_ctx: ptr, handler: fn) {
     g = _ctx as *ApiGroup
-    end_point(g.ctx, PUT, "/(\\w+)", handler)
+    end_point(g.ctx, PUT, "/:id", handler)
+    mount_schema_route(g)
 }
 
-// destroy -> DELETE {prefix}/(\w+)
+// destroy -> DELETE {prefix}/:id
 destroy(_ctx: ptr, handler: fn) {
     g = _ctx as *ApiGroup
-    end_point(g.ctx, DELETE, "/(\\w+)", handler)
+    end_point(g.ctx, DELETE, "/:id", handler)
+    mount_schema_route(g)
 }
 
 // ---- OpenAPI aggregate (FastAPI-style /openapi.json) ----

--- a/contrib/tinyweb/test_schema_api.ae
+++ b/contrib/tinyweb/test_schema_api.ae
@@ -10,10 +10,15 @@
 //
 // COVERAGE GAP CLOSED. The original mounted only `create`, so four of the
 // module's seven exports — index, show, update and destroy — were never
-// exercised despite the module being wired into CI. All four are mounted
-// and driven here. `update` matters most of the group: it is the other
-// VALIDATED verb, so a regression in validation on the PUT path was
+// exercised despite the module being wired into CI. All five verbs are
+// mounted and driven here. `update` matters most of the group: it is the
+// other VALIDATED verb, so a regression in validation on the PUT path was
 // previously invisible.
+//
+// Closing that gap is what surfaced #1625 — the member routes had never
+// matched a request, because they were registered as a regex against a
+// router that does not do regex. Fixed in the module; these specs are the
+// ones that were skipped against it.
 //
 // The original called exit(1) on the first mismatch, so one bad status
 // code hid every later case — including the OpenAPI document at the end.
@@ -30,27 +35,6 @@ import std.string(string_contains)
 
 extern exit(code: int)
 extern sleep(ms: int)
-
-// schema_api mounts its member routes (show/update/destroy) as the regex
-// "/(\\w+)". The tinyweb router does not do regex — http_route_matches in
-// std/net/aether_http_server.c supports exact segments, Express-style
-// ":param", and a "*" wildcard, and treats anything else as a literal. So
-// those three routes can only match a URL that literally contains
-// "/(\\w+)", and every real member request 404s.
-//
-// This is why the gap mattered: the routes have never worked, and nothing
-// noticed, because nothing exercised them. The specs are written out in
-// full and skipped rather than deleted — they pass as-is once the module
-// registers a pattern the router understands (verified locally by
-// switching the three patterns to "/:id": all three then pass).
-//
-// Filed as #1625. Not fixed here: that edit belongs to the module, not to a test
-// conversion, and it needs a companion change — with ":id" live, the
-// auto-mounted GET {prefix}/schema is shadowed by show(), because the
-// user's trailing block registers before json_api's own route and first
-// match wins. The module comment claims /schema is "registered before the
-// user's show() route", which the observed 404 disproves.
-const MEMBER_ROUTE_BUG = "#1625 — schema_api member routes use regex; the tinyweb router does not support it"
 
 // Handlers only run on a validated body, so they can assume the happy
 // path. Each echoes something distinctive so the spec can prove the
@@ -186,7 +170,7 @@ main() {
         // dead-member-route bug below — the route never matches, so this
         // asserts nothing until schema_api registers a pattern the router
         // understands.
-        spec.skip_it(fw, "validates the update path too", MEMBER_ROUTE_BUG) callback {
+        spec.it(fw, "validates the update path too") callback {
             ok = put("/users/7", "{\"age\":40,\"name\":\"Grace\"}")
             spec.assert_eq(http_response_status_code(ok), 200, "a valid PUT reaches the handler")
             spec.assert_eq(string_contains(http_response_body_str(ok), "update"), 1,
@@ -213,7 +197,7 @@ main() {
             http_response_free(r)
         }
 
-        spec.skip_it(fw, "routes show to the member handler", MEMBER_ROUTE_BUG) callback {
+        spec.it(fw, "routes show to the member handler") callback {
             r = get("/users/42")
             spec.assert_eq(http_response_status_code(r), 200, "show responds 200")
             spec.assert_eq(string_contains(http_response_body_str(r), "show"), 1,
@@ -221,7 +205,7 @@ main() {
             http_response_free(r)
         }
 
-        spec.skip_it(fw, "routes destroy and preserves its status", MEMBER_ROUTE_BUG) callback {
+        spec.it(fw, "routes destroy and preserves its status") callback {
             r = del("/users/42")
             spec.assert_eq(http_response_status_code(r), 204,
                 "the handler's 204 is not rewritten")

--- a/contrib/vulkan/test_vulkan_actors.ae
+++ b/contrib/vulkan/test_vulkan_actors.ae
@@ -136,11 +136,14 @@ actor Painter {
 }
 
 // The whole two-actor exchange, in one function, returning the four verdicts.
-// It lives outside the it() block below for two compiler reasons: an ask
-// (`a ? Poll {}`) does not lower inside a closure body, and an actor handle
-// captured by a closure is emitted without its `struct` keyword. Both are
-// pre-existing gaps, so the ordering-sensitive sequence stays here intact and
-// the it() block only asserts on what it returns.
+//
+// It originally sat outside the it() block to work around #1626 — an ask did
+// not lower inside a closure body, and a captured actor handle lost its
+// `struct` keyword. Both are fixed, so this COULD now be inlined into the
+// block. It stays a named function because the sequence is
+// ordering-sensitive: both actors must be started before either is polled
+// (see the note below), and keeping it whole in one place makes that
+// constraint legible rather than something to re-derive from an it() body.
 run_painters(dev: ptr) -> (int, int, int, int) {
     a = spawn(Painter())
     b = spawn(Painter())

--- a/tests/regression/test_issue1626_ask_in_closure.ae
+++ b/tests/regression/test_issue1626_ask_in_closure.ae
@@ -1,0 +1,75 @@
+// #1626 — actor `ask` inside a closure body, and an actor handle captured
+// by a closure.
+//
+// Two codegen gaps, both triggered by using an actor from inside a
+// closure / trailing block (e.g. a std.spec `it` block):
+//
+//   1. `a ? Msg {}` lowered to nothing inside a closure. Closure BODIES
+//      were emitted before the AST_MESSAGE_DEFINITION arm had registered
+//      the message types, so the ask lowering could not resolve `Msg` and
+//      emitted `/* ERROR: unknown message type Msg */` where the
+//      expression belonged — the C compiler then reported "expected
+//      expression before ';'".
+//
+//   2. A captured actor handle got an env slot typed with the BARE actor
+//      name, but that name was not typedef'd until the actor struct was
+//      emitted much later, so the slot read as an implicit int
+//      ("initialization of 'Counter *' from incompatible pointer type
+//      'int *'").
+//
+// The contrast that isolates both: the SAME ask compiles at main scope
+// and used to fail inside the closure.
+
+import std.spec
+
+message Poll {}
+message Add { n: int }
+
+actor Counter {
+    state total = 0
+    receive {
+        Add(n) -> { total = total + n }
+        Poll() -> { reply total }
+    }
+}
+
+main() {
+    fw = spec.init()
+
+    // Baseline: an ask at main scope always worked. Kept so a regression
+    // here is distinguishable from a regression in the closure path.
+    outer = spawn(Counter())
+    outer ! Add { n: 5 }
+    base = outer ? Poll {}
+
+    spec.describe(fw, "issue 1626: actors inside closures") {
+        spec.it(fw, "asks at main scope (baseline)") callback {
+            spec.assert_eq(base, 5, "main-scope ask still returns the reply")
+        }
+
+        // Bug 2: `outer` is CAPTURED by this closure.
+        spec.it(fw, "asks through a captured actor handle") callback {
+            spec.assert_eq(outer ? Poll {}, 5, "captured handle is usable")
+        }
+
+        // Bug 1: the ask is lowered inside the closure body.
+        spec.it(fw, "spawns and asks entirely inside the block") callback {
+            c = spawn(Counter())
+            c ! Add { n: 9 }
+            spec.assert_eq(c ? Poll {}, 9, "spawn + send + ask all inside a closure")
+        }
+
+        // Sends and asks interleaved, so the reply is not a constant the
+        // lowering could have folded.
+        spec.it(fw, "sees each send's effect through successive asks") callback {
+            c = spawn(Counter())
+            c ! Add { n: 2 }
+            spec.assert_eq(c ? Poll {}, 2, "after one send")
+            c ! Add { n: 3 }
+            spec.assert_eq(c ? Poll {}, 5, "after a second send")
+        }
+    }
+
+    spec.run_summary(fw)
+    exit(0)
+}


### PR DESCRIPTION
Both issues from the contrib conversion work, in one PR as asked.

## #1625 — `schema_api` member routes never matched

`show`/`update`/`destroy` were registered as the regex `"/(\w+)"`. The
tinyweb router does not do regex: `http_route_matches` supports an exact
`strcmp`, Express-style `:param` segments, and a trailing `*`, and
compares anything else literally. So those routes could only match a URL
that literally contained `/(\w+)` — every real member request 404'd, and
had since they were written. `update` is the costly one: it is the other
**validated** verb, so the PUT validation path was unexercised too.

**I had the ordering mechanism wrong in the issue, and the module comment
was right.** The router matches in **reverse** registration order —
tinyweb walks its route list forward while `http_server_add_route`
*prepends* each entry (`route->next = server->routes; server->routes =
route`). I instrumented `json_api()` to check: its body really does run
before its trailing block, and `/schema` really did register first. But
registering first means being matched **last**, so `show()` still won and
`GET {prefix}/schema` came back as a `show` with `"schema"` as the id.
The original comment's intent was correct; it could not hold while routes
were reversed at match time.

So each leaf builder now mounts `/schema` *after* registering its own
route. `create()`/`index()` cover a resource with no member verb;
`show()/update()/destroy()` re-mount it after theirs, and the later
registration wins over `/:id`.

Two wrong turns, both caught by testing rather than reasoning:
- mounting from `create()`/`index()` only — pre-empted the ordered mount
  and left `/schema` shadowed again; the spec still failed.
- guarding the mount to fire exactly once — fixed the spec but 404'd
  `/schema` for a create/index-only resource. Found by testing that shape
  directly.

The three specs skipped against this issue are **un-skipped, not
rewritten** — exactly what the skip was for.

## #1626 — actor `ask` and captured handles inside closures

Two codegen gaps, both hit when an actor is used from a closure or
trailing block (e.g. a `std.spec` `it` block). The contrast that isolates
them: the **same** ask compiles at main scope and failed inside the
closure.

**Ask lowered to nothing.** `a ? Msg {}` emitted
`/* ERROR: unknown message type Msg */` where the expression belonged, so
gcc reported `expected expression before ';'`. Closure *bodies* were
emitted before the `AST_MESSAGE_DEFINITION` arm ran — and that arm is what
calls `register_message_type` — so the registry the ask lowering consults
was still empty. `emit_closure_definitions` already had two internal
passes; the declarations half is split out and stays early (other emitted
code references those decls) while the bodies move after the messages.
That is less invasive than reordering the message emission itself, which
is interleaved with struct/pool/release emission other code depends on.

**Captured actor handle read as `int`.** The env slot is typed from
`lookup_var_c_type`, which yields the bare actor name — not typedef'd
until the actor struct is emitted much later, so it fell back to implicit
int. A forward `typedef struct X X;` now sits beside the existing
`struct X* spawn_X(...)` forward decls.

Effect: `spawn`, `!` and `?` all work inside an `it` block, so actor specs
no longer need the hoist-into-a-helper detour.

## Verified

- `test_schema_api`: **10 passing** (was 7 + 3 skipped)
- A create/index-only resource serves its draft-07 schema at
  `{prefix}/schema` — tested directly, since that was the shape my second
  attempt broke
- `example_schema_api.ae` still compiles; `test_string_free_no_leak.ae`
  still passes; all five tinyweb entries PASS through `contrib_check.sh`
- New `tests/regression/test_issue1626_ask_in_closure.ae` covers a
  main-scope baseline, a captured handle, spawn+ask fully inside a
  closure, and interleaved sends so the reply cannot be a folded constant.
  Checked **both ways**: 17 compile errors against a pre-fix compiler, 4
  passing with it.
- `make test` green; `make test-ae` failure set identical to baseline.

### One correction worth recording

`mutation_testing` looked like a regression from the codegen change — a
clean A/B said PASS before, FAIL after. It is not. Its driver gets
SIGKILLed by this sandbox's watchdog mid-run and leaves the fixture
**mutated on disk** (`"alice"` → `""`), so every later run fails its own
baseline check. My A/B was comparing a clean tree against a corrupted
fixture. Restored it and ran the test off the watchdog: passes with this
compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)