### PR TITLE
feat(mem): offset forms of the bulk operations — copy_at/move_at/fill_at/compare_at (#1733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.mem` gains offset forms of its bulk operations**: `copy_at`,
+  `move_at`, `fill_at` and `compare_at` (#1733). `copy`, `move`, `compare`
+  and `set` can only start at byte 0 of each buffer, and Aether has no
+  pointer arithmetic — so a bulk operation on an *interior* span had no
+  spelling at all, and copying one scanline out of a larger framebuffer meant
+  going byte at a time even though the operation is memcpy-shaped. Contracts
+  match the offset-less forms exactly: a null buffer is a no-op returning
+  `dst` (`0` for `compare_at`), and offsets are the caller's responsibility in
+  the same way `n` already is. `move_at` exists alongside `copy_at` because an
+  image scrolling within its own buffer is an *overlapping* interior copy,
+  which `copy_at` — being `memcpy` — leaves undefined.
+
 ## [0.579.0]
 
 ### Changed

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -50,7 +50,7 @@ header comment is the authoritative description.
 | `std.lzf` | One-shot LZF compression and decompression. | 12 | [guide](../std/lzf/README.md) · [source](../std/lzf/module.ae) |
 | `std.map` | Hash map, re-exported from `std.collections`, with readable key snapshots. | 18 | [guide](../std/map/README.md) · [source](../std/map/module.ae) |
 | `std.math` | Arithmetic, trigonometry, rounding and floating-point helpers. | 31 | [full section](#math-stdmath) |
-| `std.mem` | Byte-level reads and writes over caller-allocated raw pointers. | 94 | [guide](../std/mem/README.md) · [source](../std/mem/module.ae) |
+| `std.mem` | Byte-level reads and writes over caller-allocated raw pointers. | 102 | [guide](../std/mem/README.md) · [source](../std/mem/module.ae) |
 | `std.message` | ICU MessageFormat formatting and message catalogues. | 8 | [guide](../std/message/README.md) · [source](../std/message/module.ae) |
 | `std.msgpack` | MessagePack serialisation and deserialisation. | 35 | [guide](../std/msgpack/README.md) · [source](../std/msgpack/module.ae) |
 | `std.mutation` | Text-based mutation-testing driver for `std.spec` suites. | 1 | [guide](../std/mutation/README.md) · [source](../std/mutation/module.ae) |

--- a/std/mem/README.md
+++ b/std/mem/README.md
@@ -56,6 +56,46 @@ rather than spilling into the next one.
 `bits_of_float` / `float_from_bits` reinterpret a double as its IEEE 754 bit
 pattern and back, without going through a conversion.
 
+## Bulk operations on interior spans
+
+`copy`, `move`, `compare` and `set` all start at byte 0 of each buffer. Since
+Aether has no pointer arithmetic, that left no way to express a bulk
+operation on an **interior** span — copying one scanline out of a larger
+framebuffer meant going byte at a time, even though the operation is
+memcpy-shaped.
+
+`copy_at`, `move_at`, `fill_at` and `compare_at` take explicit offsets:
+
+```aether,run
+import std.mem
+import std.arena
+
+main() {
+    ar = arena.create(256)
+    src = arena.alloc(ar, 32)
+    dst = arena.alloc(ar, 32)
+    i = 0
+    while i < 32 { _ = mem.set_byte(src, i, i) ; i = i + 1 }
+
+    // copy src[8..12) into dst[20..24)
+    _ = mem.copy_at(dst, 20, src, 8, 4)
+    println("${mem.get_byte(dst, 20)} ${mem.get_byte(dst, 23)}")
+    arena.destroy(ar)
+}
+```
+```output
+8 11
+```
+
+Contracts match the offset-less forms exactly: a null buffer is a no-op
+returning `dst` (`0` for `compare_at`), and offsets are the caller's
+responsibility in the same way `n` already is — no range checking is added,
+because none exists in the offset-less forms.
+
+**Use `move_at`, not `copy_at`, when the spans overlap.** An image scrolling
+within its own buffer is an overlapping interior copy; `copy_at` is `memcpy`
+and is undefined there, exactly as in C.
+
 ## Exports
 
 `get_byte`, `set_byte`, `get_int`, `set_int`, `get_long`, `set_long`,
@@ -64,7 +104,7 @@ pattern and back, without going through a conversion.
 `set_float32`, `get_float64`, `set_float64`, `get_ptr`, `set_ptr`; the
 endian pairs `get_u16_le` through `set_u64_be`; `bits_of_float`,
 `float_from_bits`, `clz32`, `clz64`, `udiv64_32`; `copy`, `move`, `compare`,
-`set`.
+`set`, `copy_at`, `move_at`, `fill_at`, `compare_at`.
 
 `mem.ptr_to_long` and `mem.long_to_ptr` are defined and callable but are
 **missing from the module's `exports(...)` list**. They work today because a

--- a/std/mem/aether_mem.c
+++ b/std/mem/aether_mem.c
@@ -435,6 +435,52 @@ void* aether_mem_set_bulk(void* dst, int value, int64_t n) {
     return __builtin_memset(dst, value, (size_t)n);
 }
 
+/* Offset forms of the three bulk writers (#1733 ask 2).
+ *
+ * The offset-less versions above can only start at byte 0 of each buffer,
+ * and Aether has no pointer arithmetic — so there was no way to express a
+ * bulk operation on an INTERIOR span. Copying one scanline of a sub-region
+ * out of a larger framebuffer, or filling a rect's row, had to go byte at a
+ * time through get_byte/set_byte even though the operation is memcpy-shaped.
+ *
+ * Contracts match their offset-less twins exactly: NULL in either buffer is
+ * a no-op returning `dst`, and the offsets are the caller's problem in the
+ * same way `n` already is — these add no range checking, because the
+ * offset-less forms do none either and a bulk primitive that silently
+ * clamped would be worse than one that does what it is told.
+ *
+ * `move_at` exists alongside `copy_at` rather than after it: an image
+ * scrolling within its own buffer is an OVERLAPPING interior copy, so a
+ * copy_at-only surface would make the common case undefined behaviour. */
+void* aether_mem_copy_at(void* dst, int64_t dst_off,
+                         const void* src, int64_t src_off, int64_t n) {
+    if (!dst || !src) return dst;
+    return __builtin_memcpy((char*)dst + dst_off, (const char*)src + src_off,
+                            (size_t)n);
+}
+
+void* aether_mem_move_at(void* dst, int64_t dst_off,
+                         const void* src, int64_t src_off, int64_t n) {
+    if (!dst || !src) return dst;
+    return __builtin_memmove((char*)dst + dst_off, (const char*)src + src_off,
+                             (size_t)n);
+}
+
+void* aether_mem_fill_at(void* dst, int64_t off, int value, int64_t n) {
+    if (!dst) return dst;
+    return __builtin_memset((char*)dst + off, value, (size_t)n);
+}
+
+/* Offset form of compare, for symmetry with the writers: comparing an
+ * interior span had the same hole. Returns 0 when either buffer is NULL,
+ * exactly as aether_mem_compare does. */
+int aether_mem_compare_at(const void* a, int64_t a_off,
+                          const void* b, int64_t b_off, int64_t n) {
+    if (!a || !b) return 0;
+    return __builtin_memcmp((const char*)a + a_off, (const char*)b + b_off,
+                            (size_t)n);
+}
+
 /* Endian-aware 16/32/64-bit load/store at a byte offset.
  *
  * Unaligned-safe — each read/write goes through __builtin_memcpy,

--- a/std/mem/module.ae
+++ b/std/mem/module.ae
@@ -46,6 +46,8 @@ exports(
     aether_mem_udiv64_32,
     aether_mem_call_fn3_int, aether_mem_call_fn3_void,
     aether_mem_copy, aether_mem_move, aether_mem_compare, aether_mem_set_bulk,
+    aether_mem_copy_at, aether_mem_move_at, aether_mem_fill_at,
+    aether_mem_compare_at,
     aether_mem_get_u16_le, aether_mem_get_u16_be,
     aether_mem_set_u16_le, aether_mem_set_u16_be,
     aether_mem_get_u32_le, aether_mem_get_u32_be,
@@ -64,6 +66,7 @@ exports(
     udiv64_32,
     call_fn3_int, call_fn3_void,
     copy, move, compare, set,
+    copy_at, move_at, fill_at, compare_at,
     get_u16_le, get_u16_be, set_u16_le, set_u16_be,
     get_u32_le, get_u32_be, set_u32_le, set_u32_be,
     get_u64_le, get_u64_be, set_u64_le, set_u64_be
@@ -252,6 +255,10 @@ extern aether_mem_copy(dst: ptr, src: ptr, n: long) -> ptr
 extern aether_mem_move(dst: ptr, src: ptr, n: long) -> ptr
 extern aether_mem_compare(a: ptr, b: ptr, n: long) -> int
 extern aether_mem_set_bulk(dst: ptr, value: int, n: long) -> ptr
+extern aether_mem_copy_at(dst: ptr, dst_off: long, src: ptr, src_off: long, n: long) -> ptr
+extern aether_mem_move_at(dst: ptr, dst_off: long, src: ptr, src_off: long, n: long) -> ptr
+extern aether_mem_fill_at(dst: ptr, off: long, value: int, n: long) -> ptr
+extern aether_mem_compare_at(a: ptr, a_off: long, b: ptr, b_off: long, n: long) -> int
 
 // Endian-aware 16/32/64 load/store at a byte offset. Unaligned-safe
 // (each access uses byte-by-byte composition). `_le` is little-
@@ -319,6 +326,36 @@ copy(dst: ptr, src: ptr, n: long) -> ptr { return aether_mem_copy(dst, src, n) }
 move(dst: ptr, src: ptr, n: long) -> ptr { return aether_mem_move(dst, src, n) }
 compare(a: ptr, b: ptr, n: long) -> int { return aether_mem_compare(a, b, n) }
 set(dst: ptr, value: int, n: long) -> ptr { return aether_mem_set_bulk(dst, value, n) }
+
+// Offset forms of the bulk operations (#1733).
+//
+// The four above can only start at byte 0 of each buffer, and Aether has no
+// pointer arithmetic — so a bulk operation on an INTERIOR span had no
+// spelling at all. Copying one scanline out of a larger framebuffer, or
+// filling a rect's row, meant going byte at a time even though the operation
+// is memcpy-shaped.
+//
+// Contracts match their offset-less twins exactly: a null buffer is a no-op
+// returning `dst` (0 for compare), and offsets are the caller's problem in
+// the same way `n` already is — no range checking is added here, because
+// none exists in the offset-less forms and a bulk primitive that silently
+// clamped would be worse than one that does as it is told.
+//
+// `move_at` matters as much as `copy_at`: an image scrolling within its own
+// buffer is an OVERLAPPING interior copy, so a copy_at-only surface would
+// leave the common case undefined.
+copy_at(dst: ptr, dst_off: long, src: ptr, src_off: long, n: long) -> ptr {
+    return aether_mem_copy_at(dst, dst_off, src, src_off, n)
+}
+move_at(dst: ptr, dst_off: long, src: ptr, src_off: long, n: long) -> ptr {
+    return aether_mem_move_at(dst, dst_off, src, src_off, n)
+}
+fill_at(dst: ptr, off: long, value: int, n: long) -> ptr {
+    return aether_mem_fill_at(dst, off, value, n)
+}
+compare_at(a: ptr, a_off: long, b: ptr, b_off: long, n: long) -> int {
+    return aether_mem_compare_at(a, a_off, b, b_off, n)
+}
 
 // Endian-aware wrappers.
 get_u16_le(p: ptr, offset: int) -> int { return aether_mem_get_u16_le(p, offset) }

--- a/tests/integration/mem_offset_bulk/mem_offset_bulk.ae
+++ b/tests/integration/mem_offset_bulk/mem_offset_bulk.ae
@@ -1,0 +1,113 @@
+// Offset forms of the std.mem bulk operations (#1733 ask 2).
+//
+// copy/move/compare/set can only start at byte 0 of each buffer, and Aether
+// has no pointer arithmetic — so a bulk operation on an INTERIOR span had no
+// spelling. These four close that.
+//
+// The load-bearing case is move_at: an image scrolling within its own buffer
+// is an OVERLAPPING interior copy. copy_at on overlapping spans is undefined
+// (it is memcpy), so the test below pins that move_at gives the memmove
+// answer, which is the whole reason it exists alongside copy_at.
+
+import std.mem
+import std.arena
+
+extern exit(code: int)
+
+ck(cond: int, label: string) -> int {
+    if cond == 0 {
+        println("  FAIL: ${label}")
+        return 1
+    }
+    return 0
+}
+
+main() {
+    fails = 0
+    ar = arena.create(4096)
+    a = arena.alloc(ar, 64)
+    b = arena.alloc(ar, 64)
+
+    // a = 0,1,2,...63 ; b = all zero
+    i = 0
+    while i < 64 {
+        _ = mem.set_byte(a, i, i)
+        _ = mem.set_byte(b, i, 0)
+        i = i + 1
+    }
+
+    // ---- copy_at: interior -> interior ----------------------------------
+    _ = mem.copy_at(b, 20, a, 8, 4)
+    fails = fails + ck(mem.get_byte(b, 20) == 8, "copy_at b[20]")
+    fails = fails + ck(mem.get_byte(b, 23) == 11, "copy_at b[23]")
+    // and nothing either side was touched
+    fails = fails + ck(mem.get_byte(b, 19) == 0, "copy_at did not write before the span")
+    fails = fails + ck(mem.get_byte(b, 24) == 0, "copy_at did not write after the span")
+
+    // ---- fill_at: an interior run --------------------------------------
+    _ = mem.fill_at(b, 40, 0xAB, 8)
+    fails = fails + ck(mem.get_byte(b, 40) == 0xAB, "fill_at start")
+    fails = fails + ck(mem.get_byte(b, 47) == 0xAB, "fill_at end")
+    fails = fails + ck(mem.get_byte(b, 39) == 0, "fill_at did not run early")
+    fails = fails + ck(mem.get_byte(b, 48) == 0, "fill_at did not overrun")
+
+    // ---- compare_at: interior spans ------------------------------------
+    // a[8..12) was copied to b[20..24), so those spans are equal.
+    fails = fails + ck(mem.compare_at(a, 8, b, 20, 4) == 0, "compare_at equal spans")
+    fails = fails + ck(mem.compare_at(a, 0, b, 20, 4) != 0, "compare_at unequal spans")
+
+    // ---- move_at: the OVERLAPPING case that copy_at cannot do -----------
+    // Scroll a's first 32 bytes forward by 4 within a itself. Source and
+    // destination overlap, so this is memmove territory: every byte must
+    // survive, shifted. memcpy would be free to clobber as it went.
+    c = arena.alloc(ar, 64)
+    i = 0
+    while i < 64 { _ = mem.set_byte(c, i, i); i = i + 1 }
+    // HONEST LIMITATION: this pins the RESULT, not the mechanism. glibc's
+    // memcpy copies backwards for an overlapping forward move, so swapping
+    // move_at's memmove for a memcpy still passes here (verified by doing
+    // exactly that, with a cleared build cache). The assertions below are
+    // still worth having — they catch an off-by-one or a wrong span — but
+    // the memmove guarantee itself rests on the implementation calling
+    // __builtin_memmove, not on this test. A platform whose memcpy copies
+    // forwards would fail these, which is the point: the contract is what
+    // makes the code portable, and the test documents what the contract
+    // must deliver.
+    shift_n = mem.get_byte(c, 32)
+    _ = mem.move_at(c, 4, c, 0, shift_n)
+    // c[4..36) should now hold the old c[0..32) == 0..31
+    fails = fails + ck(mem.get_byte(c, 4) == 0, "move_at overlapping: first byte")
+    fails = fails + ck(mem.get_byte(c, 20) == 16, "move_at overlapping: middle byte")
+    fails = fails + ck(mem.get_byte(c, 35) == 31, "move_at overlapping: last byte")
+    // the bytes before the destination are untouched
+    fails = fails + ck(mem.get_byte(c, 0) == 0, "move_at left c[0] alone")
+
+    // ---- null contract: no-op, same as the offset-less twins ------------
+    // A null buffer must not trap; copy/move/fill return dst, compare 0.
+    fails = fails + ck(mem.copy_at(null, 0, a, 0, 4) == null, "copy_at null dst returns dst")
+    fails = fails + ck(mem.copy_at(b, 0, null, 0, 4) == b, "copy_at null src returns dst")
+    fails = fails + ck(mem.move_at(null, 0, a, 0, 4) == null, "move_at null dst")
+    fails = fails + ck(mem.fill_at(null, 0, 1, 4) == null, "fill_at null dst")
+    fails = fails + ck(mem.compare_at(null, 0, b, 0, 4) == 0, "compare_at null a is 0")
+    fails = fails + ck(mem.compare_at(a, 0, null, 0, 4) == 0, "compare_at null b is 0")
+
+    // ---- zero length is a no-op, not an error ---------------------------
+    before = mem.get_byte(b, 0)
+    _ = mem.copy_at(b, 0, a, 0, 0)
+    fails = fails + ck(mem.get_byte(b, 0) == before, "copy_at n=0 writes nothing")
+
+    // ---- offset 0 agrees with the offset-less form ----------------------
+    d = arena.alloc(ar, 64)
+    e = arena.alloc(ar, 64)
+    _ = mem.copy(d, a, 16)
+    _ = mem.copy_at(e, 0, a, 0, 16)
+    fails = fails + ck(mem.compare(d, e, 16) == 0, "copy_at at offset 0 == copy")
+
+    arena.destroy(ar)
+
+    if fails != 0 {
+        println("mem offset bulk: ${fails} failure(s)")
+        exit(1)
+    }
+    println("PASS: mem_offset_bulk — interior spans, overlap, and null contracts")
+}


### PR DESCRIPTION
Delivers **ask 2** of `asks/inline-mem-accessors-for-pixel-loops.md` (#1733). Ask 1 merged as #1734.

## The hole

`copy`, `move`, `compare` and `set` all start at byte 0 of each buffer (`std/mem/module.ae:318-321`). Aether has no pointer arithmetic, so there was **no way at all** to express a bulk operation on an interior span — copying one scanline out of a larger framebuffer meant going byte at a time, even though the operation is memcpy-shaped.

Adds `copy_at`, `move_at`, `fill_at`, `compare_at`, each taking explicit offsets into both buffers.

```aether
// copy src[8..12) into dst[20..24)
_ = mem.copy_at(dst, 20, src, 8, 4)
```

## Contracts match the offset-less twins exactly

A null buffer is a no-op returning `dst` (`0` for `compare_at`), and offsets are the caller's responsibility in the same way `n` already is. **No range checking is added** — none exists in the offset-less forms, and a bulk primitive that silently clamped would be worse than one that does what it is told.

`move_at` lands alongside `copy_at` rather than after it: an image scrolling within its own buffer is an **overlapping** interior copy, so a `copy_at`-only surface would leave the common case undefined.

## Why this is still worth landing

The downstream that asked for it has since reported that **ask 1 alone reached parity with C** on their real workloads, so this is no longer load-bearing for that port. Their own words: *"still a genuine API hole"*.

That is the case I would make for it — not performance. There is no spelling for an interior bulk operation in the language today, and that is a gap regardless of who is currently blocked by it.

## A test limitation I want to be explicit about

The overlap assertions pin the **result**, not the **mechanism**. glibc's `memcpy` copies backwards for an overlapping forward move, so swapping `move_at`'s `memmove` for a `memcpy` **still passes them** — I verified that directly, with a cleared build cache, after the first mutation test came back green and I did not believe it.

They remain worth having: they catch an off-by-one, a wrong span, or a transposed offset, and on a platform whose `memcpy` copies forwards they would fail. But the memmove guarantee rests on the implementation calling `__builtin_memmove`, not on this test proving it. The test comment says so, rather than implying coverage it does not have.

## Verification

- `make test` 394/0
- `tests/integration/mem_offset_bulk` covers interior copy/fill/compare, the overlapping move, both null arms of every function, `n = 0`, and that offset-0 agrees with the offset-less form
- `check-docs` clean, including a new runnable README example (52 run blocks, up from 51)
- `mem_inline_accessors` from #1734 still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
