### PR TITLE
fix(release): put the provisioned zig on PATH for the sysroot check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -791,6 +791,16 @@ jobs:
         # check uses the host copy set aside before the cross-build. No
         # fallback to build/ae: silently checking with a binary that cannot
         # run would report success without testing anything.
+        # `ae` locates zig by running `zig version`, so the provisioned one
+        # has to be ON PATH here. The build steps above never needed that --
+        # they pass ZIG=<path> to make -- which is why this only showed when
+        # the verification step invoked ae directly, and it failed the
+        # 0.601.0 release rather than shipping an unverified sysroot.
+        ZIG_BIN="${{ steps.prov.outputs.zig }}"
+        PATH="$(dirname "$ZIG_BIN"):$PATH"
+        export PATH
+        zig version || { echo "::error::provisioned zig is not runnable at $ZIG_BIN"; exit 1; }
+
         HOST_AE="$PWD/host-toolchain/ae"
         [ -x "$HOST_AE" ] || { echo "::error::host ae missing; cannot verify the sysroot"; exit 1; }
         file "$HOST_AE" | grep -q 'FreeBSD' \


### PR DESCRIPTION
**v0.601.0 did not publish.** The Release run failed in the FreeBSD job at the sysroot verification step:

```
Error: zig not found on PATH (required to cross-compile for x86_64-freebsd).
```

## Cause

`ae` locates zig by running `zig version`, so it has to be **on PATH**. The build steps in that job never needed it there — they pass `ZIG=<path>` to make — so the provisioned zig lives at an explicit path and nothing adds its directory to PATH.

That only mattered once a step invoked `ae` **directly**, which is exactly what the verification step I added in #1795 does. It's also why local testing missed it: zig was on PATH on the machine it was written on.

**This is environmental, not a defect in the packaged sysroot** — the lean sysroot links correctly once zig is findable.

## Fix

Prepend the provisioned zig's directory, and fail with a clear message if that binary isn't runnable — so `ae` can't report a missing zig that is actually present.

**Reproduced and verified**: removed zig from PATH, ran the extracted step against the real FreeBSD base, watched it fail exactly as the release did, then confirmed the fix links an `ELF ... for FreeBSD 15.0` binary.

## Note on the CI-skip

The commit carries `[skip actions]` — deliberately in the **commit**, not this title, since a token in the title becomes the merge-commit subject and would suppress the release job too.

`release.yml` is `push:`-triggered and never runs on a pull request, so the PR matrix cannot exercise this change either way. The branch is cut from `main` and carries this one file, so nothing unrelated rides along.

## What worked

The release **stopped rather than publishing an unverified sysroot**, and no bad asset shipped. A failed release run is the cost that check exists to pay — it's just unfortunate the first thing it caught was itself.

## Follow-up

`v0.601.0` needs re-cutting once this lands: the version bump merged to `main` with no release behind the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)