### PR TITLE
fix(changelog): restore [current], and fail a PR that leaves none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,31 @@ jobs:
 
         if printf '%s\n' "$changed" | grep -q '^CHANGELOG\.md$'; then
           echo "CHANGELOG.md is updated."
+
+          # ... and the entry has to be somewhere the release can find it.
+          # The release job renames the FIRST '## [current]' into the version
+          # heading, so an entry that is not under one ships nowhere.
+          #
+          # This is not hypothetical, and it is not about forgetting the
+          # heading either. When main cuts a release while a branch is open,
+          # main's '## [current]' becomes '## [0.N.0]'; merging the branch
+          # then folds its entry under that already-tagged heading and leaves
+          # the file with no '[current]' at all. That has now happened twice
+          # (0.539.0 and 0.549.0 both failed to bump), each time discovered
+          # only when the release broke. Checking it here moves the discovery
+          # to the PR that causes it.
+          if ! grep -q '^## \[current\]$' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [current]' section."
+            echo ""
+            echo "The release job renames the first '## [current]' heading into"
+            echo "the new version, so an entry outside one is not released."
+            echo "If main cut a release while this branch was open, the merge"
+            echo "folded your entry under that version's heading: move it back"
+            echo "under a fresh '## [current]' and leave the tagged section as"
+            echo "it shipped (compare with \`git show vX.Y.Z:CHANGELOG.md\`)."
+            exit 1
+          fi
+          echo "The entry is under '## [current]'."
           exit 0
         fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
-## [0.548.0]
+## [current]
 
 ### Fixed
 
@@ -68,6 +68,8 @@ version number before tagging the release.
   directly by a declaration, which C11 does not allow (C23 relaxes it and gcc
   takes it as an extension), so `make` failed on Apple clang while CI's gcc
   stayed green. The declaration is hoisted above the label.
+
+## [0.548.0]
 
 ### Fixed
 
@@ -189,7 +191,6 @@ version number before tagging the release.
   Cause is the catch-up-merge fold: merging main across a release folds a
   PR's `[current]` into the released section above it with no conflict
   marker, so it silently survives as a second heading.
-
 
 ## [0.547.0]
 


### PR DESCRIPTION
The 0.549.0 bump refused, and it was right to:

```
Error: No '## [current]' section in CHANGELOG.md, so 0.549.0
would ship with nothing recorded.
```

## What happened

main cut 0.548.0 while #1631 was open. That rename turns main's `## [current]` into `## [0.548.0]`. Merging #1631 then folded its four entries under that already-tagged heading, and the file was left with no `[current]` at all, so the next bump had nothing to rename.

Net effect on main before this PR: the four fixes from #1631 sat inside a section that shipped as 0.548.0 without them, and no release could be cut.

## What this does

1. Moves those entries back under a fresh `## [current]`.
2. Leaves `## [0.548.0]` exactly as it was tagged, verified rather than assumed:

```
$ diff <(git show v0.548.0:CHANGELOG.md | sed -n '/^## \[0.548.0\]/,/^## \[0.547.0\]/p' ...) \
       <(sed -n '/^## \[0.548.0\]/,/^## \[0.547.0\]/p' CHANGELOG.md ...)
IDENTICAL
```

3. Makes the recurrence fail its own PR. The **same thing broke the 0.539.0 bump** a few days ago and was fixed by hand; fixing it by hand is not a fix, because both times it was found only when the release broke. The "CHANGELOG entry present" job now also requires the file to *have* a `## [current]` heading when a code PR touches `CHANGELOG.md`, with an error that names this exact cause and how to undo it. Checked both ways against a no-`[current]` file and a good one.

No code changes; `[skip changelog]` because the entry this PR restores is the record.
