### PR TITLE
feat(tls13): verify servers by IP, and stop LeafCert corrupting the heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **A pure-Aether TLS 1.3 client verifies a server by IP address.**
+  `check_hostname` matched `dNSName` SANs only — `iPAddress` SANs were never
+  parsed — so connecting to a server by address, which is the normal case for
+  a local or internal endpoint, could not succeed however the certificate was
+  issued. IP literals now match against `iPAddress` SANs and never against
+  DNS names, because a certificate naming the DNS name `10.0.0.1` does not
+  authorise the address (RFC 6125 §1.7.2 keeps the namespaces apart).
+
+- **A test showing HTTPS end to end with no OpenSSL on the client side.**
+  `std.http.client` terminates TLS with OpenSSL, so a `--target` cross build,
+  which links none, fails at runtime with "HTTPS requested but the build has
+  no OpenSSL support". A downstream port read that, concluded HTTPS was
+  impossible in a cross build, and asked for a pure TLS backend to be
+  written. Most of it already existed: `std.cryptography.tls13_client` is a
+  complete pure-Aether TLS 1.3 client with full server authentication, and it
+  cross-builds. What was missing was anything demonstrating it. The new test
+  drives our own `std.http` server from that client and frames an HTTP/1.1
+  exchange over the raw TLS stream, which is the piece `std.http.client`
+  would own if the two were wired together.
+
+### Fixed
+
+- **Adding a field to a certificate struct no longer corrupts the heap.**
+  Three separate `malloc(136)` calls sized `LeafCert` by hand, and two
+  byte-identical initialisers cleared its fields in two different modules.
+  Adding one pointer makes the struct larger while the allocations still ask
+  for 136, and the overflow surfaces as a double-free inside `free_leaf`, a
+  long way from the edit that caused it. There is now one exported size
+  constant next to the struct and one exported initialiser, so a new field
+  has one place to be accounted for rather than five.
+
+- **The buffer convention in `std.cryptography` is written down.** Every
+  buffer argument there is a `std.bytes` handle, never `bytes.data(b)`, but
+  Aether has no separate type for the two so both spell as `ptr` — and
+  passing the raw data pointer compiles cleanly and then segfaults somewhere
+  unrelated. `conn_recv` likewise returns a handle rather than a pointer.
+  Stated in the module header and at the functions where getting it wrong
+  crashes.
+
 ## [0.602.0]
 
 ### Added

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -50,6 +50,8 @@ extern malloc(size: int) -> ptr
 extern free(p: ptr)
 
 exports(
+    init_leaf,
+    LEAFCERT_SIZE,
     cert_verify_content, client_cert_verify_content, sign_client_cert_verify_ecdsa_p256,
     verify_cert_verify, verify_cert_verify_rsa_pss, parse_certificate, free_leaf,
     split_ecdsa_sig,
@@ -373,6 +375,23 @@ verify_cert_verify_rsa_pss(spki_key: ptr, spki_len: int, transcript_hash: ptr, t
 // bytes buffers free deterministically via bytes.free. So OIDs, validity
 // times, and dNSNames are held as bytes; compare via bytes, or stringify a
 // transient copy when needed.
+// Byte size to malloc for a LeafCert. Aether has no sizeof, so callers that
+// heap-allocate one (trust_store_load, the delegated-responder path, and the
+// client's intermediate parser) carried the number 136 inline, arrived at by
+// counting fields by hand.
+//
+// That is a heap-corruption bug waiting for the next field: adding one
+// pointer makes the struct 144 bytes while three separate mallocs still ask
+// for 136, and the overflow only shows as a double-free inside free_leaf,
+// a long way from the edit that caused it. One constant, exported, so the
+// count lives next to the definition it has to track.
+//
+// Sized with headroom rather than exactly: 11 ptr (8) + 7 int (4) padded is
+// 144, and the slack absorbs the next field or two without another silent
+// overflow. A few spare bytes per certificate is the right trade against
+// corrupting the heap.
+const LEAFCERT_SIZE = 192
+
 struct LeafCert {
     tbs: ptr // full tbsCertificate DER (tag+len+content)
     tbs_len: int
@@ -391,6 +410,7 @@ struct LeafCert {
     not_after: ptr // validity notAfter, raw time bytes or null
     not_after_len: int
     dns_names: ptr // std.list of dNSName BYTES buffers (SAN), or null
+    ip_addrs: ptr  // std.list of iPAddress SAN BYTES buffers (4 or 16 bytes), or null
 }
 
 // Parse a DER Certificate into `out`. Returns "" on success or an error.
@@ -416,6 +436,7 @@ parse_certificate(der: ptr, len: int, out: *LeafCert) -> string {
     out.not_after = null
     out.not_after_len = 0
     out.dns_names = null
+    out.ip_addrs = null
 
     view = bytes.new(len)
     if len > 0 { bytes.set(view, len - 1, 0) }
@@ -542,6 +563,7 @@ fn parse_tbs_fields(tbsr: ptr, out: *LeafCert) -> string {
     // Remaining: optional [1]/[2] unique IDs and [3] extensions. Scan for the
     // [3] EXPLICIT extensions wrapper (tag 0xA3) and parse SAN out of it.
     out.dns_names = list_new()
+    out.ip_addrs = list_new()
     while asn1.reader_eof(tbsr) != 1 {
         ext_content, eerr = asn1.read_tlv(tbsr)
         if string.equals(eerr, "") != 1 { break }
@@ -646,6 +668,17 @@ fn decode_san_dnsnames(octet_content: ptr, out: *LeafCert) {
         name_content, nerr = asn1.read_tlv(gr)
         if string.equals(nerr, "") != 1 { break }
         tag = asn1.last_tag(gr)
+        if tag == 0x87 {
+            // iPAddress [7] IMPLICIT OCTET STRING -- 4 bytes for IPv4, 16 for
+            // IPv6, raw network order (RFC 5280 s4.2.1.6). Any other length is
+            // malformed; skip it rather than match against it.
+            alen = bytes.length(name_content)
+            if alen == 4 || alen == 16 {
+                ip = bytes.new(alen)
+                bytes.copy_from_bytes(ip, 0, name_content, 0, alen)
+                list_add_raw(out.ip_addrs, ip)
+            }
+        }
         if tag == 0x82 {
             // dNSName IA5String content
             nlen = bytes.length(name_content)
@@ -725,6 +758,16 @@ free_leaf(c: *LeafCert) {
             i = i + 1
         }
         list_free(c.dns_names)
+    }
+    if c.ip_addrs != null {
+        m = list_size(c.ip_addrs)
+        j = 0
+        while j < m {
+            a = list_get_raw(c.ip_addrs, j) as ptr
+            bytes.free(a)
+            j = j + 1
+        }
+        list_free(c.ip_addrs)
     }
 }
 
@@ -870,10 +913,88 @@ fn dnsname_matches(pat: ptr, plen: int, host: string, hlen: int) -> int {
 
 // Verify the leaf certificate identifies `host`. Checks every SAN dNSName
 // (RFC 6125; SAN-only, no CN fallback). Returns "" on a match, else an error.
+// Parse a dotted-quad into 4 bytes, or null when `host` is not an IPv4
+// literal -- which is the signal to fall through to dNSName matching.
+fn parse_ipv4(host: string, hlen: int) -> ptr {
+    out = bytes.new(4)
+    octet = 0
+    digits = 0
+    idx = 0
+    i = 0
+    bad = 0
+    while i < hlen {
+        ch = string_char_at_n(host, hlen, i) & 0xFF
+        if ch == 46 {
+            if digits == 0 { bad = 1 }
+            if idx > 2 { bad = 1 }
+            if bad == 0 {
+                bytes.set(out, idx, octet)
+                idx = idx + 1
+                octet = 0
+                digits = 0
+            }
+        } else {
+            if ch < 48 { bad = 1 }
+            if ch > 57 { bad = 1 }
+            if bad == 0 {
+                octet = octet * 10 + (ch - 48)
+                digits = digits + 1
+                if octet > 255 { bad = 1 }
+                if digits > 3 { bad = 1 }
+            }
+        }
+        i = i + 1
+    }
+    if digits == 0 { bad = 1 }
+    if idx != 3 { bad = 1 }
+    if bad == 1 {
+        bytes.free(out)
+        return null
+    }
+    bytes.set(out, 3, octet)
+    return out
+}
+
 check_hostname(c: *LeafCert, host: string) -> string {
+    hlen0 = string.length(host)
+    if hlen0 == 0 { return "empty hostname" }
+    // An IP literal is matched against iPAddress SANs and never against
+    // dNSNames: a certificate naming the DNS name "10.0.0.1" does not
+    // authorise the address 10.0.0.1, and RFC 6125 s1.7.2 keeps the two
+    // namespaces apart deliberately. Connecting by IP to a local or internal
+    // endpoint is common enough that refusing every such certificate -- which
+    // is what dNSName-only matching did -- is a real gap rather than a
+    // conservative default.
+    ipv4 = parse_ipv4(host, hlen0)
+    if ipv4 != null {
+        if c.ip_addrs == null {
+            bytes.free(ipv4)
+            return "certificate has no iPAddress SAN for this address"
+        }
+        n4 = list_size(c.ip_addrs)
+        hit = 0
+        i4 = 0
+        while i4 < n4 {
+            cand = list_get_raw(c.ip_addrs, i4) as ptr
+            if cand != null {
+                if bytes.length(cand) == 4 {
+                    same = 1
+                    b = 0
+                    while b < 4 {
+                        if (bytes.get(cand, b) & 0xFF) != (bytes.get(ipv4, b) & 0xFF) { same = 0 }
+                        b = b + 1
+                    }
+                    if same == 1 { hit = 1 }
+                }
+            }
+            i4 = i4 + 1
+        }
+        bytes.free(ipv4)
+        if hit == 1 { return "" }
+        return "certificate is not valid for the requested address"
+    }
     if c.dns_names == null { return "certificate has no subjectAltName dNSNames" }
     hlen = string.length(host)
-    if hlen == 0 { return "empty hostname" }
     n = list_size(c.dns_names)
     if n == 0 { return "certificate has no subjectAltName dNSNames" }
     i = 0
@@ -1100,7 +1221,7 @@ verify_ocsp_signature(der: ptr, len: int, issuer: *LeafCert) -> int {
                 cert_der = bytes.new(cert_der_len)
                 if cert_der_len > 0 { bytes.set(cert_der, cert_der_len - 1, 0) }
                 bytes.copy_from_bytes(cert_der, 0, der, cso, cert_der_len)
-                d = malloc(136) as *LeafCert // sizeof(LeafCert), per trust_store_load
+                d = malloc(LEAFCERT_SIZE) as *LeafCert
                 init_leaf(d)
                 perr = parse_certificate(cert_der, cert_der_len, d)
                 bytes.free(cert_der)
@@ -1634,7 +1755,7 @@ trust_store_load(path: string) -> (ptr, string) {
             if der != null {
                 // sizeof(LeafCert) = 136 on LP64 (9 ptr @8 + 8 int @4, C-packed;
                 // measured via element-stride of a *LeafCert array).
-                leaf = malloc(136) as *LeafCert
+                leaf = malloc(LEAFCERT_SIZE) as *LeafCert
                 init_leaf(leaf)
                 dlen = bytes.length(der)
                 cerr = parse_certificate(der, dlen, leaf)
@@ -1653,7 +1774,14 @@ trust_store_load(path: string) -> (ptr, string) {
 }
 
 // Zero every field of a heap-allocated LeafCert.
-fn init_leaf(l: *LeafCert) {
+//
+// Exported, and the ONLY initialiser: tls13_client had a byte-identical
+// private copy for the intermediates it parses, so a new field had to be
+// remembered in two files. Missing one leaves that field holding whatever
+// malloc returned, and free_leaf then frees a garbage pointer -- which
+// surfaces as a double-free far from the omission. One initialiser, next to
+// the struct and to free_leaf, so the three stay in step.
+init_leaf(l: *LeafCert) {
     l.tbs = null; l.tbs_len = 0
     l.sig_alg_oid = null
     l.signature = null; l.signature_len = 0
@@ -1663,6 +1791,7 @@ fn init_leaf(l: *LeafCert) {
     l.not_before = null; l.not_before_len = 0
     l.not_after = null; l.not_after_len = 0
     l.dns_names = null
+    l.ip_addrs = null
 }
 
 // Free a trust-anchor list built by trust_store_load: each *LeafCert's buffers,

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -82,6 +82,18 @@
 // PLUS pure helpers exposed for testing:
 //   transcript_new() / transcript_add(t, msg, len) / transcript_hash(t)
 
+// CONVENTION, and the one that costs people time: every buffer argument and
+// return in this module is a std.bytes HANDLE -- what bytes.new() gives you --
+// and never bytes.data(b). Aether has no separate type for the two, so they
+// both spell as `ptr`, and passing the raw data pointer compiles cleanly and
+// then segfaults somewhere unrelated. conn_recv likewise RETURNS a handle
+// ("fresh bytes; caller frees"), so read it with bytes.to_string(p, n) rather
+// than bytes.string_from_ptr.
+//
+//     rb = bytes.new(n)                       // fill it
+//     tls13_client.conn_send(conn, rb, n)     // right
+//     tls13_client.conn_send(conn, bytes.data(rb), n)   // compiles, crashes
+
 import std.bytes
 import std.string
 import std.cryptography.sha2
@@ -1312,6 +1324,9 @@ fn hs_handshake_secret(k: ptr) -> ptr { kk = k as *HsKeys; return kk.handshake_s
 // ---- application data over a completed connection ----
 
 // Send application data as one encrypted record.
+//
+// `data` is a std.bytes HANDLE, not bytes.data(b) -- see the module header.
+// Passing the raw data pointer compiles and segfaults inside seal_record.
 conn_send(conn: ptr, data: ptr, len: int) -> string {
     c = conn as *ClientConn
     rec = tls13_record.seal_record(c.app_send as ptr, tls13_record.CONTENT_APPLICATION_DATA, data, len)
@@ -2231,7 +2246,7 @@ fn parse_intermediates(body: ptr, body_len: int, out: ptr) {
                 der = bytes.new(cert_len)
                 if cert_len > 0 { bytes.set(der, cert_len - 1, 0) }
                 bytes.copy_from_bytes(der, 0, body, p, cert_len)
-                mc = malloc(136) as *LeafCert
+                mc = malloc(tls13_cert.LEAFCERT_SIZE) as *LeafCert
                 init_intermediate(mc)
                 cerr = tls13_cert.parse_certificate(der, cert_len, mc)
                 if string.equals(cerr, "") == 1 {
@@ -2256,16 +2271,11 @@ fn parse_intermediates(body: ptr, body_len: int, out: ptr) {
 }
 
 // Zero a heap LeafCert (matches tls13_cert's internal init).
+// The intermediates this parses are initialised by tls13_cert's own
+// init_leaf rather than a local copy, so a field added to LeafCert cannot be
+// cleared in one file and forgotten in the other.
 fn init_intermediate(l: *LeafCert) {
-    l.tbs = null; l.tbs_len = 0
-    l.sig_alg_oid = null
-    l.signature = null; l.signature_len = 0
-    l.spki_algo_oid = null; l.spki_key = null; l.spki_key_len = 0
-    l.issuer = null; l.issuer_len = 0
-    l.subject = null; l.subject_len = 0
-    l.not_before = null; l.not_before_len = 0
-    l.not_after = null; l.not_after_len = 0
-    l.dns_names = null
+    tls13_cert.init_leaf(l)
 }
 
 // Free a list of heap-allocated *LeafCert intermediates and the list itself.

--- a/std/cryptography/x25519/module.ae
+++ b/std/cryptography/x25519/module.ae
@@ -858,6 +858,16 @@ scalar_mult(scalar: ptr, u: ptr) -> (ptr, string) {
 }
 
 // base_point(scalar32) -> pubkey32. Public key = scalar * basepoint (u = 9).
+//
+// `scalar` is a std.bytes HANDLE (what bytes.new returns), NOT bytes.data(b).
+// Aether has no distinct type for the two, so `ptr` here reads as "any
+// pointer" and passing the raw data pointer compiles cleanly and then
+// SEGFAULTS inside the ladder. Every buffer argument in this module means the
+// handle; the same holds across std.cryptography.
+//
+//     b = bytes.new(32)          // fill it
+//     pub = x25519.base_point(b) // right
+//     pub = x25519.base_point(bytes.data(b))  // compiles, crashes
 base_point(scalar: ptr) -> ptr {
     u = bytes.new(POINT_BYTES)
     // bytes.new does NOT zero the buffer — only bytes up to the highest

--- a/tests/integration/https_pure_tls_vertical/client.ae
+++ b/tests/integration/https_pure_tls_vertical/client.ae
@@ -1,0 +1,80 @@
+// The vertical slice: HTTPS end to end with NO OpenSSL on the client side.
+//
+// std.http.client's HTTPS path is OpenSSL (std/net/aether_http.c), so it
+// returns "HTTPS requested but the build has no OpenSSL support" in any
+// `ae build --target=` cross build. std.cryptography.tls13_client is a pure
+// Aether TLS 1.3 client that has no such dependency -- this drives it against
+// our own std.http server and frames one HTTP/1.1 exchange over the raw TLS
+// byte stream, which is the piece std.http.client would own if the two were
+// wired together (asks/http-client-pure-tls-backend-for-crossbuild.md).
+//
+// The private key is a fixed 32 bytes: this is a test, and a deterministic
+// key makes a failure reproducible. Real callers pass fresh randomness.
+
+import std.cryptography.tls13_client
+import std.bytes
+import std.string
+import std.os
+
+extern exit(code: int)
+
+main() {
+    host = "127.0.0.1"   // exercises iPAddress-SAN matching
+    port = 18447
+
+    priv = bytes.new(32)
+    i = 0
+    while i < 32 {
+        bytes.set(priv, i, 7 + i)
+        i = i + 1
+    }
+
+    conn, err = tls13_client.connect(host, port, priv)
+    if err != "" {
+        println("FAIL: pure TLS handshake: ${err}")
+        exit(1)
+    }
+    println("PASS: pure-Aether TLS 1.3 handshake (no OpenSSL on this side)")
+
+    // Frame one HTTP/1.1 request over the TLS stream.
+    req = "GET / HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n"
+    rlen = string_length(req)
+    rb = bytes.new(rlen)
+    _ = bytes.copy_from_string(rb, 0, req, rlen)
+    // NB: conn_send takes a bytes HANDLE, not bytes.data(rb) -- the `ptr`
+    // in its signature means an AetherBytes*, and passing the raw data
+    // pointer segfaults inside seal_record.
+    serr = tls13_client.conn_send(conn, rb, rlen)
+    if serr != "" {
+        println("FAIL: conn_send: ${serr}")
+        exit(1)
+    }
+
+    // Read until the body marker appears or the peer closes.
+    acc = ""
+    reads = 0
+    while reads < 40 {
+        p, n, rerr = tls13_client.conn_recv(conn)
+        if rerr != "" { reads = 40 }
+        if n > 0 {
+            // conn_recv returns a bytes HANDLE ("fresh bytes; caller frees"),
+            // so read it with to_string rather than string_from_ptr.
+            chunk = bytes.to_string(p, n)
+            acc = string_concat(acc, chunk)
+            bytes.free(p)
+            if string_contains(acc, "pure-tls-vertical-ok") == 1 { reads = 40 }
+        }
+        reads = reads + 1
+    }
+
+    bytes.free(rb)
+    bytes.free(priv)
+    tls13_client.close_conn(conn)
+
+    if string_contains(acc, "pure-tls-vertical-ok") == 1 {
+        println("PASS: HTTP/1.1 response received over pure TLS")
+        exit(0)
+    }
+    println("FAIL: body marker not seen; got ${string_length(acc)} bytes")
+    exit(1)
+}

--- a/tests/integration/https_pure_tls_vertical/server.ae
+++ b/tests/integration/https_pure_tls_vertical/server.ae
@@ -1,0 +1,71 @@
+// #260 Tier 0: server-side TLS termination test driver.
+//
+// Spins up an HTTP server on TLS-enabled port 18102 with a route
+// that returns "pure-tls-vertical-ok". The shell runner verifies handshake +
+// response with curl --cacert.
+
+import std.http
+import std.os
+
+extern exit(code: int)
+// Use raw form: actor receive handlers can't cleanly discard the
+// wrapper's string return without an unused-result warning.
+extern http_server_start_raw(server: ptr) -> int
+
+const PORT = 18447
+
+handle_root(req: ptr, res: ptr, ud: ptr) {
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "pure-tls-vertical-ok")
+}
+
+message StartSrv { raw: ptr }
+message Noop {}
+
+actor SrvActor {
+    state s = 0
+    receive { StartSrv(raw) -> { s = raw; http_server_start_raw(raw) } }
+}
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+main() {
+    cert_path = os_getenv("CERT_PATH")
+    key_path = os_getenv("KEY_PATH")
+    if cert_path == 0 || key_path == 0 {
+        println("FAIL: CERT_PATH / KEY_PATH must be set")
+        exit(1)
+    }
+
+    raw = http.server_create(PORT)
+
+    // Bind all interfaces: `localhost` resolves to ::1 on some boxes and
+    // 127.0.0.1 on others, and the client must reach it either way.
+    // Bind :: so a client dialling "localhost" reaches us whether that
+    // resolves to ::1 or 127.0.0.1 -- it is ::1-only on some boxes.
+    http.server_set_host(raw, "127.0.0.1")
+    if raw == 0 {
+        println("FAIL: server_create returned null")
+        exit(1)
+    }
+
+    tls_err = http.server_set_tls(raw, cert_path, key_path)
+    if tls_err != "" {
+        println("FAIL: server_set_tls: ${tls_err}")
+        exit(1)
+    }
+    println("READY")
+
+    http.server_get(raw, "/", handle_root, 0)
+
+    spawn(SchedHelper())
+    a = spawn(SrvActor())
+    a ! StartSrv { raw: raw }
+
+    // Block forever (the runner sends SIGTERM after curl finishes).
+    sleep(60000)
+    exit(0)
+}

--- a/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
+++ b/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# HTTPS end to end with a pure-Aether TLS client: our std.http server on one
+# side, std.cryptography.tls13_client on the other, one HTTP/1.1 exchange
+# framed over the raw TLS stream.
+#
+# Why this exists. std.http.client's HTTPS path is OpenSSL
+# (std/net/aether_http.c), so `ae build --target=` -- which links no OpenSSL --
+# returns "HTTPS requested but the build has no OpenSSL support" at runtime.
+# A downstream port read the tree, concluded HTTPS was impossible in a cross
+# build, and filed asks/http-client-pure-tls-backend-for-crossbuild.md asking
+# for a pure TLS backend to be written.
+#
+# Most of it already exists: tls13_client is a complete pure-Aether TLS 1.3
+# client with full server authentication, and it cross-builds. What was
+# missing was anything demonstrating that, which is what this test is. It
+# pins the vertical slice so the claim is checkable rather than asserted, and
+# gives the std.http.client integration a target to match.
+#
+# The client half deliberately uses NO OpenSSL. The server half still does
+# (std/net/aether_http_server.c terminates TLS with SSL_accept), so this
+# proves one direction; a pure server needs tls13_hs to gain a ClientHello
+# parser and a ServerHello builder, which it does not have yet.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+PORT=18447
+
+[ -x "$AE" ] || { echo "  [SKIP] https_pure_tls_vertical: ae not built"; exit 0; }
+command -v openssl >/dev/null 2>&1 || { echo "  [SKIP] https_pure_tls_vertical: no openssl to make a cert"; exit 0; }
+
+TMP="$(mktemp -d)"
+SRV_PID=""
+cleanup() {
+    if [ -n "$SRV_PID" ]; then kill "$SRV_PID" 2>/dev/null || :; fi
+    rm -rf "$TMP" || :
+    return 0
+}
+trap cleanup EXIT
+fail() { echo "  [FAIL] $1"; exit 1; }
+
+# A self-signed cert for 127.0.0.1. The client authenticates the server for
+# real -- chain, validity and hostname -- so the cert has to carry an IP SAN
+# and be handed to the client as its trust anchor.
+openssl req -x509 -newkey rsa:2048 -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
+    -days 2 -nodes -subj "/CN=127.0.0.1" \
+    -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" >"$TMP/ssl.log" 2>&1 \
+    || { sed -n '1,10p' "$TMP/ssl.log"; fail "could not generate a test certificate"; }
+
+"$AE" build "$SCRIPT_DIR/server.ae" -o "$TMP/srv" >"$TMP/b1.log" 2>&1 \
+    || { sed -n '1,12p' "$TMP/b1.log"; fail "server did not build"; }
+"$AE" build "$SCRIPT_DIR/client.ae" -o "$TMP/cli" >"$TMP/b2.log" 2>&1 \
+    || { sed -n '1,12p' "$TMP/b2.log"; fail "pure-TLS client did not build"; }
+
+CERT_PATH="$TMP/cert.pem" KEY_PATH="$TMP/key.pem" "$TMP/srv" >"$TMP/srv.log" 2>&1 &
+SRV_PID=$!
+
+i=0
+while [ "$i" -lt 100 ]; do
+    grep -q READY "$TMP/srv.log" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+done
+grep -q READY "$TMP/srv.log" 2>/dev/null || {
+    sed -n '1,10p' "$TMP/srv.log"
+    fail "the TLS server never became READY"
+}
+
+# SSL_CERT_FILE is how tls13_client is told where its trust anchors are; with
+# a self-signed test cert that file IS the anchor. Without it the handshake
+# fails closed with "cannot load system trust store", which is correct
+# behaviour and worth stating because it is not obvious.
+OUT=$(SSL_CERT_FILE="$TMP/cert.pem" "$TMP/cli" 2>&1) || {
+    printf '%s\n' "$OUT" | grep -vE 'warning: unresolved|-->' | sed 's/^/    cli: /'
+    sed -n '1,6p' "$TMP/srv.log" | sed 's/^/    srv: /'
+    fail "the pure-TLS client did not complete the exchange"
+}
+
+case "$OUT" in
+    *"PASS: pure-Aether TLS 1.3 handshake"*) ;;
+    *) echo "$OUT" | sed 's/^/         /'; fail "no handshake confirmation" ;;
+esac
+case "$OUT" in
+    *"PASS: HTTP/1.1 response received over pure TLS"*) ;;
+    *) echo "$OUT" | sed 's/^/         /'; fail "no HTTP response over the TLS stream" ;;
+esac
+
+echo "  [PASS] https_pure_tls_vertical: std.http server <- HTTP/1.1 over pure-Aether TLS 1.3"


### PR DESCRIPTION
From `asks/http-client-pure-tls-backend-for-crossbuild.md`. All three findings in one PR — they're the same subsystem, and the second blocked the first.

## The ask's premise, verified

The same program, cross-built, under identical conditions:

```
std.http.client → "HTTPS requested but the build has no OpenSSL support"
tls13_client    → PURE-AETHER TLS 1.3 HANDSHAKE OK -> example.com:443
```

**The capability already exists and already survives `--target`.** So the ask is an integration and a visibility problem, not missing crypto. This lands the showcase that makes that checkable, plus the two defects building it exposed.

## 1. IP SANs — a real capability gap

`check_hostname` matched `dNSName` SANs **only**; `iPAddress` SANs (tag `0x87`) were never parsed. Connecting to a server by address — the normal case for a local or internal endpoint — could not succeed however the certificate was issued.

IP literals now match `iPAddress` SANs and **never** dNSNames: a certificate naming the DNS name `10.0.0.1` does not authorise the address (RFC 6125 §1.7.2).

**Both directions tested** — the right address connects; a cert carrying `IP:10.9.9.9` is refused with `certificate is not valid for the requested address`.

## 2. `LeafCert` corrupted the heap on any new field

Three separate `malloc(136)` calls sized the struct by hand, and **two byte-identical initialisers** cleared its fields in different modules. Add one pointer and the struct grows while the allocations still ask for 136 — the overflow surfaces as a **double-free inside `free_leaf`**, far from the edit.

Not hypothetical: it's what happened when the IP field went in, **twice**, and it cost more time than the feature. I reverted the first attempt entirely rather than chase it.

Now one exported size constant beside the struct, and one exported initialiser — five coupling sites down to two.

## 3. `ptr` means "bytes handle", and getting it wrong segfaults

Every buffer argument in `std.cryptography` is a `std.bytes` **handle**, never `bytes.data(b)` — but Aether has no separate type, so both spell as `ptr`:

```aether
x25519.base_point(b)              // right
x25519.base_point(bytes.data(b))  // compiles, segfaults in the ladder
```

`conn_recv` likewise **returns** a handle. This cost five failed attempts to call shipped APIs correctly *with the source open*, so it's now stated in the module header and at the functions where getting it wrong crashes.

## The showcase test

Drives our own `std.http` server from the pure client and frames an HTTP/1.1 exchange over the raw TLS stream — the piece `std.http.client` would own if the two were wired together.

The server half still terminates TLS with OpenSSL: `tls13_hs` has no ClientHello parser or ServerHello builder. Worth stating precisely, because the gap is narrower than it sounds — the **record and key-schedule layers are already role-neutral**, and signing (`ecdsa_sign`, `sign_pss`) and the `"TLS 1.3, server CertificateVerify"` context string already exist. It's one layer, not a stack.

## Verification

- `make test` 398/0
- RFC 8448 known-answer vectors and the x25519 KATs still pass — the cert changes didn't disturb the crypto
- `check-docs` clean, stdlib index regenerated
- Live handshake to `example.com:443` still works after the refactor
- valgrind: one 32-byte leak in `run_handshake_tail`, **pre-existing** (baseline leaks 48 bytes in 2 blocks) and not touched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)