### PR TITLE
ci(changelog): catch a branch rewriting an already-released section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,58 @@ jobs:
             exit 1
           fi
           echo "The entry is under '## [current]'."
+
+          # Second half of the same failure. The check above catches a merge
+          # that left NO '[current]' behind; this catches the one that folded
+          # this branch's entry into an ALREADY-RELEASED section while leaving
+          # a '[current]' in place. That version is silent -- git auto-merges
+          # it without a conflict and nothing in the output hints at it -- so
+          # the corruption ships and cannot be repaired later without
+          # rewriting a tag.
+          #
+          # Compared against origin/main rather than the git tags. Editing a
+          # released section AFTER its tag is legitimate and routine here (3
+          # of the last 8 releases have such edits, e.g. 9b6c5580 recording
+          # shipped work against 0.584.0), so "differs from the tag" would red
+          # a third of all PRs and be switched off. The real invariant is
+          # narrower and is exactly the fold: THIS branch must not change a
+          # section that main already released.
+          #
+          # Whitespace is normalised so a merge that only reflowed spacing
+          # does not read as a fold. cksum rather than cmp: MSYS2 ships no
+          # diffutils, and `cmp -s` exits non-zero both when files differ AND
+          # when cmp is missing, reporting a false failure instead of a
+          # missing tool.
+          git fetch --quiet origin main || true
+          norm() { sed -e 's/[[:space:]]*$//' | cat -s; }
+          folded=""
+          for v in $(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md \
+                       | tr -d '#[] ' | head -8); do
+            a=$(git show "origin/main:CHANGELOG.md" 2>/dev/null \
+                  | sed -n "/^## \[$v\]/,/^## \[0/p" | sed '$d' | norm)
+            [ -z "$a" ] && continue
+            b=$(sed -n "/^## \[$v\]/,/^## \[0/p" CHANGELOG.md | sed '$d' | norm)
+            if [ "$(printf '%s' "$a" | cksum)" != "$(printf '%s' "$b" | cksum)" ]; then
+              folded="$folded $v"
+            fi
+          done
+          if [ -n "$folded" ]; then
+            echo "::error::This PR rewrites already-released CHANGELOG section(s):$folded"
+            echo ""
+            echo "A release was almost certainly cut while this branch was open."
+            echo "The release job renames '## [current]' into the version"
+            echo "heading, so merging main folds this branch's entry INTO that"
+            echo "released section -- usually with no git conflict, which is why"
+            echo "nothing flagged it."
+            echo ""
+            echo "Move the entry back under a fresh '## [current]' and restore"
+            echo "the released section as main has it:"
+            for v in $folded; do
+              echo "  git show origin/main:CHANGELOG.md   # section [$v]"
+            done
+            exit 1
+          fi
+          echo "Released sections match main."
           exit 0
         fi
 


### PR DESCRIPTION
Closes #1695.

The existing "CHANGELOG entry present" gate catches the release-fold only when the merge leaves **no `## [current]`** behind. The other half is silent, and it is the damaging one.

## The failure it catches

When a release is cut while a branch is open, `main`'s `## [current]` becomes `## [0.N.0]`. Merging `main` then folds the branch's entry **into that just-released section** — and leaves a `[current]` in place, so the existing check is satisfied. Git auto-merges without a conflict; nothing in the output hints at it.

The corruption then ships, and cannot be repaired afterwards without rewriting a tag.

This happened **twice in the last two days** — 0.589.0 and 0.590.0 — both caught only by comparing sections by hand.

## Where #1695's own proposal was wrong

The issue (which I wrote) recommends comparing each released section **against its git tag**, and claims "on main today: 8 tags, 0 differ".

**That is no longer true, and the check would be unusable.** Measured across the last 8 releases:

| Release | Differing lines vs tag |
| --- | --- |
| 0.587.0 | 12 |
| 0.584.0 | 55 |
| 0.583.0 | 19 |
| (other 5) | 0 |

Editing a released section after its tag is **legitimate and routine** here — `9b6c5580` is an explicit instance, recording shipped work against 0.584.0 after it was tagged. A "differs from its tag" gate would red roughly a third of all PRs and be switched off within a week.

So this compares against **`origin/main`** instead. The real invariant is narrower and is exactly the fold: *this branch must not change a section main already released.*

## Verified against four cases

Not reasoned about — the step's shell was extracted **as YAML parses it** and run:

| Case | Expected | Result |
| --- | --- | --- |
| A correct branch | pass | ✅ |
| Pristine `main` | pass | ✅ |
| Simulated fold into 0.590.0 | fail | ✅ names `0.590.0` |
| Historical corruption at `2d0ba9fd` | fail | ✅ names `0.564.0` |

That last case is the one the issue cites as having shipped a factually wrong claim into a tagged release.

## Two details that would otherwise bite

- **Whitespace is normalised.** `main` and its own `v0.589.0` tag already differ by one blank line; that is not a fold.
- **`cksum`, not `cmp`.** MSYS2 ships no diffutils, and `cmp -s` exits non-zero both when files differ *and* when `cmp` is missing — reporting a false failure instead of a missing tool.

Workflow-only change, so the gate's own code-change rule exempts it from needing an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)