### PR TITLE
bench(lbbench): name the call that asked to sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ version number before tagging the release.
 - **Pooled upstream connections are used, not probed first.** Reusing one
   polled the socket beforehand to catch a peer that had closed during the idle
   window: one syscall on every request through the pool. The read path already
-  handled that case, and handles it better — nothing coming back on a pooled
+  handled that case, and handles it better, because nothing coming back on a pooled
   connection means the request went into the void, so it redials and resends.
   The poll only moved the discovery earlier, at the cost of asking the kernel
   every time.
@@ -29,9 +29,17 @@ version number before tagging the release.
   again on a fresh one.
 
   Counted with `strace` over ~55,000 proxied requests: **5.19 syscalls per
-  request to 4.21**, with `ppoll` falling from 1.06 to 0.06 — the remainder
+  request to 4.21**, with `ppoll` falling from 1.06 to 0.06, the remainder
   being the paths that still poll, TLS and a saturated worker pool. For scale,
   the same measurement puts nginx at about 5.
+
+### Added
+
+- **A benchmark instrument that names which call put a worker to sleep.**
+  `benchmarks/http/lbbench/switches.sh` records the scheduler tracepoint with
+  stacks, keeps only sleeps the code asked for, and attributes each to the
+  innermost frame in our own binary. Counting context switches said how many;
+  this says which calls, which is what a fix has to target.
 
 ## [0.586.0]
 

--- a/benchmarks/http/lbbench/Dockerfile
+++ b/benchmarks/http/lbbench/Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /bench
-COPY run.sh profile.sh syscalls.sh workers.sh use_mounted.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
+COPY run.sh profile.sh syscalls.sh workers.sh switches.sh use_mounted.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
 RUN chmod +x run.sh profile.sh syscalls.sh workers.sh
 ENTRYPOINT ["/bench/run.sh"]

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -61,6 +61,7 @@ baseline were never touched by it.
 | `run.sh` | rps and CPU per request, with controls | judging a result |
 | `profile.sh` | where the balancer's CPU goes | choosing what to change |
 | `syscalls.sh` | syscalls per request, exactly | checking a syscall change |
+| `switches.sh` | which call asked to sleep, by name | chasing context switches |
 
 Throughput can be unresolvable on a shared or virtualised box: a run here has
 had its controls move 198% between rounds. Syscall counts do not care: they
@@ -75,6 +76,14 @@ per-request allocations of request parsing with a bump arena moved throughput
 by −0.9% and CPU per request by +3.4%: no benefit. `profile.sh` says the same
 thing from the other side: `malloc` is 1.29% of self time, while syscall
 entry is 67%. The arena was written, measured and dropped. See #1739.
+
+**The sleeps are voluntary, and two of them per request.** `switches.sh`
+attributes them: `transport_recv` 0.91 per request and `conn_serve` 0.65,
+against 0.06 for the whole parking lot and 0.05 involuntary. Both sleepers
+have one cause, a worker owning a single connection with nothing else to run.
+Two cheaper fixes were measured and dropped: shrinking the worker pool (there
+is no involuntary cost to recover) and removing the park grace poll (worse by
+0.57 switches and about 30% CPU per request, every round). See #1758.
 
 **Syscalls are where the cost is.** Baseline measured 10.07 per proxied
 request, against the ~5 that #1719 measured for nginx. Removing the poll that

--- a/benchmarks/http/lbbench/switches.sh
+++ b/benchmarks/http/lbbench/switches.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Which calls put a worker to sleep, by name?
+#
+# run.sh counts context switches and splits voluntary from involuntary, which
+# says how many and of what kind but not where. This records the scheduler
+# tracepoint with stacks, so each sleep is attributed to the call that asked
+# for it. #1758 turns on removing two voluntary sleeps per request, and this
+# is what says which two they are rather than which two look likely.
+#
+# Voluntary only: a task leaving the CPU in state S (interruptible sleep) went
+# to sleep because the code asked. A task leaving in state R was preempted and
+# says nothing about the code.
+set -uo pipefail
+
+. /bench/use_mounted.sh
+lbbench_use_mounted switches.sh "$@"
+
+DURATION="${DURATION:-10}"
+CONNECTIONS="${CONNECTIONS:-50}"
+THREADS="${THREADS:-2}"
+GEN_CPUS="${GEN_CPUS:-0,1}"
+LB_CPUS="${LB_CPUS:-2,3}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+PERF=$(ls /usr/lib/linux-tools-*/perf 2>/dev/null | head -1)
+[ -n "$PERF" ] || PERF=$(command -v perf)
+[ -n "$PERF" ] || die "perf not installed in the image"
+
+sysctl -w kernel.perf_event_paranoid=-1 >/dev/null 2>&1 \
+    && say "perf_event_paranoid set to -1" \
+    || say "could not lower perf_event_paranoid (now $(cat /proc/sys/kernel/perf_event_paranoid)); tracepoints may be unavailable"
+
+"$PERF" list sched:sched_switch 2>/dev/null | grep -q sched_switch \
+    || die "sched:sched_switch tracepoint unavailable; needs a privileged container"
+
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+done
+
+say "building aether ..."
+cp -r /src /build && cd /build && rm -rf build
+make -j"$(nproc)" >/tmp/build.log 2>&1 || { tail -20 /tmp/build.log >&2; die "build failed"; }
+./build/ae build benchmarks/http/lb_reuse_lb.ae -o /tmp/ae-lb >/tmp/lbbuild.log 2>&1 \
+    || { tail -20 /tmp/lbbuild.log >&2; die "lb build failed"; }
+
+BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+    taskset -c "$LB_CPUS" /tmp/ae-lb >/tmp/ae-lb.log 2>&1 &
+LB=$!
+for _ in $(seq 1 40); do
+    body=$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null) && case "$body" in backend-*) break ;; esac
+    sleep 0.25
+done
+curl -sf -m 5 http://127.0.0.1:18200/ >/dev/null || die "balancer is not proxying"
+
+taskset -c "$GEN_CPUS" wrk -t"$THREADS" -c"$CONNECTIONS" -d5s http://127.0.0.1:18200/ >/dev/null 2>&1
+
+say "recording sleeps for ${DURATION}s under load ..."
+taskset -c "$GEN_CPUS" wrk -t"$THREADS" -c"$CONNECTIONS" -d"${DURATION}s" \
+    http://127.0.0.1:18200/ >/tmp/wrk.out 2>&1 &
+WRK=$!
+"$PERF" record -e sched:sched_switch -g --pid "$LB" -o /tmp/sw.data \
+    -- sleep "$DURATION" >/dev/null 2>&1
+wait "$WRK" 2>/dev/null
+REQS=$(awk '/requests in/ {print $1; exit}' /tmp/wrk.out)
+kill "$LB" 2>/dev/null
+
+[ -s /tmp/sw.data ] || die "no samples recorded"
+say ""
+say "requests during the recording: ${REQS:-?}"
+
+# One line per sample: the previous task's state, then its stack, innermost
+# first. prev_state S is a voluntary sleep; R is preemption.
+"$PERF" script -i /tmp/sw.data --no-inline 2>/dev/null > /tmp/sw.txt
+
+awk -v reqs="${REQS:-0}" '
+    # perf script prints one record per switch: a header line carrying
+    # prev_state, then the stack, innermost frame first, each frame as
+    # "<addr> <symbol>+<off> (<module>)".
+    /prev_state=/ {
+        state = "?"
+        if (match($0, /prev_state=[A-Z]+/))
+            state = substr($0, RSTART + 11, RLENGTH - 11)
+        collecting = (state == "S")
+        wait = ""; ours = ""; next
+    }
+    collecting && /^\t/ {
+        sym = $2
+        sub(/\+0x[0-9a-f]+$/, "", sym)
+        mod = $NF
+        # The kernel function that asked to sleep, skipping the scheduler
+        # plumbing every sleep goes through.
+        if (wait == "" && sym !~ /^(schedule|__schedule|schedule_timeout|io_schedule)/ \
+            && sym !~ /^(0x|\[unknown\])/ && sym != "")
+            wait = sym
+        # The innermost frame that is our own code, which is the call site
+        # worth changing. Kernel frames name the mechanism, not the caller.
+        if (ours == "" && mod ~ /ae-lb/ && sym !~ /^(0x|\[unknown\])/ && sym != "")
+            ours = sym
+        next
+    }
+    /^$/ {
+        if (collecting && wait != "") {
+            site[wait "\t" (ours == "" ? "(no frame in ae-lb)" : ours)]++
+            total++
+        }
+        collecting = 0
+    }
+    END {
+        if (total == 0) { print "  no voluntary sleeps recorded"; exit }
+        printf "\n== voluntary sleeps, by kernel wait site and our call, top 15 ==\n"
+        printf "  %-24s %-28s %8s %8s\n", "sleeps in", "asked for by", "count", "per req"
+        n = 0
+        for (s in site) { k[n] = s; n++ }
+        for (i = 0; i < n; i++)
+            for (j = i + 1; j < n; j++)
+                if (site[k[j]] > site[k[i]]) { t = k[i]; k[i] = k[j]; k[j] = t }
+        for (i = 0; i < n && i < 15; i++) {
+            split(k[i], f, "\t")
+            printf "  %-24s %-28s %8d %8.2f\n", f[1], f[2], site[k[i]], \
+                   (reqs > 0 ? site[k[i]] / reqs : 0)
+        }
+        printf "  %-24s %-28s %8d %8.2f\n", "TOTAL", "", total, (reqs > 0 ? total / reqs : 0)
+    }' /tmp/sw.txt >&2


### PR DESCRIPTION
Counting context switches said how many, and splitting voluntary from
involuntary said of what kind. Neither says which calls, and my guesses about
that were wrong twice, so this builds the instrument that answers it.

`switches.sh` records `sched:sched_switch` with stacks, keeps only the records
whose previous state is S so what it counts is sleeps the code asked for and
not preemption, and attributes each one to the innermost frame in our own
binary. The kernel frame names the mechanism; the frame in `ae-lb` names the
call worth changing.

Over 156,878 proxied requests:

| sleeps in | asked for by | per req |
|---|---|---:|
| `wait_woken` | `transport_recv` | 0.91 |
| `do_sys_poll` | `conn_serve` | 0.65 |
| `futex_wait_queue` | `http_pool_worker` | 0.30 |
| `do_epoll_wait` | `aether_io_poller_poll` | 0.05 |
| `futex_wait_queue` | `http_park_add` | 0.01 |
| | **total** | **1.96** |

**It killed the hypothesis it was built to test.** The cost looked like it had
to be the parking lot, which hands a connection to a poller thread and back to
a worker on every cycle. The whole lot is **0.06 per request**. I would have
redesigned it for nothing.

The real second sleeper is the park grace poll in
`conn_next_request_imminent`, which misses often because it looks for the next
request immediately after writing the response, before a client on a loopback
round trip could have sent one.

**Removing that poll is worse, measured.** Four rounds, order alternated,
against the committed tree:

| | ctxsw/req | CPU/req |
|---|---:|---:|
| grace 2ms | 1.94, 1.96, 1.96, 1.97 | 34.8 to 36.9 us |
| grace 0 | 2.51, 2.53, 2.53, 2.59 | 46.5 to 47.5 us |

+0.57 switches and about 30% more CPU per request, every round. Parking
immediately trades one poll sleep for the pool handoff that follows it. The
tuning stays. Throughput moved the same way but the controls moved 107% in
that run, so I am not quoting it as evidence.

Both negative results are written into the harness README so the next person
does not spend the runs again.

No production code changes here: one new script, one line in the Dockerfile,
and the README.

Refs #1758