### PR TITLE
bench(lbbench): measure work per request in instructions

### DIFF
--- a/benchmarks/http/lbbench/Dockerfile
+++ b/benchmarks/http/lbbench/Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /bench
-COPY run.sh profile.sh syscalls.sh workers.sh switches.sh use_mounted.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
+COPY run.sh profile.sh syscalls.sh workers.sh switches.sh instructions.sh use_mounted.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
 RUN chmod +x run.sh profile.sh syscalls.sh workers.sh
 ENTRYPOINT ["/bench/run.sh"]

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -28,9 +28,21 @@ another number from the same run.
 | `profile.sh` | where the balancer's CPU goes | choosing what to change |
 | `syscalls.sh` | syscalls per request, exactly | checking a syscall change |
 | `switches.sh` | which call asked to sleep, by name | chasing context switches |
+| `instructions.sh` | work done per request, in instructions | pricing a change in userspace work |
 
-`profile.sh` and `switches.sh` need `perf`, and `switches.sh` needs a
-privileged container for the scheduler tracepoint.
+`profile.sh`, `switches.sh` and `instructions.sh` need `perf`; `switches.sh`
+needs a privileged container for the scheduler tracepoint, and
+`instructions.sh` needs a hardware performance counter, which a virtual
+machine usually does not expose. It says so and stops rather than reporting a
+count it could not take.
+
+Reach for `instructions.sh` when the question is whether a change made the
+code do more work, rather than how fast it ran: CPU per request moves with
+everything else on the box, and on a loaded machine its medians have
+disagreed by more than 20% between two builds whose least-contended rounds
+differed by 1.5%. Instructions say nothing about stalls or time spent asleep,
+which is where most of this path's cost is, so it prices a change but does not
+judge a result.
 
 ## What `run.sh` reports
 

--- a/benchmarks/http/lbbench/instructions.sh
+++ b/benchmarks/http/lbbench/instructions.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# How much work does the balancer do per request, in instructions?
+#
+# run.sh measures CPU microseconds, which is the right thing to judge a result
+# but moves with everything else on the box: on a loaded machine its medians
+# have disagreed with each other by 20% between two builds that turned out to
+# differ by 1%. An instruction count is very nearly independent of what else is
+# running, so it answers a narrower question exactly: did this change make the
+# code do more work per request?
+#
+# It cannot replace run.sh. Instructions say nothing about stalls, cache
+# misses, or time spent asleep, which is where most of this path's cost is. Use
+# it to price a change in userspace work, and run.sh to judge the result.
+set -uo pipefail
+
+. /bench/use_mounted.sh
+lbbench_use_mounted instructions.sh "$@"
+
+DURATION="${DURATION:-10}"
+CONNECTIONS="${CONNECTIONS:-8}"
+GEN_CPUS="${GEN_CPUS:-0,1}"
+LB_CPUS="${LB_CPUS:-2,3}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+PERF=$(ls /usr/lib/linux-tools-*/perf 2>/dev/null | head -1)
+[ -n "$PERF" ] || PERF=$(command -v perf)
+[ -n "$PERF" ] || die "perf not installed in the image"
+
+sysctl -w kernel.perf_event_paranoid=1 >/dev/null 2>&1 || true
+
+# perf exits 0 whether or not the counter exists, printing "<not supported>"
+# where the number would be. A virtual machine usually has no performance
+# monitoring unit to expose, which is the common case for this image, so the
+# probe has to read the output rather than trust the exit status.
+probe=$("$PERF" stat -e instructions -x, true 2>&1)
+case "$probe" in
+    *not\ supported*|*not\ counted*|*"<"*)
+        die "this machine does not expose an instruction counter (no PMU, which is usual inside a VM); use run.sh and profile.sh here" ;;
+esac
+case "$probe" in
+    [0-9]*) ;;
+    *) die "could not read an instruction count from perf: $probe" ;;
+esac
+
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+done
+
+build_lb() {                      # build_lb <srcdir> <out>
+    ( cd "$1" && rm -rf build && make -j"$(nproc)" >/tmp/b.log 2>&1 \
+      && ./build/ae build benchmarks/http/lb_reuse_lb.ae -o "$2" >>/tmp/b.log 2>&1 ) \
+      || { tail -20 /tmp/b.log >&2; die "build failed for $1"; }
+}
+
+say "building ..."
+cp -r /src /build && build_lb /build /tmp/ae-lb
+AB_REF="${AB_REF:-}"
+if [ -n "$AB_REF" ]; then
+    git clone -q /src /baseline || die "cannot clone /src"
+    ( cd /baseline && git checkout -q "$AB_REF" ) || die "no such ref: $AB_REF"
+    build_lb /baseline /tmp/ae-lb-base
+fi
+
+measure_for() {                   # measure_for <binary> <label>
+    local bin="$1" label="$2" out reqs insns
+    pkill -f '/tmp/ae-lb' >/dev/null 2>&1; sleep 1
+    BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+        taskset -c "$LB_CPUS" "$bin" >/tmp/lb-"$label".log 2>&1 &
+    local pid=$!
+    for _ in $(seq 1 60); do
+        out=$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null) && case "$out" in backend-*) break ;; esac
+        sleep 0.5
+    done
+    case "$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null)" in
+        backend-*) ;; *) die "$label is not proxying" ;;
+    esac
+
+    # Warm first, so start-up work is not counted against the requests below.
+    taskset -c "$GEN_CPUS" wrk -t2 -c"$CONNECTIONS" -d3s http://127.0.0.1:18200/ >/dev/null 2>&1
+
+    # Count only while the load runs, and count the whole process tree.
+    taskset -c "$GEN_CPUS" wrk -t2 -c"$CONNECTIONS" -d"${DURATION}s" \
+        http://127.0.0.1:18200/ >/tmp/wrk-"$label".out 2>&1 &
+    local wrk_pid=$!
+    "$PERF" stat -e instructions -p "$pid" -o /tmp/perf-"$label".txt \
+        -- sleep "$DURATION" >/dev/null 2>&1
+    wait "$wrk_pid" 2>/dev/null
+
+    reqs=$(awk '/requests in/ {print $1; exit}' /tmp/wrk-"$label".out)
+    insns=$(awk '/instructions/ && $1 ~ /^[0-9,]+$/ {gsub(/,/, "", $1); print $1; exit}' \
+                /tmp/perf-"$label".txt)
+    kill "$pid" 2>/dev/null
+
+    # A count that could not be read is reported as unmeasured, never as 0:
+    # zero instructions per request is not a fast balancer, it is a missing
+    # counter, and printing it as a number invites a comparison against one.
+    if [ -z "${reqs:-}" ] || [ -z "${insns:-}" ] \
+       || [ "${reqs:-0}" -le 0 ] 2>/dev/null || [ "${insns:-0}" -le 0 ] 2>/dev/null; then
+        say "  $label: UNMEASURED (requests=${reqs:-?}, instruction count=${insns:-none})"
+        say "           perf said: $(grep -m1 instructions /tmp/perf-"$label".txt | sed 's/^ *//')"
+        return
+    fi
+    awk -v l="$label" -v i="$insns" -v r="$reqs" \
+        'BEGIN { printf "  %-10s %14.0f instructions/req  (%s requests)\n", l, i / r, r }' >&2
+}
+
+say ""
+say "== instructions per proxied request =="
+measure_for /tmp/ae-lb current
+[ -n "$AB_REF" ] && measure_for /tmp/ae-lb-base baseline
+pkill -f '/tmp/ae-lb' >/dev/null 2>&1


### PR DESCRIPTION
A narrow instrument for a question the existing ones answer badly: did a
change make the code do more work per request?

`run.sh` measures CPU per request, which is right for judging a result and
moves with everything else on the box. Asked whether the recent HTTP fixes
cost anything, it said +22% on one run and +27% on another, while the
least-contended round of each said +1.5%. That is not an answer.

An instruction count barely moves with load, so it prices the change
directly. It prices nothing else, and the script says so: instructions ignore
stalls, cache misses and time spent asleep, and asleep is where most of this
path's cost is. Use it for work, `run.sh` for result.

**It does not run on the usual image.** It needs a hardware performance
counter and this container is in a VM, which has none. Worth being explicit
about how that showed up: the first version printed `0 instructions/req`, which
is the same fault this harness was already fixed for once, a number nobody
could take printed as though it were a measurement. Zero instructions per
request is not a fast balancer, it is a missing counter. It now reads what
perf actually said and stops with the reason.

So the question that prompted it is answered by `profile.sh` for now, which
puts none of the recent validation work above its 0.3% self-time threshold.
The instrument is here for a machine with a real PMU.