### PR TITLE
feat(build): add  for sampling profilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`ae build --profile`** compiles with `-O2 -g -fno-omit-frame-pointer`, for
+  `perf record -g` and other sampling profilers. Neither existing mode served:
+  the default `-O2` build carries no DWARF and omits frame pointers, so a
+  profiler cannot unwind it — profiling `std.http.server.lb` under load, gdb
+  resolved 239 of 240 sampled frames as `??` — and `--quick`'s `-O0` inlines
+  nothing and keeps every temporary live, so its hot spots are not the shipped
+  binary's. `--profile` keeps `-O2` precisely so the profile describes the code
+  that ships. Works under `--target` too. `--coverage` still takes precedence,
+  since gcov's `-O0` is a correctness requirement rather than a preference.
+
 ## [0.574.0]
 
 ### Added

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -107,6 +107,29 @@ ae build src/main.ae --quick   # iteration-shape, -O0 -g
 
 `--quick` typically halves the gcc step on small programs, at the cost of unoptimised codegen. `ae run` already uses `-O0` regardless, since cache hits dominate over a single optimised compile.
 
+### `--profile` for sampling profilers
+
+`--profile` compiles with `-O2 -g -fno-omit-frame-pointer`:
+
+```sh
+ae build src/main.ae --profile   # -O2 -g -fno-omit-frame-pointer
+perf record -g ./main            # attributable frames
+perf report --stdio
+```
+
+Neither other mode serves this. The default `-O2` build carries no DWARF and
+omits frame pointers, so a sampling profiler cannot unwind it — profiling
+`std.http.server.lb` under load, gdb resolved 239 of 240 sampled frames as
+`??`. And `--quick`'s `-O0` inlines nothing and keeps every temporary live, so
+the hot spots it reports are not the ones the shipped binary has.
+
+`--profile` keeps `-O2` precisely so the profile describes the code you ship,
+and adds only what the profiler needs to attribute it. It works under
+`--target` as well, for profiling a cross-built binary on the target machine.
+
+`--coverage` takes precedence if both are passed: gcov's line attribution
+needs `-O0`, which is a correctness requirement rather than a preference.
+
 ### Resolving the build target
 
 `ae build` accepts either a path to a `.ae` file or a `[[bin]]` name from `aether.toml`. The two are equivalent:

--- a/tests/integration/build_profile_flag/probe.ae
+++ b/tests/integration/build_profile_flag/probe.ae
@@ -1,0 +1,15 @@
+// Subject for the --profile build-mode test. Enough work that -O2 and
+// -O0 produce visibly different binaries, and a call the profiler would
+// have something to attribute.
+
+fn accumulate(n: int) -> int {
+    total = 0
+    for (i = 0; i < n; i = i + 1) {
+        total = total + i
+    }
+    return total
+}
+
+main() {
+    println("${accumulate(100)}")
+}

--- a/tests/integration/build_profile_flag/test_build_profile_flag.sh
+++ b/tests/integration/build_profile_flag/test_build_profile_flag.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# `ae build --profile` emits a binary a sampling profiler can attribute.
+#
+# The three build modes are meant to be distinct:
+#
+#   default    -O2, no debug info      what ships
+#   --quick    -O0 -g                  fast iteration; the WRONG tool for a
+#                                      profile — at -O0 nothing inlines and
+#                                      every temporary stays live, so the hot
+#                                      spots are not the shipped binary's
+#   --profile  -O2 -g -fno-omit-...    the shipped code, attributable
+#
+# Before --profile existed, profiling std.http.server.lb meant emitting the C
+# with aetherc and hand-compiling it: the default build carries no DWARF and
+# omits frame pointers, so gdb resolved 239 of 240 sampled frames as `??`.
+#
+# Asserts:
+#   - default carries no .debug_info
+#   - --quick and --profile both do
+#   - --profile is genuinely -O2, not -O0 wearing a -g: its binary is
+#     substantially smaller than --quick's
+#   - --profile keeps frame pointers (fewer rbp pushes than -O0, but the
+#     debug info is what the check above covers; this pins the -O2 half)
+#
+# Skips cleanly when readelf is absent (non-ELF hosts).
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT|Darwin)
+        echo "  [SKIP-PLATFORM] build_profile_flag — ELF-specific section check"
+        exit 0
+        ;;
+esac
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+SRC="$SCRIPT_DIR/probe.ae"
+
+if ! command -v readelf >/dev/null 2>&1; then
+    echo "  [SKIP] build_profile_flag: readelf not on PATH"
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT INT TERM
+
+has_debug() {
+    readelf -S "$1" 2>/dev/null | grep -c "debug_info" || true
+}
+
+build() {   # build <out> [flags...]
+    out="$1"; shift
+    # Clear the module cache: it keys on source, not on build flags, so a
+    # cached artifact from the previous mode would be handed back and the
+    # comparison would measure nothing.
+    rm -rf "$HOME/.aether/cache" 2>/dev/null || true
+    "$AE" build "$@" "$SRC" -o "$out" >"$TMP/build.log" 2>&1 || {
+        echo "  [FAIL] build_profile_flag: 'ae build $* ' failed"
+        sed 's/^/    /' "$TMP/build.log" | head -10
+        exit 1
+    }
+}
+
+build "$TMP/def"
+build "$TMP/quick" --quick
+build "$TMP/prof"  --profile
+
+if [ "$(has_debug "$TMP/def")" != "0" ]; then
+    echo "  [FAIL] build_profile_flag: the default build carries debug info"
+    exit 1
+fi
+
+if [ "$(has_debug "$TMP/quick")" = "0" ]; then
+    echo "  [FAIL] build_profile_flag: --quick carries no debug info"
+    exit 1
+fi
+
+if [ "$(has_debug "$TMP/prof")" = "0" ]; then
+    echo "  [FAIL] build_profile_flag: --profile carries no debug info —"
+    echo "         a sampling profiler cannot attribute frames without it"
+    exit 1
+fi
+
+# --profile must be optimised. If it silently became -O0 it would still
+# pass the debug-info check above while reporting hot spots the shipped
+# binary does not have, which is the failure this whole flag exists to
+# avoid. -O2 output is dramatically smaller than -O0.
+QSIZE=$(wc -c < "$TMP/quick")
+PSIZE=$(wc -c < "$TMP/prof")
+if [ "$PSIZE" -ge "$QSIZE" ]; then
+    echo "  [FAIL] build_profile_flag: --profile ($PSIZE bytes) is not smaller"
+    echo "         than --quick ($QSIZE bytes) — it looks like -O0, not -O2"
+    exit 1
+fi
+
+echo "  [PASS] build_profile_flag: default has no debug info; --quick and --profile do; --profile is -O2 (${PSIZE}B vs --quick ${QSIZE}B)"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -366,6 +366,22 @@ typedef struct {
 // optimisation.
 static bool g_coverage = false;
 
+// --profile: -O2 with frame pointers and debug info, for `perf record -g`
+// and friends.
+//
+// --quick already gives -O0 -g, but -O0 is the wrong tool for a profile:
+// it inlines nothing and keeps every temporary live, so the hot spots it
+// reports are not the ones the shipped -O2 binary has. And the default
+// -O2 build carries no DWARF and omits frame pointers, so a sampling
+// profiler cannot unwind it — measured on the std.http.server.lb
+// benchmark, gdb resolved 239 of 240 sampled frames as `??`.
+//
+// The combination a profiler actually needs is -O2 (same code as ships)
+// plus -g (symbols) plus -fno-omit-frame-pointer (unwindable). None of
+// the existing modes give all three, so profiling meant emitting the C
+// with aetherc and hand-compiling it.
+static bool g_profile = false;
+
 // Build an aetherc command string with optional --lib flag
 void build_aetherc_cmd(char* cmd, size_t cmd_size, const char* input, const char* output) {
     const char* emit_flag = "";
@@ -2255,6 +2271,11 @@ static const char* opt_flags(bool optimize) {
      * source. User cflags from aether.toml append after these flags, so
      * -Wno-format remains available to opt out. */
     if (g_coverage) return "-O0 -g --coverage -Wformat";
+    /* --profile keeps -O2 so the profile describes the code that ships,
+     * and adds what a sampling profiler needs to attribute it. Checked
+     * after coverage because --coverage's -O0 is a correctness
+     * requirement for gcov, not a preference. */
+    if (g_profile) return "-O2 -g -fno-omit-frame-pointer -Wformat";
     return optimize ? "-O2 -Wformat" : "-O0 -g -Wformat";
 }
 
@@ -2476,7 +2497,8 @@ void build_gcc_cmd(char* cmd, size_t size,
     // #line) never run on a normal `ae build` — regressing #1252. Keep this in
     // sync with opt_flags(); user cflags still append after, so -Wno-format
     // remains an opt-out.
-    const char* base_opt = g_coverage ? opt_flags(optimize)
+    const char* base_opt = (g_coverage || g_profile)
+                          ? opt_flags(optimize)
                           : (optimize ? "-O2 -pipe -Wformat" : "-O0 -g -pipe -Wformat");
     const char* trace_def = g_trace ? " -DAETHER_TRACE" : "";
     /* The link-side flags ride in the same blob: gcc accepts -Wl,... anywhere
@@ -5239,12 +5261,19 @@ static int cmd_build(int argc, char** argv) {
     g_emit_lib = false;
     // Reset coverage flag — `ae build --coverage` enables it per-build.
     g_coverage = false;
+    g_profile = false;
 
     for (int i = 0; i < argc; i++) {
         if (strcmp(argv[i], "-o") == 0 && i + 1 < argc) {
             output_name = argv[++i];
         } else if (strcmp(argv[i], "--quick") == 0) {
             quick = true;
+        } else if (strcmp(argv[i], "--profile") == 0) {
+            /* -O2 -g -fno-omit-frame-pointer: the code that ships, with
+             * enough left in the binary for `perf record -g` to attribute
+             * it. See g_profile for why neither --quick nor the default
+             * serves. */
+            g_profile = true;
         } else if (strcmp(argv[i], "--trace") == 0) {
             /* #1333: compile message tracing into this binary. The runtime has
              * to be rebuilt from source for it, since a prebuilt libaether.a
@@ -5509,8 +5538,9 @@ static int cmd_build(int argc, char** argv) {
 
     if (!file) {
         fprintf(stderr, "Error: No input file specified.\n");
-        fprintf(stderr, "Usage: ae build <file.ae> [-o output] [--extra file.c] [--quick] [--target=<triple>] [-D SYMBOL]\n");
+        fprintf(stderr, "Usage: ae build <file.ae> [-o output] [--extra file.c] [--quick] [--profile] [--target=<triple>] [-D SYMBOL]\n");
         fprintf(stderr, "  --quick    Compile with -O0 -g for faster iteration (default: -O2)\n");
+        fprintf(stderr, "  --profile  Compile with -O2 -g -fno-omit-frame-pointer (for perf/gdb)\n");
         fprintf(stderr, "  --target   Cross-compile via zig cc: wasm, aarch64-macos, x86_64-macos,\n");
         fprintf(stderr, "             aarch64-linux, x86_64-linux, aarch64-freebsd, x86_64-freebsd,\n");
         fprintf(stderr, "             x86_64-windows, aarch64-windows (-> foo.exe; self-contained)\n");


### PR DESCRIPTION
`ae build --profile` compiles with `-O2 -g -fno-omit-frame-pointer`, for `perf record -g` and other sampling profilers.

## Why neither existing mode serves

| mode | flags | why it fails a profiler |
|---|---|---|
| default | `-O2` | no DWARF, frame pointers omitted — cannot unwind |
| `--quick` | `-O0 -g` | attributable, but `-O0` inlines nothing and keeps every temporary live, so its hot spots are **not the shipped binary's** |

This came out of trying to profile `std.http.server.lb` on the CachyOS box. Against the default build, **gdb resolved 239 of 240 sampled frames as `??`**. The workaround was to emit the C with `aetherc` and hand-compile it with the flags I wanted — not something a user should have to discover.

`--profile` keeps `-O2` precisely so the profile describes the code that ships, and adds only what is needed to attribute it.

## Verified both halves, not just the flag string

A `--profile` that silently became `-O0` would pass a debug-info check while reporting the wrong hot spots — the exact failure the flag exists to prevent. So the test asserts optimisation too:

```
--quick    83,344 bytes   debug_info=1
--profile  22,280 bytes   debug_info=1     <- 4x smaller: genuinely -O2
default        —          debug_info=0
```

## A trap worth naming

`opt_flags()` is **not** the only place the optimisation string is built. The mainline `-pipe` path at `ae.c:2500` has its own copy, guarded by `g_coverage ? opt_flags(...) : inline-string`, with a comment reading *"Keep this in sync with `opt_flags()`"*.

It drifted the moment I added a mode: `--profile` set the flag, `opt_flags()` returned the right string, and the emitted binary had no debug info because that path never called it. Fixed by routing `g_profile` through the same branch.

The new test catches exactly that — reverting the one-line fix makes it fail with `--profile carries no debug info`.

## Interactions

- **`--coverage` still wins** when both are passed: gcov's `-O0` is a correctness requirement for line attribution, not a preference. `ci_coverage_smoke` passes unchanged.
- **Works under `--target`** — verified a cross `aarch64-linux --profile` build carries `.debug_info`, for profiling a cross-built binary on the target machine.

## Notes

The test needs no `ae_sweep_prune.txt` entry: unlike `cross_emit_lib`'s library-shaped source, `probe.ae` has a `main` and runs standalone harmlessly (prints `4950`).

305/305 regression, `check-docs` green, docs added to `build-system.md` alongside `--quick`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
