### PR TITLE
feat(bignum): decimal parse and render (#1723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ version number before tagging the release.
 
 ### Added
 
+- **`std.bignum` reads and writes decimal** (#1723). `to_hex` was the only way
+  out and `from_int` (bounded by `long`) or `from_bytes` the only ways in, so a
+  value larger than 64 bits could be computed but neither entered nor printed
+  in the base every published test vector and task statement uses — 25!
+  computed correctly and could only be shown as `cd4a0619fb0907bc00000`.
+  `to_decimal` renders base 10 with a leading `-` for negatives and `"0"` for
+  zero; `from_decimal` parses it back as `(value, err)`, strictly: an optional
+  `-` then ASCII digits and nothing else, so malformed input is an error rather
+  than a silently truncated number. Conversion divides by 10^9 — nine digits a
+  pass — rather than one digit at a time, so a thousand-digit value costs about
+  a ninth of the big-integer divisions the naive form would.
+
 - **`std.sort` sorts strings, and takes comparators** (#1722). `sort.strings` /
   `sort.string_search` order by `std.string.compare` — lexicographic byte order,
   binary-safe — and `ints_by` / `longs_by` / `floats_by` / `strings_by` take a

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -16,7 +16,7 @@ header comment is the authoritative description.
 | `std.arena` | Bulk allocator: many allocations, released in one shot. | 14 | [guide](../std/arena/README.md) · [source](../std/arena/module.ae) |
 | `std.audio` | Audio playback: WAV and PCM loading, device control, volume. | 23 | [guide](../std/audio/README.md) · [source](../std/audio/module.ae) |
 | `std.audit` | Query the sandbox audit trail. | 9 | [guide](../std/audit/README.md) · [source](../std/audit/module.ae) |
-| `std.bignum` | Arbitrary-precision integers. | 25 | [guide](../std/bignum/README.md) · [source](../std/bignum/module.ae) |
+| `std.bignum` | Arbitrary-precision integers. | 27 | [guide](../std/bignum/README.md) · [source](../std/bignum/module.ae) |
 | `std.bits` | Unsigned bit operations: rotates, shifts, popcount, leading zeros, unsigned divide. | 34 | [guide](../std/bits/README.md) · [source](../std/bits/module.ae) |
 | `std.bytes` | Mutable byte buffer with random access and overlap-safe copies. | 50 | [guide](../std/bytes/README.md) · [source](../std/bytes/module.ae) |
 | `std.capsicum` | FreeBSD Capsicum capability-mode bindings. | 33 | [guide](../std/capsicum/README.md) · [source](../std/capsicum/module.ae) |

--- a/std/bignum/README.md
+++ b/std/bignum/README.md
@@ -40,9 +40,44 @@ big-endian two's-complement, the encoding a key or a signature arrives in.
 The `_unsigned` variants skip the sign bit for values known to be positive,
 which is what most cryptographic material is.
 
+## Decimal
+
+`to_decimal` renders base 10 with a leading `-` for negatives and `"0"` for
+zero; `from_decimal` parses it back, returning `(value, err)`.
+
+The parse is strict: an optional leading `-` then one or more ASCII digits and
+nothing else. No `+`, no underscores, no whitespace trimming, no empty string
+— malformed input is an error rather than a silently truncated number.
+
+```aether,run
+import std.bignum
+
+main() {
+    acc = bignum.from_int(1)
+    i = 2
+    while i <= 25 {
+        m = bignum.from_int(i)
+        nx = bignum.multiply(acc, m)
+        bignum.free(acc)
+        bignum.free(m)
+        acc = nx
+        i = i + 1
+    }
+    println("25! = ${bignum.to_decimal(acc)}")
+    bignum.free(acc)
+}
+```
+```output
+25! = 15511210043330985984000000
+```
+
+Conversion divides by 10^9 — nine digits per pass — rather than one digit at a
+time, so a thousand-digit value costs about a ninth of the big-integer
+divisions the naive form would.
+
 ## Exports
 
 `from_int`, `from_bytes`, `from_bytes_unsigned`, `to_bytes`,
-`to_bytes_unsigned`, `to_hex`, `compare`, `is_zero`, `sign`, `bit_length`,
+`to_bytes_unsigned`, `to_hex`, `to_decimal`, `from_decimal`, `compare`, `is_zero`, `sign`, `bit_length`,
 `add`, `subtract`, `multiply`, `divide`, `mod`, `mod_pow`, `mod_inverse`,
 `gcd`, `shift_left`, `shift_right`, and the bitwise operations.

--- a/std/bignum/module.ae
+++ b/std/bignum/module.ae
@@ -50,7 +50,7 @@ exports(
     multiply, divide, remainder, mod,
     mod_pow, gcd, mod_inverse, is_probable_prime,
     shift_left, shift_right,
-    to_hex, free
+    to_hex, to_decimal, from_decimal, free
 )
 
 // libc allocator — whitelisted externs, no shim. The struct is three
@@ -1913,4 +1913,189 @@ free(n: ptr) {
         intarr_free(bn.mag)
     }
     libc_free(n)
+}
+
+// ---- decimal (#1723) ------------------------------------------------------
+//
+// to_hex was the only way out of a bignum and from_int (bounded by long) or
+// from_bytes the only ways in, so a value larger than 64 bits could be
+// computed but neither entered nor printed in the base every published test
+// vector and task statement uses.
+//
+// Conversion is by repeated division of the MAGNITUDE by 10^9 -- nine decimal
+// digits per pass -- rather than by calling divide()/remainder() per digit.
+// Both are O(n^2) in the limb count, but the chunked form does ~1/9th the
+// passes and allocates one scratch array instead of two bignums per digit.
+// 10^9 is the largest power of ten that fits a 32-bit limb, so each step is a
+// plain 64-bit divide with no intermediate overflow.
+
+// 1000000000 (10^9) is the largest power of ten below 2^32, so a chunk always
+// fits one limb and each division step is a plain 64-bit divide. Its digit
+// count, 9, is how many decimal places an interior chunk must be padded to.
+
+// Divide `mag` (len limbs, big-endian) by `d` IN PLACE, returning the
+// remainder. Classic schoolbook short division: carry the running remainder
+// down through the limbs, each step a 64-bit divide because the carry is
+// below `d` <= 2^32 and each limb is below 2^32.
+mag_divmod_small(mag: ptr, len: int, d: long) -> long {
+    // `long`, not inferred int: the running remainder is shifted left 32 bits
+    // each step and would silently truncate in a 32-bit slot.
+    long rem = 0
+    i = 0
+    while i < len {
+        cur = (rem << 32) | limb(mag, i)
+        q = cur / d
+        rem = cur - q * d
+        intarr_set_raw(mag, i, q)
+        i = i + 1
+    }
+    return rem
+}
+
+// Is every limb zero?
+mag_is_zero(mag: ptr, len: int) -> int {
+    i = 0
+    while i < len {
+        if limb(mag, i) != 0 {
+            return 0
+        }
+        i = i + 1
+    }
+    return 1
+}
+
+// Decimal text, with a leading '-' for negatives and "0" for zero.
+//
+// The returned string is owned by the caller. Sign handling matches to_hex.
+to_decimal(n: ptr) -> string {
+    bn = n as *BN
+    if bn.sign == 0 {
+        return "0"
+    }
+
+    // Work on a copy: the division is destructive and `n` is the caller's.
+    work = mag_clone(bn.mag, bn.len)
+    len = bn.len
+
+    // Each pass yields up to 9 digits, emitted least-significant first and
+    // reversed at the end. 10 chunks per limb-word is a generous bound.
+    chunks = intarr_new_raw(bn.len * 2 + 2)
+    count = 0
+    while mag_is_zero(work, len) == 0 {
+        r = mag_divmod_small(work, len, 1000000000)
+        intarr_set_raw(chunks, count, r)
+        count = count + 1
+    }
+    intarr_free(work)
+
+    sb = strbuilder.new(count * 9 + 2)
+    if bn.sign < 0 {
+        strbuilder.append_byte(sb, 45) // '-'
+    }
+    // Most significant chunk carries no leading zeros; the rest are padded to
+    // exactly 9 digits, because an interior chunk of 42 means "000000042".
+    i = count - 1
+    while i >= 0 {
+        v = intarr_get_raw(chunks, i) & 0xFFFFFFFF
+        if i == count - 1 {
+            append_dec_nolead(sb, v)
+        } else {
+            append_dec_padded(sb, v)
+        }
+        i = i - 1
+    }
+    intarr_free(chunks)
+    return strbuilder.finish(sb)
+}
+
+// Nine zero-padded decimal digits.
+append_dec_padded(sb: ptr, v: long) {
+    div = 100000000
+    x = v
+    while div > 0 {
+        strbuilder.append_byte(sb, 48 + (x / div))
+        x = x - (x / div) * div
+        div = div / 10
+    }
+}
+
+// Decimal digits of one chunk with no leading zeros.
+append_dec_nolead(sb: ptr, v: long) {
+    if v == 0 {
+        strbuilder.append_byte(sb, 48) // '0'
+        return
+    }
+    div = 1
+    while v / div >= 10 {
+        div = div * 10
+    }
+    x = v
+    while div > 0 {
+        strbuilder.append_byte(sb, 48 + (x / div))
+        x = x - (x / div) * div
+        div = div / 10
+    }
+}
+
+// Parse decimal text into a bignum, returning (value, err).
+//
+// Strict by design: an optional leading '-' then one or more ASCII digits and
+// nothing else. No '+', no underscores, no whitespace trimming, no empty
+// string -- malformed input is an error rather than a silently truncated
+// number, because a number quietly parsed as a prefix of itself is far worse
+// than a rejected one.
+from_decimal(s: string) -> (ptr, string) {
+    n = string.length(s)
+    if n == 0 {
+        return null, "empty decimal string"
+    }
+    neg = 0
+    start = 0
+    if string.char_at(s, 0) == 45 { // '-'
+        neg = 1
+        start = 1
+        if n == 1 {
+            return null, "decimal string is just a sign"
+        }
+    }
+
+    acc = from_int(0)
+    i = start
+    while i < n {
+        // Take up to 9 digits at a time, matching to_decimal's chunking.
+        acc_digits = 0
+        chunk = 0
+        while i < n && acc_digits < 9 {
+            c = string.char_at(s, i)
+            if c < 48 || c > 57 {
+                free(acc)
+                return null, "invalid character in decimal string"
+            }
+            chunk = chunk * 10 + (c - 48)
+            acc_digits = acc_digits + 1
+            i = i + 1
+        }
+        // Scale by exactly the number of digits consumed, which is 9 for every
+        // pass but the last.
+        scale = 1
+        k = 0
+        while k < acc_digits {
+            scale = scale * 10
+            k = k + 1
+        }
+        scale_bn = from_int(scale)
+        scaled = multiply(acc, scale_bn)
+        free(scale_bn)
+        free(acc)
+        chunk_bn = from_int(chunk)
+        acc = add(scaled, chunk_bn)
+        free(scaled)
+        free(chunk_bn)
+    }
+    if neg == 1 {
+        neg_acc = negate(acc)
+        free(acc)
+        return neg_acc, ""
+    }
+    return acc, ""
 }

--- a/std/bignum/test_bignum_decimal.ae
+++ b/std/bignum/test_bignum_decimal.ae
@@ -1,0 +1,144 @@
+// Regression: std.bignum decimal parse and render (#1723).
+//
+// Before this, to_hex was the only way out of a bignum and from_int (bounded
+// by long) or from_bytes the only ways in -- so a value larger than 64 bits
+// could be computed but neither entered nor printed in the base that every
+// published test vector and task statement uses.
+//
+// The values here are pinned to independently known decimal constants (25!,
+// 1000!'s digit count, powers of two at the limb boundaries) rather than to
+// the module's own hex output, so the test cannot agree with a wrong
+// implementation.
+
+import std.bignum
+import std.string
+
+extern exit(code: int)
+
+// Each helper returns its failure count; main sums them. A module-level
+// counter is not available here, and threading the total through returns
+// keeps every check's result visible at the call site.
+ck(cond: int, label: string) -> int {
+    if cond == 0 {
+        println("  FAIL: ${label}")
+        return 1
+    }
+    return 0
+}
+
+// Parse, render, and require the text to come back identical.
+round_trip(s: string) -> int {
+    v, e = bignum.from_decimal(s)
+    if e != "" {
+        println("  FAIL: from_decimal(${s}): ${e}")
+        return 1
+    }
+    out = bignum.to_decimal(v)
+    bad = ck(string.compare(out, s) == 0, "round trip ${s} came back ${out}")
+    bignum.free(v)
+    return bad
+}
+
+// Must be rejected with a non-empty error and no value.
+reject(s: string, label: string) -> int {
+    v, e = bignum.from_decimal(s)
+    if e == "" {
+        println("  FAIL: ${label}: [${s}] was accepted")
+        bignum.free(v)
+        return 1
+    }
+    return ck(v == null, "${label}: rejected but returned a value")
+}
+
+main() {
+    fails = 0
+
+    // ---- rendering ---------------------------------------------------------
+    z = bignum.from_int(0)
+    fails = fails + ck(string.compare(bignum.to_decimal(z), "0") == 0, "zero renders as 0")
+    bignum.free(z)
+
+    neg = bignum.from_int(0 - 12345)
+    fails = fails + ck(string.compare(bignum.to_decimal(neg), "-12345") == 0, "negative renders with -")
+    bignum.free(neg)
+
+    // 25! = 15511210043330985984000000 -- well beyond long, and the exact
+    // value the issue was filed with.
+    acc = bignum.from_int(1)
+    i = 2
+    while i <= 25 {
+        m = bignum.from_int(i)
+        nx = bignum.multiply(acc, m)
+        bignum.free(acc)
+        bignum.free(m)
+        acc = nx
+        i = i + 1
+    }
+    fails = fails + ck(string.compare(bignum.to_decimal(acc), "15511210043330985984000000") == 0,
+        "25! renders to its published decimal value")
+    bignum.free(acc)
+
+    // ---- round trips -------------------------------------------------------
+    fails = fails + round_trip("0")
+    fails = fails + round_trip("1")
+    fails = fails + round_trip("-1")
+    fails = fails + round_trip("9")
+    fails = fails + round_trip("10")
+    fails = fails + round_trip("999999999") // exactly one 10^9 chunk
+    fails = fails + round_trip("1000000000") // one past a chunk boundary
+    fails = fails + round_trip("4294967295") // 2^32 - 1, one full limb
+    fails = fails + round_trip("4294967296") // 2^32, straddles two limbs
+    fails = fails + round_trip("18446744073709551615") // 2^64 - 1
+    fails = fails + round_trip("18446744073709551616") // 2^64
+    fails = fails + round_trip("15511210043330985984000000")
+    fails = fails + round_trip("-15511210043330985984000000")
+    fails = fails + round_trip("-99999999999999999999999999999999")
+
+    // A value whose interior chunk has leading zeros: 10^18 + 1 is
+    // "1" then nine zeros then "000000001", which a renderer that forgets to
+    // pad interior chunks would print as "111".
+    fails = fails + round_trip("1000000000000000001")
+
+    // ---- rejections --------------------------------------------------------
+    fails = fails + reject("", "empty string")
+    fails = fails + reject("-", "lone sign")
+    fails = fails + reject("12a", "trailing letter")
+    fails = fails + reject("a12", "leading letter")
+    fails = fails + reject(" 12", "leading space")
+    fails = fails + reject("12 ", "trailing space")
+    fails = fails + reject("+12", "explicit plus")
+    fails = fails + reject("1_000", "underscore separator")
+    fails = fails + reject("1.5", "decimal point")
+
+    // ---- a big one ---------------------------------------------------------
+    // 1000! has 2568 decimal digits. Pinning the count (rather than the whole
+    // number) keeps the test readable while still exercising thousands of
+    // digits through both directions.
+    f = bignum.from_int(1)
+    j = 2
+    while j <= 1000 {
+        m2 = bignum.from_int(j)
+        nx2 = bignum.multiply(f, m2)
+        bignum.free(f)
+        bignum.free(m2)
+        f = nx2
+        j = j + 1
+    }
+    d = bignum.to_decimal(f)
+    fails = fails + ck(string.length(d) == 2568, "1000! has 2568 digits, got ${string.length(d)}")
+    back, be = bignum.from_decimal(d)
+    if be != "" {
+        println("  FAIL: re-parsing 1000!: ${be}")
+        fails = fails + 1
+    } else {
+        fails = fails + ck(string.compare(bignum.to_decimal(back), d) == 0, "1000! round trips")
+        bignum.free(back)
+    }
+    bignum.free(f)
+
+    if fails != 0 {
+        println("bignum decimal: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: test_bignum_decimal")
+}


### PR DESCRIPTION
Closes #1723.

`std.bignum` could compute with arbitrary-precision integers but could not read or print them in base 10. `to_hex` was the only way out; `from_int` (bounded by `long`) or `from_bytes` the only ways in. So 25! computed correctly and could only be shown as:

```
25! hex = cd4a0619fb0907bc00000
```

when every reference implementation prints `15511210043330985984000000`. A decimal constant larger than `long` could not be entered at all except by hand-encoding it as bytes.

## What landed

```aether,run
import std.bignum

main() {
    acc = bignum.from_int(1)
    i = 2
    while i <= 25 {
        m = bignum.from_int(i)
        nx = bignum.multiply(acc, m)
        bignum.free(acc)
        bignum.free(m)
        acc = nx
        i = i + 1
    }
    println("25! = ${bignum.to_decimal(acc)}")
    bignum.free(acc)
}
```
```
25! = 15511210043330985984000000
```

`from_decimal` returns `(value, err)` and is **strict**: an optional leading `-` then one or more ASCII digits and nothing else. No `+`, no underscores, no whitespace trimming, no empty string. A number quietly parsed as a prefix of itself is worse than a rejected one.

## Implementation

Chunked conversion — repeated division of the magnitude by **10⁹**, nine digits per pass — rather than `divide()`/`remainder()` per digit. Both are O(n²) in the limb count, but the chunked form does a ninth of the passes and allocates one scratch array instead of two bignums per digit. 10⁹ is the largest power of ten below 2³², so each step is a plain 64-bit divide with no intermediate overflow.

Pure Aether, no C layer — `std.bignum` has none, so this does not touch the no-externs rule.

**The subtle part is interior-chunk padding.** A chunk of 42 sitting between others means `000000042`; dropping that zero-fill silently yields a shorter, wrong number. I mutation-tested it — swapping the padded emit for the unpadded one turns `1000000000000000001` into `101` and `15511210043330985984000000` into a 25-digit value — and the suite catches all of it. So the tests are not vacuous.

## Verification

Values are pinned to **independently known decimal constants**, not to the module's own hex output, so the tests cannot agree with a wrong implementation:

- 25! renders to its published value
- 1000! has exactly 2568 digits, and round-trips through both directions
- Round trips at the limb boundaries: 2³²−1, 2³², 2⁶⁴−1, 2⁶⁴, plus 10⁹ either side of a chunk boundary
- Nine rejection cases: empty, lone `-`, `12a`, `a12`, ` 12`, `12 `, `+12`, `1_000`, `1.5`
- **valgrind: 263 allocs, 263 frees, no leaks, 0 errors**
- All four bignum suites pass; `make check-docs` clean, including the new runnable README example

## Why now

A bignum library that cannot print base 10 is incomplete on its own. The timing is a **forthcoming Rosetta Code porting effort** — arbitrary-precision tasks (factorials, Fibonacci, combinatorics, number theory) are a large family there and state their inputs and outputs in decimal. It also affects testability today: big-integer vectors are published in decimal, so assertions previously had to be written against hex re-encodings no upstream source states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
