### PR TITLE
feat(build): --emit=csrc/obj under --target incl. wasm32-wasi (#1648); harden the CachyOS nightly against silent skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,6 +525,14 @@ jobs:
     - name: Install native GCC
       run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
 
+    # Still needed after #1648 wired wasm32-wasi into `ae build`, and worth
+    # saying why: `ae build --target=wasm32-wasi --emit=obj` compiles the
+    # user's generated C only — it never touches the runtime. This step is the
+    # sole thing that compiles aether_panic.c for WASI, which is exactly the
+    # regression #1645 fixed. It keeps the hand-passed defines deliberately:
+    # `ae build` now injects the same two itself, so if this bare invocation
+    # ever needs a third, the divergence surfaces here rather than silently
+    # inside the build.
     - name: Verify WASI panic runtime with Zig 0.16.0
       run: |
         ZIG="$(./scripts/get-zig.sh "$RUNNER_TEMP/zig")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,33 @@ version number before tagging the release.
   remain rejected: they link a shared library, which the cross path does not
   yet produce.
 
+- **`ae build --target=wasm32-wasi` works, with no hand-passed defines**
+  (#1648). `wasm32-wasi` now maps to a zig triple like every other target, so
+  it routes through the same cross machinery: `--emit=obj` produces a real
+  `WebAssembly (wasm) binary module`. The two defines WASI needs are injected
+  by the build rather than left to the caller — without
+  `-D__wasm_exception_handling__=1` its `setjmp.h` refuses to compile
+  ("Setjmp/longjmp support requires Exception handling support"), and without
+  `-D_WASI_EMULATED_SIGNAL` there is no POSIX signal API. CI passed both by
+  hand; now only the build knows them.
+
+  This is the **zig** wasm path and is distinct from `--target=wasm`, which
+  stays on Emscripten: emcc supplies a JS host, a DOM/filesystem shim and its
+  own pthread emulation, which is a different product from a self-contained
+  object a WASI runtime loads. Neither supersedes the other, so they are
+  selected by target name rather than one silently switching backend.
+
+  Two limits found by testing and stated rather than papered over. A full
+  executable link for `wasm32-wasi` is **rejected up front**:
+  `multicore_scheduler.c` asserts `sizeof(Mailbox) % 8 == 0` with no 64-bit
+  guard — unlike the `sizeof(Message) == 48` assertion beside it, which has one
+  — so it fails on any 32-bit target. That is a pre-existing runtime
+  portability gap (#1652), and the error names it instead of surfacing a static-assert
+  deep in a scheduler translation unit. And `wasm32-freestanding` is
+  deliberately not offered: with no libc the generated C's `#include <stdio.h>`
+  cannot resolve, so its only working mode would be `--emit=csrc`, which emits
+  the same target-neutral bytes as every other target anyway.
+
 - **`make contrib-check-lsan`: contrib/vulkan is leak-gated in CI** (#1507).
   The module rendered on the Linux leg for correctness only, because the CI
   driver is lavapipe and valgrind cannot follow its LLVM JIT: one render

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,20 @@ version number before tagging the release.
   selection stays in `#if __linux__`/`__APPLE__`/`__wasi__` and is resolved by
   the consumer's compiler — verified byte-identical across four targets in
   `tests/integration/emit_csrc_cross/`. csrc under `--target` also no longer
-  requires `zig` on PATH, since there is no link to perform.
+  requires `zig` on PATH, since nothing is compiled or linked.
+
+- **`ae build --target=<triple> --emit=obj` is now allowed** (#1648), producing
+  a real target-format object via `zig cc -target <triple> -c`: ELF/aarch64 for
+  `aarch64-linux`, COFF/amd64 for `x86_64-windows`, Mach-O for `x86_64-macos`,
+  each verified by `file` and asserted to differ from the host object. obj is
+  the other **non-linking** mode, so the guard's "the executable link rejects
+  it" rationale never applied to it either; it stops at `-c`. Unlike csrc it
+  emits machine code rather than portable source, so it does need `zig`.
+  `AE_CC`/`CC` are deliberately not consulted on the cross object path — they
+  name a host compiler, and honouring them would silently produce a host object
+  for a command that asked for a cross one. `--emit=lib` and `--emit=both`
+  remain rejected: they link a shared library, which the cross path does not
+  yet produce.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ version number before tagging the release.
 
 ### Changed
 
+- **The CachyOS nightly now records the version of every dependency it tested
+  against.** Nothing in the repo pins these, and pinning would be the wrong fix
+  — the box is rolling-release precisely so it runs ahead of CI and finds
+  breakage early. What was missing was the record: without it a green run does
+  not say what it tested, and a red run the morning after `pacman -Syu` reads
+  as a code regression rather than an upstream bump. Each run now writes
+  `deps_<stamp>.tsv` and publishes it beside the step timings — interpreter
+  versions, `pacman -Q` for the libraries that have no `--version`, and the
+  Factor fork's commit, since it is built from source. Measured on the box:
+  Racket 9.2, Lua 5.5.0, Python 3.14.6, Node 26.4.0, OpenJDK 26.0.2, Go 1.26.5.
+  Racket 9.3 shipped 2026-08-13 while the box was on 9.2, and the Racket CS
+  embedding surface the bridge compiles against is macro-based and has moved
+  across majors — exactly the upgrade this table makes legible. Reporting is
+  all the step does; whether a missing dep is fatal remains the dep gate's
+  decision.
+
 - **The CachyOS nightly now fails hard on every contrib skip.** The box is
   provisioned with every contrib dependency, so a step that SKIPs there is a
   silently shrinking test surface rather than an honest report of an absent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,30 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **`ae build --target=<triple> --emit=csrc` is now allowed** (#1648). The
+  cross guard rejected every library-shaped emit mode, justified by a comment
+  about "library-shaped C that the executable link rejects" — but `--emit=csrc`
+  never links: it writes the portable C, its catalog header and the JSON
+  catalog, and stops. The rationale simply did not apply to it, and the guard
+  was over-broad. This makes csrc the route to a **cross-compiled linkable
+  library without cross-link support**: emit the C here, and the consumer
+  compiles it for their target into the `.so`/`.a`/`.wasm` they need. The
+  emitted C is target-*neutral* rather than target-parameterised — platform
+  selection stays in `#if __linux__`/`__APPLE__`/`__wasi__` and is resolved by
+  the consumer's compiler — verified byte-identical across four targets in
+  `tests/integration/emit_csrc_cross/`. csrc under `--target` also no longer
+  requires `zig` on PATH, since there is no link to perform.
+
 ### Fixed
+
+- **`ae build --target=<triple> --emit=both` now reports the same up-front
+  error as `--emit=lib`** instead of dying at the cross linker. `--emit=both`
+  re-dispatches as an exe pass followed by a lib pass, so it never reached the
+  cross guard with the lib flag set: the exe pass ran and failed with
+  `ld.lld: error: undefined symbol: main` on a source that has no `main` by
+  design. Pre-existing, and found while unblocking csrc for #1648.
 
 - **The panic runtime now compiles for `wasm32-wasi`**: WASI has no POSIX
   `sigaction` API, so its signal-handler installer is now the same no-op stub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ version number before tagging the release.
   release workflows now use the repository-pinned Zig 0.16.0 toolchain, the
   first release with the WASI `setjmp` headers needed to compile this runtime.
 
+### Changed
+
+- **The CachyOS nightly now fails hard on every contrib skip.** The box is
+  provisioned with every contrib dependency, so a step that SKIPs there is a
+  silently shrinking test surface rather than an honest report of an absent
+  library. Three layers each hid the one below it and are now closed:
+  `make contrib` runs in `contrib_build.sh`'s explicit `MODULES=` mode (fail-hard
+  by design) with the list derived from that script's own `CATALOGUE`, so a
+  module that no longer *builds* is a failure rather than a skip — the class of
+  breakage a GCC 16 / Clang 22 box exists to find, which the dependency gate
+  cannot catch because the library is present; `make contrib-host-check` gains
+  `CONTRIB_HOST_STRICT=1`, turning a missing bridge archive into a FAIL; and a
+  new step asserts that no host spec skipped any of its cases. That last one was
+  found by testing rather than reasoning — `contrib/host/factor` builds its
+  archive with no Factor installed (the bridge is pure `dlopen`), passes both
+  earlier layers, and then skips all six cases at runtime with
+  `AETHER_FACTOR_SONAME` unset, reporting `0 passing / 6 skipped` and exiting 0.
+  The gate reads `std.spec`'s machine-readable `AE_SPEC_FORMAT=aeocha` report
+  (`skipped=<n>`) rather than parsing the ANSI-coloured human output.
+  `CONTRIB_HOST_STRICT` defaults to `0`, so GitHub CI and dev boxes are
+  unaffected.
+
 ## [0.551.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -2584,6 +2584,17 @@ test-differential: ae
 # dirs).
 CONTRIB_HOST_LANGS = js lua perl python ruby tcl go tinygo factor aether racket
 
+# CONTRIB_HOST_STRICT=1 turns "bridge archive unavailable" from a SKIP into a
+# FAILURE in the co-located-spec phase of contrib-host-check.
+#
+# The default (0) is right for portable CI runners and dev boxes, which cannot
+# be expected to have every language's dev kit installed — there, a missing
+# bridge genuinely is nothing to report. It is wrong for a dedicated build box
+# that has been provisioned with all of them: a spec that silently does not run
+# is indistinguishable from one that passes, so the coverage quietly shrinks
+# without turning anything red. The CachyOS nightly sets this to 1.
+CONTRIB_HOST_STRICT ?= 0
+
 # Documentation examples that are supposed to work (#1500, #1522).
 #
 # Two gates, both cheap. `check_doc_examples.py` reads the stdlib module doc
@@ -2700,7 +2711,12 @@ contrib-host-check: compiler ae stdlib
 	    MODULES="$$lang" bash tests/scripts/contrib_build.sh >/dev/null 2>&1 || true; \
 	  fi; \
 	  if [ ! -f "build/contrib/libaether_host_$$lang.a" ]; then \
-	    echo "    SKIP: libaether_host_$$lang.a unavailable (bridge deps not installed)"; \
+	    if [ "$(CONTRIB_HOST_STRICT)" = "1" ]; then \
+	      echo "    FAIL: libaether_host_$$lang.a unavailable (CONTRIB_HOST_STRICT=1)"; \
+	      rc=1; \
+	    else \
+	      echo "    SKIP: libaether_host_$$lang.a unavailable (bridge deps not installed)"; \
+	    fi; \
 	    continue; \
 	  fi; \
 	  out="$$(./build/ae$(EXE_EXT) run "$$t" 2>&1)"; trc=$$?; \

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -454,6 +454,46 @@ for a command that asked for a cross one. The consumer links the object with
 their own `libaether.a` and system libraries for the target, exactly as they do
 for a native `--emit=obj`.
 
+### WebAssembly: two backends, selected by target name
+
+There are **two** wasm paths, and they are not interchangeable:
+
+| Target | Backend | Produces | Supported modes |
+|---|---|---|---|
+| `--target=wasm` | Emscripten (`emcc`) | `.js` + `.wasm` bundle | executables |
+| `--target=wasm32-wasi` | `zig cc` | a self-contained wasm object | `--emit=csrc`, `--emit=obj` |
+
+Emscripten supplies a JS host, a DOM/filesystem shim and its own pthread
+emulation; the zig path produces a plain object a WASI runtime (or someone
+else's wasm link) consumes. Neither supersedes the other, so they are chosen by
+different target names rather than one silently switching backend.
+
+`wasm32-wasi` goes through the same cross machinery as every other triple, so
+`--emit=obj` yields a real module:
+
+```
+$ ae build --target=wasm32-wasi --emit=obj lib.ae -o lib.o && file lib.o
+lib.o: WebAssembly (wasm) binary module version 0x1 (MVP)
+```
+
+**The two WASI defines are injected automatically.** WASI's `setjmp.h` refuses
+to compile without `-D__wasm_exception_handling__=1` (*"Setjmp/longjmp support
+requires Exception handling support"*), and WASI has no POSIX signal API
+without `-D_WASI_EMULATED_SIGNAL`. `ae build` adds both when the target
+resolves to a WASI triple, so nothing needs passing by hand.
+
+**A full executable link for `wasm32-wasi` is not supported**, and is rejected
+up front rather than failing deep in a compile:
+`runtime/scheduler/multicore_scheduler.c` asserts
+`sizeof(Mailbox) % 8 == 0` with no 64-bit guard (unlike the
+`sizeof(Message) == 48` assertion beside it, which has one), so it fails on any
+32-bit target. Use `--target=wasm` for a runnable bundle.
+
+`wasm32-freestanding` is deliberately **not** offered: it ships no libc, so the
+generated C's `#include <stdio.h>` cannot resolve and `--emit=obj` fails
+outright. Its only working mode would be `--emit=csrc`, which emits the same
+target-neutral bytes as every other target anyway.
+
 The same vendored engine backs two native cases: a build box with no system
 libpcre2-8 (`make` compiles the vendored copy instead of stubbing
 `std.regex` out — `PCRE2=0` restores the stub, `PCRE2=vendored` forces the
@@ -472,7 +512,8 @@ so an installed toolchain never ships a silently-stubbed regex.
 | Hardened | `HARDEN=1` | See "Hardening" section below |
 | WASM | `PLATFORM=wasm` | Cooperative scheduler, Emscripten |
 | Embedded | `PLATFORM=embedded` | Cooperative scheduler, no OS |
-| Cross-OS/arch | `ae build --target=<triple>` | `zig cc` backend, POSIX host, executables + `--emit=csrc` |
+| Cross-OS/arch | `ae build --target=<triple>` | `zig cc` backend, POSIX host, executables + `--emit=csrc`/`--emit=obj` |
+| Cross-wasm | `ae build --target=wasm32-wasi` | `zig cc` backend, `--emit=csrc`/`--emit=obj` only |
 
 ## Hardening (`HARDEN=1`)
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -414,11 +414,11 @@ no sysroot** — its engine is vendored in-tree (`std/regex/pcre2/`, pinned
 upstream PCRE2 compiled by `std/regex/aether_pcre2_vendored.c`; #1389), so a
 regex-using program cross-builds self-contained for every target. A
 CROSSBUILD_SYSROOT that stages a real libpcre2-8 takes precedence over the
-vendored copy. Executables **and `--emit=csrc`** (`--emit=lib`, `--emit=both`
-and `--emit=obj` are rejected for now — they link, and the cross link path
-produces executables only), and the host must be POSIX (Linux/macOS). The
-generated binary targets another platform, so it is not runnable on the build
-host; copy it to a matching machine (or an emulator).
+vendored copy. Executables, **`--emit=csrc` and `--emit=obj`** (`--emit=lib`
+and `--emit=both` are rejected for now — they link a shared library, which the
+cross link path does not yet produce), and the host must be POSIX
+(Linux/macOS). The generated binary targets another platform, so it is not
+runnable on the build host; copy it to a matching machine (or an emulator).
 
 `--emit=csrc` is allowed under `--target` because it never links: it writes
 the portable C, its catalog header and the JSON catalog, and stops (#1648).
@@ -432,7 +432,27 @@ by the consumer's compiler, which defines those macros for whatever target it
 builds. `--target` therefore does not change the bytes emitted (asserted by
 `tests/integration/emit_csrc_cross/`); it is accepted so one command line
 works for both native and cross consumers. For the same reason csrc under
-`--target` does **not** require `zig` on PATH — there is no link to perform.
+`--target` does **not** require `zig` on PATH — nothing is compiled or linked.
+
+`--emit=obj` is the other non-linking mode, and is allowed under `--target` for
+the same reason: it stops at `zig cc -target <triple> -c`. Unlike csrc it emits
+a **target-format object** — real machine code for the triple — so it *does*
+need `zig`:
+
+```
+$ ae build --target=aarch64-linux  --emit=obj lib.ae -o lib.o && file lib.o
+lib.o: ELF 64-bit LSB relocatable, ARM aarch64
+$ ae build --target=x86_64-windows --emit=obj lib.ae -o lib.o && file lib.o
+lib.o: Intel amd64 COFF object file
+$ ae build --target=x86_64-macos   --emit=obj lib.ae -o lib.o && file lib.o
+lib.o: Mach-O 64-bit x86_64 object
+```
+
+`AE_CC`/`CC` are deliberately **not** consulted on the cross object path: they
+name a host compiler, and honouring them would silently produce a host object
+for a command that asked for a cross one. The consumer links the object with
+their own `libaether.a` and system libraries for the target, exactly as they do
+for a native `--emit=obj`.
 
 The same vendored engine backs two native cases: a build box with no system
 libpcre2-8 (`make` compiles the vendored copy instead of stubbing

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -414,10 +414,25 @@ no sysroot** — its engine is vendored in-tree (`std/regex/pcre2/`, pinned
 upstream PCRE2 compiled by `std/regex/aether_pcre2_vendored.c`; #1389), so a
 regex-using program cross-builds self-contained for every target. A
 CROSSBUILD_SYSROOT that stages a real libpcre2-8 takes precedence over the
-vendored copy. Executables only
-(`--emit=lib`/`--emit=both` are rejected for now), and the host must be POSIX
-(Linux/macOS). The generated binary targets another platform, so it is not
-runnable on the build host; copy it to a matching machine (or an emulator).
+vendored copy. Executables **and `--emit=csrc`** (`--emit=lib`, `--emit=both`
+and `--emit=obj` are rejected for now — they link, and the cross link path
+produces executables only), and the host must be POSIX (Linux/macOS). The
+generated binary targets another platform, so it is not runnable on the build
+host; copy it to a matching machine (or an emulator).
+
+`--emit=csrc` is allowed under `--target` because it never links: it writes
+the portable C, its catalog header and the JSON catalog, and stops (#1648).
+That makes it the route to a **cross-compiled linkable library without
+cross-link support** — emit the C here, and let the consumer compile it for
+their target into the `.so` / `.a` / `.wasm` they need.
+
+The emitted C is **target-neutral**, not target-parameterised: platform
+selection stays in `#if __linux__` / `__APPLE__` / `__wasi__` and is resolved
+by the consumer's compiler, which defines those macros for whatever target it
+builds. `--target` therefore does not change the bytes emitted (asserted by
+`tests/integration/emit_csrc_cross/`); it is accepted so one command line
+works for both native and cross consumers. For the same reason csrc under
+`--target` does **not** require `zig` on PATH — there is no link to perform.
 
 The same vendored engine backs two native cases: a build box with no system
 libpcre2-8 (`make` compiles the vendored copy instead of stubbing
@@ -437,7 +452,7 @@ so an installed toolchain never ships a silently-stubbed regex.
 | Hardened | `HARDEN=1` | See "Hardening" section below |
 | WASM | `PLATFORM=wasm` | Cooperative scheduler, Emscripten |
 | Embedded | `PLATFORM=embedded` | Cooperative scheduler, no OS |
-| Cross-OS/arch | `ae build --target=<triple>` | `zig cc` backend, POSIX host, executables |
+| Cross-OS/arch | `ae build --target=<triple>` | `zig cc` backend, POSIX host, executables + `--emit=csrc` |
 
 ## Hardening (`HARDEN=1`)
 

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -55,6 +55,7 @@ tests/integration/dsl_receiver_scoping_edge/
 tests/integration/dsl_receiver_scoping_nested/
 tests/integration/effect_tags/
 tests/integration/emit_csrc/
+tests/integration/emit_csrc_cross/
 tests/integration/emit_lib_const/
 tests/integration/emit_lib_deadline/
 tests/integration/emit_lib_net/

--- a/tests/cachyos/README.md
+++ b/tests/cachyos/README.md
@@ -21,12 +21,15 @@ half of the coverage gap that actually catches that class of bug.
 2. A **fail-on-missing-deps** gate — a dedicated build box should test
    everything, so an absent contrib dependency is a provisioning bug that turns
    the run RED (the opposite of `contrib_build.sh`'s probe-and-skip).
-3. `make ci` → **`make install` + a freshness check** → `make contrib` → `make
+3. **Records the version of every third-party dependency** it built and tested
+   against (see below) — captured right after the gate, so a run that later
+   fails still says what it was running.
+4. `make ci` → **`make install` + a freshness check** → `make contrib` → `make
    contrib-host-check` → **a no-skipped-cases gate over the host specs** → a
    `contrib` `ae check` sweep → `make contrib-check-valgrind` (build + run
    every contrib `test_*.ae`, valgrind-gating the leak-clean ones), each timed
    (ms) and recorded.
-4. Publishes a topline pass/fail table to the **`nightly-results`** orphan
+5. Publishes a topline pass/fail table to the **`nightly-results`** orphan
    branch (no shared history, no CI triggered) and writes a dated summary + log
    locally (last 14 kept).
 
@@ -78,6 +81,46 @@ is covered here automatically and cannot be forgotten.
 
 `CONTRIB_HOST_STRICT` defaults to `0`, so GitHub CI and dev boxes are
 unaffected — only this nightly sets it.
+
+### Dependency versions: recorded, not pinned
+
+Nothing in the repo pins any contrib dependency. `probe_racket` checks only
+that `chezscheme.h` and `racketcs.h` *exist*; the dep gate checks
+`command -v racket`; the `pacman -S` line in the header is unversioned.
+
+**That is deliberate.** This box is rolling-release precisely so it runs
+*ahead* of CI and finds breakage early — the same rationale as its GCC 16
+against CI's GCC 11. Pinning Racket would mean never learning that a new
+Racket broke the embedding surface.
+
+What was missing is the **record**. Without it a green run does not say what
+it tested, and a red run the morning after `pacman -Syu` reads as a code
+regression rather than an upstream bump — a bisect nobody should have to do.
+So each run writes `deps_<stamp>.tsv` and publishes it as a table beside the
+step timings.
+
+Measured on the box (2026-08-18), which shows why this matters:
+
+| dependency | version |
+|---|---|
+| `racket` | 9.2 |
+| `lua` | 5.5.0 |
+| `python` | 3.14.6 |
+| `node` | 26.4.0 |
+| `java` | openjdk 26.0.2 |
+| `go` | 1.26.5 |
+| `tinygo` | 0.41.1 (LLVM 20.1.1) |
+| `factor-fork` | `91a3639cf6` (a commit — it is built from source) |
+
+Racket 9.3 shipped 2026-08-13 while the box was on 9.2. The Racket CS
+embedding surface the bridge compiles against (`chezscheme.h`'s `Snil`,
+`Scons`, `Smake_bytevector`) is macro-based and has moved across majors, so
+that upgrade is exactly the kind this table makes legible.
+
+Reporting is all this step does. Whether a missing dep is fatal stays the dep
+gate's decision — duplicating that verdict here would give two sources of
+truth for one condition. A dep that is absent records `(absent)` and the step
+still passes.
 
 ### Why the nightly installs, and why it fetches tags
 

--- a/tests/cachyos/README.md
+++ b/tests/cachyos/README.md
@@ -22,9 +22,10 @@ half of the coverage gap that actually catches that class of bug.
    everything, so an absent contrib dependency is a provisioning bug that turns
    the run RED (the opposite of `contrib_build.sh`'s probe-and-skip).
 3. `make ci` → **`make install` + a freshness check** → `make contrib` → `make
-   contrib-host-check` → a `contrib` `ae check` sweep → `make
-   contrib-check-valgrind` (build + run every contrib `test_*.ae`,
-   valgrind-gating the leak-clean ones), each timed (ms) and recorded.
+   contrib-host-check` → **a no-skipped-cases gate over the host specs** → a
+   `contrib` `ae check` sweep → `make contrib-check-valgrind` (build + run
+   every contrib `test_*.ae`, valgrind-gating the leak-clean ones), each timed
+   (ms) and recorded.
 4. Publishes a topline pass/fail table to the **`nightly-results`** orphan
    branch (no shared history, no CI triggered) and writes a dated summary + log
    locally (last 14 kept).
@@ -36,6 +37,47 @@ the header comment in `nightly.sh`). Provision the contrib deps first — packag
 installs plus the `aether-lang-dev/factor-language` fork build — and export the
 `AETHER_*` dep env vars in the timer environment. The gate stays RED until every
 dep is present, by design.
+
+### Why every contrib step here is fail-hard
+
+The portable CI runners probe-and-skip because they cannot have every
+language's dev kit installed. This box can, and does — so the same skip that
+is honest on a runner is a **silently shrinking test surface** here. Each layer
+hides the one below it, so all of them have to be closed:
+
+| Layer | Default behaviour | On this box |
+| --- | --- | --- |
+| A dep is absent | — | step 1's dep gate turns the run RED |
+| A module fails to **build** | `make contrib` tallies a SKIP, exits 0 | `MODULES=<all>` → fail-hard (exit 1) |
+| A bridge **archive** is missing | phase [3/3] prints SKIP, exits 0 | `CONTRIB_HOST_STRICT=1` → FAIL |
+| A spec **runs but skips its cases** | prints `⊘`, exits 0 | `skipped=0` gate → RED |
+
+The dep gate alone is not enough for the middle two: it catches "the library
+is gone", never "the library is here and the module no longer compiles against
+it" — which is precisely the breakage a GCC 16 / Clang 22 box exists to find.
+In probe-and-skip mode that break reports as a skip and the nightly stays
+green.
+
+The last row is the subtlest and was found by testing rather than reasoning.
+`contrib/host/factor`'s archive builds fine with no Factor installed (the
+bridge is pure `dlopen`), so both `MODULES=` and `CONTRIB_HOST_STRICT` pass it
+— and then all six of its cases skip at runtime because `AETHER_FACTOR_SONAME`
+is unset, reporting `0 passing / 6 skipped` and exiting 0. `std.spec` states
+the principle directly: *"A skip that reports as a pass is worse than no skip
+at all."*
+
+That gate reads the **machine-readable** report rather than the human output:
+`AE_SPEC_FORMAT=aeocha` + `AE_SPEC_REPORT=<path>` make each spec write
+`skipped=<n>`, which is summed across the host specs. Parsing the `⊘` lines
+would mean parsing ANSI colour and would break the moment the renderer
+changes.
+
+The module list for the fail-hard build is **derived from
+`contrib_build.sh`'s own `CATALOGUE`**, not hardcoded, so a module added there
+is covered here automatically and cannot be forgotten.
+
+`CONTRIB_HOST_STRICT` defaults to `0`, so GitHub CI and dev boxes are
+unaffected — only this nightly sets it.
 
 ### Why the nightly installs, and why it fetches tags
 

--- a/tests/cachyos/nightly.sh
+++ b/tests/cachyos/nightly.sh
@@ -348,8 +348,111 @@ run_and_record() {
 
 # Thin wrappers so make steps are named commands run_and_record can invoke.
 make_ci_step() { make ci; }
-make_contrib_step() { make contrib; }
-make_host_check_step() { make contrib-host-check; }
+
+# Build EVERY contrib module by name, fail-hard.
+#
+# `make contrib` with MODULES unset is contrib_build.sh's probe-and-skip mode:
+# it tallies anything whose dep is absent as a SKIP and still exits 0. That is
+# right for portable CI runners, which cannot have every language installed —
+# and wrong here. This box is provisioned for the purpose and its dep gate
+# (step 1) has already turned the run RED if anything is missing, so by the
+# time we reach step 5 every dep IS present and a module that does not build
+# is a genuine break, not an absent library.
+#
+# The distinction matters because the two failures are not the same. The dep
+# gate catches "the library is gone"; it cannot catch "the library is here and
+# the module no longer compiles against it" — which is precisely the class of
+# breakage this box exists to find, given it runs GCC 16 / Clang 22 against
+# CI's GCC 11. In probe-and-skip mode such a break is reported as a skip and
+# the nightly stays green.
+#
+# MODULES=<list> is contrib_build.sh's explicit mode, documented there as
+# "fail-hard: any requested module that can't compile is a hard failure (exit
+# 1), not a silent skip". The list is derived from the script's own CATALOGUE
+# rather than hardcoded, so a module added there is covered here automatically
+# and cannot be forgotten.
+contrib_modules_all() {
+    sed -n 's/^[[:space:]]*"\([a-z_]*\)|.*/\1/p' "$REPO/tests/scripts/contrib_build.sh" \
+        | sort -u | paste -sd,
+}
+make_contrib_step() {
+    mods="$(contrib_modules_all)"
+    if [ -z "$mods" ]; then
+        echo "  contrib: could not derive the module list from contrib_build.sh"
+        return 1
+    fi
+    echo "  building (fail-hard): $mods"
+    make contrib MODULES="$mods"
+}
+
+# CONTRIB_HOST_STRICT=1: on this box a bridge whose archive is unavailable is a
+# provisioning failure, not a skip. Without it a spec that never runs is
+# indistinguishable from one that passes (see the Makefile comment).
+make_host_check_step() { make contrib-host-check CONTRIB_HOST_STRICT=1; }
+
+# Assert that no host spec SKIPPED any of its cases.
+#
+# CONTRIB_HOST_STRICT catches a bridge whose ARCHIVE is missing, but not the
+# layer below it: a spec whose archive built fine and which then skips every
+# case at RUNTIME because a runtime dependency is unset. contrib/host/factor is
+# the live example — with AETHER_FACTOR_SONAME unset it reports
+#
+#     0 passing
+#     6 skipped
+#
+# and exits 0, so the step passes while testing nothing. std.spec puts the
+# principle plainly (std/spec/module.ae): "A skip that reports as a pass is
+# worse than no skip at all." On a portable runner a skip is honest; on a box
+# provisioned for the purpose it is a provisioning failure.
+#
+# Rather than parse the human output (whose ⊘ lines carry ANSI colour and
+# would break the moment the renderer changes), this uses the machine-readable
+# contract std.spec already exposes: AE_SPEC_FORMAT=aeocha + AE_SPEC_REPORT
+# make each run write "skipped=<n>" to a file. Summing that key across every
+# host spec is exact and renderer-independent.
+host_specs_no_skips() {
+    rc=0
+    total_skipped=0
+    rpt="$OUTDIR/spec_report_$$.txt"
+    for t in $(find "$REPO/contrib/host" -maxdepth 2 -name 'test_*.ae' | sort); do
+        lang="$(basename "$(dirname "$t")")"
+        rm -f "$rpt"
+        # Mirror the per-language SONAME discovery `make contrib-host-check`
+        # does before running each spec (Makefile, phase [3/3]). Without it the
+        # bridges cannot dlopen their runtime and every case skips — which
+        # would make this gate fire on a correctly provisioned box.
+        case "$lang" in
+            ruby)   AETHER_RUBY_SONAME="$(ruby -rrbconfig -e 'print RbConfig::CONFIG["LIBRUBY_SO"]' 2>/dev/null)"
+                    export AETHER_RUBY_SONAME ;;
+            python) AETHER_PYTHON_SONAME="$(python3 -c 'import sysconfig,os; print(os.path.join(sysconfig.get_config_var("LIBDIR") or "", sysconfig.get_config_var("INSTSONAME") or ""))' 2>/dev/null)"
+                    export AETHER_PYTHON_SONAME ;;
+            perl)   AETHER_PERL_SONAME="$(perl -MConfig -e 'print "$Config{archlibexp}/CORE/$Config{libperl}"' 2>/dev/null)"
+                    export AETHER_PERL_SONAME ;;
+            lua)    for so in /usr/lib/*/liblua5.4.so /usr/lib/*/liblua5.3.so /usr/lib/liblua5.4.so; do
+                        [ -f "$so" ] && { AETHER_LUA_SONAME="$so"; export AETHER_LUA_SONAME; break; }
+                    done ;;
+        esac
+        AE_SPEC_FORMAT=aeocha AE_SPEC_REPORT="$rpt" \
+            "$REPO/build/ae" run "$t" >/dev/null 2>&1
+        if [ ! -f "$rpt" ]; then
+            echo "  $lang: no spec report written (spec did not reach run_summary)"
+            rc=1
+            continue
+        fi
+        n="$(sed -n 's/^skipped=//p' "$rpt" | head -1)"
+        [ -n "$n" ] || n=0
+        if [ "$n" -gt 0 ]; then
+            echo "  $lang: $n skipped case(s) — a runtime dep is unset on this box"
+            total_skipped=$((total_skipped + n))
+            rc=1
+        else
+            echo "  $lang: no skips"
+        fi
+    done
+    rm -f "$rpt"
+    [ "$rc" -eq 0 ] || echo "  => $total_skipped skipped host-spec case(s); provisioning failure"
+    return $rc
+}
 # Build + RUN every contrib test_*.ae, under valgrind where the test is
 # leak-clean by design (see .github/scripts/contrib_check.sh). This is the
 # RUNTIME coverage the type-check sweep can't provide — the class of bug that
@@ -444,6 +547,7 @@ fails=0
     run_and_record "install freshness check" verify_install_step
     run_and_record "make contrib" make_contrib_step
     run_and_record "make contrib-host-check" make_host_check_step
+    run_and_record "host specs: no skipped cases" host_specs_no_skips
     # `make ci` and `make contrib` never compile the contrib Aether code
     # (test-ae globs only tests/*, `make contrib` builds C shims). This sweep
     # type-checks every contrib module under the newer toolchain — the gap that

--- a/tests/cachyos/nightly.sh
+++ b/tests/cachyos/nightly.sh
@@ -43,6 +43,10 @@ LOG="$OUTDIR/nightly_${STAMP}.log"
 SUMMARY="$OUTDIR/nightly_${STAMP}.summary.txt"
 RESULTS_TSV="$OUTDIR/results_${STAMP}.tsv"
 STEPS_TSV="$OUTDIR/steps_${STAMP}.tsv"
+# Versions of the third-party deps this run built and tested against. Nothing
+# pins them (see capture_dep_versions), so recording them is what makes an
+# upstream bump distinguishable from a code regression.
+DEPS_TSV="$OUTDIR/deps_${STAMP}.tsv"
 # Orphan branch (no shared history, no CI) used purely to publish topline
 # results. Set AETHER_NIGHTLY_PUBLISH=0 to skip the push.
 RESULTS_BRANCH="${AETHER_NIGHTLY_BRANCH:-nightly-results}"
@@ -246,6 +250,74 @@ render_row() { # <name> <PASS|FAIL> <ms>
     fi
 }
 
+# Capture the version of every third-party dependency the contrib modules
+# build and test against, one "<name>\t<version>" line per dep.
+#
+# Why this exists: nothing in the repo PINS any of these, and pinning would be
+# the wrong fix — the box is rolling-release precisely so it runs AHEAD of CI
+# and finds breakage early (the same rationale as its GCC 16 vs CI's GCC 11).
+# What was missing is the RECORD. Without it a green run does not say what it
+# tested, and a red run the morning after `pacman -Syu` looks like a code
+# regression rather than an upstream bump — which is a bisect nobody should
+# have to do.
+#
+# Live example: Racket 9.3 shipped 2026-08-13 while this box was on 9.2. The
+# Racket CS embedding surface the bridge compiles against (chezscheme.h's
+# Snil / Scons / Smake_bytevector) is macro-based and has moved across majors,
+# so that upgrade is exactly the kind this table makes legible.
+#
+# Every probe is guarded: a dep that is absent records "(absent)" rather than
+# failing. Reporting is this function's whole job — the dep GATE (step 1) is
+# what decides whether missing is fatal, and duplicating that verdict here
+# would just give two sources of truth for one condition.
+dep_version() {
+    name="$1"; shift
+    v="$("$@" 2>/dev/null | head -1)"
+    [ -n "$v" ] || v="(absent)"
+    printf '%s\t%s\n' "$name" "$v"
+}
+
+capture_dep_versions() {
+    : > "$DEPS_TSV"
+    {
+        # `racket --version` greets rather than reports ("Welcome to Racket
+        # v9.2 [cs]."); (version) prints the bare number.
+        dep_version "racket"   racket -e '(display (version))'
+        dep_version "tclsh"    sh -c 'echo "puts [info patchlevel]" | tclsh'
+        dep_version "go"       go version
+        dep_version "tinygo"   tinygo version
+        dep_version "python"   python3 --version
+        dep_version "ruby"     ruby --version
+        dep_version "perl"     sh -c 'perl -e "print \$^V"'
+        dep_version "lua"      sh -c 'lua -v 2>&1'
+        dep_version "node"     node --version
+        dep_version "java"     sh -c 'java -version 2>&1'
+        # Libraries have no --version; take the package manager's record. Also
+        # covers the two the bridges dlopen rather than link (duktape, expat).
+        if command -v pacman >/dev/null 2>&1; then
+            for pkg in sqlite expat duktape ffmpeg racket tcl; do
+                v="$(pacman -Q "$pkg" 2>/dev/null | awk '{print $2}')"
+                [ -n "$v" ] || v="(absent)"
+                printf 'pkg:%s\t%s\n' "$pkg" "$v"
+            done
+        fi
+        # The Factor fork is built from source, so its identity is a commit,
+        # not a version. AETHER_FACTOR_SONAME points into that tree.
+        if [ -n "${AETHER_FACTOR_SONAME:-}" ] && [ -e "${AETHER_FACTOR_SONAME}" ]; then
+            fdir="$(dirname "$AETHER_FACTOR_SONAME")"
+            fv="$(git -C "$fdir" log --oneline -1 2>/dev/null)"
+            [ -n "$fv" ] || fv="(present, not a git tree)"
+            printf 'factor-fork\t%s\n' "$fv"
+        else
+            printf 'factor-fork\t%s\n' "(absent)"
+        fi
+    } >> "$DEPS_TSV" 2>/dev/null
+    # Echo into the log so the versions are visible in the run output too, not
+    # only in the published table.
+    sed 's/^/  /' "$DEPS_TSV"
+    return 0
+}
+
 publish_results() {
     [ "${AETHER_NIGHTLY_PUBLISH:-1}" = "0" ] && { echo "  (publish skipped)"; return 0; }
 
@@ -279,6 +351,23 @@ publish_results() {
                 [ -z "$n" ] && continue
                 render_row "$n" "$s" "$t"
             done < "$STEPS_TSV"
+        fi
+        echo ""
+        echo "### Dependency versions"
+        echo ""
+        echo "Nothing pins these — the box is rolling-release on purpose, so it"
+        echo "runs ahead of CI. Recorded so an upstream bump is distinguishable"
+        echo "from a code regression."
+        echo ""
+        echo "| dependency | version |"
+        echo "|------------|---------|"
+        if [ -s "$DEPS_TSV" ]; then
+            while IFS="$(printf '\t')" read -r n v; do
+                [ -z "$n" ] && continue
+                echo "| \`$n\` | $v |"
+            done < "$DEPS_TSV"
+        else
+            echo "| _(not captured)_ | — |"
         fi
         echo ""
         echo "### Contrib module type-check (\`ae check\`)"
@@ -538,6 +627,9 @@ fails=0
     # per-module sweep. (A failed dependency gate must turn the dashboard red.)
     : > "$STEPS_TSV"
     run_and_record "contrib dependency gate" require_deps
+    # Recorded right after the gate, so the versions are captured even if a
+    # later step fails — that is exactly the run where you want to know them.
+    run_and_record "dep versions" capture_dep_versions
     run_and_record "make ci" make_ci_step
     # Refresh $HOME/.local from the tree we just built, then prove it took.
     # Runs AFTER `make ci` (which builds everything) and BEFORE the sweeps, so

--- a/tests/integration/emit_csrc_cross/mylib.ae
+++ b/tests/integration/emit_csrc_cross/mylib.ae
@@ -1,0 +1,8 @@
+// Library-shaped source (no main) for the cross --emit=csrc regression.
+greet() -> int {
+    return 42
+}
+
+add(a: int, b: int) -> int {
+    return a + b
+}

--- a/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
+++ b/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
@@ -29,6 +29,17 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "  FAIL: $1"; exit 1; }
 
+# Byte-identity of two files, without cmp(1).
+#
+# The Windows MSYS2 CI shell ships no diffutils, so `cmp` is absent there —
+# the same constraint tests/integration/fmt_gate documents and works around.
+# Using `cmp` here made this test report "emitted C differs by target" on all
+# three Windows legs when the real cause was `cmp: command not found`: a
+# missing tool read as a content mismatch. cksum is POSIX and always present.
+same_bytes() {
+    [ "$(cksum < "$1")" = "$(cksum < "$2")" ]
+}
+
 # --- 1. csrc under a cross triple succeeds and writes all three artifacts ---
 if ! "$AE" build --target=aarch64-linux --emit=csrc "$SRC" -o "$TMP/out" >"$TMP/log" 2>&1; then
     cat "$TMP/log"
@@ -56,8 +67,8 @@ grep -q 'aether_greet' "$TMP/out.h" || fail "out.h lacks the aether_greet protot
 "$AE" build                          --emit=csrc "$SRC" -o "$TMP/nat" >/dev/null 2>&1 \
     || fail "native --emit=csrc was rejected"
 
-if ! cmp -s "$TMP/out.c" "$TMP/mac.c" || ! cmp -s "$TMP/out.c" "$TMP/win.c" \
-   || ! cmp -s "$TMP/out.c" "$TMP/nat.c"; then
+if ! same_bytes "$TMP/out.c" "$TMP/mac.c" || ! same_bytes "$TMP/out.c" "$TMP/win.c" \
+   || ! same_bytes "$TMP/out.c" "$TMP/nat.c"; then
     fail "emitted C differs by target; csrc is meant to be target-neutral source"
 fi
 
@@ -90,7 +101,7 @@ if command -v zig >/dev/null 2>&1; then
     # The cross object must differ from the host one — a silently-native
     # object would satisfy every check above except this.
     "$AE" build --emit=obj "$SRC" -o "$TMP/o_native.o" >/dev/null 2>&1         || fail "native --emit=obj was rejected"
-    if cmp -s "$TMP/o_aarch64-linux.o" "$TMP/o_native.o"; then
+    if same_bytes "$TMP/o_aarch64-linux.o" "$TMP/o_native.o"; then
         fail "the aarch64 object is byte-identical to the host object"
     fi
 else
@@ -105,7 +116,8 @@ fi
 if command -v zig >/dev/null 2>&1; then
     "$AE" build --target=wasm32-wasi --emit=csrc "$SRC" -o "$TMP/wasi"         >"$TMP/wasilog" 2>&1 || { cat "$TMP/wasilog"; fail "wasm32-wasi --emit=csrc was rejected"; }
     [ -s "$TMP/wasi.c" ] || fail "no C emitted for wasm32-wasi"
-    cmp -s "$TMP/wasi.c" "$TMP/out.c"         || fail "wasm32-wasi csrc differs; csrc is meant to be target-neutral"
+    same_bytes "$TMP/wasi.c" "$TMP/out.c" \
+        || fail "wasm32-wasi csrc differs; csrc is meant to be target-neutral"
 
     "$AE" build --target=wasm32-wasi --emit=obj "$SRC" -o "$TMP/wasi.o"         >"$TMP/wasiobj" 2>&1 || { cat "$TMP/wasiobj"; fail "wasm32-wasi --emit=obj was rejected"; }
     case "$(file "$TMP/wasi.o")" in

--- a/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
+++ b/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
@@ -61,17 +61,53 @@ if ! cmp -s "$TMP/out.c" "$TMP/mac.c" || ! cmp -s "$TMP/out.c" "$TMP/win.c" \
     fail "emitted C differs by target; csrc is meant to be target-neutral source"
 fi
 
-# --- 3. the linking emit modes are still rejected, up front ---
+# --- 3. --emit=obj under --target produces a TARGET-format object ---
+# obj is the other non-linking mode (#1648): it stops at `zig cc -c`, so the
+# "executable link rejects it" rationale does not apply to it either. Unlike
+# csrc it emits target-FORMAT machine code, so it does need zig — skip when
+# absent rather than fail, matching how the cross exe tests behave.
+if command -v zig >/dev/null 2>&1; then
+    for spec in "aarch64-linux:ELF:aarch64" "x86_64-windows:COFF:" "x86_64-macos:Mach-O:"; do
+        t="${spec%%:*}"; rest="${spec#*:}"; want="${rest%%:*}"; arch="${rest#*:}"
+        if ! "$AE" build --target="$t" --emit=obj "$SRC" -o "$TMP/o_$t.o"                 >"$TMP/objlog" 2>&1; then
+            cat "$TMP/objlog"
+            fail "--target=$t --emit=obj was rejected"
+        fi
+        [ -s "$TMP/o_$t.o" ] || fail "no object emitted for $t"
+        desc="$(file "$TMP/o_$t.o")"
+        case "$desc" in
+            *"$want"*) ;;
+            *) fail "$t object is not $want format: $desc" ;;
+        esac
+        if [ -n "$arch" ]; then
+            case "$desc" in
+                *"$arch"*) ;;
+                *) fail "$t object is not $arch: $desc" ;;
+            esac
+        fi
+    done
+
+    # The cross object must differ from the host one — a silently-native
+    # object would satisfy every check above except this.
+    "$AE" build --emit=obj "$SRC" -o "$TMP/o_native.o" >/dev/null 2>&1         || fail "native --emit=obj was rejected"
+    if cmp -s "$TMP/o_aarch64-linux.o" "$TMP/o_native.o"; then
+        fail "the aarch64 object is byte-identical to the host object"
+    fi
+else
+    echo "  [skip] --emit=obj cross checks: zig not on PATH"
+fi
+
+# --- 4. the linking emit modes are still rejected, up front ---
 # Up front matters: --emit=both re-dispatches as exe, and without an explicit
 # check it reaches the cross LINKER and dies with "undefined symbol: main" on
 # a source that has no main by design.
-for mode in lib obj both; do
+for mode in lib both; do
     if "$AE" build --target=aarch64-linux --emit="$mode" "$SRC" -o "$TMP/x" \
             >"$TMP/err" 2>&1; then
         fail "--emit=$mode under --target should be rejected but succeeded"
     fi
-    grep -q 'supports executables and --emit=csrc only' "$TMP/err" \
+    grep -q 'supports executables, --emit=csrc and --emit=obj' "$TMP/err" \
         || fail "--emit=$mode gave the wrong diagnostic: $(head -1 "$TMP/err")"
 done
 
-echo "  PASS: --emit=csrc works under --target; lib/obj/both still rejected"
+echo "  PASS: --emit=csrc + --emit=obj work under --target; lib/both still rejected"

--- a/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
+++ b/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
@@ -97,6 +97,34 @@ else
     echo "  [skip] --emit=obj cross checks: zig not on PATH"
 fi
 
+# --- 3b. wasm32-wasi routes through zig and needs no hand-passed defines ---
+# WASI's setjmp.h #errors without -D__wasm_exception_handling__=1, and WASI has
+# no POSIX signal API without -D_WASI_EMULATED_SIGNAL. CI passed both by hand
+# ("Verify WASI panic runtime"); `ae build` now supplies them itself, so the
+# whole point of this case is that NOTHING is passed on the command line here.
+if command -v zig >/dev/null 2>&1; then
+    "$AE" build --target=wasm32-wasi --emit=csrc "$SRC" -o "$TMP/wasi"         >"$TMP/wasilog" 2>&1 || { cat "$TMP/wasilog"; fail "wasm32-wasi --emit=csrc was rejected"; }
+    [ -s "$TMP/wasi.c" ] || fail "no C emitted for wasm32-wasi"
+    cmp -s "$TMP/wasi.c" "$TMP/out.c"         || fail "wasm32-wasi csrc differs; csrc is meant to be target-neutral"
+
+    "$AE" build --target=wasm32-wasi --emit=obj "$SRC" -o "$TMP/wasi.o"         >"$TMP/wasiobj" 2>&1 || { cat "$TMP/wasiobj"; fail "wasm32-wasi --emit=obj was rejected"; }
+    case "$(file "$TMP/wasi.o")" in
+        *WebAssembly*) ;;
+        *) fail "wasm32-wasi object is not a wasm module: $(file "$TMP/wasi.o")" ;;
+    esac
+
+    # A full executable link is NOT supported for wasm32 (the runtime
+    # scheduler's layout assertions assume 64-bit pointers). It must fail with
+    # our one-line diagnostic, not a static_assert deep in a scheduler TU.
+    printf 'main() {\n    println("hi")\n}\n' > "$TMP/app.ae"
+    if "$AE" build --target=wasm32-wasi "$TMP/app.ae" -o "$TMP/app.wasm"             >"$TMP/wasiexe" 2>&1; then
+        fail "wasm32-wasi executable link should be rejected but succeeded"
+    fi
+    grep -q 'executable link is not supported yet' "$TMP/wasiexe"         || fail "wasm32-wasi exe gave the wrong diagnostic: $(head -1 "$TMP/wasiexe")"
+else
+    echo "  [skip] wasm32-wasi checks: zig not on PATH"
+fi
+
 # --- 4. the linking emit modes are still rejected, up front ---
 # Up front matters: --emit=both re-dispatches as exe, and without an explicit
 # check it reaches the cross LINKER and dies with "undefined symbol: main" on
@@ -110,4 +138,4 @@ for mode in lib both; do
         || fail "--emit=$mode gave the wrong diagnostic: $(head -1 "$TMP/err")"
 done
 
-echo "  PASS: --emit=csrc + --emit=obj work under --target; lib/both still rejected"
+echo "  PASS: csrc/obj under --target (incl. wasm32-wasi); lib/both still rejected"

--- a/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
+++ b/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Regression: aether#1648. `ae build --target=<triple> --emit=csrc` is allowed.
+#
+# The cross guard rejected every library-shaped emit mode, justified by a
+# comment about "library-shaped C that the executable link rejects". That
+# reasoning is false for --emit=csrc, which emits C and STOPS — there is no
+# link. csrc under --target is the cross-linkable-lib path that needs no
+# cross-link support: the consumer compiles the .so/.a/.wasm themselves.
+#
+# Asserts:
+#   - --target=<triple> --emit=csrc emits .c/.h/.catalog.json and exits 0
+#   - it needs NO zig (csrc never links, so the cross linker is irrelevant)
+#   - the emitted C is target-NEUTRAL: byte-identical across triples and to
+#     the native emit, since platform selection stays in #if and is resolved
+#     by the consumer's compiler
+#   - --emit=lib / obj / both under --target are still rejected up front,
+#     with the diagnostic naming csrc as the supported mode
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+SRC="$SCRIPT_DIR/mylib.ae"
+
+TMP="${TMPDIR:-/tmp}/ae_csrc_cross_$$"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "  FAIL: $1"; exit 1; }
+
+# --- 1. csrc under a cross triple succeeds and writes all three artifacts ---
+if ! "$AE" build --target=aarch64-linux --emit=csrc "$SRC" -o "$TMP/out" >"$TMP/log" 2>&1; then
+    cat "$TMP/log"
+    fail "--target=aarch64-linux --emit=csrc was rejected"
+fi
+for f in out.c out.h out.catalog.json; do
+    [ -s "$TMP/$f" ] || fail "$f missing or empty"
+done
+
+# No native library may be produced — csrc stops before any compile.
+for bad in out.so out.dylib out.dll out; do
+    [ -e "$TMP/$bad" ] && fail "csrc produced $bad; it must not compile or link"
+done
+
+# The catalog header must carry the aether_<name> prototypes.
+grep -q 'aether_greet' "$TMP/out.h" || fail "out.h lacks the aether_greet prototype"
+
+# --- 2. the emitted C is target-neutral ---
+# Platform selection stays in #if __linux__ / __APPLE__ / __wasi__ and is
+# resolved by the CONSUMER's compiler, so --target must not change the bytes.
+"$AE" build --target=x86_64-macos   --emit=csrc "$SRC" -o "$TMP/mac"  >/dev/null 2>&1 \
+    || fail "--target=x86_64-macos --emit=csrc was rejected"
+"$AE" build --target=x86_64-windows --emit=csrc "$SRC" -o "$TMP/win"  >/dev/null 2>&1 \
+    || fail "--target=x86_64-windows --emit=csrc was rejected"
+"$AE" build                          --emit=csrc "$SRC" -o "$TMP/nat" >/dev/null 2>&1 \
+    || fail "native --emit=csrc was rejected"
+
+if ! cmp -s "$TMP/out.c" "$TMP/mac.c" || ! cmp -s "$TMP/out.c" "$TMP/win.c" \
+   || ! cmp -s "$TMP/out.c" "$TMP/nat.c"; then
+    fail "emitted C differs by target; csrc is meant to be target-neutral source"
+fi
+
+# --- 3. the linking emit modes are still rejected, up front ---
+# Up front matters: --emit=both re-dispatches as exe, and without an explicit
+# check it reaches the cross LINKER and dies with "undefined symbol: main" on
+# a source that has no main by design.
+for mode in lib obj both; do
+    if "$AE" build --target=aarch64-linux --emit="$mode" "$SRC" -o "$TMP/x" \
+            >"$TMP/err" 2>&1; then
+        fail "--emit=$mode under --target should be rejected but succeeded"
+    fi
+    grep -q 'supports executables and --emit=csrc only' "$TMP/err" \
+        || fail "--emit=$mode gave the wrong diagnostic: $(head -1 "$TMP/err")"
+done
+
+echo "  PASS: --emit=csrc works under --target; lib/obj/both still rejected"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5240,10 +5240,10 @@ static int cmd_build(int argc, char** argv) {
     const char* ztriple = cross_target_to_zig(target);
     if (target && strcmp(target, "wasm") != 0 && strcmp(target, "native") != 0 && !ztriple) {
         fprintf(stderr, "Error: Unknown target '%s'.\n", target);
-        fprintf(stderr, "Valid targets: native, wasm, or a cross triple "
+        fprintf(stderr, "Valid targets: native, wasm (Emscripten), or a cross triple "
                         "(aarch64-macos, x86_64-macos, aarch64-linux, x86_64-linux, "
                         "aarch64-freebsd, x86_64-freebsd, x86_64-windows, "
-                        "aarch64-windows).\n");
+                        "aarch64-windows, wasm32-wasi).\n");
         return 1;
     }
     int is_wasm = target && strcmp(target, "wasm") == 0;
@@ -5432,6 +5432,29 @@ static int cmd_build(int argc, char** argv) {
         // consumer compiles the .so/.a/.wasm themselves. --target therefore
         // does not change the bytes emitted; it is accepted so one command
         // line works for both native and cross consumers.
+        /* The wasm triples are wired for the NON-LINKING emit modes only.
+         * `--emit=csrc` and `--emit=obj` are proven end to end (a real
+         * `WebAssembly (wasm) binary module` object), but a full executable
+         * link is not: runtime/scheduler/multicore_scheduler.c carries
+         *
+         *     _Static_assert(sizeof(Mailbox) % 8 == 0, ...)
+         *
+         * with no 64-bit guard (unlike the `sizeof(Message) == 48` assertion
+         * directly above it, which has one), so it fails on any 32-bit target
+         * including wasm32. That is a pre-existing runtime portability gap
+         * (filed as #1652), not something this path introduces, and it wants
+         * its own change rather than a workaround here. Reject up front so the
+         * user gets one line instead of a static-assert deep in a scheduler
+         * TU. */
+        if (strstr(ztriple, "wasm") && g_emit_exe && !g_emit_csrc && !g_emit_obj) {
+            fprintf(stderr,
+                "Error: --target=%s supports --emit=csrc and --emit=obj; a full "
+                "executable link is not supported yet (the runtime scheduler's "
+                "layout assertions assume a 64-bit target).\n"
+                "  For a runnable wasm bundle use --target=wasm (Emscripten).\n",
+                target);
+            return 1;
+        }
         if (g_emit_lib && !g_emit_csrc && !g_emit_obj) {
             fprintf(stderr,
                 "Error: cross-compilation (--target=%s) supports executables, "

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5121,8 +5121,8 @@ static int cmd_build(int argc, char** argv) {
                     if (strncmp(argv[j], "--target=", 9) == 0 &&
                         strcmp(argv[j] + 9, "native") != 0) {
                         fprintf(stderr,
-                            "Error: cross-compilation (%s) supports executables and "
-                            "--emit=csrc only; --emit=lib, --emit=both and --emit=obj "
+                            "Error: cross-compilation (%s) supports executables, "
+                            "--emit=csrc and --emit=obj; --emit=lib and --emit=both "
                             "are not supported yet.\n", argv[j]);
                         return 1;
                     }
@@ -5402,11 +5402,18 @@ static int cmd_build(int argc, char** argv) {
         // then LINK it, which the executable link rejects. Reject those up
         // front, like unknown targets.
         //
-        // --emit=csrc is deliberately allowed through (#1648). It sets
-        // g_emit_lib for its codegen shape (the same aether_<name> catalog as
-        // --emit=lib), but it never invokes gcc: the build path returns as soon
-        // as the .c/.h/catalog are written. The "executable link rejects it"
-        // rationale therefore does not apply — there is no link.
+        // --emit=csrc and --emit=obj are deliberately allowed through
+        // (#1648). Both set g_emit_lib for their codegen shape (the same
+        // aether_<name> catalog as --emit=lib), but NEITHER LINKS: csrc
+        // returns as soon as the .c/.h/catalog are written, and obj stops at
+        // `zig cc -c`. The "executable link rejects it" rationale therefore
+        // does not apply to either — there is no link to reject anything.
+        //
+        // They differ in what they produce, which is why csrc needs no zig
+        // and obj does: csrc emits portable SOURCE (target-neutral, compiled
+        // later by the consumer), while obj emits a target-FORMAT object
+        // (real machine code for the triple), so it genuinely needs the cross
+        // toolchain.
         //
         // The emitted C is target-NEUTRAL, not target-parameterised: platform
         // selection stays in #if __linux__ / __APPLE__ / __wasi__ and is
@@ -5416,17 +5423,18 @@ static int cmd_build(int argc, char** argv) {
         // consumer compiles the .so/.a/.wasm themselves. --target therefore
         // does not change the bytes emitted; it is accepted so one command
         // line works for both native and cross consumers.
-        if (g_emit_lib && !g_emit_csrc) {
+        if (g_emit_lib && !g_emit_csrc && !g_emit_obj) {
             fprintf(stderr,
-                "Error: cross-compilation (--target=%s) supports executables and "
-                "--emit=csrc only; --emit=lib, --emit=both and --emit=obj are not "
+                "Error: cross-compilation (--target=%s) supports executables, "
+                "--emit=csrc and --emit=obj; --emit=lib and --emit=both are not "
                 "supported yet.\n", target);
             return 1;
         }
-        /* zig is the cross LINKER. --emit=csrc never links, so requiring zig
-         * for it would invent a dependency the build does not have — and one
-         * that would block the very case csrc exists to serve: emitting
-         * portable C on a machine that has no cross toolchain at all. */
+        /* --emit=csrc never invokes zig at all: it emits portable C and
+         * stops, so requiring zig would invent a dependency the build does
+         * not have — and would block the very case csrc exists to serve,
+         * emitting portable C on a machine with no cross toolchain. Every
+         * other mode (exe, and --emit=obj's `zig cc -c`) does need it. */
         if (!g_emit_csrc && run_cmd_quiet("zig version") != 0) {
             fprintf(stderr, "Error: zig not found on PATH (required to cross-compile for %s).\n",
                     target);
@@ -5570,6 +5578,21 @@ static int cmd_build(int argc, char** argv) {
             } else {
                 snprintf(obj_file + ol, sizeof(obj_file) - ol, ".o");
             }
+        }
+        /* #1648: under --target the object must be in the TARGET's format,
+         * so it goes through `zig cc -target <t> -c` rather than the host CC.
+         * AE_CC/CC are deliberately not consulted on this path — they name a
+         * host compiler, and honouring them would silently produce a host
+         * object for a command that asked for a cross one. */
+        if (is_cross) {
+            if (run_cross_compile_obj(c_file, obj_file, !quick, ztriple) != 0) {
+                fprintf(stderr, "Failed to compile the generated C to an object.\n");
+                return 1;
+            }
+            printf("Built object: %s\n", obj_file);
+            printf("       target %s: link it on a matching host, or with the same "
+                   "zig target.\n", target);
+            return 0;
         }
         const char* objcc = getenv("AE_CC");
         if (!objcc || !*objcc) objcc = getenv("CC");

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5107,7 +5107,26 @@ static int cmd_build(int argc, char** argv) {
                  *
                  * If the exe pass fails the lib pass is skipped and
                  * the exe's exit code is returned so the user sees
-                 * the precise error.  */
+                 * the precise error.
+                 *
+                 * Because it re-dispatches, --emit=both never reaches the
+                 * is_cross guard further down with g_emit_lib set: under
+                 * --target the exe pass runs first and dies at the cross
+                 * LINKER with "undefined symbol: main" on a library-shaped
+                 * source. Reject it here instead, where the flag is still
+                 * visible, so the user gets the same up-front diagnostic as
+                 * --emit=lib rather than an ld.lld error naming a symbol they
+                 * never wrote. (Pre-existing; #1648 only unblocks csrc.)  */
+                for (int j = 0; j < argc; j++) {
+                    if (strncmp(argv[j], "--target=", 9) == 0 &&
+                        strcmp(argv[j] + 9, "native") != 0) {
+                        fprintf(stderr,
+                            "Error: cross-compilation (%s) supports executables and "
+                            "--emit=csrc only; --emit=lib, --emit=both and --emit=obj "
+                            "are not supported yet.\n", argv[j]);
+                        return 1;
+                    }
+                }
                 int o_idx = -1;
                 for (int j = 0; j < argc - 1; j++) {
                     if (strcmp(argv[j], "-o") == 0) { o_idx = j + 1; break; }
@@ -5378,16 +5397,37 @@ static int cmd_build(int argc, char** argv) {
     // Pre-flight for cross builds: zig provides the backend compiler +
     // target libc/linker, and the program must be dependency-free (PR 1).
     if (is_cross) {
-        // Cross builds produce executables only for now; --emit=lib /
-        // --emit=both would emit library-shaped C (no main) that the
-        // executable link rejects. Reject up front, like unknown targets.
-        if (g_emit_lib) {
+        // Cross builds produce executables or portable C source. --emit=lib /
+        // --emit=both / --emit=obj would emit library-shaped C (no main) and
+        // then LINK it, which the executable link rejects. Reject those up
+        // front, like unknown targets.
+        //
+        // --emit=csrc is deliberately allowed through (#1648). It sets
+        // g_emit_lib for its codegen shape (the same aether_<name> catalog as
+        // --emit=lib), but it never invokes gcc: the build path returns as soon
+        // as the .c/.h/catalog are written. The "executable link rejects it"
+        // rationale therefore does not apply — there is no link.
+        //
+        // The emitted C is target-NEUTRAL, not target-parameterised: platform
+        // selection stays in #if __linux__ / __APPLE__ / __wasi__ and is
+        // resolved by the consumer's own compiler, which defines those macros
+        // for whatever target it builds. That is what makes csrc the
+        // cross-linkable-lib path that needs no cross-link support — the
+        // consumer compiles the .so/.a/.wasm themselves. --target therefore
+        // does not change the bytes emitted; it is accepted so one command
+        // line works for both native and cross consumers.
+        if (g_emit_lib && !g_emit_csrc) {
             fprintf(stderr,
-                "Error: cross-compilation (--target=%s) supports executables only; "
-                "--emit=lib and --emit=both are not supported yet.\n", target);
+                "Error: cross-compilation (--target=%s) supports executables and "
+                "--emit=csrc only; --emit=lib, --emit=both and --emit=obj are not "
+                "supported yet.\n", target);
             return 1;
         }
-        if (run_cmd_quiet("zig version") != 0) {
+        /* zig is the cross LINKER. --emit=csrc never links, so requiring zig
+         * for it would invent a dependency the build does not have — and one
+         * that would block the very case csrc exists to serve: emitting
+         * portable C on a machine that has no cross toolchain at all. */
+        if (!g_emit_csrc && run_cmd_quiet("zig version") != 0) {
             fprintf(stderr, "Error: zig not found on PATH (required to cross-compile for %s).\n",
                     target);
             fprintf(stderr, "Install zig 0.16.0+: https://ziglang.org/download/  (macOS: brew install zig)\n");

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -63,7 +63,40 @@ const char* cross_target_to_zig(const char* t) {
      * State the ABI version so Zig's startup objects match that base. */
     if (!strcmp(t, "aarch64-freebsd") || !strcmp(t, "arm64-freebsd")) return "aarch64-freebsd.15.0";
     if (!strcmp(t, "x86_64-freebsd")  || !strcmp(t, "amd64-freebsd")) return "x86_64-freebsd.15.0";
+    /* WebAssembly (Tier A — self-contained): zig bundles wasi-libc, so no
+     * sysroot. NOTE this is the ZIG wasm path, and is deliberately distinct
+     * from bare `--target=wasm`, which routes to Emscripten (`emcc`) and stays
+     * as it is: emcc supplies a JS host, a DOM/filesystem shim and its own
+     * pthread emulation, which is a different product from a self-contained
+     * `.wasm` a WASI runtime loads. Neither supersedes the other, so they are
+     * selected by different target names rather than one silently changing
+     * backend.
+     *
+     * wasm32-freestanding is deliberately NOT mapped. It ships no libc, so
+     * the emitted C cannot even be compiled to an object: `--emit=obj` dies on
+     * `fatal error: 'stdio.h' file not found` (the generated C includes it
+     * unconditionally). Offering a target whose only working mode is
+     * `--emit=csrc` — which produces the same target-neutral bytes as every
+     * other target anyway — would advertise support that does not exist. */
+    if (!strcmp(t, "wasm32-wasi")   || !strcmp(t, "wasm-wasi"))  return "wasm32-wasi";
     return NULL;
+}
+
+/* The two defines every WASI compile needs, as one string so the obj and exe
+ * paths cannot drift apart.
+ *
+ * WASI's setjmp.h #errors out unless exception handling is declared
+ * ("Setjmp/longjmp support requires Exception handling support"), and the
+ * runtime's panic path includes it unconditionally. _WASI_EMULATED_SIGNAL is
+ * needed for the same reason the panic guard exists: WASI has no POSIX signal
+ * API. CI passed both by hand (ci.yml "Verify WASI panic runtime"); the build
+ * now supplies them itself, so `ae build --target=wasm32-wasi` needs nothing
+ * on the command line. */
+#define AETHER_WASI_DEFINES "-D_WASI_EMULATED_SIGNAL -D__wasm_exception_handling__=1"
+
+/* True if the resolved zig triple is a WASI target. */
+static bool cross_target_is_wasi(const char* ztriple) {
+    return ztriple && strstr(ztriple, "wasi") != NULL;
 }
 
 /* True if `t` is a cross target that needs a base sysroot for system headers
@@ -247,6 +280,10 @@ int run_cross_compile_obj(const char* c_file, const char* obj_file,
         strncat(feature_defs, " -DMA_NO_COREAUDIO",
                 sizeof(feature_defs) - strlen(feature_defs) - 1);
     }
+    if (cross_target_is_wasi(ztriple)) {
+        strncat(feature_defs, " " AETHER_WASI_DEFINES,
+                sizeof(feature_defs) - strlen(feature_defs) - 1);
+    }
 
     /* Tier-B (FreeBSD) targets need the base sysroot for HEADERS here (the
      * -L is link-side, but harmless and kept so the flag string matches the
@@ -333,6 +370,10 @@ int run_cross_build(const char* c_file, const char* out_file,
     char feature_defs[2048] = "-DAETHER_HAS_SANDBOX";
     if (strstr(ztriple, "macos")) {
         strncat(feature_defs, " -DMA_NO_COREAUDIO",
+                sizeof(feature_defs) - strlen(feature_defs) - 1);
+    }
+    if (cross_target_is_wasi(ztriple)) {
+        strncat(feature_defs, " " AETHER_WASI_DEFINES,
                 sizeof(feature_defs) - strlen(feature_defs) - 1);
     }
     /* Tier-B (FreeBSD) targets need a base sysroot for headers and libraries;

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -215,6 +215,81 @@ static bool cross_cmd_fmt(char** buf, size_t* cap, const char* fmt, ...) {
     }
 }
 
+/* #1648 part (2), obj slice: compile ONE generated .c to a target-format
+ * object with `zig cc -target <t> -c`, and stop.
+ *
+ * Deliberately not run_cross_build with a flag. That function assembles the
+ * whole runtime+stdlib source set, archives it into libaether.a and LINKS an
+ * executable; --emit=obj wants none of that — the caller drops the .o into
+ * their own build and links it themselves. What the two DO share is the
+ * compile-side flag shape, so this mirrors it exactly: the same --sysroot
+ * handling for Tier-B targets, the same -DMA_NO_COREAUDIO workaround for
+ * macos, and the same include flags.
+ *
+ * What it deliberately omits is the link tail (fbsd_link, *_platform_libs,
+ * crossbuild_libs): those name libraries, and nothing is being linked. The
+ * Tier-2 CROSSBUILD_SYSROOT probe is likewise skipped — it exists to decide
+ * which -l names the LINK gets. A consumer linking this object supplies its
+ * own libaether.a and system libraries for the target, exactly as they do for
+ * a native --emit=obj.
+ */
+int run_cross_compile_obj(const char* c_file, const char* obj_file,
+                          bool optimize, const char* ztriple) {
+    const char* user_cflags = get_cflags();
+    const char* opt = optimize ? "-O2" : "-O0 -g";
+
+    /* Same macos workaround as the link path: zig's bundled macOS SDK stubs
+     * do not ship the Apple-licensed CoreAudio framework headers, so
+     * miniaudio (always compiled into the runtime) must fall back to its null
+     * backend or ANY macos cross-compile fails. */
+    char feature_defs[512] = "-DAETHER_HAS_SANDBOX";
+    if (strstr(ztriple, "macos")) {
+        strncat(feature_defs, " -DMA_NO_COREAUDIO",
+                sizeof(feature_defs) - strlen(feature_defs) - 1);
+    }
+
+    /* Tier-B (FreeBSD) targets need the base sysroot for HEADERS here (the
+     * -L is link-side, but harmless and kept so the flag string matches the
+     * link path's shape). Same explicit -I as run_cross_build: for a FreeBSD
+     * target `--sysroot` alone does not make zig cc search usr/include. */
+    char sysroot_flag[3200];
+    sysroot_flag[0] = '\0';
+    if (cross_target_needs_sysroot(ztriple)) {
+        const char* sr = getenv("AETHER_SYSROOT");
+        if (!sr || !*sr) {
+            fprintf(stderr,
+                "Error: target %s needs a FreeBSD base sysroot, but AETHER_SYSROOT is unset.\n"
+                "  Provision the FreeBSD system headers with aether-crossbuild:\n"
+                "    ./scripts/fetch-freebsd-base.sh <cpu> [major]   # e.g. x86_64 15\n"
+                "  then: AETHER_SYSROOT=<crossbuild>/bases/<cpu>-freebsd[ver] ae build ... --target=%s\n",
+                ztriple, ztriple);
+            return 1;
+        }
+        snprintf(sysroot_flag, sizeof(sysroot_flag),
+                 "--sysroot=%s -I%s/usr/include", sr, sr);
+    }
+
+    char* cmd = NULL;
+    size_t cmd_cap = 0;
+    if (!cross_cmd_fmt(&cmd, &cmd_cap,
+            "zig cc -target %s %s %s %s %s %s -c \"%s\" -o \"%s\"",
+            ztriple, sysroot_flag, opt, feature_defs, user_cflags,
+            tc.include_flags ? tc.include_flags : "",
+            c_file, obj_file)) {
+        fprintf(stderr, "Error: out of memory building the cross-compile command.\n");
+        free(cmd);
+        return 1;
+    }
+    if (tc.verbose) fprintf(stderr, "ae: %s\n", cmd);
+    int rc = run_cmd_show_warnings(cmd);
+    free(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "Error: cross-compiling %s for %s failed.\n", c_file, ztriple);
+        return 1;
+    }
+    return 0;
+}
+
 int run_cross_build(const char* c_file, const char* out_file,
                            bool optimize, const char* extra,
                            const char* ztriple) {

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -102,6 +102,10 @@ unsigned long long compute_cache_key(const char* ae_file, const char* extra_file
 /* ae_cross.c — cross-compilation via the zig cc backend (#1105). */
 const char* cross_target_to_zig(const char* t);
 bool cross_uses_unsupported_module(const char* file, char* which, size_t wsz);
+/* #1648: compile one generated .c to a target-format object (zig cc -c),
+ * without assembling or linking the runtime. Backs `--emit=obj --target=`. */
+int  run_cross_compile_obj(const char* c_file, const char* obj_file,
+                           bool optimize, const char* ztriple);
 int  run_cross_build(const char* c_file, const char* out_file,
                      bool optimize, const char* extra_files,
                      const char* ztriple);


### PR DESCRIPTION
Addresses #1648 — all of part (1), the **obj slice of part (2)**, and **`wasm32-wasi` via zig**. Adds the CachyOS nightly work as a tail.

## 1. `--emit=csrc`, `--emit=obj` and `wasm32-wasi` under `--target` (#1648)

The cross guard rejected every library-shaped emit mode, justified by its own comment:

> `--emit=lib` / `--emit=both` would emit library-shaped C (no main) that the **executable link** rejects.

That reasoning is false for `--emit=csrc`. csrc writes the portable C, its catalog header and the JSON catalog, and **stops** — the build path returns before any compile or link (#996). There is no link for library-shaped C to be rejected by. The guard caught csrc only because csrc sets `g_emit_lib` for its *codegen shape* (it reuses `--emit=lib`'s `aether_<name>` catalog), not because it links.

```
before:  ae build --target=aarch64-linux --emit=csrc lib.ae -o out
         Error: cross-compilation supports executables only...

after:   Emitted C source: out.c
         Emitted header:   out.h
         Emitted catalog:  out.catalog.json
```

**Why it matters** (from the issue): csrc under `--target` is the route to a cross-compiled linkable library *without cross-link support* — emit the C here, and the consumer compiles it for their target into the `.so`/`.a`/`.wasm` they need. That is the compile-on-install model, and it sidesteps the hard cross-link problem entirely.

### The open question in the issue, answered by measurement

The issue asked whether the emitted C needs the *target's* platform-macro selection resolved at emit time, or whether that is left to the consumer's compile — guessing the latter was "simpler and probably correct."

Measured rather than assumed: the emitted `.c` is **byte-identical** across `aarch64-linux`, `x86_64-macos`, `x86_64-windows` and the native emit (same md5). Platform selection stays in `#if __linux__` / `__APPLE__` / `__wasi__` and is resolved by the consumer's compiler, which defines those macros for whatever target it builds. So `--target` does not change the output; it is accepted so one command line works for both native and cross consumers. That property is now asserted by a test, not just believed.

### `zig` is no longer required for csrc

zig is the cross **linker**. Requiring it for a mode that never links would invent a dependency the build does not have — and would block the very case csrc exists to serve: emitting portable C on a machine with no cross toolchain at all.

### Bonus fix: `--emit=both` under `--target`

Found while testing. `--emit=both` re-dispatches as an exe pass then a lib pass, so it never reached the guard with `g_emit_lib` set — under `--target` the exe pass ran and died at the cross linker:

```
ld.lld: error: undefined symbol: main
```

...on a source that has no `main` by design. **Pre-existing**, confirmed by rebuilding without this change and reproducing the identical error. Now rejected up front with the same diagnostic as `--emit=lib`.

## `--emit=obj` under `--target` — the obj slice of part (2)

obj is the **other non-linking mode**: it compiles the generated C and stops at `-c`, so the guard's rationale never applied to it either. It tripped the guard for the same incidental reason as csrc — it sets `g_emit_lib` internally (`ae.c:5327`) for its codegen shape.

Where it *differs* from csrc is what it produces, and that is why it is a separate commit rather than the same one-line relaxation: csrc emits portable target-neutral **source**, obj emits a target-format **object** — real machine code for the triple. So it genuinely needs the cross toolchain, and routes through `zig cc -target <t> -c`.

Verified by format, not by exit code:

```
aarch64-linux    ELF 64-bit LSB relocatable, ARM aarch64
x86_64-windows   Intel amd64 COFF object file
x86_64-macos     Mach-O 64-bit x86_64 object
native           ELF 64-bit LSB relocatable, x86-64   (unchanged)
```

The test also asserts the cross object is **not byte-identical to the host one** — a silently-native object would satisfy every other check.

`run_cross_compile_obj` is deliberately **not** `run_cross_build` with a flag. That function assembles the whole runtime+stdlib source set, archives `libaether.a` and links an executable; `--emit=obj` wants none of it. It does mirror the compile-side flag shape exactly (same `--sysroot` handling for Tier-B FreeBSD targets, same `-DMA_NO_COREAUDIO` for macos), and omits the link tail and Tier-2 `CROSSBUILD_SYSROOT` probe — those decide which `-l` names the *link* gets, and nothing is linked. The consumer supplies their own `libaether.a` for the target, as for a native `--emit=obj`.

`AE_CC`/`CC` are deliberately not consulted on this path: they name a host compiler, and honouring them would silently produce a host object for a command that asked for a cross one.

## `wasm32-wasi` via zig

`wasm32-wasi` returned `NULL` from `cross_target_to_zig()` → *"Unknown target"*, while bare `--target=wasm` was hardcoded to the emcc path. It now maps to a zig triple like every other target, so `--emit=obj` produces a real module:

```
$ ae build --target=wasm32-wasi --emit=obj lib.ae -o lib.o && file lib.o
lib.o: WebAssembly (wasm) binary module version 0x1 (MVP)
```

**The two WASI defines are injected by the build**, not left to the caller. Without `-D__wasm_exception_handling__=1` WASI's `setjmp.h` refuses to compile (*"Setjmp/longjmp support requires Exception handling support"*); without `-D_WASI_EMULATED_SIGNAL` there is no POSIX signal API. I verified both, including the failure mode without them. They live in one `AETHER_WASI_DEFINES` string used by both `run_cross_compile_obj` and `run_cross_build`, so the obj and exe paths cannot drift.

**emcc and zig stay separate**, selected by target name — `--target=wasm` is Emscripten (JS host, DOM/filesystem shim, pthread emulation), `wasm32-wasi` is a self-contained object. Different products, so neither supersedes the other. `is_wasm` is an exact `strcmp` against `"wasm"`, so they cannot collide.

### Three things testing changed about the plan

**A full executable link for wasm32 does not work**, and is now rejected up front. `multicore_scheduler.c` asserts `sizeof(Mailbox) % 8 == 0` with no 64-bit guard — unlike the `sizeof(Message) == 48` assertion directly above it, which has one — so it fails on any 32-bit target. Pre-existing; filed as **#1652** with options for a real fix. The user now gets one line naming the cause instead of a `_Static_assert` deep in a scheduler TU. `csrc`/`obj` are unaffected: they compile only the user's generated C, never the runtime.

**`wasm32-freestanding` is deliberately not mapped**, though the ask floated it. No libc, so the generated C's unconditional `#include <stdio.h>` cannot resolve and `--emit=obj` dies. Its only working mode would be `--emit=csrc`, which emits the same target-neutral bytes as every other target — offering it would advertise support that does not exist.

**The CI "Verify WASI panic runtime" step is *not* redundant and stays.** Checked rather than assumed: `--emit=obj` never compiles `aether_panic.c` (grep of the emitted command line → 0), so that step remains the only thing building the panic runtime for WASI — exactly the regression #1645 fixed. A comment now says so, and notes it keeps its hand-passed defines deliberately, so any future divergence from the injected set surfaces there.

### Still out of scope

`--emit=lib` and `--emit=both` remain rejected — they link a shared library, which the cross path does not yet produce. That (plus the Windows `.dll` export handling and the OpenSSL/zlib scope caveat the issue lists) is the remainder of part (2), and **#1648 stays open for it**.

### Verification

`tests/integration/emit_csrc_cross/` asserts the issue's acceptance criterion, the target-neutrality property, that no binary is emitted, and that lib/obj/both are still rejected with the right message. **Verified to FAIL against a pre-fix `ae`** (`--emit=csrc was rejected`) and pass after.

---

## 2. CachyOS nightly: fail hard on skips, and record dep versions

Two commits, tacked on. Both touch only `tests/cachyos/` and one Makefile default.

### Skips that reported as passes

The box is provisioned with every contrib dependency, so a step that SKIPs there is not an honest report of an absent library — it is a silently shrinking test surface. Each layer hid the one below it:

| Layer | Default | On the box |
|---|---|---|
| A dep is absent | — | dep gate turns the run RED (already) |
| A module fails to **build** | `make contrib` tallies SKIP, exits 0 | `MODULES=<all>` → fail-hard |
| A bridge **archive** is missing | prints SKIP, exits 0 | `CONTRIB_HOST_STRICT=1` → FAIL |
| A spec **runs but skips its cases** | prints `⊘`, exits 0 | `skipped=0` gate → RED |

The dep gate cannot cover the middle rows: it catches *"the library is gone"*, never *"the library is here and the module no longer compiles against it"* — which is precisely the breakage a GCC 16 / Clang 22 box exists to find.

The last row was found by testing rather than reasoning. `contrib/host/factor`'s archive builds fine with **no Factor installed** (the bridge is pure `dlopen`), so it passes both layers above, then skips all six cases at runtime with `AETHER_FACTOR_SONAME` unset — reporting `0 passing / 6 skipped` and exiting 0. `std.spec` states the principle directly: *"A skip that reports as a pass is worse than no skip at all."*

That gate reads the machine-readable report `std.spec` already exposes (`AE_SPEC_FORMAT=aeocha` → `skipped=<n>`) rather than parsing ANSI-coloured output. It also mirrors the per-language `SONAME` discovery the Makefile does; without that, every `dlopen` bridge skips and the gate fires on a correctly provisioned box. Verified both ways: bare it falsely flagged lua/python/ruby (21 skips); with discovery it reports exactly what `make contrib-host-check` does.

The module list is **derived from `contrib_build.sh`'s own `CATALOGUE`**, not hardcoded, so a module added there is covered automatically. `CONTRIB_HOST_STRICT` defaults to `0` — CI and dev boxes are unaffected.

### Dependency versions: recorded, not pinned

Nothing in the repo pins any contrib dep, and pinning would be the wrong fix — the box is rolling-release precisely so it runs *ahead* of CI. What was missing is the **record**: without it a green run does not say what it tested, and a red run the morning after `pacman -Syu` reads as a code regression rather than an upstream bump.

Each run now writes `deps_<stamp>.tsv` and publishes it beside the step timings. Captured on the box:

```
racket 9.2       lua 5.5.0      python 3.14.6    node v26.4.0
go 1.26.5        tinygo 0.41.1  ruby 3.4.10      java 26.0.2
perl v5.42.2     tclsh 8.6.16   factor-fork 91a3639cf6
pkg:sqlite 3.53.4  pkg:expat 2.8.2  pkg:duktape 2.7.0  pkg:ffmpeg 8.1.2
```

Three wrinkles handled: `pacman -Q` for libraries with no `--version`; the Factor fork records a **commit** since it is built from source; and `racket --version` greets rather than reports (`"Welcome to Racket v9.2 [cs]."`), so it uses `racket -e '(display (version))'` for a bare `9.2`.

Timely: **Racket 9.3 shipped 2026-08-13** while the box was on 9.2. The Racket CS embedding surface the bridge compiles against (`chezscheme.h`'s `Snil`/`Scons`/`Smake_bytevector`) is macro-based and has moved across majors — exactly the upgrade this table makes legible.

Reporting is all that step does; whether a missing dep is fatal stays the dep gate's decision.

---

## Testing

- `make test` — **392 passed, 0 failed**
- `make test-ae` — no failures
- `make check-docs` — clean
- `tests/integration/emit_csrc_cross/` — verified to fail pre-fix, pass post-fix (twice: once against the pre-csrc build, again against the csrc-only build for the obj cases); now also covers wasm32-wasi csrc/obj and the exe rejection
- `make test-ae` — compared against a **clean `origin/main` worktree**: base `965 passed, 3 failed` (`http_server_h2`, `repl`, `windows_crt_symbols` — all environmental). An earlier branch run showed a 25-test delta which turned out to be an alphabetically contiguous `a`-through-`d` block — the window in which a concurrent `make -j8 ae` replaced the binary those tests invoke. All 26 pass on re-run in a quiet tree.
- Dep capture exercised on **both** shapes: Debian laptop (absent deps degrade to `(absent)`, pacman rows skipped) and the CachyOS box (every row resolves)

One trap worth noting for reviewers: the new test's fixture is library-shaped, so `tests/ae_sweep_prune.txt` needed the directory added beside the existing `emit_csrc/` entry — the bulk `.ae` sweep runs every `.ae` standalone and reported `[FAIL] ... (compile error)` until it was pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
