### PR TITLE
feat(wasm): make wasm32-wasi produce a runnable executable (#1655)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,8 +560,22 @@ jobs:
         set -e
         ZIG_BIN="$(./scripts/get-zig.sh "$RUNNER_TEMP/zig")"
         export PATH="$(dirname "$ZIG_BIN"):$PATH"
-        curl -sSf https://wasmtime.dev/install.sh | bash
-        WASMTIME="$HOME/.wasmtime/bin/wasmtime"
+
+        # Pinned release tarball rather than `curl https://wasmtime.dev/install.sh
+        # | bash`: that installer produced NO output and NO binary on this
+        # runner, and because the pipe's exit status is the shell's, the step
+        # sailed on and died later with "wasmtime: No such file or directory" —
+        # a confusing failure a long way from its cause. A fixed URL is
+        # reproducible, and the existence check below turns a download problem
+        # into a message that says so.
+        WASMTIME_VER=v47.0.3
+        curl -sSfL -o "$RUNNER_TEMP/wasmtime.tar.xz" \
+          "https://github.com/bytecodealliance/wasmtime/releases/download/$WASMTIME_VER/wasmtime-$WASMTIME_VER-x86_64-linux.tar.xz"
+        tar -xJf "$RUNNER_TEMP/wasmtime.tar.xz" -C "$RUNNER_TEMP"
+        WASMTIME="$RUNNER_TEMP/wasmtime-$WASMTIME_VER-x86_64-linux/wasmtime"
+        [ -x "$WASMTIME" ] || { echo "wasmtime not found at $WASMTIME"; ls -la "$RUNNER_TEMP"; exit 1; }
+        "$WASMTIME" --version
+
         make -j"$(nproc)" ae stdlib
 
         printf 'main() {\n    println("hello from wasi")\n}\n' > "$RUNNER_TEMP/hello.ae"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,39 @@ jobs:
     - name: Run WASM CI
       run: make ci-wasm
 
+    # #1655 asked for a leg that actually LINKS and RUNS a wasm32-wasi
+    # executable. Nothing did before: the step above compiles one runtime TU
+    # in isolation, and ci-wasm exercises the Emscripten backend, not the zig
+    # one. The failure this guards against is a silent HANG (wasi-libc's
+    # pthread_create stub returns EAGAIN, so a threaded build links and then
+    # spins on the scheduler's readiness barrier), which only running catches
+    # — hence the timeout, and hence asserting on the output rather than the
+    # exit code alone.
+    #
+    # The actor case is separate on purpose: it is what caught the
+    # computed-goto dispatch bug, which affected actors and nothing else.
+    - name: Link and RUN a wasm32-wasi executable
+      run: |
+        set -e
+        ZIG_BIN="$(./scripts/get-zig.sh "$RUNNER_TEMP/zig")"
+        export PATH="$(dirname "$ZIG_BIN"):$PATH"
+        curl -sSf https://wasmtime.dev/install.sh | bash
+        WASMTIME="$HOME/.wasmtime/bin/wasmtime"
+        make -j"$(nproc)" ae stdlib
+
+        printf 'main() {\n    println("hello from wasi")\n}\n' > "$RUNNER_TEMP/hello.ae"
+        ./build/ae build --target=wasm32-wasi "$RUNNER_TEMP/hello.ae" -o "$RUNNER_TEMP/hello.wasm"
+        file "$RUNNER_TEMP/hello.wasm" | grep -q WebAssembly
+        out="$(timeout 60 "$WASMTIME" "$RUNNER_TEMP/hello.wasm")"
+        echo "hello -> $out"
+        [ "$out" = "hello from wasi" ]
+
+        ./build/ae build --target=wasm32-wasi examples/actors/counter.ae \
+          -o "$RUNNER_TEMP/counter.wasm"
+        out="$(timeout 60 "$WASMTIME" "$RUNNER_TEMP/counter.wasm")"
+        echo "$out"
+        echo "$out" | grep -q 'Current value: 18'
+
   ci-embedded:
     name: Embedded ARM (Cortex-M4)
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,53 @@ version number before tagging the release.
 
 ### Added
 
+- **`ae build --target=wasm32-wasi` produces a runnable executable**, actor
+  programs included (#1655). Previously only `--emit=csrc` / `--emit=obj`
+  worked; a full link was rejected up front. The gate blamed
+  `multicore_scheduler.c`'s 64-bit layout assertion, which #1652 had already
+  fixed — the real blocker was always threading, and finding it took three
+  separate places where WASI had been forgotten beside Emscripten.
+
+  **The scheduler.** WASI has no usable threads, but zig's wasi-libc ships
+  pthread *stubs* whose `pthread_create` returns `EAGAIN` rather than leaving
+  the symbol undefined. So the threaded runtime linked, started, printed
+  "Failed to create scheduler thread", and then span forever on
+  `scheduler_start()`'s readiness barrier — a silent hang with no link error to
+  catch it, which is why `aether_thread.h`'s comment predicting a link failure
+  is now corrected. A wasi exe selects the cooperative scheduler instead, the
+  same substitution the Emscripten backend has always made, and `__wasi__`
+  joins the `AETHER_HAS_THREADS` / `NETWORKING` / `NUMA` / `AFFINITY` gates.
+
+  **A new `AETHER_HAS_PROCESS` capability.** `std/os/aether_os.c` was guarded
+  entirely by `!AETHER_HAS_FILESYSTEM`, so the only way to compile out `fork`
+  was to compile out the filesystem with it — which is how Emscripten has
+  always avoided the problem, and is wrong for WASI, whose capability-based
+  filesystem is the point of the target. The split also showed the old macro
+  was conflating things: `os_getenv`, `os_platform_raw` and the clock
+  functions were stubbed only because they shared a file with `fork`.
+
+  **Computed-goto dispatch in actor codegen.** The emitted label-address table
+  is rejected by the wasm backend — "relocations for function or section
+  offsets are only supported in metadata sections" — and the comment above the
+  guard has always said to route wasm through the switch-case fallback, but
+  the guard named only `__EMSCRIPTEN__`. `optimizer.c`'s equivalent guards
+  already listed `__wasi__` and `__wasm__`; this one was the outlier. It
+  surfaced only for actors whose dispatch table LLVM folds rather than keeps,
+  so a single-receive-arm actor failed where a two-arm one compiled.
+
+  Also fixed along the way, each a threadless- or WASI-specific gap that no
+  target had previously exercised: `<time.h>` missing from the threadless
+  branch of `aether_thread.h` (`aether_now_ns` is shared by all three
+  branches); no `PTHREAD_MUTEX_INITIALIZER` / `PTHREAD_RWLOCK_INITIALIZER` or
+  `pthread_rwlock_*` in the threadless shim; `__wasi__` absent from the list of
+  platforms that ship a real `<pthread.h>`, so the shim redefined wasi-libc's
+  own types; four stdlib files including raw `<pthread.h>` instead of the
+  shim; `umask` (absent on WASI), `getrandom` (WASI uses `getentropy`), `pipe`,
+  and miniaudio's thread-priority calls.
+
+  `--target=wasm` (Emscripten) is unchanged and remains the route to a browser
+  bundle with JS glue; `wasm32-wasi` produces a self-contained module.
+
 - **iOS arm64 cross-compilation** — `ae build --target=aarch64-ios`, plus
   `aarch64-ios-simulator` and `x86_64-ios-simulator`. iOS is the first cross
   target NOT served by `zig cc`: Apple's SDKs are Xcode-licensed and cannot be

--- a/compiler/codegen/codegen_actor.c
+++ b/compiler/codegen/codegen_actor.c
@@ -480,7 +480,14 @@ void generate_actor_definition(CodeGenerator* gen, ASTNode* actor) {
         // sections, which wasm disallows ("relocations for function or
         // section offsets are only supported in metadata sections").
         // Route wasm through the MSVC switch-case fallback the same way.
-        print_line(gen, "#if AETHER_GCC_COMPAT && !defined(__EMSCRIPTEN__)");
+        // __wasi__ / __wasm__ join __EMSCRIPTEN__ here. The comment above has
+        // always described the intent as "route wasm through the switch-case
+        // fallback", but the guard named only Emscripten, so a wasm32-wasi
+        // build still emitted the label-address table and died with exactly
+        // the error quoted above (#1655). optimizer.c's equivalent guards
+        // already list all three; this one was the outlier.
+        print_line(gen, "#if AETHER_GCC_COMPAT && !defined(__EMSCRIPTEN__) && \\");
+        print_line(gen, "    !defined(__wasi__) && !defined(__wasm__)");
         print_line(gen, "// COMPUTED GOTO DISPATCH - 15-30%% faster than switch");
         print_line(gen, "static void* dispatch_table[256] = {");
         indent(gen);

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -472,7 +472,7 @@ There are **two** wasm paths, and they are not interchangeable:
 | Target | Backend | Produces | Supported modes |
 |---|---|---|---|
 | `--target=wasm` | Emscripten (`emcc`) | `.js` + `.wasm` bundle | executables |
-| `--target=wasm32-wasi` | `zig cc` | a self-contained wasm object | `--emit=csrc`, `--emit=obj` |
+| `--target=wasm32-wasi` | `zig cc` | a self-contained wasm module | executables, `--emit=csrc`, `--emit=obj` |
 
 Emscripten supplies a JS host, a DOM/filesystem shim and its own pthread
 emulation; the zig path produces a plain object a WASI runtime (or someone
@@ -493,12 +493,35 @@ requires Exception handling support"*), and WASI has no POSIX signal API
 without `-D_WASI_EMULATED_SIGNAL`. `ae build` adds both when the target
 resolves to a WASI triple, so nothing needs passing by hand.
 
-**A full executable link for `wasm32-wasi` is not supported**, and is rejected
-up front rather than failing deep in a compile:
-`runtime/scheduler/multicore_scheduler.c` asserts
-`sizeof(Mailbox) % 8 == 0` with no 64-bit guard (unlike the
-`sizeof(Message) == 48` assertion beside it, which has one), so it fails on any
-32-bit target. Use `--target=wasm` for a runnable bundle.
+**A full executable link works** as of #1655 — including actor programs:
+
+```
+$ ae build --target=wasm32-wasi hello.ae -o hello.wasm
+$ wasmtime hello.wasm
+hello from wasi
+```
+
+Three things had to change for that, and they are worth knowing because each
+was a place where WASI had been forgotten beside Emscripten:
+
+- **The scheduler.** WASI has no usable threads, but zig's wasi-libc ships
+  pthread *stubs* whose `pthread_create` returns `EAGAIN` — so the threaded
+  runtime linked, started, printed "Failed to create scheduler thread", and
+  then span forever on `scheduler_start()`'s readiness barrier. A wasi exe now
+  selects the cooperative scheduler, the same substitution the Emscripten
+  backend has always made.
+- **`AETHER_HAS_PROCESS`** (new). `std/os/aether_os.c` was guarded entirely by
+  `!AETHER_HAS_FILESYSTEM`, so the only way to compile out `fork` was to
+  compile out the filesystem with it. Emscripten accepts that trade; WASI must
+  not, because a capability-based filesystem is the point of WASI. The two
+  capabilities are now separate.
+- **Computed-goto dispatch.** Actor codegen emits a table of label addresses,
+  which wasm rejects ("relocations for function or section offsets are only
+  supported in metadata sections"). The guard excluded `__EMSCRIPTEN__` but
+  not `__wasi__`.
+
+`--target=wasm` remains the route to a runnable **browser** bundle with JS
+glue; `wasm32-wasi` produces a self-contained module for a WASI runtime.
 
 `wasm32-freestanding` is deliberately **not** offered: it ships no libc, so the
 generated C's `#include <stdio.h>` cannot resolve and `--emit=obj` fails
@@ -525,7 +548,7 @@ so an installed toolchain never ships a silently-stubbed regex.
 | Embedded | `PLATFORM=embedded` | Cooperative scheduler, no OS |
 | Cross-OS/arch | `ae build --target=<triple>` | `zig cc` backend, POSIX host, executables + `--emit=csrc`/`--emit=obj` |
 | iOS arm64 | `ae build --target=aarch64-ios` | Xcode/`xcrun` backend, macOS host, `--emit=lib` supported — see [cross-ios.md](cross-ios.md) |
-| Cross-wasm | `ae build --target=wasm32-wasi` | `zig cc` backend, `--emit=csrc`/`--emit=obj` only |
+| Cross-wasm | `ae build --target=wasm32-wasi` | `zig cc` backend; executables + `--emit=csrc`/`--emit=obj` |
 
 ## Hardening (`HARDEN=1`)
 

--- a/runtime/config/aether_optimization_config.h
+++ b/runtime/config/aether_optimization_config.h
@@ -48,8 +48,18 @@
 // ============================================================================
 
 // --- Threads (pthreads / Win32 threads) ---
+//
+// __wasi__ joins __EMSCRIPTEN__ here, and it is the load-bearing arm of the
+// four below. wasi has no usable threads, but zig's wasi-libc ships pthread
+// STUBS (lib/libc/wasi/thread-stub/pthread_create.c) whose pthread_create
+// returns EAGAIN unconditionally. So the threaded runtime does NOT fail to
+// link the way aether_thread.h predicts — it links, starts, prints "Failed to
+// create scheduler thread", and then spins forever on scheduler_start()'s
+// readiness barrier waiting for workers that were never created. A silent
+// hang is a worse failure than a missing symbol, which is why wasi must select
+// the threadless path here rather than relying on a link error to catch it.
 #ifndef AETHER_HAS_THREADS
-#  if defined(__EMSCRIPTEN__) || defined(AETHER_NO_THREADING)
+#  if defined(__EMSCRIPTEN__) || defined(__wasi__) || defined(AETHER_NO_THREADING)
 #    define AETHER_HAS_THREADS 0
 #  else
 #    define AETHER_HAS_THREADS 1
@@ -90,9 +100,32 @@
 #  endif
 #endif
 
+// --- Process control (fork / exec / pipe / popen / waitpid / kill) ---
+//
+// Separate from AETHER_HAS_FILESYSTEM because the two are genuinely different
+// capabilities that happened to share a file. std/os/aether_os.c was guarded
+// entirely by !AETHER_HAS_FILESYSTEM, so the only way to compile out `fork`
+// was to compile out the filesystem with it. That trade is acceptable for
+// Emscripten (which passes -DAETHER_NO_FILESYSTEM anyway) and wrong for WASI,
+// whose whole point is a capability-based filesystem: preopened directories,
+// sandboxed but real. Giving that up to dodge `fork` would disable std.fs on
+// the one target that supports it properly.
+//
+// WASI has no process model at all — no fork, no exec, no pipe — so this is 0
+// there. Emscripten is listed too: it is equally processless, and naming it
+// here means the capability is honest even though its build also happens to
+// pass -DAETHER_NO_FILESYSTEM today.
+#ifndef AETHER_HAS_PROCESS
+#  if defined(__wasi__) || defined(__EMSCRIPTEN__) || defined(AETHER_NO_PROCESS)
+#    define AETHER_HAS_PROCESS 0
+#  else
+#    define AETHER_HAS_PROCESS 1
+#  endif
+#endif
+
 // --- Networking (sockets, connect, etc.) ---
 #ifndef AETHER_HAS_NETWORKING
-#  if defined(__EMSCRIPTEN__) || defined(AETHER_NO_NETWORKING)
+#  if defined(__EMSCRIPTEN__) || defined(__wasi__) || defined(AETHER_NO_NETWORKING)
 #    define AETHER_HAS_NETWORKING 0
 #  else
 #    define AETHER_HAS_NETWORKING 1
@@ -101,7 +134,7 @@
 
 // --- NUMA (Linux libnuma / Win32 NUMA API) ---
 #ifndef AETHER_HAS_NUMA
-#  if defined(AETHER_NO_NUMA) || defined(__EMSCRIPTEN__)
+#  if defined(AETHER_NO_NUMA) || defined(__EMSCRIPTEN__) || defined(__wasi__)
 #    define AETHER_HAS_NUMA 0
 #  elif defined(__linux__) || defined(_WIN32)
 #    define AETHER_HAS_NUMA 1
@@ -123,7 +156,7 @@
 
 // --- Thread Affinity (core pinning) ---
 #ifndef AETHER_HAS_AFFINITY
-#  if defined(AETHER_NO_AFFINITY) || defined(__EMSCRIPTEN__)
+#  if defined(AETHER_NO_AFFINITY) || defined(__EMSCRIPTEN__) || defined(__wasi__)
 #    define AETHER_HAS_AFFINITY 0
 #  elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
 #    define AETHER_HAS_AFFINITY 1

--- a/runtime/utils/aether_thread.h
+++ b/runtime/utils/aether_thread.h
@@ -59,11 +59,25 @@ typedef int pthread_t;
 typedef int pthread_attr_t;
 typedef int pthread_mutexattr_t;
 typedef int pthread_condattr_t;
-/* Read-write locks: std/config/aether_config.c uses them, and a threadless
- * build failed with "unknown type name 'pthread_rwlock_t'" (#1655). These
- * belong INSIDE this bare-metal-only branch — a platform that ships
- * <pthread.h> (wasi included) already has the real types, and defining ours
- * next to them is a redefinition error. */
+#endif
+
+/* Read-write locks, needed by std/config/aether_config.c.
+ *
+ * Guarded on the POSIX feature macro rather than on a platform list, because
+ * neither "has <pthread.h>" nor "is bare metal" predicts this correctly:
+ *
+ *   - bare metal has no <pthread.h> at all           -> needs our typedef
+ *   - ARM newlib SHIPS <pthread.h> but WITHOUT rwlocks -> also needs it
+ *   - glibc / musl / wasi-libc ship both              -> must NOT redefine
+ *
+ * An earlier attempt put these inside the bare-metal branch on the reasoning
+ * that "a platform shipping <pthread.h> already has the real types". Newlib
+ * disproves that: the Cortex-M4 leg failed with "unknown type name
+ * 'pthread_rwlock_t'; did you mean 'pthread_once_t'?" — the suggestion itself
+ * showing a pthread header was present, just without this type.
+ * _POSIX_READER_WRITER_LOCKS is the macro POSIX defines for exactly this
+ * question, so ask it instead of guessing per platform. */
+#if !defined(_POSIX_READER_WRITER_LOCKS) && !defined(PTHREAD_RWLOCK_INITIALIZER)
 typedef int pthread_rwlock_t;
 typedef int pthread_rwlockattr_t;
 #endif

--- a/runtime/utils/aether_thread.h
+++ b/runtime/utils/aether_thread.h
@@ -41,8 +41,14 @@
 //
 // We only provide our own typedefs for truly bare-metal environments
 // where no system headers define pthread types at all.
+//   - WASI:        <pthread.h> IS shipped by wasi-libc, with real types, even
+//                  though its pthread_create is a stub that returns EAGAIN
+//                  (#1655). Include it: defining our own `typedef int
+//                  pthread_mutex_t` alongside would be a redefinition error,
+//                  which is exactly what happened before it was listed here.
 #if defined(_POSIX_THREADS) || defined(__unix__) || defined(__linux__) || \
-    defined(__APPLE__) || defined(__EMSCRIPTEN__) || defined(_NEWLIB_VERSION)
+    defined(__APPLE__) || defined(__EMSCRIPTEN__) || defined(__wasi__) || \
+    defined(_NEWLIB_VERSION)
 #include <pthread.h>
 #else
 // Bare-metal without newlib: define minimal types
@@ -53,7 +59,16 @@ typedef int pthread_t;
 typedef int pthread_attr_t;
 typedef int pthread_mutexattr_t;
 typedef int pthread_condattr_t;
+/* Read-write locks: std/config/aether_config.c uses them, and a threadless
+ * build failed with "unknown type name 'pthread_rwlock_t'" (#1655). These
+ * belong INSIDE this bare-metal-only branch — a platform that ships
+ * <pthread.h> (wasi included) already has the real types, and defining ours
+ * next to them is a redefinition error. */
+typedef int pthread_rwlock_t;
+typedef int pthread_rwlockattr_t;
 #endif
+
+
 
 // No-op function stubs — these shadow the real pthread functions.
 // On hosted platforms with -DAETHER_NO_THREADING, the linker picks our
@@ -73,7 +88,42 @@ static inline int aether_nop_key_create(pthread_key_t* k, void (*d)(void*)) { (v
 static inline int aether_nop_key_delete(pthread_key_t k) { (void)k; return 0; }
 static inline int aether_nop_setspecific(pthread_key_t k, const void* v) { (void)k; (void)v; return 0; }
 static inline void* aether_nop_getspecific(pthread_key_t k) { (void)k; return NULL; }
+static inline int aether_nop_rwlock_init(pthread_rwlock_t* l, const void* a) { (void)l; (void)a; return 0; }
+static inline int aether_nop_rwlock_destroy(pthread_rwlock_t* l) { (void)l; return 0; }
+static inline int aether_nop_rwlock_rdlock(pthread_rwlock_t* l) { (void)l; return 0; }
+static inline int aether_nop_rwlock_wrlock(pthread_rwlock_t* l) { (void)l; return 0; }
+static inline int aether_nop_rwlock_unlock(pthread_rwlock_t* l) { (void)l; return 0; }
 static inline int aether_nop_detach(pthread_t t) { (void)t; return 0; }
+
+/* pthread_join IS stubbed (unlike pthread_create, below), because a join is
+ * only reachable after a successful create. Real call sites guard on exactly
+ * that — std/http/proxy/aether_proxy_pool.c joins its health-check thread only
+ * `if (pool->hc_started)`, and hc_started is set only when pthread_create
+ * returned 0, which cannot happen here. So the join is dead code on a
+ * threadless target, but it must still COMPILE. Leaving it undeclared broke
+ * the wasm32-wasi build (#1655) on code that can never run.
+ *
+ * pthread_create stays unstubbed on purpose: reaching one IS a logic error,
+ * and the note below explains why the linker can't be trusted to catch it. */
+static inline int aether_nop_join(pthread_t t, void** r) { (void)t; if (r) *r = NULL; return 0; }
+
+// PTHREAD_MUTEX_INITIALIZER for statically-initialised locks. The function
+// stubs above cover every DYNAMIC use, but a file-scope
+//   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+// needs the macro to exist too — runtime/sandbox/aether_audit.c does exactly
+// that, and without this a threadless build fails with "use of undeclared
+// identifier 'PTHREAD_MUTEX_INITIALIZER'" (#1655, first hit on wasm32-wasi).
+// pthread_mutex_t is an int here and every lock operation is a no-op, so any
+// value is correct; 0 matches the "unlocked" reading of the typedef.
+#ifndef PTHREAD_MUTEX_INITIALIZER
+#  define PTHREAD_MUTEX_INITIALIZER 0
+#endif
+#ifndef PTHREAD_COND_INITIALIZER
+#  define PTHREAD_COND_INITIALIZER 0
+#endif
+#ifndef PTHREAD_RWLOCK_INITIALIZER
+#  define PTHREAD_RWLOCK_INITIALIZER 0
+#endif
 
 // Redirect pthread calls to no-op stubs via macros
 #define pthread_mutex_init(m, a)     aether_nop_mutex_init((m), (a))
@@ -92,6 +142,12 @@ static inline int aether_nop_detach(pthread_t t) { (void)t; return 0; }
 #define pthread_setspecific(k, v)    aether_nop_setspecific((k), (v))
 #define pthread_getspecific(k)       aether_nop_getspecific(k)
 #define pthread_detach(t)            aether_nop_detach(t)
+#define pthread_rwlock_init(l, a)    aether_nop_rwlock_init((l), (a))
+#define pthread_rwlock_destroy(l)    aether_nop_rwlock_destroy(l)
+#define pthread_rwlock_rdlock(l)     aether_nop_rwlock_rdlock(l)
+#define pthread_rwlock_wrlock(l)     aether_nop_rwlock_wrlock(l)
+#define pthread_rwlock_unlock(l)     aether_nop_rwlock_unlock(l)
+#define pthread_join(t, r)           aether_nop_join((t), (r))
 
 // sched_yield stub — must come after any system header that declares it
 #if !defined(__linux__) && !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
@@ -99,7 +155,14 @@ static inline int aether_nop_detach(pthread_t t) { (void)t; return 0; }
 #endif
 
 // NOTE: pthread_create/pthread_join are NOT stubbed — calling them on
-// a threadless platform is a logic error and should fail at link time.
+// a threadless platform is a logic error.
+//
+// Do NOT rely on that being caught at link time. It is on most targets, but
+// zig's wasi-libc ships pthread STUBS (lib/libc/wasi/thread-stub/) whose
+// pthread_create returns EAGAIN unconditionally, so a wasi build resolves the
+// symbol, links clean, and then hangs on scheduler_start()'s readiness barrier
+// waiting for workers that were never created (#1655). The defence is
+// selecting the right scheduler source set for such targets, not the linker.
 
 #elif !defined(_WIN32)
 
@@ -349,6 +412,16 @@ static inline int aether_win32_sched_yield(void) {
 #endif
 
 // ---- monotonic nanosecond clock -----------------------------------------
+// <time.h> is included HERE rather than per-branch because aether_now_ns()
+// below is shared by all three (threadless / POSIX / Windows). The POSIX
+// branch got struct timespec and clock_gettime transitively from <pthread.h>
+// and the Windows branch includes <time.h> itself, so only the THREADLESS
+// branch was left without a declaration — which no target exercised until
+// wasm32-wasi (#1655), where it surfaced as
+//   error: call to undeclared function 'clock_gettime'
+// Including it unconditionally is harmless for the other two.
+#include <time.h>
+
 // One implementation for every caller. On Windows this routes through the
 // aether_win32_clock_gettime shim above, which splits the
 // QueryPerformanceCounter division into whole seconds plus remainder.

--- a/std/actors/aether_actor_registry.c
+++ b/std/actors/aether_actor_registry.c
@@ -14,7 +14,13 @@ static void ae_reg_rwlock_wrlock  (ae_reg_rwlock_t* lk) { AcquireSRWLockExclusiv
 static void ae_reg_rwlock_wrunlock(ae_reg_rwlock_t* lk) { ReleaseSRWLockExclusive(lk); }
 #define AE_REG_RWLOCK_INITIALIZER SRWLOCK_INIT
 #else
-#include <pthread.h>
+/* The portable thread shim, not raw <pthread.h> (see its header note).
+ * It is real pthreads on POSIX, a CRITICAL_SECTION shim on Windows, and
+ * no-op stubs where AETHER_HAS_THREADS is 0. Including <pthread.h> directly
+ * broke wasm32-wasi (#1655): wasi-libc SHIPS a pthread.h even though its
+ * pthread_create is a stub, so its real typedefs collided with the
+ * threadless shim's in the same TU. */
+#include "../../runtime/utils/aether_thread.h"
 typedef pthread_rwlock_t ae_reg_rwlock_t;
 static void ae_reg_rwlock_rdlock  (ae_reg_rwlock_t* lk) { pthread_rwlock_rdlock(lk); }
 static void ae_reg_rwlock_rdunlock(ae_reg_rwlock_t* lk) { pthread_rwlock_unlock(lk); }

--- a/std/audio/aether_audio.c
+++ b/std/audio/aether_audio.c
@@ -21,10 +21,55 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* WASI has no audio device, and miniaudio's device layer reaches for
+ * pthread_attr_setschedparam / sched_get_priority_max to raise its audio
+ * thread's priority — none of which wasi-libc declares (#1655). MA_NO_DEVICE_IO
+ * is not a way out: it removes ma_context/ma_backend, which this file's own
+ * null-backend fallback uses.
+ *
+ * So the module is stubbed wholesale on wasi, reporting the SAME shape it
+ * already reports on a box with no sound card: is_null_backend() true and a
+ * last_error() explaining why. Callers that already handle the null backend
+ * need no wasi-specific code. */
+#if defined(__wasi__)
+
+#include <stdint.h>   /* int64_t, used by the seek stub */
+
+int aether_audio_open(void) { return 0; }
+void aether_audio_close(void) { }
+int aether_audio_is_null_backend(void) { return 1; }
+const char* aether_audio_last_error(void) {
+    return "audio is unavailable on wasm32-wasi (no device, no threads)";
+}
+void* aether_audio_load_wav(const char* d, int n) { (void)d; (void)n; return NULL; }
+void* aether_audio_load_pcm(const char* d, int n, int ch, int sr, int bits) {
+    (void)d; (void)n; (void)ch; (void)sr; (void)bits; return NULL;
+}
+void aether_audio_unload(void* s) { (void)s; }
+int aether_audio_play(void* s) { (void)s; return 0; }
+int aether_audio_pause(void* s) { (void)s; return 0; }
+int aether_audio_stop(void* s) { (void)s; return 0; }
+int aether_audio_is_playing(void* s) { (void)s; return 0; }
+int aether_audio_set_volume(void* s, double v) { (void)s; (void)v; return 0; }
+double aether_audio_get_volume(void* s) { (void)s; return 0.0; }
+int aether_audio_seek_ns(void* s, int64_t ns) { (void)s; (void)ns; return 0; }
+int aether_audio_channels(void* s) { (void)s; return 0; }
+int aether_audio_sample_rate(void* s) { (void)s; return 0; }
+
+#else
+
 #define MINIAUDIO_IMPLEMENTATION
 /* Trim the build: we only need decoding + playback, no capture/encoding/
  * resource-manager niceties beyond what ma_engine needs by default. */
 #define MA_NO_ENCODING
+/* WASI has no audio device and no threads. miniaudio's device layer reaches
+ * for pthread_attr_setschedparam / sched_get_priority_max to raise its audio
+ * thread's priority, none of which wasi-libc declares (#1655). MA_NO_DEVICE_IO
+ * drops the whole backend layer — the same warn-and-degrade posture the cross
+ * path already takes for CoreAudio on a macos target, where zig's SDK stubs
+ * omit the Apple-licensed framework headers. Decoding still builds; playback
+ * reports unavailable at runtime, which is correct for a target with no
+ * audio device to play to. */
 #include "miniaudio.h"
 
 /* ---- engine ------------------------------------------------------------ */
@@ -326,3 +371,5 @@ int aether_audio_sample_rate(void* sound) {
     if (!sound) return 0;
     return sound_sample_rate((AudioSound*)sound);
 }
+
+#endif /* __wasi__ */

--- a/std/config/aether_config.c
+++ b/std/config/aether_config.c
@@ -16,7 +16,13 @@ static void ae_cfg_rwlock_wrlock(ae_cfg_rwlock_t* lk) { AcquireSRWLockExclusive(
 static void ae_cfg_rwlock_wrunlock(ae_cfg_rwlock_t* lk) { ReleaseSRWLockExclusive(lk); }
 #define AE_CFG_RWLOCK_INITIALIZER SRWLOCK_INIT
 #else
-#include <pthread.h>
+/* The portable thread shim, not raw <pthread.h> (see its header note).
+ * It is real pthreads on POSIX, a CRITICAL_SECTION shim on Windows, and
+ * no-op stubs where AETHER_HAS_THREADS is 0. Including <pthread.h> directly
+ * broke wasm32-wasi (#1655): wasi-libc SHIPS a pthread.h even though its
+ * pthread_create is a stub, so its real typedefs collided with the
+ * threadless shim's in the same TU. */
+#include "../../runtime/utils/aether_thread.h"
 typedef pthread_rwlock_t ae_cfg_rwlock_t;
 static void ae_cfg_rwlock_rdlock  (ae_cfg_rwlock_t* lk) { pthread_rwlock_rdlock(lk); }
 static void ae_cfg_rwlock_rdunlock(ae_cfg_rwlock_t* lk) { pthread_rwlock_unlock(lk); }

--- a/std/cryptography/aether_cryptography.c
+++ b/std/cryptography/aether_cryptography.c
@@ -639,6 +639,22 @@ static int fill_random(unsigned char* out, size_t n) {
     arc4random_buf(out, n);
     return 1;
 }
+#elif defined(__wasi__)
+/* WASI. wasi-libc exposes the host's CSPRNG through getentropy(3), which is
+ * backed by the random_get syscall — there is no getrandom(2) and no
+ * /dev/urandom to fall back to (WASI's filesystem is capability-scoped and a
+ * preopened /dev is not guaranteed). getentropy fills the whole buffer or
+ * fails; its documented cap is 256 bytes per call, so loop for larger asks. */
+static int fill_random(unsigned char* out, size_t n) {
+    size_t got = 0;
+    while (got < n) {
+        size_t chunk = n - got;
+        if (chunk > 256) chunk = 256;
+        if (getentropy(out + got, chunk) != 0) return 0;
+        got += chunk;
+    }
+    return 1;
+}
 #else
 /* Linux. getrandom(2) (glibc 2.25+, kernel 3.17+) is the right
  * source. The /dev/urandom fallback handles very old kernels (CI

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -883,6 +883,12 @@ int fs_write_atomic_raw(const char* path, const char* data, int length) {
     int fd = _open(tmp,
                    _O_WRONLY | _O_CREAT | _O_EXCL | _O_BINARY,
                    _S_IREAD | _S_IWRITE);
+#elif defined(__wasi__)
+    /* WASI has no umask: permissions are the host runtime's business under
+     * its capability model, and there is no process-wide mask to consult.
+     * Pass 0666 unmodified and let the host apply whatever policy it has.
+     * O_NOFOLLOW is likewise absent from wasi-libc's fcntl.h. */
+    int fd = open(tmp, O_WRONLY | O_CREAT | O_EXCL, 0666);
 #else
     mode_t um = umask(0);
     umask(um);

--- a/std/http/proxy/aether_proxy_health.c
+++ b/std/http/proxy/aether_proxy_health.c
@@ -184,6 +184,20 @@ const char* aether_proxy_health_checks_enable(AetherProxyPool* pool,
     pool->hc_healthy_threshold = healthy_threshold;
     pool->hc_unhealthy_threshold = unhealthy_threshold;
 
+#if !AETHER_HAS_THREADS
+    /* Active health checking is a background thread by definition, so there is
+     * nothing to degrade to on a threadless target (wasi, Emscripten). Report
+     * it rather than silently returning success and leaving the caller to
+     * believe upstreams are being probed — a pool that reports healthy without
+     * checking is worse than one that says it cannot check.
+     *
+     * This is a call-site guard rather than a pthread_create stub in
+     * aether_thread.h: reaching a create on a threadless platform IS a logic
+     * error, and stubbing it would let every other such site fail silently. */
+    free(pool->hc_probe_path);
+    pool->hc_probe_path = NULL;
+    return "active health checks need threads (unavailable on this target)";
+#else
     if (pthread_create(&pool->hc_thread, NULL, health_check_loop, pool) != 0) {
         free(pool->hc_probe_path);
         pool->hc_probe_path = NULL;
@@ -191,4 +205,5 @@ const char* aether_proxy_health_checks_enable(AetherProxyPool* pool,
     }
     pool->hc_started = 1;
     return "";
+#endif
 }

--- a/std/http/server/h2/aether_h2.c
+++ b/std/http/server/h2/aether_h2.c
@@ -40,7 +40,13 @@
  * matches the original v1 behaviour). */
 #if !defined(_WIN32)
 #define AETHER_H2_HAS_POOL 1
-#include <pthread.h>
+/* The portable thread shim, not raw <pthread.h> (see its header note).
+ * It is real pthreads on POSIX, a CRITICAL_SECTION shim on Windows, and
+ * no-op stubs where AETHER_HAS_THREADS is 0. Including <pthread.h> directly
+ * broke wasm32-wasi (#1655): wasi-libc SHIPS a pthread.h even though its
+ * pthread_create is a stub, so its real typedefs collided with the
+ * threadless shim's in the same TU. */
+#include "../../../../runtime/utils/aether_thread.h"
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/std/net/aether_actor_bridge.c
+++ b/std/net/aether_actor_bridge.c
@@ -96,8 +96,11 @@ static int _ae_pipe_read_fd = -1;
 static int _ae_pipe_write_fd = -1;
 
 int ae_pipe_open(void) {
-#ifdef _WIN32
-    return -1;  // pipe() is POSIX; Windows callers must use sockets.
+#if defined(_WIN32) || !AETHER_HAS_PROCESS
+    /* pipe() is POSIX; Windows callers must use sockets. WASI reaches the same
+     * arm via AETHER_HAS_PROCESS: it has no pipe(), no fork, and no process
+     * model to plumb one between (#1655). */
+    return -1;
 #else
     int fds[2];
     if (pipe(fds) != 0) return -1;

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -3,7 +3,13 @@
 #include "aether_http_pool.h"
 #if !defined(_WIN32)
 #include <signal.h>    /* pthread_sigmask / sigset_t for the embedded-server signal mask */
-#include <pthread.h>
+/* The portable thread shim, not raw <pthread.h> (see its header note).
+ * It is real pthreads on POSIX, a CRITICAL_SECTION shim on Windows, and
+ * no-op stubs where AETHER_HAS_THREADS is 0. Including <pthread.h> directly
+ * broke wasm32-wasi (#1655): wasi-libc SHIPS a pthread.h even though its
+ * pthread_create is a stub, so its real typedefs collided with the
+ * threadless shim's in the same TU. */
+#include "../../runtime/utils/aether_thread.h"
 #endif
 #include "../../runtime/config/aether_optimization_config.h"
 #include "../../runtime/aether_resource_caps.h"

--- a/std/os/aether_os.c
+++ b/std/os/aether_os.c
@@ -28,6 +28,19 @@ static char* aether_os_empty_heap(void) {
 // compiler link. Keeping the function next to its state fixes that and
 // leaves this file focused on shell/exec helpers.
 
+/* Two independent capabilities gate this file.
+ *
+ * !AETHER_HAS_FILESYSTEM stubs EVERYTHING (the historical behaviour, used by
+ * the Emscripten build, which passes -DAETHER_NO_FILESYSTEM).
+ *
+ * !AETHER_HAS_PROCESS stubs only the fork/exec/pipe/wait surface, leaving the
+ * filesystem and clock functions real. That is the WASI shape: it has a proper
+ * capability-based filesystem — preopened directories, sandboxed but real —
+ * and no process model whatsoever. Before #1655 the only way to compile out
+ * `fork` was to compile out the filesystem with it, because both lived behind
+ * one macro; that trade is fine for Emscripten and would have disabled std.fs
+ * on the one target that supports it properly.
+ */
 #if !AETHER_HAS_FILESYSTEM
 int os_system(const char* c) { (void)c; return -1; }
 char* os_exec_raw(const char* c) { (void)c; return NULL; }
@@ -115,6 +128,24 @@ int os_wall_micros_raw(void) { return 0; }
 int64_t os_now_monotonic_ms_raw(void) { return 0; }
 int64_t os_now_monotonic_ns_raw(void) { return 0; }
 int64_t os_now_unix_ms_raw(void) { return 0; }
+#elif !AETHER_HAS_PROCESS
+
+/* Filesystem yes, processes no — the WASI shape. Everything the process
+ * surface would provide is stubbed here; the filesystem, environment and
+ * clock functions fall through to their real implementations below.
+ *
+ * Return values mirror the !AETHER_HAS_FILESYSTEM stubs above so a caller
+ * sees the same "unavailable" shape on either platform. */
+int os_system(const char* c) { (void)c; return -1; }
+char* os_exec_raw(const char* c) { (void)c; return NULL; }
+int os_execv(const char* p, void* a) { (void)p; (void)a; return -1; }
+char* os_which(const char* n) { (void)n; return NULL; }
+int os_getpid_raw(void) { return 0; }
+int os_user_id_raw(void) { return -1; }
+int os_kill_raw(int pid, int sig) { (void)pid; (void)sig; return -1; }
+
+#define AETHER_OS_PROCESS_STUBBED 1
+
 #else
 
 #include <stdio.h>

--- a/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
+++ b/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
@@ -125,14 +125,33 @@ if command -v zig >/dev/null 2>&1; then
         *) fail "wasm32-wasi object is not a wasm module: $(file "$TMP/wasi.o")" ;;
     esac
 
-    # A full executable link is NOT supported for wasm32 (the runtime
-    # scheduler's layout assertions assume 64-bit pointers). It must fail with
-    # our one-line diagnostic, not a static_assert deep in a scheduler TU.
+    # A full executable link now WORKS for wasm32-wasi (#1655). It was rejected
+    # while the threaded runtime was the blocker; wasi now selects the
+    # cooperative scheduler and the exe links.
     printf 'main() {\n    println("hi")\n}\n' > "$TMP/app.ae"
-    if "$AE" build --target=wasm32-wasi "$TMP/app.ae" -o "$TMP/app.wasm"             >"$TMP/wasiexe" 2>&1; then
-        fail "wasm32-wasi executable link should be rejected but succeeded"
+    if ! "$AE" build --target=wasm32-wasi "$TMP/app.ae" -o "$TMP/app.wasm" \
+            >"$TMP/wasiexe" 2>&1; then
+        cat "$TMP/wasiexe"
+        fail "wasm32-wasi executable link failed"
     fi
-    grep -q 'executable link is not supported yet' "$TMP/wasiexe"         || fail "wasm32-wasi exe gave the wrong diagnostic: $(head -1 "$TMP/wasiexe")"
+    case "$(file "$TMP/app.wasm")" in
+        *WebAssembly*) ;;
+        *) fail "wasi exe is not a wasm module: $(file "$TMP/app.wasm")" ;;
+    esac
+
+    # An ACTOR program must link too. This is the case that caught the real
+    # bug: codegen emitted a computed-goto dispatch table (label addresses),
+    # which the wasm backend rejects with "relocations for function or section
+    # offsets are only supported in metadata sections". The guard excluded
+    # __EMSCRIPTEN__ but not __wasi__, so only wasi hit it — and only when
+    # LLVM folded the table rather than keeping it, which is why a
+    # single-receive-arm actor failed while a two-arm one compiled.
+    printf 'message Ping { n: int }\n\nactor Counter {\n    state total = 0;\n    receive { Ping(n) -> { total = total + n; } }\n}\n\nmain() { c = spawn(Counter()); c ! Ping { n: 5 }; wait_for_idle(); }\n' > "$TMP/act.ae"
+    if ! "$AE" build --target=wasm32-wasi "$TMP/act.ae" -o "$TMP/act.wasm" \
+            >"$TMP/wasiact" 2>&1; then
+        cat "$TMP/wasiact"
+        fail "wasm32-wasi actor executable failed to link"
+    fi
 else
     echo "  [skip] wasm32-wasi checks: zig not on PATH"
 fi

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5439,29 +5439,25 @@ static int cmd_build(int argc, char** argv) {
         // consumer compiles the .so/.a/.wasm themselves. --target therefore
         // does not change the bytes emitted; it is accepted so one command
         // line works for both native and cross consumers.
-        /* The wasm triples are wired for the NON-LINKING emit modes only.
-         * `--emit=csrc` and `--emit=obj` are proven end to end (a real
-         * `WebAssembly (wasm) binary module` object), but a full executable
-         * link is not: runtime/scheduler/multicore_scheduler.c carries
+        /* wasm32-wasi supports a full executable link as of #1655.
          *
-         *     _Static_assert(sizeof(Mailbox) % 8 == 0, ...)
+         * The previous gate here blamed multicore_scheduler.c's
+         * `_Static_assert(sizeof(Mailbox) % 8 == 0, ...)` for failing on 32-bit
+         * targets. #1652 fixed that assertion, and the reason was never the
+         * whole story anyway: the real blocker is THREADING. wasi has no usable
+         * threads, and zig's wasi-libc resolves pthread_create to a stub that
+         * returns EAGAIN rather than leaving the symbol undefined — so a
+         * threaded build links, starts, prints "Failed to create scheduler
+         * thread", and then spins forever on scheduler_start()'s readiness
+         * barrier. A silent hang, with no link error to catch it.
          *
-         * with no 64-bit guard (unlike the `sizeof(Message) == 48` assertion
-         * directly above it, which has one), so it fails on any 32-bit target
-         * including wasm32. That is a pre-existing runtime portability gap
-         * (filed as #1652), not something this path introduces, and it wants
-         * its own change rather than a workaround here. Reject up front so the
-         * user gets one line instead of a static-assert deep in a scheduler
-         * TU. */
-        if (strstr(ztriple, "wasm") && g_emit_exe && !g_emit_csrc && !g_emit_obj) {
-            fprintf(stderr,
-                "Error: --target=%s supports --emit=csrc and --emit=obj; a full "
-                "executable link is not supported yet (the runtime scheduler's "
-                "layout assertions assume a 64-bit target).\n"
-                "  For a runnable wasm bundle use --target=wasm (Emscripten).\n",
-                target);
-            return 1;
-        }
+         * run_cross_build now selects the cooperative scheduler for wasi (the
+         * same substitution the Emscripten backend makes) and the __wasi__ arm
+         * in aether_optimization_config.h turns the threaded path off, so the
+         * pthread_create call site is never reached. Nothing to reject.
+         *
+         * wasm32-freestanding is not a target here (it has no libc, so the
+         * generated C cannot compile at all) — see cross_target_to_zig. */
         // --emit=lib/--emit=both link, so they are rejected on the zig
         // targets. Apple targets DO support them: the link there produces a
         // Mach-O dylib, which is the primary iOS use case (an iOS app is built

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -135,6 +135,13 @@ const char* cross_target_to_zig(const char* t) {
  * on the command line. */
 #define AETHER_WASI_DEFINES "-D_WASI_EMULATED_SIGNAL -D__wasm_exception_handling__=1"
 
+/* Extra defines for a wasi EXECUTABLE link (not needed for csrc/obj, which
+ * never compile the runtime). AETHER_NO_THREADING belts-and-braces the
+ * __wasi__ arm now in aether_optimization_config.h: the capability header is
+ * the authority, but a TU that somehow misses it still gets the threadless
+ * path rather than a stub-backed hang. */
+#define AETHER_WASI_EXE_DEFINES "-DAETHER_NO_THREADING"
+
 /* True if the resolved zig triple is a WASI target. */
 static bool cross_target_is_wasi(const char* ztriple) {
     return ztriple && strstr(ztriple, "wasi") != NULL;
@@ -283,6 +290,45 @@ static int cross_collect_core_list(char out[][CROSS_SRC_PATH_MAX], int max,
         count++;
     }
     fclose(f);
+    return count;
+}
+
+/* Substitute the COOPERATIVE scheduler for the multicore one, in place.
+ *
+ * The MANIFEST names runtime/scheduler/multicore_scheduler.c, which is right
+ * for every threaded target and wrong for wasi. wasi has no usable threads,
+ * and — because zig's wasi-libc resolves pthread_create to a stub that returns
+ * EAGAIN rather than leaving it undefined — the threaded build LINKS and then
+ * hangs on scheduler_start()'s readiness barrier. Selecting the right source
+ * set is therefore the fix; there is no link error to fall back on.
+ *
+ * This mirrors what the Emscripten backend already does: build_wasm_cmd() in
+ * ae.c compiles aether_scheduler_coop.c and deliberately omits
+ * multicore_scheduler.c. aether_scheduler_coop.c implements the same
+ * scheduler_* API surface, so the swap is a drop-in.
+ *
+ * The io pollers are left alone: aether_io_poller_poll.c is the fallback wasi
+ * selects, it compiles clean for wasm32, and its registration path is inert
+ * when nothing registers a descriptor.
+ *
+ * Returns the new count (unchanged unless the swap applied). */
+static int cross_use_coop_scheduler(char srcs[][CROSS_SRC_PATH_MAX], int count,
+                                    const char* base) {
+    for (int i = 0; i < count; i++) {
+        const char* bn = strrchr(srcs[i], '/');
+        bn = bn ? bn + 1 : srcs[i];
+        if (strcmp(bn, "multicore_scheduler.c") != 0) continue;
+        int need = snprintf(srcs[i], CROSS_SRC_PATH_MAX,
+                            "%s/runtime/scheduler/aether_scheduler_coop.c", base);
+        if (need < 0 || need >= CROSS_SRC_PATH_MAX) {
+            fprintf(stderr, "Error: cooperative scheduler path too long.\n");
+            return -1;
+        }
+        return count;
+    }
+    /* Not in the manifest at all: nothing to swap, and nothing to warn about
+     * either — a manifest without the multicore scheduler is already
+     * threadless. */
     return count;
 }
 
@@ -457,6 +503,12 @@ int run_cross_build(const char* c_file, const char* out_file,
                 manifest);
         return 1;
     }
+    /* wasi links the cooperative scheduler instead of the multicore one — see
+     * cross_use_coop_scheduler for why a link error cannot be relied on here. */
+    if (cross_target_is_wasi(ztriple)) {
+        n = cross_use_coop_scheduler(srcs, n, base);
+        if (n < 0) return 1;
+    }
 
     bool is_apple = cross_target_is_apple(ztriple);
     char cc_cmd[3072];
@@ -495,7 +547,7 @@ int run_cross_build(const char* c_file, const char* out_file,
                 sizeof(feature_defs) - strlen(feature_defs) - 1);
     }
     if (cross_target_is_wasi(ztriple)) {
-        strncat(feature_defs, " " AETHER_WASI_DEFINES,
+        strncat(feature_defs, " " AETHER_WASI_DEFINES " " AETHER_WASI_EXE_DEFINES,
                 sizeof(feature_defs) - strlen(feature_defs) - 1);
     }
     /* Tier-B (FreeBSD) targets need a base sysroot for headers and libraries;


### PR DESCRIPTION
Closes #1655.

`ae build --target=wasm32-wasi` supported `--emit=csrc` and `--emit=obj` but rejected a full executable link. It now produces a **runnable** module, actor programs included:

```
$ ae build --target=wasm32-wasi hello.ae -o hello.wasm && wasmtime hello.wasm
hello from wasi

$ ae build --target=wasm32-wasi examples/actors/counter.ae -o counter.wasm
$ wasmtime counter.wasm
Count is now 5
Count is now 8
Count is now 18
Current value: 18
```

The gate blamed `multicore_scheduler.c`'s 64-bit layout assertion. #1652 had already fixed that, and it was never the real reason — the blocker was **threading**, and getting there meant fixing three separate places where WASI had been forgotten beside Emscripten.

## 1. The scheduler — a silent hang, not a link error

WASI has no usable threads, but zig's wasi-libc ships pthread **stubs** (`lib/libc/wasi/thread-stub/pthread_create.c`) whose `pthread_create` returns `EAGAIN` rather than leaving the symbol undefined.

So the threaded runtime did **not** fail to link the way `aether_thread.h` predicted. It linked, started, printed `Failed to create scheduler thread`, and then span forever on `scheduler_start()`'s readiness barrier waiting for workers that were never created. That header's comment ("should fail at link time") is corrected here rather than left to mislead the next person.

A wasi exe now selects the **cooperative scheduler** — the same substitution `build_wasm_cmd()` has always made for Emscripten — and `__wasi__` joins the `AETHER_HAS_THREADS` / `NETWORKING` / `NUMA` / `AFFINITY` gates.

## 2. A new `AETHER_HAS_PROCESS` capability

`std/os/aether_os.c` was guarded entirely by `!AETHER_HAS_FILESYSTEM`, so the only way to compile out `fork` was to compile out the filesystem with it.

That is exactly how Emscripten has always avoided the problem (`-DAETHER_NO_FILESYSTEM`), and it is wrong for WASI, whose capability-based filesystem — preopened directories, sandboxed but real — is the *point* of the target.

Splitting them also showed the old macro was conflating things: `os_getenv`, `os_platform_raw` and the clock functions were stubbed only because they shared a file with `fork`.

## 3. Computed-goto dispatch in actor codegen

The emitted label-address table is rejected by the wasm backend:

> relocations for function or section offsets are only supported in metadata sections

That is the **exact error the comment above the guard already quotes**, while telling the reader to route wasm through the switch-case fallback. But the guard named only `__EMSCRIPTEN__` — and `optimizer.c`'s equivalent guards already listed `__wasi__` and `__wasm__`, so this one was simply the outlier.

It surfaced only for actors whose dispatch table LLVM folds rather than keeps, so a **single-receive-arm** actor failed where a two-arm one compiled. Found by bisecting 11 programs; the shape initially looked like an LLVM limitation rather than our bug, and I reported it as such before the bisect corrected me.

## Also fixed

Each a threadless- or WASI-specific gap that no target had previously exercised:

- `<time.h>` missing from the threadless branch (`aether_now_ns` is shared by all three branches; only Windows included it)
- No `PTHREAD_MUTEX_INITIALIZER` / `PTHREAD_RWLOCK_INITIALIZER` or `pthread_rwlock_*` in the threadless shim
- `pthread_join` unstubbed, though it is reachable only after a successful create
- `__wasi__` absent from the list of platforms shipping a real `<pthread.h>`, so the shim redefined wasi-libc's own types
- Four stdlib files including raw `<pthread.h>` instead of the shim
- `umask` (absent on WASI), `getrandom` (WASI uses `getentropy`), `pipe`, miniaudio's thread-priority calls

Active health checks now **report** unavailable on a threadless target rather than silently succeeding — a pool that reports healthy without probing is worse than one that says it cannot probe.

## CI

A new leg **links and runs** a wasi executable, both hello and actor cases. #1655 asked for this and nothing did it before: the existing step compiles one runtime TU in isolation, and `ci-wasm` exercises the Emscripten backend, not the zig one. It asserts on output rather than exit code alone and carries a timeout, because the failure being guarded is a **hang**.

The existing "Verify WASI panic runtime" step stays, with a comment explaining why it is not redundant: `--emit=obj` compiles only the user's generated C and never touches the runtime, so that step remains the sole thing building `aether_panic.c` for WASI.

## Scope

`--target=wasm` (Emscripten) is untouched and remains the route to a browser bundle with JS glue; `wasm32-wasi` produces a self-contained module. They are selected by target name, and neither supersedes the other.

## Testing

- `make test` — 394 passed, 0 failed
- `make test-ae` — **968 passed, 3 failed**, a strict subset of the **4** an unmodified-HEAD worktree fails (`http_client_forward_proxy`, `http_server_h2`, `windows_crt_symbols`, `repl` — all environmental). Verified by A/B against a clean worktree.
- `check-docs` — clean
- `tests/integration/emit_csrc_cross/` — extended to cover the wasi exe **and** the actor case that caught the codegen bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
