### PR TITLE
test(message): the regression test std.message shipped without (#1745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.message` now has a regression test** (#1745). The ICU MessageFormat
+  module shipped with none, so its behaviour was unpinned and its recorded
+  leak figures were not reproducible — every measurement on the issue was
+  taken against a file that did not exist in the tree. The new
+  `tests/regression/test_message.ae` covers all eight exports: interpolation,
+  plural `one`/`other`, `select` including the `other` fall-through,
+  parse/format_pattern/pattern_free (including reuse of one parsed pattern),
+  malformed-pattern error reporting, and the catalogue including the
+  missing-id and null-catalogue paths. Measured against it on a clean build,
+  the module leaks nothing: 448 allocs, 448 frees, 0 bytes in use at exit.
+
 ## [0.583.0]
 
 ### Changed

--- a/tests/regression/test_message.ae
+++ b/tests/regression/test_message.ae
@@ -1,0 +1,119 @@
+// Regression test for std.message (#1745).
+//
+// The module shipped in d32769fb with no test in the tree, so its behaviour
+// was unpinned and its leak status unmeasurable — every figure in the issue
+// was taken against a file that did not exist. This covers all eight exports
+// and is the harness the leak work is measured through.
+//
+// `message` is a reserved word, so the import needs the backtick form; `(*)`
+// makes the exports bare because a namespaced spelling would be blocked by
+// the reserved word.
+
+import std.`message`(*)
+import std.map(*)
+import std.string
+
+extern exit(code: int)
+
+ck(got: string, want: string, label: string) -> int {
+    if string.compare(got, want) != 0 {
+        println("  FAIL: ${label}")
+        println("        got:  [${got}]")
+        println("        want: [${want}]")
+        return 1
+    }
+    return 0
+}
+
+main() {
+    f = 0
+
+    // ---- plain interpolation ------------------------------------------
+    args = map_new()
+    map_put_raw(args, "name", "Ada")
+    map_put_raw(args, "count", "3")
+    f = f + ck(format("en", "Hello {name}, you have {count} messages.", args),
+        "Hello Ada, you have 3 messages.", "simple interpolation")
+
+    // A literal with no placeholders passes through untouched.
+    f = f + ck(format("en", "no placeholders here", args),
+        "no placeholders here", "literal passthrough")
+
+    // An unknown placeholder substitutes empty — pinning the module's actual
+    // contract (format_nodes seeds `val = ""` and only overwrites it when
+    // map_has succeeds), not the passthrough a reader might assume.
+    f = f + ck(format("en", "{nope}", args), "", "unknown placeholder -> empty")
+
+    // ---- plural ---------------------------------------------------------
+    // The `one`/`other` split is the whole point of the plural form.
+    one = map_new()
+    map_put_raw(one, "n", "1")
+    f = f + ck(format("en", "{n, plural, one {# item} other {# items}}", one),
+        "1 item", "plural one")
+    map_free(one)
+
+    many = map_new()
+    map_put_raw(many, "n", "5")
+    f = f + ck(format("en", "{n, plural, one {# item} other {# items}}", many),
+        "5 items", "plural other")
+    map_free(many)
+
+    // ---- select ---------------------------------------------------------
+    she = map_new()
+    map_put_raw(she, "g", "female")
+    f = f + ck(format("en", "{g, select, male {he} female {she} other {they}}", she),
+        "she", "select matches a branch")
+    map_free(she)
+
+    other = map_new()
+    map_put_raw(other, "g", "nonbinary")
+    f = f + ck(format("en", "{g, select, male {he} female {she} other {they}}", other),
+        "they", "select falls through to other")
+    map_free(other)
+
+    // ---- parse / format_pattern / pattern_free --------------------------
+    // The parse-once-format-many path, which is why parse is exported.
+    pat, perr = parse("Hi {name}!")
+    if perr != "" {
+        println("  FAIL: parse returned error [${perr}]")
+        f = f + 1
+    } else {
+        f = f + ck(format_pattern("en", pat, args), "Hi Ada!", "format_pattern")
+        // Same pattern, second use — proves the pattern survives formatting.
+        f = f + ck(format_pattern("en", pat, args), "Hi Ada!", "format_pattern reuse")
+    }
+    pattern_free(pat)
+
+    // A malformed pattern must report an error rather than crash.
+    bad, berr = parse("{unclosed")
+    if berr == "" {
+        println("  FAIL: malformed pattern parsed without error")
+        f = f + 1
+    }
+    pattern_free(bad)
+
+    // ---- catalog --------------------------------------------------------
+    cat = catalog_new("en")
+    catalog_add(cat, "greeting", "Hello {name}!")
+    catalog_add(cat, "farewell", "Bye {name}.")
+    f = f + ck(catalog_format(cat, "greeting", args), "Hello Ada!", "catalog hit")
+    f = f + ck(catalog_format(cat, "farewell", args), "Bye Ada.", "catalog second id")
+
+    // A missing id yields the diagnostic form rather than empty or a crash.
+    // This is also the path that exercises the nested-concat in catalog_format.
+    f = f + ck(catalog_format(cat, "absent", args), "[missing: absent]",
+        "catalog missing id")
+    catalog_free(cat)
+
+    // A null catalogue takes the same missing-id path.
+    f = f + ck(catalog_format(null, "anything", args), "[missing: anything]",
+        "null catalog")
+
+    map_free(args)
+
+    if f != 0 {
+        println("${f} failure(s)")
+        exit(1)
+    }
+    println("All PASS")
+}


### PR DESCRIPTION
Closes #1745 — with a finding that changes what the issue asks for.

## The test now exists

`tests/regression/test_message.ae` covers all eight exports: interpolation, plural `one`/`other`, `select` including the `other` fall-through, parse/`format_pattern`/`pattern_free` with one pattern formatted twice, malformed-pattern error reporting, and the catalogue including the **missing-id** and **null-catalogue** branches — the two paths that exercise the nested `string_concat` the issue flags as Task 4.

One assertion worth noting: an unknown placeholder substitutes **empty**, not the passthrough I first assumed. `format_nodes` seeds `val = ""` and only overwrites it when `map_has` succeeds. The test pins the module's actual contract rather than my guess about it.

## The leaks do not reproduce

Measured with the issue's own recipe, clean build:

```
All PASS
total heap usage: 448 allocs, 448 frees, 17,055 bytes allocated
in use at exit: 0 bytes in 0 blocks
ERROR SUMMARY: 0 errors from 0 contexts
```

Against a stated baseline of **677 bytes definitely lost in 57 blocks**.

My first thought was that my test simply misses the leaking paths, so I wrote a 200-iteration stress over exactly the ones named — the plural/select formatter loop, the `parse` `err=""` success return, `catalog_format`'s missing-id concat:

```
total heap usage: 50,801 allocs, 50,801 frees, 1,397,896 bytes allocated
All heap blocks were freed -- no leaks are possible
```

At 677 bytes a run, that would have shown roughly 135KB lost. It shows nothing.

## What I could not determine

`std/message/module.ae` is **unchanged** by this PR and has exactly one commit in its entire history (`d32769fb`). So the leaks were not fixed in the module. Either later work in the string/heap layer reclaims them, or the original measurement was against different code.

I could not establish which, and I have not claimed to. What I can say is that the leaks are not present at 0.584.0, and there is now a test that will catch them if they return.

## The traps are still accurate and worth keeping

I verified the two that are checkable, because they are the load-bearing ones and they are not message-specific:

- **`string_free` IS `string_release`** — a literal alias at `std/string/aether_string.c:52`. Swapping one for the other changes nothing.
- **`strbuilder.finish` returns a plain libc `char*`**, not a refcounted AetherString (`aether_strbuilder.c:231` — "Hand the data buffer off to the caller as a plain libc-freeable char*"). `string_release` on one is a silent no-op.

Those explain why the three "obvious" one-liner fixes in the issue each made things worse, and they are worth preserving regardless of the current leak count.

## Suggested disposition

The issue asked for two things: a regression test, and verification of the leak status. Both are now done — the test exists, and the answer to "are they fixed" is "they are not present, cause unestablished".

If the reporter can still reproduce 677 bytes, the version and build recipe would be the useful thing to add, since this PR's harness is now the shared measurement point.

## Verification

- `make test`: **394 passed, 0 failed**
- `ae fmt` clean and idempotent on both files
- `std/message/module.ae` untouched — `git diff` on it is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
