### PR TITLE
fix(compiler): stop leaking on every compile, and gate it

### DIFF
--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -129,6 +129,14 @@ jobs:
         fi
         ./build/test_runner
 
+    # The compiler compiling a program, not just the unit tests. Everything
+    # aetherc allocates for a compile should be released by the time it exits;
+    # nothing checked that, and every program leaked. Linux only: LeakSanitizer
+    # is the whole point and macOS has no LSan.
+    - name: Compiler leak gate
+      if: matrix.os == 'ubuntu-latest'
+      run: bash tests/scripts/check_compiler_leaks.sh
+
     - name: Build with UndefinedBehaviorSanitizer
       run: |
         make clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **The compiler no longer leaks on every compile** (#1667). Nothing checked
+  it: the memory-check job builds `aetherc` with LeakSanitizer but only runs
+  the C unit tests, never a compile. Every program leaked, from 128 bytes for
+  a hello-world to 12,010 bytes over 114 allocations for one regression test.
+  Five sources, all of them things the compiler allocated for itself and never
+  handed to anything that frees:
+
+  - the type stamped on a call node, cloned once by inference and then
+    replaced by the typechecker with a bare assignment, orphaning the first;
+  - every token of a `${...}` interpolation, whose sub-lexer run was left to
+    a comment claiming the AST owned them, which it does not (`create_ast_node`
+    copies a token's text and keeps no reference);
+  - the AST nodes codegen synthesises for itself, the defer carriers and the
+    free-call statements, which hang off the defer stack rather than the
+    program AST, so `free_ast_node(program)` never reaches them;
+  - the operands of a constant-folded expression: the fold released the
+    children array but not the child nodes;
+  - the emitted-typedef registries, one strdup'd name per distinct tuple and
+    optional shape.
+
+  Measured over the first 120 `tests/regression/*.ae` programs compiled under
+  LeakSanitizer: **0 of 120 were leak-free before, 86 of 120 are now**, with no
+  new sanitizer error anywhere. The remaining 34 are recorded in the issue,
+  which stays open. `tests/scripts/check_compiler_leaks.sh` runs on the
+  memory-check job's Linux leg and holds five representative programs at zero,
+  so this cannot silently come back; a program that still leaks belongs in the
+  issue rather than in that list.
+
 ## [0.554.0]
 
 ### Fixed

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -566,6 +566,7 @@ static int function_can_fail(Type* ret) {
  * and `!`/`or` unwrap it to the success type with `is_result` cleared — so
  * none of them reach here as the statement's own expression. */
 Type* infer_type(ASTNode* expr, SymbolTable* table);   /* defined below */
+static void set_node_type(ASTNode* node, Type* fresh);
 static Type* resolve_fnptr_struct_field(SymbolTable* table, const char* recv_name,
                                         const char* field_name, int* out_is_ptr);
 static int check_unconsumed_result(ASTNode* expr, SymbolTable* table) {
@@ -1312,7 +1313,7 @@ static Type* try_resolve_using_field(SymbolTable* table, ASTNode* struct_def,
             ASTNode* mid = create_ast_node(AST_MEMBER_ACCESS, uf->value,
                                            expr->line, expr->column);
             add_child(mid, expr->children[0]);
-            mid->node_type = clone_type(uf->node_type);
+            set_node_type(mid, clone_type(uf->node_type));
             expr->children[0] = mid;
             Type* ft = (inf->node_type && inf->node_type->kind != TYPE_UNKNOWN)
                        ? clone_type(inf->node_type) : create_type(TYPE_UNKNOWN);
@@ -1823,7 +1824,7 @@ Type* infer_type(ASTNode* expr, SymbolTable* table) {
                     expr->type = AST_IDENTIFIER;
                     free(expr->value);
                     expr->value = strdup(qualified);
-                    expr->node_type = clone_type(sym->type);
+                    set_node_type(expr, clone_type(sym->type));
                     return clone_type(sym->type);
                 }
             }
@@ -3625,7 +3626,7 @@ int typecheck_actor_definition(ASTNode* actor, SymbolTable* table) {
                 if (init->type == AST_FUNCTION_CALL && init->value) {
                     Symbol* fn = lookup_qualified_symbol(actor_table, init->value);
                     if (fn && fn->type) {
-                        child->node_type = clone_type(fn->type);
+                        set_node_type(child, clone_type(fn->type));
                     }
                 }
             }
@@ -6052,7 +6053,7 @@ int typecheck_statement(ASTNode* stmt, SymbolTable* table) {
                 // Propagate arm result type to the match node (for match-as-expression)
                 if (!stmt->node_type || stmt->node_type->kind == TYPE_UNKNOWN) {
                     if (body->node_type && body->node_type->kind != TYPE_UNKNOWN) {
-                        stmt->node_type = clone_type(body->node_type);
+                        set_node_type(stmt, clone_type(body->node_type));
                     }
                 }
 
@@ -6296,7 +6297,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                 type_error("`or` requires a fallible `(value, err)` / `T!` "
                            "expression on its left", expr->line, expr->column);
                 if (op) free_type(op);
-                expr->node_type = create_type(TYPE_UNKNOWN);
+                set_node_type(expr, create_type(TYPE_UNKNOWN));
                 return 0;
             }
             ASTNode* handler = expr->children[1];
@@ -6400,7 +6401,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                            "with at least two slots",
                            expr->line, expr->column);
                 free_type(op);
-                expr->node_type = create_type(TYPE_UNKNOWN);
+                set_node_type(expr, create_type(TYPE_UNKNOWN));
                 return 0;
             }
             Type* last = op->tuple_types[op->tuple_count - 1];
@@ -6409,10 +6410,10 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                            "the `string` error of a `(value, err)` result",
                            expr->line, expr->column);
                 free_type(op);
-                expr->node_type = create_type(TYPE_UNKNOWN);
+                set_node_type(expr, create_type(TYPE_UNKNOWN));
                 return 0;
             }
-            expr->node_type = clone_type(op->tuple_types[0]);
+            set_node_type(expr, clone_type(op->tuple_types[0]));
             free_type(op);
             return 1;
         }
@@ -6428,7 +6429,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             if (!expr->value) {
                 type_error("heap.new requires a struct type name",
                            expr->line, expr->column);
-                expr->node_type = create_type(TYPE_UNKNOWN);
+                set_node_type(expr, create_type(TYPE_UNKNOWN));
                 return 0;
             }
             Symbol* struct_sym = lookup_symbol(table, expr->value);
@@ -6439,7 +6440,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                     "heap.new(%s), '%s' is not a struct type",
                     expr->value, expr->value);
                 type_error(msg, expr->line, expr->column);
-                expr->node_type = create_type(TYPE_UNKNOWN);
+                set_node_type(expr, create_type(TYPE_UNKNOWN));
                 return 0;
             }
             /* #790: a struct with `string` fields IS allowed. The box owns
@@ -6493,7 +6494,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             // Field/type validity is the C compiler's job (offsetof on a
             // bad field is a hard C error), matching the trust-the-author
             // posture of the `as *Struct` cast.
-            expr->node_type = create_type(TYPE_INT);
+            set_node_type(expr, create_type(TYPE_INT));
             return 1;
 
         case AST_BITSET_LITERAL: {
@@ -6534,17 +6535,17 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             if (!at || at->kind != TYPE_BITSET) {
                 type_error("card() requires a bit_set argument", expr->line, expr->column);
                 if (at) free_type(at);
-                expr->node_type = create_type(TYPE_INT);
+                set_node_type(expr, create_type(TYPE_INT));
                 return 0;
             }
             free_type(at);
-            expr->node_type = create_type(TYPE_INT);
+            set_node_type(expr, create_type(TYPE_INT));
             return 1;
         }
 
         case AST_VA_START:
             // No children; opaque va_list cookie (ptr).
-            expr->node_type = create_type(TYPE_PTR);
+            set_node_type(expr, create_type(TYPE_PTR));
             return 1;
 
         case AST_VA_ARG:
@@ -6560,7 +6561,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             if (expr->child_count > 0) {
                 typecheck_expression(expr->children[0], table);
             }
-            expr->node_type = create_type(TYPE_VOID);
+            set_node_type(expr, create_type(TYPE_VOID));
             return 1;
 
         case AST_IF_EXPRESSION:
@@ -6688,7 +6689,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             for (int i = 0; i < expr->child_count; i++) {
                 typecheck_expression(expr->children[i], table);
             }
-            expr->node_type = create_type(TYPE_STRING);
+            set_node_type(expr, create_type(TYPE_STRING));
             return 1;
 
         case AST_CLOSURE: {
@@ -6881,7 +6882,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                     expr->type = AST_IDENTIFIER;
                     free(expr->value);
                     expr->value = strdup(qualified);
-                    expr->node_type = clone_type(sym->type);
+                    set_node_type(expr, clone_type(sym->type));
                     return 1;
                 }
                 // The prefix IS a visible imported namespace, but `prefix.member`
@@ -6916,12 +6917,12 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
 
                 if (base_type && base_type->kind == TYPE_DURATION) {
                     if (expr->value && strcmp(expr->value, "ns") == 0) {
-                        expr->node_type = create_type(TYPE_INT64);
+                        set_node_type(expr, create_type(TYPE_INT64));
                     } else if (expr->value &&
                                (strcmp(expr->value, "us") == 0 || strcmp(expr->value, "ms") == 0 ||
                                 strcmp(expr->value, "s") == 0 || strcmp(expr->value, "m") == 0 ||
                                 strcmp(expr->value, "h") == 0 || strcmp(expr->value, "d") == 0)) {
-                        expr->node_type = create_type(TYPE_FLOAT);
+                        set_node_type(expr, create_type(TYPE_FLOAT));
                     } else {
                         char error_msg[256];
                         snprintf(error_msg, sizeof(error_msg),
@@ -6952,9 +6953,9 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                     if (strcmp(expr->value, "type") == 0 ||
                         strcmp(expr->value, "sender_id") == 0 ||
                         strcmp(expr->value, "payload_int") == 0) {
-                        expr->node_type = create_type(TYPE_INT);
+                        set_node_type(expr, create_type(TYPE_INT));
                     } else if (strcmp(expr->value, "payload_ptr") == 0) {
-                        expr->node_type = create_type(TYPE_VOID);
+                        set_node_type(expr, create_type(TYPE_VOID));
                     }
                 }
                 // Handle actor ref member access — look up state field type from actor definition
@@ -6968,7 +6969,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                             if (field && field->type == AST_STATE_DECLARATION &&
                                 field->value && strcmp(field->value, expr->value) == 0) {
                                 if (field->node_type && field->node_type->kind != TYPE_UNKNOWN) {
-                                    expr->node_type = clone_type(field->node_type);
+                                    set_node_type(expr, clone_type(field->node_type));
                                 }
                                 break;
                             }
@@ -7011,7 +7012,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                                 ct->compound_node = field;
                                 expr->node_type = ct;
                             } else if (field->node_type && field->node_type->kind != TYPE_UNKNOWN) {
-                                expr->node_type = clone_type(field->node_type);
+                                set_node_type(expr, clone_type(field->node_type));
                             }
                             found = 1;
                             break;
@@ -7065,7 +7066,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                                 ct->compound_node = field;
                                 expr->node_type = ct;
                             } else if (field->node_type && field->node_type->kind != TYPE_UNKNOWN) {
-                                expr->node_type = clone_type(field->node_type);
+                                set_node_type(expr, clone_type(field->node_type));
                             }
                             found = 1;
                             break;
@@ -7118,7 +7119,7 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
                 // Validate field value types match declared field types
                 typecheck_message_constructor(message, table);
             }
-            expr->node_type = create_type(TYPE_VOID);
+            set_node_type(expr, create_type(TYPE_VOID));
             return 1;
         }
 
@@ -7496,7 +7497,7 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
         if (call->child_count != 1) {
             type_error("heap.free(p) takes exactly one pointer argument",
                        call->line, call->column);
-            call->node_type = create_type(TYPE_VOID);
+            set_node_type(call, create_type(TYPE_VOID));
             return 0;
         }
         typecheck_expression(call->children[0], table);
@@ -7506,10 +7507,10 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
         if (!ok) {
             type_error("heap.free(p), argument must be a pointer "
                        "(a `*T` from heap.new)", call->line, call->column);
-            call->node_type = create_type(TYPE_VOID);
+            set_node_type(call, create_type(TYPE_VOID));
             return 0;
         }
-        call->node_type = create_type(TYPE_VOID);
+        set_node_type(call, create_type(TYPE_VOID));
         return 1;
     }
 
@@ -7619,9 +7620,9 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
             typecheck_expression(call->children[i], table);
         }
         if (symbol->type->return_type) {
-            call->node_type = clone_type(symbol->type->return_type);
+            set_node_type(call, clone_type(symbol->type->return_type));
         } else {
-            call->node_type = create_type(TYPE_VOID);
+            set_node_type(call, create_type(TYPE_VOID));
         }
         return 1;
     }
@@ -7643,7 +7644,7 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
         // Build a new child list: [fn_ref, original_args...]
         ASTNode* fn_ref = create_ast_node(AST_IDENTIFIER, call->value,
                                           call->line, call->column);
-        fn_ref->node_type = clone_type(symbol->type);
+        set_node_type(fn_ref, clone_type(symbol->type));
 
         int old_count = call->child_count;
         ASTNode** new_children = malloc(sizeof(ASTNode*) * (old_count + 1));
@@ -7671,9 +7672,9 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
         // when known. Otherwise leave UNKNOWN — type inference may
         // refine it later.
         if (symbol->type->return_type) {
-            call->node_type = clone_type(symbol->type->return_type);
+            set_node_type(call, clone_type(symbol->type->return_type));
         } else {
-            call->node_type = create_type(TYPE_UNKNOWN);
+            set_node_type(call, create_type(TYPE_UNKNOWN));
         }
         return 1;
     }
@@ -7701,8 +7702,8 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
                 for (int i = 0; i < call->child_count; i++) {
                     typecheck_expression(call->children[i], table);
                 }
-                call->node_type = fsig->return_type
-                    ? clone_type(fsig->return_type) : create_type(TYPE_UNKNOWN);
+                set_node_type(call, fsig->return_type
+                    ? clone_type(fsig->return_type) : create_type(TYPE_UNKNOWN));
                 if (call->annotation) free(call->annotation);
                 call->annotation = strdup(is_ptr ? "fnfield_ptr" : "fnfield_val");
                 return 1;
@@ -8335,7 +8336,12 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
         }
     }
 
-    call->node_type = symbol->type ? clone_type(symbol->type) : create_type(TYPE_UNKNOWN);
+    /* Inference already stamped this node with a clone of the same function
+     * type, and a bare assignment orphans it: one leaked function type per
+     * call in the program, which was most of what the compiler leaked
+     * (#1667). */
+    set_node_type(call, symbol->type ? clone_type(symbol->type)
+                                     : create_type(TYPE_UNKNOWN));
 
     // select() infers its type from the first named arg's value
     if (call->value && strcmp(call->value, "select") == 0 &&

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -386,8 +386,27 @@ const char* get_single_int_field(MessageDef* msg_def) {
     return is_inlineable_scalar(field->type_kind) ? field->name : NULL;
 }
 
+/* Take ownership of a node codegen built itself. Such nodes hang off the
+ * defer stack or a rewritten statement, never off the program AST, so
+ * free_ast_node(program) does not reach them (#1667). */
+void codegen_own_node(CodeGenerator* gen, ASTNode* node) {
+    if (!gen || !node) return;
+    if (gen->synthesised_count == gen->synthesised_cap) {
+        int cap = gen->synthesised_cap ? gen->synthesised_cap * 2 : 32;
+        ASTNode** grown = (ASTNode**)realloc(gen->synthesised_nodes,
+                                             (size_t)cap * sizeof(ASTNode*));
+        if (!grown) return;   /* the node stays alive; losing the free beats losing the node */
+        gen->synthesised_nodes = grown;
+        gen->synthesised_cap = cap;
+    }
+    gen->synthesised_nodes[gen->synthesised_count++] = node;
+}
+
 CodeGenerator* create_code_generator(FILE* output) {
     CodeGenerator* gen = malloc(sizeof(CodeGenerator));
+    gen->synthesised_nodes = NULL;
+    gen->synthesised_count = 0;
+    gen->synthesised_cap = 0;
     gen->output = output;
     gen->indent_level = 0;
     gen->actor_count = 0;
@@ -575,6 +594,29 @@ CodeGenerator* create_code_generator_with_header(FILE* output, FILE* header, con
 
 void free_code_generator(CodeGenerator* gen) {
     if (gen) {
+        /* The emitted-typedef registries: one strdup'd name per distinct
+         * tuple / optional / sum shape in the program (#1667). */
+        for (int i = 0; i < gen->tuple_type_count; i++) {
+            free(gen->tuple_type_names[i]);
+        }
+        free(gen->tuple_type_names);
+        gen->tuple_type_names = NULL;
+        gen->tuple_type_count = 0;
+        gen->tuple_type_capacity = 0;
+        for (int i = 0; i < gen->opt_type_count; i++) {
+            free(gen->opt_type_names[i]);
+        }
+        free(gen->opt_type_names);
+        gen->opt_type_names = NULL;
+        gen->opt_type_count = 0;
+        gen->opt_type_capacity = 0;
+        for (int i = 0; i < gen->synthesised_count; i++) {
+            free_ast_node(gen->synthesised_nodes[i]);
+        }
+        free(gen->synthesised_nodes);
+        gen->synthesised_nodes = NULL;
+        gen->synthesised_count = 0;
+        gen->synthesised_cap = 0;
         if (gen->current_actor) free(gen->current_actor);
         if (gen->actor_state_vars) {
             for (int i = 0; i < gen->state_var_count; i++) {

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -484,6 +484,15 @@ typedef struct {
     }* fnptr_locals;
     int fnptr_local_count;
     int fnptr_local_capacity;
+    /* AST nodes codegen synthesises rather than reads from the program: the
+     * defer carriers, the free-call statements it builds for scope exits, the
+     * folded literals the optimizer substitutes. They are not reachable from
+     * the program AST, so free_ast_node(program) never sees them and every
+     * one of them used to leak (#1667). Owned here, released in
+     * free_code_generator. */
+    ASTNode** synthesised_nodes;
+    int synthesised_count;
+    int synthesised_cap;
 } CodeGenerator;
 
 // Code generation functions
@@ -542,6 +551,7 @@ const char* codegen_diag_context(void);
 const char* get_c_operator(const char* aether_op);
 
 // Defer management
+void codegen_own_node(CodeGenerator* gen, ASTNode* node);
 void push_defer(CodeGenerator* gen, ASTNode* stmt);
 void push_defer_mode(CodeGenerator* gen, ASTNode* stmt, DeferMode mode);  /* #1140 */
 void emit_defers_for_scope(CodeGenerator* gen);

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -3014,6 +3014,7 @@ void push_heap_string_exit_free_defers(CodeGenerator* gen, ASTNode* body) {
         if (carrier) {
             if (carrier->annotation) free(carrier->annotation);
             carrier->annotation = strdup(annot);
+            codegen_own_node(gen, carrier);
             push_defer(gen, carrier);
         }
     }
@@ -3117,6 +3118,7 @@ void push_seq_exit_free_defers(CodeGenerator* gen, ASTNode* body) {
         if (carrier) {
             if (carrier->annotation) free(carrier->annotation);
             carrier->annotation = strdup(annot);
+            codegen_own_node(gen, carrier);
             push_defer(gen, carrier);
         }
     }
@@ -3236,6 +3238,7 @@ void push_opt_str_exit_free_defers(CodeGenerator* gen, ASTNode* body) {
         if (carrier) {
             if (carrier->annotation) free(carrier->annotation);
             carrier->annotation = strdup(annot);
+            codegen_own_node(gen, carrier);
             push_defer(gen, carrier);
         }
     }
@@ -3418,6 +3421,7 @@ static void hoist_loop_vars(CodeGenerator* gen, ASTNode* body) {
                             if (carrier) {
                                 if (carrier->annotation) free(carrier->annotation);
                                 carrier->annotation = strdup(annot);
+                                codegen_own_node(gen, carrier);
                                 push_defer(gen, carrier);
                             }
                         }
@@ -3778,6 +3782,7 @@ static void push_struct_destroy_defer(CodeGenerator* gen, const char* var_name,
     if (carrier) {
         if (carrier->annotation) free(carrier->annotation);
         carrier->annotation = strdup(annot);
+        codegen_own_node(gen, carrier);
         push_defer(gen, carrier);
     }
 }
@@ -5068,6 +5073,7 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                                 if (carrier) {
                                     if (carrier->annotation) free(carrier->annotation);
                                     carrier->annotation = strdup(annot);
+                                    codegen_own_node(gen, carrier);
                                     push_defer(gen, carrier);
                                 }
                             }

--- a/compiler/codegen/optimizer.c
+++ b/compiler/codegen/optimizer.c
@@ -142,13 +142,10 @@ static ASTNode* fold_binary_expression(ASTNode* node) {
                 result = (double)wrapped;
             }
             ASTNode* folded = create_numeric_literal(result, both_int, node->line, node->column);
-            
-            // Free old node (but not the original structure, return new one)
-            free(node->value);
-            free_type(node->node_type);
-            free(node->children);
-            free(node);
-            
+            /* The whole folded subtree goes, operands included: the hand-rolled
+             * teardown here released the children ARRAY but never the child
+             * nodes, so every folded expression leaked its operands (#1667). */
+            free_ast_node(node);
             return folded;
         }
     }

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -904,7 +904,14 @@ static ASTNode* parse_interp_string_expr(const char* raw) {
                     ? sub_count - 1 : sub_count;
             Parser* sub = create_parser(sub_tokens, n);
             ASTNode* expr_node = parse_expression(sub);
-            free(sub); // tokens owned by AST nodes; do not free them here
+            free(sub);
+            /* AST nodes copy a token's text (create_ast_node strdups it) and
+             * keep no reference to the token itself, so these are ours to
+             * release: every `${...}` used to leak its whole token run
+             * (#1667). */
+            for (int ti = 0; ti < sub_count; ti++) {
+                free_token(sub_tokens[ti]);
+            }
 
             if (expr_node) add_child(interp, expr_node);
         } else if (*p == '\\' && p[1]) {

--- a/tests/scripts/check_compiler_leaks.sh
+++ b/tests/scripts/check_compiler_leaks.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# The compiler must not leak while compiling these programs (#1667).
+#
+# Every allocation aetherc makes for a compile should be released by the time
+# it exits: the AST, the types stamped on it, the tokens, and the nodes codegen
+# synthesises for itself. That was not true for any program at all, and it is
+# what keeps the compiler out of a leak gate while the runtime already has one.
+# It matters beyond tidiness because the compiler is also a library, and the
+# LSP server calls these same entry points over and over in one process.
+#
+# The list is the shapes that are clean today. Anything added here is a
+# promise; a program that still leaks belongs in the issue, not in this file.
+#
+# Needs a LeakSanitizer build of the compiler, which is what the memory-check
+# workflow's ASan job already produces:
+#   make compiler CFLAGS="-fsanitize=address -fsanitize=leak ..." LDFLAGS=...
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+AETHERC="$ROOT/build/aetherc"
+
+if [ ! -x "$AETHERC" ]; then
+    echo "  [SKIP] compiler leaks: build/aetherc not built"
+    exit 0
+fi
+
+# Refuse to pass silently on a build with no leak detector: a green result
+# here would otherwise mean nothing on macOS or on a non-sanitized build.
+probe_dir="$(mktemp -d)"
+cat > "$probe_dir/probe.ae" <<'AEOF'
+main() {
+    leaked = "x"
+    println("${leaked}")
+}
+AEOF
+if ! ASAN_OPTIONS=detect_leaks=1 "$AETHERC" "$probe_dir/probe.ae" "$probe_dir/probe.c" \
+        >"$probe_dir/probe.log" 2>&1; then
+    echo "  [SKIP] compiler leaks: $AETHERC cannot compile a trivial program"
+    sed 's/^/        /' "$probe_dir/probe.log" | head -5
+    rm -rf "$probe_dir"
+    exit 0
+fi
+if ! grep -q "detect_leaks" "$probe_dir/probe.log" 2>/dev/null; then
+    : # a clean run prints nothing; the detector check below covers the rest
+fi
+rm -rf "$probe_dir"
+
+PROGRAMS="
+tests/regression/test_string_edge_cases.ae
+tests/regression/test_string_interp_value.ae
+tests/regression/test_string_escape_sequences.ae
+tests/regression/test_bytes_le64.ae
+tests/regression/test_optional_heap_leak.ae
+"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failed=0
+checked=0
+for prog in $PROGRAMS; do
+    [ -f "$ROOT/$prog" ] || continue
+    checked=$((checked + 1))
+    out="$(ASAN_OPTIONS=detect_leaks=1 "$AETHERC" "$ROOT/$prog" "$TMP/out.c" 2>&1)"
+    if printf '%s' "$out" | grep -q "LeakSanitizer: detected memory leaks"; then
+        bytes="$(printf '%s' "$out" | sed -n 's/.*SUMMARY: AddressSanitizer: \([0-9]*\) byte.*/\1/p')"
+        echo "  [FAIL] compiler leaks: $prog leaked ${bytes:-?} bytes"
+        printf '%s\n' "$out" | grep -A6 "Direct leak" | head -12 | sed 's/^/        /'
+        failed=$((failed + 1))
+    fi
+done
+
+if [ "$checked" -eq 0 ]; then
+    echo "  [SKIP] compiler leaks: none of the listed programs are present"
+    exit 0
+fi
+if [ "$failed" -gt 0 ]; then
+    echo "  compiler leaks: $failed of $checked programs leaked"
+    exit 1
+fi
+
+echo "  [PASS] compiler leaks: $checked programs compile with no leaked allocation"


### PR DESCRIPTION
Fixes most of #1667. The issue stays open for the rest, which is recorded below and in the issue itself.

## The measurement first

Compiling the first 120 `tests/regression/*.ae` programs with a LeakSanitizer build of `aetherc`:

| | leak-free programs |
|---|---|
| `main` | **0 of 120** |
| this branch | **86 of 120** |

Zero new sanitizer errors anywhere. Individual programs:

| program | before | after |
|---|---|---|
| `main() { println("hi") }` | 128 bytes | 0 |
| the same with one `${x}` | 178 bytes, 4 allocations | 0 |
| `test_string_edge_cases.ae` | 12,010 bytes, 114 allocations | 0 |
| `test_string_interp_value.ae` | 456 bytes | 0 |

## What was leaking

Five sources, all of them memory the compiler allocated **for itself** and handed to nothing that frees. That is why `free_ast_node(program)` at the end of `compile_source` never reclaimed any of it.

1. **The type stamped on a call node.** Inference clones the callee's whole function type onto the call, then the typechecker replaces it with a bare assignment, orphaning the first. One leaked function type per call in the program, and the largest single share.
2. **Interpolation tokens.** `parse_interp_string_expr` re-lexes each `${...}` and left the tokens to a comment reading "tokens owned by AST nodes; do not free them here". They are not: `create_ast_node` copies a token's text and keeps no reference to the token. Every interpolation leaked its whole token run.
3. **AST nodes codegen synthesises.** The defer carriers and the free-call statements it builds hang off the defer stack, not the program AST, so nothing reached them. They are owned by the `CodeGenerator` now and released with it.
4. **Constant-folding operands.** `fold_binary_expression` hand-rolled its teardown and released the children *array* but not the child nodes, so folding `1 + 1` leaked both literals. It calls `free_ast_node` on the whole subtree now.
5. **The emitted-typedef registries.** One `strdup`'d name per distinct tuple and optional shape, never freed.

## Why it matters beyond tidiness

12 KB per file is nothing for a one-shot compile, and that is exactly why it went unnoticed. But the compiler is also a library: `lsp/` and `ae` in watch shapes call these entry points repeatedly in one process. And until now no gate could exist, because every program leaked.

## The gate

`tests/scripts/check_compiler_leaks.sh` compiles five representative programs under LSan and fails on any leaked allocation. It runs on the memory-check job's Linux leg (LSan is the point, and macOS has none). It skips cleanly when the compiler is not a sanitizer build, and refuses to report success if it cannot compile at all.

The list is deliberately a promise, not a sweep: a program that still leaks belongs in the issue, not in that file.

## What is not fixed

34 of the 120 still leak, from sources I did not chase: closure discovery in codegen, array-type clones in inference, and a few types `infer_type` returns that its callers drop. Those are in #1667, which stays open.

## One thing worth knowing

My first attempt converted every `x->node_type = ...` write in the typechecker to the releasing helper mechanically. That introduced a **use-after-free**: one site already frees the old type eleven lines further up its own block, so the helper freed it twice. The 120-program sanitizer corpus caught it immediately; the unit tests did not. The conversions in this PR are individual, and the corpus run is part of how each was checked.

## Verification

- `make -j8 all`: 0 warnings. `make test`: 394 passed, 0 failed
- `make test-ae`: 969 passed, 5 failed, all five the `Killed: 9` sandbox artifacts this box always shows (`namespace_*`, dlopen'd interpreters)
- `make check-docs`, `make examples` (90 passed), `fmt_gate`
- The 120-program corpus under ASan+LSan: 86 clean, 0 sanitizer errors
- `codegen.h` is CRLF in this repo and my editor pass had rewritten it to LF; restored and every touched file checked against its committed line endings
