### PR TITLE
feat(tls13): verify servers by IP, fix LeafCert coupling, and add the server handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **A pure-Aether TLS 1.3 client verifies a server by IP address.**
+  `check_hostname` matched `dNSName` SANs only — `iPAddress` SANs were never
+  parsed — so connecting to a server by address, which is the normal case for
+  a local or internal endpoint, could not succeed however the certificate was
+  issued. IP literals now match against `iPAddress` SANs and never against
+  DNS names, because a certificate naming the DNS name `10.0.0.1` does not
+  authorise the address (RFC 6125 §1.7.2 keeps the namespaces apart).
+
+- **A test showing HTTPS end to end with no OpenSSL on the client side.**
+  `std.http.client` terminates TLS with OpenSSL, so a `--target` cross build,
+  which links none, fails at runtime with "HTTPS requested but the build has
+  no OpenSSL support". A downstream port read that, concluded HTTPS was
+  impossible in a cross build, and asked for a pure TLS backend to be
+  written. Most of it already existed: `std.cryptography.tls13_client` is a
+  complete pure-Aether TLS 1.3 client with full server authentication, and it
+  cross-builds. What was missing was anything demonstrating it. The new test
+  drives our own `std.http` server from that client and frames an HTTP/1.1
+  exchange over the raw TLS stream, which is the piece `std.http.client`
+  would own if the two were wired together.
+
+### Fixed
+
+- **Adding a field to a certificate struct no longer corrupts the heap.**
+  Three separate `malloc(136)` calls sized `LeafCert` by hand, and two
+  byte-identical initialisers cleared its fields in two different modules.
+  Adding one pointer makes the struct larger while the allocations still ask
+  for 136, and the overflow surfaces as a double-free inside `free_leaf`, a
+  long way from the edit that caused it. There is now one exported size
+  constant next to the struct and one exported initialiser, so a new field
+  has one place to be accounted for rather than five.
+
+- **The buffer convention in `std.cryptography` is written down.** Every
+  buffer argument there is a `std.bytes` handle, never `bytes.data(b)`, but
+  Aether has no separate type for the two so both spell as `ptr` — and
+  passing the raw data pointer compiles cleanly and then segfaults somewhere
+  unrelated. `conn_recv` likewise returns a handle rather than a pointer.
+  Stated in the module header and at the functions where getting it wrong
+  crashes.
+
 ## [0.602.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ version number before tagging the release.
 
 ### Added
 
+- **The TLS 1.3 handshake module can read a ClientHello and write a
+  ServerHello.** `tls13_hs` built ClientHellos and parsed ServerHellos —
+  the client's half of the conversation and nothing else — so a pure-Aether
+  TLS *server* had no way to start. The record layer and key schedule were
+  already role-neutral (the key schedule is label-driven, so `"s hs traffic"`
+  is the same call as `"c hs traffic"`), signing already existed, and the
+  `"TLS 1.3, server CertificateVerify"` context string was already there.
+  The gap was one layer, and it was the inverse of parsers that already
+  existed.
+
+  This is not about dropping OpenSSL, which stays the default where present.
+  It is that three of the four client/server × OpenSSL/pure permutations
+  worked and the fourth was empty, so our TLS was never exercised against
+  our TLS — only against static vectors and OpenSSL peers. A bug both halves
+  made together had nowhere to show up. It also means a cross-built binary
+  cannot serve HTTPS at all today, which is the same hole the client side
+  was filed about.
+
+  `parse_client_hello` reads a **real OpenSSL ClientHello** captured off the
+  wire, not just one we built ourselves, and `server_hello` round-trips
+  through the independently-written `parse_server_hello`. HelloRetryRequest
+  is not implemented: a client offering only groups we cannot complete gets
+  a clear error rather than a silently wrong negotiation.
+
 - **A pure-Aether TLS 1.3 client verifies a server by IP address.**
   `check_hostname` matched `dNSName` SANs only — `iPAddress` SANs were never
   parsed — so connecting to a server by address, which is the normal case for

--- a/asks/tls13-pure-server-completion.md
+++ b/asks/tls13-pure-server-completion.md
@@ -1,0 +1,176 @@
+# Complete the pure-Aether TLS 1.3 **server**, so all four client/server × OpenSSL/pure permutations work
+
+**Status of the tree when this was written:** PR #1804 adds `parse_client_hello`
+and `server_hello` to `std/cryptography/tls13_hs/`. This document is the work
+that remains after that lands.
+
+**This is not about removing OpenSSL.** It stays the default where present.
+The goal is that the pure path works on *both* ends, so our TLS gets exercised
+against our TLS, and so a cross-built binary can serve HTTPS as well as consume
+it.
+
+---
+
+## The permutation matrix (verified, not assumed)
+
+|                | OpenSSL backend        | Pure-Aether backend                    |
+| -------------- | ---------------------- | -------------------------------------- |
+| **HTTP client** | ✅ works, native builds only | ✅ works, **including cross builds** |
+| **HTTP server** | ✅ works, native builds only | ❌ **this task**                      |
+
+Both "native only" cells were verified by cross-building and running:
+
+```
+$ ./cross_built_client            # std.http.client, --target=x86_64-linux
+ERR: HTTPS requested but the build has no OpenSSL support (rebuild with OpenSSL installed)
+
+$ ./cross_built_server            # std.http server_set_tls, same target
+set_tls -> [TLS unavailable: built without OpenSSL]
+```
+
+Two things the empty cell costs:
+
+1. **A cross-built binary cannot serve HTTPS at all.** Same hole the client side
+   was filed about, from the other end.
+2. **Our TLS is never tested against our TLS.** `tls13_client` is exercised by
+   static RFC 8448 vectors and by OpenSSL peers only, so a mistake both halves
+   make *together* has nowhere to surface.
+
+---
+
+## What already exists (do not rewrite any of this)
+
+Measured before scoping, so the task is smaller than "implement a TLS server":
+
+| Piece | Where | State |
+| --- | --- | --- |
+| Record layer `seal_record` / `open_record` | `std/cryptography/tls13_record/` | **role-neutral** — zero references to client/server; takes keys, not a role |
+| Key schedule | `std/cryptography/tls13_ks/` | **role-neutral** — `traffic_secret(algo, secret, label, th, th_len)` is label-driven, so `"s hs traffic"` is the same call as `"c hs traffic"` |
+| `finished_key` / `finished_verify_data` | `tls13_kdf` (exported ~line 124) | **role-neutral** — takes a secret |
+| ECDSA / RSA-PSS signing | `p256.ecdsa_sign`, `rsa.sign_pss` | exists |
+| `"TLS 1.3, server CertificateVerify"` context | `tls13_cert`, `cert_verify_content` | **already there**, used today for *verifying* |
+| `cert_verify_content_ctx(context, hash, len)` | `tls13_cert` | parameterised by context string — a server signer is the same call with the server context |
+| PEM parsing | `std/cryptography/pem/` `parse(text) -> (ptr, string, string)` | exists |
+| Certificate parsing | `tls13_cert.parse_certificate` | exists |
+| `parse_client_hello` / `server_hello` | `tls13_hs` (PR #1804) | **done** |
+| Handshake message type constants | `tls13_hs` `HS_*` | all present |
+
+---
+
+## The work
+
+### Task 1 — the four remaining server handshake messages
+
+All in `std/cryptography/tls13_hs/module.ae`. Each is the **inverse of a parser
+that already exists** in `std/cryptography/tls13_client/module.ae`, so read the
+client's parser first and mirror it.
+
+1. **`encrypted_extensions()`** — `HS_ENCRYPTED_EXTENSIONS = 8`. In the minimal
+   case this is an empty extensions block (2 zero bytes) wrapped in a handshake
+   header. The client already parses it.
+2. **`certificate_msg(chain_der, lengths)`** — `HS_CERTIFICATE = 11`. RFC 8446
+   §4.4.2: 1-byte `certificate_request_context` (empty for a server), then
+   `certificate_list<0..2^24-1>` of `{ cert_data<1..2^24-1>, extensions<0..2^16-1> }`.
+   Extensions are empty per entry in the minimal case.
+3. **`certificate_verify_msg(scheme, signature)`** — `HS_CERTIFICATE_VERIFY = 15`.
+   `{ algorithm(2), signature<0..2^16-1> }`. The signature is over
+   `cert_verify_content(transcript_hash)` — the **server** context string, which
+   already exists. Add `sign_server_cert_verify_ecdsa_p256` in `tls13_cert`
+   mirroring the existing `sign_client_cert_verify_ecdsa_p256` (line ~110);
+   the only difference is which `cert_verify_content*` it hashes.
+4. **`finished_msg(verify_data, len)`** — `HS_FINISHED = 20`. Body is just the
+   verify_data. Compute it with the existing `finished_key` /
+   `finished_verify_data` from the **server** handshake traffic secret.
+
+**Follow the existing style exactly**: `put8`/`put16`/`put24`/`put_bytes` helpers,
+a generous fixed buffer, patch lengths at the end, copy to a right-sized buffer,
+free the scratch. `server_hello` (PR #1804) is the worked example.
+
+### Task 2 — a `tls13_server` module driving the flight
+
+New: `std/cryptography/tls13_server/module.ae`, mirroring
+`std/cryptography/tls13_client/module.ae` (2308 lines — read it, this is the
+same shape reversed).
+
+```
+accept(sock, cert_chain, cert_lens, priv_key, x25519_priv) -> (ptr, string)
+conn_send(conn, data, len) -> string        // same signature as the client's
+conn_recv(conn) -> (ptr, int, string)
+close_conn(conn)
+```
+
+Flight order (RFC 8446 §2), the mirror of `run_handshake_tail` (client line ~924):
+
+1. read ClientHello → `parse_client_hello`
+2. X25519 shared secret from the client's key_share + our ephemeral private
+3. key schedule: early → handshake → master, deriving **both** directions
+4. send ServerHello (plaintext), then under handshake keys:
+   EncryptedExtensions, Certificate, CertificateVerify, Finished
+5. read the client's Finished, verify its MAC
+6. switch to application traffic keys
+
+### Task 3 — wire it into the HTTP server
+
+`std/net/aether_http_server.c`, function **`conn_tls_accept` (line ~695)**, which
+today calls `SSL_accept`. Add a pure branch selected the same way the client
+side will be — an env/option, defaulting to OpenSSL where compiled in.
+
+`conn_recv` / `conn_send` (lines ~305 and ~316) **already dispatch on `c->ssl`**,
+so the framing layer above needs no changes. This is the same C/Aether boundary
+the client has, from the other side; look at how PR #1804's vertical-slice test
+drives the client from Aether for the shape.
+
+---
+
+## Testing — the bar this must clear
+
+Follow `tests/integration/crypto_tls13_server_hs/` and
+`tests/integration/https_pure_tls_vertical/` (both from PR #1804).
+
+**Required, in increasing order of what they prove:**
+
+1. Each new message builder round-trips through the **client's existing parser**
+   for that message. Those parsers were written independently against RFC 8448,
+   so agreement is not a builder checking its own output.
+2. The vertical-slice test extended to **all four permutations**: pure client ↔
+   pure server, pure client ↔ OpenSSL server, OpenSSL client (curl) ↔ pure
+   server, and the existing OpenSSL ↔ OpenSSL.
+3. **`curl --cacert ... https://127.0.0.1:port/` against the pure server must
+   work.** This is the one that matters. Everything above passes if our two
+   halves agree on a wire format nobody else speaks; curl is a third-party
+   implementation and will reject a malformed flight.
+4. Negative cases: malformed ClientHello, unsupported group, bad Finished MAC.
+
+**Do not** mark this done on 1 and 2 alone.
+
+---
+
+## Pitfalls, all of which have already cost time in this tree
+
+- **`ptr` means a `std.bytes` HANDLE, never `bytes.data(b)`.** Aether has no
+  separate type, so both spell as `ptr`; passing the raw data pointer **compiles
+  cleanly and segfaults** somewhere unrelated. `conn_recv` likewise *returns* a
+  handle — read it with `bytes.to_string(p, n)`, not `bytes.string_from_ptr`.
+  This cost five failed attempts to call shipped APIs correctly with the source
+  open. See the header of `tls13_client/module.ae`.
+- **Adding a field to `LeafCert`**: use the exported `LEAFCERT_SIZE` constant and
+  the exported `init_leaf`. Before PR #1804 there were three hand-counted
+  `malloc(136)` calls and two duplicate initialisers; adding one pointer
+  corrupted the heap and surfaced as a double-free far from the edit.
+- **`tests/ae_sweep_prune.txt`**: any new test directory whose `.ae` files are
+  not standalone programs (a client needing a peer, a server that blocks) must
+  be listed there, or the bulk sweep runs them and CI fails while local shell
+  tests pass.
+- **`fmt_gate` covers `std/` as well as `tests/`.** Run
+  `ae fmt std examples tests` before pushing; `make test` does not cover it.
+- **HelloRetryRequest is not implemented** and `parse_client_hello` returns an
+  explicit error for it. A browser or a client preferring a group we do not
+  support will hit that path. Implementing HRR is optional for a first cut but
+  must be *stated*, not discovered.
+
+## Definition of done
+
+`curl` completes an HTTPS request against an Aether server built with **no
+OpenSSL at all**, and the same server is reachable from `tls13_client`. Both
+run in CI, and a cross-built (`ae build --target=...`) server binary serves
+HTTPS.

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -410,7 +410,7 @@ struct LeafCert {
     not_after: ptr // validity notAfter, raw time bytes or null
     not_after_len: int
     dns_names: ptr // std.list of dNSName BYTES buffers (SAN), or null
-    ip_addrs: ptr  // std.list of iPAddress SAN BYTES buffers (4 or 16 bytes), or null
+    ip_addrs: ptr // std.list of iPAddress SAN BYTES buffers (4 or 16 bytes), or null
 }
 
 // Parse a DER Certificate into `out`. Returns "" on success or an error.

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -50,6 +50,8 @@ extern malloc(size: int) -> ptr
 extern free(p: ptr)
 
 exports(
+    init_leaf,
+    LEAFCERT_SIZE,
     cert_verify_content, client_cert_verify_content, sign_client_cert_verify_ecdsa_p256,
     verify_cert_verify, verify_cert_verify_rsa_pss, parse_certificate, free_leaf,
     split_ecdsa_sig,
@@ -373,6 +375,23 @@ verify_cert_verify_rsa_pss(spki_key: ptr, spki_len: int, transcript_hash: ptr, t
 // bytes buffers free deterministically via bytes.free. So OIDs, validity
 // times, and dNSNames are held as bytes; compare via bytes, or stringify a
 // transient copy when needed.
+// Byte size to malloc for a LeafCert. Aether has no sizeof, so callers that
+// heap-allocate one (trust_store_load, the delegated-responder path, and the
+// client's intermediate parser) carried the number 136 inline, arrived at by
+// counting fields by hand.
+//
+// That is a heap-corruption bug waiting for the next field: adding one
+// pointer makes the struct 144 bytes while three separate mallocs still ask
+// for 136, and the overflow only shows as a double-free inside free_leaf,
+// a long way from the edit that caused it. One constant, exported, so the
+// count lives next to the definition it has to track.
+//
+// Sized with headroom rather than exactly: 11 ptr (8) + 7 int (4) padded is
+// 144, and the slack absorbs the next field or two without another silent
+// overflow. A few spare bytes per certificate is the right trade against
+// corrupting the heap.
+const LEAFCERT_SIZE = 192
+
 struct LeafCert {
     tbs: ptr // full tbsCertificate DER (tag+len+content)
     tbs_len: int
@@ -391,6 +410,7 @@ struct LeafCert {
     not_after: ptr // validity notAfter, raw time bytes or null
     not_after_len: int
     dns_names: ptr // std.list of dNSName BYTES buffers (SAN), or null
+    ip_addrs: ptr  // std.list of iPAddress SAN BYTES buffers (4 or 16 bytes), or null
 }
 
 // Parse a DER Certificate into `out`. Returns "" on success or an error.
@@ -416,6 +436,7 @@ parse_certificate(der: ptr, len: int, out: *LeafCert) -> string {
     out.not_after = null
     out.not_after_len = 0
     out.dns_names = null
+    out.ip_addrs = null
 
     view = bytes.new(len)
     if len > 0 { bytes.set(view, len - 1, 0) }
@@ -542,6 +563,7 @@ fn parse_tbs_fields(tbsr: ptr, out: *LeafCert) -> string {
     // Remaining: optional [1]/[2] unique IDs and [3] extensions. Scan for the
     // [3] EXPLICIT extensions wrapper (tag 0xA3) and parse SAN out of it.
     out.dns_names = list_new()
+    out.ip_addrs = list_new()
     while asn1.reader_eof(tbsr) != 1 {
         ext_content, eerr = asn1.read_tlv(tbsr)
         if string.equals(eerr, "") != 1 { break }
@@ -646,6 +668,17 @@ fn decode_san_dnsnames(octet_content: ptr, out: *LeafCert) {
         name_content, nerr = asn1.read_tlv(gr)
         if string.equals(nerr, "") != 1 { break }
         tag = asn1.last_tag(gr)
+        if tag == 0x87 {
+            // iPAddress [7] IMPLICIT OCTET STRING -- 4 bytes for IPv4, 16 for
+            // IPv6, raw network order (RFC 5280 s4.2.1.6). Any other length is
+            // malformed; skip it rather than match against it.
+            alen = bytes.length(name_content)
+            if alen == 4 || alen == 16 {
+                ip = bytes.new(alen)
+                bytes.copy_from_bytes(ip, 0, name_content, 0, alen)
+                list_add_raw(out.ip_addrs, ip)
+            }
+        }
         if tag == 0x82 {
             // dNSName IA5String content
             nlen = bytes.length(name_content)
@@ -725,6 +758,16 @@ free_leaf(c: *LeafCert) {
             i = i + 1
         }
         list_free(c.dns_names)
+    }
+    if c.ip_addrs != null {
+        m = list_size(c.ip_addrs)
+        j = 0
+        while j < m {
+            a = list_get_raw(c.ip_addrs, j) as ptr
+            bytes.free(a)
+            j = j + 1
+        }
+        list_free(c.ip_addrs)
     }
 }
 
@@ -870,10 +913,88 @@ fn dnsname_matches(pat: ptr, plen: int, host: string, hlen: int) -> int {
 
 // Verify the leaf certificate identifies `host`. Checks every SAN dNSName
 // (RFC 6125; SAN-only, no CN fallback). Returns "" on a match, else an error.
+// Parse a dotted-quad into 4 bytes, or null when `host` is not an IPv4
+// literal -- which is the signal to fall through to dNSName matching.
+fn parse_ipv4(host: string, hlen: int) -> ptr {
+    out = bytes.new(4)
+    octet = 0
+    digits = 0
+    idx = 0
+    i = 0
+    bad = 0
+    while i < hlen {
+        ch = string_char_at_n(host, hlen, i) & 0xFF
+        if ch == 46 {
+            if digits == 0 { bad = 1 }
+            if idx > 2 { bad = 1 }
+            if bad == 0 {
+                bytes.set(out, idx, octet)
+                idx = idx + 1
+                octet = 0
+                digits = 0
+            }
+        } else {
+            if ch < 48 { bad = 1 }
+            if ch > 57 { bad = 1 }
+            if bad == 0 {
+                octet = octet * 10 + (ch - 48)
+                digits = digits + 1
+                if octet > 255 { bad = 1 }
+                if digits > 3 { bad = 1 }
+            }
+        }
+        i = i + 1
+    }
+    if digits == 0 { bad = 1 }
+    if idx != 3 { bad = 1 }
+    if bad == 1 {
+        bytes.free(out)
+        return null
+    }
+    bytes.set(out, 3, octet)
+    return out
+}
+
 check_hostname(c: *LeafCert, host: string) -> string {
+    hlen0 = string.length(host)
+    if hlen0 == 0 { return "empty hostname" }
+    // An IP literal is matched against iPAddress SANs and never against
+    // dNSNames: a certificate naming the DNS name "10.0.0.1" does not
+    // authorise the address 10.0.0.1, and RFC 6125 s1.7.2 keeps the two
+    // namespaces apart deliberately. Connecting by IP to a local or internal
+    // endpoint is common enough that refusing every such certificate -- which
+    // is what dNSName-only matching did -- is a real gap rather than a
+    // conservative default.
+    ipv4 = parse_ipv4(host, hlen0)
+    if ipv4 != null {
+        if c.ip_addrs == null {
+            bytes.free(ipv4)
+            return "certificate has no iPAddress SAN for this address"
+        }
+        n4 = list_size(c.ip_addrs)
+        hit = 0
+        i4 = 0
+        while i4 < n4 {
+            cand = list_get_raw(c.ip_addrs, i4) as ptr
+            if cand != null {
+                if bytes.length(cand) == 4 {
+                    same = 1
+                    b = 0
+                    while b < 4 {
+                        if (bytes.get(cand, b) & 0xFF) != (bytes.get(ipv4, b) & 0xFF) { same = 0 }
+                        b = b + 1
+                    }
+                    if same == 1 { hit = 1 }
+                }
+            }
+            i4 = i4 + 1
+        }
+        bytes.free(ipv4)
+        if hit == 1 { return "" }
+        return "certificate is not valid for the requested address"
+    }
     if c.dns_names == null { return "certificate has no subjectAltName dNSNames" }
     hlen = string.length(host)
-    if hlen == 0 { return "empty hostname" }
     n = list_size(c.dns_names)
     if n == 0 { return "certificate has no subjectAltName dNSNames" }
     i = 0
@@ -1100,7 +1221,7 @@ verify_ocsp_signature(der: ptr, len: int, issuer: *LeafCert) -> int {
                 cert_der = bytes.new(cert_der_len)
                 if cert_der_len > 0 { bytes.set(cert_der, cert_der_len - 1, 0) }
                 bytes.copy_from_bytes(cert_der, 0, der, cso, cert_der_len)
-                d = malloc(136) as *LeafCert // sizeof(LeafCert), per trust_store_load
+                d = malloc(LEAFCERT_SIZE) as *LeafCert
                 init_leaf(d)
                 perr = parse_certificate(cert_der, cert_der_len, d)
                 bytes.free(cert_der)
@@ -1634,7 +1755,7 @@ trust_store_load(path: string) -> (ptr, string) {
             if der != null {
                 // sizeof(LeafCert) = 136 on LP64 (9 ptr @8 + 8 int @4, C-packed;
                 // measured via element-stride of a *LeafCert array).
-                leaf = malloc(136) as *LeafCert
+                leaf = malloc(LEAFCERT_SIZE) as *LeafCert
                 init_leaf(leaf)
                 dlen = bytes.length(der)
                 cerr = parse_certificate(der, dlen, leaf)
@@ -1653,7 +1774,14 @@ trust_store_load(path: string) -> (ptr, string) {
 }
 
 // Zero every field of a heap-allocated LeafCert.
-fn init_leaf(l: *LeafCert) {
+//
+// Exported, and the ONLY initialiser: tls13_client had a byte-identical
+// private copy for the intermediates it parses, so a new field had to be
+// remembered in two files. Missing one leaves that field holding whatever
+// malloc returned, and free_leaf then frees a garbage pointer -- which
+// surfaces as a double-free far from the omission. One initialiser, next to
+// the struct and to free_leaf, so the three stay in step.
+init_leaf(l: *LeafCert) {
     l.tbs = null; l.tbs_len = 0
     l.sig_alg_oid = null
     l.signature = null; l.signature_len = 0
@@ -1663,6 +1791,7 @@ fn init_leaf(l: *LeafCert) {
     l.not_before = null; l.not_before_len = 0
     l.not_after = null; l.not_after_len = 0
     l.dns_names = null
+    l.ip_addrs = null
 }
 
 // Free a trust-anchor list built by trust_store_load: each *LeafCert's buffers,

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -82,6 +82,18 @@
 // PLUS pure helpers exposed for testing:
 //   transcript_new() / transcript_add(t, msg, len) / transcript_hash(t)
 
+// CONVENTION, and the one that costs people time: every buffer argument and
+// return in this module is a std.bytes HANDLE -- what bytes.new() gives you --
+// and never bytes.data(b). Aether has no separate type for the two, so they
+// both spell as `ptr`, and passing the raw data pointer compiles cleanly and
+// then segfaults somewhere unrelated. conn_recv likewise RETURNS a handle
+// ("fresh bytes; caller frees"), so read it with bytes.to_string(p, n) rather
+// than bytes.string_from_ptr.
+//
+//     rb = bytes.new(n)                       // fill it
+//     tls13_client.conn_send(conn, rb, n)     // right
+//     tls13_client.conn_send(conn, bytes.data(rb), n)   // compiles, crashes
+
 import std.bytes
 import std.string
 import std.cryptography.sha2
@@ -1312,6 +1324,9 @@ fn hs_handshake_secret(k: ptr) -> ptr { kk = k as *HsKeys; return kk.handshake_s
 // ---- application data over a completed connection ----
 
 // Send application data as one encrypted record.
+//
+// `data` is a std.bytes HANDLE, not bytes.data(b) -- see the module header.
+// Passing the raw data pointer compiles and segfaults inside seal_record.
 conn_send(conn: ptr, data: ptr, len: int) -> string {
     c = conn as *ClientConn
     rec = tls13_record.seal_record(c.app_send as ptr, tls13_record.CONTENT_APPLICATION_DATA, data, len)
@@ -2231,7 +2246,7 @@ fn parse_intermediates(body: ptr, body_len: int, out: ptr) {
                 der = bytes.new(cert_len)
                 if cert_len > 0 { bytes.set(der, cert_len - 1, 0) }
                 bytes.copy_from_bytes(der, 0, body, p, cert_len)
-                mc = malloc(136) as *LeafCert
+                mc = malloc(tls13_cert.LEAFCERT_SIZE) as *LeafCert
                 init_intermediate(mc)
                 cerr = tls13_cert.parse_certificate(der, cert_len, mc)
                 if string.equals(cerr, "") == 1 {
@@ -2256,16 +2271,11 @@ fn parse_intermediates(body: ptr, body_len: int, out: ptr) {
 }
 
 // Zero a heap LeafCert (matches tls13_cert's internal init).
+// The intermediates this parses are initialised by tls13_cert's own
+// init_leaf rather than a local copy, so a field added to LeafCert cannot be
+// cleared in one file and forgotten in the other.
 fn init_intermediate(l: *LeafCert) {
-    l.tbs = null; l.tbs_len = 0
-    l.sig_alg_oid = null
-    l.signature = null; l.signature_len = 0
-    l.spki_algo_oid = null; l.spki_key = null; l.spki_key_len = 0
-    l.issuer = null; l.issuer_len = 0
-    l.subject = null; l.subject_len = 0
-    l.not_before = null; l.not_before_len = 0
-    l.not_after = null; l.not_after_len = 0
-    l.dns_names = null
+    tls13_cert.init_leaf(l)
 }
 
 // Free a list of heap-allocated *LeafCert intermediates and the list itself.

--- a/std/cryptography/tls13_hs/module.ae
+++ b/std/cryptography/tls13_hs/module.ae
@@ -36,6 +36,7 @@ extern string_length(s: string) -> int
 extern string_char_at_n(str: string, known_length: int, index: int) -> int
 
 exports(
+    ChParsed, parse_client_hello, free_ch, server_hello,
     client_hello, client_hello_sni, client_hello_full, client_hello_pq, client_hello_psk, PskCh, parse_server_hello,
     ShParsed,
     TLS_CHACHA20_POLY1305_SHA256, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
@@ -502,6 +503,251 @@ client_hello_psk(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, ho
 // Parse a ServerHello (RFC 8446 §4.1.3) into `out`. Returns "" on success or
 // an error string. `msg` includes the 4-byte handshake header. On success,
 // out.key_share (if present) is a fresh buffer the caller must free.
+// ---- server side: building a ServerHello -------------------------------
+//
+// The inverse of parse_server_hello. RFC 8446 s4.1.3: legacy_version is
+// always 0x0303, the session id is echoed back verbatim, compression is
+// null, and the negotiated version travels in supported_versions rather than
+// the version field -- which is why a TLS 1.3 ServerHello looks like a TLS
+// 1.2 one to a middlebox.
+//
+// Returns a fresh bytes buffer holding the complete handshake message
+// (4-byte header + body); caller frees.
+server_hello(random: ptr, session_id: ptr, sid_len: int, cipher_suite: int,
+             group: int, pubkey: ptr, pubkey_len: int) -> ptr {
+    buf = bytes.new(512)
+    bytes.set(buf, 511, 0) // force full zero-fill
+
+    body = 4 // reserve the handshake header; length filled at the end
+
+    // legacy_version
+    off = put16(buf, body, 0x0303)
+    // random[32]
+    off = put_bytes(buf, off, random, 32)
+    // legacy_session_id_echo<0..32> -- verbatim, or empty when the client
+    // sent none. Echoing it is what makes a middlebox believe this is a
+    // resumed TLS 1.2 session and leave the connection alone.
+    off = put8(buf, off, sid_len)
+    if sid_len > 0 { off = put_bytes(buf, off, session_id, sid_len) }
+    // cipher_suite
+    off = put16(buf, off, cipher_suite)
+    // legacy_compression_method
+    off = put8(buf, off, 0)
+
+    // extensions: supported_versions + key_share, which is the complete set
+    // a TLS 1.3 ServerHello may carry (everything else moved into
+    // EncryptedExtensions).
+    ext_len_at = off
+    off = put16(buf, off, 0) // patched below
+
+    ext_start = off
+    // supported_versions: selected_version only (no list, unlike the CH)
+    off = put16(buf, off, 0x002b)
+    off = put16(buf, off, 2)
+    off = put16(buf, off, 0x0304)
+    // key_share: server_share = { group(2), len(2), key }
+    off = put16(buf, off, 0x0033)
+    off = put16(buf, off, 4 + pubkey_len)
+    off = put16(buf, off, group)
+    off = put16(buf, off, pubkey_len)
+    off = put_bytes(buf, off, pubkey, pubkey_len)
+
+    // patch the extensions length
+    ext_total = off - ext_start
+    put16(buf, ext_len_at, ext_total)
+
+    // handshake header: type + 3-byte body length
+    put8(buf, 0, HS_SERVER_HELLO)
+    put24(buf, 1, off - 4)
+
+    out = bytes.new(off)
+    bytes.copy_from_bytes(out, 0, buf, 0, off)
+    bytes.free(buf)
+    return out
+}
+
+// ---- server side: parsing a ClientHello -------------------------------
+//
+// The inverse of client_hello_full. A server needs the client's random (for
+// the transcript), the session id (echoed verbatim), which cipher suites and
+// groups were offered, and the key_share it can complete. Everything else in
+// a ClientHello is either ignored in TLS 1.3 or advisory.
+//
+// Deliberately narrow: this reads the extensions a TLS 1.3 handshake needs
+// and skips the rest rather than rejecting them, because a real client sends
+// plenty we do not care about (ALPN, session_ticket, padding) and refusing an
+// unknown extension would fail handshakes that are perfectly valid.
+struct ChParsed {
+    random: ptr        // 32 bytes, fresh (caller frees) or null
+    session_id: ptr    // legacy_session_id, fresh (caller frees) or null
+    session_id_len: int
+    cipher_suite: int  // the first offered suite we support, else 0
+    group: int         // the key_share group we can complete, else 0
+    key_share: ptr     // the client's public for `group`, fresh, or null
+    key_share_len: int
+    has_sni: int       // 1 if a server_name extension was present
+    saw_supported_versions: int // 1 if the client offered TLS 1.3
+}
+
+// Free the buffers a ChParsed owns. Idempotent.
+free_ch(c: *ChParsed) {
+    if c.random != null { bytes.free(c.random) c.random = null }
+    if c.session_id != null { bytes.free(c.session_id) c.session_id = null }
+    if c.key_share != null { bytes.free(c.key_share) c.key_share = null }
+}
+
+// Parse a ClientHello handshake message. Returns "" on success.
+//
+// Suite and group selection happen here rather than in the caller because
+// both are "first offered thing we support", and doing it during the single
+// pass avoids keeping the whole offered list alive just to choose from it.
+parse_client_hello(msg: ptr, len: int, out: *ChParsed) -> string {
+    out.random = null
+    out.session_id = null
+    out.session_id_len = 0
+    out.cipher_suite = 0
+    out.group = 0
+    out.key_share = null
+    out.key_share_len = 0
+    out.has_sni = 0
+    out.saw_supported_versions = 0
+
+    if len < 4 { return "client hello: truncated header" }
+    if get8(msg, 0) != HS_CLIENT_HELLO { return "client hello: wrong msg type" }
+    body_len = get24(msg, 1)
+    if body_len + 4 > len { return "client hello: length overruns buffer" }
+
+    p = 4
+    // legacy_version (2) -- always 0x0303 in TLS 1.3; the real version is in
+    // the supported_versions extension.
+    if p + 2 > len { return "client hello: truncated version" }
+    p = p + 2
+
+    // random[32]
+    if p + 32 > len { return "client hello: truncated random" }
+    rnd = bytes.new(32)
+    bytes.copy_from_bytes(rnd, 0, msg, p, 32)
+    out.random = rnd
+    p = p + 32
+
+    // legacy_session_id<0..32>
+    if p + 1 > len { return "client hello: truncated session id len" }
+    sid_len = get8(msg, p)
+    p = p + 1
+    if sid_len > 32 { return "client hello: session id too long" }
+    if p + sid_len > len { return "client hello: truncated session id" }
+    if sid_len > 0 {
+        sid = bytes.new(sid_len)
+        bytes.copy_from_bytes(sid, 0, msg, p, sid_len)
+        out.session_id = sid
+    }
+    out.session_id_len = sid_len
+    p = p + sid_len
+
+    // cipher_suites<2..2^16-2>: take the first one we implement, in the
+    // CLIENT's order. Server-preference ordering is a policy choice and this
+    // has no policy to express yet.
+    if p + 2 > len { return "client hello: truncated cipher suites length" }
+    cs_len = get16(msg, p)
+    p = p + 2
+    if p + cs_len > len { return "client hello: cipher suites overrun" }
+    cs_end = p + cs_len
+    while p + 1 < cs_end {
+        cs = get16(msg, p)
+        if out.cipher_suite == 0 {
+            if cs == TLS_AES_128_GCM_SHA256 { out.cipher_suite = cs }
+            if cs == TLS_AES_256_GCM_SHA384 { out.cipher_suite = cs }
+            if cs == TLS_CHACHA20_POLY1305_SHA256 { out.cipher_suite = cs }
+        }
+        p = p + 2
+    }
+    p = cs_end
+    if out.cipher_suite == 0 { return "client hello: no mutually supported cipher suite" }
+
+    // legacy_compression_methods<1..2^8-1> -- must contain only null(0).
+    if p + 1 > len { return "client hello: truncated compression" }
+    comp_len = get8(msg, p)
+    p = p + 1
+    if p + comp_len > len { return "client hello: compression overrun" }
+    p = p + comp_len
+
+    // extensions<8..2^16-1>
+    if p + 2 > len { return "client hello: truncated extensions length" }
+    ext_total = get16(msg, p)
+    p = p + 2
+    ext_end = p + ext_total
+    if ext_end > len { return "client hello: extensions overrun" }
+
+    while p + 4 <= ext_end {
+        ext_type = get16(msg, p)
+        ext_len = get16(msg, p + 2)
+        d = p + 4
+        if d + ext_len > ext_end { return "client hello: extension overruns" }
+
+        if ext_type == 0x0000 {
+            // server_name: presence is all a server needs here; the name
+            // itself only matters once there is more than one certificate.
+            out.has_sni = 1
+        }
+        if ext_type == 0x002b {
+            // supported_versions<2..254>: list of 2-byte versions, preceded
+            // by a 1-byte length. 0x0304 is TLS 1.3.
+            if ext_len >= 1 {
+                sv_len = get8(msg, d)
+                q = d + 1
+                sv_end = q + sv_len
+                if sv_end > d + ext_len { sv_end = d + ext_len }
+                while q + 1 < sv_end {
+                    if get16(msg, q) == 0x0304 { out.saw_supported_versions = 1 }
+                    q = q + 2
+                }
+            }
+        }
+        if ext_type == 0x0033 {
+            // key_share: client_shares<0..2^16-1> of { group(2), len(2), key }.
+            // Take the first entry whose group we can complete.
+            if ext_len >= 2 {
+                ks_total = get16(msg, d)
+                q = d + 2
+                ks_end = q + ks_total
+                if ks_end > d + ext_len { ks_end = d + ext_len }
+                while q + 4 <= ks_end {
+                    g = get16(msg, q)
+                    klen = get16(msg, q + 2)
+                    kstart = q + 4
+                    if kstart + klen > ks_end { q = ks_end } else {
+                        if out.group == 0 {
+                            if g == GROUP_X25519 {
+                                if klen == 32 {
+                                    kb = bytes.new(klen)
+                                    bytes.copy_from_bytes(kb, 0, msg, kstart, klen)
+                                    out.group = g
+                                    out.key_share = kb
+                                    out.key_share_len = klen
+                                }
+                            }
+                        }
+                        q = kstart + klen
+                    }
+                }
+            }
+        }
+        p = d + ext_len
+    }
+
+    if out.saw_supported_versions == 0 {
+        return "client hello: no supported_versions offering TLS 1.3"
+    }
+    if out.group == 0 {
+        // A real server answers this with a HelloRetryRequest naming a group
+        // it does support. Not implemented: this returns a clear error so the
+        // caller fails the handshake rather than silently negotiating
+        // something it cannot complete.
+        return "client hello: no key_share for a supported group (HelloRetryRequest not implemented)"
+    }
+    return ""
+}
+
 parse_server_hello(msg: ptr, len: int, out: *ShParsed) -> string {
     out.version = 0
     out.cipher_suite = 0

--- a/std/cryptography/tls13_hs/module.ae
+++ b/std/cryptography/tls13_hs/module.ae
@@ -514,7 +514,7 @@ client_hello_psk(random: ptr, session_id: ptr, sid_len: int, x25519_pub: ptr, ho
 // Returns a fresh bytes buffer holding the complete handshake message
 // (4-byte header + body); caller frees.
 server_hello(random: ptr, session_id: ptr, sid_len: int, cipher_suite: int,
-             group: int, pubkey: ptr, pubkey_len: int) -> ptr {
+    group: int, pubkey: ptr, pubkey_len: int) -> ptr {
     buf = bytes.new(512)
     bytes.set(buf, 511, 0) // force full zero-fill
 
@@ -578,14 +578,14 @@ server_hello(random: ptr, session_id: ptr, sid_len: int, cipher_suite: int,
 // plenty we do not care about (ALPN, session_ticket, padding) and refusing an
 // unknown extension would fail handshakes that are perfectly valid.
 struct ChParsed {
-    random: ptr        // 32 bytes, fresh (caller frees) or null
-    session_id: ptr    // legacy_session_id, fresh (caller frees) or null
+    random: ptr // 32 bytes, fresh (caller frees) or null
+    session_id: ptr // legacy_session_id, fresh (caller frees) or null
     session_id_len: int
-    cipher_suite: int  // the first offered suite we support, else 0
-    group: int         // the key_share group we can complete, else 0
-    key_share: ptr     // the client's public for `group`, fresh, or null
+    cipher_suite: int // the first offered suite we support, else 0
+    group: int // the key_share group we can complete, else 0
+    key_share: ptr // the client's public for `group`, fresh, or null
     key_share_len: int
-    has_sni: int       // 1 if a server_name extension was present
+    has_sni: int // 1 if a server_name extension was present
     saw_supported_versions: int // 1 if the client offered TLS 1.3
 }
 

--- a/std/cryptography/x25519/module.ae
+++ b/std/cryptography/x25519/module.ae
@@ -858,6 +858,16 @@ scalar_mult(scalar: ptr, u: ptr) -> (ptr, string) {
 }
 
 // base_point(scalar32) -> pubkey32. Public key = scalar * basepoint (u = 9).
+//
+// `scalar` is a std.bytes HANDLE (what bytes.new returns), NOT bytes.data(b).
+// Aether has no distinct type for the two, so `ptr` here reads as "any
+// pointer" and passing the raw data pointer compiles cleanly and then
+// SEGFAULTS inside the ladder. Every buffer argument in this module means the
+// handle; the same holds across std.cryptography.
+//
+//     b = bytes.new(32)          // fill it
+//     pub = x25519.base_point(b) // right
+//     pub = x25519.base_point(bytes.data(b))  // compiles, crashes
 base_point(scalar: ptr) -> ptr {
     u = bytes.new(POINT_BYTES)
     // bytes.new does NOT zero the buffer — only bytes up to the highest

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -127,6 +127,7 @@ tests/integration/http_server_keepalive/
 tests/integration/http_server_observability/
 tests/integration/http_server_ops/
 tests/integration/http_server_sse/
+tests/integration/https_pure_tls_vertical/
 tests/integration/http_server_tls/
 tests/integration/http_server_websocket/
 tests/integration/http_stream_upload/
@@ -198,3 +199,4 @@ tests/integration/zlib_roundtrip/
 tests/integration/condition_continuation_pipe/
 tests/integration/self_shadowing_import/
 tests/integration/tuple_through_fn/
+tests/integration/crypto_tls13_server_hs/

--- a/tests/integration/crypto_tls13_client/README.md
+++ b/tests/integration/crypto_tls13_client/README.md
@@ -5,11 +5,27 @@ pure, offline pieces of `std.cryptography.tls13_client` against the canonical
 RFC 8448 §3 trace: the transcript-hash accumulator, the handshake key
 derivation, and the Finished key/verify-data. No network.
 
-## Live-server handshake check (manual)
+`../https_pure_tls_vertical/` — the **automated end-to-end** test. Stands up
+our own `std.http` server with TLS and drives a full socket handshake against
+it from this client, then frames an HTTP/1.1 exchange over the encrypted
+stream. That covers the socket path the KAT above deliberately does not: a
+real ServerHello, a real certificate chain, hostname verification (by IP, via
+an `iPAddress` SAN) and application data both ways. No OpenSSL on the client
+side, which is what makes it the check that a cross build still has working
+HTTPS.
 
-The full socket-driven handshake is verified against a real TLS 1.3 server
-(OpenSSL `s_server`) rather than in CI, because a live-server integration test
-is inherently flakier than a KAT. To reproduce:
+`../crypto_tls13_server_hs/` — the server-direction handshake messages,
+including parsing a **real ClientHello captured from `openssl s_client`**, so
+the wire format is validated against another implementation rather than only
+against ourselves.
+
+## Live-server handshake check against OpenSSL (manual)
+
+The two automated tests above cover our own peers. This reproduces a handshake
+against OpenSSL's `s_server` specifically, which is worth doing by hand when
+touching the handshake: it is the check that catches a mistake both of our
+halves make together. Kept manual rather than in CI because a live-server
+integration test is inherently flakier than a KAT. To reproduce:
 
 ```sh
 # 1. a P-256 self-signed cert (exercises the ECDSA CertificateVerify path)

--- a/tests/integration/crypto_tls13_server_hs/test_tls13_server_hs.ae
+++ b/tests/integration/crypto_tls13_server_hs/test_tls13_server_hs.ae
@@ -1,0 +1,185 @@
+// Server-side TLS 1.3 handshake messages: parse_client_hello and
+// server_hello, the two directions tls13_hs was missing.
+//
+// Three checks, in increasing order of what they prove:
+//
+//  1. server_hello round-trips through parse_server_hello. That reader was
+//     written independently against RFC 8448 vectors, so agreement between
+//     the two is not self-consistency in the way a builder checking its own
+//     output would be.
+//  2. parse_client_hello reads a ClientHello built by client_hello_sni.
+//  3. parse_client_hello reads a REAL ClientHello captured from OpenSSL's
+//     s_client. This is the one that matters: 1 and 2 would both pass if our
+//     two halves agreed on a wire format nobody else speaks.
+
+import std.cryptography.tls13_hs
+import std.bytes
+
+extern exit(code: int)
+
+fn hexval(c: int) -> int {
+    if c >= 48 && c <= 57 { return c - 48 }
+    if c >= 97 && c <= 102 { return c - 87 }
+    if c >= 65 && c <= 70 { return c - 55 }
+    return 0
+}
+
+fn from_hex(h: string) -> ptr {
+    hl = string_length(h)
+    n = hl / 2
+    b = bytes.new(n)
+    i = 0
+    while i < n {
+        hi = hexval(string_char_at_n(h, hl, i * 2))
+        lo = hexval(string_char_at_n(h, hl, i * 2 + 1))
+        bytes.set(b, i, (hi << 4) | lo)
+        i = i + 1
+    }
+    return b
+}
+
+fn filled(n: int, base: int) -> ptr {
+    b = bytes.new(n)
+    i = 0
+    while i < n { bytes.set(b, i, (base + i) & 0xFF) i = i + 1 }
+    return b
+}
+
+main() {
+    fails = 0
+
+    // ---- 1. server_hello -> parse_server_hello ----
+    rnd = filled(32, 0)
+    sid = filled(32, 200)
+    pub = filled(32, 100)
+    sh = tls13_hs.server_hello(rnd, sid, 32, 0x1301, 0x001d, pub, 32)
+    shn = bytes.length(sh)
+    sp = ShParsed { version: 0, cipher_suite: 0, group: 0, key_share: null,
+                    key_share_len: 0, is_hello_retry: 0, psk_accepted: 0 }
+    serr = tls13_hs.parse_server_hello(sh, shn, &sp)
+    if serr != "" {
+        println("FAIL 1: parse_server_hello rejected our ServerHello: ${serr}")
+        fails = fails + 1
+    }
+    if sp.cipher_suite != 0x1301 {
+        println("FAIL 1: suite round-tripped as ${sp.cipher_suite}, want 4865")
+        fails = fails + 1
+    }
+    if sp.group != 0x001d {
+        println("FAIL 1: group round-tripped as ${sp.group}, want 29")
+        fails = fails + 1
+    }
+    if sp.key_share_len != 32 {
+        println("FAIL 1: key_share_len ${sp.key_share_len}, want 32")
+        fails = fails + 1
+    }
+    if sp.is_hello_retry != 0 {
+        println("FAIL 1: a plain ServerHello was read as a HelloRetryRequest")
+        fails = fails + 1
+    }
+    if fails == 0 { println("ok   server_hello round-trips through parse_server_hello") }
+    bytes.free(sh)
+    bytes.free(rnd)
+    bytes.free(sid)
+    bytes.free(pub)
+
+    // ---- 2. our own ClientHello -> parse_client_hello ----
+    r2 = filled(32, 1)
+    s2 = filled(32, 9)
+    p2 = filled(32, 50)
+    ch = tls13_hs.client_hello_sni(r2, s2, 32, p2, "example.com")
+    chn = bytes.length(ch)
+    c = ChParsed { random: null, session_id: null, session_id_len: 0,
+                   cipher_suite: 0, group: 0, key_share: null, key_share_len: 0,
+                   has_sni: 0, saw_supported_versions: 0 }
+    cerr = tls13_hs.parse_client_hello(ch, chn, &c)
+    if cerr != "" {
+        println("FAIL 2: parse_client_hello rejected our own ClientHello: ${cerr}")
+        fails = fails + 1
+    }
+    if c.group != 0x001d {
+        println("FAIL 2: group ${c.group}, want 29")
+        fails = fails + 1
+    }
+    if c.key_share_len != 32 {
+        println("FAIL 2: key_share_len ${c.key_share_len}, want 32")
+        fails = fails + 1
+    }
+    if c.has_sni != 1 {
+        println("FAIL 2: server_name extension not seen")
+        fails = fails + 1
+    }
+    if c.saw_supported_versions != 1 {
+        println("FAIL 2: supported_versions offering TLS 1.3 not seen")
+        fails = fails + 1
+    }
+    if cerr == "" { println("ok   parse_client_hello reads client_hello_sni output") }
+    tls13_hs.free_ch(&c)
+    bytes.free(ch)
+    bytes.free(r2)
+    bytes.free(s2)
+    bytes.free(p2)
+
+    // ---- 3. a REAL OpenSSL ClientHello ----
+    // Captured from `openssl s_client -tls1_3`, record header stripped.
+    // Pinned as hex so the test needs no network and no openssl at runtime.
+    real = from_hex("010000d80303a26f0f61fa6b6244e1548db0188f0fa57f107488d1c4713fcc9afe43ec1706b720482e35a004944c80913a161b0640236fe2187f0a1c5f44b5dfbfba42598a5c3b000813021303130100ff01000087000b000403000102000a00160014001d0017001e0019001801000101010201030104002300000016000000170000000d001e001c040305030603080708080809080a080b080408050806040105010601002b0003020304002d00020101003300260024001d0020d226a9273e4dfbbe7d79136fe6ca97d08bf5f3130def8ff16b6aa5f6b620bd4d")
+    rn = bytes.length(real)
+    rc = ChParsed { random: null, session_id: null, session_id_len: 0,
+                    cipher_suite: 0, group: 0, key_share: null, key_share_len: 0,
+                    has_sni: 0, saw_supported_versions: 0 }
+    rerr = tls13_hs.parse_client_hello(real, rn, &rc)
+    if rerr != "" {
+        println("FAIL 3: rejected a real OpenSSL ClientHello: ${rerr}")
+        fails = fails + 1
+    } else {
+        if rc.key_share_len != 32 {
+            println("FAIL 3: key_share_len ${rc.key_share_len}, want 32")
+            fails = fails + 1
+        }
+        if rc.group != 0x001d {
+            println("FAIL 3: group ${rc.group}, want 29 (X25519)")
+            fails = fails + 1
+        }
+        if rc.cipher_suite == 0 {
+            println("FAIL 3: no cipher suite negotiated")
+            fails = fails + 1
+        }
+        if rc.saw_supported_versions != 1 {
+            println("FAIL 3: real CH did not register as TLS 1.3")
+            fails = fails + 1
+        }
+    }
+    if rerr == "" { println("ok   parse_client_hello reads a real OpenSSL ClientHello") }
+    tls13_hs.free_ch(&rc)
+    bytes.free(real)
+
+    // ---- 4. malformed input is refused ----
+    // A parser that only ever sees well-formed input proves little; these are
+    // the shapes a hostile or broken peer actually sends.
+    tiny = bytes.new(2)
+    tc = ChParsed { random: null, session_id: null, session_id_len: 0, cipher_suite: 0,
+                    group: 0, key_share: null, key_share_len: 0, has_sni: 0,
+                    saw_supported_versions: 0 }
+    if tls13_hs.parse_client_hello(tiny, 2, &tc) == "" {
+        println("FAIL 4: a 2-byte message was accepted as a ClientHello")
+        fails = fails + 1
+    }
+    bytes.free(tiny)
+
+    wrong = bytes.new(64)
+    bytes.set(wrong, 0, 2) // HS_SERVER_HELLO
+    if tls13_hs.parse_client_hello(wrong, 64, &tc) == "" {
+        println("FAIL 4: a ServerHello was accepted as a ClientHello")
+        fails = fails + 1
+    }
+    bytes.free(wrong)
+    println("ok   malformed ClientHellos are refused")
+
+    if fails != 0 {
+        println("tls13_server_hs: ${fails} failure(s)")
+        exit(1)
+    }
+    println("tls13_server_hs: all checks pass")
+    exit(0)
+}

--- a/tests/integration/crypto_tls13_server_hs/test_tls13_server_hs.ae
+++ b/tests/integration/crypto_tls13_server_hs/test_tls13_server_hs.ae
@@ -55,7 +55,7 @@ main() {
     sh = tls13_hs.server_hello(rnd, sid, 32, 0x1301, 0x001d, pub, 32)
     shn = bytes.length(sh)
     sp = ShParsed { version: 0, cipher_suite: 0, group: 0, key_share: null,
-                    key_share_len: 0, is_hello_retry: 0, psk_accepted: 0 }
+        key_share_len: 0, is_hello_retry: 0, psk_accepted: 0 }
     serr = tls13_hs.parse_server_hello(sh, shn, &sp)
     if serr != "" {
         println("FAIL 1: parse_server_hello rejected our ServerHello: ${serr}")
@@ -90,8 +90,8 @@ main() {
     ch = tls13_hs.client_hello_sni(r2, s2, 32, p2, "example.com")
     chn = bytes.length(ch)
     c = ChParsed { random: null, session_id: null, session_id_len: 0,
-                   cipher_suite: 0, group: 0, key_share: null, key_share_len: 0,
-                   has_sni: 0, saw_supported_versions: 0 }
+        cipher_suite: 0, group: 0, key_share: null, key_share_len: 0,
+        has_sni: 0, saw_supported_versions: 0 }
     cerr = tls13_hs.parse_client_hello(ch, chn, &c)
     if cerr != "" {
         println("FAIL 2: parse_client_hello rejected our own ClientHello: ${cerr}")
@@ -126,8 +126,8 @@ main() {
     real = from_hex("010000d80303a26f0f61fa6b6244e1548db0188f0fa57f107488d1c4713fcc9afe43ec1706b720482e35a004944c80913a161b0640236fe2187f0a1c5f44b5dfbfba42598a5c3b000813021303130100ff01000087000b000403000102000a00160014001d0017001e0019001801000101010201030104002300000016000000170000000d001e001c040305030603080708080809080a080b080408050806040105010601002b0003020304002d00020101003300260024001d0020d226a9273e4dfbbe7d79136fe6ca97d08bf5f3130def8ff16b6aa5f6b620bd4d")
     rn = bytes.length(real)
     rc = ChParsed { random: null, session_id: null, session_id_len: 0,
-                    cipher_suite: 0, group: 0, key_share: null, key_share_len: 0,
-                    has_sni: 0, saw_supported_versions: 0 }
+        cipher_suite: 0, group: 0, key_share: null, key_share_len: 0,
+        has_sni: 0, saw_supported_versions: 0 }
     rerr = tls13_hs.parse_client_hello(real, rn, &rc)
     if rerr != "" {
         println("FAIL 3: rejected a real OpenSSL ClientHello: ${rerr}")
@@ -159,8 +159,8 @@ main() {
     // the shapes a hostile or broken peer actually sends.
     tiny = bytes.new(2)
     tc = ChParsed { random: null, session_id: null, session_id_len: 0, cipher_suite: 0,
-                    group: 0, key_share: null, key_share_len: 0, has_sni: 0,
-                    saw_supported_versions: 0 }
+        group: 0, key_share: null, key_share_len: 0, has_sni: 0,
+        saw_supported_versions: 0 }
     if tls13_hs.parse_client_hello(tiny, 2, &tc) == "" {
         println("FAIL 4: a 2-byte message was accepted as a ClientHello")
         fails = fails + 1

--- a/tests/integration/https_pure_tls_vertical/client.ae
+++ b/tests/integration/https_pure_tls_vertical/client.ae
@@ -19,7 +19,7 @@ import std.os
 extern exit(code: int)
 
 main() {
-    host = "127.0.0.1"   // exercises iPAddress-SAN matching
+    host = "127.0.0.1" // exercises iPAddress-SAN matching
     port = 18447
 
     priv = bytes.new(32)

--- a/tests/integration/https_pure_tls_vertical/client.ae
+++ b/tests/integration/https_pure_tls_vertical/client.ae
@@ -1,0 +1,80 @@
+// The vertical slice: HTTPS end to end with NO OpenSSL on the client side.
+//
+// std.http.client's HTTPS path is OpenSSL (std/net/aether_http.c), so it
+// returns "HTTPS requested but the build has no OpenSSL support" in any
+// `ae build --target=` cross build. std.cryptography.tls13_client is a pure
+// Aether TLS 1.3 client that has no such dependency -- this drives it against
+// our own std.http server and frames one HTTP/1.1 exchange over the raw TLS
+// byte stream, which is the piece std.http.client would own if the two were
+// wired together (asks/http-client-pure-tls-backend-for-crossbuild.md).
+//
+// The private key is a fixed 32 bytes: this is a test, and a deterministic
+// key makes a failure reproducible. Real callers pass fresh randomness.
+
+import std.cryptography.tls13_client
+import std.bytes
+import std.string
+import std.os
+
+extern exit(code: int)
+
+main() {
+    host = "127.0.0.1"   // exercises iPAddress-SAN matching
+    port = 18447
+
+    priv = bytes.new(32)
+    i = 0
+    while i < 32 {
+        bytes.set(priv, i, 7 + i)
+        i = i + 1
+    }
+
+    conn, err = tls13_client.connect(host, port, priv)
+    if err != "" {
+        println("FAIL: pure TLS handshake: ${err}")
+        exit(1)
+    }
+    println("PASS: pure-Aether TLS 1.3 handshake (no OpenSSL on this side)")
+
+    // Frame one HTTP/1.1 request over the TLS stream.
+    req = "GET / HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n"
+    rlen = string_length(req)
+    rb = bytes.new(rlen)
+    _ = bytes.copy_from_string(rb, 0, req, rlen)
+    // NB: conn_send takes a bytes HANDLE, not bytes.data(rb) -- the `ptr`
+    // in its signature means an AetherBytes*, and passing the raw data
+    // pointer segfaults inside seal_record.
+    serr = tls13_client.conn_send(conn, rb, rlen)
+    if serr != "" {
+        println("FAIL: conn_send: ${serr}")
+        exit(1)
+    }
+
+    // Read until the body marker appears or the peer closes.
+    acc = ""
+    reads = 0
+    while reads < 40 {
+        p, n, rerr = tls13_client.conn_recv(conn)
+        if rerr != "" { reads = 40 }
+        if n > 0 {
+            // conn_recv returns a bytes HANDLE ("fresh bytes; caller frees"),
+            // so read it with to_string rather than string_from_ptr.
+            chunk = bytes.to_string(p, n)
+            acc = string_concat(acc, chunk)
+            bytes.free(p)
+            if string_contains(acc, "pure-tls-vertical-ok") == 1 { reads = 40 }
+        }
+        reads = reads + 1
+    }
+
+    bytes.free(rb)
+    bytes.free(priv)
+    tls13_client.close_conn(conn)
+
+    if string_contains(acc, "pure-tls-vertical-ok") == 1 {
+        println("PASS: HTTP/1.1 response received over pure TLS")
+        exit(0)
+    }
+    println("FAIL: body marker not seen; got ${string_length(acc)} bytes")
+    exit(1)
+}

--- a/tests/integration/https_pure_tls_vertical/server.ae
+++ b/tests/integration/https_pure_tls_vertical/server.ae
@@ -1,0 +1,71 @@
+// #260 Tier 0: server-side TLS termination test driver.
+//
+// Spins up an HTTP server on TLS-enabled port 18102 with a route
+// that returns "pure-tls-vertical-ok". The shell runner verifies handshake +
+// response with curl --cacert.
+
+import std.http
+import std.os
+
+extern exit(code: int)
+// Use raw form: actor receive handlers can't cleanly discard the
+// wrapper's string return without an unused-result warning.
+extern http_server_start_raw(server: ptr) -> int
+
+const PORT = 18447
+
+handle_root(req: ptr, res: ptr, ud: ptr) {
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "pure-tls-vertical-ok")
+}
+
+message StartSrv { raw: ptr }
+message Noop {}
+
+actor SrvActor {
+    state s = 0
+    receive { StartSrv(raw) -> { s = raw; http_server_start_raw(raw) } }
+}
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+main() {
+    cert_path = os_getenv("CERT_PATH")
+    key_path = os_getenv("KEY_PATH")
+    if cert_path == 0 || key_path == 0 {
+        println("FAIL: CERT_PATH / KEY_PATH must be set")
+        exit(1)
+    }
+
+    raw = http.server_create(PORT)
+
+    // Bind all interfaces: `localhost` resolves to ::1 on some boxes and
+    // 127.0.0.1 on others, and the client must reach it either way.
+    // Bind :: so a client dialling "localhost" reaches us whether that
+    // resolves to ::1 or 127.0.0.1 -- it is ::1-only on some boxes.
+    http.server_set_host(raw, "127.0.0.1")
+    if raw == 0 {
+        println("FAIL: server_create returned null")
+        exit(1)
+    }
+
+    tls_err = http.server_set_tls(raw, cert_path, key_path)
+    if tls_err != "" {
+        println("FAIL: server_set_tls: ${tls_err}")
+        exit(1)
+    }
+    println("READY")
+
+    http.server_get(raw, "/", handle_root, 0)
+
+    spawn(SchedHelper())
+    a = spawn(SrvActor())
+    a ! StartSrv { raw: raw }
+
+    // Block forever (the runner sends SIGTERM after curl finishes).
+    sleep(60000)
+    exit(0)
+}

--- a/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
+++ b/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
@@ -46,10 +46,15 @@ fail() { echo "  [FAIL] $1"; exit 1; }
 # and be handed to the client as its trust anchor.
 # MSYS2_ARG_CONV_EXCL: on MSYS2 the shell rewrites any argument that looks
 # like a POSIX path, so `-subj "/CN=127.0.0.1"` reaches openssl as
-# "D:/a/_temp/msys64/CN=127.0.0.1" and it refuses the subject. The variable is
-# inert everywhere else -- verified on Linux, where the subject and both SANs
-# come out identical with and without it.
-MSYS2_ARG_CONV_EXCL='*' \
+# "C:/Program Files/Git/CN=127.0.0.1" and it refuses the subject.
+#
+# Scoped to the subject prefix rather than '*'. Excluding everything also
+# stops the -keyout/-out paths being converted, and openssl then cannot open
+# "/tmp/tmp.XXXX/key.pem" on Windows at all -- which swaps one failure for
+# another. Verified both ways on a real MINGW64 box: '*' reproduces
+# `Can't open ... for writing`, '/CN=' produces the right subject and both
+# SANs. Inert on Linux, where the output is identical with and without it.
+MSYS2_ARG_CONV_EXCL='/CN=' \
 openssl req -x509 -newkey rsa:2048 -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
     -days 2 -nodes -subj "/CN=127.0.0.1" \
     -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" >"$TMP/ssl.log" 2>&1 \

--- a/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
+++ b/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
@@ -44,6 +44,12 @@ fail() { echo "  [FAIL] $1"; exit 1; }
 # A self-signed cert for 127.0.0.1. The client authenticates the server for
 # real -- chain, validity and hostname -- so the cert has to carry an IP SAN
 # and be handed to the client as its trust anchor.
+# MSYS2_ARG_CONV_EXCL: on MSYS2 the shell rewrites any argument that looks
+# like a POSIX path, so `-subj "/CN=127.0.0.1"` reaches openssl as
+# "D:/a/_temp/msys64/CN=127.0.0.1" and it refuses the subject. The variable is
+# inert everywhere else -- verified on Linux, where the subject and both SANs
+# come out identical with and without it.
+MSYS2_ARG_CONV_EXCL='*' \
 openssl req -x509 -newkey rsa:2048 -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
     -days 2 -nodes -subj "/CN=127.0.0.1" \
     -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" >"$TMP/ssl.log" 2>&1 \

--- a/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
+++ b/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# HTTPS end to end with a pure-Aether TLS client: our std.http server on one
+# side, std.cryptography.tls13_client on the other, one HTTP/1.1 exchange
+# framed over the raw TLS stream.
+#
+# Why this exists. std.http.client's HTTPS path is OpenSSL
+# (std/net/aether_http.c), so `ae build --target=` -- which links no OpenSSL --
+# returns "HTTPS requested but the build has no OpenSSL support" at runtime.
+# A downstream port read the tree, concluded HTTPS was impossible in a cross
+# build, and filed asks/http-client-pure-tls-backend-for-crossbuild.md asking
+# for a pure TLS backend to be written.
+#
+# Most of it already exists: tls13_client is a complete pure-Aether TLS 1.3
+# client with full server authentication, and it cross-builds. What was
+# missing was anything demonstrating that, which is what this test is. It
+# pins the vertical slice so the claim is checkable rather than asserted, and
+# gives the std.http.client integration a target to match.
+#
+# The client half deliberately uses NO OpenSSL. The server half still does
+# (std/net/aether_http_server.c terminates TLS with SSL_accept), so this
+# proves one direction; a pure server needs tls13_hs to gain a ClientHello
+# parser and a ServerHello builder, which it does not have yet.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+PORT=18447
+
+[ -x "$AE" ] || { echo "  [SKIP] https_pure_tls_vertical: ae not built"; exit 0; }
+command -v openssl >/dev/null 2>&1 || { echo "  [SKIP] https_pure_tls_vertical: no openssl to make a cert"; exit 0; }
+
+TMP="$(mktemp -d)"
+SRV_PID=""
+cleanup() {
+    if [ -n "$SRV_PID" ]; then kill "$SRV_PID" 2>/dev/null || :; fi
+    rm -rf "$TMP" || :
+    return 0
+}
+trap cleanup EXIT
+fail() { echo "  [FAIL] $1"; exit 1; }
+
+# A self-signed cert for 127.0.0.1. The client authenticates the server for
+# real -- chain, validity and hostname -- so the cert has to carry an IP SAN
+# and be handed to the client as its trust anchor.
+openssl req -x509 -newkey rsa:2048 -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
+    -days 2 -nodes -subj "/CN=127.0.0.1" \
+    -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" >"$TMP/ssl.log" 2>&1 \
+    || { sed -n '1,10p' "$TMP/ssl.log"; fail "could not generate a test certificate"; }
+
+"$AE" build "$SCRIPT_DIR/server.ae" -o "$TMP/srv" >"$TMP/b1.log" 2>&1 \
+    || { sed -n '1,12p' "$TMP/b1.log"; fail "server did not build"; }
+"$AE" build "$SCRIPT_DIR/client.ae" -o "$TMP/cli" >"$TMP/b2.log" 2>&1 \
+    || { sed -n '1,12p' "$TMP/b2.log"; fail "pure-TLS client did not build"; }
+
+CERT_PATH="$TMP/cert.pem" KEY_PATH="$TMP/key.pem" "$TMP/srv" >"$TMP/srv.log" 2>&1 &
+SRV_PID=$!
+
+i=0
+while [ "$i" -lt 100 ]; do
+    grep -q READY "$TMP/srv.log" 2>/dev/null && break
+    sleep 0.1
+    i=$((i + 1))
+done
+grep -q READY "$TMP/srv.log" 2>/dev/null || {
+    sed -n '1,10p' "$TMP/srv.log"
+    fail "the TLS server never became READY"
+}
+
+# SSL_CERT_FILE is how tls13_client is told where its trust anchors are; with
+# a self-signed test cert that file IS the anchor. Without it the handshake
+# fails closed with "cannot load system trust store", which is correct
+# behaviour and worth stating because it is not obvious.
+OUT=$(SSL_CERT_FILE="$TMP/cert.pem" "$TMP/cli" 2>&1) || {
+    printf '%s\n' "$OUT" | grep -vE 'warning: unresolved|-->' | sed 's/^/    cli: /'
+    sed -n '1,6p' "$TMP/srv.log" | sed 's/^/    srv: /'
+    fail "the pure-TLS client did not complete the exchange"
+}
+
+case "$OUT" in
+    *"PASS: pure-Aether TLS 1.3 handshake"*) ;;
+    *) echo "$OUT" | sed 's/^/         /'; fail "no handshake confirmation" ;;
+esac
+case "$OUT" in
+    *"PASS: HTTP/1.1 response received over pure TLS"*) ;;
+    *) echo "$OUT" | sed 's/^/         /'; fail "no HTTP response over the TLS stream" ;;
+esac
+
+echo "  [PASS] https_pure_tls_vertical: std.http server <- HTTP/1.1 over pure-Aether TLS 1.3"


### PR DESCRIPTION
Combines what were #1803 and #1804 — same subsystem, one CI run. From `asks/http-client-pure-tls-backend-for-crossbuild.md`.

## The ask's premise, verified

The same program, cross-built, under identical conditions:

```
std.http.client → "HTTPS requested but the build has no OpenSSL support"
tls13_client    → PURE-AETHER TLS 1.3 HANDSHAKE OK -> example.com:443
```

**The capability already exists and already survives `--target`.** So this is integration and visibility, not missing crypto — plus the defects that building the showcase exposed, and the server-side gap that keeps our TLS from ever being tested against our TLS.

## 1. IP SANs — a real capability gap

`check_hostname` matched `dNSName` SANs **only**; `iPAddress` SANs (tag `0x87`) were never parsed, so verifying a server *by address* — the normal case for a local or internal endpoint — could not succeed however the certificate was issued.

IP literals now match `iPAddress` SANs and **never** dNSNames (RFC 6125 §1.7.2). Both directions tested: the right address connects, a cert carrying `IP:10.9.9.9` is refused.

## 2. `LeafCert` corrupted the heap on any new field

Three `malloc(136)` calls sized the struct by hand, and **two byte-identical initialisers** cleared its fields in different modules. Add one pointer and the struct grows while the allocations still ask for 136 — surfacing as a **double-free inside `free_leaf`**, far from the edit.

Not hypothetical: it's what happened when the IP field went in, **twice**. I reverted the first attempt wholesale rather than chase it green. Now one exported size constant and one exported initialiser — five coupling sites down to two.

## 3. `ptr` means "bytes handle", and getting it wrong segfaults

```aether
x25519.base_point(b)              // right
x25519.base_point(bytes.data(b))  // compiles, segfaults in the ladder
```

Aether has no separate type, so both spell as `ptr`. This cost five failed attempts to call shipped APIs correctly *with the source open*. Now stated in the module header and at the functions where getting it wrong crashes.

## 4. The server handshake — the empty cell

| | OpenSSL | Pure |
| --- | --- | --- |
| **Client** | ✅ native only | ✅ **incl. cross builds** |
| **Server** | ✅ native only | ❌ **was empty** |

**Not about dropping OpenSSL** — it stays the default where present. The empty cell cost two things: our TLS was never exercised against our TLS (only static vectors and OpenSSL peers, so a mistake both halves make together had nowhere to surface), and **a cross-built binary cannot serve HTTPS at all** (`TLS unavailable: built without OpenSSL`).

Measured before writing anything, the gap was one layer: the record layer has **zero role references**, the key schedule is **label-driven** (`"s hs traffic"` is the same call), and signing plus the `"TLS 1.3, server CertificateVerify"` string already existed.

## Testing, in increasing order of what it proves

| Check | Proves |
| --- | --- |
| `server_hello` → `parse_server_hello` | agrees with a reader written independently against RFC 8448 |
| `client_hello_sni` → `parse_client_hello` | our two halves agree |
| **real OpenSSL ClientHello** → `parse_client_hello` | we speak the format *others* speak |
| a vertical slice: our server ← pure client | HTTPS end to end, no OpenSSL client-side |

The third matters most — the first two would both pass if our halves agreed on a format nobody else speaks. Captured from `openssl s_client -tls1_3`, pinned as hex so the test needs neither network nor openssl:

```
suite=4866 (AES-256-GCM) group=29 (X25519) ks_len=32 sid_len=32
```

Malformed input is refused too.

## Stated limitations

- **HelloRetryRequest is not implemented.** A client offering only unsupported groups gets an explicit error, not a silently unfinishable negotiation. That's the "works with our client" vs "works with a browser" line.
- **This is handshake messages, not a working server.** Still needed: EncryptedExtensions, Certificate, CertificateVerify, the server-direction Finished, and wiring into `aether_http_server.c` — whose loop is C and does `SSL_accept`.

## Verification

`make test` 398/0 · RFC 8448 vectors and x25519 KATs still pass · `fmt_gate` and `check-docs` clean · live handshake to `example.com:443` still works · valgrind: one 32-byte leak in `run_handshake_tail`, **pre-existing** (baseline 48 bytes in 2 blocks) and untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
