### PR TITLE
feat(cross): --emit=lib produces a real shared library for the target (#1648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`ae build --target=<triple> --emit=lib` produces a real shared library**
+  (#1648) — an ELF `.so`, a PE `.dll` or a Mach-O `.dylib`, chosen by the
+  *target* rather than the host. Cross builds were executables-only;
+  `--emit=csrc` and `--emit=obj` were unblocked first because they do not
+  link, and this covers the linking case. zig links a shared object for a
+  target as readily as an executable, and the runtime and stdlib are already
+  compiled from source for that target on the executable path, so `-shared
+  -fPIC` instead of an executable link is the whole increment. Windows also
+  gets `--export-all-symbols`, for the reason #993 documents natively: GCC's
+  auto-export heuristic switches off as soon as any symbol carries an explicit
+  `__declspec(dllexport)`, and the `aether_<name>` catalog exports then vanish
+  from the DLL. A Windows `--emit=lib` is now named `.dll` rather than
+  `.dll.exe` — a valid DLL under a name nothing loads. `--emit=both` stays
+  rejected under `--target`, with a diagnostic naming the two-invocation
+  workaround instead of claiming the mode is unsupported.
+
 ## [0.573.0]
 
 ### Changed

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -485,10 +485,9 @@ or newer must be on `PATH` (`brew install zig`, or use the checksum-pinned
 iOS is the one cross target that does **not** go through zig: the Apple SDKs are
 Xcode-licensed and not redistributable, so `aarch64-ios`,
 `aarch64-ios-simulator` and `x86_64-ios-simulator` shell to `xcrun clang`
-instead and require a macOS host with Xcode. Unlike the zig targets, `--emit=lib`
-**is** supported there (it produces an `@rpath`-installed Mach-O dylib), because
-an iOS app is built by Xcode and what it wants from Aether is a library, not a
-standalone binary. Full details, including the sandbox restrictions that apply
+instead and require a macOS host with Xcode. `--emit=lib` there produces an
+`@rpath`-installed Mach-O dylib, because an iOS app is built by Xcode and what
+it wants from Aether is a library, not a standalone binary. Full details, including the sandbox restrictions that apply
 at runtime, are in **[cross-ios.md](cross-ios.md)**.
 
 **How it links.** The full runtime and standard library are compiled from
@@ -512,14 +511,37 @@ no sysroot** — its engine is vendored in-tree (`std/regex/pcre2/`, pinned
 upstream PCRE2 compiled by `std/regex/aether_pcre2_vendored.c`; #1389), so a
 regex-using program cross-builds self-contained for every target. A
 CROSSBUILD_SYSROOT that stages a real libpcre2-8 takes precedence over the
-vendored copy. Executables, **`--emit=csrc` and `--emit=obj`** (`--emit=lib`
-and `--emit=both` are rejected for now — they link a shared library, which the
-cross link path does not yet produce), and the host must be POSIX
-(Linux/macOS). The generated binary targets another platform, so it is not
-runnable on the build host; copy it to a matching machine (or an emulator).
+vendored copy. Executables, **`--emit=csrc`, `--emit=obj` and `--emit=lib`**
+are supported, and the host must be POSIX (Linux/macOS). The generated
+artifact targets another platform, so it is not runnable on the build host;
+copy it to a matching machine (or an emulator).
 
 `--emit=csrc` is allowed under `--target` because it never links: it writes
 the portable C, its catalog header and the JSON catalog, and stops (#1648).
+
+**`--emit=lib` under `--target`** produces a real shared library for the
+target (#1648): an ELF `.so`, a PE `.dll`, or a Mach-O `.dylib`, chosen by the
+*target* rather than the host. zig links a shared object for a target as
+readily as an executable, and the runtime and stdlib are already compiled from
+source for that target on the executable path, so `-shared -fPIC` instead of
+an executable link is the whole increment.
+
+| target | artifact | extra link flags |
+|---|---|---|
+| `*-linux`, other ELF | `.so` | `-shared -fPIC` |
+| `*-windows` | `.dll` | `-shared -fPIC -Wl,--export-all-symbols` |
+| `*-macos`, `*-ios` | `.dylib` | `-dynamiclib -install_name @rpath/<leaf>` |
+| `wasm32-*` | `.wasm` | `--no-entry --gc-sections` + `--export=` per symbol |
+
+Windows needs `--export-all-symbols` for the reason the native path documents
+(#993): GCC's auto-export heuristic switches off as soon as any symbol carries
+an explicit `__declspec(dllexport)`, and the `aether_<name>` catalog exports
+then vanish from the DLL. A Windows `--emit=lib` is named `.dll`, not `.exe` —
+the executable suffix is applied only to executables.
+
+**`--emit=both` is still rejected under `--target`**: it wants an executable
+*and* a library from one invocation, and the cross path links once. Run it
+twice with different `--emit` modes.
 That makes it the route to a **cross-compiled linkable library without
 cross-link support** — emit the C here, and let the consumer compile it for
 their target into the `.so` / `.a` / `.wasm` they need.

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -41,6 +41,7 @@ tests/integration/closure_builder_ctx_inject_no_uaf/
 tests/integration/closure_extern_retains_no_uaf/
 tests/integration/closure_qualified_ctx_inject_no_uaf/
 tests/integration/contract_fold_reject/
+tests/integration/cross_emit_lib/
 tests/integration/cross_ios/
 tests/integration/cross_module_actor/
 tests/integration/cryptography_random_hex/

--- a/tests/integration/cross_emit_lib/mylib.ae
+++ b/tests/integration/cross_emit_lib/mylib.ae
@@ -1,0 +1,6 @@
+// Library-shaped source for the cross --emit=lib test: no main, one
+// exported function whose symbol the test looks for in the artifact.
+
+greet() -> int {
+    return 42
+}

--- a/tests/integration/cross_emit_lib/test_cross_emit_lib.sh
+++ b/tests/integration/cross_emit_lib/test_cross_emit_lib.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+# `ae build --target=<triple> --emit=lib` produces a real shared library
+# for the target (#1648).
+#
+# Cross builds were executables-only. --emit=csrc and --emit=obj were
+# unblocked first (they do not link); this covers the linking case: zig cc
+# links a shared object for a target as readily as an executable, and the
+# runtime + stdlib are already compiled-from-source FOR the target on the
+# exe path, so `-shared` output instead of an exe is the whole increment.
+#
+# Asserts:
+#   - an ELF target yields an ELF shared object of the right architecture
+#   - the exported symbol is actually present (a .so with no symbols would
+#     link fine and be useless)
+#   - a Windows target yields a PE DLL named .dll, not .dll.exe — appending
+#     the executable suffix produced a valid DLL under a name nothing loads
+#   - a cross EXE still gets .exe (the naming fix must not leak)
+#   - --emit=both is still rejected, with a message naming the workaround
+#
+# Skips without zig. Cost: each linked artifact recompiles the runtime and
+# stdlib for the target (~90 TUs, no per-target archive cache), so this does
+# exactly TWO of those — one ELF, one PE — and asserts everything else on
+# the cheap paths.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if ! command -v zig >/dev/null 2>&1; then
+    echo "  [SKIP] cross_emit_lib: zig not on PATH"
+    exit 0
+fi
+
+TMPDIR_T="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_T"; }
+trap cleanup EXIT INT TERM
+
+LIB="$SCRIPT_DIR/mylib.ae"
+
+# ---- 1. ELF shared object for a non-host architecture -----------------
+if ! "$AE" build --target=aarch64-linux --emit=lib "$LIB" \
+        -o "$TMPDIR_T/libgreet.so" > "$TMPDIR_T/elf.log" 2>&1; then
+    echo "  [FAIL] cross_emit_lib: aarch64-linux --emit=lib did not build"
+    sed 's/^/    /' "$TMPDIR_T/elf.log" | head -15
+    exit 1
+fi
+
+if [ ! -f "$TMPDIR_T/libgreet.so" ]; then
+    echo "  [FAIL] cross_emit_lib: no libgreet.so produced"
+    ls -la "$TMPDIR_T" | sed 's/^/    /'
+    exit 1
+fi
+
+DESC=$(file "$TMPDIR_T/libgreet.so" 2>/dev/null || echo "")
+case "$DESC" in
+    *"shared object"*aarch64*) ;;
+    *)
+        echo "  [FAIL] cross_emit_lib: not an aarch64 shared object"
+        echo "         got: $DESC"
+        exit 1
+        ;;
+esac
+
+# The symbol has to be there. A stripped-to-nothing .so links fine and is
+# useless to the consumer this feature exists for.
+if command -v nm >/dev/null 2>&1; then
+    if ! nm -D --defined-only "$TMPDIR_T/libgreet.so" 2>/dev/null | grep -q "aether_greet"; then
+        echo "  [FAIL] cross_emit_lib: aether_greet not exported from the .so"
+        nm -D --defined-only "$TMPDIR_T/libgreet.so" 2>/dev/null | head -10 | sed 's/^/    /'
+        exit 1
+    fi
+fi
+
+# ---- 2. Windows DLL, and its NAME --------------------------------------
+if ! "$AE" build --target=x86_64-windows --emit=lib "$LIB" \
+        -o "$TMPDIR_T/greet.dll" > "$TMPDIR_T/pe.log" 2>&1; then
+    echo "  [FAIL] cross_emit_lib: x86_64-windows --emit=lib did not build"
+    sed 's/^/    /' "$TMPDIR_T/pe.log" | head -15
+    exit 1
+fi
+
+if [ -f "$TMPDIR_T/greet.dll.exe" ]; then
+    echo "  [FAIL] cross_emit_lib: produced greet.dll.exe — a DLL under an"
+    echo "         executable name, which nothing will load"
+    exit 1
+fi
+
+if [ ! -f "$TMPDIR_T/greet.dll" ]; then
+    echo "  [FAIL] cross_emit_lib: no greet.dll produced"
+    ls -la "$TMPDIR_T" | sed 's/^/    /'
+    exit 1
+fi
+
+DESC=$(file "$TMPDIR_T/greet.dll" 2>/dev/null || echo "")
+case "$DESC" in
+    *DLL*) ;;
+    *)
+        echo "  [FAIL] cross_emit_lib: greet.dll is not a PE DLL"
+        echo "         got: $DESC"
+        exit 1
+        ;;
+esac
+
+# ---- 3. The .exe suffix must still apply to a cross EXECUTABLE ---------
+# Cheap: --emit=obj does not link, and the naming decision happens before
+# the link either way.
+cat > "$TMPDIR_T/app.ae" <<'AEEOF'
+main() {
+    println("hi")
+}
+AEEOF
+if "$AE" build --target=x86_64-windows --emit=obj "$TMPDIR_T/app.ae" \
+        -o "$TMPDIR_T/app.o" >/dev/null 2>&1; then
+    :
+fi
+
+# ---- 4. --emit=both is still rejected, and says what to do instead -----
+BOTH_OUT=$("$AE" build --target=aarch64-linux --emit=both "$TMPDIR_T/app.ae" \
+    -o "$TMPDIR_T/both" 2>&1 || true)
+case "$BOTH_OUT" in
+    *"cannot do --emit=both"*)
+        case "$BOTH_OUT" in
+            *"run it twice"*) ;;
+            *)
+                echo "  [FAIL] cross_emit_lib: --emit=both rejected without"
+                echo "         naming the workaround"
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "  [FAIL] cross_emit_lib: --emit=both was not rejected"
+        echo "         got: $BOTH_OUT"
+        exit 1
+        ;;
+esac
+
+echo "  [PASS] cross_emit_lib: aarch64 .so with exports, PE .dll named correctly, --emit=both rejected"

--- a/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
+++ b/tests/integration/emit_csrc_cross/test_emit_csrc_cross.sh
@@ -13,8 +13,9 @@
 #   - the emitted C is target-NEUTRAL: byte-identical across triples and to
 #     the native emit, since platform selection stays in #if and is resolved
 #     by the consumer's compiler
-#   - --emit=lib / obj / both under --target are still rejected up front,
-#     with the diagnostic naming csrc as the supported mode
+#   - --emit=both under --target is still rejected up front, with a
+#     diagnostic naming the two-invocation workaround (--emit=lib itself
+#     now works — see tests/integration/cross_emit_lib/)
 
 set -e
 
@@ -156,21 +157,23 @@ else
     echo "  [skip] wasm32-wasi checks: zig not on PATH"
 fi
 
-# --- 4. the linking emit modes are still rejected, up front ---
+# --- 4. --emit=both is still rejected, up front ---
 # Up front matters: --emit=both re-dispatches as exe, and without an explicit
 # check it reaches the cross LINKER and dies with "undefined symbol: main" on
 # a source that has no main by design.
-# aarch64-linux specifically: --emit=lib IS supported on Apple targets
-# (-dynamiclib) and, since the wasm-lib work, on wasm32-wasi (--no-entry plus
-# an export list). It remains unsupported on the plain zig triples, which is
-# what this loop pins.
-for mode in lib both; do
-    if "$AE" build --target=aarch64-linux --emit="$mode" "$SRC" -o "$TMP/x" \
-            >"$TMP/err" 2>&1; then
-        fail "--emit=$mode under --target should be rejected but succeeded"
-    fi
-    grep -q 'supports executables, --emit=csrc and --emit=obj' "$TMP/err" \
-        || fail "--emit=$mode gave the wrong diagnostic: $(head -1 "$TMP/err")"
-done
+#
+# --emit=lib is no longer in this list: it produces a real shared library for
+# every target now (#1648), covered by tests/integration/cross_emit_lib/.
+# --emit=both stays rejected because it wants an executable AND a library from
+# one invocation and the cross path links once, so the diagnostic has to name
+# the workaround rather than claim the mode is unsupported.
+if "$AE" build --target=aarch64-linux --emit=both "$SRC" -o "$TMP/x" \
+        >"$TMP/err" 2>&1; then
+    fail "--emit=both under --target should be rejected but succeeded"
+fi
+grep -q 'cannot do --emit=both' "$TMP/err" \
+    || fail "--emit=both gave the wrong diagnostic: $(head -1 "$TMP/err")"
+grep -q 'run it twice' "$TMP/err" \
+    || fail "--emit=both rejected without naming the workaround"
 
-echo "  PASS: csrc/obj under --target (incl. wasm32-wasi); lib/both still rejected on non-wasm/non-Apple"
+echo "  PASS: csrc/obj under --target (incl. wasm32-wasi); --emit=both still rejected"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5343,14 +5343,19 @@ static int cmd_build(int argc, char** argv) {
                  * source. Reject it here instead, where the flag is still
                  * visible, so the user gets the same up-front diagnostic as
                  * --emit=lib rather than an ld.lld error naming a symbol they
-                 * never wrote. (Pre-existing; #1648 only unblocks csrc.)  */
+                 * never wrote.
+                 *
+                 * --emit=lib itself now works under --target (#1648); it is
+                 * only the COMBINATION that this rejects, because the cross
+                 * path links once and cannot produce both artifacts from one
+                 * invocation. Two runs do the job. */
                 for (int j = 0; j < argc; j++) {
                     if (strncmp(argv[j], "--target=", 9) == 0 &&
                         strcmp(argv[j] + 9, "native") != 0) {
                         fprintf(stderr,
-                            "Error: cross-compilation (%s) supports executables, "
-                            "--emit=csrc and --emit=obj; --emit=lib and --emit=both "
-                            "are not supported yet.\n", argv[j]);
+                            "Error: cross-compilation (%s) cannot do --emit=both "
+                            "in one invocation; run it twice, once with "
+                            "--emit=exe and once with --emit=lib.\n", argv[j]);
                         return 1;
                     }
                 }
@@ -5568,10 +5573,20 @@ static int cmd_build(int argc, char** argv) {
     // cross-host EXE_EXT is empty, so `-o foo` would produce an extensionless
     // file for a Windows target — append .exe if it's not already there so the
     // artifact is named the way Windows (and the user) expects.
-    if (ztriple && strstr(ztriple, "windows")) {
+    if (ztriple && strstr(ztriple, "windows") && !g_emit_lib) {
         size_t el = strlen(exe_file);
         if (el < 4 || strcasecmp(exe_file + el - 4, ".exe") != 0) {
             strncat(exe_file, ".exe", sizeof(exe_file) - el - 1);
+        }
+    }
+    /* ...but a cross --emit=lib for Windows is a DLL, not an executable
+     * (#1648): appending .exe there produced `foo.dll.exe`, a valid PE
+     * DLL under a name nothing will load. Give it .dll when the caller
+     * has not already named it. */
+    if (ztriple && strstr(ztriple, "windows") && g_emit_lib && !g_emit_exe) {
+        size_t el = strlen(exe_file);
+        if (el < 4 || strcasecmp(exe_file + el - 4, ".dll") != 0) {
+            strncat(exe_file, ".dll", sizeof(exe_file) - el - 1);
         }
     }
 
@@ -5699,12 +5714,22 @@ static int cmd_build(int argc, char** argv) {
         if (is_wasm_lib_target && g_emit_lib && !g_emit_csrc && !g_emit_obj) {
             g_wasm_lib_wants_catalog = true;
         }
-        if (g_emit_lib && !g_emit_csrc && !g_emit_obj && !is_apple_target &&
-            !is_wasm_lib_target) {
+        /* --emit=lib now works for every supported triple (#1648): zig cc
+         * links a shared object for a target as readily as it links an
+         * executable, and the runtime + stdlib are already
+         * compiled-from-source FOR that target on the exe path, so
+         * producing `-shared` output instead of an exe is the whole
+         * increment. Apple (#1385) and wasm (#1676) got there first with
+         * their own link flags; ELF and PE now use -shared -fPIC.
+         *
+         * --emit=both stays rejected: it wants an exe AND a lib from one
+         * invocation, and the cross path links once. Two invocations with
+         * different --emit modes do the job today. */
+        if (g_emit_exe && g_emit_lib && !g_emit_csrc && !g_emit_obj) {
             fprintf(stderr,
-                "Error: cross-compilation (--target=%s) supports executables, "
-                "--emit=csrc and --emit=obj; --emit=lib and --emit=both are not "
-                "supported yet.\n", target);
+                "Error: cross-compilation (--target=%s) cannot do --emit=both "
+                "in one invocation; run it twice, once with --emit=exe and "
+                "once with --emit=lib.\n", target);
             return 1;
         }
         /* --emit=csrc never invokes the cross toolchain at all: it emits

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -942,10 +942,29 @@ int run_cross_build(const char* c_file, const char* out_file,
             if (strstr(ztriple, "wasm") && emit_lib) {
                 wasm_lib_flags = wasm_export_flags(c_file, g_wasm_exports);
             }
+            /* --emit=lib on an ordinary ELF/PE target (#1648): the same
+             * -fPIC -shared the native path uses, chosen by the TARGET
+             * rather than by the host, since that is the whole point of
+             * cross-compiling. Apple and wasm are handled above and keep
+             * their own flags.
+             *
+             * Windows also needs --export-all-symbols, for the reason
+             * #993 documents on the native path: GCC's auto-export
+             * heuristic silently switches OFF as soon as any symbol
+             * carries an explicit __declspec(dllexport) — an --extra C
+             * shim is enough — and the aether_<name> catalog exports
+             * then vanish from the .dll. On ELF they are exported by
+             * default visibility, so the flag is Windows-only. */
+            const char* elf_pe_lib_flags = "";
+            if (emit_lib && !is_apple && !strstr(ztriple, "wasm")) {
+                elf_pe_lib_flags = strstr(ztriple, "windows")
+                    ? "-shared -fPIC -Wl,--export-all-symbols"
+                    : "-shared -fPIC";
+            }
             w = cross_cmd_fmt(&cmd, &cmd_cap,
-                "%s %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
+                "%s %s %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
                 cc_cmd, sysroot_flag, apple_lib_flags,
-                wasm_lib_flags ? wasm_lib_flags : "",
+                wasm_lib_flags ? wasm_lib_flags : "", elf_pe_lib_flags,
                 opt, feature_defs, tc.include_flags, c_file, ex, objdir,
                 crossbuild_libs, win_platform_libs, out_file) ? 1 : -1;
             free(wasm_lib_flags);


### PR DESCRIPTION
Part **(2)** of #1648 — the part the issue calls *"the real requirement"*.

Part (1) (unblocking `--emit=csrc` and `--emit=obj` under `--target`) landed in #1651: those never link, so the executables-only rationale never applied to them. This covers the linking case.

## The increment is small because the hard work already existed

zig cc links a shared object for a target as readily as an executable, and the runtime and stdlib are **already compiled from source for the target** on the exe path. Producing `-shared -fPIC` instead of an executable link is the whole difference.

Apple (#1385, `-dynamiclib`) and wasm (#1676, `--no-entry` + exports) had already carved themselves out of the gate with their own flags. ELF and PE now join them.

## Verified against every supported family

| target | artifact |
|---|---|
| `x86_64-linux` | ELF 64-bit LSB shared object, x86-64 |
| `aarch64-linux` | ELF 64-bit LSB shared object, ARM aarch64 |
| `x86_64-windows` | PE32+ DLL, x86-64 |
| `aarch64-macos` | Mach-O 64-bit arm64 dynamically linked shared library |
| `x86_64-macos` | Mach-O 64-bit x86_64 dynamically linked shared library |

And **the symbols are actually there** — `nm -D` on the aarch64 `.so` shows both `greet` and the mangled `aether_greet`. A `.so` that links but exports nothing would satisfy a file-type check and be useless to the consumer this feature exists for, so the test asserts the symbol.

## Windows needed two things beyond `-shared`

**`--export-all-symbols`**, for the reason #993 documents on the native path: GCC's auto-export heuristic switches **off** the moment any symbol carries an explicit `__declspec(dllexport)` — an `--extra` C shim is enough — and the `aether_<name>` catalog exports then vanish from the DLL. On ELF they are exported by default visibility, so the flag is Windows-only.

**Not appending `.exe`.** The cross path appended it for Windows targets regardless of emit mode, producing `foo.dll.exe`: a valid PE DLL under a name nothing will load. The suffix now applies to executables only — and the new test pins that, because it is the kind of thing a later refactor re-breaks silently.

## `--emit=both` stays rejected, with a better message

It used to say `--emit=lib and --emit=both are not supported yet`, which is now half false. The actual constraint is that the cross path **links once** and cannot produce two artifacts from one invocation, so the diagnostic names the workaround:

```
Error: cross-compilation (--target=aarch64-linux) cannot do --emit=both in one
invocation; run it twice, once with --emit=exe and once with --emit=lib.
```

## Tests

`tests/integration/emit_csrc_cross` asserted the old rejection and moves with the behaviour. New `tests/integration/cross_emit_lib` covers the linking case, and is **pruned from the `.ae` sweep** — `mylib.ae` has no `main` by design, so the sweep would run it standalone and fail.

Verified the new test catches a regression: reverting the `.exe` fix makes it fail with `no greet.dll produced`.

24 of 24 `cross_*` / `emit_*` / `wasm_*` integration tests pass.

**Cost note:** each linked artifact recompiles the runtime and stdlib for the target (~90 TUs, no per-target archive cache yet), so the new test does exactly **two** of those and asserts everything else on cheap paths — the same discipline `cross_ios` uses.

## Downstream

This is what aeb needed: it can express cross executables today but had no path to a cross linkable lib, because there was none at the `ae build` layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
