### PR TITLE
ci: supersede stale runs instead of stacking them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
 
+# A newer push to the same ref supersedes the older run. Without this every
+# push stacked another full run: 26 active runs and 19 queued at once, which
+# starved sibling repos sharing the org's runners for the better part of an
+# hour, and left CI reporting on commits that had already been replaced.
+#
+# PR runs cancel; pushes to main do not. A main run is the one that fills the
+# shared caches (see the Restore/Save split in windows.yml), and cancelling it
+# would leave PR runs rebuilding from cold.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================
   # Full CI suite — Linux (GCC), Linux (Clang), macOS (Clang)

--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -7,6 +7,18 @@ on:
     branches: [ main, master, develop ]
   workflow_dispatch:
 
+# A newer push to the same ref supersedes the older run. Without this every
+# push stacked another full run: 26 active runs and 19 queued at once, which
+# starved sibling repos sharing the org's runners for the better part of an
+# hour, and left CI reporting on commits that had already been replaced.
+#
+# PR runs cancel; pushes to main do not. A main run is the one that fills the
+# shared caches (see the Restore/Save split in windows.yml), and cancelling it
+# would leave PR runs rebuilding from cold.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   valgrind-test:
     name: Valgrind Memory Leak Check

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,18 @@ on:
 # on a Linux runner is therefore a separate piece of work, tracked in its
 # own issue; the compile half stands on its own.
 
+# A newer push to the same ref supersedes the older run. Without this every
+# push stacked another full run: 26 active runs and 19 queued at once, which
+# starved sibling repos sharing the org's runners for the better part of an
+# hour, and left CI reporting on commits that had already been replaced.
+#
+# PR runs cancel; pushes to main do not. A main run is the one that fills the
+# shared caches (see the Restore/Save split in windows.yml), and cancelling it
+# would leave PR runs rebuilding from cold.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================
   # FAST LANE — cross-build for Windows on a Linux runner


### PR DESCRIPTION
`ci.yml`, `memory-check.yml` and `windows.yml` have no concurrency group, so every push starts another full run and nothing retires the old one.

Measured on this repo a few minutes ago: **26 active runs and 19 queued at once**, including four runs of the same workflow on `perf/1663-connection-parking` at four different commits, the oldest an hour into building a commit that had already been replaced.

Two costs, neither of them just waste:

- These runs share the org's runner pool. A sibling repo's single job (aesite, one `ubuntu-latest` test) sat queued behind this pile for the better part of an hour.
- The CI signal was reporting on commits nobody was looking at any more, which is worse than no signal because it looks like coverage.

A per-workflow, per-ref group fixes it. A newer push to the same ref supersedes the older run.

### Why `cancel-in-progress` is conditional

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR runs cancel. Pushes to `main` do not, deliberately: the main run is what fills the shared caches (`windows.yml`'s Restore/Save split only SAVES on main), so cancelling it would leave every subsequent PR rebuilding from cold. Cancelling a half-finished main build is also a good way to leave a cache holding a partial object set.

### Not touched

`release.yml` already serializes with `group: release` and `cancel-in-progress: false`, which is correct. A release must never be cancelled by a later merge, and that stays exactly as it is.

All four workflow files parse as valid YAML after the change.