### PR TITLE
feat(sort,map,set): string sorting, comparators, and readable key snapshots (#1722, #1724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.sort` sorts strings, and takes comparators** (#1722). `sort.strings` /
+  `sort.string_search` order by `std.string.compare` — lexicographic byte order,
+  binary-safe — and `ints_by` / `longs_by` / `floats_by` / `strings_by` take a
+  comparator for any other order. Previously the module sorted only `int`,
+  `long` and `float` arrays with no way to express a different ordering, so
+  anything else meant hand-writing a sort at each call site. `string[]` carries
+  no length, so the string forms take an explicit count. Separate `_by` names
+  rather than an optional argument, so the default path keeps a direct
+  comparison instead of an indirect call per element. Sorts remain in place and
+  are still not stable.
+
+- **`std.map` and `std.set` key/item snapshots can now be read** (#1724).
+  `map.keys` and `set.items` returned a snapshot that could only be held and
+  freed: there was no size or element accessor, so a map's key set was
+  unreachable from Aether and callers kept a parallel array of keys purely to
+  have something iterable. `keys_size`/`keys_get` and `items_size`/`items_get`
+  expose what the C snapshot already held — a contiguous array with an exact
+  count. The returned strings are borrowed, valid until the snapshot is freed
+  and only while the container still holds them; iteration order stays
+  unspecified, so sort for deterministic output. Out-of-range and null return
+  `""` rather than trapping. Nothing in the tree had ever read a key from a
+  snapshot, which is how the gap went unnoticed.
+
 ## [0.575.0]
 
 ### Added

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -48,7 +48,7 @@ header comment is the authoritative description.
 | `std.log` | Levelled logging with timestamps, colours and counters. | 9 | [full section](#logging-stdlog) |
 | `std.longarr` | Fixed-size packed-long buffer. | 13 | [guide](../std/longarr/README.md) · [source](../std/longarr/module.ae) |
 | `std.lzf` | One-shot LZF compression and decompression. | 12 | [guide](../std/lzf/README.md) · [source](../std/lzf/module.ae) |
-| `std.map` | Hash map, re-exported from `std.collections`. | 14 | [guide](../std/map/README.md) · [source](../std/map/module.ae) |
+| `std.map` | Hash map, re-exported from `std.collections`, with readable key snapshots. | 18 | [guide](../std/map/README.md) · [source](../std/map/module.ae) |
 | `std.math` | Arithmetic, trigonometry, rounding and floating-point helpers. | 31 | [full section](#math-stdmath) |
 | `std.mem` | Byte-level reads and writes over caller-allocated raw pointers. | 94 | [guide](../std/mem/README.md) · [source](../std/mem/module.ae) |
 | `std.message` | ICU MessageFormat formatting and message catalogues. | 8 | [guide](../std/message/README.md) · [source](../std/message/module.ae) |
@@ -63,10 +63,10 @@ header comment is the authoritative description.
 | `std.pqueue` | Priority queue over (priority, item) pairs, backed by a binary heap. | 18 | [guide](../std/pqueue/README.md) · [source](../std/pqueue/module.ae) |
 | `std.regex` | Perl-compatible regular expressions, backed by PCRE2. | 45 | [guide](../std/regex/README.md) · [source](../std/regex/module.ae) |
 | `std.schema` | Declarative typed validation and coercion. | 31 | [guide](../std/schema/README.md) · [source](../std/schema/module.ae) |
-| `std.set` | Unordered set of unique strings. | 18 | [guide](../std/set/README.md) · [source](../std/set/module.ae) |
+| `std.set` | Unordered set of unique strings. | 22 | [guide](../std/set/README.md) · [source](../std/set/module.ae) |
 | `std.signal` | POSIX signal-number constants. | 11 | [guide](../std/signal/README.md) · [source](../std/signal/module.ae) |
 | `std.snapshot` | Copy-on-write snapshot cell for read-mostly shared data. | 10 | [guide](../std/snapshot/README.md) · [source](../std/snapshot/module.ae) |
-| `std.sort` | In-place ascending sort and binary search over the packed numeric arrays. | 6 | [guide](../std/sort/README.md) · [source](../std/sort/module.ae) |
+| `std.sort` | In-place sort and binary search over packed numeric arrays and string arrays, with optional comparators. | 12 | [guide](../std/sort/README.md) · [source](../std/sort/module.ae) |
 | `std.spec` | BDD test framework: describe and it, hooks, assertions, structured reports. | 46 | [guide](../std/spec/README.md) · [source](../std/spec/module.ae) |
 | `std.strbuilder` | Amortised-O(1) string building. | 33 | [guide](../std/strbuilder/README.md) · [source](../std/strbuilder/module.ae) |
 | `std.string` | Managed strings: construction, search, slicing, case, split and join. | 92 | [full section](#strings-stdstring) |

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -700,3 +700,27 @@ void map_keys_free(MapKeys* keys) {
     aether_caps_free(keys, sizeof(MapKeys));
 }
 
+/* Read side of the snapshot (#1724).
+ *
+ * map_keys_raw already produces a contiguous AetherString* array with an exact
+ * count, but nothing exposed a way to look inside it, so an Aether caller could
+ * allocate and free a snapshot and never read a key from it. These two are that
+ * missing half.
+ *
+ * The returned string is BORROWED from the live map entry: it is valid until
+ * map_keys_free, and only while the map still holds that entry. Mutating the
+ * map after taking a snapshot does not update the snapshot, and a key removed
+ * from the map leaves a dangling pointer here. Callers who need to outlive the
+ * map must retain or copy. Out-of-range and NULL return NULL rather than
+ * trapping, so a bad index is a visible null instead of a wild read. */
+int map_keys_size_raw(MapKeys* keys) {
+    if (!keys) return 0;
+    return keys->count;
+}
+
+AetherString* map_keys_get_raw(MapKeys* keys, int index) {
+    if (!keys || !keys->keys) return NULL;
+    if (index < 0 || index >= keys->count) return NULL;
+    return keys->keys[index];
+}
+

--- a/std/collections/aether_collections.h
+++ b/std/collections/aether_collections.h
@@ -81,6 +81,12 @@ typedef struct {
 MapKeys* map_keys_raw(HashMap* map);
 void map_keys_free(MapKeys* keys);
 
+// Read a snapshot. The returned string is borrowed: valid until
+// map_keys_free, and only while the map still holds that entry. Out-of-range
+// or NULL yields NULL.
+int map_keys_size_raw(MapKeys* keys);
+AetherString* map_keys_get_raw(MapKeys* keys, int index);
+
 // -------------------------------------------------------------------
 // IntArray — fixed-size packed int buffer with O(1) random access.
 //

--- a/std/map/README.md
+++ b/std/map/README.md
@@ -39,10 +39,23 @@ membership, so `map.get(m, "absent")` returns `(null, "")`. Use `map_has` for
 the unambiguous membership test, and null-check the pointer.
 
 `map_keys` returns the key set for iteration, and must be released with
-`map_keys_free`.
+`map_keys_free`. Read it with `keys_size` and `keys_get`.
+
+The returned strings are **borrowed** from the live map: valid until
+`keys_free`, and only while the map still holds that entry. The snapshot does
+not track later mutation, so a key removed from the map leaves a dangling
+entry in a snapshot taken before the removal. Retain or copy anything that has
+to outlive either.
+
+Iteration order is bucket order and is **unspecified**. Sort the keys
+(`std.sort.strings`) when the output has to be deterministic.
+
+An out-of-range or negative index returns `""` rather than trapping. An empty
+string is also a legitimate key, so check `keys_size` first if the difference
+matters.
 
 ## Exports
 
 `map_new`, `put`, `map_put_raw`, `map_put_string_owned`, `get`,
 `map_get_raw`, `map_has`, `map_remove`, `map_size`, `map_clear`, `keys`,
-`map_keys_raw`, `map_keys_free`, `map_free`.
+`map_keys_raw`, `map_keys_free`, `keys_size`, `keys_get`, `map_free`.

--- a/std/map/module.ae
+++ b/std/map/module.ae
@@ -9,7 +9,8 @@
 exports(
     map_new, map_put_raw, map_put_string_owned, map_get_raw, map_has, map_remove,
     map_size, map_clear, map_free, map_keys_raw, map_keys_free,
-    put, get, keys
+    map_keys_size_raw, map_keys_get_raw,
+    put, get, keys, keys_size, keys_get
 )
 
 extern map_new() -> ptr
@@ -30,6 +31,8 @@ extern map_clear(map: ptr)
 extern map_free(map: ptr)
 extern map_keys_raw(map: ptr) -> ptr
 extern map_keys_free(keys: ptr)
+extern map_keys_size_raw(keys: ptr) -> int
+extern map_keys_get_raw(keys: ptr, index: int) -> string
 
 // Insert or update a key-value pair. Returns "" on success, error on
 // failure (null map/key or OOM).
@@ -64,4 +67,39 @@ keys(map: ptr) -> {
         return null, "allocation failed"
     }
     return k, ""
+}
+
+// ---- reading a keys snapshot (#1724) --------------------------------------
+//
+// `keys` hands back a snapshot; these read it. Before this pair the snapshot
+// could only be allocated and freed, so a map's key set was unreachable from
+// Aether and callers kept a parallel array of keys purely to have something
+// iterable.
+//
+// The strings are BORROWED from the live map: valid until `keys_free`, and
+// only while the map still holds that entry. The snapshot does not track
+// later mutation -- a key removed from the map leaves a dangling entry here.
+// Retain or copy anything that must outlive either.
+//
+// Iteration order is bucket order and is UNSPECIFIED. Callers who need a
+// deterministic order sort the keys (std.sort.strings).
+
+keys_size(keys: ptr) -> int {
+    if keys == null {
+        return 0
+    }
+    return map_keys_size_raw(keys)
+}
+
+// Out of range or null returns "" rather than trapping, so a bad index is a
+// visible empty string instead of a wild read. An empty string is also a
+// legitimate key, so callers who must distinguish check keys_size first.
+keys_get(keys: ptr, index: int) -> string {
+    if keys == null {
+        return ""
+    }
+    if index < 0 || index >= map_keys_size_raw(keys) {
+        return ""
+    }
+    return map_keys_get_raw(keys, index)
 }

--- a/std/set/README.md
+++ b/std/set/README.md
@@ -36,7 +36,16 @@ after remove: 1
 `contains` returns a `bool`, so it reads directly in a condition — no
 comparison against 1 needed.
 
+## Reading the members
+
+`items` returns a snapshot of the members; read it with `items_size` and
+`items_get`. Same contract as `map.keys`: the strings are **borrowed** and
+valid until `items_free`, the order is **unspecified** (sort with
+`std.sort.strings` for a deterministic listing), and an out-of-range index
+returns `""` rather than trapping.
+
 ## Exports
 
 `new`, `add`, `contains`, `remove`, `size`, `clear`, `free`, `items`,
+`items_size`, `items_get`,
 plus the `aether_set_*` raw forms.

--- a/std/set/module.ae
+++ b/std/set/module.ae
@@ -25,7 +25,9 @@
 exports(
     aether_set_new, aether_set_add, aether_set_has, aether_set_remove, aether_set_size, aether_set_clear, aether_set_free,
     aether_set_items_raw, aether_set_items_free,
-    new, add, contains, remove, size, clear, free, items, items_free
+    map_keys_size_raw, map_keys_get_raw,
+    new, add, contains, remove, size, clear, free, items, items_free,
+    items_size, items_get
 )
 
 // ---- raw externs (std/collections/aether_set.c) ----
@@ -38,6 +40,10 @@ extern aether_set_clear(set: ptr)
 extern aether_set_free(set: ptr)
 extern aether_set_items_raw(set: ptr) -> ptr
 extern aether_set_items_free(items: ptr)
+// aether_set_items_raw returns the same MapKeys snapshot map.keys does, so
+// the read side is literally the same two functions (#1724).
+extern map_keys_size_raw(items: ptr) -> int
+extern map_keys_get_raw(items: ptr, index: int) -> string
 
 // ---- Aether-side wrappers ----
 
@@ -94,4 +100,30 @@ items(set: ptr) -> {
 // Release a snapshot returned by `set.items`.
 items_free(items: ptr) {
     aether_set_items_free(items)
+}
+
+// ---- reading an items snapshot (#1724) ------------------------------------
+//
+// Same contract as map.keys_size / map.keys_get, because `items` returns the
+// same snapshot type: the strings are BORROWED, valid until `items_free` and
+// only while the set still holds them, and iteration order is unspecified.
+// Sort (std.sort.strings) for a deterministic order.
+
+items_size(items: ptr) -> int {
+    if items == null {
+        return 0
+    }
+    return map_keys_size_raw(items)
+}
+
+// Out of range or null returns "" rather than trapping. An empty string is
+// also a legitimate item, so callers who must distinguish check items_size.
+items_get(items: ptr, index: int) -> string {
+    if items == null {
+        return ""
+    }
+    if index < 0 || index >= map_keys_size_raw(items) {
+        return ""
+    }
+    return map_keys_get_raw(items, index)
 }

--- a/std/set/test_set.ae
+++ b/std/set/test_set.ae
@@ -91,8 +91,34 @@ main() {
     if snap == null {
         fail("set.items returned null snapshot")
     }
+    // Reading the snapshot (#1724). Before this, `items` could only be
+    // allocated and freed -- nothing in the tree ever read an item out of one,
+    // which is how the gap survived unnoticed.
+    isz = set.items_size(snap)
+    if isz != set.size(s) {
+        fail("items_size ${isz} != set size ${set.size(s)}")
+    }
+    ii = 0
+    while ii < isz {
+        if set.items_get(snap, ii) == "" {
+            fail("in-range items_get(${ii}) came back empty")
+        }
+        ii = ii + 1
+    }
+    if set.items_get(snap, isz) != "" {
+        fail("items_get past the end should be empty")
+    }
+    if set.items_get(snap, -1) != "" {
+        fail("items_get at a negative index should be empty")
+    }
+    if set.items_size(null) != 0 {
+        fail("items_size(null) should be 0")
+    }
+    if set.items_get(null, 0) != "" {
+        fail("items_get(null) should be empty")
+    }
     set.items_free(snap)
-    println("PASS 6: items snapshots the members")
+    println("PASS 6: items snapshots the members, and the snapshot can be read")
 
     // 7. keys are copied, not aliased
     set.clear(s)

--- a/std/sort/README.md
+++ b/std/sort/README.md
@@ -38,6 +38,60 @@ sorted: 1 .. 9
 index of 7: 3
 ```
 
+## Strings
+
+`string[]` is a bare C array with no carried length, so the string entry
+points take an explicit element count. Ordering is `std.string.compare`:
+lexicographic **byte** order, binary-safe. That matches the default in C, Go
+and Zig; locale-aware collation is a separate concern and lives in
+`contrib/i18n`.
+
+```aether,run
+import std.sort
+import std.string
+
+main() {
+    a = ["pear", "apple", "fig"]
+    sort.strings(a, 3)
+    println("${a[0]} ${a[1]} ${a[2]}")
+    println("fig at ${sort.string_search(a, 3, "fig")}")
+}
+```
+```output
+apple fig pear
+fig at 1
+```
+
+## Custom orders
+
+The `_by` forms take a comparator returning `<0`, `0`, or `>0`. It must be a
+strict weak ordering — an inconsistent comparator yields an unspecified
+permutation rather than a crash, but not a sorted array either.
+
+They are separate names rather than an optional argument so the default path
+keeps a direct comparison instead of an indirect call per element.
+
+```aether,run
+import std.sort
+import std.string
+
+descending(a: string, b: string) -> int {
+    return 0 - string.compare(a, b)
+}
+
+main() {
+    a = ["pear", "apple", "fig"]
+    sort.strings_by(a, 3, descending)
+    println("${a[0]} ${a[1]} ${a[2]}")
+}
+```
+```output
+pear fig apple
+```
+
 ## Exports
 
-`ints`, `longs`, `floats`, `int_search`, `long_search`, `float_search`.
+`ints`, `longs`, `floats`, `int_search`, `long_search`, `float_search`,
+`strings`, `string_search`, `ints_by`, `longs_by`, `floats_by`, `strings_by`.
+
+All sorts are IN PLACE and none is stable.

--- a/std/sort/module.ae
+++ b/std/sort/module.ae
@@ -14,8 +14,12 @@
 
 exports(
     ints, longs, floats,
-    int_search, long_search, float_search
+    int_search, long_search, float_search,
+    strings, string_search,
+    ints_by, longs_by, floats_by, strings_by
 )
+
+import std.string
 
 // ---- array externs (bound to the same C the array modules use) -----------
 extern intarr_size(arr: ptr) -> int
@@ -176,4 +180,205 @@ float_search(arr: ptr, x: double) -> int {
         if v < x { lo = mid + 1 } else { hi = mid }
     }
     return lo
+}
+
+// ---- strings --------------------------------------------------------------
+//
+// `string[]` is a bare C array with no carried length, unlike the intarr /
+// longarr / floatarr handles above, so these take an explicit element count.
+// Passing a count larger than the array reads out of bounds exactly as it
+// would in C -- the array does not know its own size and cannot check.
+//
+// Ordering is std.string.compare: lexicographic BYTE order, binary-safe
+// (embedded NULs take part). That is the same default C, Go and Zig use.
+// Locale-aware collation is a different question and stays in contrib/i18n.
+
+strings(arr: string[], n: int) {
+    if n < 2 { return }
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4
+    }
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = arr[i]
+            j = i
+            while j >= gap && string.compare(arr[j - gap], tmp) > 0 {
+                arr[j] = arr[j - gap]
+                j = j - gap
+            }
+            arr[j] = tmp
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
+}
+
+// Lower bound: the index of the first element not ordered before `x`, which
+// is where `x` would be inserted to keep the array sorted. Equal to `n` when
+// every element sorts before `x`. Same contract as int_search.
+string_search(arr: string[], n: int, x: string) -> int {
+    lo = 0
+    hi = n
+    while lo < hi {
+        mid = lo + (hi - lo) / 2
+        if string.compare(arr[mid], x) < 0 { lo = mid + 1 } else { hi = mid }
+    }
+    return lo
+}
+
+// ---- comparator forms -----------------------------------------------------
+//
+// `cmp(a, b)` returns <0 when a sorts before b, 0 when they tie, >0 when a
+// sorts after. It must be a strict weak ordering: an inconsistent comparator
+// gives an unspecified permutation, not a crash, but not a sorted array
+// either.
+//
+// Separate names rather than an optional argument on `ints`/`strings` so the
+// default path keeps a direct comparison instead of an indirect call per
+// element -- these sorts are in place and hot, and the natural order is what
+// almost every caller wants.
+//
+// Not stable, like every sort in this module.
+
+ints_by(arr: ptr, cmp: fn(int, int) -> int) {
+    n = intarr_size(arr)
+    if n < 2 { return }
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4
+    }
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = intarr_get_unchecked(arr, i)
+            j = i
+            while j >= gap && cmp(intarr_get_unchecked(arr, j - gap), tmp) > 0 {
+                intarr_set_unchecked(arr, j, intarr_get_unchecked(arr, j - gap))
+                j = j - gap
+            }
+            intarr_set_unchecked(arr, j, tmp)
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
+}
+
+longs_by(arr: ptr, cmp: fn(long, long) -> int) {
+    n = longarr_size(arr)
+    if n < 2 { return }
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4
+    }
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = longarr_get_unchecked(arr, i)
+            j = i
+            while j >= gap && cmp(longarr_get_unchecked(arr, j - gap), tmp) > 0 {
+                longarr_set_unchecked(arr, j, longarr_get_unchecked(arr, j - gap))
+                j = j - gap
+            }
+            longarr_set_unchecked(arr, j, tmp)
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
+}
+
+floats_by(arr: ptr, cmp: fn(double, double) -> int) {
+    n = floatarr_size(arr)
+    if n < 2 { return }
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4
+    }
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = floatarr_get_unchecked(arr, i)
+            j = i
+            while j >= gap && cmp(floatarr_get_unchecked(arr, j - gap), tmp) > 0 {
+                floatarr_set_unchecked(arr, j, floatarr_get_unchecked(arr, j - gap))
+                j = j - gap
+            }
+            floatarr_set_unchecked(arr, j, tmp)
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
+}
+
+strings_by(arr: string[], n: int, cmp: fn(string, string) -> int) {
+    if n < 2 { return }
+    gap = 1
+    idx = 0
+    while idx < 8 && CIURA[idx] < n {
+        gap = CIURA[idx]
+        idx = idx + 1
+    }
+    while gap < n / 2 {
+        gap = (gap * 9) / 4
+    }
+    while gap >= 1 {
+        i = gap
+        while i < n {
+            tmp = arr[i]
+            j = i
+            while j >= gap && cmp(arr[j - gap], tmp) > 0 {
+                arr[j] = arr[j - gap]
+                j = j - gap
+            }
+            arr[j] = tmp
+            i = i + 1
+        }
+        if gap == 1 {
+            gap = 0
+        } else {
+            gap = (gap * 4) / 9
+            if gap < 1 { gap = 1 }
+        }
+    }
 }

--- a/std/sort/test_sort.ae
+++ b/std/sort/test_sort.ae
@@ -9,6 +9,7 @@ import std.longarr
 import std.floatarr
 import std.sort
 import std.string
+import std.string
 
 extern exit(code: int)
 
@@ -27,6 +28,18 @@ fn is_sorted_int(a: ptr, n: int) -> bool {
         i = i + 1
     }
     return true
+}
+
+cmp_desc(a: string, b: string) -> int {
+    return 0 - string.compare(a, b)
+}
+
+cmp_abs(a: int, b: int) -> int {
+    x = a
+    y = b
+    if x < 0 { x = 0 - x }
+    if y < 0 { y = 0 - y }
+    return x - y
 }
 
 main() {
@@ -126,6 +139,58 @@ main() {
     intarr.free(srt2)
     longarr.free(la)
     floatarr.free(fa)
+
+    // ---- strings (#1722) --------------------------------------------------
+    // `string[]` carries no length, so these take an explicit count.
+    ss_mixed = ["pear", "apple", "fig", "banana", "apple"]
+    sort.strings(ss_mixed, 5)
+    fails = fails + ck(string.compare(ss_mixed[0], "apple") == 0, "string sort first")
+    fails = fails + ck(string.compare(ss_mixed[1], "apple") == 0, "string sort duplicate kept")
+    fails = fails + ck(string.compare(ss_mixed[4], "pear") == 0, "string sort last")
+
+    // Already sorted, and reverse sorted, both land in the same order.
+    ss_sorted = ["a", "b", "c"]
+    sort.strings(ss_sorted, 3)
+    fails = fails + ck(string.compare(ss_sorted[0], "a") == 0 && string.compare(ss_sorted[2], "c") == 0,
+                       "string sort already-sorted")
+    ss_rev = ["c", "b", "a"]
+    sort.strings(ss_rev, 3)
+    fails = fails + ck(string.compare(ss_rev[0], "a") == 0 && string.compare(ss_rev[2], "c") == 0,
+                       "string sort reverse-sorted")
+
+    // n < 2 must be a no-op, not a read past the end.
+    ss_one = ["only"]
+    sort.strings(ss_one, 1)
+    fails = fails + ck(string.compare(ss_one[0], "only") == 0, "string sort single element")
+    ss_zero = ["x"]
+    sort.strings(ss_zero, 0)
+    fails = fails + ck(string.compare(ss_zero[0], "x") == 0, "string sort empty count")
+
+    // Lower bound: present, absent-before-all, absent-after-all.
+    fails = fails + ck(sort.string_search(ss_mixed, 5, "fig") == 3, "string search present")
+    fails = fails + ck(sort.string_search(ss_mixed, 5, "aaa") == 0, "string search before all")
+    fails = fails + ck(sort.string_search(ss_mixed, 5, "zzz") == 5, "string search after all")
+
+    // ---- comparator forms (#1722) -----------------------------------------
+    // Descending strings, the case a natural-order comparator generalises.
+    ss_desc = ["pear", "apple", "fig"]
+    sort.strings_by(ss_desc, 3, cmp_desc)
+    fails = fails + ck(string.compare(ss_desc[0], "pear") == 0 && string.compare(ss_desc[2], "apple") == 0,
+                       "strings_by descending")
+
+    // Ints by absolute value: an order the natural sort cannot express.
+    ab, abe = intarr.new(4)
+    if abe == "" {
+        _ = intarr.set(ab, 0, -7)
+        _ = intarr.set(ab, 1, 3)
+        _ = intarr.set(ab, 2, -1)
+        _ = intarr.set(ab, 3, 5)
+        sort.ints_by(ab, cmp_abs)
+        v0, _ = intarr.get(ab, 0)
+        v3, _ = intarr.get(ab, 3)
+        fails = fails + ck(v0 == -1 && v3 == -7, "ints_by absolute value")
+        intarr.free(ab)
+    }
 
     if fails != 0 {
         println("sort: ${fails} failure(s)")

--- a/std/sort/test_sort.ae
+++ b/std/sort/test_sort.ae
@@ -152,11 +152,11 @@ main() {
     ss_sorted = ["a", "b", "c"]
     sort.strings(ss_sorted, 3)
     fails = fails + ck(string.compare(ss_sorted[0], "a") == 0 && string.compare(ss_sorted[2], "c") == 0,
-                       "string sort already-sorted")
+        "string sort already-sorted")
     ss_rev = ["c", "b", "a"]
     sort.strings(ss_rev, 3)
     fails = fails + ck(string.compare(ss_rev[0], "a") == 0 && string.compare(ss_rev[2], "c") == 0,
-                       "string sort reverse-sorted")
+        "string sort reverse-sorted")
 
     // n < 2 must be a no-op, not a read past the end.
     ss_one = ["only"]
@@ -176,7 +176,7 @@ main() {
     ss_desc = ["pear", "apple", "fig"]
     sort.strings_by(ss_desc, 3, cmp_desc)
     fails = fails + ck(string.compare(ss_desc[0], "pear") == 0 && string.compare(ss_desc[2], "apple") == 0,
-                       "strings_by descending")
+        "strings_by descending")
 
     // Ints by absolute value: an order the natural sort cannot express.
     ab, abe = intarr.new(4)

--- a/tests/regression/test_collections_wrappers.ae
+++ b/tests/regression/test_collections_wrappers.ae
@@ -78,6 +78,39 @@ main() {
     else if k == null { println("  FAIL: keys null"); fails = fails + 1 }
     else { print("  PASS: keys returns (snapshot, '')\n") }
 
+    // Reading the snapshot (#1724): before this pair, `keys` could only be
+    // allocated and freed, so a map's key set was unreachable from Aether.
+    if k != null {
+        ksz = map.keys_size(k)
+        if ksz != 2 { println("  FAIL: keys_size ${ksz} != 2"); fails = fails + 1 }
+        else { println("  PASS: keys_size matches map size") }
+
+        // Both inserted keys appear exactly once across the index range.
+        saw_a = 0
+        saw_b = 0
+        ki = 0
+        while ki < ksz {
+            kv = map.keys_get(k, ki)
+            if kv == "a" { saw_a = saw_a + 1 }
+            if kv == "b" { saw_b = saw_b + 1 }
+            ki = ki + 1
+        }
+        if saw_a != 1 || saw_b != 1 {
+            println("  FAIL: expected each key once, saw a=${saw_a} b=${saw_b}")
+            fails = fails + 1
+        } else {
+            println("  PASS: every key readable exactly once")
+        }
+
+        // Out of range and null are empty, not a trap or a wild read.
+        if map.keys_get(k, ksz) != "" || map.keys_get(k, -1) != "" {
+            println("  FAIL: out-of-range keys_get should be empty"); fails = fails + 1
+        } else { println("  PASS: out-of-range keys_get is empty") }
+        if map.keys_size(null) != 0 || map.keys_get(null, 0) != "" {
+            println("  FAIL: null snapshot should be size 0 / empty"); fails = fails + 1
+        } else { println("  PASS: null snapshot handled") }
+    }
+
     if k != null { map.keys_free(k) }
 
     kn, kne = map.keys(null)

--- a/tests/regression/test_map_keys_sorted_output.ae
+++ b/tests/regression/test_map_keys_sorted_output.ae
@@ -1,0 +1,71 @@
+// Deterministic output from a map: the case #1722 and #1724 exist for.
+//
+// "Print the word counts alphabetically" was not expressible before these
+// landed. Map iteration order is bucket order and unspecified, so a
+// deterministic listing needs two things that were both missing: a way to
+// read the key snapshot (#1724), and a way to sort strings (#1722).
+//
+// This test pins the whole shape end to end, so neither half can regress
+// into being individually present but jointly useless.
+
+import std.map
+import std.sort
+import std.string
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    words = ["pear", "apple", "fig", "apple", "banana", "fig", "apple"]
+    m = map.map_new()
+    i = 0
+    while i < 7 {
+        w = words[i]
+        cur, _ = map.get(m, w)
+        n = 0
+        if cur != null {
+            n, _ = string.to_int(cur)
+        }
+        map.put(m, w, "${n + 1}")
+        i = i + 1
+    }
+
+    k, e = map.keys(m)
+    if e != "" { fail("map.keys: ${e}") }
+    count = map.keys_size(k)
+    if count != 4 { fail("expected 4 distinct words, got ${count}") }
+
+    // Copy the borrowed keys into an array the sort can reorder. The snapshot
+    // itself must not be reordered: its entries are borrowed from live map
+    // entries and it is freed by count.
+    ordered = ["", "", "", ""]
+    j = 0
+    while j < count {
+        ordered[j] = map.keys_get(k, j)
+        j = j + 1
+    }
+    sort.strings(ordered, count)
+
+    if string.compare(ordered[0], "apple") != 0 { fail("first key ${ordered[0]}, want apple") }
+    if string.compare(ordered[1], "banana") != 0 { fail("second key ${ordered[1]}, want banana") }
+    if string.compare(ordered[2], "fig") != 0 { fail("third key ${ordered[2]}, want fig") }
+    if string.compare(ordered[3], "pear") != 0 { fail("fourth key ${ordered[3]}, want pear") }
+
+    // Counts still reachable through the sorted keys.
+    a, _ = map.get(m, ordered[0])
+    av, _ = string.to_int(a)
+    if av != 3 { fail("apple count ${av}, want 3") }
+
+    f, _ = map.get(m, ordered[2])
+    fv, _ = string.to_int(f)
+    if fv != 2 { fail("fig count ${fv}, want 2") }
+
+    map.keys_free(k)
+    map.map_free(m)
+
+    println("PASS: map keys read, sorted, and printed in a deterministic order")
+}


### PR DESCRIPTION
Closes #1722. Closes #1724.

Two gaps filed separately, done together because they are one piece of work: sorted output from a map needs both halves, and #1724's headline case is untestable without #1722.

## What was missing

**`std.sort`** sorted `int`, `long` and `float` arrays and nothing else — no string sort at all, and no way to express an order other than ascending. Sorting four strings meant writing this at the call site:

```aether
i = 1
while i < n {
    key = a[i]
    j = i - 1
    while j >= 0 && string.compare(a[j], key) > 0 {
        a[j + 1] = a[j]
        j = j - 1
    }
    a[j + 1] = key
    i = i + 1
}
```

**`map.keys` / `set.items`** returned a snapshot that could only be held and freed. No size accessor, no element accessor — so a map's key set was unreachable from Aether, and callers kept a parallel array of keys purely to have something iterable.

## What landed

`sort.strings`, `sort.string_search`, and `ints_by` / `longs_by` / `floats_by` / `strings_by`. Plus `map.keys_size` / `keys_get` and `set.items_size` / `items_get`.

Together they make the case both issues exist for expressible for the first time — word counts printed alphabetically:

```aether
k, e = map.keys(m)
count = map.keys_size(k)
j = 0
while j < count {
    ordered[j] = map.keys_get(k, j)
    j = j + 1
}
sort.strings(ordered, count)
```
```
apple: 3
banana: 1
fig: 2
pear: 1
```

That is pinned as `tests/regression/test_map_keys_sorted_output.ae`, so neither half can regress into being individually present but jointly useless.

## Design decisions worth reviewing

**`string[]` takes an explicit count.** Unlike the `intarr`/`longarr`/`floatarr` handles, a `string[]` is a bare C array carrying no length — `a.length` does not compile. So the string entry points are `strings(arr, n)`. Passing a count larger than the array reads out of bounds exactly as it would in C; the array cannot check.

**`_by` as separate names, not an optional argument.** The natural-order path keeps a direct comparison instead of an indirect call per element. These sorts are in place and hot, and natural order is what almost every caller wants. This was flagged as an open question in #1722 and is the one API choice I would most welcome a second opinion on.

**Borrowed strings from snapshots.** `keys_get` returns a pointer into the live map entry: valid until `keys_free`, and only while the map still holds it. Documented in both READMEs including the trap — the snapshot does not track later mutation, so a key removed after the snapshot leaves a dangling entry. A `keys_get_owned` returning a retained copy could follow if borrowing proves error-prone; I did not add it speculatively.

**Nothing generic.** The sort module's header says its concrete-type scoping is deliberate, and that still holds: `strings` is one more concrete type. Only the comparator adds anything new, and it takes a function value, not a type parameter. Similarly #1724 exposes what the C snapshot already held rather than attempting the broader "no common iteration protocol across containers" problem — if a protocol lands later it subsumes these four accessors.

## A bug this turned up

The C symbols are named `map_keys_size_raw` / `map_keys_get_raw`. My first version dropped the suffix, and the exported extern `map_keys_get` then **shadowed the Aether wrapper `keys_get` at the call site** — the wrapper was never entered and its bounds guard was silently bypassed. It surfaced as an out-of-range index returning `(null)` instead of `""`; I confirmed the dispatch by instrumenting the wrapper and watching the print never appear.

Every other wrapper pair in `std.map` already uses the `_raw` suffix (`map_get_raw` behind `get`), so this follows the existing convention rather than inventing one. Worth knowing that the collision fails silently rather than as a compile error.

## Why now

Both are ordinary stdlib holes worth closing on their own. The timing is a **forthcoming Rosetta Code porting effort**, where they would be hit constantly: 239 of that corpus's Python entries call `sorted()` — roughly 14% of tasks — and "print the counts in order" is one of the first shapes anyone writes.

## Verification

- `make test`: **394 passed, 0 failed**
- `check_doc_blocks.py`: 189 blocks compile, 50 run and match their output — including two new runnable examples in `std/sort/README.md`
- `check_module_readmes.py`: 71/71 covered, export lists verified against the modules
- String sort tested for empty, single, already-sorted, reverse-sorted and duplicate inputs, plus the three lower-bound cases; comparators tested with descending strings and ints by absolute value; snapshot reads tested at every in-range index, past-end, negative and null

🤖 Generated with [Claude Code](https://claude.com/claude-code)
