### PR TITLE
feat(spec): assert on the failure path — assert_err, assert_err_contains, assert_ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.spec` can assert on the failure path** — `assert_err`,
+  `assert_err_contains` and `assert_ok`, for the `(value, err)` convention std
+  uses throughout. Asked for by the html-sanitizer line while porting a C#
+  suite, but the gap is Aether's own: the error arm is the one most likely to
+  be wrong and least likely to be tested, and the matcher set was entirely
+  success-path.
+
+  The workaround was `assert_true(err != "", ...)`, which is worse than it
+  looks. It reports "expected true" and **discards the error string**, so a
+  failing test says nothing about what went wrong — the reporter hit exactly
+  this, with 71 of 101 failing tests undiagnosable until they swapped a
+  boolean check for one that printed both sides. `assert_ok(err, ...)` prints
+  the error it got.
+
+  `assert_err_contains` matches a substring deliberately: a test pins the
+  reason without pinning the exact wording, so rephrasing a message does not
+  break every spec that asserts on it.
+
+  `assert_ok` earns its place by being the one people omit. With no positive
+  form to reach for, error-path tests get written and success-path ones do
+  not, and a function that starts failing everywhere still passes its suite.
+  `docs/testing.md` gained a section on this — and lost an example that taught
+  the very anti-pattern these replace (`assert_false(err, "no error")`).
+
+  `assert_panics` is deliberately NOT here. The ask records it as a separate,
+  larger piece — it needs the harness to survive a panic, and interacts with
+  `--no-contracts` and with wasi, where `AETHER_SIGLONGJMP` is `abort()` and
+  cannot unwind at all.
+
+
+
 ## [0.560.0]
 
 ### Added

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -94,13 +94,40 @@ spec.assert_eq(count, 4, "four jobs")          // int equality
 spec.assert_not_eq(a, b, "distinct")
 spec.assert_gt(size, 0, "non-empty")
 spec.assert_true(ok, "the thing worked")
-spec.assert_false(err, "no error")
+spec.assert_false(flag, "flag is clear")
 spec.assert_str_eq(name, "Ada", "user name")   // exact string equality
 spec.assert_str_eq_diff(got, want, "payload")  // caret under first diff
 spec.assert_contains(body, "world", "greeting")
 spec.assert_null(ptr, "was freed")
 spec.assert_not_null(user, "was loaded")
 ```
+
+### Asserting on the failure path
+
+`std` returns `(value, err)` throughout — `err` is `""` on success and a
+message on failure. Three matchers state that outcome directly:
+
+```aether,fragment
+v, err = thing.parse(input)
+spec.assert_ok(err, "parse should accept good input")
+
+v, err = thing.parse(bad)
+spec.assert_err(err, "parse should reject bad input")
+spec.assert_err_contains(err, "unexpected token", "and should say why")
+```
+
+Prefer these over `assert_true(err != "", ...)`. That form reports only
+"expected true" and **discards the error string**, so a failing test tells you
+nothing about what went wrong; `assert_ok` prints the error it got. It also
+reads as a mechanism rather than an outcome.
+
+`assert_err_contains` matches a substring on purpose: a test pins the *reason*
+without pinning the exact wording, so rephrasing a message does not break
+every spec that asserts on it.
+
+`assert_ok` is worth reaching for even when the call "obviously" succeeds — it
+is the one people omit, and a suite with only error-path assertions stays green
+while the success path rots.
 
 `assert_str_eq_diff` aligns the two values and points a caret at the first
 differing byte — reach for it when a plain "expected X got Y" would bury

--- a/std/spec/module.ae
+++ b/std/spec/module.ae
@@ -78,6 +78,9 @@ exports(
     fail, assert_true, assert_false,
     assert_eq, assert_str_eq, assert_str_eq_diff, assert_not_eq, assert_gt,
     assert_contains, assert_null, assert_not_null,
+    // Failure-path matchers for the (value, err) convention. assert_true(err
+    // != "") discards the error string; these print it.
+    assert_err, assert_err_contains, assert_ok,
     // Timing-budget matcher (caller-measured monotonic-ns span vs a
     // Duration literal)
     expect_elapsed_under,
@@ -586,6 +589,53 @@ assert_gt(actual: int, expected: int, msg: string) {
 assert_contains(haystack: string, needle: string, msg: string) {
     if string.contains(haystack, needle) == 0 {
         fail("${msg} — '${haystack}' does not contain '${needle}'")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Failure-path matchers for the `(value, err)` convention
+//
+// std returns `(value, err)` throughout, with err "" on success and a
+// message on failure. That error arm is the one most likely to be wrong and
+// least likely to be tested, and until now the matcher set was entirely
+// success-path — so a spec author wrote `assert_true(err != "", ...)` by hand.
+//
+// That works and is worse than it looks. assert_true reports "expected true"
+// and DISCARDS the error string, so a failing test tells you nothing about
+// what the error actually was. These print the error they did or did not get.
+//
+// assert_ok earns its place by being the one people omit: with no positive
+// form to reach for, error-path tests get written and success-path ones do
+// not, and a function that starts failing everywhere still passes its suite.
+// ---------------------------------------------------------------------------
+
+// The call was expected to fail: `err` must be non-empty.
+assert_err(err: string, msg: string) {
+    if string.length(err) == 0 {
+        fail("${msg} — expected an error, got success (err was empty)")
+    }
+}
+
+// The call was expected to fail FOR A REASON: `err` must be non-empty and
+// contain `needle`. Substring rather than equality on purpose — a test pins
+// the reason without pinning the exact wording, so rephrasing a message does
+// not break every spec that asserts on it.
+assert_err_contains(err: string, needle: string, msg: string) {
+    if string.length(err) == 0 {
+        fail("${msg} — expected an error containing '${needle}', got success")
+        return
+    }
+    if string.contains(err, needle) == 0 {
+        fail("${msg} — expected the error to contain '${needle}', got '${err}'")
+    }
+}
+
+// The call was expected to succeed: `err` must be empty. Printing the error
+// is the whole point — this is the assertion that tells you WHY something
+// that should have worked did not.
+assert_ok(err: string, msg: string) {
+    if string.length(err) != 0 {
+        fail("${msg} — expected success, got error '${err}'")
     }
 }
 

--- a/tests/regression/test_spec_module.ae
+++ b/tests/regression/test_spec_module.ae
@@ -57,6 +57,18 @@ main() {
                 spec.assert_null(null, "null is null")
                 spec.assert_not_null(fw, "fw non-null")
             }
+
+            // Failure-path matchers for the (value, err) convention: err is
+            // "" on success and a message on failure, so assert_err wants a
+            // non-empty string and assert_ok an empty one. All-green by
+            // construction like the rest of this file, so what is pinned here
+            // is that each matcher ACCEPTS the outcome it is meant to accept.
+            spec.it("failure-path matchers") callback {
+                spec.assert_err("boom", "a non-empty err is an error")
+                spec.assert_err_contains("unexpected token at 3", "unexpected token",
+                    "and the reason can be pinned by substring")
+                spec.assert_ok("", "an empty err is success")
+            }
         }
 
         spec.describe("fluent facade") {


### PR DESCRIPTION
Implements `asks/spec-error-and-panic-assertions.md` from the html-sanitizer line — the `(value, err)` family.

## The gap

`(value, err)` is the dominant idiom across `std` — `err` is `""` on success, a message on failure. The `std.spec` matcher set was **entirely success-path**, so the error arm — the one most likely to be wrong and least likely to be tested — had no matcher at all.

```aether
v, err = thing.parse(bad_input)
spec.assert_err(err, "parse should reject bad input")
spec.assert_err_contains(err, "unexpected token", "and should say why")

v, err = thing.parse(good_input)
spec.assert_ok(err, "parse should accept good input")
```

## Why not `assert_true(err != "")`

Because it **discards the error string**. Side by side on the same condition:

| | message on failure |
|---|---|
| `assert_true(err != "")` | `expected true` |
| `assert_ok(err, ...)` | `expected success, got error 'file not found: /nope'` |

The reporter hit this concretely: **71 of 101 failing tests** in their port were undiagnosable until they swapped a boolean check for one that printed both sides.

`assert_err_contains` matches a substring deliberately — a test pins the *reason* without pinning the exact wording, so rephrasing a message does not break every spec asserting on it. It also distinguishes "wrong reason" from "no error at all", which are different bugs:

```
FAIL: should say why — expected the error to contain 'unexpected token', got 'permission denied'
FAIL: should have failed — expected an error containing 'unexpected token', got success
```

`assert_ok` earns its place by being **the one people omit**. With no positive form to reach for, error-path tests get written and success-path ones do not — and a function that starts failing everywhere still passes its suite.

## Found while documenting

`docs/testing.md` was teaching the very anti-pattern these replace:

```aether
spec.assert_false(err, "no error")
```

Now `assert_false(flag, "flag is clear")`, with a new section on the failure-path matchers beside it.

## Scope

**`assert_panics` is deliberately not here.** The ask records it as separate, larger work — it needs the harness to survive a panic, and interacts with `--no-contracts` and with wasi, where `AETHER_SIGLONGJMP` is `abort()` and cannot unwind at all. The ask is explicit that if only one family lands it should be this one.

## Also in here

CHANGELOG repair. Releasing 0.560.0 while this sat unstaged wedged the `[current]` heading **inside** 0.559.0 — leaving that release with an **empty body** — and duplicated the batch-3 entry into `[current]` despite it having already shipped. 0.558.0, 0.559.0 and 0.560.0 are now each byte-identical to `git show vX.Y.Z:CHANGELOG.md`.

*(Separately: an audit against every recent tag found five older sections — 0.542.0, 0.545.0, 0.546.0, 0.547.0, 0.552.0 — that differ from their tags on `main` today. **No content is lost**; every bullet from every tag still exists in the file. They are either later additions the tag predates, or entries filed under a neighbouring release. Out of scope here, worth its own pass.)*

## Testing

- Verified against a real `std` call — `fs.read` on a missing path — not only synthetic strings
- All four failure modes checked for a **useful message**, not just the happy path
- `test_spec_module.ae` extended; 13 passing
- `make test` 394/0 · `make test-ae` 975 passed, 3 failed (the usual three environmental) · `fmt_gate` PASS · `check-docs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
