### PR TITLE
fix(cflags): publish the Windows system libs that linking libaether requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **`ae cflags --libs` now publishes the Windows system libraries** that
+  linking `libaether` requires. It emitted none of them, so the documented
+  `gcc your.c $(ae cflags)` recipe failed on Windows with
+  `undefined reference to __imp_SymInitialize` and friends as soon as the
+  panic symboliser was pulled in — reproduced on a Windows box, then fixed
+  and re-verified there. `ae build` linked fine throughout because it carried
+  its own private copy of the list, and that asymmetry was the real bug:
+  `cflags` is the contract for what linking `libaether` needs on a box, so
+  `ae build`'s knowledge must not exceed it, or every downstream consumer
+  re-learns each delta as a platform-specific link break. Both now use one
+  shared `AETHER_WIN_SYSTEM_LIBS` definition. Non-Windows output is unchanged.
+
 ## [0.580.0]
 
 ### Added

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1616,6 +1616,35 @@ static void load_defines_from_toml(void) {
 // Returns empty string if not found or no aether.toml.
 // `${VAR}` occurrences are expanded against the process environment
 // (see expand_env_vars()).
+/* The Windows system libraries linking libaether requires (#347, and the
+ * cflags gap the aether-ui line reported on 2026-08-25).
+ *
+ * ONE definition, used by both `ae build`'s own link line and
+ * `ae cflags --libs`. They were separately maintained, and cflags carried
+ * none of them -- so `ae build` linked fine while any external consumer
+ * following the documented `gcc your.c $(ae cflags)` recipe got undefined
+ * __imp_Sym* the moment libaether's panic symboliser was pulled in.
+ *
+ * That asymmetry is the actual bug: cflags is the contract for "what does
+ * linking libaether require on this box", so `ae build`'s private knowledge
+ * must never exceed it. Keeping one string is what makes that true by
+ * construction rather than by remembering.
+ *
+ * Why each is here:
+ *   ws2_32   Winsock2 -- aether_http/net are always compiled into the runtime
+ *   crypt32 gdi32 user32 advapi32 bcrypt
+ *            pulled in by static libssl/libcrypto
+ *   dbghelp  SymInitialize/SymFromAddr, the panic stack-trace symboliser
+ *            (CaptureStackBackTrace is kernel32 and always linked; the
+ *            symbolisation half is not)
+ *
+ * Mirrors WIN_LINK_LIBS in the Makefile, minus -static, which is a link-mode
+ * choice rather than a library and belongs to whoever drives the link. */
+#if defined(_WIN32)
+#define AETHER_WIN_SYSTEM_LIBS \
+    "-lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp"
+#endif
+
 static const char* get_link_flags(void) {
     static char flags[1024] = "";
     static bool checked = false;
@@ -2414,10 +2443,9 @@ void build_gcc_cmd(char* cmd, size_t size,
     else
         snprintf(opt, sizeof(opt), "-static %s%s%s%s", opt_flags(optimize),
                  harden_cflags(optimize), harden_ldflags(), trace_def);
-    // -ldbghelp is required for the panic stack-trace path
-    // (CaptureStackBackTrace is in kernel32 / always-linked, but
-    // SymInitialize/SymFromAddr live in dbghelp). Issue #347.
-    const char* win_link_libs = "-lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp";
+    /* See AETHER_WIN_SYSTEM_LIBS: one list, shared with `ae cflags --libs`
+     * so the two cannot drift apart again. */
+    const char* win_link_libs = AETHER_WIN_SYSTEM_LIBS;
     char lib_dir[1024];
     if (tc.has_lib) {
         strncpy(lib_dir, tc.lib, sizeof(lib_dir) - 1);
@@ -7356,6 +7384,17 @@ static int cmd_cflags(int argc, char** argv) {
         if (wrote_anything) fputc(' ', stdout);
         fputs("-pthread -lm", stdout);
         wrote_anything = 1;
+
+        /* Windows system libraries. libaether references Winsock, the Crypto
+         * API and dbghelp's symboliser regardless of which std modules the
+         * consumer imports, so these are unconditional -- exactly as they are
+         * on `ae build`'s own link line, which uses this same macro. Omitting
+         * them made the documented `gcc your.c $(ae cflags)` recipe fail to
+         * link on Windows. */
+#if defined(_WIN32)
+        fputc(' ', stdout);
+        fputs(AETHER_WIN_SYSTEM_LIBS, stdout);
+#endif
 
         // Transitive deps. libaether.a was compiled with whatever optional
         // libraries pkg-config detected at Aether-build time (PCRE2 for


### PR DESCRIPTION
Closes the ask in `asks/cflags-libs-omits-dbghelp-on-windows.md` (aether-ui line).

## The bug

`ae cflags --libs` published **no Windows system libraries at all** — not just `-ldbghelp`. So the documented recipe

```
gcc your.c $(ae cflags) -o your
```

failed to link on Windows the moment libaether's panic symboliser was pulled in.

**Reproduced on winbaz** (Windows/MSYS2), linking a C consumer that references `aether_panic`:

```
undefined reference to `__imp_SymFromAddr'
undefined reference to `__imp_SymGetOptions'
undefined reference to `__imp_SymInitialize'
undefined reference to `__imp_SymSetOptions'
```

`SymInitialize`/`SymFromAddr` live in `dbghelp.dll`; `CaptureStackBackTrace` is kernel32 and always linked, so only the *symbolisation* half was missing — which is why this stayed hidden until a consumer actually reached the panic path.

## The real bug is the asymmetry

`ae build` linked fine throughout, because it carried **its own private copy** of the list at `ae.c:2420`. As the ask puts it: cflags is the contract for "what does linking libaether require on this box", so `ae build`'s private knowledge must never exceed it — or every downstream consumer re-learns each delta as a platform-specific link break. The aeb line hit it first; aether-ui carries `-ldbghelp` by hand as the workaround today.

Fixed by hoisting **one** `AETHER_WIN_SYSTEM_LIBS` definition that both the build link line and `cflags --libs` consume, so they cannot drift again. That is the part that makes this stay fixed.

The list mirrors the Makefile's `WIN_LINK_LIBS` minus `-static`, which is a link-mode choice rather than a library and belongs to whoever drives the link.

## Verified on Windows, before and after

Built on winbaz from this branch. **Before** (the pre-fix flag set) — the four undefined `__imp_Sym*` above. **After**:

```
$ ./build/ae.exe cflags --libs
-LC:\Users\paul\scm\aether/build -laether -pthread -lm -lws2_32 -lcrypt32
-lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp -lz

$ gcc /tmp/c4.c $(./build/ae.exe cflags) -o /tmp/c4.exe && /tmp/c4.exe
ok
```

That is the ask's own acceptance check (`ae cflags --libs | grep dbghelp` on a Windows box), plus the link it exists to enable.

Non-Windows is untouched — the block is `_WIN32`-guarded, and Linux `ae cflags --libs` is byte-identical before and after.

## Note

The ask asked me to "audit the rest of `WIN_LINK_LIBS`". Done: `ws2_32`, `crypt32`, `gdi32`, `user32`, `advapi32`, `bcrypt` were **all** absent too, not only `dbghelp`. All are now published, with a comment recording why each is needed — Winsock because `aether_http`/`net` are always compiled into the runtime, the Crypto/GDI set because static libssl/libcrypto pull them in, dbghelp for the symboliser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
