### PR TITLE
Make the Mailbox layout assertion real, and 32-bit-clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,28 @@ version number before tagging the release.
 
 ### Fixed
 
+- **`multicore_scheduler.c` now compiles for 32-bit targets** (#1652). The
+  `Message` layout assertion was guarded by `#if INTPTR_MAX == INT64_MAX`; the
+  `Mailbox` one directly below it was not, so every ILP32 triple failed to
+  compile the translation unit. The check was also not doing what its comment
+  claimed: `sizeof(Mailbox) % 8 == 0` is vacuously **true** on LP64 (Mailbox
+  contains pointers, so its size is necessarily a multiple of 8) and vacuously
+  **false** on ILP32 (1036 % 8 == 4) — it asserted a property no conforming ABI
+  can violate, and the only thing it ever detected was the pointer width.
+  Replaced with the invariant the derived-actor cast actually depends on: that
+  `sizeof(Mailbox)` equals the ring buffer plus its three counters rounded to
+  the struct's alignment, stated per pointer width. That fires when a layout
+  change would genuinely shift the fields after `mailbox` in
+  `AETHER_ACTOR_BASE_FIELDS`, and now does so on both widths instead of being
+  switched off on one. Guarded against `AETHER_DEBUG_MAILBOX`, which is itself
+  an instance of the hazard: it changes `sizeof(Mailbox)` on ILP32 (1036 →
+  1040) but vanishes into tail padding on LP64, so defining it for some
+  translation units and not others corrupts derived-actor layout on 32-bit
+  targets while silently getting away with it on 64-bit ones. New
+  `tests/integration/scheduler_ilp32/` compiles the TU for `arm64_32` and
+  asserts the target really is ILP32, since nothing else in CI builds a 32-bit
+  multicore scheduler.
+
 - **`ae build --target=<triple> --emit=both` now reports the same up-front
   error as `--emit=lib`** instead of dying at the cross linker. `--emit=both`
   re-dispatches as an exe pass followed by a lib pass, so it never reached the

--- a/runtime/scheduler/multicore_scheduler.c
+++ b/runtime/scheduler/multicore_scheduler.c
@@ -162,11 +162,50 @@ static inline void aether_step_safe(ActorBase* actor) {
     aether_fire_death_hook(actor->id, reason);
 }
 
-// Layout assertions to catch struct padding/size mismatches between translation units
+/* Layout assertions to catch struct padding/size mismatches between
+ * translation units. A derived actor is cast to ActorBase*, and both mirror
+ * AETHER_ACTOR_BASE_FIELDS, so any disagreement about Mailbox's layout
+ * silently shifts every field after it.
+ *
+ * Both sizes are pointer-width dependent (Message carries an intptr_t and
+ * three pointers), so each width states its own expectation. The previous
+ * `sizeof(Mailbox) % 8 == 0` spelling could not: on LP64 it was vacuously
+ * TRUE (Mailbox contains pointers, so its size is necessarily a multiple of
+ * 8) and on ILP32 vacuously FALSE (1036 % 8 == 4) — which is why every
+ * 32-bit target failed to compile this TU rather than being checked by it
+ * (#1652). It asserted a property no conforming ABI can violate, and the
+ * only thing it ever detected was the pointer width.
+ *
+ * The Mailbox check below is the one the comment always claimed: the ring
+ * buffer plus its three counters, with no interior padding and only natural
+ * tail padding.
+ *
+ * It is deliberately a size check rather than a field inventory, because size
+ * is exactly what the derived-actor cast depends on: the fields after
+ * `mailbox` shift if and only if sizeof(Mailbox) shifts. A field small enough
+ * to land in existing tail padding therefore does NOT trip it — correctly, as
+ * it moves nothing. That is width-dependent: on LP64 there are 4 bytes of tail
+ * padding to absorb an int, on ILP32 there are none, so the same edit fires
+ * there and not here.
+ *
+ * AETHER_DEBUG_MAILBOX adds _send_guard and is therefore excluded. Note that
+ * flag is itself the hazard this block guards against: on ILP32 it changes
+ * sizeof(Mailbox) (1036 -> 1040), while on LP64 it disappears into existing
+ * tail padding. Defining it for some translation units but not all corrupts
+ * derived-actor layout on 32-bit targets and silently gets away with it on
+ * 64-bit ones. */
+#define AETHER_ROUND_UP(n, a) (((n) + (a) - 1) / (a) * (a))
 #if INTPTR_MAX == INT64_MAX
 _Static_assert(sizeof(Message) == 48, "Message size changed, update tests");
+#elif INTPTR_MAX == INT32_MAX
+_Static_assert(sizeof(Message) == 32, "Message size changed, update tests");
 #endif
-_Static_assert(sizeof(Mailbox) % 8 == 0, "Mailbox not 8-byte aligned");
+#ifndef AETHER_DEBUG_MAILBOX
+_Static_assert(sizeof(Mailbox) == AETHER_ROUND_UP(sizeof(Message) * MAILBOX_SIZE
+                                                  + 3 * sizeof(int),
+                                                  _Alignof(Mailbox)),
+               "Mailbox layout changed (unexpected padding or a new field)");
+#endif
 
 Scheduler schedulers[MAX_CORES];
 int num_cores = 0;

--- a/tests/integration/scheduler_ilp32/test_scheduler_ilp32.sh
+++ b/tests/integration/scheduler_ilp32/test_scheduler_ilp32.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Regression: aether#1652. multicore_scheduler.c must compile for a 32-bit
+# (ILP32) target.
+#
+# It did not. The Message assertion was guarded by `#if INTPTR_MAX ==
+# INT64_MAX`, the Mailbox one directly below it was not:
+#
+#     _Static_assert(sizeof(Mailbox) % 8 == 0, "Mailbox not 8-byte aligned");
+#
+# On LP64 that is vacuously true — Mailbox contains pointers, so its size is
+# necessarily a multiple of 8 — and on ILP32 it is vacuously false
+# (sizeof(Mailbox) == 1036, 1036 % 8 == 4). It asserted a property no
+# conforming ABI can violate, and the only thing it ever detected was the
+# pointer width, so every 32-bit triple failed to compile the TU.
+#
+# Nothing in CI links a 32-bit executable: the Cortex-M4 leg builds the
+# COOPERATIVE scheduler (PLATFORM=embedded, a different file), --target=wasm
+# goes through Emscripten, and every zig triple in the matrix is 64-bit. So
+# this compiles the one TU for an ILP32 target directly.
+#
+# Uses the watchOS SDK's arm64_32 (32-bit pointers, arm64 ISA) because it is a
+# real ILP32 target with real headers available wherever Xcode is. The bug is
+# not watchOS-specific — any 32-bit triple reproduces it.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+fail() { echo "  FAIL: $1"; exit 1; }
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "  [skip] ILP32 scheduler compile: needs macOS + an Xcode SDK"
+    exit 0
+fi
+SDK=$(xcrun --sdk watchos --show-sdk-path 2>/dev/null) || SDK=""
+if [ -z "$SDK" ]; then
+    echo "  [skip] ILP32 scheduler compile: no watchOS SDK (Xcode not installed)"
+    exit 0
+fi
+
+TMP="${TMPDIR:-/tmp}/ae_ilp32_$$"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+
+INC=$("$ROOT/build/ae" cflags --cflags)
+
+# 1. The TU compiles for ILP32 at all (this is the #1652 regression).
+xcrun --sdk watchos clang -target arm64_32-apple-watchos8.0 -isysroot "$SDK" \
+    -O2 -w -c "$ROOT/runtime/scheduler/multicore_scheduler.c" $INC \
+    -o "$TMP/sched.o" 2>"$TMP/err" \
+    || { cat "$TMP/err"; fail "multicore_scheduler.c does not compile for arm64_32 (ILP32)"; }
+
+# 2. Confirm ILP32 really was in effect — otherwise a toolchain change that
+#    silently produced a 64-bit object would make this test vacuous, which is
+#    the exact failure mode the assertion it guards already had.
+cat > "$TMP/width.c" <<'EOF'
+#include <stdint.h>
+_Static_assert(INTPTR_MAX == INT32_MAX, "not an ILP32 target");
+EOF
+xcrun --sdk watchos clang -target arm64_32-apple-watchos8.0 -isysroot "$SDK" \
+    -w -c "$TMP/width.c" -o "$TMP/width.o" 2>"$TMP/werr" \
+    || { cat "$TMP/werr"; fail "arm64_32 target is not ILP32 — this test proves nothing"; }
+
+echo "  PASS: multicore_scheduler.c compiles for ILP32 (arm64_32), width confirmed"


### PR DESCRIPTION
Fixes the ILP32 compile failure in `runtime/scheduler/multicore_scheduler.c`.

Refs #1652. That issue asked which of three options to take, and offered option 2 — "relax it to the actual invariant" — with the caveat that it "needs someone who knows what the mailbox alignment is actually protecting". I went looking, and the answer turns out to be **nothing**.

## The assertion never checked anything

```c
_Static_assert(sizeof(Mailbox) % 8 == 0, "Mailbox not 8-byte aligned");
```

- On **LP64** this is vacuously **true**. `Mailbox` contains `Message`, which contains pointers, so `_Alignof(Mailbox) == 8`, and C already guarantees `sizeof` is a multiple of `_Alignof`. It cannot fail.
- On **ILP32** it is vacuously **false**: `sizeof(Mailbox) == 1036`, and `1036 % 8 == 4`.

It asserted a property no conforming ABI can violate, and the only thing it ever detected was the pointer width. So option 1 (extend the guard) would have preserved a check that never checked anything, and the person who knows what the alignment protects does not exist — there was no invariant there to know.

## What replaced it

The invariant the derived-actor cast actually depends on. A derived actor is cast to `ActorBase*`, and both mirror `AETHER_ACTOR_BASE_FIELDS`, where `Mailbox mailbox;` is followed by `void (*step)(void*);` and everything else. Those fields shift **if and only if `sizeof(Mailbox)` shifts** — so that is the thing worth pinning:

```c
_Static_assert(sizeof(Mailbox) == AETHER_ROUND_UP(sizeof(Message) * MAILBOX_SIZE
                                                  + 3 * sizeof(int),
                                                  _Alignof(Mailbox)),
               "Mailbox layout changed (unexpected padding or a new field)");
```

plus `sizeof(Message)` pinned per width (48 on LP64, 32 on ILP32 — the latter measured, not assumed). This works on **both** widths rather than being switched off on one.

It is deliberately a size check rather than a field inventory. A field small enough to land in existing tail padding does not trip it — correctly, because it moves nothing. That is width-dependent, and I verified both halves: injecting an `int` into `Mailbox` fires the assertion on ILP32 and (correctly) does not on LP64, which has 4 bytes of tail padding to absorb it.

## A hazard this surfaced

`AETHER_DEBUG_MAILBOX` is itself an instance of the problem the block is meant to guard against. It adds `atomic_flag _send_guard`, which:

- on **ILP32** changes `sizeof(Mailbox)` 1036 → 1040
- on **LP64** vanishes into existing tail padding, 1552 → 1552

So defining it for some translation units and not others corrupts derived-actor layout on 32-bit targets, and silently gets away with it on 64-bit ones. It is excluded from the new assertion, with that written down next to it.

## Verification

Reproduced against **watchOS `arm64_32`** (32-bit pointers, arm64 ISA, real SDK) rather than only wasm — the bug is not wasm-specific, as the issue says. Before:

```
error: static assertion failed due to requirement 'sizeof(Mailbox) % 8 == 0'
note: expression evaluates to '4 == 0'
```

After: compiles clean for `arm64_32-apple-watchos`, `armv7k-apple-watchos`, and LP64 native.

New `tests/integration/scheduler_ilp32/` compiles the TU for `arm64_32`, and **separately asserts the target really is ILP32** — so a toolchain change cannot quietly make the test vacuous, which is exactly what had happened to the assertion it guards. It fails against the old code and passes against the new (checked both ways).

`make test-ae` 970/970, `make test` 394/394. The test dir contributes no `.ae` files, so unlike some integration dirs it needs no `tests/ae_sweep_prune.txt` entry.

## What this does NOT do

- **It does not establish that 32-bit multicore is correct.** It makes the TU compile and the assertion meaningful. The issue's deeper question stands.
- **It does not lift the `wasm32-wasi` executable-link rejection** from #1648. That rejection may now be removable, but I could not verify it (no zig on this machine), and the issue raises a design question I should not answer unilaterally: wasm32 is single-threaded in the runtimes we would target, so the **cooperative** scheduler is arguably the right selection and the real fix may be target selection rather than this assertion. Worth deciding before wiring the exe path.

## Unrelated observation, not fixed

`OptimizedActor` (`runtime/scheduler/scheduler_optimizations.h:47`) is a hand-rolled mirror of the base fields that has **already drifted** from `AETHER_ACTOR_BASE_FIELDS` — different field order (`id`/`active`/`assigned_core`/`mailbox`/`step` vs the macro's `active`/`id`/`mailbox`/`step`/`thread`/…). It is precisely what that macro's comment warns about ("anything that mirrors this layout by hand drifts the moment a field is added here, and the corruption is silent").

It is harmless today: it is declared in that header and referenced nowhere in the tree. Flagging rather than deleting, since dead-code removal is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
