### PR TITLE
fix(typecheck): diagnose a bare trailing block passed to an `fn` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ version number before tagging the release.
   `proposed-aea-lib.md` proposed compiled `.aea` module artifacts. Proposals
   belong in the tracker, where they can be discussed and closed.
 
+### Fixed
+
+- **A bare trailing block passed where a closure is required now gets a real
+  diagnostic.** `f(x) { ... }` parses as a DSL block — it inlines at the call
+  site and is never hoisted — so when the callee's last parameter is `fn`
+  there is no closure value to pass. Codegen looked up closure id
+  `atoi("trailing") == 0`, found nothing registered, and emitted a reference
+  to a `_closure_fn_0` it never generated, leaving the user with
+  `error: '_closure_fn_0' undeclared` — a leaked internal symbol name on a
+  line they cannot act on. The typechecker now catches it and names the fix:
+  write `callback { ... }` (or `|params| { ... }`) so the block becomes a real
+  closure the function can hold and call later.
+
 ## [0.582.0]
 
 ### Changed

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -802,6 +802,29 @@ static int count_required_params(ASTNode* func) {
 // Returns 1 if the function's first parameter is _ctx: ptr. Such functions
 // can be called either with _ctx passed explicitly (got == expected) or with
 // _ctx auto-injected by the builder-DSL runtime (got == expected - 1).
+/* Does this function's LAST declared parameter have type `fn`?
+ *
+ * Such a function wants a real (hoisted, capturing) closure — `callback { }`
+ * or `|x| { }` — not a bare trailing block. A bare `{ }` parses as a DSL
+ * block, which inlines at the call site and is never hoisted, so codegen
+ * emits a reference to a `_closure_fn_N` it never generated and the C
+ * compiler fails with `'_closure_fn_0' undeclared`. Detecting it here turns
+ * that into a diagnostic that names the fix. */
+static int last_param_is_fn(ASTNode* func) {
+    if (!func || func->child_count < 2) return 0;
+    ASTNode* last_param = NULL;
+    for (int i = 0; i < func->child_count - 1; i++) {
+        ASTNode* child = func->children[i];
+        if (child && (child->type == AST_VARIABLE_DECLARATION ||
+                      child->type == AST_PATTERN_VARIABLE ||
+                      child->type == AST_PATTERN_LITERAL)) {
+            last_param = child;
+        }
+    }
+    return last_param && last_param->node_type &&
+           last_param->node_type->kind == TYPE_FUNCTION;
+}
+
 static int has_ctx_first_param(ASTNode* func) {
     if (!func || func->child_count == 0) return 0;
     for (int i = 0; i < func->child_count - 1; i++) {
@@ -7753,6 +7776,39 @@ int typecheck_function_call(ASTNode* call, SymbolTable* table) {
         int required = count_required_params(symbol->node);
         int ctx_first = has_ctx_first_param(symbol->node);
         int got = call->child_count;
+
+        /* A bare trailing block cannot stand in for an `fn` parameter.
+         *
+         * `f(x) { ... }` parses as a DSL block: it inlines at the call site
+         * and is never hoisted, so there is no closure VALUE to pass. When
+         * the callee's last parameter is `fn`, codegen then emits a
+         * reference to a `_closure_fn_N` it never generated and the C
+         * compiler fails with `'_closure_fn_0' undeclared` — a leaked
+         * internal symbol name, at a line the user cannot act on.
+         *
+         * Note this cannot live in the arity-mismatch branch below: the
+         * trailing block still occupies an argument slot, so `got` equals
+         * `expected` and that branch never runs. The signature is what
+         * distinguishes the two readings, not the count. */
+        if (last_param_is_fn(symbol->node)) {
+            for (int i = 0; i < call->child_count; i++) {
+                ASTNode* c = call->children[i];
+                if (c && c->type == AST_CLOSURE && c->value &&
+                    strcmp(c->value, "trailing") == 0) {
+                    char cb_msg[320];
+                    snprintf(cb_msg, sizeof(cb_msg),
+                             "'%s' takes a closure as its last parameter, but "
+                             "the trailing block here is a DSL block that runs "
+                             "inline. Write `callback { ... }` (or `|params| "
+                             "{ ... }`) so it becomes a real closure the "
+                             "function can hold and call later",
+                             call->value ? call->value : "function");
+                    type_error(cb_msg, call->line, call->column);
+                    return 0;
+                }
+            }
+        }
+
         // If mismatch, try excluding trailing closures (for functions that
         // don't accept fn params but have trailing blocks for DSL syntax)
         if (got != expected && !(ctx_first && got == expected - 1)) {


### PR DESCRIPTION
Came out of a lateral question about whether the `foo() callback { ... }` grammar is clunky. It isn't the grammar that's the problem — it's what happens when you get it wrong.

## Before

```aether
run_it(label: string, action: fn) { ... }

h = run_it("x") { println("later") }
```

```
error: '_closure_fn_0' undeclared (first use in this function)
```

A leaked internal symbol name, on a line the user cannot act on, from the C compiler rather than from Aether.

## After

```
error[E0200]: 'run_it' takes a closure as its last parameter, but the trailing
block here is a DSL block that runs inline. Write `callback { ... }` (or
`|params| { ... }`) so it becomes a real closure the function can hold and
call later
  --> cb3.ae:8:16
```

## Why it happened

A bare `f(x) { ... }` parses as a DSL block: it inlines at the call site and is never hoisted, so there is no closure *value* to pass. The AST node is an `AST_CLOSURE` valued `"trailing"`, and codegen does:

```c
int id = expr->value ? atoi(expr->value) : 0;   // atoi("trailing") == 0
```

It then looks up closure id 0, finds nothing registered (the node was never hoisted), and emits a reference to `_closure_fn_0` — which is why the error *always* named that exact symbol.

## One placement subtlety, recorded in the code

The check cannot live in the arity-mismatch branch, which is where it looks like it belongs. The trailing block still occupies an argument slot, so `got == expected` and that branch never runs — my first attempt sat there and never fired. The callee's **signature** is what distinguishes the two readings, not the argument count. There is a comment saying so, because the next person will reach for the same wrong spot.

## Verified against real usage, not just the repro

A false positive here would be expensive: there are **963** `) callback {` call sites across aether (256) and aether-ui (707), and 188 of them are `spec.it(...)` in the test framework itself.

- `make test`: **394 passed, 0 failed**
- Full `.ae` sweep: **995 passed**, only the two known pre-existing failures (h2 framing, msvcrt-on-Linux)
- `callback { }` and `|x| { }` both still work
- DSL blocks on non-`fn` functions still inline correctly (verified the immediate-vs-deferred timing directly: `frame(...) { }` runs now, `store(...) callback { }` runs later)
- `spec_format_reporting` passes

## What this does not do

It does not change the grammar. `callback` stays. The keyword is eight characters that name a real semantic fork — the same syntax means "run now" or "run later" depending on the callee — and it names it at the call site, where the reader is, rather than requiring them to know the signature. A terser sigil would be shorter but arbitrary; this PR just makes the failure mode legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
