### PR TITLE
test(std): spec-based unit tests for eight untested modules (#1584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **Spec-based unit tests for eight previously untested `std` modules**
+  (#1584). `uuid`, `ksuid`, `ulid`, `tsid`, `nanoid`, `actors`, `lzf` and
+  `zlib` had no test of any kind — the `std.http.server.lb` class of gap the
+  issue was filed about. 53 cases, co-located as `std/<module>/test_*.ae`,
+  and the first co-located tests written against `std.spec` rather than
+  relocated from the central suites, which is the dogfooding half of the
+  proposal. Modules with zero coverage anywhere drop from eight to two
+  (`casper` is FreeBSD-only, `log` writes to stdout). Two behaviours had to
+  be measured rather than read off the source and are now pinned: `lzf`
+  refuses any input it cannot shrink, whatever its length, reporting only
+  `"lzf compress failed"`; and `zlib.gzip_inflate` rejects a raw deflate
+  stream rather than returning garbage.
+
 ## [0.563.0]
 
 ### Fixed

--- a/std/actors/test_actors_registry.ae
+++ b/std/actors/test_actors_registry.ae
@@ -1,0 +1,99 @@
+// std.actors unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. The registry is a
+// name -> actor_ref map with a small set of documented edge cases:
+// rebinding a name overwrites without error, unregister reports
+// whether it removed anything, and whereis on a missing name yields
+// null. Those contracts are what this covers.
+//
+// registry_clear exists for exactly this purpose, so each `it` starts
+// from an empty registry via before_each rather than depending on the
+// order the cases run in.
+
+import std.spec
+import std.actors
+
+message Ping {}
+
+actor Probe {
+    state n = 0
+    receive { Ping() -> { n = n + 1 } }
+}
+
+main() {
+    fw = spec.init()
+
+    spec.describe(fw, "std.actors registry") {
+        spec.before_each() callback {
+            actors.registry_clear()
+        }
+
+        spec.it("starts empty after a clear") callback {
+            spec.assert_eq(actors.registry_size(), 0, "size is 0")
+        }
+
+        spec.it("binds a name and looks it up") callback {
+            a = spawn(Probe())
+            actors.register("probe", a)
+            spec.assert_eq(actors.is_registered("probe"), 1, "probe is bound")
+            spec.assert_eq(actors.registry_size(), 1, "one binding")
+        }
+
+        spec.it("reports an unbound name as not registered") callback {
+            spec.assert_eq(actors.is_registered("absent"), 0,
+                "absent is not bound")
+        }
+
+        spec.it("overwrites a rebound name without error") callback {
+            // Documented: register on an existing name replaces the
+            // binding rather than failing, and does not grow the map.
+            a = spawn(Probe())
+            b = spawn(Probe())
+            actors.register("dup", a)
+            actors.register("dup", b)
+            spec.assert_eq(actors.registry_size(), 1,
+                "rebinding does not add an entry")
+            spec.assert_eq(actors.is_registered("dup"), 1, "dup still bound")
+        }
+
+        spec.it("removes a binding and reports that it did") callback {
+            a = spawn(Probe())
+            actors.register("gone", a)
+            spec.assert_eq(actors.unregister("gone"), 1, "unregister returns 1")
+            spec.assert_eq(actors.is_registered("gone"), 0, "no longer bound")
+            spec.assert_eq(actors.registry_size(), 0, "size back to 0")
+        }
+
+        spec.it("reports removing an unbound name as no-op") callback {
+            spec.assert_eq(actors.unregister("never"), 0,
+                "unregister of an unbound name returns 0")
+        }
+
+        spec.it("tracks several bindings independently") callback {
+            a = spawn(Probe())
+            b = spawn(Probe())
+            c = spawn(Probe())
+            actors.register("one", a)
+            actors.register("two", b)
+            actors.register("three", c)
+            spec.assert_eq(actors.registry_size(), 3, "three bindings")
+            actors.unregister("two")
+            spec.assert_eq(actors.registry_size(), 2, "two left")
+            spec.assert_eq(actors.is_registered("one"), 1, "one survives")
+            spec.assert_eq(actors.is_registered("two"), 0, "two removed")
+            spec.assert_eq(actors.is_registered("three"), 1, "three survives")
+        }
+
+        spec.it("clears every binding at once") callback {
+            a = spawn(Probe())
+            b = spawn(Probe())
+            actors.register("x", a)
+            actors.register("y", b)
+            actors.registry_clear()
+            spec.assert_eq(actors.registry_size(), 0, "registry emptied")
+            spec.assert_eq(actors.is_registered("x"), 0, "x gone")
+        }
+    }
+
+    spec.run_summary(fw)
+}

--- a/std/ksuid/test_ksuid_generate.ae
+++ b/std/ksuid/test_ksuid_generate.ae
@@ -1,0 +1,79 @@
+// std.ksuid unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. A KSUID is a 27-char
+// base62 string over a 20-byte payload: a 4-byte big-endian seconds
+// timestamp (offset by a 2014 epoch) followed by 16 random bytes. The
+// assertions cover the shape, the alphabet, the (value, err) contract,
+// and time-ordering across a sleep.
+//
+// Ordering is checked across a >1s sleep because the timestamp has
+// SECOND resolution: two KSUIDs minted in the same second differ only
+// in their random tail and are not required to sort by mint time.
+
+import std.spec
+import std.ksuid
+import std.string
+
+const KSUID_ALPHA = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// Every character must come from the base62 alphabet.
+fn all_chars_in_alphabet(id: string) -> int {
+    i = 0
+    while i < string.length(id) {
+        c = string.char_at(id, i)
+        found = 0
+        j = 0
+        while j < 62 {
+            if string.char_at(KSUID_ALPHA, j) == c {
+                found = 1
+            }
+            j = j + 1
+        }
+        if found == 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+main() {
+    fw = spec.init()
+
+    spec.describe(fw, "std.ksuid") {
+        spec.it("returns a 27-char id and no error") callback {
+            id, err = ksuid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_eq(string.length(id), 27, "27 chars")
+        }
+
+        spec.it("uses only base62 characters") callback {
+            id, err = ksuid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_true(all_chars_in_alphabet(id),
+                "id '${id}' is all base62")
+        }
+
+        spec.it("does not repeat across calls") callback {
+            a, e1 = ksuid.generate()
+            b, e2 = ksuid.generate()
+            spec.assert_ok(e1, "first generate succeeds")
+            spec.assert_ok(e2, "second generate succeeds")
+            spec.assert_true(string.equals(a, b) == 0, "two ksuids differ")
+        }
+
+        spec.it("sorts lexicographically by mint time") callback {
+            // The timestamp is second-resolution, so the sleep has to
+            // cross a second boundary for ordering to be guaranteed.
+            a, e1 = ksuid.generate()
+            sleep(1100)
+            b, e2 = ksuid.generate()
+            spec.assert_ok(e1, "first generate succeeds")
+            spec.assert_ok(e2, "second generate succeeds")
+            spec.assert_true(string.compare(a, b) < 0,
+                "later ksuid sorts after: ${a} < ${b}")
+        }
+    }
+
+    spec.run_summary(fw)
+}

--- a/std/lzf/test_lzf_roundtrip.ae
+++ b/std/lzf/test_lzf_roundtrip.ae
@@ -1,0 +1,114 @@
+// std.lzf unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. LZF is a byte-exact
+// compressor, so the assertions that matter are round-trip fidelity
+// across inputs with different compressibility, the (data, length, err)
+// contract, and the documented rejections of negative lengths.
+//
+// LZF is not required to shrink every input — highly random data can
+// come back larger, which is why max_compressed_size exists and why no
+// assertion here claims compression always reduces size. Only the
+// repetitive case asserts an actual saving.
+
+import std.spec
+import std.lzf
+import std.string
+
+main() {
+    fw = spec.init()
+
+    spec.describe(fw, "std.lzf round trip") {
+        spec.it("restores highly repetitive data byte for byte") callback {
+            original = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            n = string.length(original)
+            packed, plen, err = lzf.compress(original, n)
+            spec.assert_ok(err, "compress succeeds")
+            spec.assert_true(plen > 0, "compressed length is positive")
+            back, blen, derr = lzf.decompress(packed, plen, n)
+            spec.assert_ok(derr, "decompress succeeds")
+            spec.assert_eq(blen, n, "length restored")
+            spec.assert_str_eq(back, original, "content restored")
+        }
+
+        spec.it("actually shrinks repetitive input") callback {
+            original = "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc"
+            n = string.length(original)
+            packed, plen, err = lzf.compress(original, n)
+            spec.assert_ok(err, "compress succeeds")
+            spec.assert_true(plen < n,
+                "compressed ${plen} < original ${n}")
+        }
+
+        spec.it("restores mixed text byte for byte") callback {
+            original = "The quick brown fox jumps over the lazy dog, 0123456789."
+            n = string.length(original)
+            packed, plen, err = lzf.compress(original, n)
+            spec.assert_ok(err, "compress succeeds")
+            back, blen, derr = lzf.decompress(packed, plen, n)
+            spec.assert_ok(derr, "decompress succeeds")
+            spec.assert_eq(blen, n, "length restored")
+            spec.assert_str_eq(back, original, "content restored")
+        }
+
+        spec.it("round-trips a short repetitive input") callback {
+            // 16 bytes of a repeating pair — the smallest case measured
+            // to survive a round trip here.
+            original = "abababababababab"
+            n = string.length(original)
+            packed, plen, err = lzf.compress(original, n)
+            spec.assert_ok(err, "compress succeeds")
+            back, blen, derr = lzf.decompress(packed, plen, n)
+            spec.assert_ok(derr, "decompress succeeds")
+            spec.assert_eq(blen, n, "length restored")
+            spec.assert_str_eq(back, original, "content restored")
+        }
+
+        spec.it("declines input it cannot shrink") callback {
+            // Not a length floor — a compressibility one. LZF reports
+            // failure rather than emitting a larger-than-input block, so
+            // an all-distinct string is refused at any of the sizes
+            // measured here. Worth pinning because the error is opaque
+            // ("lzf compress failed") and a caller feeding it
+            // already-compressed or random bytes will hit it routinely.
+            data, n, err = lzf.compress("abcdefgh", 8)
+            spec.assert_err(err, "incompressible 8-byte input is refused")
+            spec.assert_eq(n, 0, "no length on the error path")
+
+            data2, n2, err2 = lzf.compress("abcdefghijklmnopqrstuvwx", 24)
+            spec.assert_err(err2, "incompressible 24-byte input is refused")
+            spec.assert_eq(n2, 0, "no length on the error path")
+        }
+    }
+
+    spec.describe(fw, "std.lzf bounds") {
+        spec.it("reports a headroom bound for a given length") callback {
+            // The worst case for LZF is slightly larger than the input,
+            // so the bound must exceed it rather than merely match.
+            spec.assert_true(lzf.max_compressed_size(100) > 100,
+                "bound leaves headroom over 100 bytes")
+        }
+
+        spec.it("rejects a negative input length on compress") callback {
+            data, n, err = lzf.compress("abc", -1)
+            spec.assert_err_contains(err, "negative input length",
+                "compress(-1) says why")
+            spec.assert_eq(n, 0, "no length on the error path")
+        }
+
+        spec.it("rejects a negative input length on decompress") callback {
+            data, n, err = lzf.decompress("abc", -1, 10)
+            spec.assert_err_contains(err, "negative input length",
+                "decompress(-1, _) says why")
+            spec.assert_eq(n, 0, "no length on the error path")
+        }
+
+        spec.it("rejects a negative output length on decompress") callback {
+            data, n, err = lzf.decompress("abc", 3, -1)
+            spec.assert_err_contains(err, "negative output length",
+                "decompress(_, -1) says why")
+            spec.assert_eq(n, 0, "no length on the error path")
+        }
+    }
+
+    spec.run_summary(fw)
+}

--- a/std/nanoid/test_nanoid_generate.ae
+++ b/std/nanoid/test_nanoid_generate.ae
@@ -1,0 +1,92 @@
+// std.nanoid unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. A NanoID is n chars
+// drawn from a 64-symbol URL-safe alphabet; generate() is the 21-char
+// default and generate_n(n) takes a length. The assertions cover both
+// shapes, the alphabet, uniqueness, and — unusually for this cluster —
+// a real rejected-input path, since generate_n(0) is defined to fail.
+
+import std.spec
+import std.nanoid
+import std.string
+
+const NANO_ALPHA = "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+fn all_chars_in_alphabet(id: string) -> int {
+    i = 0
+    while i < string.length(id) {
+        c = string.char_at(id, i)
+        found = 0
+        j = 0
+        while j < 64 {
+            if string.char_at(NANO_ALPHA, j) == c {
+                found = 1
+            }
+            j = j + 1
+        }
+        if found == 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+main() {
+    fw = spec.init()
+
+    spec.describe(fw, "std.nanoid generate") {
+        spec.it("returns a 21-char id and no error") callback {
+            id, err = nanoid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_eq(string.length(id), 21, "21 chars")
+        }
+
+        spec.it("uses only the URL-safe alphabet") callback {
+            id, err = nanoid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_true(all_chars_in_alphabet(id),
+                "id '${id}' is all URL-safe")
+        }
+
+        spec.it("does not repeat across calls") callback {
+            a, e1 = nanoid.generate()
+            b, e2 = nanoid.generate()
+            spec.assert_ok(e1, "first generate succeeds")
+            spec.assert_ok(e2, "second generate succeeds")
+            spec.assert_true(string.equals(a, b) == 0, "two nanoids differ")
+        }
+    }
+
+    spec.describe(fw, "std.nanoid generate_n") {
+        spec.it("honours the requested length") callback {
+            id, err = nanoid.generate_n(8)
+            spec.assert_ok(err, "generate_n(8) succeeds")
+            spec.assert_eq(string.length(id), 8, "8 chars")
+        }
+
+        spec.it("produces a single character for n = 1") callback {
+            id, err = nanoid.generate_n(1)
+            spec.assert_ok(err, "generate_n(1) succeeds")
+            spec.assert_eq(string.length(id), 1, "1 char")
+        }
+
+        spec.it("rejects a length below 1") callback {
+            // The one genuine failure path in this cluster — worth
+            // asserting the reason, not merely that it failed.
+            id, err = nanoid.generate_n(0)
+            spec.assert_err(err, "generate_n(0) is rejected")
+            spec.assert_err_contains(err, "n must be >= 1",
+                "generate_n(0) says why")
+            spec.assert_eq(string.length(id), 0, "no id on the error path")
+        }
+
+        spec.it("rejects a negative length") callback {
+            id, err = nanoid.generate_n(-5)
+            spec.assert_err(err, "generate_n(-5) is rejected")
+            spec.assert_eq(string.length(id), 0, "no id on the error path")
+        }
+    }
+
+    spec.run_summary(fw)
+}

--- a/std/tsid/test_tsid_generate.ae
+++ b/std/tsid/test_tsid_generate.ae
@@ -1,0 +1,84 @@
+// std.tsid unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. A TSID is 13 chars of
+// Crockford base32 over a 64-bit value: a 42-bit millisecond timestamp
+// (2020 epoch) shifted left by 22, with 22 random bits in the low end.
+// The assertions cover the shape, the alphabet, the (value, err)
+// contract, and time-ordering across a sleep.
+//
+// The high nibble is worth pinning: the module packs the timestamp into
+// bits 22..63 of a 64-bit value, so with a 2020 epoch the top four bits
+// stay 0 until roughly 2160. A regression that mis-shifts the timestamp
+// shows up as a non-'0' leading character.
+
+import std.spec
+import std.tsid
+import std.string
+
+const TSID_ALPHA = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+fn all_chars_in_alphabet(id: string) -> int {
+    i = 0
+    while i < string.length(id) {
+        c = string.char_at(id, i)
+        found = 0
+        j = 0
+        while j < 32 {
+            if string.char_at(TSID_ALPHA, j) == c {
+                found = 1
+            }
+            j = j + 1
+        }
+        if found == 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+main() {
+    fw = spec.init()
+
+    spec.describe(fw, "std.tsid") {
+        spec.it("returns a 13-char id and no error") callback {
+            id, err = tsid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_eq(string.length(id), 13, "13 chars")
+        }
+
+        spec.it("uses only Crockford base32 characters") callback {
+            id, err = tsid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_true(all_chars_in_alphabet(id),
+                "id '${id}' is all Crockford base32")
+        }
+
+        spec.it("leaves the high nibble clear this century") callback {
+            id, err = tsid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_str_eq(string.substring(id, 0, 1), "0",
+                "leading char is '0' until ~2160")
+        }
+
+        spec.it("does not repeat across calls") callback {
+            a, e1 = tsid.generate()
+            b, e2 = tsid.generate()
+            spec.assert_ok(e1, "first generate succeeds")
+            spec.assert_ok(e2, "second generate succeeds")
+            spec.assert_true(string.equals(a, b) == 0, "two tsids differ")
+        }
+
+        spec.it("sorts lexicographically by mint time") callback {
+            a, e1 = tsid.generate()
+            sleep(5)
+            b, e2 = tsid.generate()
+            spec.assert_ok(e1, "first generate succeeds")
+            spec.assert_ok(e2, "second generate succeeds")
+            spec.assert_true(string.compare(a, b) < 0,
+                "later tsid sorts after: ${a} < ${b}")
+        }
+    }
+
+    spec.run_summary(fw)
+}

--- a/std/ulid/test_ulid_generate.ae
+++ b/std/ulid/test_ulid_generate.ae
@@ -1,0 +1,88 @@
+// std.ulid unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. A ULID is 26 chars of
+// Crockford base32 over 16 bytes: a 48-bit big-endian millisecond
+// timestamp then 80 random bits. The assertions cover the shape, the
+// alphabet (Crockford excludes I, L, O and U), the (value, err)
+// contract, and time-ordering.
+//
+// Ordering is checked across a sleep rather than back to back: the
+// timestamp has millisecond resolution and the module adds no
+// monotonic counter, so two ULIDs from the same millisecond sort by
+// their random tail.
+
+import std.spec
+import std.ulid
+import std.string
+
+const ULID_ALPHA = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+fn all_chars_in_alphabet(id: string) -> int {
+    i = 0
+    while i < string.length(id) {
+        c = string.char_at(id, i)
+        found = 0
+        j = 0
+        while j < 32 {
+            if string.char_at(ULID_ALPHA, j) == c {
+                found = 1
+            }
+            j = j + 1
+        }
+        if found == 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+main() {
+    fw = spec.init()
+
+    spec.describe(fw, "std.ulid") {
+        spec.it("returns a 26-char id and no error") callback {
+            id, err = ulid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_eq(string.length(id), 26, "26 chars")
+        }
+
+        spec.it("uses only Crockford base32 characters") callback {
+            id, err = ulid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_true(all_chars_in_alphabet(id),
+                "id '${id}' is all Crockford base32")
+        }
+
+        spec.it("excludes the ambiguous letters I, L, O and U") callback {
+            // The whole point of Crockford's alphabet: these four are
+            // omitted so a transcribed ULID cannot be misread.
+            id, err = ulid.generate()
+            spec.assert_ok(err, "generate succeeds")
+            spec.assert_true(string.contains(id, "I") == 0, "no I in ${id}")
+            spec.assert_true(string.contains(id, "L") == 0, "no L in ${id}")
+            spec.assert_true(string.contains(id, "O") == 0, "no O in ${id}")
+            spec.assert_true(string.contains(id, "U") == 0, "no U in ${id}")
+        }
+
+        spec.it("does not repeat across calls") callback {
+            a, e1 = ulid.generate()
+            b, e2 = ulid.generate()
+            spec.assert_ok(e1, "first generate succeeds")
+            spec.assert_ok(e2, "second generate succeeds")
+            spec.assert_true(string.equals(a, b) == 0, "two ulids differ")
+        }
+
+        spec.it("sorts lexicographically by mint time") callback {
+            a, e1 = ulid.generate()
+            sleep(5)
+            b, e2 = ulid.generate()
+            spec.assert_ok(e1, "first generate succeeds")
+            spec.assert_ok(e2, "second generate succeeds")
+            spec.assert_true(string.compare(a, b) < 0,
+                "later ulid sorts after: ${a} < ${b}")
+        }
+    }
+
+    spec.run_summary(fw)
+}

--- a/std/uuid/test_uuid_generate.ae
+++ b/std/uuid/test_uuid_generate.ae
@@ -1,0 +1,128 @@
+// std.uuid unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. Both generators are
+// pure formatting over CSPRNG bytes, so what is worth asserting is the
+// shape RFC 9562 mandates — length, hyphen positions, the version
+// nibble and the variant bits — plus the (value, err) contract and
+// that two calls differ.
+//
+// v7's timestamp ordering is deliberately NOT asserted across a
+// sub-millisecond pair: the module documents that it adds no monotonic
+// counter, so two IDs minted in the same millisecond sort arbitrarily.
+// The test sorts across a sleep instead, which is the guarantee the
+// module actually makes.
+
+import std.spec
+import std.uuid
+import std.string
+
+// A canonical UUID is 8-4-4-4-12 hex with hyphens at 8, 13, 18, 23.
+fn check_canonical_shape(fw: ptr, id: string, label: string) {
+    spec.assert_eq(string.length(id), 36, "${label}: 36 chars")
+    spec.assert_str_eq(string.substring(id, 8, 9), "-", "${label}: hyphen at 8")
+    spec.assert_str_eq(string.substring(id, 13, 14), "-", "${label}: hyphen at 13")
+    spec.assert_str_eq(string.substring(id, 18, 19), "-", "${label}: hyphen at 18")
+    spec.assert_str_eq(string.substring(id, 23, 24), "-", "${label}: hyphen at 23")
+}
+
+// Every non-hyphen position must be a lowercase hex digit.
+fn count_hex_digits(id: string) -> int {
+    n = 0
+    i = 0
+    while i < string.length(id) {
+        c = string.char_at(id, i)
+        if (c >= 48 && c <= 57) || (c >= 97 && c <= 102) {
+            n = n + 1
+        }
+        i = i + 1
+    }
+    return n
+}
+
+main() {
+    fw = spec.init()
+
+    spec.describe(fw, "std.uuid v4") {
+        spec.it("returns a canonical 36-char id and no error") callback {
+            id, err = uuid.v4()
+            spec.assert_ok(err, "v4 succeeds")
+            check_canonical_shape(fw, id, "v4")
+        }
+
+        spec.it("sets the version nibble to 4") callback {
+            id, err = uuid.v4()
+            spec.assert_ok(err, "v4 succeeds")
+            // Position 14 is the first nibble of the third group.
+            spec.assert_str_eq(string.substring(id, 14, 15), "4",
+                "v4: version nibble")
+        }
+
+        spec.it("sets the RFC 9562 variant to one of 8/9/a/b") callback {
+            id, err = uuid.v4()
+            spec.assert_ok(err, "v4 succeeds")
+            v = string.substring(id, 19, 20)
+            ok = 0
+            if string.equals(v, "8") == 1 { ok = 1 }
+            if string.equals(v, "9") == 1 { ok = 1 }
+            if string.equals(v, "a") == 1 { ok = 1 }
+            if string.equals(v, "b") == 1 { ok = 1 }
+            spec.assert_true(ok, "v4: variant nibble '${v}' is 8/9/a/b")
+        }
+
+        spec.it("uses only lowercase hex outside the hyphens") callback {
+            id, err = uuid.v4()
+            spec.assert_ok(err, "v4 succeeds")
+            spec.assert_eq(count_hex_digits(id), 32, "v4: 32 hex digits")
+        }
+
+        spec.it("does not repeat across calls") callback {
+            a, e1 = uuid.v4()
+            b, e2 = uuid.v4()
+            spec.assert_ok(e1, "first v4 succeeds")
+            spec.assert_ok(e2, "second v4 succeeds")
+            spec.assert_true(string.equals(a, b) == 0, "two v4s differ")
+        }
+    }
+
+    spec.describe(fw, "std.uuid v7") {
+        spec.it("returns a canonical 36-char id and no error") callback {
+            id, err = uuid.v7()
+            spec.assert_ok(err, "v7 succeeds")
+            check_canonical_shape(fw, id, "v7")
+        }
+
+        spec.it("sets the version nibble to 7") callback {
+            id, err = uuid.v7()
+            spec.assert_ok(err, "v7 succeeds")
+            spec.assert_str_eq(string.substring(id, 14, 15), "7",
+                "v7: version nibble")
+        }
+
+        spec.it("sets the RFC 9562 variant to one of 8/9/a/b") callback {
+            id, err = uuid.v7()
+            spec.assert_ok(err, "v7 succeeds")
+            v = string.substring(id, 19, 20)
+            ok = 0
+            if string.equals(v, "8") == 1 { ok = 1 }
+            if string.equals(v, "9") == 1 { ok = 1 }
+            if string.equals(v, "a") == 1 { ok = 1 }
+            if string.equals(v, "b") == 1 { ok = 1 }
+            spec.assert_true(ok, "v7: variant nibble '${v}' is 8/9/a/b")
+        }
+
+        spec.it("sorts lexicographically by mint time") callback {
+            // Across a sleep, not back to back: the module states it
+            // carries no monotonic counter, so same-millisecond IDs
+            // are allowed to sort arbitrarily.
+            a, e1 = uuid.v7()
+            sleep(5)
+            b, e2 = uuid.v7()
+            spec.assert_ok(e1, "first v7 succeeds")
+            spec.assert_ok(e2, "second v7 succeeds")
+            spec.assert_true(string.compare(a, b) < 0,
+                "v7 minted later sorts after: ${a} < ${b}")
+        }
+    }
+
+    spec.run_summary(fw)
+}

--- a/std/zlib/test_zlib_roundtrip.ae
+++ b/std/zlib/test_zlib_roundtrip.ae
@@ -1,0 +1,102 @@
+// std.zlib unit tests (#1584) — co-located with the module.
+//
+// The module had no test of any kind before this. Both codecs are
+// byte-exact, so the assertions are round-trip fidelity for the raw
+// deflate and the gzip-framed variants, the compression-level range,
+// and the (data, length, err) contract.
+//
+// The whole suite is gated on zlib.available(): the backend is an
+// optional build dependency, and a box built without it should report
+// these as skipped rather than failed. A provisioning gap is not a code
+// defect — but nor should it pass silently, which is what skip_all_if
+// exists for (#1610).
+
+import std.spec
+import std.zlib
+import std.string
+
+const SAMPLE = "the quick brown fox jumps over the lazy dog, and then does it again and again"
+
+main() {
+    fw = spec.init()
+
+    // The backend is an optional build dependency. Skipping is reported
+    // (never silent) so a box built without zlib is distinguishable from
+    // one where these actually ran.
+    unavailable = spec.skip_all_if(fw, zlib.available() == 0,
+        "zlib backend not built in")
+
+    if unavailable == 0 {
+        spec.describe(fw, "std.zlib deflate/inflate") {
+            spec.it("round-trips a string byte for byte") callback {
+                n = string.length(SAMPLE)
+                packed, plen, err = zlib.deflate(SAMPLE, n, 6)
+                spec.assert_ok(err, "deflate succeeds")
+                spec.assert_true(plen > 0, "compressed length is positive")
+                back, blen, derr = zlib.inflate(packed, plen)
+                spec.assert_ok(derr, "inflate succeeds")
+                spec.assert_eq(blen, n, "length restored")
+                spec.assert_str_eq(back, SAMPLE, "content restored")
+            }
+
+            spec.it("shrinks repetitive input") callback {
+                original = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                n = string.length(original)
+                packed, plen, err = zlib.deflate(original, n, 6)
+                spec.assert_ok(err, "deflate succeeds")
+                spec.assert_true(plen < n, "compressed ${plen} < original ${n}")
+            }
+
+            spec.it("round-trips at every compression level") callback {
+                // 0 is store-only and 9 is maximum; both must survive a
+                // round trip, and 0 is the level most likely to be handled
+                // by a different code path.
+                n = string.length(SAMPLE)
+                for (lvl = 0; lvl <= 9; lvl = lvl + 1) {
+                    packed, plen, err = zlib.deflate(SAMPLE, n, lvl)
+                    spec.assert_ok(err, "deflate at level ${lvl}")
+                    back, blen, derr = zlib.inflate(packed, plen)
+                    spec.assert_ok(derr, "inflate at level ${lvl}")
+                    spec.assert_str_eq(back, SAMPLE, "content restored at ${lvl}")
+                }
+            }
+        }
+
+        spec.describe(fw, "std.zlib gzip framing") {
+            spec.it("round-trips through the gzip container") callback {
+                n = string.length(SAMPLE)
+                packed, plen, err = zlib.gzip_deflate(SAMPLE, n, 6)
+                spec.assert_ok(err, "gzip_deflate succeeds")
+                back, blen, derr = zlib.gzip_inflate(packed, plen)
+                spec.assert_ok(derr, "gzip_inflate succeeds")
+                spec.assert_eq(blen, n, "length restored")
+                spec.assert_str_eq(back, SAMPLE, "content restored")
+            }
+
+            spec.it("emits the gzip magic bytes") callback {
+                // A gzip member starts 1f 8b; a raw deflate stream does not.
+                // This is what distinguishes the two entry points, so it is
+                // worth asserting rather than trusting the name.
+                n = string.length(SAMPLE)
+                packed, plen, err = zlib.gzip_deflate(SAMPLE, n, 6)
+                spec.assert_ok(err, "gzip_deflate succeeds")
+                spec.assert_eq(string.char_at_n(packed, plen, 0), 31,
+                    "first byte is 0x1f")
+                spec.assert_eq(string.char_at_n(packed, plen, 1), 139,
+                    "second byte is 0x8b")
+            }
+
+            spec.it("rejects raw deflate output as gzip") callback {
+                // The two framings are not interchangeable; feeding one to
+                // the other's reader must fail rather than return garbage.
+                n = string.length(SAMPLE)
+                packed, plen, err = zlib.deflate(SAMPLE, n, 6)
+                spec.assert_ok(err, "deflate succeeds")
+                back, blen, derr = zlib.gzip_inflate(packed, plen)
+                spec.assert_err(derr, "gzip_inflate rejects a raw deflate stream")
+            }
+        }
+    }
+
+    spec.run_summary(fw)
+}


### PR DESCRIPTION
Another tranche of #1584, following batches 1–3 (#1674 and its predecessors).

## What this adds

Eight `std` modules had **no test of any kind** — the `std.http.server.lb` class of gap #1584 exists to surface. 53 cases across them:

| module | cases | covers |
|---|---|---|
| `uuid` | 9 | v4/v7 canonical shape, version nibble, RFC 9562 variant, sortability |
| `ksuid` | 4 | 27-char base62 shape, alphabet, second-resolution ordering |
| `ulid` | 5 | 26-char Crockford base32, the excluded I/L/O/U, ordering |
| `tsid` | 5 | 13-char shape, alphabet, high-nibble epoch headroom |
| `nanoid` | 7 | default and explicit lengths, URL-safe alphabet, rejected lengths |
| `actors` | 8 | registry bind/lookup/rebind/unregister/clear contracts |
| `lzf` | 9 | round-trip fidelity, compressibility refusal, negative-length guards |
| `zlib` | 6 | deflate/inflate at every level, gzip framing, magic bytes |

Modules with zero coverage anywhere go from **eight to two**. The remaining pair want a harness rather than a unit test: `casper` is FreeBSD-only Capsicum, `log` writes to stdout.

## Why these are a bit different from batches 1–3

All 36 existing co-located tests are files *moved* from the central suites, and none import `std.spec`. These are the first written **against `std.spec`**, which is the dogfooding half of the proposal that had not started.

They also exercise the failure-path matchers from #1678 — `assert_ok`, `assert_err`, `assert_err_contains`. Every module here returns `(value, err)`, which is precisely the convention those matchers were added for, so this doubles as their first real use.

## Two behaviours worth knowing

Both had to be measured rather than read off the source, and are now pinned:

- **`lzf` refuses any input it cannot shrink**, whatever its length. It first looks like an 8-byte floor — an all-`x` string compresses at 8 bytes — but `"abcdefgh"` is refused, and so is a 24-byte all-distinct string. A caller feeding it random or already-compressed bytes hits this routinely and gets only `"lzf compress failed"`.
- **`zlib.gzip_inflate` rejects a raw deflate stream** rather than returning garbage, so the two framings are not silently interchangeable.

## Verification

Every suite was checked against a **mutation of the module it covers** — a version nibble, a returned length, an alphabet, a dropped guard — to confirm it fails when the module is wrong rather than merely passing today. One early mutation (`bytes.new(27)` → `26` in `ksuid`) produced no failure; that turned out to be an inert scratch buffer rather than a weak test, and mutating the actually-returned `bytes.finish(rev, 27)` does fail the length assertion.

`ae fmt --check` clean on all eight, all pass locally, and none are caught by `tests/ae_sweep_prune.txt`.

## No infrastructure changes

`find std -name 'test_*.ae'` is already a sweep root, and `make install` already deletes `std/**/test_*.ae` — both landed with earlier batches, so this tranche is test files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)