### PR TITLE
iOS arm64 cross target via an Xcode/xcrun backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ version number before tagging the release.
 
 ### Added
 
+- **iOS arm64 cross-compilation** — `ae build --target=aarch64-ios`, plus
+  `aarch64-ios-simulator` and `x86_64-ios-simulator`. iOS is the first cross
+  target NOT served by `zig cc`: Apple's SDKs are Xcode-licensed and cannot be
+  redistributed the way zig's musl/mingw bundles are, so these triples shell to
+  `xcrun clang` against the SDK `xcrun` reports (which keeps a relocated Xcode,
+  a beta Xcode, and `DEVELOPER_DIR` all working). The backend is selected off
+  the `-apple-` in the resolved triple, so the object loop, archive step and
+  link step stay shared with the zig path rather than forking into a second
+  pipeline. Requires a macOS host with Xcode; the Command Line Tools alone
+  carry no iPhoneOS SDK and the build says so up front.
+
+  **`--emit=lib` is supported here**, unlike on the zig cross targets, and is
+  the point of the feature: iOS does not run loose executables, so an app built
+  by Xcode wants a loadable library from Aether, not a standalone binary. The
+  dylib is linked `-install_name @rpath/<leaf>` so it loads from inside an
+  `.app` bundle instead of recording the build machine's path. `--emit=obj` and
+  `--emit=csrc` work too (csrc needs no Xcode at all, since it never invokes a
+  toolchain). Device and simulator are separate targets, not a flag on one:
+  same arch, different Mach-O platform (`IOS` vs `IOSSIMULATOR`), and a binary
+  for one will not load on the other. The deployment target is part of the
+  clang triple and defaults to iOS 15.0; `AETHER_IOS_MIN` overrides it. See
+  `docs/cross-ios.md`, tested in `tests/integration/cross_ios/`.
+
 - **`ae build --target=<triple> --emit=csrc` is now allowed** (#1648). The
   cross guard rejected every library-shaped emit mode, justified by a comment
   about "library-shaped C that the executable link rejects" — but `--emit=csrc`
@@ -87,6 +110,18 @@ version number before tagging the release.
   driver's frames to `<unknown module>` that no module suppression can match.
 
 ### Fixed
+
+- **`std.os` now compiles for iOS.** iOS marks `system(3)`
+  `__API_UNAVAILABLE`, so merely naming it failed the compile and took the
+  whole of `std/os/aether_os.c` — and therefore any iOS build of the runtime —
+  down with it. `os.system` now returns `-1` there, the same value the
+  sandbox-denied and spawn-failure paths already use, instead of the module
+  being dropped from the build. Gated on a new Tier-0 platform capability
+  `AETHER_HAS_SHELL` (`runtime/config/aether_optimization_config.h`), which
+  sits alongside `AETHER_HAS_FILESYSTEM` and friends, is 0 on
+  iOS/tvOS/watchOS, and can be forced off anywhere with `-DAETHER_NO_SHELL`.
+  `os.run` / `os.run_capture` (fork+exec, argv-based) are unaffected — only the
+  legacy shell-out is.
 
 - **`ae build --target=<triple> --emit=both` now reports the same up-front
   error as `--emit=lib`** instead of dying at the cross linker. `--emit=both`

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -393,6 +393,17 @@ Supported triples: `aarch64-macos`, `x86_64-macos`, `aarch64-linux`,
 or newer must be on `PATH` (`brew install zig`, or use the checksum-pinned
 `scripts/get-zig.sh`); the build fails fast with an install hint otherwise.
 
+### iOS: `--target=aarch64-ios` (Xcode backend)
+
+iOS is the one cross target that does **not** go through zig: the Apple SDKs are
+Xcode-licensed and not redistributable, so `aarch64-ios`,
+`aarch64-ios-simulator` and `x86_64-ios-simulator` shell to `xcrun clang`
+instead and require a macOS host with Xcode. Unlike the zig targets, `--emit=lib`
+**is** supported there (it produces an `@rpath`-installed Mach-O dylib), because
+an iOS app is built by Xcode and what it wants from Aether is a library, not a
+standalone binary. Full details, including the sandbox restrictions that apply
+at runtime, are in **[cross-ios.md](cross-ios.md)**.
+
 **How it links.** The full runtime and standard library are compiled from
 source for the target and archived, then the program links against that
 archive, so the linker pulls only the objects it references, exactly as a
@@ -513,6 +524,7 @@ so an installed toolchain never ships a silently-stubbed regex.
 | WASM | `PLATFORM=wasm` | Cooperative scheduler, Emscripten |
 | Embedded | `PLATFORM=embedded` | Cooperative scheduler, no OS |
 | Cross-OS/arch | `ae build --target=<triple>` | `zig cc` backend, POSIX host, executables + `--emit=csrc`/`--emit=obj` |
+| iOS arm64 | `ae build --target=aarch64-ios` | Xcode/`xcrun` backend, macOS host, `--emit=lib` supported — see [cross-ios.md](cross-ios.md) |
 | Cross-wasm | `ae build --target=wasm32-wasi` | `zig cc` backend, `--emit=csrc`/`--emit=obj` only |
 
 ## Hardening (`HARDEN=1`)

--- a/docs/cross-ios.md
+++ b/docs/cross-ios.md
@@ -1,0 +1,126 @@
+# Cross-compiling for iOS (arm64)
+
+`ae build --target=aarch64-ios` builds Mach-O arm64 artifacts for iPhone and
+iPad, and `--target=aarch64-ios-simulator` / `--target=x86_64-ios-simulator`
+build for the simulator. Unlike every other cross target, iOS is driven by the
+**Xcode toolchain** rather than by `zig cc`.
+
+## Why iOS is not a zig target
+
+The other cross targets are self-contained because zig bundles each one's libc,
+headers and linker. Apple's SDKs are Xcode-licensed and cannot be redistributed
+that way, so there is no bundled-toolchain path for iOS and there will not be
+one. `--target=aarch64-ios` therefore shells to `xcrun clang` with the SDK
+`xcrun` reports, which means:
+
+- **The build host must be a Mac with Xcode installed.** The Command Line Tools
+  alone carry no iPhoneOS SDK. If `xcrun --sdk iphoneos --show-sdk-path` fails,
+  so does the build, with a message saying exactly that.
+- `xcrun` is asked for the SDK path rather than hardcoding
+  `/Applications/Xcode.app/...`, so a relocated Xcode, a beta Xcode, or a
+  `DEVELOPER_DIR` override all work.
+- Device and simulator are **separate targets**, not a flag on one target. They
+  use different SDKs and stamp different Mach-O platforms (`IOS` vs
+  `IOSSIMULATOR`); a binary built for one will not load on the other.
+
+## What to build: usually a library, not an executable
+
+iOS does not run loose executables. A binary only launches from inside a signed
+`.app` bundle, so on iOS the useful artifact is almost always a **library that
+Xcode links into an app**, not a standalone program:
+
+```bash
+# A Mach-O dylib with the aether_<name>() C ABI, ready to embed in an app.
+ae build --target=aarch64-ios --emit=lib mylib.ae -o libmylib.dylib
+
+# An executable, if you really want one (still needs signing + a bundle).
+ae build --target=aarch64-ios hello.ae -o hello
+
+# A target-format object, to hand to your own link step / Xcode build phase.
+ae build --target=aarch64-ios --emit=obj mylib.ae -o mylib.o
+
+# Portable C + catalog, compiled later by Xcode itself. Needs no Xcode here.
+ae build --target=aarch64-ios --emit=csrc mylib.ae -o mylib
+```
+
+`--emit=lib` is **supported on iOS** — it is the primary case — whereas the zig
+cross targets still reject it. The dylib is linked with
+`-install_name @rpath/<leaf>`, which is what an Xcode *Embed Frameworks* phase
+expects; without it the load command would record the build-machine path and the
+library would fail to load from inside the bundle.
+
+The exported symbols are the ordinary `aether_<name>()` C ABI (see
+[emit-lib.md](emit-lib.md)), so Swift and Objective-C call them through a
+bridging header with no glue. Note that `--emit=lib` writes only the library —
+the **header comes from `--emit=csrc`** (same catalog codegen, so the two cannot
+drift) or from `aetherc --emit-header`:
+
+```bash
+ae build --target=aarch64-ios --emit=csrc mylib.ae -o mylib   # -> mylib.h
+```
+
+```swift
+// bridging header: #include "mylib.h"
+let sum = aether_add(2, 3)
+```
+
+A `-> string` export returns an `AetherString*`, not a `char*`; read its bytes
+with `aether_string_data()`.
+
+## Deployment target
+
+The deployment target is part of the clang triple, so it is fixed at build
+time. The default is **iOS 15.0**; override it with `AETHER_IOS_MIN`:
+
+```bash
+AETHER_IOS_MIN=17.0 ae build --target=aarch64-ios --emit=lib mylib.ae -o libmylib.dylib
+```
+
+It lands in `LC_BUILD_VERSION`, which you can check with
+`vtool -show-build <file>`.
+
+## What does not work on iOS
+
+iOS is a sandboxed platform, and some of the standard library assumes a
+general-purpose OS underneath. None of this fails the build; it is behaviour to
+plan around.
+
+| Surface | Status on iOS |
+|---|---|
+| `os.system` (shell-out) | Always returns `-1`. iOS marks `system(3)` unavailable, so there is no shell to exec into. See `AETHER_HAS_SHELL`. |
+| `os.run` / `os.run_capture` | Compile and link, but iOS forbids spawning child processes in an app sandbox. |
+| `std.dl` | `dlopen` is restricted to libraries already inside the app bundle. |
+| `std.audio` | Reports unavailable. miniaudio's iOS backend is AVAudioSession (Objective-C), which is not valid C, so the null backend is selected via `-DMA_NO_COREAUDIO` — the same treatment the macOS cross target gets. |
+| `libaether_sandbox.so` | Not available. It is an `LD_PRELOAD` mechanism, which iOS has no equivalent of. Use `--emit=lib` capability gating and `hide` / `seal except` instead, both of which are compile-time and work everywhere. |
+| `std.fs` paths | Confined to the app's container by the OS sandbox. |
+| OpenSSL / zlib / nghttp2 | Not linked, so HTTPS/TLS, hashing, base64 and compression report errors at runtime — the same warn-and-degrade as every other cross target without a `CROSSBUILD_SYSROOT`. `std.regex` is the exception and always works (vendored PCRE2). |
+
+`AETHER_HAS_SHELL` is a Tier-0 platform capability alongside
+`AETHER_HAS_FILESYSTEM` and friends (`runtime/config/aether_optimization_config.h`).
+It is 0 on iOS/tvOS/watchOS and can be forced off anywhere with
+`-DAETHER_NO_SHELL`.
+
+## Building a fat / XCFramework artifact
+
+`ae` emits one slice per invocation. Combine them with Apple's own tools:
+
+```bash
+ae build --target=aarch64-ios           --emit=lib mylib.ae -o device/libmylib.dylib
+ae build --target=aarch64-ios-simulator --emit=lib mylib.ae -o sim/libmylib.dylib
+
+# Device and simulator slices cannot go in one fat binary (same arch, different
+# platform) — that is exactly what an XCFramework is for.
+xcodebuild -create-xcframework \
+    -library device/libmylib.dylib \
+    -library sim/libmylib.dylib \
+    -output MyLib.xcframework
+```
+
+## Signing
+
+`ae` does not sign anything. Sign the artifact as part of your Xcode build, or
+by hand:
+
+```bash
+codesign -s "Apple Development: you@example.com" libmylib.dylib
+```

--- a/runtime/config/aether_optimization_config.c
+++ b/runtime/config/aether_optimization_config.c
@@ -170,7 +170,8 @@ void aether_print_config(void) {
     printf("  SIMD:       %s\n", AETHER_HAS_SIMD       ? "YES" : "NO");
     printf("  Affinity:   %s\n", AETHER_HAS_AFFINITY   ? "YES" : "NO");
     printf("  getenv:     %s\n", AETHER_HAS_GETENV     ? "YES" : "NO");
-    printf("  malloc:     %s\n\n", AETHER_HAS_MALLOC   ? "YES" : "NO");
+    printf("  malloc:     %s\n", AETHER_HAS_MALLOC     ? "YES" : "NO");
+    printf("  shell:      %s\n\n", AETHER_HAS_SHELL    ? "YES" : "NO");
 
     printf("PROFILE: %s (msg_pool=%d)\n",
            aether_profile_name(g_aether_config.profile),

--- a/runtime/config/aether_optimization_config.h
+++ b/runtime/config/aether_optimization_config.h
@@ -33,6 +33,13 @@
 #include <stdlib.h>
 #include "../utils/aether_compiler.h"
 
+// TargetConditionals.h is what distinguishes iOS/tvOS/watchOS from macOS:
+// every Apple platform defines __APPLE__, so __APPLE__ alone cannot tell a
+// Mac from an iPhone. Needed by AETHER_HAS_SHELL below.
+#if defined(__APPLE__)
+#  include <TargetConditionals.h>
+#endif
+
 // ============================================================================
 // TIER 0: PLATFORM CAPABILITIES (compile-time detection)
 // Auto-detected from target platform. Override with -DAETHER_NO_<FEATURE>.
@@ -64,6 +71,22 @@
 #    define AETHER_HAS_FILESYSTEM 0
 #  else
 #    define AETHER_HAS_FILESYSTEM 1
+#  endif
+#endif
+
+// --- Shell-out (system(3)) ---
+// iOS/tvOS/watchOS mark system() __API_UNAVAILABLE, so referencing it is a
+// hard compile error, not a link-time or runtime failure — the whole
+// translation unit fails. Sandboxed Apple platforms have no shell to exec
+// into, so this is a real capability axis, not a portability wart. popen()
+// and the fork/exec path are NOT affected and stay available.
+#ifndef AETHER_HAS_SHELL
+#  if defined(AETHER_NO_SHELL)
+#    define AETHER_HAS_SHELL 0
+#  elif defined(__APPLE__) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#    define AETHER_HAS_SHELL 0
+#  else
+#    define AETHER_HAS_SHELL 1
 #  endif
 #endif
 
@@ -202,6 +225,7 @@ typedef struct {
     bool has_affinity;
     bool has_getenv;
     bool has_malloc;
+    bool has_shell;
 } AetherPlatformCaps;
 
 static inline AetherPlatformCaps aether_platform_caps(void) {
@@ -215,6 +239,7 @@ static inline AetherPlatformCaps aether_platform_caps(void) {
         .has_affinity   = AETHER_HAS_AFFINITY,
         .has_getenv     = AETHER_HAS_GETENV,
         .has_malloc     = AETHER_HAS_MALLOC,
+        .has_shell      = AETHER_HAS_SHELL,
     };
 }
 

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -174,6 +174,15 @@ static int win_launch(const char* prog, void* argv_list, void* env_list,
 int os_system(const char* cmd) {
     if (!cmd) return -1;
     if (!aether_sandbox_check("exec", cmd)) return -1;
+#if !AETHER_HAS_SHELL
+    /* iOS/tvOS/watchOS: no shell to exec into, and system() is marked
+     * __API_UNAVAILABLE there, so even naming it fails the compile. Report
+     * the same -1 the sandbox-denied and spawn-failure paths use rather
+     * than dropping the whole module from the build. os.run / os.run_capture
+     * (fork+exec, argv-based) are unaffected and remain the portable way to
+     * spawn a child; system() was always the legacy shell-out. */
+    return -1;
+#else
     int status = system(cmd);
     if (status == -1) return -1;
 #ifdef _WIN32
@@ -192,6 +201,7 @@ int os_system(const char* cmd) {
     if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
     return -1;
 #endif
+#endif /* AETHER_HAS_SHELL */
 }
 
 char* os_exec_raw(const char* cmd) {

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -42,6 +42,7 @@ tests/integration/closure_builder_ctx_inject_no_uaf/
 tests/integration/closure_extern_retains_no_uaf/
 tests/integration/closure_qualified_ctx_inject_no_uaf/
 tests/integration/contract_fold_reject/
+tests/integration/cross_ios/
 tests/integration/cross_module_actor/
 tests/integration/cryptography_random_hex/
 tests/integration/cryptography_sha/

--- a/tests/integration/cross_ios/hello.ae
+++ b/tests/integration/cross_ios/hello.ae
@@ -1,0 +1,4 @@
+main() {
+    let n = 6 * 7
+    print("answer=${n}")
+}

--- a/tests/integration/cross_ios/mylib.ae
+++ b/tests/integration/cross_ios/mylib.ae
@@ -1,0 +1,3 @@
+export add(a: int, b: int) -> int {
+    return a + b
+}

--- a/tests/integration/cross_ios/test_cross_ios.sh
+++ b/tests/integration/cross_ios/test_cross_ios.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+# `ae build --target=aarch64-ios` and the simulator variants.
+#
+# iOS is the one cross target NOT served by zig: Apple's SDKs are Xcode-
+# licensed and not redistributable, so these triples shell to `xcrun clang`
+# with the SDK xcrun reports. That also makes iOS the one cross target where
+# --emit=lib is supported, because an iOS app is built by Xcode and what it
+# wants from Aether is a loadable library, not a standalone binary (iOS will
+# not run a loose executable at all).
+#
+# Asserts:
+#   - aarch64-ios / aarch64-ios-simulator / x86_64-ios-simulator are accepted
+#   - the Mach-O PLATFORM distinguishes device (IOS) from simulator
+#     (IOSSIMULATOR) — same arch, non-interchangeable binaries
+#   - AETHER_IOS_MIN sets the deployment target (LC_BUILD_VERSION minos)
+#   - --emit=lib produces a dylib whose install_name is @rpath-relative (an
+#     absolute build path there fails to load from inside an .app bundle)
+#   - --emit=csrc needs no Xcode at all (it never invokes the toolchain)
+#
+# Skips off macOS, or when Xcode's iPhoneOS SDK is absent (the Command Line
+# Tools alone do not carry one).
+#
+# NB on cost: an executable/dylib build recompiles the whole runtime and
+# stdlib for the target (~90 TUs, no per-target archive cache yet), so this
+# does exactly TWO of those. Everything that can be asserted on a single-TU
+# --emit=obj is, because that path is ~100x cheaper and carries the same
+# LC_BUILD_VERSION the linked artifacts do.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+SRC="$SCRIPT_DIR/mylib.ae"      # exports, no main() — lib/obj/csrc
+EXE_SRC="$SCRIPT_DIR/hello.ae"  # has main() — executable build
+
+TMP="${TMPDIR:-/tmp}/ae_cross_ios_$$"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "  FAIL: $1"; exit 1; }
+
+# --- csrc first: it must work with no Xcode, so it runs before the skip ---
+"$AE" build --target=aarch64-ios --emit=csrc "$SRC" -o "$TMP/csrc" >/dev/null 2>&1 \
+    || fail "--target=aarch64-ios --emit=csrc was rejected"
+[ -f "$TMP/csrc.c" ] && [ -f "$TMP/csrc.h" ] \
+    || fail "--emit=csrc under an iOS target emitted no .c/.h"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "  [skip] iOS cross checks: not a macOS host"
+    echo "  PASS: --emit=csrc under an iOS target (rest skipped)"
+    exit 0
+fi
+if ! xcrun --sdk iphoneos --show-sdk-path >/dev/null 2>&1; then
+    echo "  [skip] iOS cross checks: no iPhoneOS SDK (Xcode not installed)"
+    echo "  PASS: --emit=csrc under an iOS target (rest skipped)"
+    exit 0
+fi
+
+macho_platform() { vtool -show-build "$1" 2>/dev/null | awk '/platform/ {print $2; exit}'; }
+macho_minos()    { vtool -show-build "$1" 2>/dev/null | awk '/minos/ {print $2; exit}'; }
+
+# --- 1. target matrix, on the cheap --emit=obj path ---
+build_obj() { # <target> <out> [env-assignment]
+    if [ -n "$3" ]; then
+        env "$3" "$AE" build --target="$1" --emit=obj "$SRC" -o "$2" >"$TMP/log" 2>&1 \
+            || { cat "$TMP/log"; fail "--target=$1 --emit=obj ($3) failed"; }
+    else
+        "$AE" build --target="$1" --emit=obj "$SRC" -o "$2" >"$TMP/log" 2>&1 \
+            || { cat "$TMP/log"; fail "--target=$1 --emit=obj failed"; }
+    fi
+}
+
+build_obj aarch64-ios            "$TMP/dev.o"
+build_obj aarch64-ios-simulator  "$TMP/sim.o"
+build_obj x86_64-ios-simulator   "$TMP/sim64.o"
+build_obj aarch64-ios            "$TMP/min.o" AETHER_IOS_MIN=17.0
+
+file "$TMP/dev.o"   | grep -q 'Mach-O 64-bit object arm64' \
+    || fail "device object is not arm64 Mach-O: $(file "$TMP/dev.o")"
+file "$TMP/sim64.o" | grep -q 'Mach-O 64-bit object x86_64' \
+    || fail "x86_64 simulator object is not x86_64 Mach-O: $(file "$TMP/sim64.o")"
+
+# Device and simulator are the same ARCH but different PLATFORM; that is the
+# whole reason they are separate targets rather than one with a flag.
+[ "$(macho_platform "$TMP/dev.o")" = "IOS" ] \
+    || fail "device object platform is '$(macho_platform "$TMP/dev.o")', expected IOS"
+[ "$(macho_platform "$TMP/sim.o")" = "IOSSIMULATOR" ] \
+    || fail "simulator object platform is '$(macho_platform "$TMP/sim.o")', expected IOSSIMULATOR"
+
+[ "$(macho_minos "$TMP/dev.o")" = "15.0" ] \
+    || fail "default minos is '$(macho_minos "$TMP/dev.o")', expected 15.0"
+[ "$(macho_minos "$TMP/min.o")" = "17.0" ] \
+    || fail "AETHER_IOS_MIN=17.0 gave minos '$(macho_minos "$TMP/min.o")'"
+
+# --- 2. a real executable link (full runtime compile) ---
+"$AE" build --target=aarch64-ios "$EXE_SRC" -o "$TMP/dev" >"$TMP/log" 2>&1 \
+    || { cat "$TMP/log"; fail "--target=aarch64-ios executable build failed"; }
+file "$TMP/dev" | grep -q 'Mach-O 64-bit executable arm64' \
+    || fail "device build is not a Mach-O arm64 executable: $(file "$TMP/dev")"
+[ "$(macho_platform "$TMP/dev")" = "IOS" ] \
+    || fail "device exe platform is '$(macho_platform "$TMP/dev")', expected IOS"
+
+# --- 3. --emit=lib is SUPPORTED on iOS (unlike the zig cross targets) ---
+"$AE" build --target=aarch64-ios --emit=lib "$SRC" -o "$TMP/libmylib.dylib" >"$TMP/log" 2>&1 \
+    || { cat "$TMP/log"; fail "--target=aarch64-ios --emit=lib was rejected"; }
+file "$TMP/libmylib.dylib" | grep -q 'Mach-O 64-bit dynamically linked shared library arm64' \
+    || fail "--emit=lib did not produce an arm64 dylib: $(file "$TMP/libmylib.dylib")"
+# An absolute install_name here is the classic "works on my Mac, fails in the
+# .app" bug: the loader would look for the dylib at its BUILD path.
+otool -D "$TMP/libmylib.dylib" | tail -1 | grep -q '^@rpath/' \
+    || fail "dylib install_name is not @rpath-relative: $(otool -D "$TMP/libmylib.dylib" | tail -1)"
+nm -gU "$TMP/libmylib.dylib" | grep -q '_aether_add' \
+    || fail "dylib does not export _aether_add"
+
+echo "  PASS: iOS device/simulator objects, arm64 exe, @rpath dylib, csrc; AETHER_IOS_MIN honoured"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5243,7 +5243,8 @@ static int cmd_build(int argc, char** argv) {
         fprintf(stderr, "Valid targets: native, wasm (Emscripten), or a cross triple "
                         "(aarch64-macos, x86_64-macos, aarch64-linux, x86_64-linux, "
                         "aarch64-freebsd, x86_64-freebsd, x86_64-windows, "
-                        "aarch64-windows, wasm32-wasi).\n");
+                        "aarch64-windows, wasm32-wasi, aarch64-ios, "
+                        "aarch64-ios-simulator, x86_64-ios-simulator).\n");
         return 1;
     }
     int is_wasm = target && strcmp(target, "wasm") == 0;
@@ -5285,6 +5286,9 @@ static int cmd_build(int argc, char** argv) {
         fprintf(stderr, "             aarch64-linux, x86_64-linux, aarch64-freebsd, x86_64-freebsd,\n");
         fprintf(stderr, "             x86_64-windows, aarch64-windows (-> foo.exe; self-contained)\n");
         fprintf(stderr, "             (freebsd needs AETHER_SYSROOT=<base sysroot>; see aether-crossbuild)\n");
+        fprintf(stderr, "             aarch64-ios, aarch64-ios-simulator, x86_64-ios-simulator\n");
+        fprintf(stderr, "             (iOS uses Xcode/xcrun, not zig; macOS host only, --emit=lib ok;\n");
+        fprintf(stderr, "              AETHER_IOS_MIN sets the deployment target, default 15.0)\n");
         return 1;
     }
 
@@ -5406,6 +5410,9 @@ static int cmd_build(int argc, char** argv) {
     // Pre-flight for cross builds: zig provides the backend compiler +
     // target libc/linker, and the program must be dependency-free (PR 1).
     if (is_cross) {
+        // Apple targets (iOS) are driven by Xcode/xcrun rather than zig;
+        // the checks below fork on this.
+        int is_apple_target = cross_target_is_apple(ztriple);
         // Cross builds produce executables or portable C source. --emit=lib /
         // --emit=both / --emit=obj would emit library-shaped C (no main) and
         // then LINK it, which the executable link rejects. Reject those up
@@ -5455,19 +5462,44 @@ static int cmd_build(int argc, char** argv) {
                 target);
             return 1;
         }
-        if (g_emit_lib && !g_emit_csrc && !g_emit_obj) {
+        // --emit=lib/--emit=both link, so they are rejected on the zig
+        // targets. Apple targets DO support them: the link there produces a
+        // Mach-O dylib, which is the primary iOS use case (an iOS app is built
+        // by Xcode, so Aether's job is to hand it a loadable library rather
+        // than a standalone binary iOS would not let you run anyway).
+        if (g_emit_lib && !g_emit_csrc && !g_emit_obj && !is_apple_target) {
             fprintf(stderr,
                 "Error: cross-compilation (--target=%s) supports executables, "
                 "--emit=csrc and --emit=obj; --emit=lib and --emit=both are not "
                 "supported yet.\n", target);
             return 1;
         }
-        /* --emit=csrc never invokes zig at all: it emits portable C and
-         * stops, so requiring zig would invent a dependency the build does
-         * not have — and would block the very case csrc exists to serve,
-         * emitting portable C on a machine with no cross toolchain. Every
-         * other mode (exe, and --emit=obj's `zig cc -c`) does need it. */
-        if (!g_emit_csrc && run_cmd_quiet("zig version") != 0) {
+        /* --emit=csrc never invokes the cross toolchain at all: it emits
+         * portable C and stops, so requiring zig (or Xcode) would invent a
+         * dependency the build does not have — and would block the very case
+         * csrc exists to serve, emitting portable C on a machine with no cross
+         * toolchain. Every other mode (exe, and --emit=obj's `cc -c`) needs it. */
+        if (is_apple_target) {
+            /* The Apple SDKs are Xcode-licensed and not redistributable, so
+             * there is no bundled-toolchain path here: the host must be a Mac
+             * with Xcode. Checking xcrun up front turns "no iOS SDK" into one
+             * clear message rather than a wall of missing-header errors. */
+#ifndef __APPLE__
+            if (!g_emit_csrc) {
+                fprintf(stderr,
+                    "Error: --target=%s requires a macOS host with Xcode installed "
+                    "(the iOS SDK is not redistributable, so it cannot be bundled).\n", target);
+                return 1;
+            }
+#else
+            if (!g_emit_csrc && run_cmd_quiet("xcrun --version") != 0) {
+                fprintf(stderr, "Error: xcrun not found (required to cross-compile for %s).\n",
+                        target);
+                fprintf(stderr, "Install Xcode, then: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer\n");
+                return 1;
+            }
+#endif
+        } else if (!g_emit_csrc && run_cmd_quiet("zig version") != 0) {
             fprintf(stderr, "Error: zig not found on PATH (required to cross-compile for %s).\n",
                     target);
             fprintf(stderr, "Install zig 0.16.0+: https://ziglang.org/download/  (macOS: brew install zig)\n");
@@ -5623,7 +5655,7 @@ static int cmd_build(int argc, char** argv) {
             }
             printf("Built object: %s\n", obj_file);
             printf("       target %s: link it on a matching host, or with the same "
-                   "zig target.\n", target);
+                   "cross target.\n", target);
             return 0;
         }
         const char* objcc = getenv("AE_CC");
@@ -5674,7 +5706,7 @@ static int cmd_build(int argc, char** argv) {
     int build_ret;
     if (is_cross) {
         const char* extra = extra_files[0] ? extra_files : NULL;
-        build_ret = run_cross_build(c_file, exe_file, !quick, extra, ztriple);
+        build_ret = run_cross_build(c_file, exe_file, !quick, extra, ztriple, g_emit_lib != 0);
         if (build_ret != 0) {
             fprintf(stderr, "Build failed.\n");
             return 1;

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -42,6 +42,39 @@
  *  documented follow-up. Native builds are entirely unaffected.
  * ------------------------------------------------------------------ */
 
+/* Recognised spellings of the iOS targets, arch aliases included, matching the
+ * arm64-/amd64- tolerance the zig arms already have. Device and simulator are
+ * separate targets, not a flag on one target: they differ in SDK, in Mach-O
+ * platform (IOS vs IOSSIMULATOR), and a binary for one will not load on the
+ * other. */
+static bool cross_target_is_ios_alias(const char* t) {
+    return !strcmp(t, "aarch64-ios")           || !strcmp(t, "arm64-ios")           ||
+           !strcmp(t, "aarch64-ios-simulator") || !strcmp(t, "arm64-ios-simulator") ||
+           !strcmp(t, "x86_64-ios-simulator")  || !strcmp(t, "amd64-ios-simulator");
+}
+
+/* Compose the clang triple for an iOS alias, e.g. "arm64-apple-ios15.0" or
+ * "x86_64-apple-ios15.0-simulator". The deployment target is part of the
+ * triple — that is how clang stamps LC_BUILD_VERSION minos — so it has to be
+ * decided here rather than added as a separate flag. AETHER_IOS_MIN overrides
+ * the default for a project that must support older devices, or that needs a
+ * newer floor to use a newer SDK symbol.
+ *
+ * NB the returned pointer is into a static buffer, unlike the string literals
+ * every other arm returns: one resolved target per build is the only use, and
+ * a second call for a different iOS alias would overwrite the first result. */
+#define CROSS_IOS_MIN_DEFAULT "15.0"
+static const char* cross_ios_triple(const char* t) {
+    static char triple[64];
+    const char* minv = getenv("AETHER_IOS_MIN");
+    if (!minv || !*minv) minv = CROSS_IOS_MIN_DEFAULT;
+    const char* arch = (!strncmp(t, "x86_64", 6) || !strncmp(t, "amd64", 5))
+                       ? "x86_64" : "arm64";
+    const char* sim = strstr(t, "-simulator") ? "-simulator" : "";
+    snprintf(triple, sizeof(triple), "%s-apple-ios%s%s", arch, minv, sim);
+    return triple;
+}
+
 /* Map an Aether target string to a zig `-target` triple. Returns NULL
  * for anything that isn't a supported cross triple (native / wasm /
  * unknown), which the caller treats as "not a cross build". */
@@ -79,6 +112,14 @@ const char* cross_target_to_zig(const char* t) {
      * `--emit=csrc` — which produces the same target-neutral bytes as every
      * other target anyway — would advertise support that does not exist. */
     if (!strcmp(t, "wasm32-wasi")   || !strcmp(t, "wasm-wasi"))  return "wasm32-wasi";
+    /* iOS (Tier C — Apple toolchain, NOT zig): zig bundles no Apple SDK, and
+     * the iOS SDK is Xcode-licensed so it cannot be redistributed the way the
+     * musl/mingw bundles are. There is therefore no self-contained path here;
+     * these triples route to `xcrun clang` instead. The returned string IS the
+     * clang -target triple, deployment target included, and the backend is
+     * selected off the "-apple-" in it rather than a parallel flag, so the
+     * rest of the cross pipeline stays single-triple-driven. */
+    if (cross_target_is_ios_alias(t)) return cross_ios_triple(t);
     return NULL;
 }
 
@@ -97,6 +138,74 @@ const char* cross_target_to_zig(const char* t) {
 /* True if the resolved zig triple is a WASI target. */
 static bool cross_target_is_wasi(const char* ztriple) {
     return ztriple && strstr(ztriple, "wasi") != NULL;
+}
+
+/* True when `triple` (a cross_target_to_zig result) names an Apple target that
+ * must be driven by the Xcode toolchain rather than zig. */
+bool cross_target_is_apple(const char* triple) {
+    return triple && strstr(triple, "-apple-") != NULL;
+}
+
+/* Resolve an SDK name to its filesystem root via `xcrun --show-sdk-path`.
+ * Asking xcrun rather than hardcoding /Applications/Xcode.app/... is what
+ * makes this work with a relocated Xcode, a beta Xcode, or a DEVELOPER_DIR
+ * override — all of which are normal on a machine that ships iOS apps.
+ * Returns false when Xcode is absent or only the Command Line Tools are
+ * installed (which carry no iPhoneOS SDK). */
+static bool cross_apple_sdk_path(const char* sdk, char* out, size_t osz) {
+    if (!sdk || !out || osz == 0) return false;
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd), "xcrun --sdk %s --show-sdk-path 2>/dev/null", sdk);
+    FILE* p = popen(cmd, "r");
+    if (!p) return false;
+    out[0] = '\0';
+    if (!fgets(out, (int)osz, p)) { pclose(p); return false; }
+    int rc = pclose(p);
+    size_t n = strlen(out);
+    while (n && (out[n-1] == '\n' || out[n-1] == '\r')) out[--n] = '\0';
+    return rc == 0 && n > 0;
+}
+
+/* The `xcrun --sdk` name for an Apple triple. Device and simulator are
+ * different SDKs with different libSystem stubs, so this cannot be derived
+ * from the architecture alone. */
+const char* cross_apple_sdk(const char* triple) {
+    if (!cross_target_is_apple(triple)) return NULL;
+    return strstr(triple, "-simulator") ? "iphonesimulator" : "iphoneos";
+}
+
+/* Resolve the compiler and archiver command prefixes for a target, so every
+ * compile / archive / link below is composed against these strings rather than
+ * a literal "zig cc". The Apple path is then a different DRIVER, not a
+ * different code path — the object loop, the archive step and the link step
+ * stay shared.
+ *
+ * Apple targets shell to the Xcode toolchain via xcrun, which resolves the
+ * right clang and ar for the selected SDK. -isysroot is mandatory: without it
+ * clang finds the host macOS headers and silently builds for the wrong
+ * platform. `ar_out` may be NULL when the caller only compiles.
+ * Returns false (having printed the reason) if the Apple SDK cannot be found. */
+static bool cross_toolchain(const char* ztriple, char* cc_out, size_t cc_sz,
+                            char* ar_out, size_t ar_sz) {
+    if (cross_target_is_apple(ztriple)) {
+        const char* sdk = cross_apple_sdk(ztriple);
+        char sysroot[2048];
+        if (!cross_apple_sdk_path(sdk, sysroot, sizeof(sysroot))) {
+            fprintf(stderr,
+                "Error: could not locate the %s SDK (xcrun --sdk %s --show-sdk-path failed).\n"
+                "  Cross-compiling for iOS needs Xcode, not just the Command Line Tools:\n"
+                "    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer\n",
+                sdk, sdk);
+            return false;
+        }
+        snprintf(cc_out, cc_sz, "xcrun --sdk %s clang -target %s -isysroot \"%s\"",
+                 sdk, ztriple, sysroot);
+        if (ar_out) snprintf(ar_out, ar_sz, "xcrun --sdk %s ar", sdk);
+        return true;
+    }
+    snprintf(cc_out, cc_sz, "zig cc -target %s", ztriple);
+    if (ar_out) snprintf(ar_out, ar_sz, "zig ar");
+    return true;
 }
 
 /* True if `t` is a cross target that needs a base sysroot for system headers
@@ -276,7 +385,7 @@ int run_cross_compile_obj(const char* c_file, const char* obj_file,
      * miniaudio (always compiled into the runtime) must fall back to its null
      * backend or ANY macos cross-compile fails. */
     char feature_defs[512] = "-DAETHER_HAS_SANDBOX";
-    if (strstr(ztriple, "macos")) {
+    if (strstr(ztriple, "macos") || strstr(ztriple, "-apple-ios")) {
         strncat(feature_defs, " -DMA_NO_COREAUDIO",
                 sizeof(feature_defs) - strlen(feature_defs) - 1);
     }
@@ -306,11 +415,14 @@ int run_cross_compile_obj(const char* c_file, const char* obj_file,
                  "--sysroot=%s -I%s/usr/include", sr, sr);
     }
 
+    char cc_cmd[3072];
+    if (!cross_toolchain(ztriple, cc_cmd, sizeof(cc_cmd), NULL, 0)) return 1;
+
     char* cmd = NULL;
     size_t cmd_cap = 0;
     if (!cross_cmd_fmt(&cmd, &cmd_cap,
-            "zig cc -target %s %s %s %s %s %s -c \"%s\" -o \"%s\"",
-            ztriple, sysroot_flag, opt, feature_defs, user_cflags,
+            "%s %s %s %s %s %s -c \"%s\" -o \"%s\"",
+            cc_cmd, sysroot_flag, opt, feature_defs, user_cflags,
             tc.include_flags ? tc.include_flags : "",
             c_file, obj_file)) {
         fprintf(stderr, "Error: out of memory building the cross-compile command.\n");
@@ -329,7 +441,7 @@ int run_cross_compile_obj(const char* c_file, const char* obj_file,
 
 int run_cross_build(const char* c_file, const char* out_file,
                            bool optimize, const char* extra,
-                           const char* ztriple) {
+                           const char* ztriple, bool emit_lib) {
     char manifest[2048], base[1024];
     if (!cross_find_manifest(manifest, sizeof(manifest), base, sizeof(base))) {
         fprintf(stderr,
@@ -345,6 +457,11 @@ int run_cross_build(const char* c_file, const char* out_file,
                 manifest);
         return 1;
     }
+
+    bool is_apple = cross_target_is_apple(ztriple);
+    char cc_cmd[3072];
+    char ar_cmd[1024];
+    if (!cross_toolchain(ztriple, cc_cmd, sizeof(cc_cmd), ar_cmd, sizeof(ar_cmd))) return 1;
 
     /* Fresh per-build object directory under the system temp. */
     char objdir[1024];
@@ -368,7 +485,12 @@ int run_cross_build(const char* c_file, const char* out_file,
      * COMPILES REAL (its -DAETHER_HAS_* here). Sized for the base defs plus
      * every Tier-2 macro. */
     char feature_defs[2048] = "-DAETHER_HAS_SANDBOX";
-    if (strstr(ztriple, "macos")) {
+    /* iOS needs the same treatment for a different reason: miniaudio's Apple
+     * backend is CoreAudio on macOS but AVAudioSession (Objective-C) on iOS,
+     * so aether_audio.c stops being valid C there and fails the compile for
+     * every program, audio or not. MA_NO_COREAUDIO selects the null backend on
+     * both, so std.audio reports unavailable at runtime instead. */
+    if (strstr(ztriple, "macos") || strstr(ztriple, "-apple-ios")) {
         strncat(feature_defs, " -DMA_NO_COREAUDIO",
                 sizeof(feature_defs) - strlen(feature_defs) - 1);
     }
@@ -589,8 +711,8 @@ int run_cross_build(const char* c_file, const char* out_file,
             snprintf(objpath, sizeof(objpath), "%s/%.*so", objdir,
                      (int)(strlen(bn) - 1), bn);
             if (!cross_cmd_fmt(&cmd, &cmd_cap,
-                "zig cc -target %s %s %s %s %s %s -c \"%s\" -o \"%s\"",
-                ztriple, sysroot_flag, opt, feature_defs, user_cflags, tc.include_flags,
+                "%s %s %s %s %s %s -c \"%s\" -o \"%s\"",
+                cc_cmd, sysroot_flag, opt, feature_defs, user_cflags, tc.include_flags,
                 srcs[i], objpath)) {
                 fprintf(stderr, "Error: out of memory building the cross-compile command.\n");
                 compile_failed = true;
@@ -618,7 +740,7 @@ int run_cross_build(const char* c_file, const char* out_file,
          *    link pulls only what the program references (native
          *    `-laether` semantics). */
         if (!cross_cmd_fmt(&cmd, &cmd_cap,
-            "zig ar rcs \"%s/libaether.a\" %s", objdir, objlist)) {
+            "%s rcs \"%s/libaether.a\" %s", ar_cmd, objdir, objlist)) {
             fprintf(stderr, "Error: out of memory building the cross-compile archive command.\n");
             break;
         }
@@ -638,16 +760,29 @@ int run_cross_build(const char* c_file, const char* out_file,
              * symbols (casper's cap_*, openssl's SSL_*, …), so they must
              * follow it on the link line for ld.lld's single-pass resolution. */
             w = cross_cmd_fmt(&cmd, &cmd_cap,
-                "zig cc -target %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -lm -o \"%s\"",
-                ztriple, sysroot_flag, fbsd_link, opt, feature_defs, tc.include_flags,
+                "%s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -lm -o \"%s\"",
+                cc_cmd, sysroot_flag, fbsd_link, opt, feature_defs, tc.include_flags,
                 c_file, ex, objdir, fbsd_platform_libs, crossbuild_libs, out_file) ? 1 : -1;
         } else {
             /* Tier A (linux/macos/windows): compact form + any CROSSBUILD_SYSROOT
              * Tier-2 libs AND the Windows system libs after libaether.a (it
              * references their symbols — BCryptGenRandom etc.). */
+            /* --emit=lib on an Apple target produces a Mach-O dylib. It needs
+             * -dynamiclib and an -install_name: without one the load command
+             * records the BUILD path, and the dylib then fails to load from
+             * inside an .app bundle. @rpath/<leaf> is what an Xcode "Embed
+             * Frameworks" phase expects. */
+            char apple_lib_flags[1152];
+            apple_lib_flags[0] = '\0';
+            if (is_apple && emit_lib) {
+                const char* leaf = strrchr(out_file, '/');
+                leaf = leaf ? leaf + 1 : out_file;
+                snprintf(apple_lib_flags, sizeof(apple_lib_flags),
+                         "-dynamiclib -install_name @rpath/%s", leaf);
+            }
             w = cross_cmd_fmt(&cmd, &cmd_cap,
-                "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
-                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, crossbuild_libs, win_platform_libs, out_file) ? 1 : -1;
+                "%s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
+                cc_cmd, sysroot_flag, apple_lib_flags, opt, feature_defs, tc.include_flags, c_file, ex, objdir, crossbuild_libs, win_platform_libs, out_file) ? 1 : -1;
         }
         if (w < 0) {
             fprintf(stderr, "Error: out of memory building the cross-compile link command.\n");

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -99,8 +99,11 @@ void tc_lib_dir_append(const char* spec);
 unsigned long long compute_cache_key(const char* ae_file, const char* extra_files,
                                      const char* opt_level, const char* extra_salt);
 
-/* ae_cross.c — cross-compilation via the zig cc backend (#1105). */
+/* ae_cross.c — cross-compilation via the zig cc backend (#1105), plus the
+ * Xcode/xcrun backend for Apple targets that zig cannot serve. */
 const char* cross_target_to_zig(const char* t);
+bool cross_target_is_apple(const char* triple);
+const char* cross_apple_sdk(const char* triple);
 bool cross_uses_unsupported_module(const char* file, char* which, size_t wsz);
 /* #1648: compile one generated .c to a target-format object (zig cc -c),
  * without assembling or linking the runtime. Backs `--emit=obj --target=`. */
@@ -108,6 +111,6 @@ int  run_cross_compile_obj(const char* c_file, const char* obj_file,
                            bool optimize, const char* ztriple);
 int  run_cross_build(const char* c_file, const char* out_file,
                      bool optimize, const char* extra_files,
-                     const char* ztriple);
+                     const char* ztriple, bool emit_lib);
 
 #endif /* AE_INTERNAL_H */


### PR DESCRIPTION
Adds `ae build --target=aarch64-ios`, plus `aarch64-ios-simulator` and `x86_64-ios-simulator`.

Refs #1385 — **partially**. Please read "What this does NOT do" before merging on the assumption M1 is met.

## Deviation from the plan in #1385

The issue specified routing iOS through zig as a **Tier-B** target, with the Xcode SDK supplied via `AETHER_SYSROOT`, mirroring FreeBSD. This drives **`xcrun clang` directly** instead.

zig cannot actually help here: it bundles no Apple SDK, so the only thing it would contribute is a second toolchain sitting between us and an SDK we still have to locate ourselves. Asking `xcrun` for the SDK path additionally means a relocated Xcode, a beta Xcode, and `DEVELOPER_DIR` all work with nothing for the user to set. Call it Tier C.

If you would rather keep the FreeBSD-shaped symmetry and go through zig with `AETHER_SYSROOT`, say so and I will rework it — but the sysroot would be pure ceremony on this target.

## How it fits the existing cross path

The backend is chosen off the `-apple-` in the resolved triple, and a shared `cross_toolchain()` supplies the `cc`/`ar` command prefixes. The object loop, archive step and link step stay **common with the zig path** rather than forking a second pipeline. `run_cross_compile_obj()` (the `--emit=obj` path from #1648) uses the same helper, so it is not left behind on a literal `zig cc`.

- **`--emit=lib` is allowed on Apple targets only**, where the zig targets still reject it. iOS runs no loose executables, so a library is the entire point of the target. Linked `-install_name @rpath/<leaf>`; without that the load command records the build machine's path and the library fails to load from inside an `.app`.
- **Deployment target** is part of the clang triple (that is how clang stamps `LC_BUILD_VERSION` minos), so it is composed at triple-resolution time. Default 15.0, `AETHER_IOS_MIN` overrides.
- **`std.audio`** gets the same `-DMA_NO_COREAUDIO` as the macOS cross target, for a different reason: miniaudio's iOS backend is AVAudioSession, so `aether_audio.c` stops being valid C there and would fail *every* iOS build, audio or not.
- **`std.os`** (work item 3, partially): iOS marks `system(3)` `__API_UNAVAILABLE`, so naming it failed the compile and took the whole module — and therefore any iOS runtime build — with it. Now gated on a new Tier-0 capability `AETHER_HAS_SHELL`, alongside `AETHER_HAS_FILESYSTEM`; `os.system` returns `-1` there. Forceable anywhere with `-DAETHER_NO_SHELL`.

## Verified

Against Xcode iOS SDK 26.2, macOS arm64:

| Check | Result |
|---|---|
| device exe | Mach-O arm64, `platform IOS`, minos 15.0 |
| simulator exe | Mach-O arm64, `platform IOSSIMULATOR` |
| `--emit=lib` | arm64 dylib, `@rpath/` install_name, exports `_aether_add` |
| `--emit=obj` | Mach-O arm64 object |
| `--emit=csrc` | works with **no Xcode** (never invokes a toolchain) |
| `AETHER_IOS_MIN=17.0` | minos 17.0 |
| Swift links it | `swiftc` for device **and** simulator, resolving `@rpath/libcore.dylib` |
| Swift calls it | ints and strings, **run on macOS** — see caveat below |

`make test-ae` 970/970, `make test` 394/394. `tests/integration/emit_csrc_cross` still passes: its `--emit=lib` rejection is pinned to a zig target, so the Apple exception does not disturb it.

New test `tests/integration/cross_ios/`, skipping off macOS or without an iPhoneOS SDK. It uses the ~100x cheaper single-TU `--emit=obj` for the platform/minos assertions and does only two full runtime links. Added to `tests/ae_sweep_prune.txt` — otherwise the bulk `.ae` sweep would build the export-only `mylib.ae` as an executable and fail, the same reason `emit_csrc`/`emit_obj` are pruned.

## What this does NOT do (against #1385's work items)

1. **No static archive.** The issue asks for a `.a`; this produces a `.dylib`. A `.a` linked straight into the app target avoids the Embed-Frameworks phase and the signing dance, and is the more conventional shape for a compute core. The cross build already archives a `libaether.a` internally and then deletes it, so `--emit=staticlib` is a natural follow-up.
2. **fork/exec/posix_spawn are not stubbed** (work item 3, remainder). They compile — the iOS SDK declares them — and fail at runtime rather than reporting "unsupported on iOS". Only `system(3)` is handled, because only it broke the build.
3. **The ~34 `__APPLE__` guards are unaudited** (work item 4). Untouched.
4. **No CI lane** (work item 5). The test is local-only.
5. **Nothing has been RUN on iOS.** This is the big one: every result above is link-time and load-command inspection. `simctl spawn` is broken on my machine — it fails for a bare `int main(){}` C binary too — so the acceptance criterion "runs its exports in the iOS simulator" is **unmet**. The scheduler and actor threading have zero runtime evidence on iOS.

So M1 is partially met: the build half works, the runs-in-the-simulator half is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
